### PR TITLE
Add set parameter command

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -570,6 +570,8 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             return;
         }
 
+        UpdateMaxHighlightedCount();
+
         // Wait until the initial data is loaded. This is required so there isn't a race between data loading and using resources here.
         await _loadingTcs.Task;
 

--- a/src/Aspire.Hosting/ApplicationModel/KnownResourceCommands.cs
+++ b/src/Aspire.Hosting/ApplicationModel/KnownResourceCommands.cs
@@ -24,4 +24,14 @@ public static class KnownResourceCommands
     /// The command name for restarting a resource.
     /// </summary>
     public static readonly string RestartCommand = "resource-restart";
+
+    /// <summary>
+    /// The command name for setting a parameter value.
+    /// </summary>
+    public static readonly string SetParameterCommand = "parameter-set";
+
+    /// <summary>
+    /// The command name for deleting a parameter value.
+    /// </summary>
+    public static readonly string DeleteParameterCommand = "parameter-delete";
 }

--- a/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
@@ -40,7 +40,19 @@ public class ParameterResource : Resource, IManifestExpressionProvider, IValuePr
     [Obsolete("Use GetValueAsync for async access or pass the ParameterResource directly to methods that accept it (e.g., environment variables).")]
     public string Value => GetValueAsync(default).AsTask().GetAwaiter().GetResult()!;
 
-    internal string ValueInternal => _lazyValue.Value;
+    internal string ValueInternal
+    {
+        get
+        {
+            // If the WaitForValueTcs has a set value then prefer it.
+            if (WaitForValueTcs?.Task is { IsCompleted: true } valueTask)
+            {
+                return valueTask.Result;
+            }
+
+            return _lazyValue.Value;
+        }
+    }
 
     /// <summary>
     /// Represents how the default value of the parameter should be retrieved.

--- a/src/Aspire.Hosting/CompatibilitySuppressions.xml
+++ b/src/Aspire.Hosting/CompatibilitySuppressions.xml
@@ -52,6 +52,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aspire.Hosting.Pipelines.IDeploymentStateManager.DeleteSectionAsync(Aspire.Hosting.Pipelines.DeploymentStateSection,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
     <Target>P:Aspire.Hosting.IDeveloperCertificateService.UseForHttps</Target>
     <Left>lib/net8.0/Aspire.Hosting.dll</Left>
     <Right>lib/net8.0/Aspire.Hosting.dll</Right>

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -5,6 +5,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Pipelines;
@@ -26,7 +27,13 @@ public sealed class ParameterProcessor(
     IDeploymentStateManager deploymentStateManager,
     IUserSecretsManager userSecretsManager)
 {
+    internal const string SaveToUserSecretsName = "SaveToUserSecrets";
+    internal const string DeleteFromUserSecretsName = "DeleteFromUserSecrets";
+
     private readonly List<ParameterResource> _unresolvedParameters = [];
+    private readonly object _resolutionTaskLock = new();
+    private CancellationTokenSource? _allParametersResolvedCts;
+    private Task? _parameterResolutionTask;
 
     /// <summary>
     /// Initializes parameter resources and handles unresolved parameters if interaction service is available.
@@ -50,23 +57,38 @@ public sealed class ParameterProcessor(
         if (interactionService.IsAvailable && _unresolvedParameters.Count > 0)
         {
             // Start the loop that will allow the user to specify values for unresolved parameters.
-            var parameterResolutionTask = Task.Run(async () =>
-            {
-                try
-                {
-                    await HandleUnresolvedParametersAsync().ConfigureAwait(false);
-                    logger.LogDebug("All unresolved parameters have been handled successfully.");
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "Failed to handle unresolved parameters.");
-                }
-            });
+            var task = EnsureParameterResolutionTaskRunningAsync();
 
             if (waitForResolution)
             {
-                await parameterResolutionTask.ConfigureAwait(false);
+                await task.ConfigureAwait(false);
             }
+        }
+    }
+
+    private Task EnsureParameterResolutionTaskRunningAsync()
+    {
+        lock (_resolutionTaskLock)
+        {
+            if (_parameterResolutionTask is null || _parameterResolutionTask.IsCompleted)
+            {
+                var cts = new CancellationTokenSource();
+                _allParametersResolvedCts = cts;
+                _parameterResolutionTask = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await HandleUnresolvedParametersAsync(_unresolvedParameters, cts.Token).ConfigureAwait(false);
+                        logger.LogDebug("All unresolved parameters have been handled successfully.");
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex, "Failed to handle unresolved parameters.");
+                    }
+                });
+            }
+
+            return _parameterResolutionTask;
         }
     }
 
@@ -113,7 +135,6 @@ public sealed class ParameterProcessor(
 
             await ProcessResourceDependenciesAsync(resource, executionContext, referencedParameters, currentDependencySet, cancellationToken).ConfigureAwait(false);
         }
-
     }
 
     private async Task ProcessResourceDependenciesAsync(IResource resource, DistributedApplicationExecutionContext executionContext, Dictionary<string, ParameterResource> referencedParameters, HashSet<object?> currentDependencySet, CancellationToken cancellationToken)
@@ -152,19 +173,18 @@ public sealed class ParameterProcessor(
 
     private async Task ProcessParameterAsync(ParameterResource parameterResource)
     {
+        // Add the "Set parameter" command if the app is running and the interaction service is available.
+        // This command allows the user to set the parameter value at runtime.
+        if (executionContext.IsRunMode && interactionService.IsAvailable && !parameterResource.Annotations.OfType<ResourceCommandAnnotation>().Any(a => a.Name == KnownResourceCommands.SetParameterCommand))
+        {
+            AddSetParameterCommand(parameterResource);
+        }
+
         try
         {
             var value = parameterResource.ValueInternal ?? "";
 
-            await notificationService.PublishUpdateAsync(parameterResource, s =>
-            {
-                return s with
-                {
-                    Properties = s.Properties.SetResourceProperty(KnownProperties.Parameter.Value, value, parameterResource.Secret),
-                    State = KnownResourceStates.Running
-                };
-            })
-            .ConfigureAwait(false);
+            await UpdateParameterStateAsync(parameterResource, value, KnownResourceStates.Running).ConfigureAwait(false);
 
             parameterResource.WaitForValueTcs?.TrySetResult(value);
         }
@@ -199,163 +219,376 @@ public sealed class ParameterProcessor(
                 KnownResourceStateStyles.Warn :
                 KnownResourceStateStyles.Error;
 
-            await notificationService.PublishUpdateAsync(parameterResource, s =>
-            {
-                return s with
-                {
-                    State = new(stateText, stateStyle),
-                    Properties = s.Properties.SetResourceProperty(KnownProperties.Parameter.Value, ex.Message)
-                };
-            })
-            .ConfigureAwait(false);
+            await UpdateParameterStateAsync(parameterResource, ex.Message, new(stateText, stateStyle)).ConfigureAwait(false);
         }
     }
 
-    // Internal for testing purposes.
-    private async Task HandleUnresolvedParametersAsync()
+    private void AddSetParameterCommand(ParameterResource parameterResource)
     {
-        await HandleUnresolvedParametersAsync(_unresolvedParameters).ConfigureAwait(false);
+        parameterResource.Annotations.Add(new ResourceCommandAnnotation(
+            name: KnownResourceCommands.SetParameterCommand,
+            displayName: CommandStrings.SetParameterName,
+            executeCommand: async context =>
+            {
+                await SetParameterAsync(parameterResource, context.CancellationToken).ConfigureAwait(false);
+                return CommandResults.Success();
+            },
+            updateState: _ => ResourceCommandState.Enabled,
+            displayDescription: CommandStrings.SetParameterDescription,
+            parameter: null,
+            confirmationMessage: null,
+            iconName: "Key",
+            iconVariant: IconVariant.Regular,
+            isHighlighted: true));
+
+        parameterResource.Annotations.Add(new ResourceCommandAnnotation(
+            name: KnownResourceCommands.DeleteParameterCommand,
+            displayName: CommandStrings.DeleteParameterName,
+            executeCommand: async context =>
+            {
+                await DeleteParameterAsync(parameterResource, context.CancellationToken).ConfigureAwait(false);
+                return CommandResults.Success();
+            },
+            updateState: _ => HasParameterValue(parameterResource) ? ResourceCommandState.Enabled : ResourceCommandState.Hidden,
+            displayDescription: CommandStrings.DeleteParameterDescription,
+            parameter: null,
+            confirmationMessage: null,
+            iconName: "Delete",
+            iconVariant: IconVariant.Regular,
+            isHighlighted: true));
+    }
+
+    private static bool HasParameterValue(ParameterResource parameterResource)
+    {
+        try
+        {
+            var value = parameterResource.ValueInternal;
+            return !string.IsNullOrEmpty(value);
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Prompts the user to set a value for a single parameter.
+    /// </summary>
+    /// <param name="parameterResource">The parameter resource to set the value for.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task that completes when the user has set the value or cancelled.</returns>
+    public async Task SetParameterAsync(ParameterResource parameterResource, CancellationToken cancellationToken = default)
+    {
+        var input = parameterResource.CreateInput();
+
+        // Pre-populate input with existing value if the parameter has one
+        try
+        {
+            var existingValue = parameterResource.ValueInternal;
+            if (!string.IsNullOrEmpty(existingValue))
+            {
+                input.Value = existingValue;
+            }
+        }
+        catch (Exception)
+        {
+            // No existing value, leave input empty
+        }
+
+        var parameterSection = await deploymentStateManager.AcquireSectionAsync(parameterResource.ConfigurationKey, cancellationToken).ConfigureAwait(false);
+        var hasSavedState = parameterSection.Data.Count > 0 && input.Value != null;
+
+        var saveParameterInput = CreateSaveParameterInput(hasSavedState);
+
+        var inputs = new List<InteractionInput> { input, saveParameterInput };
+
+        var result = await interactionService.PromptInputsAsync(
+            InteractionStrings.SetParameterTitle,
+            InteractionStrings.SetParameterMessage,
+            inputs,
+            new InputsDialogInteractionOptions
+            {
+                PrimaryButtonText = InteractionStrings.ParametersInputsPrimaryButtonText,
+                ShowDismiss = true,
+                EnableMessageMarkdown = true,
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (result.Canceled)
+        {
+            return;
+        }
+
+        if (string.IsNullOrEmpty(input.Value))
+        {
+            return;
+        }
+
+        var inputValue = input.Value;
+        var shouldSave = saveParameterInput?.Value is not null &&
+            bool.TryParse(saveParameterInput.Value, out var saveToDeploymentState) && saveToDeploymentState;
+
+        await ApplyParameterValueAsync(parameterResource, inputValue, shouldSave, cancellationToken).ConfigureAwait(false);
+
+        // Remove the parameter from unresolved parameters list.
+        OnParameterResolved(_unresolvedParameters, parameterResource);
+    }
+
+    private InteractionInput CreateSaveParameterInput(bool hasExistingValue)
+    {
+        return new InteractionInput
+        {
+            Name = SaveToUserSecretsName,
+            InputType = InputType.Boolean,
+            Label = InteractionStrings.ParametersInputsRememberLabel,
+            // Default to true if value already exists (was read from user secrets)
+            Value = hasExistingValue ? "true" : null,
+            Description = !userSecretsManager.IsAvailable
+                ? InteractionStrings.ParametersInputsRememberDescriptionNotConfigured
+                : null,
+            EnableDescriptionMarkdown = true,
+            Disabled = !userSecretsManager.IsAvailable
+        };
+    }
+
+    /// <summary>
+    /// Deletes a parameter value from the deployment state and marks it as unresolved.
+    /// </summary>
+    /// <param name="parameterResource">The parameter resource to delete the value for.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task that completes when the value has been deleted.</returns>
+    public async Task DeleteParameterAsync(ParameterResource parameterResource, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var parameterSection = await deploymentStateManager.AcquireSectionAsync(parameterResource.ConfigurationKey, cancellationToken).ConfigureAwait(false);
+            var hasSavedState = parameterSection.Data.Count > 0;
+
+            // Show different message based on whether value is saved in user secrets
+            var message = hasSavedState
+                ? string.Format(CultureInfo.CurrentCulture, InteractionStrings.DeleteParameterMessageWithUserSecrets, parameterResource.Name)
+                : string.Format(CultureInfo.CurrentCulture, InteractionStrings.DeleteParameterMessage, parameterResource.Name);
+
+            var inputs = new List<InteractionInput>();
+            InteractionInput? deleteFromUserSecretsInput = null;
+
+            // Add checkbox to delete from user secrets if value is saved there
+            if (hasSavedState)
+            {
+                deleteFromUserSecretsInput = new InteractionInput
+                {
+                    Name = DeleteFromUserSecretsName,
+                    InputType = InputType.Boolean,
+                    Label = InteractionStrings.ParametersInputsDeleteLabel
+                };
+                inputs.Add(deleteFromUserSecretsInput);
+            }
+
+            var result = await interactionService.PromptInputsAsync(
+                InteractionStrings.DeleteParameterTitle,
+                message,
+                inputs,
+                new InputsDialogInteractionOptions
+                {
+                    PrimaryButtonText = InteractionStrings.DeleteParameterPrimaryButtonText,
+                    ShowDismiss = true,
+                    EnableMessageMarkdown = true,
+                },
+                cancellationToken).ConfigureAwait(false);
+
+            if (result.Canceled)
+            {
+                return;
+            }
+
+            // Check if user wants to delete from user secrets
+            var deleteFromUserSecrets = deleteFromUserSecretsInput?.Value is { Length: > 0 } deleteInputValue &&
+                bool.TryParse(deleteInputValue, out var shouldDelete) && shouldDelete;
+
+            if (deleteFromUserSecrets)
+            {
+                parameterSection.Data.Clear();
+                await deploymentStateManager.DeleteSectionAsync(parameterSection, cancellationToken).ConfigureAwait(false);
+                logger.LogInformation("Parameter value deleted from deployment state for {ParameterName}.", parameterResource.Name);
+
+                loggerService.GetLogger(parameterResource)
+                    .LogInformation("Parameter resource {ResourceName} value has been deleted from user secrets.", parameterResource.Name);
+            }
+            else
+            {
+                logger.LogInformation("Parameter value cleared for {ParameterName} (not deleted from user secrets).", parameterResource.Name);
+
+                loggerService.GetLogger(parameterResource)
+                    .LogInformation("Parameter resource {ResourceName} value has been cleared.", parameterResource.Name);
+            }
+
+            // Add the parameter back to unresolved parameters
+            if (!_unresolvedParameters.Contains(parameterResource))
+            {
+                _unresolvedParameters.Add(parameterResource);
+
+                // Reset the WaitForValueTcs so the parameter can be resolved again
+                var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+                tcs.SetException(new MissingParameterValueException("Parameter value has been deleted."));
+                parameterResource.WaitForValueTcs = tcs;
+
+                // Update the parameter's state to show it's missing a value
+                await UpdateParameterStateAsync(parameterResource, "Parameter value has been deleted", new("Value missing", KnownResourceStateStyles.Warn)).ConfigureAwait(false);
+
+                // Start the resolution task if it's not running
+                _ = EnsureParameterResolutionTaskRunningAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to delete parameter {ParameterName} from deployment state.", parameterResource.Name);
+        }
+    }
+
+    private async Task ApplyParameterValueAsync(ParameterResource parameterResource, string inputValue, bool saveToDeploymentState, CancellationToken cancellationToken = default)
+    {
+        // Update the parameter resource with the new value.
+        // The parameter could already have a value set so recreate TCS in that situation.
+        if (parameterResource.WaitForValueTcs?.Task.IsCompleted ?? false)
+        {
+            parameterResource.WaitForValueTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        parameterResource.WaitForValueTcs?.TrySetResult(inputValue);
+
+        await UpdateParameterStateAsync(parameterResource, inputValue, KnownResourceStates.Running).ConfigureAwait(false);
+
+        // Log that the parameter has been resolved
+        loggerService.GetLogger(parameterResource)
+            .LogInformation("Parameter resource {ResourceName} has been resolved via user interaction.", parameterResource.Name);
+
+        // Save to deployment state if requested and in run mode
+        if (executionContext.IsRunMode && saveToDeploymentState)
+        {
+            try
+            {
+                var slot = await deploymentStateManager.AcquireSectionAsync(parameterResource.ConfigurationKey, cancellationToken).ConfigureAwait(false);
+                slot.SetValue(inputValue);
+                await deploymentStateManager.SaveSectionAsync(slot, cancellationToken).ConfigureAwait(false);
+                logger.LogInformation("Parameter value saved to deployment state for {ParameterName}.", parameterResource.Name);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to save parameter {ParameterName} to deployment state.", parameterResource.Name);
+            }
+        }
     }
 
     // Internal for testing purposes - allows passing specific parameters to test.
-    internal async Task HandleUnresolvedParametersAsync(IList<ParameterResource> unresolvedParameters)
+    internal async Task HandleUnresolvedParametersAsync(IList<ParameterResource> unresolvedParameters, CancellationToken cancellationToken)
     {
         var stateModified = false;
 
+        // This method will continue in a loop until all unresolved parameters are resolved.
+        while (unresolvedParameters.Count > 0)
         {
+            var showNotification = executionContext.IsRunMode;
+            var showSaveToSecrets = executionContext.IsRunMode;
 
-            // This method will continue in a loop until all unresolved parameters are resolved.
-            while (unresolvedParameters.Count > 0)
+            var proceedToInputs = true;
+
+            if (showNotification)
             {
-                var showNotification = executionContext.IsRunMode;
-                var showSaveToSecrets = executionContext.IsRunMode;
+                // First we show a notification that there are unresolved parameters.
+                var result = await interactionService.PromptNotificationAsync(
+                    InteractionStrings.ParametersBarTitle,
+                    InteractionStrings.ParametersBarMessage,
+                    new NotificationInteractionOptions
+                    {
+                        Intent = MessageIntent.Warning,
+                        PrimaryButtonText = InteractionStrings.ParametersBarPrimaryButtonText
+                    },
+                    cancellationToken).ConfigureAwait(false);
 
-                var proceedToInputs = true;
+                proceedToInputs = result.Data;
+            }
 
-                if (showNotification)
+            if (proceedToInputs)
+            {
+                // Now we build up a new form base on the unresolved parameters.
+                var resourceInputs = new List<(ParameterResource ParameterResource, InteractionInput Input)>();
+
+                foreach (var parameter in unresolvedParameters)
                 {
-                    // First we show a notification that there are unresolved parameters.
-                    var result = await interactionService.PromptNotificationAsync(
-                        InteractionStrings.ParametersBarTitle,
-                        InteractionStrings.ParametersBarMessage,
-                         new NotificationInteractionOptions
-                         {
-                             Intent = MessageIntent.Warning,
-                             PrimaryButtonText = InteractionStrings.ParametersBarPrimaryButtonText
-                         })
-                        .ConfigureAwait(false);
-
-                    proceedToInputs = result.Data;
+                    // Create an input for each unresolved parameter.
+                    var input = parameter.CreateInput();
+                    resourceInputs.Add((parameter, input));
                 }
 
-                if (proceedToInputs)
+                var inputs = resourceInputs.Select(i => i.Input).ToList();
+                InteractionInput? saveParameters = null;
+
+                if (showSaveToSecrets)
                 {
-                    // Now we build up a new form base on the unresolved parameters.
-                    var resourceInputs = new List<(ParameterResource ParameterResource, InteractionInput Input)>();
+                    saveParameters = CreateSaveParameterInput(hasExistingValue: false);
+                    inputs.Add(saveParameters);
+                }
 
-                    foreach (var parameter in unresolvedParameters)
+                var message = executionContext.IsPublishMode
+                    ? InteractionStrings.ParametersInputsMessagePublishMode
+                    : InteractionStrings.ParametersInputsMessage;
+
+                var valuesPrompt = await interactionService.PromptInputsAsync(
+                    InteractionStrings.ParametersInputsTitle,
+                    message,
+                    [.. inputs],
+                    new InputsDialogInteractionOptions
                     {
-                        // Create an input for each unresolved parameter.
-                        var input = parameter.CreateInput();
-                        resourceInputs.Add((parameter, input));
-                    }
+                        PrimaryButtonText = InteractionStrings.ParametersInputsPrimaryButtonText,
+                        ShowDismiss = true,
+                        EnableMessageMarkdown = true,
+                    },
+                    cancellationToken).ConfigureAwait(false);
 
-                    var inputs = resourceInputs.Select(i => i.Input).ToList();
-                    InteractionInput? saveParameters = null;
+                if (!valuesPrompt.Canceled)
+                {
+                    var shouldSave = saveParameters?.Value is not null &&
+                        bool.TryParse(saveParameters.Value, out var saveToDeploymentState) && saveToDeploymentState;
 
-                    if (showSaveToSecrets)
+                    // Iterate through the unresolved parameters and set their values based on user input.
+                    for (var i = resourceInputs.Count - 1; i >= 0; i--)
                     {
-                        saveParameters = new InteractionInput
+                        var (parameter, input) = (resourceInputs[i].ParameterResource, resourceInputs[i].Input);
+                        var inputValue = input.Value;
+
+                        if (string.IsNullOrEmpty(inputValue))
                         {
-                            Name = "RememberParameters",
-                            InputType = InputType.Boolean,
-                            Label = InteractionStrings.ParametersInputsRememberLabel,
-                            Description = !userSecretsManager.IsAvailable 
-                                ? InteractionStrings.ParametersInputsRememberDescriptionNotConfigured 
-                                : null,
-                            EnableDescriptionMarkdown = true,
-                            Disabled = !userSecretsManager.IsAvailable
-                        };
-                        inputs.Add(saveParameters);
-                    }
-
-                    var message = executionContext.IsPublishMode
-                        ? InteractionStrings.ParametersInputsMessagePublishMode
-                        : InteractionStrings.ParametersInputsMessage;
-
-                    var valuesPrompt = await interactionService.PromptInputsAsync(
-                        InteractionStrings.ParametersInputsTitle,
-                        message,
-                        [.. inputs],
-                        new InputsDialogInteractionOptions
-                        {
-                            PrimaryButtonText = InteractionStrings.ParametersInputsPrimaryButtonText,
-                            ShowDismiss = true,
-                            EnableMessageMarkdown = true,
-                        })
-                        .ConfigureAwait(false);
-
-                    if (!valuesPrompt.Canceled)
-                    {
-                        // Iterate through the unresolved parameters and set their values based on user input.
-                        for (var i = resourceInputs.Count - 1; i >= 0; i--)
-                        {
-                            var (parameter, input) = (resourceInputs[i].ParameterResource, resourceInputs[i].Input);
-                            var inputValue = input.Value;
-
-                            if (string.IsNullOrEmpty(inputValue))
-                            {
-                                // If the input value is null, we skip this parameter.
-                                continue;
-                            }
-
-                            parameter.WaitForValueTcs?.TrySetResult(inputValue);
-
-                            // Update the parameter resource state to active with the provided value.
-                            await notificationService.PublishUpdateAsync(parameter, s =>
-                            {
-                                return s with
-                                {
-                                    Properties = s.Properties.SetResourceProperty(KnownProperties.Parameter.Value, inputValue, parameter.Secret),
-                                    State = KnownResourceStates.Running
-                                };
-                            })
-                            .ConfigureAwait(false);
-
-                            // Log that the parameter has been resolved
-                            loggerService.GetLogger(parameter)
-                                .LogInformation("Parameter resource {ResourceName} has been resolved via user interaction.", parameter.Name);
-
-                            if (executionContext.IsRunMode && showSaveToSecrets && saveParameters?.Value is not null)
-                            {
-                                var shouldSave = bool.TryParse(saveParameters.Value, out var saveToDeploymentState) && saveToDeploymentState;
-                                if (shouldSave)
-                                {
-                                    try
-                                    {
-                                        var slot = await deploymentStateManager.AcquireSectionAsync(parameter.ConfigurationKey).ConfigureAwait(false);
-                                        slot.SetValue(inputValue);
-                                        await deploymentStateManager.SaveSectionAsync(slot).ConfigureAwait(false);
-                                        stateModified = true;
-                                    }
-                                    catch (Exception ex)
-                                    {
-                                        logger.LogWarning(ex, "Failed to save parameter {ParameterName} to deployment state.", parameter.Name);
-                                    }
-                                }
-                            }
-
-                            // Remove the parameter from unresolved parameters list.
-                            unresolvedParameters.RemoveAt(i);
+                            // If the input value is null, we skip this parameter.
+                            continue;
                         }
+
+                        await ApplyParameterValueAsync(parameter, inputValue, shouldSave, cancellationToken).ConfigureAwait(false);
+
+                        if (shouldSave)
+                        {
+                            stateModified = true;
+                        }
+
+                        // Remove the parameter from unresolved parameters list.
+                        OnParameterResolved(unresolvedParameters, parameter);
                     }
                 }
             }
+        }
 
-            if (stateModified)
-            {
-                logger.LogInformation("Parameter values saved to deployment state.");
-            }
+        if (stateModified)
+        {
+            logger.LogInformation("Parameter values saved to deployment state.");
+        }
+    }
+
+    private void OnParameterResolved(IList<ParameterResource> unresolvedParameters, ParameterResource parameter)
+    {
+        unresolvedParameters.Remove(parameter);
+
+        if (unresolvedParameters.Count == 0)
+        {
+            _allParametersResolvedCts?.Cancel();
         }
     }
 
@@ -385,5 +618,17 @@ public sealed class ParameterProcessor(
         {
             logger.LogInformation("{SavedCount} parameter values saved to deployment state.", savedCount);
         }
+    }
+
+    private async Task UpdateParameterStateAsync(ParameterResource parameterResource, string value, ResourceStateSnapshot? state)
+    {
+        await notificationService.PublishUpdateAsync(parameterResource, s =>
+        {
+            return s with
+            {
+                Properties = s.Properties.SetResourceProperty(KnownProperties.Parameter.Value, value, parameterResource.Secret),
+                State = state
+            };
+        }).ConfigureAwait(false);
     }
 }

--- a/src/Aspire.Hosting/Pipelines/IDeploymentStateManager.cs
+++ b/src/Aspire.Hosting/Pipelines/IDeploymentStateManager.cs
@@ -33,4 +33,13 @@ public interface IDeploymentStateManager
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <exception cref="InvalidOperationException">Thrown when a version conflict is detected, indicating the section was modified after it was acquired.</exception>
     Task SaveSectionAsync(DeploymentStateSection section, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Delete a section of deployment state with optimistic concurrency control.
+    /// The section must have a matching version number or a concurrency exception will be thrown.
+    /// </summary>
+    /// <param name="section">The section to delete, including version information.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <exception cref="InvalidOperationException">Thrown when a version conflict is detected, indicating the section was modified after it was acquired.</exception>
+    Task DeleteSectionAsync(DeploymentStateSection section, CancellationToken cancellationToken = default);
 }

--- a/src/Aspire.Hosting/Resources/CommandStrings.Designer.cs
+++ b/src/Aspire.Hosting/Resources/CommandStrings.Designer.cs
@@ -79,6 +79,42 @@ namespace Aspire.Hosting.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Delete parameter value.
+        /// </summary>
+        internal static string DeleteParameterDescription {
+            get {
+                return ResourceManager.GetString("DeleteParameterDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete parameter.
+        /// </summary>
+        internal static string DeleteParameterName {
+            get {
+                return ResourceManager.GetString("DeleteParameterName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Set parameter value.
+        /// </summary>
+        internal static string SetParameterDescription {
+            get {
+                return ResourceManager.GetString("SetParameterDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Set parameter.
+        /// </summary>
+        internal static string SetParameterName {
+            get {
+                return ResourceManager.GetString("SetParameterName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Start resource.
         /// </summary>
         internal static string StartDescription {

--- a/src/Aspire.Hosting/Resources/CommandStrings.resx
+++ b/src/Aspire.Hosting/Resources/CommandStrings.resx
@@ -135,4 +135,16 @@
   <data name="StopName" xml:space="preserve">
     <value>Stop</value>
   </data>
+  <data name="SetParameterDescription" xml:space="preserve">
+    <value>Set parameter value</value>
+  </data>
+  <data name="SetParameterName" xml:space="preserve">
+    <value>Set parameter</value>
+  </data>
+  <data name="DeleteParameterDescription" xml:space="preserve">
+    <value>Delete parameter value</value>
+  </data>
+  <data name="DeleteParameterName" xml:space="preserve">
+    <value>Delete parameter</value>
+  </data>
 </root>

--- a/src/Aspire.Hosting/Resources/InteractionStrings.Designer.cs
+++ b/src/Aspire.Hosting/Resources/InteractionStrings.Designer.cs
@@ -133,6 +133,44 @@ namespace Aspire.Hosting.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Are you sure you want to delete the value for parameter `{0}`? .
+        /// </summary>
+        internal static string DeleteParameterMessage {
+            get {
+                return ResourceManager.GetString("DeleteParameterMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Are you sure you want to delete the value for parameter `{0}`?
+        ///
+        ///The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there..
+        /// </summary>
+        internal static string DeleteParameterMessageWithUserSecrets {
+            get {
+                return ResourceManager.GetString("DeleteParameterMessageWithUserSecrets", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete.
+        /// </summary>
+        internal static string DeleteParameterPrimaryButtonText {
+            get {
+                return ResourceManager.GetString("DeleteParameterPrimaryButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete parameter value.
+        /// </summary>
+        internal static string DeleteParameterTitle {
+            get {
+                return ResourceManager.GetString("DeleteParameterTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There are unresolved parameters that need to be set. Please provide values for them..
         /// </summary>
         internal static string ParametersBarMessage {
@@ -160,6 +198,15 @@ namespace Aspire.Hosting.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Delete from user secrets.
+        /// </summary>
+        internal static string ParametersInputsDeleteLabel {
+            get {
+                return ResourceManager.GetString("ParametersInputsDeleteLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Please provide values for the unresolved parameters. Parameters can be saved to [user secrets](https://aka.ms/aspire/user-secrets) for future use..
         /// </summary>
         internal static string ParametersInputsMessage {
@@ -167,7 +214,7 @@ namespace Aspire.Hosting.Resources {
                 return ResourceManager.GetString("ParametersInputsMessage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Please provide values for the unresolved parameters..
         /// </summary>
@@ -219,6 +266,26 @@ namespace Aspire.Hosting.Resources {
         internal static string ParametersInputsTitle {
             get {
                 return ResourceManager.GetString("ParametersInputsTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+        ///
+        ///New parameter values may not be used until dependent resources are restarted..
+        /// </summary>
+        internal static string SetParameterMessage {
+            get {
+                return ResourceManager.GetString("SetParameterMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Set parameter.
+        /// </summary>
+        internal static string SetParameterTitle {
+            get {
+                return ResourceManager.GetString("SetParameterTitle", resourceCulture);
             }
         }
         

--- a/src/Aspire.Hosting/Resources/InteractionStrings.resx
+++ b/src/Aspire.Hosting/Resources/InteractionStrings.resx
@@ -184,4 +184,32 @@
   <data name="ContainerRuntimeNotInstalledMessage" xml:space="preserve">
     <value>Container runtime could not be found. See https://aka.ms/dotnet/aspire/containers for more details on supported container runtimes.</value>
   </data>
+  <data name="SetParameterTitle" xml:space="preserve">
+    <value>Set parameter</value>
+  </data>
+  <data name="SetParameterMessage" xml:space="preserve">
+    <value>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</value>
+    <comment>Contains markdown</comment>
+  </data>
+  <data name="ParametersInputsDeleteLabel" xml:space="preserve">
+    <value>Delete from user secrets</value>
+  </data>
+  <data name="DeleteParameterTitle" xml:space="preserve">
+    <value>Delete parameter value</value>
+  </data>
+  <data name="DeleteParameterMessage" xml:space="preserve">
+    <value>Are you sure you want to delete the value for parameter `{0}`? </value>
+    <comment>Contains markdown. {0} is the parameter name.</comment>
+  </data>
+  <data name="DeleteParameterMessageWithUserSecrets" xml:space="preserve">
+    <value>Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</value>
+    <comment>Contains markdown. {0} is the parameter name.</comment>
+  </data>
+  <data name="DeleteParameterPrimaryButtonText" xml:space="preserve">
+    <value>Delete</value>
+  </data>
 </root>

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.cs.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.cs.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="DeleteParameterDescription">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterName">
+        <source>Delete parameter</source>
+        <target state="new">Delete parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart resource</source>
         <target state="translated">Restartovat prostředek</target>
@@ -10,6 +20,16 @@
       <trans-unit id="RestartName">
         <source>Restart</source>
         <target state="translated">Restartovat</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterDescription">
+        <source>Set parameter value</source>
+        <target state="new">Set parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterName">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.de.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.de.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="DeleteParameterDescription">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterName">
+        <source>Delete parameter</source>
+        <target state="new">Delete parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart resource</source>
         <target state="translated">Ressource neu starten</target>
@@ -10,6 +20,16 @@
       <trans-unit id="RestartName">
         <source>Restart</source>
         <target state="translated">Neu starten</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterDescription">
+        <source>Set parameter value</source>
+        <target state="new">Set parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterName">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.es.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.es.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="DeleteParameterDescription">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterName">
+        <source>Delete parameter</source>
+        <target state="new">Delete parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart resource</source>
         <target state="translated">Reiniciar recurso</target>
@@ -10,6 +20,16 @@
       <trans-unit id="RestartName">
         <source>Restart</source>
         <target state="translated">Reiniciar</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterDescription">
+        <source>Set parameter value</source>
+        <target state="new">Set parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterName">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.fr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.fr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="DeleteParameterDescription">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterName">
+        <source>Delete parameter</source>
+        <target state="new">Delete parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart resource</source>
         <target state="translated">Redémarrer la ressource</target>
@@ -10,6 +20,16 @@
       <trans-unit id="RestartName">
         <source>Restart</source>
         <target state="translated">Redémarrer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterDescription">
+        <source>Set parameter value</source>
+        <target state="new">Set parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterName">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.it.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.it.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="DeleteParameterDescription">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterName">
+        <source>Delete parameter</source>
+        <target state="new">Delete parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart resource</source>
         <target state="translated">Riavvia risorsa</target>
@@ -10,6 +20,16 @@
       <trans-unit id="RestartName">
         <source>Restart</source>
         <target state="translated">Riavvia</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterDescription">
+        <source>Set parameter value</source>
+        <target state="new">Set parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterName">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.ja.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.ja.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="DeleteParameterDescription">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterName">
+        <source>Delete parameter</source>
+        <target state="new">Delete parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart resource</source>
         <target state="translated">リソースの再起動</target>
@@ -10,6 +20,16 @@
       <trans-unit id="RestartName">
         <source>Restart</source>
         <target state="translated">再起動</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterDescription">
+        <source>Set parameter value</source>
+        <target state="new">Set parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterName">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.ko.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.ko.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="DeleteParameterDescription">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterName">
+        <source>Delete parameter</source>
+        <target state="new">Delete parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart resource</source>
         <target state="translated">리소스 다시 시작</target>
@@ -10,6 +20,16 @@
       <trans-unit id="RestartName">
         <source>Restart</source>
         <target state="translated">다시 시작</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterDescription">
+        <source>Set parameter value</source>
+        <target state="new">Set parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterName">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.pl.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.pl.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="DeleteParameterDescription">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterName">
+        <source>Delete parameter</source>
+        <target state="new">Delete parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart resource</source>
         <target state="translated">Uruchom ponownie zasób</target>
@@ -10,6 +20,16 @@
       <trans-unit id="RestartName">
         <source>Restart</source>
         <target state="translated">Ponownie uruchom</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterDescription">
+        <source>Set parameter value</source>
+        <target state="new">Set parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterName">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.pt-BR.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.pt-BR.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="DeleteParameterDescription">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterName">
+        <source>Delete parameter</source>
+        <target state="new">Delete parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart resource</source>
         <target state="translated">Reiniciar recurso</target>
@@ -10,6 +20,16 @@
       <trans-unit id="RestartName">
         <source>Restart</source>
         <target state="translated">Reiniciar</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterDescription">
+        <source>Set parameter value</source>
+        <target state="new">Set parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterName">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.ru.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.ru.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="DeleteParameterDescription">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterName">
+        <source>Delete parameter</source>
+        <target state="new">Delete parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart resource</source>
         <target state="translated">Перезапустить ресурс</target>
@@ -10,6 +20,16 @@
       <trans-unit id="RestartName">
         <source>Restart</source>
         <target state="translated">Перезапустить</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterDescription">
+        <source>Set parameter value</source>
+        <target state="new">Set parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterName">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.tr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.tr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="DeleteParameterDescription">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterName">
+        <source>Delete parameter</source>
+        <target state="new">Delete parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart resource</source>
         <target state="translated">Kaynağı yeniden başlat</target>
@@ -10,6 +20,16 @@
       <trans-unit id="RestartName">
         <source>Restart</source>
         <target state="translated">Yeniden başlat</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterDescription">
+        <source>Set parameter value</source>
+        <target state="new">Set parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterName">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.zh-Hans.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="DeleteParameterDescription">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterName">
+        <source>Delete parameter</source>
+        <target state="new">Delete parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart resource</source>
         <target state="translated">重启资源</target>
@@ -10,6 +20,16 @@
       <trans-unit id="RestartName">
         <source>Restart</source>
         <target state="translated">重启</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterDescription">
+        <source>Set parameter value</source>
+        <target state="new">Set parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterName">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">

--- a/src/Aspire.Hosting/Resources/xlf/CommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/CommandStrings.zh-Hant.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../CommandStrings.resx">
     <body>
+      <trans-unit id="DeleteParameterDescription">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterName">
+        <source>Delete parameter</source>
+        <target state="new">Delete parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart resource</source>
         <target state="translated">重新啟動資源</target>
@@ -10,6 +20,16 @@
       <trans-unit id="RestartName">
         <source>Restart</source>
         <target state="translated">重新啟動</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterDescription">
+        <source>Set parameter value</source>
+        <target state="new">Set parameter value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterName">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.cs.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.cs.xlf
@@ -42,6 +42,30 @@
         <target state="translated">Modul runtime kontejneru není v pořádku</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteParameterMessage">
+        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`? </target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterMessageWithUserSecrets">
+        <source>Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterPrimaryButtonText">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterTitle">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersBarMessage">
         <source>There are unresolved parameters that need to be set. Please provide values for them.</source>
         <target state="translated">Existují nevyřešené parametry, které je třeba nastavit. Zadejte pro ně hodnoty.</target>
@@ -55,6 +79,11 @@
       <trans-unit id="ParametersBarTitle">
         <source>Unresolved parameters</source>
         <target state="translated">Nerozpoznané parametry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParametersInputsDeleteLabel">
+        <source>Delete from user secrets</source>
+        <target state="new">Delete from user secrets</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsMessage">
@@ -110,6 +139,20 @@
       <trans-unit id="VersionCheckTitle">
         <source>Update now</source>
         <target state="translated">Aktualizovat teď</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterMessage">
+        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</source>
+        <target state="new">Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="SetParameterTitle">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.de.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.de.xlf
@@ -42,6 +42,30 @@
         <target state="translated">Containerruntime fehlerhaft</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteParameterMessage">
+        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`? </target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterMessageWithUserSecrets">
+        <source>Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterPrimaryButtonText">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterTitle">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersBarMessage">
         <source>There are unresolved parameters that need to be set. Please provide values for them.</source>
         <target state="translated">Es gibt nicht aufgelöste Parameter, die festgelegt werden müssen. Geben Sie Werte für diese an.</target>
@@ -55,6 +79,11 @@
       <trans-unit id="ParametersBarTitle">
         <source>Unresolved parameters</source>
         <target state="translated">Nicht aufgelöste Parameter</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParametersInputsDeleteLabel">
+        <source>Delete from user secrets</source>
+        <target state="new">Delete from user secrets</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsMessage">
@@ -110,6 +139,20 @@
       <trans-unit id="VersionCheckTitle">
         <source>Update now</source>
         <target state="translated">Jetzt aktualisieren</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterMessage">
+        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</source>
+        <target state="new">Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="SetParameterTitle">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.es.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.es.xlf
@@ -42,6 +42,30 @@
         <target state="translated">El entorno de ejecución del contenedor está en mal estado</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteParameterMessage">
+        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`? </target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterMessageWithUserSecrets">
+        <source>Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterPrimaryButtonText">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterTitle">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersBarMessage">
         <source>There are unresolved parameters that need to be set. Please provide values for them.</source>
         <target state="translated">Hay parámetros sin resolver que deben configurarse. Proporcione valores para ellos.</target>
@@ -55,6 +79,11 @@
       <trans-unit id="ParametersBarTitle">
         <source>Unresolved parameters</source>
         <target state="translated">Parámetros sin resolver</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParametersInputsDeleteLabel">
+        <source>Delete from user secrets</source>
+        <target state="new">Delete from user secrets</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsMessage">
@@ -110,6 +139,20 @@
       <trans-unit id="VersionCheckTitle">
         <source>Update now</source>
         <target state="translated">Actualizar ahora</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterMessage">
+        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</source>
+        <target state="new">Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="SetParameterTitle">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.fr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.fr.xlf
@@ -42,6 +42,30 @@
         <target state="translated">Runtime de conteneur défectueux</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteParameterMessage">
+        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`? </target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterMessageWithUserSecrets">
+        <source>Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterPrimaryButtonText">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterTitle">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersBarMessage">
         <source>There are unresolved parameters that need to be set. Please provide values for them.</source>
         <target state="translated">Vous devez définir des paramètres non résolus. Veuillez leur fournir des valeurs.</target>
@@ -55,6 +79,11 @@
       <trans-unit id="ParametersBarTitle">
         <source>Unresolved parameters</source>
         <target state="translated">Paramètres non résolus</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParametersInputsDeleteLabel">
+        <source>Delete from user secrets</source>
+        <target state="new">Delete from user secrets</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsMessage">
@@ -110,6 +139,20 @@
       <trans-unit id="VersionCheckTitle">
         <source>Update now</source>
         <target state="translated">Mettez à jour maintenant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterMessage">
+        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</source>
+        <target state="new">Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="SetParameterTitle">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.it.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.it.xlf
@@ -42,6 +42,30 @@
         <target state="translated">Runtime del contenitore non integro</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteParameterMessage">
+        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`? </target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterMessageWithUserSecrets">
+        <source>Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterPrimaryButtonText">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterTitle">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersBarMessage">
         <source>There are unresolved parameters that need to be set. Please provide values for them.</source>
         <target state="translated">Sono presenti parametri non risolti che devono essere impostati. Specifica i valori per questi parametri.</target>
@@ -55,6 +79,11 @@
       <trans-unit id="ParametersBarTitle">
         <source>Unresolved parameters</source>
         <target state="translated">Parametri non risolti</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParametersInputsDeleteLabel">
+        <source>Delete from user secrets</source>
+        <target state="new">Delete from user secrets</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsMessage">
@@ -110,6 +139,20 @@
       <trans-unit id="VersionCheckTitle">
         <source>Update now</source>
         <target state="translated">Aggiorna adesso</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterMessage">
+        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</source>
+        <target state="new">Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="SetParameterTitle">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ja.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ja.xlf
@@ -42,6 +42,30 @@
         <target state="translated">異常なコンテナー ランタイム</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteParameterMessage">
+        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`? </target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterMessageWithUserSecrets">
+        <source>Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterPrimaryButtonText">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterTitle">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersBarMessage">
         <source>There are unresolved parameters that need to be set. Please provide values for them.</source>
         <target state="translated">設定する必要のある未解決のパラメーターがあります。それらの値を指定してください。</target>
@@ -55,6 +79,11 @@
       <trans-unit id="ParametersBarTitle">
         <source>Unresolved parameters</source>
         <target state="translated">未解決のパラメーター</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParametersInputsDeleteLabel">
+        <source>Delete from user secrets</source>
+        <target state="new">Delete from user secrets</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsMessage">
@@ -110,6 +139,20 @@
       <trans-unit id="VersionCheckTitle">
         <source>Update now</source>
         <target state="translated">今すぐ更新</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterMessage">
+        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</source>
+        <target state="new">Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="SetParameterTitle">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ko.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ko.xlf
@@ -42,6 +42,30 @@
         <target state="translated">컨테이너 런타임 비정상</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteParameterMessage">
+        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`? </target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterMessageWithUserSecrets">
+        <source>Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterPrimaryButtonText">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterTitle">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersBarMessage">
         <source>There are unresolved parameters that need to be set. Please provide values for them.</source>
         <target state="translated">설정해야 하는 해결되지 않은 매개 변수가 있습니다. 값을 입력하세요.</target>
@@ -55,6 +79,11 @@
       <trans-unit id="ParametersBarTitle">
         <source>Unresolved parameters</source>
         <target state="translated">해결되지 않은 매개 변수</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParametersInputsDeleteLabel">
+        <source>Delete from user secrets</source>
+        <target state="new">Delete from user secrets</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsMessage">
@@ -110,6 +139,20 @@
       <trans-unit id="VersionCheckTitle">
         <source>Update now</source>
         <target state="translated">지금 업데이트</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterMessage">
+        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</source>
+        <target state="new">Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="SetParameterTitle">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pl.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pl.xlf
@@ -42,6 +42,30 @@
         <target state="translated">Nieprawidłowa kondycja środowiska uruchomieniowego kontenera</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteParameterMessage">
+        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`? </target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterMessageWithUserSecrets">
+        <source>Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterPrimaryButtonText">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterTitle">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersBarMessage">
         <source>There are unresolved parameters that need to be set. Please provide values for them.</source>
         <target state="translated">Istnieją nierozpoznane parametry, które należy ustawić. Podaj dla nich wartości.</target>
@@ -55,6 +79,11 @@
       <trans-unit id="ParametersBarTitle">
         <source>Unresolved parameters</source>
         <target state="translated">Nierozpoznane parametry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParametersInputsDeleteLabel">
+        <source>Delete from user secrets</source>
+        <target state="new">Delete from user secrets</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsMessage">
@@ -110,6 +139,20 @@
       <trans-unit id="VersionCheckTitle">
         <source>Update now</source>
         <target state="translated">Zaktualizuj teraz</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterMessage">
+        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</source>
+        <target state="new">Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="SetParameterTitle">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pt-BR.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pt-BR.xlf
@@ -42,6 +42,30 @@
         <target state="translated">Tempo de execução do contêiner não íntegro</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteParameterMessage">
+        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`? </target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterMessageWithUserSecrets">
+        <source>Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterPrimaryButtonText">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterTitle">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersBarMessage">
         <source>There are unresolved parameters that need to be set. Please provide values for them.</source>
         <target state="translated">Há parâmetros não resolvidos que precisam ser definidos. Insira valores para eles.</target>
@@ -55,6 +79,11 @@
       <trans-unit id="ParametersBarTitle">
         <source>Unresolved parameters</source>
         <target state="translated">Parâmetros não resolvidos</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParametersInputsDeleteLabel">
+        <source>Delete from user secrets</source>
+        <target state="new">Delete from user secrets</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsMessage">
@@ -110,6 +139,20 @@
       <trans-unit id="VersionCheckTitle">
         <source>Update now</source>
         <target state="translated">Atualize agora</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterMessage">
+        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</source>
+        <target state="new">Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="SetParameterTitle">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ru.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ru.xlf
@@ -42,6 +42,30 @@
         <target state="translated">Неработоспособная среда выполнения контейнера</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteParameterMessage">
+        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`? </target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterMessageWithUserSecrets">
+        <source>Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterPrimaryButtonText">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterTitle">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersBarMessage">
         <source>There are unresolved parameters that need to be set. Please provide values for them.</source>
         <target state="translated">Существуют неразрешенные параметры, которые необходимо настроить. Укажите значения для них.</target>
@@ -55,6 +79,11 @@
       <trans-unit id="ParametersBarTitle">
         <source>Unresolved parameters</source>
         <target state="translated">Неразрешенные параметры</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParametersInputsDeleteLabel">
+        <source>Delete from user secrets</source>
+        <target state="new">Delete from user secrets</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsMessage">
@@ -110,6 +139,20 @@
       <trans-unit id="VersionCheckTitle">
         <source>Update now</source>
         <target state="translated">Обновить сейчас</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterMessage">
+        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</source>
+        <target state="new">Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="SetParameterTitle">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.tr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.tr.xlf
@@ -42,6 +42,30 @@
         <target state="translated">Kapsayıcı çalışma zamanı iyi durumda değil</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteParameterMessage">
+        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`? </target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterMessageWithUserSecrets">
+        <source>Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterPrimaryButtonText">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterTitle">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersBarMessage">
         <source>There are unresolved parameters that need to be set. Please provide values for them.</source>
         <target state="translated">Ayarlanması gereken çözülmemiş parametreler var. Lütfen bunlara değerler girin.</target>
@@ -55,6 +79,11 @@
       <trans-unit id="ParametersBarTitle">
         <source>Unresolved parameters</source>
         <target state="translated">Çözülmemiş parametreler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParametersInputsDeleteLabel">
+        <source>Delete from user secrets</source>
+        <target state="new">Delete from user secrets</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsMessage">
@@ -110,6 +139,20 @@
       <trans-unit id="VersionCheckTitle">
         <source>Update now</source>
         <target state="translated">Şimdi güncelleştirin</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterMessage">
+        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</source>
+        <target state="new">Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="SetParameterTitle">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hans.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hans.xlf
@@ -42,6 +42,30 @@
         <target state="translated">容器运行时不正常</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteParameterMessage">
+        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`? </target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterMessageWithUserSecrets">
+        <source>Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterPrimaryButtonText">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterTitle">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersBarMessage">
         <source>There are unresolved parameters that need to be set. Please provide values for them.</source>
         <target state="translated">有未解析的参数需要设置。请为这些参数提供值。</target>
@@ -55,6 +79,11 @@
       <trans-unit id="ParametersBarTitle">
         <source>Unresolved parameters</source>
         <target state="translated">未解析的参数</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParametersInputsDeleteLabel">
+        <source>Delete from user secrets</source>
+        <target state="new">Delete from user secrets</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsMessage">
@@ -110,6 +139,20 @@
       <trans-unit id="VersionCheckTitle">
         <source>Update now</source>
         <target state="translated">立即更新</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterMessage">
+        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</source>
+        <target state="new">Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="SetParameterTitle">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hant.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hant.xlf
@@ -42,6 +42,30 @@
         <target state="translated">容器執行階段狀況不良</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteParameterMessage">
+        <source>Are you sure you want to delete the value for parameter `{0}`? </source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`? </target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterMessageWithUserSecrets">
+        <source>Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</source>
+        <target state="new">Are you sure you want to delete the value for parameter `{0}`?
+
+The value is currently saved in [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets). You can choose to also delete it from there.</target>
+        <note>Contains markdown. {0} is the parameter name.</note>
+      </trans-unit>
+      <trans-unit id="DeleteParameterPrimaryButtonText">
+        <source>Delete</source>
+        <target state="new">Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeleteParameterTitle">
+        <source>Delete parameter value</source>
+        <target state="new">Delete parameter value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ParametersBarMessage">
         <source>There are unresolved parameters that need to be set. Please provide values for them.</source>
         <target state="translated">有些未解析的參數需要設定。請提供它們的值。</target>
@@ -55,6 +79,11 @@
       <trans-unit id="ParametersBarTitle">
         <source>Unresolved parameters</source>
         <target state="translated">未解析的參數</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParametersInputsDeleteLabel">
+        <source>Delete from user secrets</source>
+        <target state="new">Delete from user secrets</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsMessage">
@@ -110,6 +139,20 @@
       <trans-unit id="VersionCheckTitle">
         <source>Update now</source>
         <target state="translated">立即更新</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SetParameterMessage">
+        <source>Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</source>
+        <target state="new">Please provide a value for the parameter. The parameter can be saved to [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets) for future use.
+
+New parameter values may not be used until dependent resources are restarted.</target>
+        <note>Contains markdown</note>
+      </trans-unit>
+      <trans-unit id="SetParameterTitle">
+        <source>Set parameter</source>
+        <target state="new">Set parameter</target>
         <note />
       </trans-unit>
     </body>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
@@ -229,6 +229,11 @@ public class AzureBicepProvisionerTests
             return Task.FromResult(new DeploymentStateSection(sectionName, [], 0));
         }
 
+        public Task DeleteSectionAsync(DeploymentStateSection section, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
         public Task SaveSectionAsync(DeploymentStateSection section, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -1236,6 +1236,8 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         public Task<DeploymentStateSection> AcquireSectionAsync(string sectionName, CancellationToken cancellationToken = default)
             => Task.FromResult(new DeploymentStateSection(sectionName, [], 0));
 
+        public Task DeleteSectionAsync(DeploymentStateSection section, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
         public Task SaveSectionAsync(DeploymentStateSection section, CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 

--- a/tests/Aspire.Hosting.Azure.Tests/ProvisioningTestHelpers.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ProvisioningTestHelpers.cs
@@ -619,6 +619,11 @@ internal sealed class TestUserSecretsManager : IDeploymentStateManager
         return Task.FromResult(new DeploymentStateSection(sectionName, sectionData, 0));
     }
 
+    public Task DeleteSectionAsync(DeploymentStateSection section, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
     public Task SaveSectionAsync(DeploymentStateSection section, CancellationToken cancellationToken = default)
     {
         _state[section.SectionName] = section.Data;

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -515,6 +515,11 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         {
             return Task.CompletedTask;
         }
+
+        public Task DeleteSectionAsync(DeploymentStateSection section, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class CustomResource(string name) : Resource(name);

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -8,6 +8,7 @@ using Aspire.Hosting.Pipelines.Internal;
 using Aspire.Hosting.Resources;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -32,7 +33,7 @@ public class ParameterProcessorTests
         };
 
         // Act
-        await parameterProcessor.InitializeParametersAsync(parameters);
+        await parameterProcessor.InitializeParametersAsync(parameters).DefaultTimeout();
 
         // Assert
         foreach (var param in parameters)
@@ -40,7 +41,7 @@ public class ParameterProcessorTests
             Assert.NotNull(param.WaitForValueTcs);
             Assert.True(param.WaitForValueTcs.Task.IsCompletedSuccessfully);
 #pragma warning disable CS0618 // Type or member is obsolete
-            Assert.Equal(param.Value, await param.WaitForValueTcs.Task);
+            Assert.Equal(param.Value, await param.WaitForValueTcs.Task.DefaultTimeout());
 #pragma warning restore CS0618 // Type or member is obsolete
         }
     }
@@ -58,7 +59,7 @@ public class ParameterProcessorTests
         };
 
         // Act
-        await parameterProcessor.InitializeParametersAsync(parameters);
+        await parameterProcessor.InitializeParametersAsync(parameters).DefaultTimeout();
 
         // Assert
         foreach (var param in parameters)
@@ -66,7 +67,7 @@ public class ParameterProcessorTests
             Assert.NotNull(param.WaitForValueTcs);
             Assert.True(param.WaitForValueTcs.Task.IsCompletedSuccessfully);
 #pragma warning disable CS0618 // Type or member is obsolete
-            Assert.Equal(param.Value, await param.WaitForValueTcs.Task);
+            Assert.Equal(param.Value, await param.WaitForValueTcs.Task.DefaultTimeout());
 #pragma warning restore CS0618 // Type or member is obsolete
         }
     }
@@ -90,10 +91,10 @@ public class ParameterProcessorTests
         });
 
         // Act
-        await parameterProcessor.InitializeParametersAsync([secretParam]);
+        await parameterProcessor.InitializeParametersAsync([secretParam]).DefaultTimeout();
 
         // Wait for the notification
-        await watchTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await watchTask.DefaultTimeout();
 
         // Assert
         var (resource, snapshot) = Assert.Single(updates);
@@ -110,7 +111,7 @@ public class ParameterProcessorTests
         var parameterWithMissingValue = CreateParameterWithMissingValue("missingParam");
 
         // Act
-        await parameterProcessor.InitializeParametersAsync([parameterWithMissingValue]);
+        await parameterProcessor.InitializeParametersAsync([parameterWithMissingValue]).DefaultTimeout();
 
         // Assert
         Assert.NotNull(parameterWithMissingValue.WaitForValueTcs);
@@ -126,7 +127,7 @@ public class ParameterProcessorTests
         var parameterWithMissingValue = CreateParameterWithMissingValue("missingParam");
 
         // Act
-        await parameterProcessor.InitializeParametersAsync([parameterWithMissingValue]);
+        await parameterProcessor.InitializeParametersAsync([parameterWithMissingValue]).DefaultTimeout();
 
         // Assert
         Assert.NotNull(parameterWithMissingValue.WaitForValueTcs);
@@ -144,7 +145,7 @@ public class ParameterProcessorTests
         var parameterWithMissingValue = CreateParameterWithMissingValue("missingParam");
 
         // Act
-        await parameterProcessor.InitializeParametersAsync([parameterWithMissingValue]);
+        await parameterProcessor.InitializeParametersAsync([parameterWithMissingValue]).DefaultTimeout();
 
         // Assert - Parameter should remain unresolved when dashboard is enabled
         Assert.NotNull(parameterWithMissingValue.WaitForValueTcs);
@@ -159,7 +160,7 @@ public class ParameterProcessorTests
         var parameterWithError = CreateParameterWithGenericError("errorParam");
 
         // Act
-        await parameterProcessor.InitializeParametersAsync([parameterWithError]);
+        await parameterProcessor.InitializeParametersAsync([parameterWithError]).DefaultTimeout();
 
         // Assert
         Assert.NotNull(parameterWithError.WaitForValueTcs);
@@ -194,10 +195,10 @@ public class ParameterProcessorTests
         var updates = notificationService.WatchAsync().GetAsyncEnumerator();
 
         // Act - Start handling unresolved parameters
-        var handleTask = parameterProcessor.HandleUnresolvedParametersAsync(parameters);
+        var handleTask = parameterProcessor.HandleUnresolvedParametersAsync(parameters, CancellationToken.None);
 
         // Assert - Wait for the first interaction (message bar)
-        var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+        var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
         Assert.Equal(InteractionStrings.ParametersBarTitle, messageBarInteraction.Title);
         Assert.Equal(InteractionStrings.ParametersBarMessage, messageBarInteraction.Message);
 
@@ -205,7 +206,7 @@ public class ParameterProcessorTests
         messageBarInteraction.CompletionTcs.SetResult(InteractionResult.Ok(true)); // Data = true (user clicked Enter Values)
 
         // Wait for the inputs interaction
-        var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+        var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
         Assert.Equal(InteractionStrings.ParametersInputsTitle, inputsInteraction.Title);
         Assert.Equal(InteractionStrings.ParametersInputsMessage, inputsInteraction.Message);
         Assert.True(inputsInteraction.Options!.EnableMessageMarkdown);
@@ -236,34 +237,34 @@ public class ParameterProcessorTests
                 Assert.False(input.Required);
             });
 
-        inputsInteraction.Inputs[0].Value = "value1";
-        inputsInteraction.Inputs[1].Value = "value2";
-        inputsInteraction.Inputs[2].Value = "secretValue";
+        inputsInteraction.Inputs["param1"].Value = "value1";
+        inputsInteraction.Inputs["param2"].Value = "value2";
+        inputsInteraction.Inputs["secretParam"].Value = "secretValue";
 
         inputsInteraction.CompletionTcs.SetResult(InteractionResult.Ok(inputsInteraction.Inputs));
 
         // Wait for the handle task to complete
-        await handleTask;
+        await handleTask.DefaultTimeout();
 
         // Assert - All parameters should now be resolved
         Assert.True(param1.WaitForValueTcs!.Task.IsCompletedSuccessfully);
         Assert.True(param2.WaitForValueTcs!.Task.IsCompletedSuccessfully);
         Assert.True(secretParam.WaitForValueTcs!.Task.IsCompletedSuccessfully);
-        Assert.Equal("value1", await param1.WaitForValueTcs.Task);
-        Assert.Equal("value2", await param2.WaitForValueTcs.Task);
-        Assert.Equal("secretValue", await secretParam.WaitForValueTcs.Task);
+        Assert.Equal("value1", await param1.WaitForValueTcs.Task.DefaultTimeout());
+        Assert.Equal("value2", await param2.WaitForValueTcs.Task.DefaultTimeout());
+        Assert.Equal("secretValue", await secretParam.WaitForValueTcs.Task.DefaultTimeout());
 
         // Notification service should have received updates for each parameter
         // Marking them as Running with the provided values
-        await updates.MoveNextAsync();
+        await updates.MoveNextAsync().DefaultTimeout();
         Assert.Equal(KnownResourceStates.Running, updates.Current.Snapshot.State?.Text);
         Assert.Equal("value1", updates.Current.Snapshot.Properties.FirstOrDefault(p => p.Name == KnownProperties.Parameter.Value)?.Value);
 
-        await updates.MoveNextAsync();
+        await updates.MoveNextAsync().DefaultTimeout();
         Assert.Equal(KnownResourceStates.Running, updates.Current.Snapshot.State?.Text);
         Assert.Equal("value2", updates.Current.Snapshot.Properties.FirstOrDefault(p => p.Name == KnownProperties.Parameter.Value)?.Value);
 
-        await updates.MoveNextAsync();
+        await updates.MoveNextAsync().DefaultTimeout();
         Assert.Equal(KnownResourceStates.Running, updates.Current.Snapshot.State?.Text);
         Assert.Equal("secretValue", updates.Current.Snapshot.Properties.FirstOrDefault(p => p.Name == KnownProperties.Parameter.Value)?.Value);
         Assert.True(updates.Current.Snapshot.Properties.FirstOrDefault(p => p.Name == KnownProperties.Parameter.Value)?.IsSensitive ?? false);
@@ -280,17 +281,17 @@ public class ParameterProcessorTests
         parameterWithMissingValue.WaitForValueTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         // Act - Start handling unresolved parameters
-        _ = parameterProcessor.HandleUnresolvedParametersAsync([parameterWithMissingValue]);
+        _ = parameterProcessor.HandleUnresolvedParametersAsync([parameterWithMissingValue], CancellationToken.None);
 
         // Wait for the message bar interaction
-        var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+        var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
         Assert.Equal(InteractionStrings.ParametersBarTitle, messageBarInteraction.Title);
 
         // Complete the message bar interaction with false (user chose not to enter values)
         messageBarInteraction.CompletionTcs.SetResult(InteractionResult.Cancel<bool>());
 
         // Assert that the message bar will show up again if there are still unresolved parameters
-        var nextMessageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+        var nextMessageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
         Assert.Equal(InteractionStrings.ParametersBarTitle, nextMessageBarInteraction.Title);
 
         // Assert - Parameter should remain unresolved since user cancelled
@@ -305,7 +306,7 @@ public class ParameterProcessorTests
         var parameterProcessor = CreateParameterProcessor();
 
         // Act & Assert - Should not throw
-        await parameterProcessor.InitializeParametersAsync([]);
+        await parameterProcessor.InitializeParametersAsync([]).DefaultTimeout();
     }
 
     [Fact]
@@ -323,10 +324,10 @@ public class ParameterProcessorTests
         var logsTask = ConsoleLoggingTestHelpers.WatchForLogsAsync(loggerService, 1, parameterWithMissingValue);
 
         // Act
-        await parameterProcessor.InitializeParametersAsync([parameterWithMissingValue]);
+        await parameterProcessor.InitializeParametersAsync([parameterWithMissingValue]).DefaultTimeout();
 
         // Wait for logs to be written
-        var logs = await logsTask.WaitAsync(TimeSpan.FromSeconds(5));
+        var logs = await logsTask.DefaultTimeout();
 
         // Assert - Should log warning without exception details
         Assert.Single(logs);
@@ -347,10 +348,10 @@ public class ParameterProcessorTests
         var logsTask = ConsoleLoggingTestHelpers.WatchForLogsAsync(loggerService, 1, parameterWithError);
 
         // Act
-        await parameterProcessor.InitializeParametersAsync([parameterWithError]);
+        await parameterProcessor.InitializeParametersAsync([parameterWithError]).DefaultTimeout();
 
         // Wait for logs to be written
-        var logs = await logsTask.WaitAsync(TimeSpan.FromSeconds(5));
+        var logs = await logsTask.DefaultTimeout();
 
         // Assert - Should log error message
         Assert.Single(logs);
@@ -378,22 +379,22 @@ public class ParameterProcessorTests
         var logsTask = ConsoleLoggingTestHelpers.WatchForLogsAsync(loggerService, 1, parameter);
 
         // Act - Start handling unresolved parameters
-        var handleTask = parameterProcessor.HandleUnresolvedParametersAsync([parameter]);
+        var handleTask = parameterProcessor.HandleUnresolvedParametersAsync([parameter], CancellationToken.None);
 
         // Wait for the message bar interaction
-        var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+        var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
         messageBarInteraction.CompletionTcs.SetResult(InteractionResult.Ok(true));
 
         // Wait for the inputs interaction
-        var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
-        inputsInteraction.Inputs[0].Value = "testValue";
+        var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+        inputsInteraction.Inputs["testParam"].Value = "testValue";
         inputsInteraction.CompletionTcs.SetResult(InteractionResult.Ok(inputsInteraction.Inputs));
 
         // Wait for the handle task to complete
-        await handleTask;
+        await handleTask.DefaultTimeout();
 
         // Wait for logs to be written
-        var logs = await logsTask.WaitAsync(TimeSpan.FromSeconds(5));
+        var logs = await logsTask.DefaultTimeout();
 
         // Assert - Should log that parameter was resolved via user interaction
         Assert.Single(logs);
@@ -428,25 +429,25 @@ public class ParameterProcessorTests
         }
 
         // Act
-        _ = parameterProcessor.HandleUnresolvedParametersAsync(parameters);
+        _ = parameterProcessor.HandleUnresolvedParametersAsync(parameters, CancellationToken.None);
 
         // Wait for the message bar interaction and complete it
-        var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+        var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
         messageBarInteraction.CompletionTcs.SetResult(InteractionResult.Ok(true));
 
         // Wait for the inputs interaction
-        var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+        var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
 
         // Assert
         Assert.Equal(3, inputsInteraction.Inputs.Count); // 2 parameters + 1 save option
 
-        var param1Input = inputsInteraction.Inputs[0];
+        var param1Input = inputsInteraction.Inputs["param1"];
         Assert.Equal("param1", param1Input.Label);
         Assert.Equal("This is a test parameter", param1Input.Description);
         Assert.False(param1Input.EnableDescriptionMarkdown);
         Assert.Equal(InputType.Text, param1Input.InputType);
 
-        var param2Input = inputsInteraction.Inputs[1];
+        var param2Input = inputsInteraction.Inputs["param2"];
         Assert.Equal("param2", param2Input.Label);
         Assert.Equal("This parameter has **markdown** formatting", param2Input.Description);
         Assert.True(param2Input.EnableDescriptionMarkdown);
@@ -471,19 +472,19 @@ public class ParameterProcessorTests
         secretParam.WaitForValueTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         // Act
-        _ = parameterProcessor.HandleUnresolvedParametersAsync(parameters);
+        _ = parameterProcessor.HandleUnresolvedParametersAsync(parameters, CancellationToken.None);
 
         // Wait for the message bar interaction and complete it
-        var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+        var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
         messageBarInteraction.CompletionTcs.SetResult(InteractionResult.Ok(true));
 
         // Wait for the inputs interaction
-        var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+        var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
 
         // Assert
         Assert.Equal(2, inputsInteraction.Inputs.Count); // 1 secret parameter + 1 save option
 
-        var secretInput = inputsInteraction.Inputs[0];
+        var secretInput = inputsInteraction.Inputs["secretParam"];
         Assert.Equal("secretParam", secretInput.Label);
         Assert.Equal("This is a secret parameter", secretInput.Description);
         Assert.False(secretInput.EnableDescriptionMarkdown);
@@ -586,7 +587,7 @@ public class ParameterProcessorTests
         var parameterProcessor = CreateParameterProcessor();
 
         // Act
-        await parameterProcessor.InitializeParametersAsync(model);
+        await parameterProcessor.InitializeParametersAsync(model).DefaultTimeout();
 
         // Assert
         var explicitParameterResource = model.Resources.OfType<ParameterResource>().First(p => p.Name == "explicitParam");
@@ -596,8 +597,8 @@ public class ParameterProcessorTests
         Assert.NotNull(referencedParameterResource.WaitForValueTcs);
         Assert.True(explicitParameterResource.WaitForValueTcs.Task.IsCompletedSuccessfully);
         Assert.True(referencedParameterResource.WaitForValueTcs.Task.IsCompletedSuccessfully);
-        Assert.Equal("explicitValue", await explicitParameterResource.WaitForValueTcs.Task);
-        Assert.Equal("referencedValue", await referencedParameterResource.WaitForValueTcs.Task);
+        Assert.Equal("explicitValue", await explicitParameterResource.WaitForValueTcs.Task.DefaultTimeout());
+        Assert.Equal("referencedValue", await referencedParameterResource.WaitForValueTcs.Task.DefaultTimeout());
     }
 
     [Fact]
@@ -611,7 +612,7 @@ public class ParameterProcessorTests
         var parameterProcessor = CreateParameterProcessor();
 
         // Act & Assert - Should not throw
-        await parameterProcessor.InitializeParametersAsync(model);
+        await parameterProcessor.InitializeParametersAsync(model).DefaultTimeout();
     }
 
     [Fact]
@@ -631,14 +632,14 @@ public class ParameterProcessorTests
         var parameterProcessor = CreateParameterProcessor();
 
         // Act
-        await parameterProcessor.InitializeParametersAsync(model);
+        await parameterProcessor.InitializeParametersAsync(model).DefaultTimeout();
 
         // Assert
         var explicitParameterResource = model.Resources.OfType<ParameterResource>().Single();
         Assert.Equal("explicitParam", explicitParameterResource.Name);
         Assert.NotNull(explicitParameterResource.WaitForValueTcs);
         Assert.True(explicitParameterResource.WaitForValueTcs.Task.IsCompletedSuccessfully);
-        Assert.Equal("explicitValue", await explicitParameterResource.WaitForValueTcs.Task);
+        Assert.Equal("explicitValue", await explicitParameterResource.WaitForValueTcs.Task.DefaultTimeout());
     }
 
     [Fact]
@@ -657,14 +658,14 @@ public class ParameterProcessorTests
         var parameterProcessor = CreateParameterProcessor();
 
         // Act
-        await parameterProcessor.InitializeParametersAsync(model);
+        await parameterProcessor.InitializeParametersAsync(model).DefaultTimeout();
 
         // Assert
         var parameterResource = model.Resources.OfType<ParameterResource>().Single();
         Assert.Equal("envParam", parameterResource.Name);
         Assert.NotNull(parameterResource.WaitForValueTcs);
         Assert.True(parameterResource.WaitForValueTcs.Task.IsCompletedSuccessfully);
-        Assert.Equal("envValue", await parameterResource.WaitForValueTcs.Task);
+        Assert.Equal("envValue", await parameterResource.WaitForValueTcs.Task.DefaultTimeout());
     }
 
     [Fact]
@@ -680,13 +681,13 @@ public class ParameterProcessorTests
         var parameterProcessor = CreateParameterProcessor();
 
         // Act
-        await parameterProcessor.InitializeParametersAsync(model, waitForResolution: true);
+        await parameterProcessor.InitializeParametersAsync(model, waitForResolution: true).DefaultTimeout();
 
         // Assert
         var parameterResource = model.Resources.OfType<ParameterResource>().Single();
         Assert.NotNull(parameterResource.WaitForValueTcs);
         Assert.True(parameterResource.WaitForValueTcs.Task.IsCompletedSuccessfully);
-        Assert.Equal("testValue", await parameterResource.WaitForValueTcs.Task);
+        Assert.Equal("testValue", await parameterResource.WaitForValueTcs.Task.DefaultTimeout());
     }
 
     [Fact]
@@ -702,13 +703,13 @@ public class ParameterProcessorTests
         var parameterProcessor = CreateParameterProcessor();
 
         // Act
-        await parameterProcessor.InitializeParametersAsync(model, waitForResolution: false);
+        await parameterProcessor.InitializeParametersAsync(model, waitForResolution: false).DefaultTimeout();
 
         // Assert
         var parameterResource = model.Resources.OfType<ParameterResource>().Single();
         Assert.NotNull(parameterResource.WaitForValueTcs);
         Assert.True(parameterResource.WaitForValueTcs.Task.IsCompletedSuccessfully);
-        Assert.Equal("testValue", await parameterResource.WaitForValueTcs.Task);
+        Assert.Equal("testValue", await parameterResource.WaitForValueTcs.Task.DefaultTimeout());
     }
 
     [Fact]
@@ -728,7 +729,7 @@ public class ParameterProcessorTests
         var parameterProcessor = CreateParameterProcessor(interactionService: interactionService);
 
         // Act
-        await parameterProcessor.InitializeParametersAsync(model);
+        await parameterProcessor.InitializeParametersAsync(model).DefaultTimeout();
 
         // Assert
         var parameterResource = model.Resources.OfType<ParameterResource>().Single();
@@ -758,7 +759,7 @@ public class ParameterProcessorTests
         var parameterProcessor = CreateParameterProcessor();
 
         // Act - Should not hang or throw due to circular references
-        await parameterProcessor.InitializeParametersAsync(model);
+        await parameterProcessor.InitializeParametersAsync(model).DefaultTimeout();
 
         // Assert
         var parameters = model.Resources.OfType<ParameterResource>().ToList();
@@ -798,7 +799,7 @@ public class ParameterProcessorTests
         var parameterProcessor = app.Services.GetRequiredService<ParameterProcessor>();
 
         // Act - Should not throw InvalidOperationException about IServiceProvider not being available
-        await parameterProcessor.InitializeParametersAsync(model);
+        await parameterProcessor.InitializeParametersAsync(model).DefaultTimeout();
 
         // Assert
         Assert.True(serviceProviderAccessed);
@@ -829,7 +830,7 @@ public class ParameterProcessorTests
         var parameterProcessor = CreateParameterProcessor();
 
         // Act - The excluded container should be skipped during parameter collection
-        await parameterProcessor.InitializeParametersAsync(model);
+        await parameterProcessor.InitializeParametersAsync(model).DefaultTimeout();
 
         // Assert
         // The environment callback should have been invoked during parameter collection
@@ -845,6 +846,281 @@ public class ParameterProcessorTests
         // The parameter should be initialized since it's explicitly in the model
         Assert.NotNull(parameterResource.WaitForValueTcs);
         Assert.True(parameterResource.WaitForValueTcs.Task.IsCompletedSuccessfully);
+    }
+
+    [Fact]
+    public async Task ProcessParameterAsync_WithInteractionServiceAvailable_AddsSetParameterCommand()
+    {
+        // Arrange
+        var testInteractionService = new TestInteractionService { IsAvailable = true };
+        var parameterProcessor = CreateParameterProcessor(interactionService: testInteractionService);
+        var parameter = CreateParameterResource("testParam", "testValue");
+
+        // Act
+        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+
+        // Assert - Command should be added when interaction service is available
+        var setValueCommand = parameter.Annotations.OfType<ResourceCommandAnnotation>()
+            .SingleOrDefault(a => a.Name == KnownResourceCommands.SetParameterCommand);
+        Assert.NotNull(setValueCommand);
+        Assert.Equal(CommandStrings.SetParameterName, setValueCommand.DisplayName);
+        Assert.Equal(CommandStrings.SetParameterDescription, setValueCommand.DisplayDescription);
+        Assert.True(setValueCommand.IsHighlighted);
+    }
+
+    [Fact]
+    public async Task ProcessParameterAsync_WithInteractionServiceNotAvailable_DoesNotAddSetParameterCommand()
+    {
+        // Arrange
+        var testInteractionService = new TestInteractionService { IsAvailable = false };
+        var parameterProcessor = CreateParameterProcessor(interactionService: testInteractionService);
+        var parameter = CreateParameterResource("testParam", "testValue");
+
+        // Act
+        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+
+        // Assert - Command should not be added when interaction service is not available
+        var setValueCommand = parameter.Annotations.OfType<ResourceCommandAnnotation>()
+            .SingleOrDefault(a => a.Name == KnownResourceCommands.SetParameterCommand);
+        Assert.Null(setValueCommand);
+    }
+
+    [Fact]
+    public async Task SetParameterAsync_WithUserInput_UpdatesParameterValue()
+    {
+        // Arrange
+        var testInteractionService = new TestInteractionService { IsAvailable = true };
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+        var parameterProcessor = CreateParameterProcessor(
+            notificationService: notificationService,
+            interactionService: testInteractionService);
+        var parameter = CreateParameterResource("testParam", "initialValue");
+
+        // Initialize the parameter
+        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+
+        // Reset WaitForValueTcs to track updates
+        parameter.WaitForValueTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Act - Start the SetParameterAsync task
+        var setValueTask = Task.Run(async () =>
+        {
+            await parameterProcessor.SetParameterAsync(parameter);
+        });
+
+        // Wait for the input dialog to be presented
+        var inputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+        Assert.Equal(InteractionStrings.SetParameterTitle, inputInteraction.Title);
+        Assert.Equal(InteractionStrings.SetParameterMessage, inputInteraction.Message);
+        // Should have 2 inputs: parameter value input + SaveToUserSecrets checkbox (in run mode)
+        Assert.Equal(2, inputInteraction.Inputs.Count);
+        Assert.Equal("testParam", inputInteraction.Inputs["testParam"].Label);
+        // Existing value should be pre-populated
+        Assert.Equal("initialValue", inputInteraction.Inputs["testParam"].Value);
+        // SaveToUserSecrets shouldn't be true because the existing value isn't saved to sate.
+        Assert.Null(inputInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName].Value);
+
+        // Complete the interaction with a new value
+        inputInteraction.Inputs["testParam"].Value = "newValue";
+        inputInteraction.CompletionTcs.SetResult(InteractionResult.Ok(inputInteraction.Inputs));
+
+        // Wait for the set value task to complete
+        await setValueTask.DefaultTimeout();
+
+        // Assert - Parameter value should be updated
+        Assert.Equal("newValue", await parameter.GetValueAsync(CancellationToken.None).DefaultTimeout());
+    }
+
+    [Fact]
+    public async Task SetParameterAsync_WhenUserCancels_ParameterValueUnchanged()
+    {
+        // Arrange
+        var testInteractionService = new TestInteractionService { IsAvailable = true };
+        var parameterProcessor = CreateParameterProcessor(interactionService: testInteractionService);
+        var parameter = CreateParameterResource("testParam", "initialValue");
+
+        // Initialize the parameter
+        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+
+        // Reset WaitForValueTcs to track updates
+        var originalTcs = parameter.WaitForValueTcs;
+        parameter.WaitForValueTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Act - Start the SetParameterAsync task
+        var setValueTask = Task.Run(async () =>
+        {
+            await parameterProcessor.SetParameterAsync(parameter);
+        });
+
+        // Wait for the input dialog to be presented
+        var inputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+
+        // Cancel the interaction
+        inputInteraction.CompletionTcs.SetResult(InteractionResult.Cancel<InteractionInputCollection>());
+
+        // Wait for the set value task to complete
+        await setValueTask.DefaultTimeout();
+
+        // Assert - Parameter value should remain unchanged (WaitForValueTcs not set)
+        Assert.False(parameter.WaitForValueTcs!.Task.IsCompleted);
+    }
+
+    [Fact]
+    public async Task SetParameterAsync_WithSecretParameter_UsesSecretTextInput()
+    {
+        // Arrange
+        var testInteractionService = new TestInteractionService { IsAvailable = true };
+        var parameterProcessor = CreateParameterProcessor(interactionService: testInteractionService);
+        var parameter = CreateParameterResource("secretParam", "secretValue", secret: true);
+
+        // Initialize the parameter
+        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+
+        // Reset WaitForValueTcs to track updates
+        parameter.WaitForValueTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Act - Start the SetParameterAsync task
+        var setValueTask = Task.Run(async () =>
+        {
+            await parameterProcessor.SetParameterAsync(parameter);
+        });
+
+        // Wait for the input dialog to be presented
+        var inputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+
+        // Assert - Should use SecretText input type for secret parameters
+        Assert.Equal(2, inputInteraction.Inputs.Count);
+        Assert.Equal(InputType.SecretText, inputInteraction.Inputs["secretParam"].InputType);
+        // Existing value should be pre-populated for secrets too
+        Assert.Equal("secretValue", inputInteraction.Inputs["secretParam"].Value);
+
+        // Complete the interaction
+        inputInteraction.Inputs["secretParam"].Value = "newSecretValue";
+        inputInteraction.CompletionTcs.SetResult(InteractionResult.Ok(inputInteraction.Inputs));
+
+        await setValueTask.DefaultTimeout();
+
+        // Assert - Parameter value should be updated
+        Assert.Equal("newSecretValue", await parameter.WaitForValueTcs!.Task.DefaultTimeout());
+    }
+
+    [Fact]
+    public async Task SetParameterAsync_ResolvingLastParameter_CancelsPromptNotification()
+    {
+        // Arrange
+        var testInteractionService = new TestInteractionService { IsAvailable = true };
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+        var parameterProcessor = CreateParameterProcessor(
+            notificationService: notificationService,
+            interactionService: testInteractionService);
+
+        var parameter = CreateParameterWithMissingValue("testParam");
+
+        // Use InitializeParametersAsync to properly set up the internal state
+        // This will trigger HandleUnresolvedParametersAsync in a background task
+        // with the internal _allParametersResolvedCts.Token
+        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+
+        // Wait for the notification to appear from the background task
+        var notificationInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+        Assert.Equal(InteractionStrings.ParametersBarTitle, notificationInteraction.Title);
+
+        // Capture the cancellation token passed to the notification
+        var notificationCancellationToken = notificationInteraction.CancellationToken;
+        Assert.False(notificationCancellationToken.IsCancellationRequested);
+
+        // Now use SetParameterAsync to resolve the parameter (which is the last unresolved parameter)
+        var setValueTask = Task.Run(async () =>
+        {
+            await parameterProcessor.SetParameterAsync(parameter);
+        });
+
+        // Wait for the SetParameterAsync input dialog to appear
+        var inputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+        Assert.Equal(InteractionStrings.SetParameterTitle, inputInteraction.Title);
+
+        // Complete the SetParameterAsync interaction with a value
+        inputInteraction.Inputs["testParam"].Value = "resolvedValue";
+        inputInteraction.CompletionTcs.SetResult(InteractionResult.Ok(inputInteraction.Inputs));
+
+        await setValueTask.DefaultTimeout();
+
+        // The parameter should be resolved with the correct value
+        Assert.Equal("resolvedValue", await parameter.GetValueAsync(CancellationToken.None).DefaultTimeout());
+
+        // Assert - The notification's cancellation token should now be canceled
+        // because the last parameter was resolved via SetParameterAsync
+        Assert.True(notificationCancellationToken.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task SetParameterAsync_CalledTwice_SecondInteractionShowsPreviousValueAndSaveChecked()
+    {
+        // Arrange
+        var testInteractionService = new TestInteractionService { IsAvailable = true };
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+        var capturingStateManager = new CapturingMockDeploymentStateManager();
+        var parameterProcessor = CreateParameterProcessor(
+            notificationService: notificationService,
+            interactionService: testInteractionService,
+            deploymentStateManager: capturingStateManager);
+
+        var parameter = CreateParameterWithMissingValue("testParam");
+
+        // Initialize the parameter - this starts HandleUnresolvedParametersAsync in background
+        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+
+        // Wait for the notification to appear from the background task
+        var notificationInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
+        Assert.Equal(InteractionStrings.ParametersBarTitle, notificationInteraction.Title);
+
+        // First SetParameterAsync call - set and save a value
+        var firstSetValueTask = Task.Run(async () =>
+        {
+            await parameterProcessor.SetParameterAsync(parameter);
+        });
+
+        // Wait for the first input dialog
+        var firstInputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
+        Assert.Equal(InteractionStrings.SetParameterTitle, firstInputInteraction.Title);
+
+        // First time: no saved state, so SaveToUserSecrets should be null/unchecked
+        Assert.Null(firstInputInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName].Value);
+
+        // Set the value and enable save
+        firstInputInteraction.Inputs["testParam"].Value = "firstValue";
+        firstInputInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName].Value = "true";
+        firstInputInteraction.CompletionTcs.SetResult(InteractionResult.Ok(firstInputInteraction.Inputs));
+
+        await firstSetValueTask.DefaultTimeout();
+
+        // Verify first value was set
+        Assert.Equal("firstValue", await parameter.GetValueAsync(CancellationToken.None).DefaultTimeout());
+
+        // Second SetParameterAsync call - should show previously set value
+        var secondSetValueTask = Task.Run(async () =>
+        {
+            await parameterProcessor.SetParameterAsync(parameter);
+        });
+
+        // Wait for the second input dialog
+        var secondInputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
+        Assert.Equal(InteractionStrings.SetParameterTitle, secondInputInteraction.Title);
+
+        // Assert - Second interaction should have the previously set value pre-populated
+        Assert.Equal("firstValue", secondInputInteraction.Inputs["testParam"].Value);
+
+        // Assert - SaveToUserSecrets should be checked (true) since parameter has saved state
+        Assert.Equal("true", secondInputInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName].Value);
+
+        // Complete the second interaction with a new value
+        secondInputInteraction.Inputs["testParam"].Value = "secondValue";
+        secondInputInteraction.CompletionTcs.SetResult(InteractionResult.Ok(secondInputInteraction.Inputs));
+
+        await secondSetValueTask.DefaultTimeout();
+
+        // Verify second value was set
+        Assert.Equal("secondValue", await parameter.GetValueAsync(CancellationToken.None).DefaultTimeout());
     }
 
     private static ParameterProcessor CreateParameterProcessor(
@@ -887,6 +1163,11 @@ public class ParameterProcessorTests
         }
 
         public Task SaveSectionAsync(DeploymentStateSection section, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteSectionAsync(DeploymentStateSection section, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
@@ -958,12 +1239,12 @@ public class ParameterProcessorTests
         };
 
         // Act
-        await parameterProcessor.InitializeParametersAsync([parameterWithGenerateDefault]);
+        await parameterProcessor.InitializeParametersAsync([parameterWithGenerateDefault]).DefaultTimeout();
 
         // Assert - Should succeed because value exists in configuration
         Assert.NotNull(parameterWithGenerateDefault.WaitForValueTcs);
         Assert.True(parameterWithGenerateDefault.WaitForValueTcs.Task.IsCompletedSuccessfully);
-        Assert.Equal("existingValue", await parameterWithGenerateDefault.WaitForValueTcs.Task);
+        Assert.Equal("existingValue", await parameterWithGenerateDefault.WaitForValueTcs.Task.DefaultTimeout());
     }
 
     [Fact]
@@ -987,17 +1268,17 @@ public class ParameterProcessorTests
 
         List<ParameterResource> parameters = [connectionStringParam];
 
-        var handleTask = parameterProcessor.HandleUnresolvedParametersAsync(parameters);
+        var handleTask = parameterProcessor.HandleUnresolvedParametersAsync(parameters, CancellationToken.None);
 
-        var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+        var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
         messageBarInteraction.CompletionTcs.SetResult(InteractionResult.Ok(true));
 
-        var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
-        inputsInteraction.Inputs[0].Value = "Server=localhost;Database=mydb";
-        inputsInteraction.Inputs[1].Value = "true";
+        var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+        inputsInteraction.Inputs["mydb"].Value = "Server=localhost;Database=mydb";
+        inputsInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName].Value = "true";
         inputsInteraction.CompletionTcs.SetResult(InteractionResult.Ok(inputsInteraction.Inputs));
 
-        await handleTask;
+        await handleTask.DefaultTimeout();
 
         // Verify the value was saved correctly in the flattened state
         Assert.True(capturingStateManager.State.TryGetPropertyValue("ConnectionStrings:mydb", out var valueNode));
@@ -1028,17 +1309,17 @@ public class ParameterProcessorTests
 
         List<ParameterResource> parameters = [regularParam];
 
-        var handleTask = parameterProcessor.HandleUnresolvedParametersAsync(parameters);
+        var handleTask = parameterProcessor.HandleUnresolvedParametersAsync(parameters, CancellationToken.None);
 
-        var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+        var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
         messageBarInteraction.CompletionTcs.SetResult(InteractionResult.Ok(true));
 
-        var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
-        inputsInteraction.Inputs[0].Value = "myvalue";
-        inputsInteraction.Inputs[1].Value = "true";
+        var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+        inputsInteraction.Inputs["myparam"].Value = "myvalue";
+        inputsInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName].Value = "true";
         inputsInteraction.CompletionTcs.SetResult(InteractionResult.Ok(inputsInteraction.Inputs));
 
-        await handleTask;
+        await handleTask.DefaultTimeout();
 
         // Verify the value was saved correctly in the flattened state
         Assert.True(capturingStateManager.State.TryGetPropertyValue("Parameters:myparam", out var valueNode));
@@ -1072,17 +1353,17 @@ public class ParameterProcessorTests
 
         List<ParameterResource> parameters = [customParam];
 
-        var handleTask = parameterProcessor.HandleUnresolvedParametersAsync(parameters);
+        var handleTask = parameterProcessor.HandleUnresolvedParametersAsync(parameters, CancellationToken.None);
 
-        var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
+        var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
         messageBarInteraction.CompletionTcs.SetResult(InteractionResult.Ok(true));
 
-        var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
-        inputsInteraction.Inputs[0].Value = "customvalue";
-        inputsInteraction.Inputs[1].Value = "true";
+        var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+        inputsInteraction.Inputs["customparam"].Value = "customvalue";
+        inputsInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName].Value = "true";
         inputsInteraction.CompletionTcs.SetResult(InteractionResult.Ok(inputsInteraction.Inputs));
 
-        await handleTask;
+        await handleTask.DefaultTimeout();
 
         // Verify the value was saved correctly in the flattened state
         Assert.True(capturingStateManager.State.TryGetPropertyValue("MyCustomSection:MyCustomKey", out var valueNode));
@@ -1090,6 +1371,217 @@ public class ParameterProcessorTests
 
         // Verify the entire state structure as JSON (mimics what gets saved to disk)
         await VerifyJson(capturingStateManager.State.ToJsonString());
+    }
+
+    [Fact]
+    public async Task SetParameterAsync_WithSavedState_OnlyShowsValueAndSaveInputs()
+    {
+        // Arrange
+        var capturingStateManager = new CapturingMockDeploymentStateManager();
+        var testInteractionService = new TestInteractionService { IsAvailable = true };
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+        var parameterProcessor = CreateParameterProcessor(
+            notificationService: notificationService,
+            interactionService: testInteractionService,
+            deploymentStateManager: capturingStateManager);
+
+        var parameter = CreateParameterResource("testParam", "initialValue");
+
+        // Initialize the parameter
+        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+
+        // First SetParameterAsync call - set and save a value to establish saved state
+        var firstSetValueTask = Task.Run(async () =>
+        {
+            await parameterProcessor.SetParameterAsync(parameter);
+        });
+
+        var firstInputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
+        // First time: should have 2 inputs (value + save)
+        Assert.Equal(2, firstInputInteraction.Inputs.Count);
+
+        // Set the value and save it
+        firstInputInteraction.Inputs["testParam"].Value = "savedValue";
+        firstInputInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName].Value = "true";
+        firstInputInteraction.CompletionTcs.SetResult(InteractionResult.Ok(firstInputInteraction.Inputs));
+
+        await firstSetValueTask.DefaultTimeout();
+
+        // Second SetParameterAsync call - should still only have 2 inputs (delete is now a separate command)
+        var secondSetValueTask = Task.Run(async () =>
+        {
+            await parameterProcessor.SetParameterAsync(parameter);
+        });
+
+        var secondInputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
+
+        // Assert - Should have 2 inputs: value + save (delete is now a separate command)
+        Assert.Equal(2, secondInputInteraction.Inputs.Count);
+        Assert.True(secondInputInteraction.Inputs.ContainsName("testParam"));
+        Assert.True(secondInputInteraction.Inputs.ContainsName(ParameterProcessor.SaveToUserSecretsName));
+
+        // Complete the interaction
+        secondInputInteraction.CompletionTcs.SetResult(InteractionResult.Ok(secondInputInteraction.Inputs));
+
+        await secondSetValueTask.DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task DeleteParameterAsync_DeletesFromDeploymentState()
+    {
+        // Arrange
+        var capturingStateManager = new CapturingMockDeploymentStateManager();
+        var testInteractionService = new TestInteractionService { IsAvailable = true };
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+        var parameterProcessor = CreateParameterProcessor(
+            notificationService: notificationService,
+            interactionService: testInteractionService,
+            deploymentStateManager: capturingStateManager);
+
+        var parameter = CreateParameterResource("testParam", "initialValue");
+
+        // Initialize the parameter
+        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+
+        // First SetParameterAsync call - set and save a value to establish saved state
+        var firstSetValueTask = Task.Run(async () =>
+        {
+            await parameterProcessor.SetParameterAsync(parameter);
+        });
+
+        var firstInputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
+        firstInputInteraction.Inputs["testParam"].Value = "savedValue";
+        firstInputInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName].Value = "true";
+        firstInputInteraction.CompletionTcs.SetResult(InteractionResult.Ok(firstInputInteraction.Inputs));
+
+        await firstSetValueTask.DefaultTimeout();
+
+        // Verify value was saved
+        Assert.True(capturingStateManager.State.Count > 0);
+
+        // Call DeleteParameterAsync to delete the value - need to run in background as it shows a prompt
+        var deleteTask = Task.Run(async () =>
+        {
+            await parameterProcessor.DeleteParameterAsync(parameter);
+        });
+
+        // Wait for the delete confirmation dialog
+        var deleteConfirmation = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
+        Assert.Equal(InteractionStrings.DeleteParameterTitle, deleteConfirmation.Title);
+        // Should have delete from user secrets checkbox since value is saved
+        Assert.True(deleteConfirmation.Inputs.ContainsName(ParameterProcessor.DeleteFromUserSecretsName));
+        Assert.Null(deleteConfirmation.Inputs[ParameterProcessor.DeleteFromUserSecretsName].Value);
+
+        // Confirm the deletion with delete from user secrets checked
+        deleteConfirmation.Inputs[ParameterProcessor.DeleteFromUserSecretsName].Value = "true";
+        deleteConfirmation.CompletionTcs.SetResult(InteractionResult.Ok(deleteConfirmation.Inputs));
+
+        await deleteTask.DefaultTimeout();
+
+        // Assert - State should be cleared
+        // The section still exists but should have no data
+        var section = await capturingStateManager.AcquireSectionAsync($"Parameters:{parameter.Name}").DefaultTimeout();
+        Assert.Empty(section.Data);
+    }
+
+    [Fact]
+    public async Task SetParameterAsync_WithoutSavedState_DoesNotShowDeleteCheckbox()
+    {
+        // Arrange
+        var testInteractionService = new TestInteractionService { IsAvailable = true };
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+        var parameterProcessor = CreateParameterProcessor(
+            notificationService: notificationService,
+            interactionService: testInteractionService);
+
+        var parameter = CreateParameterResource("testParam", "initialValue");
+
+        // Initialize the parameter
+        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+
+        // Act - Start the SetParameterAsync task
+        var setValueTask = Task.Run(async () =>
+        {
+            await parameterProcessor.SetParameterAsync(parameter);
+        });
+
+        // Wait for the input dialog to be presented
+        var inputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
+
+        // Assert - Should only have 2 inputs (value + save), no delete checkbox
+        Assert.Equal(2, inputInteraction.Inputs.Count);
+        Assert.True(inputInteraction.Inputs.ContainsName("testParam"));
+        Assert.True(inputInteraction.Inputs.ContainsName(ParameterProcessor.SaveToUserSecretsName));
+        Assert.False(inputInteraction.Inputs.ContainsName("DeleteParameter"));
+
+        // Complete the interaction
+        inputInteraction.CompletionTcs.SetResult(InteractionResult.Cancel<InteractionInputCollection>());
+        await setValueTask.DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task DeleteParameterAsync_AddsParameterBackToUnresolvedAndStartsResolutionTask()
+    {
+        // Arrange
+        var capturingStateManager = new CapturingMockDeploymentStateManager();
+        var testInteractionService = new TestInteractionService { IsAvailable = true };
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+        var parameterProcessor = CreateParameterProcessor(
+            notificationService: notificationService,
+            interactionService: testInteractionService,
+            deploymentStateManager: capturingStateManager);
+
+        var parameter = CreateParameterResource("testParam", "initialValue");
+
+        // Initialize the parameter
+        await parameterProcessor.InitializeParametersAsync([parameter]).DefaultTimeout();
+
+        // First SetParameterAsync call - set and save a value to establish saved state
+        var firstSetValueTask = Task.Run(async () =>
+        {
+            await parameterProcessor.SetParameterAsync(parameter);
+        });
+
+        var firstInputInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
+        firstInputInteraction.Inputs["testParam"].Value = "savedValue";
+        firstInputInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName].Value = "true";
+        firstInputInteraction.CompletionTcs.SetResult(InteractionResult.Ok(firstInputInteraction.Inputs));
+
+        await firstSetValueTask.DefaultTimeout();
+
+        // Call DeleteParameterAsync to delete the value - need to run in background as it shows a prompt
+        var deleteTask = Task.Run(async () =>
+        {
+            await parameterProcessor.DeleteParameterAsync(parameter);
+        });
+
+        // Wait for the delete confirmation dialog
+        var deleteConfirmation = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
+        Assert.Equal(InteractionStrings.DeleteParameterTitle, deleteConfirmation.Title);
+
+        // Confirm the deletion
+        deleteConfirmation.CompletionTcs.SetResult(InteractionResult.Ok(deleteConfirmation.Inputs));
+
+        await deleteTask.DefaultTimeout();
+
+        // After delete, the resolution task should start and show a notification
+        var notificationInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
+        Assert.Equal(InteractionStrings.ParametersBarTitle, notificationInteraction.Title);
+
+        // Dismiss the notification to proceed to inputs dialog
+        notificationInteraction.CompletionTcs.SetResult(InteractionResult.Ok(true));
+
+        // The inputs dialog should appear with the deleted parameter
+        var inputsInteraction = await testInteractionService.Interactions.Reader.ReadAsync().AsTask().DefaultTimeout();
+        Assert.Equal(InteractionStrings.ParametersInputsTitle, inputsInteraction.Title);
+        Assert.True(inputsInteraction.Inputs.ContainsName("testParam"));
+
+        // Complete the interaction with a new value
+        inputsInteraction.Inputs["testParam"].Value = "newValue";
+        inputsInteraction.CompletionTcs.SetResult(InteractionResult.Ok(inputsInteraction.Inputs));
+
+        // Verify the parameter was resolved with the new value
+        Assert.Equal("newValue", await parameter.GetValueAsync(CancellationToken.None).DefaultTimeout());
     }
 
     private sealed class CapturingMockDeploymentStateManager : IDeploymentStateManager
@@ -1120,6 +1612,20 @@ public class ParameterProcessorTests
 
             // Store the section data in the unflattened state object
             _unflattenedState[section.SectionName] = section.Data.DeepClone().AsObject();
+
+            // Flatten the state to mimic what FileDeploymentStateManager saves to disk
+            _flattenedState = JsonFlattener.FlattenJsonObject(_unflattenedState);
+
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteSectionAsync(DeploymentStateSection section, CancellationToken cancellationToken = default)
+        {
+            // Increment version to allow multiple saves with the same instance (mimics FileDeploymentStateManager)
+            section.Version++;
+
+            // Remove the section from the unflattened state object
+            _unflattenedState.Remove(section.SectionName);
 
             // Flatten the state to mimic what FileDeploymentStateManager saves to disk
             _flattenedState = JsonFlattener.FlattenJsonObject(_unflattenedState);

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -522,7 +522,7 @@ public class ParameterProcessorTests
         var paramInput = inputsInteraction.Inputs["param1"];
         Assert.Equal("param1", paramInput.Label);
 
-        var saveCheckbox = inputsInteraction.Inputs["RememberParameters"];
+        var saveCheckbox = inputsInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName];
         Assert.Equal(InteractionStrings.ParametersInputsRememberLabel, saveCheckbox.Label);
         Assert.Equal(InputType.Boolean, saveCheckbox.InputType);
         Assert.True(saveCheckbox.Disabled); // Should be disabled when user secrets not available
@@ -561,7 +561,7 @@ public class ParameterProcessorTests
         var paramInput = inputsInteraction.Inputs["param1"];
         Assert.Equal("param1", paramInput.Label);
 
-        var saveCheckbox = inputsInteraction.Inputs["RememberParameters"];
+        var saveCheckbox = inputsInteraction.Inputs[ParameterProcessor.SaveToUserSecretsName];
         Assert.Equal(InteractionStrings.ParametersInputsRememberLabel, saveCheckbox.Label);
         Assert.Equal(InputType.Boolean, saveCheckbox.InputType);
         Assert.False(saveCheckbox.Disabled); // Should be enabled when user secrets are available

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -507,7 +507,7 @@ public class ParameterProcessorTests
         List<ParameterResource> parameters = [param];
 
         // Act
-        _ = parameterProcessor.HandleUnresolvedParametersAsync(parameters);
+        _ = parameterProcessor.HandleUnresolvedParametersAsync(parameters, CancellationToken.None);
 
         // Wait for the message bar interaction and complete it
         var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
@@ -518,10 +518,10 @@ public class ParameterProcessorTests
 
         // Assert - Should have 2 inputs (parameter + disabled save checkbox)
         Assert.Equal(2, inputsInteraction.Inputs.Count);
-        
+
         var paramInput = inputsInteraction.Inputs["param1"];
         Assert.Equal("param1", paramInput.Label);
-        
+
         var saveCheckbox = inputsInteraction.Inputs["RememberParameters"];
         Assert.Equal(InteractionStrings.ParametersInputsRememberLabel, saveCheckbox.Label);
         Assert.Equal(InputType.Boolean, saveCheckbox.InputType);
@@ -546,7 +546,7 @@ public class ParameterProcessorTests
         List<ParameterResource> parameters = [param];
 
         // Act
-        _ = parameterProcessor.HandleUnresolvedParametersAsync(parameters);
+        _ = parameterProcessor.HandleUnresolvedParametersAsync(parameters, CancellationToken.None);
 
         // Wait for the message bar interaction and complete it
         var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync();
@@ -557,10 +557,10 @@ public class ParameterProcessorTests
 
         // Assert - Should have 2 inputs (parameter + enabled save checkbox)
         Assert.Equal(2, inputsInteraction.Inputs.Count);
-        
+
         var paramInput = inputsInteraction.Inputs["param1"];
         Assert.Equal("param1", paramInput.Label);
-        
+
         var saveCheckbox = inputsInteraction.Inputs["RememberParameters"];
         Assert.Equal(InteractionStrings.ParametersInputsRememberLabel, saveCheckbox.Label);
         Assert.Equal(InputType.Boolean, saveCheckbox.InputType);

--- a/tests/Shared/TestInteractionService.cs
+++ b/tests/Shared/TestInteractionService.cs
@@ -25,9 +25,12 @@ internal sealed class TestInteractionService : IInteractionService
         throw new NotImplementedException();
     }
 
-    public Task<InteractionResult<InteractionInput>> PromptInputAsync(string title, string? message, InteractionInput input, InputsDialogInteractionOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<InteractionResult<InteractionInput>> PromptInputAsync(string title, string? message, InteractionInput input, InputsDialogInteractionOptions? options = null, CancellationToken cancellationToken = default)
     {
-        throw new NotImplementedException();
+        var data = new InteractionData(title, message, new InteractionInputCollection([input]), options, cancellationToken, new TaskCompletionSource<object>());
+        Interactions.Writer.TryWrite(data);
+        var result = (InteractionResult<InteractionInput>)await data.CompletionTcs.Task;
+        return result;
     }
 
     public async Task<InteractionResult<InteractionInputCollection>> PromptInputsAsync(string title, string? message, IReadOnlyList<InteractionInput> inputs, InputsDialogInteractionOptions? options = null, CancellationToken cancellationToken = default)


### PR DESCRIPTION
This pull request introduces a new "Set parameter value" command for parameter resources, allowing users to update parameter values interactively when supported. The change includes the implementation of the command, its integration into the parameter processing workflow, and the addition of localization resources for the new command in multiple languages.

**New parameter command functionality:**

* Added a new command `SetParameterValueCommand` to `KnownResourceCommands` for setting parameter values on resources.
* Implemented logic in `ParameterProcessor` to add the "Set parameter value" command to parameter resources when the interaction service is available and the command is not already present.
* Added the `AddSetParameterValueCommand` method and the asynchronous `SetParameterValueAsync` method in `ParameterProcessor`, which prompts the user for a new value, updates the parameter resource, and persists the change if in run mode.

Updates:

* Added delete parameter command
* Added logic to hide and show unresolved parameters message bar as needed.

Addresses https://github.com/dotnet/aspire/issues/13430

<img width="1310" height="799" alt="image" src="https://github.com/user-attachments/assets/01299557-cd5f-43e0-925a-cade4efd2120" />

<img width="830" height="486" alt="image" src="https://github.com/user-attachments/assets/a391c1bf-0b50-4098-a762-3b5cb99e6b3d" />

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
