### PR TITLE
Fix: KafkaServerResource documentation

### DIFF
--- a/src/Aspire.Hosting.Kafka/KafkaServerResource.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaServerResource.cs
@@ -21,7 +21,7 @@ public class KafkaServerResource(string name) : ContainerResource(name), IResour
 
     /// <summary>
     /// Gets the primary endpoint for the Kafka broker. This endpoint is used for host processes to Kafka broker communication.
-    /// To connect to the Kafka broker from a host process, use <see cref="InternalEndpoint"/>.
+    /// To connect to the Kafka broker from a container, use <see cref="InternalEndpoint"/>.
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
 


### PR DESCRIPTION
## Description

This pull request makes a minor documentation clarification in the `KafkaServerResource` class. The summary comment for the `PrimaryEndpoint` property is updated to clarify that the `InternalEndpoint` is intended for container-to-Kafka broker communication, not host process communication.

- Documentation update:
  * [`KafkaServerResource.cs`](diffhunk://#diff-66c661c789bdc7f90eae870d935c4730aa54a34f2f1e3bd7553d622841ce5a97L24-R24): Updated the XML summary of the `PrimaryEndpoint` property to specify that `InternalEndpoint` should be used for container-to-Kafka broker communication instead of host processes.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No