### PR TITLE
Add export all button to dashboard

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -41,6 +41,13 @@
                               aria-label="@Loc[nameof(Dialogs.SettingsRemoveAllButtonText)]">
                     @Loc[nameof(Dialogs.SettingsRemoveAllButtonText)]
                 </FluentButton>
+                <FluentButton IconStart="@(new Icons.Regular.Size16.ArrowDownload())"
+                              OnClick="ExportAllAsync"
+                              Loading="@_isExporting"
+                              Title="@Loc[nameof(Dialogs.SettingsExportAllButtonText)]"
+                              aria-label="@Loc[nameof(Dialogs.SettingsExportAllButtonText)]">
+                    @Loc[nameof(Dialogs.SettingsExportAllButtonText)]
+                </FluentButton>
             </div>
         </div>
 

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -304,6 +304,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         // ShortcutManager is scoped because we want shortcuts to apply one browser window.
         builder.Services.AddScoped<ShortcutManager>();
         builder.Services.AddScoped<ConsoleLogsManager>();
+        builder.Services.AddScoped<TelemetryExportService>();
         builder.Services.AddSingleton<IInstrumentUnitResolver, DefaultInstrumentUnitResolver>();
 
         builder.Services.AddScoped<IAIContextProvider, AIContextProvider>();

--- a/src/Aspire.Dashboard/Model/TelemetryExportService.cs
+++ b/src/Aspire.Dashboard/Model/TelemetryExportService.cs
@@ -1,0 +1,398 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Model.Serialization;
+using Aspire.Dashboard.Otlp.Storage;
+
+namespace Aspire.Dashboard.Model;
+
+/// <summary>
+/// Service for exporting telemetry and console logs data.
+/// </summary>
+public sealed class TelemetryExportService
+{
+    private readonly TelemetryRepository _telemetryRepository;
+    private readonly IDashboardClient _dashboardClient;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryExportService"/> class.
+    /// </summary>
+    /// <param name="telemetryRepository">The telemetry repository.</param>
+    /// <param name="dashboardClient">The dashboard client.</param>
+    public TelemetryExportService(TelemetryRepository telemetryRepository, IDashboardClient dashboardClient)
+    {
+        _telemetryRepository = telemetryRepository;
+        _dashboardClient = dashboardClient;
+    }
+
+    /// <summary>
+    /// Exports all telemetry and console logs as a zip archive stream.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A memory stream containing the zip archive.</returns>
+    public async Task<MemoryStream> ExportAllAsync(CancellationToken cancellationToken)
+    {
+        var memoryStream = new MemoryStream();
+
+        using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var resources = _telemetryRepository.GetResources();
+
+            // Export console logs
+            await ExportConsoleLogsAsync(archive, cancellationToken).ConfigureAwait(false);
+
+            // Export structured logs (OTLP JSON)
+            ExportStructuredLogs(archive, resources);
+
+            // Export traces (OTLP JSON)
+            ExportTraces(archive, resources);
+
+            // Export metrics (OTLP JSON)
+            ExportMetrics(archive, resources);
+        }
+
+        memoryStream.Position = 0;
+        return memoryStream;
+    }
+
+    private async Task ExportConsoleLogsAsync(ZipArchive archive, CancellationToken cancellationToken)
+    {
+        if (!_dashboardClient.IsEnabled)
+        {
+            return;
+        }
+
+        var resources = _dashboardClient.GetResources();
+
+        // Fetch console logs for all resources in parallel
+        var logTasks = resources.Select(async resource =>
+        {
+            var logs = new StringBuilder();
+
+            await foreach (var logBatch in _dashboardClient.GetConsoleLogs(resource.Name, cancellationToken).ConfigureAwait(false))
+            {
+                foreach (var logLine in logBatch)
+                {
+                    logs.AppendLine(logLine.Content);
+                }
+            }
+
+            return (Resource: resource, Logs: logs);
+        });
+
+        var results = await Task.WhenAll(logTasks).ConfigureAwait(false);
+
+        // Write results to archive sequentially (ZipArchive is not thread-safe)
+        foreach (var (resource, logs) in results)
+        {
+            if (logs.Length > 0)
+            {
+                var resourceName = ResourceViewModel.GetResourceName(resource, resources);
+                var entry = archive.CreateEntry($"consolelogs/{SanitizeFileName(resourceName)}.txt");
+                using var entryStream = entry.Open();
+                using var writer = new StreamWriter(entryStream, Encoding.UTF8);
+                await writer.WriteAsync(logs.ToString()).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private void ExportStructuredLogs(ZipArchive archive, List<OtlpResource> resources)
+    {
+        foreach (var resource in resources)
+        {
+            var logs = _telemetryRepository.GetLogs(new GetLogsContext
+            {
+                ResourceKey = resource.ResourceKey,
+                StartIndex = 0,
+                Count = int.MaxValue,
+                Filters = []
+            });
+
+            if (logs.Items.Count == 0)
+            {
+                continue;
+            }
+
+            var resourceName = OtlpResource.GetResourceName(resource, resources);
+            var logsJson = ConvertLogsToOtlpJson(resource, logs.Items);
+            WriteJsonToArchive(archive, $"structuredlogs/{SanitizeFileName(resourceName)}.json", logsJson);
+        }
+    }
+
+    private void ExportTraces(ZipArchive archive, List<OtlpResource> resources)
+    {
+        foreach (var resource in resources)
+        {
+            var tracesResponse = _telemetryRepository.GetTraces(new GetTracesRequest
+            {
+                ResourceKey = resource.ResourceKey,
+                StartIndex = 0,
+                Count = int.MaxValue,
+                FilterText = string.Empty,
+                Filters = []
+            });
+
+            if (tracesResponse.PagedResult.Items.Count == 0)
+            {
+                continue;
+            }
+
+            var resourceName = OtlpResource.GetResourceName(resource, resources);
+            var tracesJson = ConvertTracesToOtlpJson(resource, tracesResponse.PagedResult.Items);
+            WriteJsonToArchive(archive, $"traces/{SanitizeFileName(resourceName)}.json", tracesJson);
+        }
+    }
+
+    private void ExportMetrics(ZipArchive archive, List<OtlpResource> resources)
+    {
+        foreach (var resource in resources)
+        {
+            var instruments = _telemetryRepository.GetInstrumentsSummaries(resource.ResourceKey);
+
+            if (instruments.Count == 0)
+            {
+                continue;
+            }
+
+            var resourceName = OtlpResource.GetResourceName(resource, resources);
+            var metricsJson = ConvertMetricsToOtlpJson(resource, instruments);
+            WriteJsonToArchive(archive, $"metrics/{SanitizeFileName(resourceName)}.json", metricsJson);
+        }
+    }
+
+    internal static OtlpLogsDataJson ConvertLogsToOtlpJson(OtlpResource resource, IReadOnlyList<OtlpLogEntry> logs)
+    {
+        // Group logs by scope
+        var logsByScope = logs.GroupBy(l => l.Scope);
+
+        var scopeLogs = logsByScope.Select(scopeGroup => new OtlpScopeLogsJson
+        {
+            Scope = ConvertScope(scopeGroup.Key),
+            LogRecords = scopeGroup.Select(ConvertLogEntry).ToArray()
+        }).ToArray();
+
+        return new OtlpLogsDataJson
+        {
+            ResourceLogs =
+            [
+                new OtlpResourceLogsJson
+                {
+                    Resource = ConvertResource(resource),
+                    ScopeLogs = scopeLogs
+                }
+            ]
+        };
+    }
+
+    private static OtlpLogRecordJson ConvertLogEntry(OtlpLogEntry log)
+    {
+        return new OtlpLogRecordJson
+        {
+            TimeUnixNano = OtlpHelpers.DateTimeToUnixNanoseconds(log.TimeStamp),
+            SeverityNumber = log.SeverityNumber,
+            SeverityText = log.Severity.ToString(),
+            Body = new OtlpAnyValueJson { StringValue = log.Message },
+            Attributes = ConvertAttributes(log.Attributes),
+            TraceId = string.IsNullOrEmpty(log.TraceId) ? null : log.TraceId,
+            SpanId = string.IsNullOrEmpty(log.SpanId) ? null : log.SpanId,
+            Flags = log.Flags,
+            EventName = log.EventName
+        };
+    }
+
+    internal static OtlpTracesDataJson ConvertTracesToOtlpJson(OtlpResource resource, IReadOnlyList<OtlpTrace> traces)
+    {
+        // Group spans by scope
+        var allSpans = traces.SelectMany(t => t.Spans).ToList();
+        var spansByScope = allSpans.GroupBy(s => s.Scope);
+
+        var scopeSpans = spansByScope.Select(scopeGroup => new OtlpScopeSpansJson
+        {
+            Scope = ConvertScope(scopeGroup.Key),
+            Spans = scopeGroup.Select(ConvertSpan).ToArray()
+        }).ToArray();
+
+        return new OtlpTracesDataJson
+        {
+            ResourceSpans =
+            [
+                new OtlpResourceSpansJson
+                {
+                    Resource = ConvertResource(resource),
+                    ScopeSpans = scopeSpans
+                }
+            ]
+        };
+    }
+
+    private static OtlpSpanJson ConvertSpan(OtlpSpan span)
+    {
+        return new OtlpSpanJson
+        {
+            TraceId = span.TraceId,
+            SpanId = span.SpanId,
+            ParentSpanId = string.IsNullOrEmpty(span.ParentSpanId) ? null : span.ParentSpanId,
+            Name = span.Name,
+            Kind = MapSpanKind(span.Kind),
+            StartTimeUnixNano = OtlpHelpers.DateTimeToUnixNanoseconds(span.StartTime),
+            EndTimeUnixNano = OtlpHelpers.DateTimeToUnixNanoseconds(span.EndTime),
+            Attributes = ConvertAttributes(span.Attributes),
+            Status = ConvertSpanStatus(span.Status, span.StatusMessage),
+            Events = span.Events.Count > 0 ? span.Events.Select(ConvertSpanEvent).ToArray() : null,
+            Links = span.Links.Count > 0 ? span.Links.Select(ConvertSpanLink).ToArray() : null,
+            TraceState = span.State
+        };
+    }
+
+    private static int MapSpanKind(global::Aspire.Dashboard.Otlp.Model.OtlpSpanKind kind)
+    {
+        return kind switch
+        {
+            global::Aspire.Dashboard.Otlp.Model.OtlpSpanKind.Unspecified => global::Aspire.Dashboard.Otlp.Model.Serialization.OtlpSpanKind.Unspecified,
+            global::Aspire.Dashboard.Otlp.Model.OtlpSpanKind.Internal => global::Aspire.Dashboard.Otlp.Model.Serialization.OtlpSpanKind.Internal,
+            global::Aspire.Dashboard.Otlp.Model.OtlpSpanKind.Server => global::Aspire.Dashboard.Otlp.Model.Serialization.OtlpSpanKind.Server,
+            global::Aspire.Dashboard.Otlp.Model.OtlpSpanKind.Client => global::Aspire.Dashboard.Otlp.Model.Serialization.OtlpSpanKind.Client,
+            global::Aspire.Dashboard.Otlp.Model.OtlpSpanKind.Producer => global::Aspire.Dashboard.Otlp.Model.Serialization.OtlpSpanKind.Producer,
+            global::Aspire.Dashboard.Otlp.Model.OtlpSpanKind.Consumer => global::Aspire.Dashboard.Otlp.Model.Serialization.OtlpSpanKind.Consumer,
+            _ => global::Aspire.Dashboard.Otlp.Model.Serialization.OtlpSpanKind.Unspecified
+        };
+    }
+
+    private static OtlpSpanStatusJson? ConvertSpanStatus(OtlpSpanStatusCode status, string? statusMessage)
+    {
+        if (status == OtlpSpanStatusCode.Unset && string.IsNullOrEmpty(statusMessage))
+        {
+            return null;
+        }
+
+        return new OtlpSpanStatusJson
+        {
+            Code = (int)status,
+            Message = statusMessage
+        };
+    }
+
+    private static OtlpSpanEventJson ConvertSpanEvent(OtlpSpanEvent evt)
+    {
+        return new OtlpSpanEventJson
+        {
+            TimeUnixNano = OtlpHelpers.DateTimeToUnixNanoseconds(evt.Time),
+            Name = evt.Name,
+            Attributes = ConvertAttributes(evt.Attributes)
+        };
+    }
+
+    private static OtlpSpanLinkJson ConvertSpanLink(OtlpSpanLink link)
+    {
+        return new OtlpSpanLinkJson
+        {
+            TraceId = link.TraceId,
+            SpanId = link.SpanId,
+            TraceState = link.TraceState,
+            Attributes = ConvertAttributes(link.Attributes)
+        };
+    }
+
+    internal static OtlpMetricsDataJson ConvertMetricsToOtlpJson(OtlpResource resource, List<OtlpInstrumentSummary> instruments)
+    {
+        // Group instruments by scope
+        var instrumentsByScope = instruments.GroupBy(i => i.Parent);
+
+        var scopeMetrics = instrumentsByScope.Select(scopeGroup => new OtlpScopeMetricsJson
+        {
+            Scope = ConvertScope(scopeGroup.Key),
+            Metrics = scopeGroup.Select(ConvertInstrument).ToArray()
+        }).ToArray();
+
+        return new OtlpMetricsDataJson
+        {
+            ResourceMetrics =
+            [
+                new OtlpResourceMetricsJson
+                {
+                    Resource = ConvertResource(resource),
+                    ScopeMetrics = scopeMetrics
+                }
+            ]
+        };
+    }
+
+    private static OtlpMetricJson ConvertInstrument(OtlpInstrumentSummary instrument)
+    {
+        // We only export the summary information since we don't have access to the raw data points
+        return new OtlpMetricJson
+        {
+            Name = instrument.Name,
+            Description = instrument.Description,
+            Unit = instrument.Unit
+        };
+    }
+
+    private static OtlpResourceJson ConvertResource(OtlpResource resource)
+    {
+        return new OtlpResourceJson
+        {
+            Attributes =
+            [
+                new OtlpKeyValueJson
+                {
+                    Key = OtlpResource.SERVICE_NAME,
+                    Value = new OtlpAnyValueJson { StringValue = resource.ResourceName }
+                },
+                new OtlpKeyValueJson
+                {
+                    Key = OtlpResource.SERVICE_INSTANCE_ID,
+                    Value = new OtlpAnyValueJson { StringValue = resource.InstanceId }
+                }
+            ]
+        };
+    }
+
+    private static OtlpInstrumentationScopeJson ConvertScope(OtlpScope scope)
+    {
+        return new OtlpInstrumentationScopeJson
+        {
+            Name = scope.Name,
+            Version = string.IsNullOrEmpty(scope.Version) ? null : scope.Version,
+            Attributes = scope.Attributes.Length > 0 ? ConvertAttributes(scope.Attributes) : null
+        };
+    }
+
+    private static OtlpKeyValueJson[]? ConvertAttributes(KeyValuePair<string, string>[] attributes)
+    {
+        if (attributes.Length == 0)
+        {
+            return null;
+        }
+
+        return attributes.Select(a => new OtlpKeyValueJson
+        {
+            Key = a.Key,
+            Value = new OtlpAnyValueJson { StringValue = a.Value }
+        }).ToArray();
+    }
+
+    private static void WriteJsonToArchive<T>(ZipArchive archive, string path, T data)
+    {
+        var entry = archive.CreateEntry(path);
+        using var entryStream = entry.Open();
+        JsonSerializer.Serialize(entryStream, data, OtlpJsonSerializerContext.IndentedOptions);
+    }
+
+    private static string SanitizeFileName(string name)
+    {
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var sanitized = new StringBuilder(name.Length);
+
+        foreach (var c in name)
+        {
+            sanitized.Append(invalidChars.Contains(c) ? '_' : c);
+        }
+
+        return sanitized.ToString();
+    }
+}

--- a/src/Aspire.Dashboard/Model/TelemetryExportService.cs
+++ b/src/Aspire.Dashboard/Model/TelemetryExportService.cs
@@ -237,7 +237,7 @@ public sealed class TelemetryExportService
             SpanId = span.SpanId,
             ParentSpanId = string.IsNullOrEmpty(span.ParentSpanId) ? null : span.ParentSpanId,
             Name = span.Name,
-            Kind = MapSpanKind(span.Kind),
+            Kind = (int)span.Kind,
             StartTimeUnixNano = OtlpHelpers.DateTimeToUnixNanoseconds(span.StartTime),
             EndTimeUnixNano = OtlpHelpers.DateTimeToUnixNanoseconds(span.EndTime),
             Attributes = ConvertAttributes(span.Attributes),
@@ -245,20 +245,6 @@ public sealed class TelemetryExportService
             Events = span.Events.Count > 0 ? span.Events.Select(ConvertSpanEvent).ToArray() : null,
             Links = span.Links.Count > 0 ? span.Links.Select(ConvertSpanLink).ToArray() : null,
             TraceState = span.State
-        };
-    }
-
-    private static int MapSpanKind(global::Aspire.Dashboard.Otlp.Model.OtlpSpanKind kind)
-    {
-        return kind switch
-        {
-            global::Aspire.Dashboard.Otlp.Model.OtlpSpanKind.Unspecified => global::Aspire.Dashboard.Otlp.Model.Serialization.OtlpSpanKind.Unspecified,
-            global::Aspire.Dashboard.Otlp.Model.OtlpSpanKind.Internal => global::Aspire.Dashboard.Otlp.Model.Serialization.OtlpSpanKind.Internal,
-            global::Aspire.Dashboard.Otlp.Model.OtlpSpanKind.Server => global::Aspire.Dashboard.Otlp.Model.Serialization.OtlpSpanKind.Server,
-            global::Aspire.Dashboard.Otlp.Model.OtlpSpanKind.Client => global::Aspire.Dashboard.Otlp.Model.Serialization.OtlpSpanKind.Client,
-            global::Aspire.Dashboard.Otlp.Model.OtlpSpanKind.Producer => global::Aspire.Dashboard.Otlp.Model.Serialization.OtlpSpanKind.Producer,
-            global::Aspire.Dashboard.Otlp.Model.OtlpSpanKind.Consumer => global::Aspire.Dashboard.Otlp.Model.Serialization.OtlpSpanKind.Consumer,
-            _ => global::Aspire.Dashboard.Otlp.Model.Serialization.OtlpSpanKind.Unspecified
         };
     }
 

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
@@ -175,6 +175,15 @@ public static class OtlpHelpers
         return DateTime.UnixEpoch.AddTicks(ticks);
     }
 
+    /// <summary>
+    /// Converts a DateTime to Unix nanoseconds.
+    /// </summary>
+    public static ulong DateTimeToUnixNanoseconds(DateTime dateTime)
+    {
+        var timeSinceEpoch = dateTime.ToUniversalTime() - DateTime.UnixEpoch;
+        return (ulong)timeSinceEpoch.Ticks * TimeSpan.NanosecondsPerTick;
+    }
+
     private static long NanosecondsToTicks(ulong nanoseconds)
     {
         return (long)(nanoseconds / TimeSpan.NanosecondsPerTick);

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using Aspire.Dashboard.Model.Otlp;
 using OpenTelemetry.Proto.Logs.V1;
+using SeverityNumberProto = OpenTelemetry.Proto.Logs.V1.SeverityNumber;
 
 namespace Aspire.Dashboard.Otlp.Model;
 
@@ -92,32 +93,32 @@ public class OtlpLogEntry
         return OtlpHelpers.UnixNanoSecondsToDateTime(resolvedTimeUnixNano);
     }
 
-    private static LogLevel MapSeverity(OpenTelemetry.Proto.Logs.V1.SeverityNumber severityNumber) => severityNumber switch
+    private static LogLevel MapSeverity(SeverityNumberProto severityNumber) => severityNumber switch
     {
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Trace => LogLevel.Trace,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Trace2 => LogLevel.Trace,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Trace3 => LogLevel.Trace,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Trace4 => LogLevel.Trace,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Debug => LogLevel.Debug,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Debug2 => LogLevel.Debug,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Debug3 => LogLevel.Debug,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Debug4 => LogLevel.Debug,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Info => LogLevel.Information,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Info2 => LogLevel.Information,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Info3 => LogLevel.Information,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Info4 => LogLevel.Information,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Warn => LogLevel.Warning,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Warn2 => LogLevel.Warning,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Warn3 => LogLevel.Warning,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Warn4 => LogLevel.Warning,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Error => LogLevel.Error,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Error2 => LogLevel.Error,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Error3 => LogLevel.Error,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Error4 => LogLevel.Error,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Fatal => LogLevel.Critical,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Fatal2 => LogLevel.Critical,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Fatal3 => LogLevel.Critical,
-        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Fatal4 => LogLevel.Critical,
+        SeverityNumberProto.Trace => LogLevel.Trace,
+        SeverityNumberProto.Trace2 => LogLevel.Trace,
+        SeverityNumberProto.Trace3 => LogLevel.Trace,
+        SeverityNumberProto.Trace4 => LogLevel.Trace,
+        SeverityNumberProto.Debug => LogLevel.Debug,
+        SeverityNumberProto.Debug2 => LogLevel.Debug,
+        SeverityNumberProto.Debug3 => LogLevel.Debug,
+        SeverityNumberProto.Debug4 => LogLevel.Debug,
+        SeverityNumberProto.Info => LogLevel.Information,
+        SeverityNumberProto.Info2 => LogLevel.Information,
+        SeverityNumberProto.Info3 => LogLevel.Information,
+        SeverityNumberProto.Info4 => LogLevel.Information,
+        SeverityNumberProto.Warn => LogLevel.Warning,
+        SeverityNumberProto.Warn2 => LogLevel.Warning,
+        SeverityNumberProto.Warn3 => LogLevel.Warning,
+        SeverityNumberProto.Warn4 => LogLevel.Warning,
+        SeverityNumberProto.Error => LogLevel.Error,
+        SeverityNumberProto.Error2 => LogLevel.Error,
+        SeverityNumberProto.Error3 => LogLevel.Error,
+        SeverityNumberProto.Error4 => LogLevel.Error,
+        SeverityNumberProto.Fatal => LogLevel.Critical,
+        SeverityNumberProto.Fatal2 => LogLevel.Critical,
+        SeverityNumberProto.Fatal3 => LogLevel.Critical,
+        SeverityNumberProto.Fatal4 => LogLevel.Critical,
         _ => LogLevel.None
     };
 

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
@@ -16,6 +16,7 @@ public class OtlpLogEntry
     public DateTime TimeStamp { get; }
     public uint Flags { get; }
     public LogLevel Severity { get; }
+    public int SeverityNumber { get; }
     public string Message { get; }
     public string SpanId { get; }
     public string TraceId { get; }
@@ -61,6 +62,7 @@ public class OtlpLogEntry
         });
 
         Flags = record.Flags;
+        SeverityNumber = (int)record.SeverityNumber;
         Severity = MapSeverity(record.SeverityNumber);
 
         Message = record.Body is { } body
@@ -90,32 +92,32 @@ public class OtlpLogEntry
         return OtlpHelpers.UnixNanoSecondsToDateTime(resolvedTimeUnixNano);
     }
 
-    private static LogLevel MapSeverity(SeverityNumber severityNumber) => severityNumber switch
+    private static LogLevel MapSeverity(OpenTelemetry.Proto.Logs.V1.SeverityNumber severityNumber) => severityNumber switch
     {
-        SeverityNumber.Trace => LogLevel.Trace,
-        SeverityNumber.Trace2 => LogLevel.Trace,
-        SeverityNumber.Trace3 => LogLevel.Trace,
-        SeverityNumber.Trace4 => LogLevel.Trace,
-        SeverityNumber.Debug => LogLevel.Debug,
-        SeverityNumber.Debug2 => LogLevel.Debug,
-        SeverityNumber.Debug3 => LogLevel.Debug,
-        SeverityNumber.Debug4 => LogLevel.Debug,
-        SeverityNumber.Info => LogLevel.Information,
-        SeverityNumber.Info2 => LogLevel.Information,
-        SeverityNumber.Info3 => LogLevel.Information,
-        SeverityNumber.Info4 => LogLevel.Information,
-        SeverityNumber.Warn => LogLevel.Warning,
-        SeverityNumber.Warn2 => LogLevel.Warning,
-        SeverityNumber.Warn3 => LogLevel.Warning,
-        SeverityNumber.Warn4 => LogLevel.Warning,
-        SeverityNumber.Error => LogLevel.Error,
-        SeverityNumber.Error2 => LogLevel.Error,
-        SeverityNumber.Error3 => LogLevel.Error,
-        SeverityNumber.Error4 => LogLevel.Error,
-        SeverityNumber.Fatal => LogLevel.Critical,
-        SeverityNumber.Fatal2 => LogLevel.Critical,
-        SeverityNumber.Fatal3 => LogLevel.Critical,
-        SeverityNumber.Fatal4 => LogLevel.Critical,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Trace => LogLevel.Trace,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Trace2 => LogLevel.Trace,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Trace3 => LogLevel.Trace,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Trace4 => LogLevel.Trace,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Debug => LogLevel.Debug,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Debug2 => LogLevel.Debug,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Debug3 => LogLevel.Debug,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Debug4 => LogLevel.Debug,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Info => LogLevel.Information,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Info2 => LogLevel.Information,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Info3 => LogLevel.Information,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Info4 => LogLevel.Information,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Warn => LogLevel.Warning,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Warn2 => LogLevel.Warning,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Warn3 => LogLevel.Warning,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Warn4 => LogLevel.Warning,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Error => LogLevel.Error,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Error2 => LogLevel.Error,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Error3 => LogLevel.Error,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Error4 => LogLevel.Error,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Fatal => LogLevel.Critical,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Fatal2 => LogLevel.Critical,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Fatal3 => LogLevel.Critical,
+        OpenTelemetry.Proto.Logs.V1.SeverityNumber.Fatal4 => LogLevel.Critical,
         _ => LogLevel.None
     };
 

--- a/src/Aspire.Dashboard/Otlp/Model/Serialization/OtlpJsonProtobufConverter.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/Serialization/OtlpJsonProtobufConverter.cs
@@ -317,10 +317,7 @@ internal static class OtlpJsonToProtobufConverter
             }
         }
         logRecord.DroppedAttributesCount = json.DroppedAttributesCount;
-        if (json.Flags.HasValue)
-        {
-            logRecord.Flags = json.Flags.Value;
-        }
+        logRecord.Flags = json.Flags;
         if (json.TraceId is not null)
         {
             logRecord.TraceId = HexToByteString(json.TraceId);

--- a/src/Aspire.Dashboard/Otlp/Model/Serialization/OtlpJsonSerializerContext.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/Serialization/OtlpJsonSerializerContext.cs
@@ -69,4 +69,15 @@ internal sealed partial class OtlpJsonSerializerContext : JsonSerializerContext
         WriteIndented = false,
         TypeInfoResolver = Default
     };
+
+    /// <summary>
+    /// Gets the serializer options for OTLP JSON serialization with indented output.
+    /// </summary>
+    public static JsonSerializerOptions IndentedOptions { get; } = new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = true,
+        TypeInfoResolver = Default
+    };
 }

--- a/src/Aspire.Dashboard/Otlp/Model/Serialization/OtlpLogsJson.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/Serialization/OtlpLogsJson.cs
@@ -119,7 +119,8 @@ internal sealed class OtlpLogRecordJson
     /// Flags, a bit field (fixed32 per protobuf).
     /// </summary>
     [JsonPropertyName("flags")]
-    public uint? Flags { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public uint Flags { get; set; }
 
     /// <summary>
     /// A unique identifier for a trace. Serialized as lowercase hex per OTLP/JSON spec.

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -1266,10 +1266,10 @@ public sealed class TelemetryRepository : IDisposable
             Status = ConvertStatus(span.Status),
             StatusMessage = span.Status?.Message,
             Attributes = span.Attributes.ToKeyValuePairs(context),
-            State = span.TraceState,
+            State = !string.IsNullOrEmpty(span.TraceState) ? span.TraceState : null,
             Events = events,
             Links = links,
-            BackLinks = new()
+            BackLinks = []
         };
 
         foreach (var e in span.Events.OrderBy(e => e.TimeUnixNano))

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -1114,6 +1114,15 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Export all.
+        /// </summary>
+        public static string SettingsExportAllButtonText {
+            get {
+                return ResourceManager.GetString("SettingsExportAllButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Format JSON.
         /// </summary>
         public static string TextVisualizerDialogJsonFormat {

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -271,6 +271,9 @@
   <data name="SettingsRemoveAllButtonText" xml:space="preserve">
     <value>Remove all</value>
   </data>
+  <data name="SettingsExportAllButtonText" xml:space="preserve">
+    <value>Export all</value>
+  </data>
   <data name="TextVisualizerSecretWarningTitle" xml:space="preserve">
     <value>Sensitive value hidden</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -582,6 +582,11 @@
         <target state="translated">Verze: {0}</target>
         <note>{0} is the dashboard version string</note>
       </trans-unit>
+      <trans-unit id="SettingsExportAllButtonText">
+        <source>Export all</source>
+        <target state="new">Export all</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsRemoveAllButtonText">
         <source>Remove all</source>
         <target state="translated">Odebrat vše</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -582,6 +582,11 @@
         <target state="translated">Version: {0}</target>
         <note>{0} is the dashboard version string</note>
       </trans-unit>
+      <trans-unit id="SettingsExportAllButtonText">
+        <source>Export all</source>
+        <target state="new">Export all</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsRemoveAllButtonText">
         <source>Remove all</source>
         <target state="translated">Alle entfernen</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -582,6 +582,11 @@
         <target state="translated">Versión: {0}</target>
         <note>{0} is the dashboard version string</note>
       </trans-unit>
+      <trans-unit id="SettingsExportAllButtonText">
+        <source>Export all</source>
+        <target state="new">Export all</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsRemoveAllButtonText">
         <source>Remove all</source>
         <target state="translated">Quitar todo</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -582,6 +582,11 @@
         <target state="translated">Version : {0}</target>
         <note>{0} is the dashboard version string</note>
       </trans-unit>
+      <trans-unit id="SettingsExportAllButtonText">
+        <source>Export all</source>
+        <target state="new">Export all</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsRemoveAllButtonText">
         <source>Remove all</source>
         <target state="translated">Supprimer tout</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -582,6 +582,11 @@
         <target state="translated">Versione: {0}</target>
         <note>{0} is the dashboard version string</note>
       </trans-unit>
+      <trans-unit id="SettingsExportAllButtonText">
+        <source>Export all</source>
+        <target state="new">Export all</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsRemoveAllButtonText">
         <source>Remove all</source>
         <target state="translated">Rimuovi tutto</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -582,6 +582,11 @@
         <target state="translated">バージョン: {0}</target>
         <note>{0} is the dashboard version string</note>
       </trans-unit>
+      <trans-unit id="SettingsExportAllButtonText">
+        <source>Export all</source>
+        <target state="new">Export all</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsRemoveAllButtonText">
         <source>Remove all</source>
         <target state="translated">すべて削除</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -582,6 +582,11 @@
         <target state="translated">버전: {0}</target>
         <note>{0} is the dashboard version string</note>
       </trans-unit>
+      <trans-unit id="SettingsExportAllButtonText">
+        <source>Export all</source>
+        <target state="new">Export all</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsRemoveAllButtonText">
         <source>Remove all</source>
         <target state="translated">모두 제거</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -582,6 +582,11 @@
         <target state="translated">Wersja: {0}</target>
         <note>{0} is the dashboard version string</note>
       </trans-unit>
+      <trans-unit id="SettingsExportAllButtonText">
+        <source>Export all</source>
+        <target state="new">Export all</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsRemoveAllButtonText">
         <source>Remove all</source>
         <target state="translated">Usuń wszystko</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -582,6 +582,11 @@
         <target state="translated">Versão: {0}</target>
         <note>{0} is the dashboard version string</note>
       </trans-unit>
+      <trans-unit id="SettingsExportAllButtonText">
+        <source>Export all</source>
+        <target state="new">Export all</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsRemoveAllButtonText">
         <source>Remove all</source>
         <target state="translated">Remover tudo</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -582,6 +582,11 @@
         <target state="translated">Версия: {0}</target>
         <note>{0} is the dashboard version string</note>
       </trans-unit>
+      <trans-unit id="SettingsExportAllButtonText">
+        <source>Export all</source>
+        <target state="new">Export all</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsRemoveAllButtonText">
         <source>Remove all</source>
         <target state="translated">Удалить все</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -582,6 +582,11 @@
         <target state="translated">Sürüm: {0}</target>
         <note>{0} is the dashboard version string</note>
       </trans-unit>
+      <trans-unit id="SettingsExportAllButtonText">
+        <source>Export all</source>
+        <target state="new">Export all</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsRemoveAllButtonText">
         <source>Remove all</source>
         <target state="translated">Tümünü kaldır</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -582,6 +582,11 @@
         <target state="translated">版本: {0}</target>
         <note>{0} is the dashboard version string</note>
       </trans-unit>
+      <trans-unit id="SettingsExportAllButtonText">
+        <source>Export all</source>
+        <target state="new">Export all</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsRemoveAllButtonText">
         <source>Remove all</source>
         <target state="translated">全部移除</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -582,6 +582,11 @@
         <target state="translated">版本: {0}</target>
         <note>{0} is the dashboard version string</note>
       </trans-unit>
+      <trans-unit id="SettingsExportAllButtonText">
+        <source>Export all</source>
+        <target state="new">Export all</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsRemoveAllButtonText">
         <source>Remove all</source>
         <target state="translated">全部移除</target>

--- a/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
@@ -1,0 +1,456 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Model.Serialization;
+using Aspire.Dashboard.Otlp.Storage;
+using Google.Protobuf.Collections;
+using OpenTelemetry.Proto.Logs.V1;
+using OpenTelemetry.Proto.Trace.V1;
+using Xunit;
+using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
+
+namespace Aspire.Dashboard.Tests.Model;
+
+public sealed class TelemetryExportServiceTests
+{
+    private static readonly DateTime s_testTime = new(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void ConvertLogsToOtlpJson_SingleLog_ReturnsCorrectStructure()
+    {
+        // Arrange
+        var repository = CreateRepository();
+        var addContext = new AddContext();
+        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "TestService", instanceId: "instance-1"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords = { CreateLogRecord(time: s_testTime, message: "Test log message", severity: OpenTelemetry.Proto.Logs.V1.SeverityNumber.Info, eventName: "TestEvent", traceId: "abcd1234abcd1234", spanId: "efgh5678", attributes: [new KeyValuePair<string, string>("custom.attr", "custom-value")]) }
+                    }
+                }
+            }
+        });
+
+        var resources = repository.GetResources();
+        var resource = resources[0];
+        var logs = repository.GetLogs(new GetLogsContext
+        {
+            ResourceKey = resource.ResourceKey,
+            StartIndex = 0,
+            Count = int.MaxValue,
+            Filters = []
+        });
+
+        // Act
+        var result = TelemetryExportService.ConvertLogsToOtlpJson(resource, logs.Items);
+
+        // Assert
+        Assert.NotNull(result.ResourceLogs);
+        Assert.Single(result.ResourceLogs);
+
+        var resourceLogs = result.ResourceLogs[0];
+        Assert.NotNull(resourceLogs.Resource);
+        Assert.NotNull(resourceLogs.Resource.Attributes);
+        Assert.Contains(resourceLogs.Resource.Attributes, a => a.Key == OtlpResource.SERVICE_NAME && a.Value?.StringValue == "TestService");
+        Assert.Contains(resourceLogs.Resource.Attributes, a => a.Key == OtlpResource.SERVICE_INSTANCE_ID && a.Value?.StringValue == "instance-1");
+
+        Assert.NotNull(resourceLogs.ScopeLogs);
+        Assert.Single(resourceLogs.ScopeLogs);
+
+        var scopeLogs = resourceLogs.ScopeLogs[0];
+        Assert.NotNull(scopeLogs.Scope);
+        Assert.Equal("TestLogger", scopeLogs.Scope.Name);
+
+        Assert.NotNull(scopeLogs.LogRecords);
+        Assert.Single(scopeLogs.LogRecords);
+
+        var logRecord = scopeLogs.LogRecords[0];
+        Assert.Equal("Test log message", logRecord.Body?.StringValue);
+        Assert.Equal(OtlpSeverityNumber.Info, logRecord.SeverityNumber);
+        Assert.Equal("Information", logRecord.SeverityText);
+        Assert.Equal("TestEvent", logRecord.EventName);
+        Assert.Equal(OtlpHelpers.DateTimeToUnixNanoseconds(s_testTime), logRecord.TimeUnixNano);
+        Assert.Equal("61626364313233346162636431323334", logRecord.TraceId); // hex of UTF-8 bytes of "abcd1234abcd1234"
+        Assert.Equal("6566676835363738", logRecord.SpanId); // hex of UTF-8 bytes of "efgh5678"
+        Assert.NotNull(logRecord.Attributes);
+        Assert.Contains(logRecord.Attributes, a => a.Key == "custom.attr" && a.Value?.StringValue == "custom-value");
+    }
+
+    [Fact]
+    public void ConvertLogsToOtlpJson_MultipleLogs_GroupsByScope()
+    {
+        // Arrange
+        var repository = CreateRepository();
+        var addContext = new AddContext();
+        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "TestService", instanceId: "instance-1"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("Logger1"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(time: s_testTime, message: "Log from Logger1"),
+                            CreateLogRecord(time: s_testTime.AddSeconds(1), message: "Another log from Logger1")
+                        }
+                    },
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("Logger2"),
+                        LogRecords = { CreateLogRecord(time: s_testTime.AddSeconds(2), message: "Log from Logger2") }
+                    }
+                }
+            }
+        });
+
+        var resources = repository.GetResources();
+        var resource = resources[0];
+        var logs = repository.GetLogs(new GetLogsContext
+        {
+            ResourceKey = resource.ResourceKey,
+            StartIndex = 0,
+            Count = int.MaxValue,
+            Filters = []
+        });
+
+        // Act
+        var result = TelemetryExportService.ConvertLogsToOtlpJson(resource, logs.Items);
+
+        // Assert
+        Assert.NotNull(result.ResourceLogs);
+        Assert.Single(result.ResourceLogs);
+
+        var resourceLogs = result.ResourceLogs[0];
+        Assert.NotNull(resourceLogs.ScopeLogs);
+        Assert.Equal(2, resourceLogs.ScopeLogs.Length);
+
+        var logger1Scope = resourceLogs.ScopeLogs.FirstOrDefault(s => s.Scope?.Name == "Logger1");
+        Assert.NotNull(logger1Scope);
+        Assert.NotNull(logger1Scope.LogRecords);
+        Assert.Equal(2, logger1Scope.LogRecords.Length);
+
+        var logger2Scope = resourceLogs.ScopeLogs.FirstOrDefault(s => s.Scope?.Name == "Logger2");
+        Assert.NotNull(logger2Scope);
+        Assert.NotNull(logger2Scope.LogRecords);
+        Assert.Single(logger2Scope.LogRecords);
+    }
+
+    [Theory]
+    [InlineData(SeverityNumber.Trace, "Trace")]
+    [InlineData(SeverityNumber.Trace2, "Trace")]
+    [InlineData(SeverityNumber.Trace3, "Trace")]
+    [InlineData(SeverityNumber.Trace4, "Trace")]
+    [InlineData(SeverityNumber.Debug, "Debug")]
+    [InlineData(SeverityNumber.Debug2, "Debug")]
+    [InlineData(SeverityNumber.Debug3, "Debug")]
+    [InlineData(SeverityNumber.Debug4, "Debug")]
+    [InlineData(SeverityNumber.Info, "Information")]
+    [InlineData(SeverityNumber.Info2, "Information")]
+    [InlineData(SeverityNumber.Info3, "Information")]
+    [InlineData(SeverityNumber.Info4, "Information")]
+    [InlineData(SeverityNumber.Warn, "Warning")]
+    [InlineData(SeverityNumber.Warn2, "Warning")]
+    [InlineData(SeverityNumber.Warn3, "Warning")]
+    [InlineData(SeverityNumber.Warn4, "Warning")]
+    [InlineData(SeverityNumber.Error, "Error")]
+    [InlineData(SeverityNumber.Error2, "Error")]
+    [InlineData(SeverityNumber.Error3, "Error")]
+    [InlineData(SeverityNumber.Error4, "Error")]
+    [InlineData(SeverityNumber.Fatal, "Critical")]
+    [InlineData(SeverityNumber.Fatal2, "Critical")]
+    [InlineData(SeverityNumber.Fatal3, "Critical")]
+    [InlineData(SeverityNumber.Fatal4, "Critical")]
+    public void ConvertLogsToOtlpJson_RoundTripsSeverityNumber(SeverityNumber inputSeverity, string expectedSeverityText)
+    {
+        // Arrange
+        var repository = CreateRepository();
+        var addContext = new AddContext();
+        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope(),
+                        LogRecords = { CreateLogRecord(severity: inputSeverity) }
+                    }
+                }
+            }
+        });
+
+        var resources = repository.GetResources();
+        var resource = resources[0];
+        var logs = repository.GetLogs(new GetLogsContext
+        {
+            ResourceKey = resource.ResourceKey,
+            StartIndex = 0,
+            Count = int.MaxValue,
+            Filters = []
+        });
+
+        // Act
+        var result = TelemetryExportService.ConvertLogsToOtlpJson(resource, logs.Items);
+
+        // Assert
+        var logRecord = result.ResourceLogs![0].ScopeLogs![0].LogRecords![0];
+        // Verify exact severity number is preserved (round-trip)
+        Assert.Equal((int)inputSeverity, logRecord.SeverityNumber);
+        // Verify severity text is the mapped LogLevel
+        Assert.Equal(expectedSeverityText, logRecord.SeverityText);
+    }
+
+    [Fact]
+    public void ConvertTracesToOtlpJson_SingleTrace_ReturnsCorrectStructure()
+    {
+        // Arrange
+        var repository = CreateRepository();
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "TestService", instanceId: "instance-1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope("TestTracer"),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "trace123456789012",
+                                spanId: "span1234",
+                                startTime: s_testTime,
+                                endTime: s_testTime.AddSeconds(5),
+                                kind: Span.Types.SpanKind.Server,
+                                status: new Status { Code = Status.Types.StatusCode.Error, Message = "Something went wrong" },
+                                attributes: [new KeyValuePair<string, string>("http.method", "GET")])
+                        }
+                    }
+                }
+            }
+        });
+
+        var resources = repository.GetResources();
+        var resource = resources[0];
+        var traces = repository.GetTraces(new GetTracesRequest
+        {
+            ResourceKey = resource.ResourceKey,
+            StartIndex = 0,
+            Count = int.MaxValue,
+            FilterText = string.Empty,
+            Filters = []
+        });
+
+        // Act
+        var result = TelemetryExportService.ConvertTracesToOtlpJson(resource, traces.PagedResult.Items);
+
+        // Assert
+        Assert.NotNull(result.ResourceSpans);
+        Assert.Single(result.ResourceSpans);
+
+        var resourceSpans = result.ResourceSpans[0];
+        Assert.NotNull(resourceSpans.Resource);
+        Assert.NotNull(resourceSpans.Resource.Attributes);
+        Assert.Contains(resourceSpans.Resource.Attributes, a => a.Key == OtlpResource.SERVICE_NAME && a.Value?.StringValue == "TestService");
+
+        Assert.NotNull(resourceSpans.ScopeSpans);
+        Assert.Single(resourceSpans.ScopeSpans);
+
+        var scopeSpans = resourceSpans.ScopeSpans[0];
+        Assert.NotNull(scopeSpans.Scope);
+        Assert.Equal("TestTracer", scopeSpans.Scope.Name);
+
+        Assert.NotNull(scopeSpans.Spans);
+        Assert.Single(scopeSpans.Spans);
+
+        var span = scopeSpans.Spans[0];
+        Assert.Equal(Aspire.Dashboard.Otlp.Model.Serialization.OtlpSpanKind.Server, span.Kind);
+        Assert.Equal("7472616365313233343536373839303132", span.TraceId); // hex of UTF-8 bytes of "trace123456789012"
+        Assert.Equal("7370616e31323334", span.SpanId); // hex of UTF-8 bytes of "span1234"
+        Assert.Equal("Test span. Id: span1234", span.Name);
+        Assert.Equal(OtlpHelpers.DateTimeToUnixNanoseconds(s_testTime), span.StartTimeUnixNano);
+        Assert.Equal(OtlpHelpers.DateTimeToUnixNanoseconds(s_testTime.AddSeconds(5)), span.EndTimeUnixNano);
+        Assert.NotNull(span.Status);
+        Assert.Equal(OtlpStatusCode.Error, span.Status.Code);
+        Assert.Equal("Something went wrong", span.Status.Message);
+        Assert.NotNull(span.Attributes);
+        Assert.Contains(span.Attributes, a => a.Key == "http.method" && a.Value?.StringValue == "GET");
+    }
+
+    [Fact]
+    public void ConvertTracesToOtlpJson_SpanWithParent_IncludesParentSpanId()
+    {
+        // Arrange
+        var repository = CreateRepository();
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "trace123456789012", spanId: "parent12", startTime: s_testTime, endTime: s_testTime.AddSeconds(10)),
+                            CreateSpan(traceId: "trace123456789012", spanId: "child123", startTime: s_testTime.AddSeconds(1), endTime: s_testTime.AddSeconds(5), parentSpanId: "parent12")
+                        }
+                    }
+                }
+            }
+        });
+
+        var resources = repository.GetResources();
+        var resource = resources[0];
+        var traces = repository.GetTraces(new GetTracesRequest
+        {
+            ResourceKey = resource.ResourceKey,
+            StartIndex = 0,
+            Count = int.MaxValue,
+            FilterText = string.Empty,
+            Filters = []
+        });
+
+        // Act
+        var result = TelemetryExportService.ConvertTracesToOtlpJson(resource, traces.PagedResult.Items);
+
+        // Assert
+        var spans = result.ResourceSpans![0].ScopeSpans![0].Spans!;
+        Assert.Equal(2, spans.Length);
+
+        var parentSpan = spans.First(s => s.ParentSpanId is null);
+        var childSpan = spans.First(s => s.ParentSpanId is not null);
+
+        Assert.NotNull(childSpan.ParentSpanId);
+    }
+
+    [Fact]
+    public void ConvertMetricsToOtlpJson_SingleInstrument_ReturnsCorrectStructure()
+    {
+        // Arrange
+        var repository = CreateRepository();
+        var addContext = new AddContext();
+        repository.AddMetrics(addContext, new RepeatedField<OpenTelemetry.Proto.Metrics.V1.ResourceMetrics>()
+        {
+            new OpenTelemetry.Proto.Metrics.V1.ResourceMetrics
+            {
+                Resource = CreateResource(name: "TestService", instanceId: "instance-1"),
+                ScopeMetrics =
+                {
+                    new OpenTelemetry.Proto.Metrics.V1.ScopeMetrics
+                    {
+                        Scope = CreateScope("TestMeter"),
+                        Metrics = { CreateSumMetric("test_counter", s_testTime) }
+                    }
+                }
+            }
+        });
+
+        var resources = repository.GetResources();
+        var resource = resources[0];
+        var instruments = repository.GetInstrumentsSummaries(resource.ResourceKey);
+
+        // Act
+        var result = TelemetryExportService.ConvertMetricsToOtlpJson(resource, instruments);
+
+        // Assert
+        Assert.NotNull(result.ResourceMetrics);
+        Assert.Single(result.ResourceMetrics);
+
+        var resourceMetrics = result.ResourceMetrics[0];
+        Assert.NotNull(resourceMetrics.Resource);
+        Assert.NotNull(resourceMetrics.Resource.Attributes);
+        Assert.Contains(resourceMetrics.Resource.Attributes, a => a.Key == OtlpResource.SERVICE_NAME && a.Value?.StringValue == "TestService");
+
+        Assert.NotNull(resourceMetrics.ScopeMetrics);
+        Assert.Single(resourceMetrics.ScopeMetrics);
+
+        var scopeMetrics = resourceMetrics.ScopeMetrics[0];
+        Assert.NotNull(scopeMetrics.Scope);
+        Assert.Equal("TestMeter", scopeMetrics.Scope.Name);
+
+        Assert.NotNull(scopeMetrics.Metrics);
+        Assert.Single(scopeMetrics.Metrics);
+
+        var metric = scopeMetrics.Metrics[0];
+        Assert.Equal("test_counter", metric.Name);
+        Assert.Equal("Test metric description", metric.Description);
+        Assert.Equal("widget", metric.Unit);
+    }
+
+    [Fact]
+    public void ConvertMetricsToOtlpJson_MultipleInstruments_GroupsByScope()
+    {
+        // Arrange
+        var repository = CreateRepository();
+        var addContext = new AddContext();
+        repository.AddMetrics(addContext, new RepeatedField<OpenTelemetry.Proto.Metrics.V1.ResourceMetrics>()
+        {
+            new OpenTelemetry.Proto.Metrics.V1.ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new OpenTelemetry.Proto.Metrics.V1.ScopeMetrics
+                    {
+                        Scope = CreateScope("Meter1"),
+                        Metrics =
+                        {
+                            CreateSumMetric("counter1", s_testTime),
+                            CreateSumMetric("counter2", s_testTime)
+                        }
+                    },
+                    new OpenTelemetry.Proto.Metrics.V1.ScopeMetrics
+                    {
+                        Scope = CreateScope("Meter2"),
+                        Metrics = { CreateHistogramMetric("histogram1", s_testTime) }
+                    }
+                }
+            }
+        });
+
+        var resources = repository.GetResources();
+        var resource = resources[0];
+        var instruments = repository.GetInstrumentsSummaries(resource.ResourceKey);
+
+        // Act
+        var result = TelemetryExportService.ConvertMetricsToOtlpJson(resource, instruments);
+
+        // Assert
+        Assert.NotNull(result.ResourceMetrics);
+        Assert.Single(result.ResourceMetrics);
+
+        var resourceMetrics = result.ResourceMetrics[0];
+        Assert.NotNull(resourceMetrics.ScopeMetrics);
+        Assert.Equal(2, resourceMetrics.ScopeMetrics.Length);
+
+        var meter1Scope = resourceMetrics.ScopeMetrics.FirstOrDefault(s => s.Scope?.Name == "Meter1");
+        Assert.NotNull(meter1Scope);
+        Assert.NotNull(meter1Scope.Metrics);
+        Assert.Equal(2, meter1Scope.Metrics.Length);
+
+        var meter2Scope = resourceMetrics.ScopeMetrics.FirstOrDefault(s => s.Scope?.Name == "Meter2");
+        Assert.NotNull(meter2Scope);
+        Assert.NotNull(meter2Scope.Metrics);
+        Assert.Single(meter2Scope.Metrics);
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
-using Aspire.Dashboard.Otlp.Model.Serialization;
 using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Proto.Logs.V1;
@@ -74,7 +73,7 @@ public sealed class TelemetryExportServiceTests
 
         var logRecord = scopeLogs.LogRecords[0];
         Assert.Equal("Test log message", logRecord.Body?.StringValue);
-        Assert.Equal(OtlpSeverityNumber.Info, logRecord.SeverityNumber);
+        Assert.Equal((int)SeverityNumber.Info, logRecord.SeverityNumber);
         Assert.Equal("Information", logRecord.SeverityText);
         Assert.Equal("TestEvent", logRecord.EventName);
         Assert.Equal(OtlpHelpers.DateTimeToUnixNanoseconds(s_testTime), logRecord.TimeUnixNano);
@@ -280,14 +279,14 @@ public sealed class TelemetryExportServiceTests
         Assert.Single(scopeSpans.Spans);
 
         var span = scopeSpans.Spans[0];
-        Assert.Equal(Aspire.Dashboard.Otlp.Model.Serialization.OtlpSpanKind.Server, span.Kind);
+        Assert.Equal((int)OtlpSpanKind.Server, span.Kind);
         Assert.Equal("7472616365313233343536373839303132", span.TraceId); // hex of UTF-8 bytes of "trace123456789012"
         Assert.Equal("7370616e31323334", span.SpanId); // hex of UTF-8 bytes of "span1234"
         Assert.Equal("Test span. Id: span1234", span.Name);
         Assert.Equal(OtlpHelpers.DateTimeToUnixNanoseconds(s_testTime), span.StartTimeUnixNano);
         Assert.Equal(OtlpHelpers.DateTimeToUnixNanoseconds(s_testTime.AddSeconds(5)), span.EndTimeUnixNano);
         Assert.NotNull(span.Status);
-        Assert.Equal(OtlpStatusCode.Error, span.Status.Code);
+        Assert.Equal((int)Status.Types.StatusCode.Error, span.Status.Code);
         Assert.Equal("Something went wrong", span.Status.Message);
         Assert.NotNull(span.Attributes);
         Assert.Contains(span.Attributes, a => a.Key == "http.method" && a.Value?.StringValue == "GET");


### PR DESCRIPTION
This pull request adds an "Export all" feature to the dashboard's settings dialog, allowing users to export all telemetry data as a ZIP file.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
