### PR TITLE
Ensure WithHostHttpsPort works when chained inline

### DIFF
--- a/src/Aspire.Hosting.Yarp/YarpResource.cs
+++ b/src/Aspire.Hosting.Yarp/YarpResource.cs
@@ -16,6 +16,11 @@ public class YarpResource : ContainerResource, IResourceWithServiceDiscovery, IC
 
     internal List<YarpCluster> Clusters { get; } = [];
 
+    /// <summary>
+    /// Gets or sets the HTTPS host port for the YARP resource.
+    /// </summary>
+    internal int? HostHttpsPort { get; set; }
+
     /// <param name="name">The name of the resource.</param>
     public YarpResource(string name) : base(name)
     {

--- a/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
@@ -78,7 +78,13 @@ public static class YarpResourceExtensions
                     // If a TLS certificate is configured, ensure the YARP resource has an HTTPS endpoint and
                     // configure the environment variables to use it.
                     yarpBuilder
-                        .WithHttpsEndpoint(targetPort: HttpsPort)
+                        .WithEndpoint("https", ep =>
+                        {
+                            // Create or update the HTTPS endpoint
+                            ep.TargetPort ??= HttpsPort;
+                            ep.UriScheme = "https";
+                            ep.Port ??= resource.HostHttpsPort;
+                        }, createIfNotExists: true)
                         .WithEnvironment("ASPNETCORE_HTTPS_PORT", resource.GetEndpoint("https").Property(EndpointProperty.Port))
                         .WithEnvironment("ASPNETCORE_URLS", $"{resource.GetEndpoint("https").Property(EndpointProperty.Scheme)}://*:{resource.GetEndpoint("https").Property(EndpointProperty.TargetPort)};{resource.GetEndpoint("http").Property(EndpointProperty.Scheme)}://*:{resource.GetEndpoint("http").Property(EndpointProperty.TargetPort)}");
                 }
@@ -150,10 +156,9 @@ public static class YarpResourceExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        return builder.WithEndpoint("https", endpoint =>
-        {
-            endpoint.Port = port;
-        }, createIfNotExists: false);
+        builder.Resource.HostHttpsPort = port;
+
+        return builder;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
@@ -158,7 +158,7 @@ public static class YarpResourceExtensions
 
         builder.Resource.HostHttpsPort = port;
 
-        return builder;
+        return builder.WithEndpoint("https", ep => ep.Port = port, createIfNotExists: false);
     }
 
     /// <summary>


### PR DESCRIPTION
## Description

Fixes an issue where `.WithHostHttpsPort` wouldn't work due to the HTTPS endpoint being created in `BeforeStartEvent`.