### PR TITLE
feat: add custom Orleans provider type annotation

### DIFF
--- a/Aspire.slnx
+++ b/Aspire.slnx
@@ -527,6 +527,7 @@
     <Project Path="tests/Aspire.Hosting.Go.Tests/Aspire.Hosting.Go.Tests.csproj" />
     <Project Path="tests/Aspire.Hosting.JavaScript.Tests/Aspire.Hosting.JavaScript.Tests.csproj" />
     <Project Path="tests/Aspire.Hosting.OpenAI.Tests/Aspire.Hosting.OpenAI.Tests.csproj" />
+    <Project Path="tests/Aspire.Hosting.Orleans.Tests/Aspire.Hosting.Orleans.Tests.csproj" />
     <Project Path="tests/Aspire.Hosting.Oracle.Tests/Aspire.Hosting.Oracle.Tests.csproj" />
     <Project Path="tests/Aspire.Hosting.PostgreSQL.Tests/Aspire.Hosting.PostgreSQL.Tests.csproj" />
     <Project Path="tests/Aspire.Hosting.Python.Tests/Aspire.Hosting.Python.Tests.csproj" />

--- a/src/Aspire.Hosting.Orleans/OrleansProviderTypeAnnotation.cs
+++ b/src/Aspire.Hosting.Orleans/OrleansProviderTypeAnnotation.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Orleans;
+
+/// <summary>
+/// Specifies the Orleans provider type for a resource.
+/// </summary>
+/// <param name="providerType">The Orleans provider type to use for the resource.</param>
+public sealed class OrleansProviderTypeAnnotation(string providerType) : IResourceAnnotation
+{
+    /// <summary>
+    /// Gets the Orleans provider type to use for the resource.
+    /// </summary>
+    public string ProviderType { get; } = ValidateProviderType(providerType);
+
+    private static string ValidateProviderType(string providerType)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerType);
+
+        return providerType;
+    }
+}

--- a/src/Aspire.Hosting.Orleans/OrleansServiceExtensions.cs
+++ b/src/Aspire.Hosting.Orleans/OrleansServiceExtensions.cs
@@ -360,6 +360,39 @@ public static class OrleansServiceExtensions
     }
 
     /// <summary>
+    /// Configures a resource to use the specified Orleans provider type.
+    /// </summary>
+    /// <param name="builder">The connection-string resource builder.</param>
+    /// <param name="providerType">The Orleans provider type to use for the resource.</param>
+    /// <returns>The resource builder.</returns>
+    /// <remarks>
+    /// Use this when a resource can be used as a drop-in replacement for an Orleans provider type that is
+    /// inferred from a different resource name. For example, Garnet can be used wherever Orleans expects a
+    /// Redis provider.
+    /// </remarks>
+    /// <example>
+    /// Configure a Garnet resource as a Redis Orleans provider:
+    /// <code>
+    /// var garnet = builder.AddGarnet("garnet")
+    ///     .WithOrleansProviderType("Redis");
+    ///
+    /// var orleans = builder.AddOrleans("orleans")
+    ///     .WithClustering(garnet);
+    /// </code>
+    /// </example>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="providerType"/> is null, empty, or consists only of white-space characters.</exception>
+    [AspireExport]
+    public static IResourceBuilder<T> WithOrleansProviderType<T>(this IResourceBuilder<T> builder, string providerType)
+        where T : IResourceWithConnectionString
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerType);
+
+        return builder.WithAnnotation(new OrleansProviderTypeAnnotation(providerType), ResourceAnnotationMutationBehavior.Replace);
+    }
+
+    /// <summary>
     /// Returns a model of the clients of an Orleans service.
     /// </summary>
     /// <param name="orleansService">The Orleans service</param>

--- a/src/Aspire.Hosting.Orleans/ProviderConfiguration.cs
+++ b/src/Aspire.Hosting.Orleans/ProviderConfiguration.cs
@@ -10,6 +10,35 @@ namespace Aspire.Hosting.Orleans;
 /// </summary>
 internal sealed class ProviderConfiguration(string providerType, string? serviceKey = null, IResourceBuilder<IResourceWithConnectionString>? resource = null) : IProviderConfiguration
 {
+    private readonly string _providerType = ValidateProviderType(providerType);
+
+    private static string GetProviderType(IResourceBuilder<IResourceWithConnectionString> resourceBuilder)
+    {
+        string providerType;
+
+        if (resourceBuilder.Resource.TryGetAnnotationsOfType<OrleansProviderTypeAnnotation>(out var annotations) && annotations.FirstOrDefault() is OrleansProviderTypeAnnotation annotation)
+        {
+            providerType = annotation.ProviderType;
+        }
+        else
+        {
+            const string resource = "Resource";
+            var resourceType = resourceBuilder.Resource.GetType().Name;
+
+            // Use a simple transformation to get the provider type: remove the "Resource" suffix if it exists.
+            providerType = resourceType.EndsWith(resource, StringComparison.Ordinal) ? resourceType[..^resource.Length] : resourceType;
+        }
+
+        return providerType;
+    }
+
+    private static string ValidateProviderType(string providerType)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerType);
+
+        return providerType;
+    }
+
     /// <summary>
     /// Initializes a new instance of <see cref="ProviderConfiguration"/>.
     /// </summary>
@@ -17,12 +46,8 @@ internal sealed class ProviderConfiguration(string providerType, string? service
     /// <returns>The new provider configuration.</returns>
     internal static ProviderConfiguration Create(IResourceBuilder<IResourceWithConnectionString> resourceBuilder)
     {
-        const string resource = "Resource";
         var serviceKey = resourceBuilder.Resource.Name;
-        var resourceType = resourceBuilder.Resource.GetType().Name;
-
-        // Use a simple transformation to get the provider type: remove the "Resource" suffix if it exists.
-        var providerType = resourceType.EndsWith(resource, StringComparison.Ordinal) ? resourceType[..^resource.Length] : resourceType;
+        var providerType = GetProviderType(resourceBuilder);
 
         return new(providerType, serviceKey, resourceBuilder);
     }
@@ -36,7 +61,7 @@ internal sealed class ProviderConfiguration(string providerType, string? service
     public void ConfigureResource<T>(IResourceBuilder<T> resourceBuilder, string configurationSectionName) where T : IResourceWithEnvironment
     {
         var envVarPrefix = configurationSectionName.Replace(":", "__");
-        resourceBuilder.WithEnvironment($"Orleans__{envVarPrefix}__ProviderType", providerType);
+        resourceBuilder.WithEnvironment($"Orleans__{envVarPrefix}__ProviderType", _providerType);
         if (!string.IsNullOrEmpty(serviceKey))
         {
             resourceBuilder.WithEnvironment($"Orleans__{envVarPrefix}__ServiceKey", serviceKey);

--- a/tests/Aspire.Hosting.Orleans.Tests/Aspire.Hosting.Orleans.Tests.csproj
+++ b/tests/Aspire.Hosting.Orleans.Tests/Aspire.Hosting.Orleans.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Aspire.Hosting.AppHost\Aspire.Hosting.AppHost.csproj" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Orleans\Aspire.Hosting.Orleans.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Aspire.Hosting.Orleans.Tests/OrleansProviderTypeTests.cs
+++ b/tests/Aspire.Hosting.Orleans.Tests/OrleansProviderTypeTests.cs
@@ -1,0 +1,147 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting.Orleans.Tests;
+
+public class OrleansProviderTypeTests
+{
+    [Fact]
+    public async Task ProviderTypeDefaultsToResourceTypeNameWithoutResourceSuffix()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var provider = builder.AddResource(new TestProviderResource("provider")
+        {
+            ConnectionString = "connectionString"
+        });
+
+        var orleans = builder.AddOrleans("orleans")
+            .WithClustering(provider);
+
+        var silo = builder.AddContainer("silo", "image")
+            .WithReference(orleans);
+
+        var config = await GetEnvironmentVariablesAsync(silo.Resource, builder);
+
+        Assert.Equal("TestProvider", config["Orleans__Clustering__ProviderType"]);
+        Assert.Equal("provider", config["Orleans__Clustering__ServiceKey"]);
+    }
+
+    [Fact]
+    public async Task WithOrleansProviderTypeOverridesProviderType()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var provider = builder.AddResource(new TestProviderResource("provider")
+        {
+            ConnectionString = "connectionString"
+        }).WithOrleansProviderType("Redis");
+
+        var orleans = builder.AddOrleans("orleans")
+            .WithClustering(provider);
+
+        var silo = builder.AddContainer("silo", "image")
+            .WithReference(orleans);
+
+        var config = await GetEnvironmentVariablesAsync(silo.Resource, builder);
+
+        Assert.Equal("Redis", config["Orleans__Clustering__ProviderType"]);
+        Assert.Equal("provider", config["Orleans__Clustering__ServiceKey"]);
+    }
+
+    [Fact]
+    public async Task WithOrleansProviderTypeReplacesPreviousProviderType()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var provider = builder.AddResource(new TestProviderResource("provider")
+        {
+            ConnectionString = "connectionString"
+        })
+            .WithOrleansProviderType("Redis")
+            .WithOrleansProviderType("AdoNet");
+
+        var annotation = Assert.Single(provider.Resource.Annotations.OfType<OrleansProviderTypeAnnotation>());
+        Assert.Equal("AdoNet", annotation.ProviderType);
+
+        var orleans = builder.AddOrleans("orleans")
+            .WithClustering(provider);
+
+        var silo = builder.AddContainer("silo", "image")
+            .WithReference(orleans);
+
+        var config = await GetEnvironmentVariablesAsync(silo.Resource, builder);
+
+        Assert.Equal("AdoNet", config["Orleans__Clustering__ProviderType"]);
+    }
+
+    [Fact]
+    public void WithOrleansProviderTypeShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<TestProviderResource> builder = null!;
+
+        var action = () => builder.WithOrleansProviderType("Redis");
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void WithOrleansProviderTypeShouldThrowWhenProviderTypeIsNullOrWhiteSpace(string? providerType)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var provider = builder.AddResource(new TestProviderResource("provider")
+        {
+            ConnectionString = "connectionString"
+        });
+
+        var action = () => provider.WithOrleansProviderType(providerType!);
+
+        var exception = providerType is null
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(providerType), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void CtorOrleansProviderTypeAnnotationShouldThrowWhenProviderTypeIsNullOrWhiteSpace(string? providerType)
+    {
+        var action = () => new OrleansProviderTypeAnnotation(providerType!);
+
+        var exception = providerType is null
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(providerType), exception.ParamName);
+    }
+
+    private sealed class TestProviderResource(string name) : Resource(name), IResourceWithConnectionString
+    {
+        public string? ConnectionString { get; init; }
+
+        public ReferenceExpression ConnectionStringExpression =>
+            ReferenceExpression.Create($"{ConnectionString}");
+    }
+
+    private static async Task<Dictionary<string, object>> GetEnvironmentVariablesAsync(IResource resource, IDistributedApplicationBuilder builder)
+    {
+        var env = new Dictionary<string, object>();
+        var context = new EnvironmentCallbackContext(builder.ExecutionContext, resource, env);
+
+        foreach (var callback in resource.Annotations.OfType<EnvironmentCallbackAnnotation>())
+        {
+            await callback.Callback(context).ConfigureAwait(false);
+        }
+
+        return env;
+    }
+}


### PR DESCRIPTION
## Description

The algorithm of deriving the provider type from the resource type name does not work in every case. For example, if you want to use Garnet as a drop-in replacement for Redis, Orleans does not find the corrent provider builder, because there is none defined for "Garnet".

With the new `OrleansProviderTypeAnnotation`, users can explicitly specify the provider type to use for a given resource.

Example:

```
var garnet = builder.AddGarnet("garnet")
                    .WithOrleansProviderType("Redis");

var orleans = builder.AddOrleans()
                     .WithClustering(garnet);
```

Fixes dotnet/orleans#9848

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No (I didn't find a related test project)
- Did you add public API?
  - [X] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [X] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [X] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [X] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
  - [ ] No
