### PR TITLE
Make `MinLength` required on `GenerateParameterDefault`

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ParameterDefault.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterDefault.cs
@@ -81,7 +81,7 @@ public sealed class GenerateParameterDefault : ParameterDefault
     /// <summary>
     /// Gets or sets the minimum length of the generated value.
     /// </summary>
-    public int MinLength { get; set; }
+    public int MinLength { get; set; } = 22;
 
     /// <summary>
     /// Gets or sets a value indicating whether to include lowercase alphabet characters in the result.

--- a/tests/Aspire.Hosting.Tests/ApplicationModel/GenerateParameterDefaultTests.cs
+++ b/tests/Aspire.Hosting.Tests/ApplicationModel/GenerateParameterDefaultTests.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting.Tests.ApplicationModel;
+
+public class GenerateParameterDefaultTests
+{
+    [Fact]
+    public void GetDefaultValue_Respects_Length_And_LowerOnly()
+    {
+        var gd = new GenerateParameterDefault
+        {
+            MinLength = 10,
+            Lower = true,
+            Upper = false,
+            Numeric = false,
+            Special = false
+        };
+
+        var value = gd.GetDefaultValue();
+
+        Assert.Equal(10, value.Length);
+        Assert.True(value.All(PasswordGenerator.LowerCaseChars.Contains));
+    }
+
+    [Fact]
+    public void GetDefaultValue_Respects_Minimum_Type_Counts()
+    {
+        var gd = new GenerateParameterDefault
+        {
+            MinLength = 12,
+            Lower = true,
+            Upper = true,
+            Numeric = true,
+            Special = true,
+            MinLower = 2,
+            MinUpper = 1,
+            MinNumeric = 1,
+            MinSpecial = 2
+        };
+
+        var value = gd.GetDefaultValue();
+
+        Assert.True(value.Count(PasswordGenerator.LowerCaseChars.Contains) >= gd.MinLower);
+        Assert.True(value.Count(PasswordGenerator.UpperCaseChars.Contains) >= gd.MinUpper);
+        Assert.True(value.Count(PasswordGenerator.NumericChars.Contains) >= gd.MinNumeric);
+        Assert.True(value.Count(PasswordGenerator.SpecialChars.Contains) >= gd.MinSpecial);
+        Assert.True(value.Length >= 12);
+    }
+
+    [Fact]
+    public void GetDefaultValue_Default_HasAtLeast128BitsOfEntropy()
+    {
+        var defaultGenerator = new GenerateParameterDefault();
+
+        var choiceCount =
+            PasswordGenerator.LowerCaseChars.Length +
+            PasswordGenerator.UpperCaseChars.Length +
+            PasswordGenerator.NumericChars.Length +
+            PasswordGenerator.SpecialChars.Length;
+
+        var entropyBits = defaultGenerator.MinLength * Math.Log2(choiceCount);
+
+        Assert.True(entropyBits >= 128, $"Default password entropy ({entropyBits} bits) must be at least 128 bits.");
+    }
+}


### PR DESCRIPTION
## Description

Default `GenerateParameterDefault` password to 128 bits of entropy

Previously if you forgot to specify a `MinLength`, you would end up with a password of length zero which is a bit surprising and dangerous.  Set a default value that will give 128 bits of entropy.

Fixes #10570

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
