### PR TITLE
Fix `WithYarn` with `AddViteApp`

### DIFF
--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -738,7 +738,13 @@ public static class JavaScriptHostingExtensions
         installArgs ??= GetDefaultYarnInstallArgs(resource, hasYarnLock, hasYarnBerry);
 
         var cacheMount = hasYarnBerry ? ".yarn/cache" : "/root/.cache/yarn";
-        var packageManager = new JavaScriptPackageManagerAnnotation("yarn", runScriptCommand: "run", cacheMount);
+        var packageManager = new JavaScriptPackageManagerAnnotation("yarn", runScriptCommand: "run", cacheMount)
+        {
+            // Yarn doesn't require "--" separator
+            // Yarn v1 strips the separator automatically but produces the warning suggesting to remove it.
+            // Later Yarn versions don't strip the separator and pass it to the script as-is, causing Vite to ignore subsequent arguments.
+            CommandSeparator = null
+        };
         var packageFilesSourcePattern = "package.json";
         if (hasYarnLock)
         {

--- a/tests/Aspire.Hosting.JavaScript.Tests/AddViteAppWithPnpmTests.cs
+++ b/tests/Aspire.Hosting.JavaScript.Tests/AddViteAppWithPnpmTests.cs
@@ -22,7 +22,7 @@ public class AddViteAppWithPnpmTests
 
         // Verify the JavaScriptApp resource exists with pnpm command
         var nodeResource = Assert.Single(appModel.Resources.OfType<JavaScriptAppResource>());
-        
+
         Assert.True(nodeResource.TryGetLastAnnotation<JavaScriptPackageManagerAnnotation>(out var packageManager));
         Assert.Equal("pnpm", packageManager.ExecutableName);
         Assert.Equal("run", packageManager.ScriptCommand);
@@ -96,12 +96,12 @@ public class AddViteAppWithPnpmTests
         var context = new CommandLineArgsCallbackContext(args, nodeResource);
         commandLineArgsAnnotation.Callback(context);
 
-        // Should be: ["run", "dev", "--", "--port", "{port}"]
-        // yarn strips the -- separator before passing to the script, just like npm
+        // Should be: ["run", "dev", "--port", "{port}"]
+        // NOT: ["run", "dev", "--", "--port", "{port}"]
+        // yarn does not strip the -- separator, so we don't include it
         Assert.Collection(args,
             arg => Assert.Equal("run", arg),
             arg => Assert.Equal("dev", arg),
-            arg => Assert.Equal("--", arg),
             arg => Assert.Equal("--port", arg),
             arg => { }); // port value is dynamic
     }


### PR DESCRIPTION
## Description

Don't add '--' argument to yarn, as it confuses Vite

Fixes #13622 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
