### PR TITLE
Persist resource collapsed state

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -235,7 +235,6 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         _onToggleResourceTypeCallback = EventCallback.Factory.Create(this, OnToggleResourceType);
 
         _hideResourceGraph = DashboardOptions.CurrentValue.UI.DisableResourceGraph ?? false;
-        _collapsedResourceNamesKey = BrowserStorageKeys.CollapsedResourceNamesKey(DashboardClient.ApplicationName);
 
         PageViewModel = new ResourcesViewModel
         {
@@ -256,6 +255,10 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             _showHiddenResources = showHiddenResources.Value;
         }
         UpdateMenuButtons();
+
+        // Must wait until after the dashboard is connected so the application name is correct.
+        await DashboardClient.WhenConnected;
+        _collapsedResourceNamesKey = BrowserStorageKeys.CollapsedResourceNamesKey(DashboardClient.ApplicationName);
 
         var collapsedResult = await LocalStorage.GetAsync<List<string>>(_collapsedResourceNamesKey);
         if (collapsedResult.Success)

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -42,6 +42,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     private EventCallback _onToggleCollapseAllCallback;
     private EventCallback _onToggleResourceTypeCallback;
     private bool _hideResourceGraph;
+    private string _collapsedResourceNamesKey = null!;
     private Dictionary<ResourceKey, int>? _resourceUnviewedErrorCounts;
 
     [Inject]
@@ -58,6 +59,8 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     public required IJSRuntime JS { get; init; }
     [Inject]
     public required ISessionStorage SessionStorage { get; init; }
+    [Inject]
+    public required ILocalStorage LocalStorage { get; init; }
     [Inject]
     public required IAIContextProvider AIContextProvider { get; init; }
     [Inject]
@@ -196,6 +199,12 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
     protected override async Task OnInitializedAsync()
     {
+        if (!DashboardClient.IsEnabled)
+        {
+            // Should never reach here.
+            throw new InvalidOperationException("Unable to display the resources page because the dashboard client is not enabled.");
+        }
+
         TelemetryContextProvider.Initialize(TelemetryContext);
         _aiContext = AIContextProvider.AddNew(nameof(Resources), c =>
         {
@@ -226,6 +235,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         _onToggleResourceTypeCallback = EventCallback.Factory.Create(this, OnToggleResourceType);
 
         _hideResourceGraph = DashboardOptions.CurrentValue.UI.DisableResourceGraph ?? false;
+        _collapsedResourceNamesKey = BrowserStorageKeys.CollapsedResourceNamesKey(DashboardClient.ApplicationName);
 
         PageViewModel = new ResourcesViewModel
         {
@@ -247,19 +257,16 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         }
         UpdateMenuButtons();
 
-        if (DashboardClient.IsEnabled)
+        var collapsedResult = await LocalStorage.GetAsync<List<string>>(_collapsedResourceNamesKey);
+        if (collapsedResult.Success)
         {
-            var collapsedResult = await SessionStorage.GetAsync<List<string>>(BrowserStorageKeys.ResourcesCollapsedResourceNames);
-            if (collapsedResult.Success)
+            foreach (var resourceName in collapsedResult.Value)
             {
-                foreach (var resourceName in collapsedResult.Value)
-                {
-                    _collapsedResourceNames.Add(resourceName);
-                }
+                _collapsedResourceNames.Add(resourceName);
             }
-
-            await SubscribeResourcesAsync();
         }
+
+        await SubscribeResourcesAsync();
 
         _logsSubscription = TelemetryRepository.OnNewLogs(null, SubscriptionType.Other, async () =>
         {
@@ -458,7 +465,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         // Rearrange resources based on parent information.
         // This must happen after resources are ordered so nested resources are in the right order.
         // Collapsed resources are filtered out of results.
-        var orderedResources = ResourceGridViewModel.OrderNestedResources(filteredResources.ToList(), r => _collapsedResourceNames.Contains(r.Name))
+        var orderedResources = ResourceGridViewModel.OrderNestedResources(filteredResources.ToList(), r => _collapsedResourceNames.Contains(r.PersistentKey))
             .Where(r => !r.IsHidden)
             .ToList();
 
@@ -539,7 +546,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
     private bool HasCollapsedResources()
     {
-        return _resourceByName.Any(r => !r.Value.IsResourceHidden(_showHiddenResources) && _collapsedResourceNames.Contains(r.Key));
+        return _resourceByName.Any(r => !r.Value.IsResourceHidden(_showHiddenResources) && _collapsedResourceNames.Contains(r.Value.PersistentKey));
     }
 
     private void UpdateMaxHighlightedCount()
@@ -677,7 +684,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
                 {
                     if (_resourceByName.TryGetValue(value, out current))
                     {
-                        _collapsedResourceNames.Remove(value);
+                        _collapsedResourceNames.Remove(current.PersistentKey);
                         continue;
                     }
                 }
@@ -804,14 +811,14 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
         if (viewModel.IsCollapsed)
         {
-            _collapsedResourceNames.Add(viewModel.Resource.Name);
+            _collapsedResourceNames.Add(viewModel.Resource.PersistentKey);
         }
         else
         {
-            _collapsedResourceNames.Remove(viewModel.Resource.Name);
+            _collapsedResourceNames.Remove(viewModel.Resource.PersistentKey);
         }
 
-        await SessionStorage.SetAsync(BrowserStorageKeys.ResourcesCollapsedResourceNames, _collapsedResourceNames.ToList());
+        await LocalStorage.SetAsync(_collapsedResourceNamesKey, _collapsedResourceNames.ToList());
         await _dataGrid.SafeRefreshDataAsync();
         UpdateMenuButtons();
     }
@@ -827,18 +834,18 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         {
             foreach (var resource in resourcesWithChildren)
             {
-                _collapsedResourceNames.Remove(resource.Name);
+                _collapsedResourceNames.Remove(resource.PersistentKey);
             }
         }
         else
         {
             foreach (var resource in resourcesWithChildren)
             {
-                _collapsedResourceNames.Add(resource.Name);
+                _collapsedResourceNames.Add(resource.PersistentKey);
             }
         }
 
-        await SessionStorage.SetAsync(BrowserStorageKeys.ResourcesCollapsedResourceNames, _collapsedResourceNames.ToList());
+        await LocalStorage.SetAsync(_collapsedResourceNamesKey, _collapsedResourceNames.ToList());
         await _dataGrid.SafeRefreshDataAsync();
         UpdateMenuButtons();
     }

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -27,6 +27,7 @@ public sealed class ResourceViewModel
     public required string ResourceType { get; init; }
     public required string DisplayName { get; init; }
     public required string Uid { get; init; }
+    public required int ReplicaIndex { get; init; }
     public required string? State { get; init; }
     public required string? StateStyle { get; init; }
     public required DateTime? CreationTimeStamp { get; init; }
@@ -45,6 +46,12 @@ public sealed class ResourceViewModel
     public string? IconName { get; init; }
     public IconVariant? IconVariant { get; init; }
     public bool IsParameter => string.Equals(ResourceType, KnownResourceTypes.Parameter, StringComparison.Ordinal);
+
+    /// <summary>
+    /// A persistent key for the resource that takes into account replicas.
+    /// This key should be used instead of resource name because the name includes randomly generated suffix that changes each time the app host is restarted.
+    /// </summary>
+    public string PersistentKey { get => field ??= $"{DisplayName}_{ReplicaIndex}"; }
 
     /// <summary>
     /// Gets the cached addresses for this resource that can be used for peer matching.

--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -348,7 +348,7 @@ internal sealed class DashboardClient : IDashboardClient
         Debug.Assert(Monitor.IsEntered(_lock), "Caller must hold _lock.");
 
         // There is no consistent way to know which replica is instance 1 vs instance 2. It shouldn't ever matter.
-        // This index provides an easy way to indentify resources across app runs that takes into account replicas.
+        // This index provides an easy way to identify resources across app runs that takes into account replicas.
         var replicas = _resourceByName.Values.Count(r => r.DisplayName == displayName);
         return replicas + 1;
     }

--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -343,6 +343,16 @@ internal sealed class DashboardClient : IDashboardClient
         }
     }
 
+    private int CalculateReplicaIndex(string displayName)
+    {
+        Debug.Assert(Monitor.IsEntered(_lock), "Caller must hold _lock.");
+
+        // There is no consistent way to know which replica is instance 1 vs instance 2. It shouldn't ever matter.
+        // This index provides an easy way to indentify resources across app runs that takes into account replicas.
+        var replicas = _resourceByName.Values.Count(r => r.DisplayName == displayName);
+        return replicas + 1;
+    }
+
     private async Task<RetryResult> WatchResourcesAsync(RetryContext retryContext, CancellationToken cancellationToken)
     {
         var call = _client!.WatchResources(new WatchResourcesRequest { IsReconnect = retryContext.ErrorCount != 0 }, headers: _headers, cancellationToken: cancellationToken);
@@ -366,7 +376,7 @@ internal sealed class DashboardClient : IDashboardClient
                     foreach (var resource in response.InitialData.Resources)
                     {
                         // Add to map.
-                        var viewModel = resource.ToViewModel(_knownPropertyLookup, _logger);
+                        var viewModel = resource.ToViewModel(CalculateReplicaIndex(resource.DisplayName), _knownPropertyLookup, _logger);
                         _resourceByName[resource.Name] = viewModel;
 
                         // Send this update to any subscribers too.
@@ -386,7 +396,7 @@ internal sealed class DashboardClient : IDashboardClient
                         if (change.KindCase == WatchResourcesChange.KindOneofCase.Upsert)
                         {
                             // Upsert (i.e. add or replace)
-                            var viewModel = change.Upsert.ToViewModel(_knownPropertyLookup, _logger);
+                            var viewModel = change.Upsert.ToViewModel(CalculateReplicaIndex(change.Upsert.DisplayName), _knownPropertyLookup, _logger);
                             _resourceByName[change.Upsert.Name] = viewModel;
                             changes.Add(new(ResourceViewModelChangeType.Upsert, viewModel));
                         }
@@ -791,7 +801,7 @@ internal sealed class DashboardClient : IDashboardClient
             {
                 foreach (var data in initialData)
                 {
-                    _resourceByName[data.Name] = data.ToViewModel(_knownPropertyLookup, _logger);
+                    _resourceByName[data.Name] = data.ToViewModel(CalculateReplicaIndex(data.DisplayName), _knownPropertyLookup, _logger);
                 }
             }
         }

--- a/src/Aspire.Dashboard/ServiceClient/Partials.cs
+++ b/src/Aspire.Dashboard/ServiceClient/Partials.cs
@@ -16,7 +16,7 @@ partial class Resource
     /// <summary>
     /// Converts this gRPC message object to a view model for use in the dashboard UI.
     /// </summary>
-    public ResourceViewModel ToViewModel(IKnownPropertyLookup knownPropertyLookup, ILogger logger)
+    public ResourceViewModel ToViewModel(int replicaIndex, IKnownPropertyLookup knownPropertyLookup, ILogger logger)
     {
         try
         {
@@ -26,6 +26,7 @@ partial class Resource
                 ResourceType = ValidateNotNull(ResourceType),
                 DisplayName = ValidateNotNull(DisplayName),
                 Uid = ValidateNotNull(Uid),
+                ReplicaIndex = replicaIndex,
                 CreationTimeStamp = ValidateNotNull(CreatedAt).ToDateTime(),
                 StartTimeStamp = StartedAt?.ToDateTime(),
                 StopTimeStamp = StoppedAt?.ToDateTime(),

--- a/src/Aspire.Dashboard/Utils/BrowserStorageKeys.cs
+++ b/src/Aspire.Dashboard/Utils/BrowserStorageKeys.cs
@@ -25,6 +25,10 @@ internal static class BrowserStorageKeys
     public const string DashboardTelemetrySettings = "Aspire_Settings_DashboardTelemetry";
     public const string ResourcesShowHiddenResources = "Aspire_Resources_ShowHiddenResources";
 
+    public const string CollapsedResourceNamesKeyPrefix = "Aspire_Resources_CollapsedResourceNames_";
+    public const string SplitterOrientationKeyPrefix = "Aspire_SplitterOrientation_";
+    public const string SplitterSizeKeyPrefix = "Aspire_SplitterSize_";
+
     public static string CollapsedResourceNamesKey(string applicationName)
     {
         ArgumentNullException.ThrowIfNull(applicationName);
@@ -39,16 +43,16 @@ internal static class BrowserStorageKeys
             }
         }
 
-        return $"Aspire_Resources_CollapsedResourceNames_{builder.ToString()}";
+        return $"{CollapsedResourceNamesKeyPrefix}{builder.ToString()}";
     }
 
     public static string SplitterOrientationKey(string viewKey)
     {
-        return $"Aspire_SplitterOrientation_{viewKey}";
+        return $"{SplitterOrientationKeyPrefix}{viewKey}";
     }
 
     public static string SplitterSizeKey(string viewKey, Orientation orientation)
     {
-        return $"Aspire_SplitterSize_{orientation}_{viewKey}";
+        return $"{SplitterSizeKeyPrefix}{orientation}_{viewKey}";
     }
 }

--- a/src/Aspire.Dashboard/Utils/BrowserStorageKeys.cs
+++ b/src/Aspire.Dashboard/Utils/BrowserStorageKeys.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text;
 using Microsoft.FluentUI.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Utils;
@@ -17,13 +18,26 @@ internal static class BrowserStorageKeys
     public const string ResourcesPageState = "Resources_PageState";
     public const string ConsoleLogConsoleSettings = "Aspire_ConsoleLog_ConsoleSettings";
     public const string ConsoleLogFilters = "Aspire_ConsoleLog_Filters";
-    public const string ResourcesCollapsedResourceNames = "Aspire_Resources_CollapsedResourceNames";
     public const string TextVisualizerDialogSettings = "Aspire_TextVisualizerDialog_TextVisualizerDialogSettings";
     public const string ResourcesShowResourceTypes = "Aspire_Resources_ShowResourceTypes";
 
     public const string AssistantChatAssistantSettings = "Aspire_AssistantChat_AssistantSettings";
     public const string DashboardTelemetrySettings = "Aspire_Settings_DashboardTelemetry";
     public const string ResourcesShowHiddenResources = "Aspire_Resources_ShowHiddenResources";
+
+    public static string CollapsedResourceNamesKey(string applicationName)
+    {
+        ArgumentNullException.ThrowIfNull(applicationName);
+
+        var builder = new StringBuilder(applicationName.Length);
+
+        foreach (var character in applicationName)
+        {
+            builder.Append(char.IsLetterOrDigit(character) ? character : '_');
+        }
+
+        return $"Aspire_Resources_CollapsedResourceNames_{builder.ToString()}";
+    }
 
     public static string SplitterOrientationKey(string viewKey)
     {

--- a/src/Aspire.Dashboard/Utils/BrowserStorageKeys.cs
+++ b/src/Aspire.Dashboard/Utils/BrowserStorageKeys.cs
@@ -31,9 +31,12 @@ internal static class BrowserStorageKeys
 
         var builder = new StringBuilder(applicationName.Length);
 
-        foreach (var character in applicationName)
+        foreach (var c in applicationName)
         {
-            builder.Append(char.IsLetterOrDigit(character) ? character : '_');
+            if (char.IsLetterOrDigit(c))
+            {
+                builder.Append(c);
+            }
         }
 
         return $"Aspire_Resources_CollapsedResourceNames_{builder.ToString()}";

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -361,7 +361,8 @@ public partial class ResourcesTests : DashboardTestContext
         ImmutableArray<HealthReportViewModel>? healthReports,
         bool isHidden = false,
         string? stateStyle = null,
-        ImmutableDictionary<string, ResourcePropertyViewModel>? properties = null)
+        ImmutableDictionary<string, ResourcePropertyViewModel>? properties = null,
+        int? replicaIndex = null)
     {
         return new ResourceViewModel
         {
@@ -371,6 +372,7 @@ public partial class ResourcesTests : DashboardTestContext
             KnownState = state is not null && Enum.TryParse<KnownResourceState>(state, out var knownState) ? knownState : null,
             DisplayName = name,
             Uid = name,
+            ReplicaIndex = replicaIndex ?? 0,
             HealthReports = healthReports ?? [],
 
             StateStyle = stateStyle,

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/ResourceSetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/ResourceSetupHelpers.cs
@@ -40,7 +40,7 @@ internal static class ResourceSetupHelpers
         context.JSInterop.SetupVoid("scrollToTop", _ => true);
     }
 
-    public static void SetupResourcesPage(TestContext context, ViewportInformation viewport, IDashboardClient? dashboardClient = null)
+    public static void SetupResourcesPage(TestContext context, ViewportInformation viewport, IDashboardClient? dashboardClient = null, ILocalStorage? localStorage = null)
     {
         FluentUISetupHelpers.SetupFluentDivider(context);
         FluentUISetupHelpers.SetupFluentInputLabel(context);
@@ -54,7 +54,7 @@ internal static class ResourceSetupHelpers
         FluentUISetupHelpers.SetupFluentOverflow(context);
         FluentUISetupHelpers.SetupFluentMenu(context);
 
-        FluentUISetupHelpers.AddCommonDashboardServices(context);
+        FluentUISetupHelpers.AddCommonDashboardServices(context, localStorage: localStorage);
         context.Services.AddSingleton<IconResolver>();
         context.Services.AddSingleton<ILogger<StructuredLogs>>(NullLogger<StructuredLogs>.Instance);
         context.Services.AddSingleton<StructuredLogsViewModel>();

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/TestLocalStorage.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/TestLocalStorage.cs
@@ -9,9 +9,15 @@ public sealed class TestLocalStorage : ILocalStorage
 {
     public Func<string, (bool Success, object? Value)>? OnGetUnprotectedAsync { get; set; }
     public Action<string, object?>? OnSetUnprotectedAsync { get; set; }
+    public Func<string, (bool Success, object? Value)>? OnGetAsync { get; set; }
 
     public Task<StorageResult<T>> GetAsync<T>(string key)
     {
+        if (OnGetAsync is { } callback)
+        {
+            var (success, value) = callback(key);
+            return Task.FromResult(new StorageResult<T>(success: success, value: (T)(value ?? default(T))!));
+        }
         return Task.FromResult(new StorageResult<T>(success: false, value: default));
     }
 

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
@@ -47,7 +47,7 @@ public sealed class ResourceViewModelTests
         };
 
         // Act
-        var vm = resource.ToViewModel(new MockKnownPropertyLookup(), NullLogger.Instance);
+        var vm = ToViewModel(resource);
 
         // Assert
         Assert.Collection(vm.Environment,
@@ -75,7 +75,7 @@ public sealed class ResourceViewModelTests
         };
 
         // Act
-        var vm = resource.ToViewModel(new MockKnownPropertyLookup(), NullLogger.Instance);
+        var vm = ToViewModel(resource);
 
         // Assert
         Assert.Collection(vm.Properties,
@@ -99,7 +99,7 @@ public sealed class ResourceViewModelTests
         };
 
         // Act
-        var ex = Assert.Throws<InvalidOperationException>(() => resource.ToViewModel(new MockKnownPropertyLookup(), NullLogger.Instance));
+        var ex = Assert.Throws<InvalidOperationException>(() => ToViewModel(resource));
 
         // Assert
         Assert.Equal(@"Error converting resource ""TestName-abc"" to ResourceViewModel.", ex.Message);
@@ -125,11 +125,11 @@ public sealed class ResourceViewModelTests
         var kp = new KnownProperty("foo", loc => "bar");
 
         // Act
-        var viewModel = resource.ToViewModel(new MockKnownPropertyLookup(123, kp), NullLogger.Instance);
+        var vm = ToViewModel(resource, knownPropertyLookup: new MockKnownPropertyLookup(123, kp));
 
         // Assert
         Assert.Collection(
-            viewModel.Properties.OrderBy(p => p.Key),
+            vm.Properties.OrderBy(p => p.Key),
             p =>
             {
                 Assert.Equal("Property1", p.Key);
@@ -167,7 +167,7 @@ public sealed class ResourceViewModelTests
         };
 
         // Act
-        var vm = resource.ToViewModel(new MockKnownPropertyLookup(), NullLogger.Instance);
+        var vm = ToViewModel(resource);
 
         // Assert
         Assert.Equal("Database", vm.IconName);
@@ -189,7 +189,7 @@ public sealed class ResourceViewModelTests
         };
 
         // Act
-        var vm = resource.ToViewModel(new MockKnownPropertyLookup(), NullLogger.Instance);
+        var vm = ToViewModel(resource);
 
         // Assert
         Assert.Equal("CloudArrowUp", vm.IconName);
@@ -210,10 +210,15 @@ public sealed class ResourceViewModelTests
         };
 
         // Act
-        var vm = resource.ToViewModel(new MockKnownPropertyLookup(), NullLogger.Instance);
+        var vm = ToViewModel(resource);
 
         // Assert
         Assert.Null(vm.IconName);
         Assert.Null(vm.IconVariant);
+    }
+
+    private static ResourceViewModel ToViewModel(Resource resource, IKnownPropertyLookup? knownPropertyLookup = null)
+    {
+        return resource.ToViewModel(replicaIndex: 0, knownPropertyLookup ?? new MockKnownPropertyLookup(), NullLogger.Instance);
     }
 }

--- a/tests/Shared/DashboardModel/ModelTestHelpers.cs
+++ b/tests/Shared/DashboardModel/ModelTestHelpers.cs
@@ -35,6 +35,7 @@ public static class ModelTestHelpers
             ResourceType = resourceType ?? KnownResourceTypes.Container,
             DisplayName = displayName ?? resourceName ?? "Display name!",
             Uid = Guid.NewGuid().ToString(),
+            ReplicaIndex = 0,
             CreationTimeStamp = DateTime.UtcNow,
             StartTimeStamp = DateTime.UtcNow,
             StopTimeStamp = DateTime.UtcNow,

--- a/tests/Shared/TestDashboardClient.cs
+++ b/tests/Shared/TestDashboardClient.cs
@@ -19,7 +19,7 @@ public class TestDashboardClient : IDashboardClient
     private readonly IList<ResourceViewModel>? _initialResources;
 
     public bool IsEnabled { get; }
-    public Task WhenConnected { get; } = Task.CompletedTask;
+    public Task WhenConnected { get; }
     public string ApplicationName { get; } = "TestApp";
 
     public TestDashboardClient(
@@ -30,10 +30,12 @@ public class TestDashboardClient : IDashboardClient
         Func<Channel<WatchInteractionsResponseUpdate>>? interactionChannelProvider = null,
         Channel<ResourceCommandResponseViewModel>? resourceCommandsChannel = null,
         Channel<WatchInteractionsRequestUpdate>? sendInteractionUpdateChannel = null,
-        IList<ResourceViewModel>? initialResources = null)
+        IList<ResourceViewModel>? initialResources = null,
+        Task? whenConnected = null)
     {
         IsEnabled = isEnabled ?? false;
         ApplicationName = applicationName ?? "TestApp";
+        WhenConnected = whenConnected ?? Task.CompletedTask;
         _consoleLogsChannelProvider = consoleLogsChannelProvider;
         _resourceChannelProvider = resourceChannelProvider;
         _interactionChannelProvider = interactionChannelProvider;


### PR DESCRIPTION
## Description

Change persisting resource collapsed state so it works across dashboard sessions.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
