### PR TITLE
More telemetry export work

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -128,6 +128,7 @@
         </FluentButton>
         <FluentButton IconStart="@(new Icons.Regular.Size16.Delete())"
                       OnClick="RemoveSelectedAsync"
+                      Loading="@_isRemoving"
                       Disabled="@AreNoneSelected()"
                       Title="@Loc[nameof(Dialogs.ManageDataRemoveButtonText)]"
                       aria-label="@Loc[nameof(Dialogs.ManageDataRemoveButtonText)]">
@@ -155,3 +156,8 @@
         </div>
     }
 </div>
+
+@if (!string.IsNullOrEmpty(_errorMessage))
+{
+    <div class="error-message">@_errorMessage</div>
+}

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
-using System.Collections.Immutable;
 using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.ManageData;
@@ -521,12 +520,11 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
             if (consoleLogResourcesToFilter.Count > 0)
             {
                 var filterDate = TimeProvider.GetUtcNow().UtcDateTime;
-                var filters = new ConsoleLogsFilters
+                var filters = ConsoleLogsManager.Filters;
+                foreach (var resourceName in consoleLogResourcesToFilter)
                 {
-                    FilterResourceLogsDates = consoleLogResourcesToFilter
-                        .ToDictionary(r => r, _ => filterDate, StringComparers.ResourceName)
-                        .ToImmutableDictionary()
-                };
+                    filters = filters.WithResourceCleared(resourceName, filterDate);
+                }
                 await ConsoleLogsManager.UpdateFiltersAsync(filters);
             }
         }

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.ManageData;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
+using Aspire.Dashboard.Telemetry;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
@@ -52,6 +54,9 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
     [Inject]
     public required IStringLocalizer<ControlsStrings> ControlsStringsLoc { get; init; }
 
+    [Inject]
+    public required ITelemetryErrorRecorder ErrorRecorder { get; init; }
+
     private readonly ConcurrentDictionary<string, ResourceViewModel> _resourceByName = new(StringComparers.ResourceName);
     private readonly Dictionary<string, ResourceDataRow> _resourceDataRows = new(StringComparers.ResourceName);
     private readonly HashSet<string> _expandedResourceNames = new(StringComparers.ResourceName);
@@ -63,6 +68,8 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
     private Task? _resourceSubscriptionTask;
     private FluentDataGrid<ManageDataGridItem>? _dataGrid;
     private bool _isExporting;
+    private bool _isRemoving;
+    private string? _errorMessage;
     private bool _isImporting;
     private Subscription? _resourcesSubscription;
 
@@ -489,25 +496,49 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
 
     private async Task RemoveSelectedAsync()
     {
-        var selectedResources = GetSelectedResourcesAndDataTypes();
-
-        // Clear telemetry signals via repository
-        TelemetryRepository.ClearSelectedSignals(selectedResources);
-
-        // Handle console logs filtering separately (not stored in TelemetryRepository)
-        var consoleLogResourcesToFilter = selectedResources
-            .Where(kvp => kvp.Value.Contains(AspireDataType.ConsoleLogs))
-            .Select(kvp => kvp.Key)
-            .ToList();
-
-        if (consoleLogResourcesToFilter.Count > 0)
+        if (_isRemoving)
         {
-            var filterDate = TimeProvider.GetUtcNow().UtcDateTime;
-            var filters = new ConsoleLogsFilters
+            return;
+        }
+
+        _isRemoving = true;
+        _errorMessage = null;
+        StateHasChanged();
+
+        try
+        {
+            var selectedResources = GetSelectedResourcesAndDataTypes();
+
+            // Clear telemetry signals via repository
+            TelemetryRepository.ClearSelectedSignals(selectedResources);
+
+            // Handle console logs filtering separately (not stored in TelemetryRepository)
+            var consoleLogResourcesToFilter = selectedResources
+                .Where(kvp => kvp.Value.Contains(AspireDataType.ConsoleLogs))
+                .Select(kvp => kvp.Key)
+                .ToList();
+
+            if (consoleLogResourcesToFilter.Count > 0)
             {
-                FilterResourceLogsDates = consoleLogResourcesToFilter.ToDictionary(r => r, _ => filterDate, StringComparers.ResourceName)
-            };
-            await ConsoleLogsManager.UpdateFiltersAsync(filters);
+                var filterDate = TimeProvider.GetUtcNow().UtcDateTime;
+                var filters = new ConsoleLogsFilters
+                {
+                    FilterResourceLogsDates = consoleLogResourcesToFilter
+                        .ToDictionary(r => r, _ => filterDate, StringComparers.ResourceName)
+                        .ToImmutableDictionary()
+                };
+                await ConsoleLogsManager.UpdateFiltersAsync(filters);
+            }
+        }
+        catch (Exception ex)
+        {
+            _errorMessage = $"{Loc[nameof(Resources.Dialogs.ManageDataRemoveErrorMessage)]}: {ex.Message}";
+            ErrorRecorder.RecordError("Failed to remove data", ex, writeToLogging: true);
+        }
+        finally
+        {
+            _isRemoving = false;
+            StateHasChanged();
         }
 
         await OnTelemetryChangedAsync();
@@ -549,6 +580,7 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
         }
 
         _isExporting = true;
+        _errorMessage = null;
         StateHasChanged();
 
         try
@@ -559,6 +591,11 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
 
             using var streamRef = new DotNetStreamReference(memoryStream, leaveOpen: false);
             await JS.InvokeVoidAsync("downloadStreamAsFile", fileName, streamRef);
+        }
+        catch (Exception ex)
+        {
+            _errorMessage = $"{Loc[nameof(Resources.Dialogs.ManageDataExportErrorMessage)]}: {ex.Message}";
+            ErrorRecorder.RecordError("Failed to export data", ex, writeToLogging: true);
         }
         finally
         {

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
@@ -547,6 +547,7 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
     private void OnInputFileProgressChange(FluentInputFileEventArgs args)
     {
         _isImporting = true;
+        _errorMessage = null;
     }
 
     private async Task OnInputFileCompleted(IEnumerable<FluentInputFileEventArgs> args)
@@ -564,6 +565,11 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
                     await OnTelemetryChangedAsync();
                 }
             }
+        }
+        catch (Exception ex)
+        {
+            _errorMessage = $"{Loc[nameof(Resources.Dialogs.ManageDataImportErrorMessage)]}: {ex.Message}";
+            ErrorRecorder.RecordError("Failed to import data", ex, writeToLogging: true);
         }
         finally
         {

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.css
@@ -19,3 +19,9 @@
     grid-template-columns: 1fr auto;
     margin-top: 16px;
 }
+
+.error-message {
+    color: var(--error);
+    font-size: var(--type-ramp-minus-1-font-size);
+    margin-top: 8px;
+}

--- a/src/Aspire.Dashboard/ConsoleLogs/LogEntrySerializer.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/LogEntrySerializer.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ConsoleLogs;
+
+namespace Aspire.Dashboard.ConsoleLogs;
+
+/// <summary>
+/// Provides methods for serializing log entries to text.
+/// </summary>
+internal static class LogEntrySerializer
+{
+    /// <summary>
+    /// Writes a collection of log entries to a stream, stripping ANSI control sequences.
+    /// </summary>
+    /// <param name="entries">The log entries to serialize.</param>
+    /// <param name="stream">The stream to write to.</param>
+    public static void WriteLogEntriesToStream(IList<LogEntry> entries, Stream stream)
+    {
+        using var writer = new StreamWriter(stream, leaveOpen: true);
+
+        foreach (var entry in entries)
+        {
+            if (entry.Type is LogEntryType.Pause)
+            {
+                continue;
+            }
+
+            if (entry.RawContent is not null)
+            {
+                writer.WriteLine(AnsiParser.StripControlSequences(entry.RawContent));
+            }
+            else
+            {
+                writer.WriteLine();
+            }
+        }
+
+        writer.Flush();
+    }
+}

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -304,6 +304,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         // ShortcutManager is scoped because we want shortcuts to apply one browser window.
         builder.Services.AddScoped<ShortcutManager>();
         builder.Services.AddScoped<ConsoleLogsManager>();
+        builder.Services.AddScoped<ConsoleLogsFetcher>();
         builder.Services.AddScoped<TelemetryExportService>();
         builder.Services.AddScoped<TelemetryImportService>();
         builder.Services.AddSingleton<IInstrumentUnitResolver, DefaultInstrumentUnitResolver>();

--- a/src/Aspire.Dashboard/Model/ConsoleLogsFetcher.cs
+++ b/src/Aspire.Dashboard/Model/ConsoleLogsFetcher.cs
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.ConsoleLogs;
+using Aspire.Hosting.ConsoleLogs;
+
+namespace Aspire.Dashboard.Model;
+
+/// <summary>
+/// Fetches console logs from the dashboard client and converts them to log entries.
+/// </summary>
+public sealed class ConsoleLogsFetcher
+{
+    private readonly IDashboardClient _dashboardClient;
+    private readonly ConsoleLogsManager _consoleLogsManager;
+
+    public bool IsEnabled => _dashboardClient.IsEnabled;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConsoleLogsFetcher"/> class.
+    /// </summary>
+    /// <param name="dashboardClient">The dashboard client.</param>
+    /// <param name="consoleLogsManager">The console logs manager.</param>
+    public ConsoleLogsFetcher(IDashboardClient dashboardClient, ConsoleLogsManager consoleLogsManager)
+    {
+        _dashboardClient = dashboardClient;
+        _consoleLogsManager = consoleLogsManager;
+    }
+
+    private async Task<List<LogEntry>> FetchLogEntriesAsync(string resourceName, DateTime? filterDate, CancellationToken cancellationToken)
+    {
+        var logEntries = new List<LogEntry>();
+        var logParser = new LogParser(ConsoleColor.Black);
+
+        await foreach (var batch in _dashboardClient.GetConsoleLogs(resourceName, cancellationToken).ConfigureAwait(false))
+        {
+            foreach (var logLine in batch)
+            {
+                var logEntry = logParser.CreateLogEntry(logLine.Content, logLine.IsErrorMessage, resourcePrefix: null);
+
+                // Apply filter if specified
+                if (filterDate is not null && logEntry.Timestamp is not null && logEntry.Timestamp <= filterDate)
+                {
+                    continue;
+                }
+
+                logEntries.Add(logEntry);
+            }
+        }
+
+        return logEntries;
+    }
+
+    /// <summary>
+    /// Fetches console logs for all resources and converts them to log entries.
+    /// </summary>
+    public async Task<Dictionary<string, List<LogEntry>>> FetchLogEntriesAsync(HashSet<string> resourceNames, CancellationToken cancellationToken)
+    {
+        if (!_dashboardClient.IsEnabled)
+        {
+            throw new InvalidOperationException("Can't fetch console logs when the dashboard client is not enabled.");
+        }
+
+        var resources = _dashboardClient.GetResources().Where(r => resourceNames.Contains(r.Name)).ToList();
+        var result = new Dictionary<string, List<LogEntry>>(StringComparer.OrdinalIgnoreCase);
+
+        // Fetch logs for all resources in parallel
+        var logTasks = resources.Select(async resource =>
+        {
+            var filterDate = _consoleLogsManager.GetFilterDate(resource.Name);
+            var logEntries = await FetchLogEntriesAsync(resource.Name, filterDate, cancellationToken).ConfigureAwait(false);
+            var resourceName = ResourceViewModel.GetResourceName(resource, resources);
+            return (ResourceName: resourceName, LogEntries: logEntries);
+        });
+
+        var results = await Task.WhenAll(logTasks).ConfigureAwait(false);
+
+        foreach (var (resourceName, logEntries) in results)
+        {
+            if (logEntries.Count > 0)
+            {
+                result[resourceName] = logEntries;
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/Aspire.Dashboard/Model/ConsoleLogsFilters.cs
+++ b/src/Aspire.Dashboard/Model/ConsoleLogsFilters.cs
@@ -1,27 +1,66 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Aspire.Dashboard.Model;
 
 /// <summary>
 /// Immutable filters for console logs. This type is serialized to browser storage.
 /// </summary>
-public sealed record ConsoleLogsFilters
+public sealed class ConsoleLogsFilters
 {
-    public DateTime? FilterAllLogsDate { get; init; }
-    public ImmutableDictionary<string, DateTime> FilterResourceLogsDates { get; init; } = ImmutableDictionary<string, DateTime>.Empty;
+    public static readonly ConsoleLogsFilters Default = new()
+    {
+        FilterAllLogsDate = null,
+        FilterResourceLogsDates = new Dictionary<string, DateTime>()
+    };
+
+    private Dictionary<string, DateTime> _filterResourceLogsDates = default!;
+
+    public required DateTime? FilterAllLogsDate { get; init; }
+
+    public required IReadOnlyDictionary<string, DateTime> FilterResourceLogsDates
+    {
+        get => _filterResourceLogsDates;
+        init
+        {
+            _filterResourceLogsDates = value is Dictionary<string, DateTime> newDictionary
+                ? newDictionary
+                : new Dictionary<string, DateTime>(value, StringComparers.ResourceName);
+        }
+    }
 
     /// <summary>
     /// Creates new filters with all logs cleared at the specified date.
     /// </summary>
     public static ConsoleLogsFilters CreateClearAll(DateTime clearDate) =>
-        new() { FilterAllLogsDate = clearDate, FilterResourceLogsDates = ImmutableDictionary<string, DateTime>.Empty };
+        new() { FilterAllLogsDate = clearDate, FilterResourceLogsDates = new Dictionary<string, DateTime>() };
 
     /// <summary>
     /// Creates new filters based on this instance with a specific resource cleared at the specified date.
     /// </summary>
-    public ConsoleLogsFilters WithResourceCleared(string resourceName, DateTime clearDate) =>
-        this with { FilterResourceLogsDates = FilterResourceLogsDates.SetItem(resourceName, clearDate) };
+    public ConsoleLogsFilters WithResourceCleared(string resourceName, DateTime clearDate)
+    {
+        var newDictionary = new Dictionary<string, DateTime>(_filterResourceLogsDates, StringComparers.ResourceName)
+        {
+            [resourceName] = clearDate
+        };
+        return new ConsoleLogsFilters { FilterAllLogsDate = FilterAllLogsDate, FilterResourceLogsDates = newDictionary };
+    }
+
+    /// <summary>
+    /// Tries to get the filter date for a specific resource.
+    /// </summary>
+    public bool TryGetResourceFilterDate(string resourceName, [NotNullWhen(true)] out DateTime? filterDate)
+    {
+        if (_filterResourceLogsDates.TryGetValue(resourceName, out var date))
+        {
+            filterDate = date;
+            return true;
+        }
+
+        filterDate = null;
+        return false;
+    }
 }

--- a/src/Aspire.Dashboard/Model/ConsoleLogsFilters.cs
+++ b/src/Aspire.Dashboard/Model/ConsoleLogsFilters.cs
@@ -1,11 +1,27 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
+
 namespace Aspire.Dashboard.Model;
 
-// This type is serialized to browser storage.
-public sealed class ConsoleLogsFilters
+/// <summary>
+/// Immutable filters for console logs. This type is serialized to browser storage.
+/// </summary>
+public sealed record ConsoleLogsFilters
 {
-    public DateTime? FilterAllLogsDate { get; set; }
-    public Dictionary<string, DateTime> FilterResourceLogsDates { get; set; } = [];
+    public DateTime? FilterAllLogsDate { get; init; }
+    public ImmutableDictionary<string, DateTime> FilterResourceLogsDates { get; init; } = ImmutableDictionary<string, DateTime>.Empty;
+
+    /// <summary>
+    /// Creates new filters with all logs cleared at the specified date.
+    /// </summary>
+    public static ConsoleLogsFilters CreateClearAll(DateTime clearDate) =>
+        new() { FilterAllLogsDate = clearDate, FilterResourceLogsDates = ImmutableDictionary<string, DateTime>.Empty };
+
+    /// <summary>
+    /// Creates new filters based on this instance with a specific resource cleared at the specified date.
+    /// </summary>
+    public ConsoleLogsFilters WithResourceCleared(string resourceName, DateTime clearDate) =>
+        this with { FilterResourceLogsDates = FilterResourceLogsDates.SetItem(resourceName, clearDate) };
 }

--- a/src/Aspire.Dashboard/Model/ConsoleLogsManager.cs
+++ b/src/Aspire.Dashboard/Model/ConsoleLogsManager.cs
@@ -101,4 +101,26 @@ public sealed class ConsoleLogsManager
             await subscription.ExecuteAsync().ConfigureAwait(false);
         }
     }
+
+    /// <summary>
+    /// Gets the filter date for a resource based on the current filters.
+    /// </summary>
+    /// <param name="resourceName">The resource name.</param>
+    /// <returns>The filter date, or null if no filter applies.</returns>
+    public DateTime? GetFilterDate(string resourceName)
+    {
+        if (!_hasInitialized || _filters is null)
+        {
+            return null;
+        }
+
+        // Check for resource-specific filter first
+        if (_filters.FilterResourceLogsDates.TryGetValue(resourceName, out var resourceFilterDate))
+        {
+            return resourceFilterDate;
+        }
+
+        // Fall back to global filter
+        return _filters.FilterAllLogsDate;
+    }
 }

--- a/src/Aspire.Dashboard/Model/ConsoleLogsManager.cs
+++ b/src/Aspire.Dashboard/Model/ConsoleLogsManager.cs
@@ -45,7 +45,7 @@ public sealed class ConsoleLogsManager
         if (!_hasInitialized)
         {
             var filtersResult = await _sessionStorage.GetAsync<ConsoleLogsFilters>(BrowserStorageKeys.ConsoleLogFilters).ConfigureAwait(false);
-            _filters = filtersResult.Success ? filtersResult.Value : new();
+            _filters = filtersResult.Success ? filtersResult.Value : ConsoleLogsFilters.Default;
 
             _hasInitialized = true;
         }
@@ -115,7 +115,7 @@ public sealed class ConsoleLogsManager
         }
 
         // Check for resource-specific filter first
-        if (_filters.FilterResourceLogsDates.TryGetValue(resourceName, out var resourceFilterDate))
+        if (_filters.TryGetResourceFilterDate(resourceName, out var resourceFilterDate))
         {
             return resourceFilterDate;
         }

--- a/src/Aspire.Dashboard/Model/TelemetryExportService.cs
+++ b/src/Aspire.Dashboard/Model/TelemetryExportService.cs
@@ -4,6 +4,7 @@
 using System.IO.Compression;
 using System.Text;
 using System.Text.Json;
+using Aspire.Dashboard.ConsoleLogs;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Model.Serialization;
 using Aspire.Dashboard.Otlp.Storage;
@@ -16,17 +17,17 @@ namespace Aspire.Dashboard.Model;
 public sealed class TelemetryExportService
 {
     private readonly TelemetryRepository _telemetryRepository;
-    private readonly IDashboardClient _dashboardClient;
+    private readonly ConsoleLogsFetcher _consoleLogsFetcher;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TelemetryExportService"/> class.
     /// </summary>
     /// <param name="telemetryRepository">The telemetry repository.</param>
-    /// <param name="dashboardClient">The dashboard client.</param>
-    public TelemetryExportService(TelemetryRepository telemetryRepository, IDashboardClient dashboardClient)
+    /// <param name="consoleLogsFetcher">The console log fetcher.</param>
+    public TelemetryExportService(TelemetryRepository telemetryRepository, ConsoleLogsFetcher consoleLogsFetcher)
     {
         _telemetryRepository = telemetryRepository;
-        _dashboardClient = dashboardClient;
+        _consoleLogsFetcher = consoleLogsFetcher;
     }
 
     /// <summary>
@@ -90,50 +91,21 @@ public sealed class TelemetryExportService
         return memoryStream;
     }
 
-    private async Task ExportConsoleLogsAsync(ZipArchive archive, HashSet<string>? resourceFilter, CancellationToken cancellationToken)
+    private async Task ExportConsoleLogsAsync(ZipArchive archive, HashSet<string> resourceNames, CancellationToken cancellationToken)
     {
-        if (!_dashboardClient.IsEnabled)
+        if (!_consoleLogsFetcher.IsEnabled)
         {
             return;
         }
 
-        var resources = _dashboardClient.GetResources();
-
-        // Filter resources if a filter is provided
-        if (resourceFilter is not null)
-        {
-            resources = resources.Where(r => resourceFilter.Contains(r.Name)).ToList();
-        }
-
-        // Fetch console logs for all resources in parallel
-        var logTasks = resources.Select(async resource =>
-        {
-            var logs = new StringBuilder();
-
-            await foreach (var logBatch in _dashboardClient.GetConsoleLogs(resource.Name, cancellationToken).ConfigureAwait(false))
-            {
-                foreach (var logLine in logBatch)
-                {
-                    logs.AppendLine(logLine.Content);
-                }
-            }
-
-            return (Resource: resource, Logs: logs);
-        });
-
-        var results = await Task.WhenAll(logTasks).ConfigureAwait(false);
+        var allLogEntries = await _consoleLogsFetcher.FetchLogEntriesAsync(resourceNames, cancellationToken).ConfigureAwait(false);
 
         // Write results to archive sequentially (ZipArchive is not thread-safe)
-        foreach (var (resource, logs) in results)
+        foreach (var (resourceName, logEntries) in allLogEntries)
         {
-            if (logs.Length > 0)
-            {
-                var resourceName = ResourceViewModel.GetResourceName(resource, _dashboardClient.GetResources());
-                var entry = archive.CreateEntry($"consolelogs/{SanitizeFileName(resourceName)}.txt");
-                using var entryStream = entry.Open();
-                using var writer = new StreamWriter(entryStream, Encoding.UTF8);
-                await writer.WriteAsync(logs.ToString()).ConfigureAwait(false);
-            }
+            var entry = archive.CreateEntry($"consolelogs/{SanitizeFileName(resourceName)}.txt");
+            using var entryStream = entry.Open();
+            LogEntrySerializer.WriteLogEntriesToStream(logEntries, entryStream);
         }
     }
 

--- a/src/Aspire.Dashboard/Otlp/Model/Serialization/OtlpJsonSerializerContext.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/Serialization/OtlpJsonSerializerContext.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -67,6 +68,7 @@ internal sealed partial class OtlpJsonSerializerContext : JsonSerializerContext
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         WriteIndented = false,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
         TypeInfoResolver = Default
     };
 
@@ -78,6 +80,7 @@ internal sealed partial class OtlpJsonSerializerContext : JsonSerializerContext
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         WriteIndented = true,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
         TypeInfoResolver = Default
     };
 }

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -772,6 +772,15 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to import data.
+        /// </summary>
+        public static string ManageDataImportErrorMessage {
+            get {
+                return ResourceManager.GetString("ManageDataImportErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Manage.
         /// </summary>
         public static string ManageDataManageButtonText {

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -736,6 +736,114 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Console logs.
+        /// </summary>
+        public static string ManageDataConsoleLogs {
+            get {
+                return ResourceManager.GetString("ManageDataConsoleLogs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Manage logs and telemetry.
+        /// </summary>
+        public static string ManageDataDialogTitle {
+            get {
+                return ResourceManager.GetString("ManageDataDialogTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Export selected.
+        /// </summary>
+        public static string ManageDataExportButtonText {
+            get {
+                return ResourceManager.GetString("ManageDataExportButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to export data.
+        /// </summary>
+        public static string ManageDataExportErrorMessage {
+            get {
+                return ResourceManager.GetString("ManageDataExportErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Manage.
+        /// </summary>
+        public static string ManageDataManageButtonText {
+            get {
+                return ResourceManager.GetString("ManageDataManageButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Metrics.
+        /// </summary>
+        public static string ManageDataMetrics {
+            get {
+                return ResourceManager.GetString("ManageDataMetrics", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No resources found.
+        /// </summary>
+        public static string ManageDataNoResources {
+            get {
+                return ResourceManager.GetString("ManageDataNoResources", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove selected.
+        /// </summary>
+        public static string ManageDataRemoveButtonText {
+            get {
+                return ResourceManager.GetString("ManageDataRemoveButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to remove data.
+        /// </summary>
+        public static string ManageDataRemoveErrorMessage {
+            get {
+                return ResourceManager.GetString("ManageDataRemoveErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Structured logs.
+        /// </summary>
+        public static string ManageDataStructuredLogs {
+            get {
+                return ResourceManager.GetString("ManageDataStructuredLogs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Summary.
+        /// </summary>
+        public static string ManageDataSummaryColumnHeader {
+            get {
+                return ResourceManager.GetString("ManageDataSummaryColumnHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Traces.
+        /// </summary>
+        public static string ManageDataTraces {
+            get {
+                return ResourceManager.GetString("ManageDataTraces", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Aspire MCP API key.
         /// </summary>
         public static string McpServerDialogApiKeyLabel {
@@ -1114,20 +1222,11 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to export data.
+        ///   Looks up a localized string similar to Import logs and telemetry.
         /// </summary>
-        public static string ManageDataExportErrorMessage {
+        public static string SettingsImportButtonText {
             get {
-                return ResourceManager.GetString("ManageDataExportErrorMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Failed to remove data.
-        /// </summary>
-        public static string ManageDataRemoveErrorMessage {
-            get {
-                return ResourceManager.GetString("ManageDataRemoveErrorMessage", resourceCulture);
+                return ResourceManager.GetString("SettingsImportButtonText", resourceCulture);
             }
         }
         
@@ -1137,15 +1236,6 @@ namespace Aspire.Dashboard.Resources {
         public static string SettingsRemoveAllButtonText {
             get {
                 return ResourceManager.GetString("SettingsRemoveAllButtonText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Import logs and telemetry.
-        /// </summary>
-        public static string SettingsImportButtonText {
-            get {
-                return ResourceManager.GetString("SettingsImportButtonText", resourceCulture);
             }
         }
         
@@ -1209,96 +1299,6 @@ namespace Aspire.Dashboard.Resources {
         public static string TextVisualizerSelectFormatType {
             get {
                 return ResourceManager.GetString("TextVisualizerSelectFormatType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Manage logs and telemetry.
-        /// </summary>
-        public static string ManageDataDialogTitle {
-            get {
-                return ResourceManager.GetString("ManageDataDialogTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Console logs.
-        /// </summary>
-        public static string ManageDataConsoleLogs {
-            get {
-                return ResourceManager.GetString("ManageDataConsoleLogs", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Metrics.
-        /// </summary>
-        public static string ManageDataMetrics {
-            get {
-                return ResourceManager.GetString("ManageDataMetrics", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Structured logs.
-        /// </summary>
-        public static string ManageDataStructuredLogs {
-            get {
-                return ResourceManager.GetString("ManageDataStructuredLogs", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Traces.
-        /// </summary>
-        public static string ManageDataTraces {
-            get {
-                return ResourceManager.GetString("ManageDataTraces", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Manage.
-        /// </summary>
-        public static string ManageDataManageButtonText {
-            get {
-                return ResourceManager.GetString("ManageDataManageButtonText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Export selected.
-        /// </summary>
-        public static string ManageDataExportButtonText {
-            get {
-                return ResourceManager.GetString("ManageDataExportButtonText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to No resources found.
-        /// </summary>
-        public static string ManageDataNoResources {
-            get {
-                return ResourceManager.GetString("ManageDataNoResources", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Remove selected.
-        /// </summary>
-        public static string ManageDataRemoveButtonText {
-            get {
-                return ResourceManager.GetString("ManageDataRemoveButtonText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Summary.
-        /// </summary>
-        public static string ManageDataSummaryColumnHeader {
-            get {
-                return ResourceManager.GetString("ManageDataSummaryColumnHeader", resourceCulture);
             }
         }
     }

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -1105,20 +1105,38 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove all.
-        /// </summary>
-        public static string SettingsRemoveAllButtonText {
-            get {
-                return ResourceManager.GetString("SettingsRemoveAllButtonText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Export all.
         /// </summary>
         public static string SettingsExportAllButtonText {
             get {
                 return ResourceManager.GetString("SettingsExportAllButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to export data.
+        /// </summary>
+        public static string ManageDataExportErrorMessage {
+            get {
+                return ResourceManager.GetString("ManageDataExportErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to remove data.
+        /// </summary>
+        public static string ManageDataRemoveErrorMessage {
+            get {
+                return ResourceManager.GetString("ManageDataRemoveErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove all.
+        /// </summary>
+        public static string SettingsRemoveAllButtonText {
+            get {
+                return ResourceManager.GetString("SettingsRemoveAllButtonText", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -280,6 +280,9 @@
   <data name="ManageDataExportErrorMessage" xml:space="preserve">
     <value>Failed to export data</value>
   </data>
+  <data name="ManageDataImportErrorMessage" xml:space="preserve">
+    <value>Failed to import data</value>
+  </data>
   <data name="ManageDataRemoveErrorMessage" xml:space="preserve">
     <value>Failed to remove data</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -277,6 +277,12 @@
   <data name="SettingsImportButtonText" xml:space="preserve">
     <value>Import logs and telemetry</value>
   </data>
+  <data name="ManageDataExportErrorMessage" xml:space="preserve">
+    <value>Failed to export data</value>
+  </data>
+  <data name="ManageDataRemoveErrorMessage" xml:space="preserve">
+    <value>Failed to remove data</value>
+  </data>
   <data name="TextVisualizerSecretWarningTitle" xml:space="preserve">
     <value>Sensitive value hidden</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -392,6 +392,11 @@
         <target state="new">Export selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataImportErrorMessage">
+        <source>Failed to import data</source>
+        <target state="new">Failed to import data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -642,6 +642,16 @@
         <target state="new">Import logs and telemetry</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataExportErrorMessage">
+        <source>Failed to export data</source>
+        <target state="new">Failed to export data</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveErrorMessage">
+        <source>Failed to remove data</source>
+        <target state="new">Failed to remove data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsRemoveAllButtonText">
         <source>Remove all</source>
         <target state="translated">Odebrat vše</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -397,6 +397,11 @@
         <target state="new">Failed to export data</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataImportErrorMessage">
+        <source>Failed to import data</source>
+        <target state="new">Failed to import data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -392,6 +392,11 @@
         <target state="new">Export selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataExportErrorMessage">
+        <source>Failed to export data</source>
+        <target state="new">Failed to export data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -410,6 +415,11 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveErrorMessage">
+        <source>Failed to remove data</source>
+        <target state="new">Failed to remove data</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -397,6 +397,11 @@
         <target state="new">Failed to export data</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataImportErrorMessage">
+        <source>Failed to import data</source>
+        <target state="new">Failed to import data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -392,6 +392,11 @@
         <target state="new">Export selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataExportErrorMessage">
+        <source>Failed to export data</source>
+        <target state="new">Failed to export data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -410,6 +415,11 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveErrorMessage">
+        <source>Failed to remove data</source>
+        <target state="new">Failed to remove data</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -397,6 +397,11 @@
         <target state="new">Failed to export data</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataImportErrorMessage">
+        <source>Failed to import data</source>
+        <target state="new">Failed to import data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -392,6 +392,11 @@
         <target state="new">Export selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataExportErrorMessage">
+        <source>Failed to export data</source>
+        <target state="new">Failed to export data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -410,6 +415,11 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveErrorMessage">
+        <source>Failed to remove data</source>
+        <target state="new">Failed to remove data</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -397,6 +397,11 @@
         <target state="new">Failed to export data</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataImportErrorMessage">
+        <source>Failed to import data</source>
+        <target state="new">Failed to import data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -392,6 +392,11 @@
         <target state="new">Export selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataExportErrorMessage">
+        <source>Failed to export data</source>
+        <target state="new">Failed to export data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -410,6 +415,11 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveErrorMessage">
+        <source>Failed to remove data</source>
+        <target state="new">Failed to remove data</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -397,6 +397,11 @@
         <target state="new">Failed to export data</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataImportErrorMessage">
+        <source>Failed to import data</source>
+        <target state="new">Failed to import data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -392,6 +392,11 @@
         <target state="new">Export selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataExportErrorMessage">
+        <source>Failed to export data</source>
+        <target state="new">Failed to export data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -410,6 +415,11 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveErrorMessage">
+        <source>Failed to remove data</source>
+        <target state="new">Failed to remove data</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -397,6 +397,11 @@
         <target state="new">Failed to export data</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataImportErrorMessage">
+        <source>Failed to import data</source>
+        <target state="new">Failed to import data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -392,6 +392,11 @@
         <target state="new">Export selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataExportErrorMessage">
+        <source>Failed to export data</source>
+        <target state="new">Failed to export data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -410,6 +415,11 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveErrorMessage">
+        <source>Failed to remove data</source>
+        <target state="new">Failed to remove data</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -397,6 +397,11 @@
         <target state="new">Failed to export data</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataImportErrorMessage">
+        <source>Failed to import data</source>
+        <target state="new">Failed to import data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -392,6 +392,11 @@
         <target state="new">Export selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataExportErrorMessage">
+        <source>Failed to export data</source>
+        <target state="new">Failed to export data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -410,6 +415,11 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveErrorMessage">
+        <source>Failed to remove data</source>
+        <target state="new">Failed to remove data</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -397,6 +397,11 @@
         <target state="new">Failed to export data</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataImportErrorMessage">
+        <source>Failed to import data</source>
+        <target state="new">Failed to import data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -392,6 +392,11 @@
         <target state="new">Export selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataExportErrorMessage">
+        <source>Failed to export data</source>
+        <target state="new">Failed to export data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -410,6 +415,11 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveErrorMessage">
+        <source>Failed to remove data</source>
+        <target state="new">Failed to remove data</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -397,6 +397,11 @@
         <target state="new">Failed to export data</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataImportErrorMessage">
+        <source>Failed to import data</source>
+        <target state="new">Failed to import data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -392,6 +392,11 @@
         <target state="new">Export selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataExportErrorMessage">
+        <source>Failed to export data</source>
+        <target state="new">Failed to export data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -410,6 +415,11 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveErrorMessage">
+        <source>Failed to remove data</source>
+        <target state="new">Failed to remove data</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -397,6 +397,11 @@
         <target state="new">Failed to export data</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataImportErrorMessage">
+        <source>Failed to import data</source>
+        <target state="new">Failed to import data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -392,6 +392,11 @@
         <target state="new">Export selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataExportErrorMessage">
+        <source>Failed to export data</source>
+        <target state="new">Failed to export data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -410,6 +415,11 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveErrorMessage">
+        <source>Failed to remove data</source>
+        <target state="new">Failed to remove data</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -397,6 +397,11 @@
         <target state="new">Failed to export data</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataImportErrorMessage">
+        <source>Failed to import data</source>
+        <target state="new">Failed to import data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -392,6 +392,11 @@
         <target state="new">Export selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataExportErrorMessage">
+        <source>Failed to export data</source>
+        <target state="new">Failed to export data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -410,6 +415,11 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveErrorMessage">
+        <source>Failed to remove data</source>
+        <target state="new">Failed to remove data</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -397,6 +397,11 @@
         <target state="new">Failed to export data</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataImportErrorMessage">
+        <source>Failed to import data</source>
+        <target state="new">Failed to import data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -392,6 +392,11 @@
         <target state="new">Export selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataExportErrorMessage">
+        <source>Failed to export data</source>
+        <target state="new">Failed to export data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -410,6 +415,11 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveErrorMessage">
+        <source>Failed to remove data</source>
+        <target state="new">Failed to remove data</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataStructuredLogs">

--- a/tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj
+++ b/tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj
@@ -27,6 +27,7 @@
     <Compile Include="$(TestsSharedDir)TestAIContextProvider.cs" Link="shared/TestAIContextProvider.cs" />
     <Compile Include="$(TestsSharedDir)TestStringLocalizer.cs" Link="shared/TestStringLocalizer.cs" />
     <Compile Include="$(TestsSharedDir)TestDashboardClient.cs" Link="shared/TestDashboardClient.cs" />
+    <Compile Include="$(TestsSharedDir)TestSessionStorage.cs" Link="shared/TestSessionStorage.cs" />
     <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" Link="shared/AsyncTestHelpers.cs" />
     <Compile Include="$(TestsSharedDir)Telemetry\*.cs" LinkBase="shared/Telemetry" />
     <Compile Include="$(TestsSharedDir)Logging\*.cs" LinkBase="shared/Logging" />

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -528,7 +528,7 @@ public partial class ConsoleLogsTests : DashboardTestContext
         var earliestEntry = instance._logEntries.GetEntries()[0];
         timeProvider.UtcNow = earliestEntry.Timestamp!.Value;
 
-        await consoleLogsManager.UpdateFiltersAsync(new ConsoleLogsFilters { FilterAllLogsDate = earliestEntry.Timestamp!.Value });
+        await consoleLogsManager.UpdateFiltersAsync(new ConsoleLogsFilters { FilterAllLogsDate = earliestEntry.Timestamp!.Value, FilterResourceLogsDates = new Dictionary<string, DateTime>() });
 
         cut.WaitForState(() => instance._logEntries.EntriesCount == 0);
 

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsTests.cs
@@ -8,6 +8,7 @@ using Aspire.Dashboard.Components.Resize;
 using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Tests.Shared;
 using Aspire.Dashboard.Utils;
 using Bunit;
 using Google.Protobuf.Collections;

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/FluentUISetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/FluentUISetupHelpers.cs
@@ -8,6 +8,7 @@ using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Assistant;
 using Aspire.Dashboard.Model.BrowserStorage;
 using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Tests.Shared;
 using Aspire.Dashboard.Telemetry;
 using Aspire.Dashboard.Tests;
 using Bunit;

--- a/tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
+++ b/tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
@@ -40,6 +40,7 @@
     <Compile Include="$(TestsSharedDir)TestAIContextProvider.cs" Link="shared/TestAIContextProvider.cs" />
     <Compile Include="$(TestsSharedDir)TestStringLocalizer.cs" Link="shared/TestStringLocalizer.cs" />
     <Compile Include="$(TestsSharedDir)TestDashboardClient.cs" Link="shared/TestDashboardClient.cs" />
+    <Compile Include="$(TestsSharedDir)TestSessionStorage.cs" Link="shared/TestSessionStorage.cs" />
     <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" Link="shared/AsyncTestHelpers.cs" />
     <Compile Include="$(TestsSharedDir)TestCertificateLoader.cs" Link="shared/TestCertificateLoader.cs" />
     <Compile Include="$(TestsSharedDir)Logging\*.cs" LinkBase="shared/Logging" />

--- a/tests/Aspire.Dashboard.Tests/Model/ConsoleLogsFiltersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ConsoleLogsFiltersTests.cs
@@ -66,7 +66,7 @@ public sealed class ConsoleLogsFiltersTests
     public void TryGetResourceFilterDate_ReturnsFalse_WhenResourceNotFound()
     {
         // Arrange
-        var filters = new ConsoleLogsFilters();
+        var filters = new ConsoleLogsFilters { FilterAllLogsDate = null, FilterResourceLogsDates = new Dictionary<string, DateTime>() };
 
         // Act & Assert
         Assert.False(filters.TryGetResourceFilterDate("non-existent", out var filterDate));

--- a/tests/Aspire.Dashboard.Tests/Model/ConsoleLogsFiltersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ConsoleLogsFiltersTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
 using System.Text.Json;
 using Aspire.Dashboard.Model;
 using Xunit;
@@ -17,8 +16,10 @@ public sealed class ConsoleLogsFiltersTests
         var filters = new ConsoleLogsFilters
         {
             FilterAllLogsDate = new DateTime(2023, 1, 2, 3, 4, 5, DateTimeKind.Utc),
-            FilterResourceLogsDates = ImmutableDictionary<string, DateTime>.Empty
-                .Add("test-abc", new DateTime(2023, 1, 2, 3, 4, 5, DateTimeKind.Utc))
+            FilterResourceLogsDates = new Dictionary<string, DateTime>
+            {
+                ["test-abc"] = new DateTime(2023, 1, 2, 3, 4, 5, DateTimeKind.Utc)
+            }
         };
 
         // Act
@@ -28,5 +29,47 @@ public sealed class ConsoleLogsFiltersTests
         // Assert
         Assert.Equal(filters.FilterAllLogsDate, deserialized.FilterAllLogsDate);
         Assert.Equivalent(filters.FilterResourceLogsDates, deserialized.FilterResourceLogsDates);
+    }
+
+    [Fact]
+    public void WithResourceCleared_PreservesExistingFilters()
+    {
+        // Arrange
+        var existingAllLogsDate = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var existingResourceDate = new DateTime(2023, 1, 2, 0, 0, 0, DateTimeKind.Utc);
+        var filters = new ConsoleLogsFilters
+        {
+            FilterAllLogsDate = existingAllLogsDate,
+            FilterResourceLogsDates = new Dictionary<string, DateTime>
+            {
+                ["existing-resource"] = existingResourceDate
+            }
+        };
+
+        // Act
+        var newResourceDate = new DateTime(2023, 1, 3, 0, 0, 0, DateTimeKind.Utc);
+        var updatedFilters = filters.WithResourceCleared("new-resource", newResourceDate);
+
+        // Assert - existing FilterAllLogsDate is preserved
+        Assert.Equal(existingAllLogsDate, updatedFilters.FilterAllLogsDate);
+
+        // Assert - existing resource filter is preserved
+        Assert.True(updatedFilters.TryGetResourceFilterDate("existing-resource", out var existingDate));
+        Assert.Equal(existingResourceDate, existingDate);
+
+        // Assert - new resource filter is added
+        Assert.True(updatedFilters.TryGetResourceFilterDate("new-resource", out var newDate));
+        Assert.Equal(newResourceDate, newDate);
+    }
+
+    [Fact]
+    public void TryGetResourceFilterDate_ReturnsFalse_WhenResourceNotFound()
+    {
+        // Arrange
+        var filters = new ConsoleLogsFilters();
+
+        // Act & Assert
+        Assert.False(filters.TryGetResourceFilterDate("non-existent", out var filterDate));
+        Assert.Null(filterDate);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/ConsoleLogsFiltersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ConsoleLogsFiltersTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using System.Text.Json;
 using Aspire.Dashboard.Model;
 using Xunit;
@@ -16,10 +17,8 @@ public sealed class ConsoleLogsFiltersTests
         var filters = new ConsoleLogsFilters
         {
             FilterAllLogsDate = new DateTime(2023, 1, 2, 3, 4, 5, DateTimeKind.Utc),
-            FilterResourceLogsDates =
-            {
-                ["test-abc"] = new DateTime(2023, 1, 2, 3, 4, 5, DateTimeKind.Utc)
-            }
+            FilterResourceLogsDates = ImmutableDictionary<string, DateTime>.Empty
+                .Add("test-abc", new DateTime(2023, 1, 2, 3, 4, 5, DateTimeKind.Utc))
         };
 
         // Act

--- a/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
@@ -497,7 +497,7 @@ public sealed class TelemetryExportServiceTests
         // Verify the content of the exported structured logs for resource1
         var resource1LogsEntry = archive.Entries.First(e => e.FullName.Contains("structuredlogs") && e.FullName.Contains("resource1"));
         using var logStream = resource1LogsEntry.Open();
-        var logsData = await JsonSerializer.DeserializeAsync<OtlpTelemetryDataJson>(logStream);
+        var logsData = await JsonSerializer.DeserializeAsync(logStream, OtlpJsonSerializerContext.Default.OtlpTelemetryDataJson);
         var logRecord = logsData?.ResourceLogs?.FirstOrDefault()?.ScopeLogs?.FirstOrDefault()?.LogRecords?.FirstOrDefault();
         Assert.NotNull(logRecord);
         Assert.Equal("log-resource1-111", logRecord.Body?.StringValue);
@@ -505,7 +505,7 @@ public sealed class TelemetryExportServiceTests
         // Verify the content of the exported traces for resource2
         var resource2TracesEntry = archive.Entries.First(e => e.FullName.Contains("traces") && e.FullName.Contains("resource2"));
         using var traceStream = resource2TracesEntry.Open();
-        var tracesData = await JsonSerializer.DeserializeAsync<OtlpTelemetryDataJson>(traceStream);
+        var tracesData = await JsonSerializer.DeserializeAsync(traceStream, OtlpJsonSerializerContext.Default.OtlpTelemetryDataJson);
         var span = tracesData?.ResourceSpans?.FirstOrDefault()?.ScopeSpans?.FirstOrDefault()?.Spans?.FirstOrDefault();
         Assert.NotNull(span);
         Assert.Contains("resource2-222", span.Name);
@@ -513,7 +513,7 @@ public sealed class TelemetryExportServiceTests
         // Verify the content of the exported metrics for resource3
         var resource3MetricsEntry = archive.Entries.First(e => e.FullName.Contains("metrics") && e.FullName.Contains("resource3"));
         using var metricsStream = resource3MetricsEntry.Open();
-        var metricsData = await JsonSerializer.DeserializeAsync<OtlpTelemetryDataJson>(metricsStream);
+        var metricsData = await JsonSerializer.DeserializeAsync(metricsStream, OtlpJsonSerializerContext.Default.OtlpTelemetryDataJson);
         var metric = metricsData?.ResourceMetrics?.FirstOrDefault()?.ScopeMetrics?.FirstOrDefault()?.Metrics?.FirstOrDefault();
         Assert.NotNull(metric);
         Assert.Equal("metric-resource3-333", metric.Name);
@@ -678,7 +678,7 @@ public sealed class TelemetryExportServiceTests
         Assert.Contains(japaneseEventName, jsonContent);
 
         // Deserialize the JSON to verify the content is correct after round-trip
-        var logsData = System.Text.Json.JsonSerializer.Deserialize<OtlpLogsDataJson>(jsonContent, OtlpJsonSerializerContext.Default.OtlpLogsDataJson);
+        var logsData = JsonSerializer.Deserialize(jsonContent, OtlpJsonSerializerContext.Default.OtlpTelemetryDataJson);
 
         Assert.NotNull(logsData);
         Assert.NotNull(logsData.ResourceLogs);

--- a/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
@@ -9,6 +9,7 @@ using Aspire.Dashboard.Otlp.Model.Serialization;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Tests.Shared;
 using Google.Protobuf.Collections;
+using Microsoft.AspNetCore.InternalTesting;
 using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Proto.Trace.V1;
 using Xunit;
@@ -462,8 +463,7 @@ public sealed class TelemetryExportServiceTests
     {
         // Arrange
         var repository = CreateRepository();
-        var dashboardClient = new TestDashboardClient();
-        var exportService = new TelemetryExportService(repository, dashboardClient);
+        var exportService = await CreateExportServiceAsync(repository);
 
         // Add test data for three resources
         AddTestData(repository, "resource1", "111");
@@ -517,6 +517,208 @@ public sealed class TelemetryExportServiceTests
         var metric = metricsData?.ResourceMetrics?.FirstOrDefault()?.ScopeMetrics?.FirstOrDefault()?.Metrics?.FirstOrDefault();
         Assert.NotNull(metric);
         Assert.Equal("metric-resource3-333", metric.Name);
+    }
+
+    [Fact]
+    public async Task ExportAllAsync_WhenDashboardClientDisabled_ExportsOnlyTelemetry()
+    {
+        // Arrange
+        var repository = CreateRepository();
+        var addContext = new AddContext();
+
+        // Add logs
+        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "Service1", instanceId: "instance-1"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("Logger1"),
+                        LogRecords = { CreateLogRecord(time: s_testTime, message: "Structured log") }
+                    }
+                }
+            }
+        });
+
+        // Dashboard client is disabled (no console logs)
+        var service = await CreateExportServiceAsync(repository, isDashboardClientEnabled: false);
+
+        // Build selection for all resources with all data types
+        var selectedResources = BuildAllResourcesSelection(repository);
+
+        // Act
+        using var zipStream = await service.ExportSelectedAsync(selectedResources, CancellationToken.None).DefaultTimeout();
+
+        // Assert
+        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        var entryNames = archive.Entries.Select(e => e.FullName).Order().ToList();
+
+        // Verify only structured logs are exported (no console logs)
+        Assert.Collection(entryNames,
+            name => Assert.Equal("structuredlogs/Service1.json", name));
+    }
+
+    [Fact]
+    public async Task ExportSelectedAsync_SkipsEmptyResources()
+    {
+        // Arrange
+        var repository = CreateRepository();
+        var addContext = new AddContext();
+
+        // Add logs for only one resource
+        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "ServiceWithLogs", instanceId: "instance-1"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("Logger1"),
+                        LogRecords = { CreateLogRecord(time: s_testTime, message: "Log message") }
+                    }
+                }
+            }
+        });
+
+        // Add traces for a different resource
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "ServiceWithTraces", instanceId: "instance-2"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope("Tracer1"),
+                        Spans = { CreateSpan(traceId: "trace123456789012", spanId: "span1111", startTime: s_testTime, endTime: s_testTime.AddSeconds(5)) }
+                    }
+                }
+            }
+        });
+
+        var service = await CreateExportServiceAsync(repository, isDashboardClientEnabled: false);
+
+        // Build selection for all resources with all data types
+        var selectedResources = BuildAllResourcesSelection(repository);
+
+        // Act
+        using var zipStream = await service.ExportSelectedAsync(selectedResources, CancellationToken.None).DefaultTimeout();
+
+        // Assert
+        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        var entryNames = archive.Entries.Select(e => e.FullName).Order().ToList();
+
+        // Verify each resource only has its own data type exported
+        Assert.Collection(entryNames,
+            name => Assert.Equal("structuredlogs/ServiceWithLogs.json", name),
+            name => Assert.Equal("traces/ServiceWithTraces.json", name));
+    }
+
+    [Fact]
+    public async Task ExportSelectedAsync_JapaneseCharactersInLogs_PreservesContent()
+    {
+        // Arrange
+        var repository = CreateRepository();
+        var addContext = new AddContext();
+
+        const string japaneseMessage = "これはテストログメッセージです"; // "This is a test log message"
+        const string japaneseAttributeValue = "日本語の属性値"; // "Japanese attribute value"
+        const string japaneseEventName = "テストイベント"; // "Test event"
+
+        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "JapaneseService", instanceId: "instance-1"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("JapaneseLogger"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(
+                                time: s_testTime,
+                                message: japaneseMessage,
+                                severity: SeverityNumber.Info,
+                                eventName: japaneseEventName,
+                                attributes: [new KeyValuePair<string, string>("japanese.attr", japaneseAttributeValue)])
+                        }
+                    }
+                }
+            }
+        });
+
+        var service = await CreateExportServiceAsync(repository, isDashboardClientEnabled: false);
+
+        // Build selection for all resources with all data types
+        var selectedResources = BuildAllResourcesSelection(repository);
+
+        // Act
+        using var zipStream = await service.ExportSelectedAsync(selectedResources, CancellationToken.None).DefaultTimeout();
+
+        // Assert
+        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+
+        var logEntry = archive.GetEntry("structuredlogs/JapaneseService.json");
+        Assert.NotNull(logEntry);
+
+        using var reader = new StreamReader(logEntry.Open());
+        var jsonContent = await reader.ReadToEndAsync().DefaultTimeout();
+
+        // Verify Japanese characters appear directly in JSON (not Unicode-escaped)
+        Assert.Contains(japaneseMessage, jsonContent);
+        Assert.Contains(japaneseAttributeValue, jsonContent);
+        Assert.Contains(japaneseEventName, jsonContent);
+
+        // Deserialize the JSON to verify the content is correct after round-trip
+        var logsData = System.Text.Json.JsonSerializer.Deserialize<OtlpLogsDataJson>(jsonContent, OtlpJsonSerializerContext.Default.OtlpLogsDataJson);
+
+        Assert.NotNull(logsData);
+        Assert.NotNull(logsData.ResourceLogs);
+        Assert.Single(logsData.ResourceLogs);
+
+        var resourceLogs = logsData.ResourceLogs[0];
+        Assert.NotNull(resourceLogs.ScopeLogs);
+        Assert.Single(resourceLogs.ScopeLogs);
+
+        var scopeLogs = resourceLogs.ScopeLogs[0];
+        Assert.NotNull(scopeLogs.LogRecords);
+        Assert.Single(scopeLogs.LogRecords);
+
+        var logRecord = scopeLogs.LogRecords[0];
+
+        // Verify Japanese characters are preserved after serialization and deserialization
+        Assert.Equal(japaneseMessage, logRecord.Body?.StringValue);
+        Assert.Equal(japaneseEventName, logRecord.EventName);
+
+        Assert.NotNull(logRecord.Attributes);
+        var japaneseAttr = Assert.Single(logRecord.Attributes, a => a.Key == "japanese.attr");
+        Assert.Equal(japaneseAttributeValue, japaneseAttr.Value?.StringValue);
+    }
+
+    private static async Task<TelemetryExportService> CreateExportServiceAsync(TelemetryRepository repository, bool isDashboardClientEnabled = true)
+    {
+        var dashboardClient = new TestDashboardClient(isEnabled: isDashboardClientEnabled);
+        var sessionStorage = new TestSessionStorage();
+        var consoleLogsManager = new ConsoleLogsManager(sessionStorage);
+        await consoleLogsManager.EnsureInitializedAsync();
+        var consoleLogsFetcher = new ConsoleLogsFetcher(dashboardClient, consoleLogsManager);
+        return new TelemetryExportService(repository, consoleLogsFetcher);
+    }
+
+    private static Dictionary<string, HashSet<AspireDataType>> BuildAllResourcesSelection(TelemetryRepository repository)
+    {
+        var allResources = repository.GetResources();
+        return allResources.ToDictionary(
+            r => r.ResourceKey.GetCompositeName(),
+            _ => new HashSet<AspireDataType>([AspireDataType.ConsoleLogs, AspireDataType.StructuredLogs, AspireDataType.Traces, AspireDataType.Metrics]));
     }
 
     private static void AddTestData(TelemetryRepository repository, string resourceName, string instanceId)

--- a/tests/Shared/TestSessionStorage.cs
+++ b/tests/Shared/TestSessionStorage.cs
@@ -3,7 +3,7 @@
 
 using Aspire.Dashboard.Model.BrowserStorage;
 
-namespace Aspire.Dashboard.Components.Tests.Shared;
+namespace Aspire.Dashboard.Tests.Shared;
 
 public sealed class TestSessionStorage : ISessionStorage
 {


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the console logs export and filtering functionality, as well as enhances error handling in the settings export dialog. The main themes are improved error reporting for telemetry export, a more robust and immutable approach to log filtering, and significant refactoring for console log fetching and serialization.

Error message:
<img width="413" height="747" alt="image" src="https://github.com/user-attachments/assets/67898684-7a79-479a-9193-6bfe7f7c31d1" />

~I think long term this button will move to its own dialog so we can display more information. e.g. summary of what was exported, have UI for importing multiple files, improved UI for deleting data.~

**Update:** Export and remove buttons are now on the manage data dialog.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
