### PR TITLE
Fixing bugs for sticky slot app settings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,7 +39,7 @@
     <PackageVersion Include="Azure.Provisioning" Version="1.4.0" />
     <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.AppContainers" Version="1.1.0" />
-    <PackageVersion Include="Azure.Provisioning.AppService" Version="1.3.0" />
+    <PackageVersion Include="Azure.Provisioning.AppService" Version="1.3.1" />
     <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.ContainerRegistry" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="1.1.0" />

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentUtility.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentUtility.cs
@@ -18,7 +18,7 @@ internal static class AzureAppServiceEnvironmentUtility
     public static BicepValue<string> GetDashboardHostName(string aspireResourceName)
     {
         return BicepFunction.Take(
-    BicepFunction.Interpolate($"{BicepFunction.ToLower(aspireResourceName)}-{BicepFunction.ToLower(ResourceName)}-{BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)}"), 60);
+    BicepFunction.Interpolate($"{BicepFunction.ToLower(aspireResourceName)}-{BicepFunction.ToLower(ResourceName)}-{BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)}"), AzureAppServiceWebSiteResource.MaxHostPrefixLength);
     }
 
     public static WebSite AddDashboard(AzureResourceInfrastructure infra,

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentUtility.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentUtility.cs
@@ -18,7 +18,7 @@ internal static class AzureAppServiceEnvironmentUtility
     public static BicepValue<string> GetDashboardHostName(string aspireResourceName)
     {
         return BicepFunction.Take(
-    BicepFunction.Interpolate($"{BicepFunction.ToLower(aspireResourceName)}-{BicepFunction.ToLower(ResourceName)}-{BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)}"), AzureAppServiceWebSiteResource.MaxHostPrefixLength);
+    BicepFunction.Interpolate($"{BicepFunction.ToLower(aspireResourceName)}-{BicepFunction.ToLower(ResourceName)}-{BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)}"), 60);
     }
 
     public static WebSite AddDashboard(AzureResourceInfrastructure infra,

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
@@ -238,9 +238,10 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
         var computeEnv = (AzureAppServiceEnvironmentResource)TargetResource.GetDeploymentTargetAnnotation()!.ComputeEnvironment!;
         var websiteSuffix = await computeEnv.WebSiteSuffix.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
         var websiteName = $"{TargetResource.Name.ToLowerInvariant()}-{websiteSuffix}";
-        int maxWebSiteLength = deploymentSlot is null ?
-            MaxWebSiteNameLength :
-            MaxWebSiteNameHostPrefixLengthWithSlot;
+
+        int maxWebSiteLength = string.IsNullOrWhiteSpace(deploymentSlot) ?
+            MaxHostPrefixLength :
+            MaxWebSiteHostPrefixLengthWithSlot;
 
         if (websiteName.Length > maxWebSiteLength)
         {
@@ -249,20 +250,19 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
 
         if (!string.IsNullOrWhiteSpace(deploymentSlot))
         {
-            if (deploymentSlot.Length > MaxSlotHostPrefixLength)
-            {
-                deploymentSlot = deploymentSlot.Substring(0, MaxSlotHostPrefixLength);
-            }
             websiteName += $"-{deploymentSlot}";
+
+            if (websiteName.Length > MaxHostPrefixLength)
+            {
+                websiteName = websiteName.Substring(0, MaxHostPrefixLength);
+            }
         }
 
         return websiteName;
     }
 
     private const string AzureManagementScope = "https://management.azure.com/.default";
-    private const string AzureManagementEndpoint = "https://management.azure.com/";
-    internal const int MaxWebSiteNameLength = 60;
-    internal const int MaxWebSiteNameHostPrefixLengthWithSlot = 40;
-    internal const int MaxSlotHostPrefixLength = 21;
-
+    private const string AzureManagementEndpoint = "https://management.azure.com/"
+    internal const int MaxHostPrefixLength = 59;
+    internal const int MaxWebSiteHostPrefixLengthWithSlot = 40;
 }

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
@@ -239,17 +239,12 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
         var websiteSuffix = await computerEnv.WebSiteSuffix.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
         var websiteName = $"{TargetResource.Name.ToLowerInvariant()}-{websiteSuffix}";
 
-        int maxWebSiteLength = string.IsNullOrWhiteSpace(deploymentSlot) ?
-            60 :
-            MaxWebSitePrefixLengthWithSlot;
-
-        websiteName = TruncateToMaxLength(websiteName, maxWebSiteLength);
-
         if (string.IsNullOrWhiteSpace(deploymentSlot))
         {
-            return websiteName;
+            return TruncateToMaxLength(websiteName, 60);
         }
 
+        websiteName = TruncateToMaxLength(websiteName, MaxWebSiteNamePrefixLengthWithSlot);
         websiteName += $"-{deploymentSlot}";
 
         return TruncateToMaxLength(websiteName, MaxHostPrefixLengthWithSlot);
@@ -269,5 +264,5 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
     // For Azure App Service, the maximum length for a host name is 63 characters. With slot, the host name is 59 characters, with 4 characters reserved for random slot suffix (very edge case).
     // Source of truth: https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites?path=%2Fsrc%2FHosting%2FAdministrationService%2FMicrosoft.Web.Hosting.Administration.Api%2FCommonConstants.cs&_a=contents&version=GBdev
     internal const int MaxHostPrefixLengthWithSlot = 59;
-    internal const int MaxWebSitePrefixLengthWithSlot = 40;
+    internal const int MaxWebSiteNamePrefixLengthWithSlot = 40;
 }

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
@@ -48,8 +48,8 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
                 Name = $"check-{targetResource.Name}-exists",
                 Action = async ctx =>
                 {
-                    var computeEnv = (AzureAppServiceEnvironmentResource)deploymentTargetAnnotation.ComputeEnvironment!;
-                    var isSlotDeployment = computeEnv.DeploymentSlot is not null || computeEnv.DeploymentSlotParameter is not null;
+                    var computerEnv = (AzureAppServiceEnvironmentResource)deploymentTargetAnnotation.ComputeEnvironment!;
+                    var isSlotDeployment = computerEnv.DeploymentSlot is not null || computerEnv.DeploymentSlotParameter is not null;
                     if (!isSlotDeployment)
                     {
                         return;
@@ -75,14 +75,14 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
                 Name = $"update-{targetResource.Name}-provisionable-resource",
                 Action = async ctx =>
                 {
-                    var computeEnv = (AzureAppServiceEnvironmentResource)deploymentTargetAnnotation.ComputeEnvironment!;
+                    var computerEnv = (AzureAppServiceEnvironmentResource)deploymentTargetAnnotation.ComputeEnvironment!;
 
                     if (!targetResource.TryGetLastAnnotation<AzureAppServiceWebsiteRefreshProvisionableResourceAnnotation>(out _))
                     {
                         return;
                     } 
 
-                    if (computeEnv.TryGetLastAnnotation<AzureAppServiceEnvironmentContextAnnotation>(out var environmentContextAnnotation))
+                    if (computerEnv.TryGetLastAnnotation<AzureAppServiceEnvironmentContextAnnotation>(out var environmentContextAnnotation))
                     {
                         var context = environmentContextAnnotation.EnvironmentContext.GetAppServiceContext(targetResource);
                         var provisioningOptions = ctx.Services.GetRequiredService<IOptions<AzureProvisioningOptions>>();
@@ -117,14 +117,14 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
                 Description = $"Prints the deployment summary and URL for {targetResource.Name}.",
                 Action = async ctx =>
                 {
-                    var computeEnv = (AzureAppServiceEnvironmentResource)deploymentTargetAnnotation.ComputeEnvironment!;
+                    var computerEnv = (AzureAppServiceEnvironmentResource)deploymentTargetAnnotation.ComputeEnvironment!;
                     string? deploymentSlot = null;
 
-                    if (computeEnv.DeploymentSlot is not null || computeEnv.DeploymentSlotParameter is not null)
+                    if (computerEnv.DeploymentSlot is not null || computerEnv.DeploymentSlotParameter is not null)
                     {
-                        deploymentSlot = computeEnv.DeploymentSlotParameter is null ?
-                           computeEnv.DeploymentSlot :
-                           await computeEnv.DeploymentSlotParameter.GetValueAsync(ctx.CancellationToken).ConfigureAwait(false);
+                        deploymentSlot = computerEnv.DeploymentSlotParameter is null ?
+                           computerEnv.DeploymentSlot :
+                           await computerEnv.DeploymentSlotParameter.GetValueAsync(ctx.CancellationToken).ConfigureAwait(false);
                     }
 
                     var hostName = await GetAppServiceWebsiteNameAsync(ctx, deploymentSlot).ConfigureAwait(false);
@@ -235,8 +235,8 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
     /// <returns>A task that represents the asynchronous operation. The task result contains the website name.</returns>
     private async Task<string> GetAppServiceWebsiteNameAsync(PipelineStepContext context, string? deploymentSlot = null)
     {
-        var computeEnv = (AzureAppServiceEnvironmentResource)TargetResource.GetDeploymentTargetAnnotation()!.ComputeEnvironment!;
-        var websiteSuffix = await computeEnv.WebSiteSuffix.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
+        var computerEnv = (AzureAppServiceEnvironmentResource)TargetResource.GetDeploymentTargetAnnotation()!.ComputeEnvironment!;
+        var websiteSuffix = await computerEnv.WebSiteSuffix.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
         var websiteName = $"{TargetResource.Name.ToLowerInvariant()}-{websiteSuffix}";
 
         int maxWebSiteLength = string.IsNullOrWhiteSpace(deploymentSlot) ?
@@ -257,7 +257,7 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
                 websiteName = websiteName.Substring(0, MaxHostPrefixLengthWithSlot);
             }
         }
-
+        
         return websiteName;
     }
 

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
@@ -243,22 +243,25 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
             60 :
             MaxWebSitePrefixLengthWithSlot;
 
-        if (websiteName.Length > maxWebSiteLength)
+        websiteName = TruncateToMaxLength(websiteName, maxWebSiteLength);
+
+        if (string.IsNullOrWhiteSpace(deploymentSlot))
         {
-            websiteName = websiteName.Substring(0, maxWebSiteLength);
+            return websiteName;
         }
 
-        if (!string.IsNullOrWhiteSpace(deploymentSlot))
-        {
-            websiteName += $"-{deploymentSlot}";
+        websiteName += $"-{deploymentSlot}";
 
-            if (websiteName.Length > MaxHostPrefixLengthWithSlot)
-            {
-                websiteName = websiteName.Substring(0, MaxHostPrefixLengthWithSlot);
-            }
+        return TruncateToMaxLength(websiteName, MaxHostPrefixLengthWithSlot);
+    }
+
+    private static string TruncateToMaxLength(string value, int maxLength)
+    {
+        if (value.Length <= maxLength)
+        {
+            return value;
         }
-        
-        return websiteName;
+        return value.Substring(0, maxLength);
     }
 
     private const string AzureManagementScope = "https://management.azure.com/.default";

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
@@ -263,6 +263,8 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
 
     private const string AzureManagementScope = "https://management.azure.com/.default";
     private const string AzureManagementEndpoint = "https://management.azure.com/";
+    // For Azure App Service, the maximum length for a host name is 63 characters. With slot, the host name is 59 characters, with 4 characters reserved for random slot suffix (very edge case).
+    // Source of truth: https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites?path=%2Fsrc%2FHosting%2FAdministrationService%2FMicrosoft.Web.Hosting.Administration.Api%2FCommonConstants.cs&_a=contents&version=GBdev
     internal const int MaxHostPrefixLengthWithSlot = 59;
     internal const int MaxWebSitePrefixLengthWithSlot = 40;
 }

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
@@ -262,7 +262,7 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
     }
 
     private const string AzureManagementScope = "https://management.azure.com/.default";
-    private const string AzureManagementEndpoint = "https://management.azure.com/"
+    private const string AzureManagementEndpoint = "https://management.azure.com/";
     internal const int MaxHostPrefixLength = 59;
     internal const int MaxWebSiteHostPrefixLengthWithSlot = 40;
 }

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
@@ -240,8 +240,8 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
         var websiteName = $"{TargetResource.Name.ToLowerInvariant()}-{websiteSuffix}";
 
         int maxWebSiteLength = string.IsNullOrWhiteSpace(deploymentSlot) ?
-            MaxHostPrefixLength :
-            MaxWebSiteHostPrefixLengthWithSlot;
+            60 :
+            MaxWebSitePrefixLengthWithSlot;
 
         if (websiteName.Length > maxWebSiteLength)
         {
@@ -252,9 +252,9 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
         {
             websiteName += $"-{deploymentSlot}";
 
-            if (websiteName.Length > MaxHostPrefixLength)
+            if (websiteName.Length > MaxHostPrefixLengthWithSlot)
             {
-                websiteName = websiteName.Substring(0, MaxHostPrefixLength);
+                websiteName = websiteName.Substring(0, MaxHostPrefixLengthWithSlot);
             }
         }
 
@@ -263,6 +263,6 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
 
     private const string AzureManagementScope = "https://management.azure.com/.default";
     private const string AzureManagementEndpoint = "https://management.azure.com/";
-    internal const int MaxHostPrefixLength = 59;
-    internal const int MaxWebSiteHostPrefixLengthWithSlot = 40;
+    internal const int MaxHostPrefixLengthWithSlot = 59;
+    internal const int MaxWebSitePrefixLengthWithSlot = 40;
 }

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -430,7 +430,7 @@ internal sealed class AzureAppServiceWebsiteContext(
             }
 
             // make app service references as sticky settings for slots
-            if (kv.Value is EndpointReference || kv.Value is EndpointReferenceExpression)
+            if (kv.Value is EndpointReference)
             {
                 slotConfigNames.Add(kv.Key);
             }

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -555,7 +555,6 @@ internal sealed class AzureAppServiceWebsiteContext(
                     webSiteObject.BicepIdentifier,
                     webSiteObject.SiteConfig.AppSettings,
                     acrClientIdParameter,
-                    slotConfigNames,
                     deploymentSlot);
             }
             infra.Add(webSiteObject);
@@ -568,7 +567,6 @@ internal sealed class AzureAppServiceWebsiteContext(
                     slot.BicepIdentifier,
                     slot.SiteConfig.AppSettings,
                     acrClientIdParameter,
-                    slotConfigNames,
                     deploymentSlot);
             }
             infra.Add(slot);
@@ -577,6 +575,9 @@ internal sealed class AzureAppServiceWebsiteContext(
         if (webSiteRa is not null)
         {
             infra.Add(webSiteRa);
+
+            // Make OTEL_SERVICE_NAME a deployment slot sticky appsetting if dashboard is enabled
+            slotConfigNames.Add("OTEL_SERVICE_NAME");
         }
 
         if (environmentContext.Environment.EnableApplicationInsights)
@@ -777,7 +778,6 @@ internal sealed class AzureAppServiceWebsiteContext(
         String bicepIdentifier,
         BicepList<AppServiceNameValuePair> appSettings,
         ProvisioningParameter acrClientIdParameter,
-        HashSet<string> appSettingNames,
         BicepValue<string>? deploymentSlot = null)
     {
         bool isSlot = deploymentSlot is not null;
@@ -801,9 +801,6 @@ internal sealed class AzureAppServiceWebsiteContext(
         appSettings.Add(new AppServiceNameValuePair { Name = "WEBSITE_ENABLE_ASPIRE_OTEL_SIDECAR", Value = "true" });
         appSettings.Add(new AppServiceNameValuePair { Name = "OTEL_COLLECTOR_URL", Value = dashboardUri });
         appSettings.Add(new AppServiceNameValuePair { Name = "OTEL_CLIENT_ID", Value = acrClientIdParameter });
-
-        // make OTEL_SERVICE_NAME app setting a slot sticky setting
-        appSettingNames.Add("OTEL_SERVICE_NAME");
 
         var websiteRaName = BicepFunction.CreateGuid(id, contributorId, websiteRaId);
         RoleAssignment roleAssignment = new RoleAssignment(raResourceName)

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -886,6 +886,11 @@ internal sealed class AzureAppServiceWebsiteContext(
     /// <param name="stickyConfigNames">The set of deployment slot app settings</param>
     private void AddStickySlotSettings(WebSite? parentWebSite, HashSet<string> stickyConfigNames)
     {
+        if (stickyConfigNames.Count == 0)
+        {
+            return;
+        }
+
         SlotConfigNames slotConfigNames = new("slotConfigNames")
         {
             Parent = parentWebSite

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -406,8 +406,6 @@ internal sealed class AzureAppServiceWebsiteContext(
             {
                 slot.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = "WEBSITES_PORT", Value = targetPort });
             }
-
-            slotConfigNames.Add("WEBSITES_PORT");
         }
 
         foreach (var kv in EnvironmentVariables)
@@ -431,7 +429,11 @@ internal sealed class AzureAppServiceWebsiteContext(
                 slot.SiteConfig.AppSettings.Add(new AppServiceNameValuePair { Name = kv.Key, Value = value });
             }
 
-            slotConfigNames.Add(kv.Key);
+            // make app service references as sticky settings for slots
+            if (kv.Value is EndpointReference || kv.Value is EndpointReferenceExpression)
+            {
+                slotConfigNames.Add(kv.Key);
+            }
         }
 
         if (Args.Count > 0)

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -47,7 +47,7 @@ internal sealed class AzureAppServiceWebsiteContext(
     public BicepValue<string> GetSlotHostName(BicepValue<string> deploymentSlot)
     {
         var websitePrefix = BicepFunction.Take(
-            BicepFunction.Interpolate($"{BicepFunction.ToLower(resource.Name)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()}"), AzureAppServiceWebSiteResource.MaxWebSitePrefixLengthWithSlot);
+            BicepFunction.Interpolate($"{BicepFunction.ToLower(resource.Name)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()}"), AzureAppServiceWebSiteResource.MaxWebSiteNamePrefixLengthWithSlot);
 
         return BicepFunction.Take(
             BicepFunction.Interpolate($"{websitePrefix}-{BicepFunction.ToLower(deploymentSlot)}"), AzureAppServiceWebSiteResource.MaxHostPrefixLengthWithSlot);

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -37,7 +37,7 @@ internal sealed class AzureAppServiceWebsiteContext(
     // Naming the app service is globally unique (domain names), so we use the resource group ID to create a unique name
     // within the naming spec for the app service.
     private BicepValue<string> HostName => BicepFunction.Take(
-        BicepFunction.Interpolate($"{BicepFunction.ToLower(resource.Name)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()}"), 60);
+        BicepFunction.Interpolate($"{BicepFunction.ToLower(resource.Name)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()}"), AzureAppServiceWebSiteResource.MaxHostPrefixLength);
 
     /// <summary>
     /// Gets the hostname for a deployment slot by appending the slot name to the base website name.
@@ -47,12 +47,10 @@ internal sealed class AzureAppServiceWebsiteContext(
     public BicepValue<string> GetSlotHostName(BicepValue<string> deploymentSlot)
     {
         var websitePrefix = BicepFunction.Take(
-            BicepFunction.Interpolate($"{BicepFunction.ToLower(resource.Name)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()}"), AzureAppServiceWebSiteResource.MaxWebSiteNameHostPrefixLengthWithSlot);
+            BicepFunction.Interpolate($"{BicepFunction.ToLower(resource.Name)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()}"), AzureAppServiceWebSiteResource.MaxWebSiteHostPrefixLengthWithSlot);
 
-        var slotPrefix = BicepFunction.Take(
-            BicepFunction.Interpolate($"-{BicepFunction.ToLower(deploymentSlot)}"), AzureAppServiceWebSiteResource.MaxSlotHostPrefixLength);
-
-        return BicepFunction.Interpolate($"{websitePrefix}-{slotPrefix}");
+        return BicepFunction.Take(
+            BicepFunction.Interpolate($"{websitePrefix}-{BicepFunction.ToLower(deploymentSlot)}"), AzureAppServiceWebSiteResource.MaxHostPrefixLength);
     }
 
     public async Task ProcessAsync(CancellationToken cancellationToken)

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -37,7 +37,7 @@ internal sealed class AzureAppServiceWebsiteContext(
     // Naming the app service is globally unique (domain names), so we use the resource group ID to create a unique name
     // within the naming spec for the app service.
     private BicepValue<string> HostName => BicepFunction.Take(
-        BicepFunction.Interpolate($"{BicepFunction.ToLower(resource.Name)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()}"), AzureAppServiceWebSiteResource.MaxHostPrefixLength);
+        BicepFunction.Interpolate($"{BicepFunction.ToLower(resource.Name)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()}"), 60);
 
     /// <summary>
     /// Gets the hostname for a deployment slot by appending the slot name to the base website name.
@@ -47,10 +47,10 @@ internal sealed class AzureAppServiceWebsiteContext(
     public BicepValue<string> GetSlotHostName(BicepValue<string> deploymentSlot)
     {
         var websitePrefix = BicepFunction.Take(
-            BicepFunction.Interpolate($"{BicepFunction.ToLower(resource.Name)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()}"), AzureAppServiceWebSiteResource.MaxWebSiteHostPrefixLengthWithSlot);
+            BicepFunction.Interpolate($"{BicepFunction.ToLower(resource.Name)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()}"), AzureAppServiceWebSiteResource.MaxWebSitePrefixLengthWithSlot);
 
         return BicepFunction.Take(
-            BicepFunction.Interpolate($"{websitePrefix}-{BicepFunction.ToLower(deploymentSlot)}"), AzureAppServiceWebSiteResource.MaxHostPrefixLength);
+            BicepFunction.Interpolate($"{websitePrefix}-{BicepFunction.ToLower(deploymentSlot)}"), AzureAppServiceWebSiteResource.MaxHostPrefixLengthWithSlot);
     }
 
     public async Task ProcessAsync(CancellationToken cancellationToken)

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -774,6 +774,15 @@ internal sealed class AzureAppServiceWebsiteContext(
         return parameter.AsProvisioningParameter(Infra, isSecure: secretType == SecretType.Normal);
     }
 
+    /// <summary>
+    /// Add app settings and role assignment for Aspire dashboard
+    /// </summary>
+    /// <param name="id">resource identifier</param>
+    /// <param name="bicepIdentifier">bicep identifier for the website</param>
+    /// <param name="appSettings">list of app settings</param>
+    /// <param name="acrClientIdParameter">acr identity client id</param>
+    /// <param name="deploymentSlot">deployment slot</param>
+    /// <returns></returns>
     private RoleAssignment AddDashboardPermissionAndSettings(BicepValue<ResourceIdentifier> id,
         String bicepIdentifier,
         BicepList<AppServiceNameValuePair> appSettings,
@@ -812,9 +821,13 @@ internal sealed class AzureAppServiceWebsiteContext(
             RoleDefinitionId = websiteRaId,
         };
 
-        return roleAssignment!;
+        return roleAssignment;
     }
 
+    /// <summary>
+    /// Add appsettings to enable application insights for the website or slot
+    /// </summary>
+    /// <param name="appSettings">The list of app settings</param>
     private void EnableApplicationInsightsForWebSite(BicepList<AppServiceNameValuePair> appSettings)
     {
         var appInsightsInstrumentationKey = environmentContext.Environment.AzureAppInsightsInstrumentationKeyReference.AsProvisioningParameter(Infra);
@@ -837,6 +850,11 @@ internal sealed class AzureAppServiceWebsiteContext(
         });
     }
 
+    /// <summary>
+    /// Add app settings related to managed identity assigned to the website or slot
+    /// </summary>
+    /// <param name="appSettings">The list of app settings</param>
+    /// <param name="clientId">Managed identity client id</param>
     private static void UpdateIdentityAppSettings(BicepList<AppServiceNameValuePair> appSettings, ProvisioningParameter clientId)
     {
         appSettings.Add(new AppServiceNameValuePair

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceContainerWithoutTargetPortUsesDefaultPort.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceContainerWithoutTargetPortUsesDefaultPort.verified.bicep
@@ -92,3 +92,13 @@ resource container1_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-
   }
   scope: webapp
 }
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceProjectWithApplicationInsightsSetsAppSettings.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceProjectWithApplicationInsightsSetsAppSettings.verified.bicep
@@ -122,3 +122,13 @@ resource project1_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01
   }
   scope: webapp
 }
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceProjectWithoutTargetPortUsesContainerPort.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceProjectWithoutTargetPortUsesContainerPort.verified.bicep
@@ -106,3 +106,13 @@ resource project1_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01
   }
   scope: webapp
 }
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceToEnvironmentWithoutDashboard.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceToEnvironmentWithoutDashboard.verified.bicep
@@ -74,3 +74,14 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
     }
   }
 }
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'PROJECT1_HTTP'
+      'services__project1__http__0'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithArgs.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithArgs.verified.bicep
@@ -118,3 +118,15 @@ resource project2_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01
   }
   scope: webapp
 }
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'PROJECT1_HTTP'
+      'services__project1__http__0'
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDeploymentSlot.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDeploymentSlot.verified.bicep
@@ -111,3 +111,13 @@ resource project1_website_slot_ra 'Microsoft.Authorization/roleAssignments@2022-
   }
   scope: webappslot
 }
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDeploymentSlotParameter.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDeploymentSlotParameter.verified.bicep
@@ -113,3 +113,13 @@ resource project1_website_slot_ra 'Microsoft.Authorization/roleAssignments@2022-
   }
   scope: webappslot
 }
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithTargetPort.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithTargetPort.verified.bicep
@@ -120,3 +120,17 @@ resource project2_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01
   }
   scope: webapp
 }
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'PROJECT1_HTTPS'
+      'services__project1__https__0'
+      'PROJECT1_HTTP'
+      'services__project1__http__0'
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithTargetPortMultipleEndpoints.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithTargetPortMultipleEndpoints.verified.bicep
@@ -108,3 +108,13 @@ resource project2_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01
   }
   scope: webapp
 }
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddContainerAppEnvironmentAddsDeploymentTargetWithContainerAppToProjectResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddContainerAppEnvironmentAddsDeploymentTargetWithContainerAppToProjectResources.verified.bicep
@@ -107,3 +107,13 @@ resource api_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   }
   scope: webapp
 }
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddDockerfileWithAppServiceInfrastructureAddsDeploymentTargetWithAppServiceToContainerResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddDockerfileWithAppServiceInfrastructureAddsDeploymentTargetWithAppServiceToContainerResources.verified.bicep
@@ -96,3 +96,13 @@ resource api_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   }
   scope: webapp
 }
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceSupportBaitAndSwitchResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceSupportBaitAndSwitchResources.verified.bicep
@@ -104,3 +104,13 @@ resource api_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   }
   scope: webapp
 }
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.EndpointReferencesAreResolvedAcrossProjects.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.EndpointReferencesAreResolvedAcrossProjects.verified.bicep
@@ -114,3 +114,15 @@ resource project2_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01
   }
   scope: webapp
 }
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'PROJECT1_HTTP'
+      'services__project1__http__0'
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.KeyvaultReferenceHandling.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.KeyvaultReferenceHandling.verified.bicep
@@ -164,3 +164,13 @@ resource api_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   }
   scope: webapp
 }
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.ResourceWithProbes.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.ResourceWithProbes.verified.bicep
@@ -107,3 +107,13 @@ resource project1_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01
   }
   scope: webapp
 }
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.UnknownManifestExpressionProviderIsHandledWithAllocateParameter.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.UnknownManifestExpressionProviderIsHandledWithAllocateParameter.verified.bicep
@@ -112,3 +112,13 @@ resource api_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   }
   scope: webapp
 }
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_AzureAppService_Works#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_AzureAppService_Works#00.verified.bicep
@@ -112,3 +112,13 @@ resource myapp_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' =
   }
   scope: webapp
 }
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}


### PR DESCRIPTION
## Description

### Current behavior
When an Aspire project is deployed, all the app service and slots are deployed with app settings that are not sticky to the deployment slots. When slot swap is done, the app settings also get swapped as expected.

This results in incorrect behavior for these cases:
- Otel service name - The telemetry from production starts showing up for the slot it is swapped with.
- App Service dependencies - The production slot of a service should continue to refer to the production slot of dependent services after the swap (similarly, all stage / dev slot app services should reference other stage / dev slot services, which get created together).

### Description of the fix
- We are making the slots for otel service name and app service dependencies as specific to deployment slots. These will not get swapped on slot swap operation.
- Updated the Azure.Provizioning.AppService version to 1.3.1 which adds support for `SlotConfigNames`.
- Fixes another issue with the creation of host names by correctly truncating web app and slot names in case they are longer than the allowed length. Host name creation logic.
    - Without slot, the maximum length can be 60 characters. No change
    - With slot, the web app name is truncated to 40 characters. It is then concatenated to "-{slot name}". The concatenated string is then truncated to 59 characters.

Fixes https://github.com/dotnet/aspire/issues/13660

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
