### PR TITLE
Add checks for deprecated 'aspire' workload and enhance container runtime checks

### DIFF
--- a/src/Aspire.Cli/JsonSourceGenerationContext.cs
+++ b/src/Aspire.Cli/JsonSourceGenerationContext.cs
@@ -16,6 +16,7 @@ namespace Aspire.Cli;
 [JsonSerializable(typeof(DoctorCheckResponse))]
 [JsonSerializable(typeof(EnvironmentCheckResult))]
 [JsonSerializable(typeof(DoctorCheckSummary))]
+[JsonSerializable(typeof(ContainerVersionJson))]
 internal partial class JsonSourceGenerationContext : JsonSerializerContext
 {
 }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -199,6 +199,7 @@ public class Program
         // Environment checking services.
         builder.Services.AddSingleton<IEnvironmentCheck, WslEnvironmentCheck>();
         builder.Services.AddSingleton<IEnvironmentCheck, DotNetSdkCheck>();
+        builder.Services.AddSingleton<IEnvironmentCheck, DeprecatedWorkloadCheck>();
         builder.Services.AddSingleton<IEnvironmentCheck, DevCertsCheck>();
         builder.Services.AddSingleton<IEnvironmentCheck, ContainerRuntimeCheck>();
         builder.Services.AddSingleton<IEnvironmentChecker, EnvironmentChecker>();

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/ContainerRuntimeCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/ContainerRuntimeCheck.cs
@@ -545,6 +545,9 @@ internal sealed class ContainerVersionJson
     public ContainerServerJson? Server { get; set; }
 }
 
+/// <summary>
+/// JSON structure for the Client section of container runtime version output.
+/// </summary>
 internal sealed class ContainerClientJson
 {
     [JsonPropertyName("Version")]
@@ -554,6 +557,9 @@ internal sealed class ContainerClientJson
     public string? Context { get; set; }
 }
 
+/// <summary>
+/// JSON structure for the Server section of container runtime version output.
+/// </summary>
 internal sealed class ContainerServerJson
 {
     [JsonPropertyName("Version")]

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/ContainerRuntimeCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/ContainerRuntimeCheck.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 
@@ -134,10 +135,11 @@ internal sealed partial class ContainerRuntimeCheck(ILogger<ContainerRuntimeChec
 
             // Parse the version from JSON output first, even if the command failed
             // (docker version -f json outputs client info even when daemon is not running)
-            var versionInfo = ParseVersionFromJsonOutput(versionOutput);
+            var versionInfo = ContainerVersionInfo.Parse(versionOutput);
             var clientVersion = versionInfo.ClientVersion;
             var serverVersion = versionInfo.ServerVersion;
             var context = versionInfo.Context;
+            var serverOs = versionInfo.ServerOs;
 
             // Determine if this is Docker Desktop based on context
             var isDockerDesktop = runtime == "Docker" &&
@@ -298,6 +300,21 @@ internal sealed partial class ContainerRuntimeCheck(ILogger<ContainerRuntimeChec
             var versionSuffix = clientVersion is not null ? $" (version {clientVersion})" : string.Empty;
             var runtimeName = isDockerDesktop ? "Docker Desktop" : runtime;
 
+            // Check if Docker is running in Windows container mode (only Linux containers are supported)
+            if (runtime == "Docker" && string.Equals(serverOs, "windows", StringComparison.OrdinalIgnoreCase))
+            {
+                return new EnvironmentCheckResult
+                {
+                    Category = "container",
+                    Name = "container-runtime",
+                    Status = EnvironmentCheckStatus.Fail,
+                    Message = $"{runtimeName} is running in Windows container mode{versionSuffix}",
+                    Details = "Aspire requires Linux containers. Windows containers are not supported.",
+                    Fix = "Switch Docker Desktop to Linux containers mode (right-click Docker tray icon → 'Switch to Linux containers...')",
+                    Link = "https://aka.ms/dotnet/aspire/containers"
+                };
+            }
+
             // For Docker Engine (not Desktop), check tunnel configuration
             if (runtime == "Docker" && !isDockerDesktop)
             {
@@ -342,64 +359,6 @@ internal sealed partial class ContainerRuntimeCheck(ILogger<ContainerRuntimeChec
                 Status = EnvironmentCheckStatus.Fail,
                 Message = $"Failed to check {runtime}"
             };
-        }
-    }
-
-    /// <summary>
-    /// Parses client and server versions from container runtime 'version -f json' output.
-    /// </summary>
-    internal static (Version? ClientVersion, Version? ServerVersion, string? Context) ParseVersionFromJsonOutput(string output)
-    {
-        if (string.IsNullOrWhiteSpace(output))
-        {
-            return (null, null, null);
-        }
-
-        try
-        {
-            using var document = JsonDocument.Parse(output);
-            var root = document.RootElement;
-
-            Version? clientVersion = null;
-            Version? serverVersion = null;
-            string? context = null;
-
-            // Try to get Client.Version and Client.Context
-            if (root.TryGetProperty("Client", out var client))
-            {
-                if (client.TryGetProperty("Version", out var clientVersionElement))
-                {
-                    var versionString = clientVersionElement.GetString();
-                    if (!string.IsNullOrEmpty(versionString))
-                    {
-                        Version.TryParse(versionString, out clientVersion);
-                    }
-                }
-
-                if (client.TryGetProperty("Context", out var contextElement))
-                {
-                    context = contextElement.GetString();
-                }
-            }
-
-            // Try to get Server.Version (Docker specific, may be null if daemon not running)
-            if (root.TryGetProperty("Server", out var server) &&
-                server.ValueKind != JsonValueKind.Null &&
-                server.TryGetProperty("Version", out var serverVersionElement))
-            {
-                var versionString = serverVersionElement.GetString();
-                if (!string.IsNullOrEmpty(versionString))
-                {
-                    Version.TryParse(versionString, out serverVersion);
-                }
-            }
-
-            return (clientVersion, serverVersion, context);
-        }
-        catch (JsonException)
-        {
-            // JSON parsing failed, return null to allow fallback to text parsing
-            return (null, null, null);
         }
     }
 
@@ -529,4 +488,77 @@ internal sealed partial class ContainerRuntimeCheck(ILogger<ContainerRuntimeChec
             return false;
         }
     }
+}
+
+/// <summary>
+/// Parsed container runtime version information.
+/// </summary>
+internal sealed record ContainerVersionInfo(
+    Version? ClientVersion,
+    Version? ServerVersion,
+    string? Context,
+    string? ServerOs)
+{
+    /// <summary>
+    /// Parses container version info from 'docker/podman version -f json' output.
+    /// </summary>
+    public static ContainerVersionInfo Parse(string? output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+        {
+            return new ContainerVersionInfo(null, null, null, null);
+        }
+
+        try
+        {
+            var json = JsonSerializer.Deserialize(output, JsonSourceGenerationContext.Default.ContainerVersionJson);
+            if (json is null)
+            {
+                return new ContainerVersionInfo(null, null, null, null);
+            }
+
+            Version.TryParse(json.Client?.Version, out var clientVersion);
+            Version.TryParse(json.Server?.Version, out var serverVersion);
+
+            return new ContainerVersionInfo(
+                clientVersion,
+                serverVersion,
+                json.Client?.Context,
+                json.Server?.Os);
+        }
+        catch (JsonException)
+        {
+            return new ContainerVersionInfo(null, null, null, null);
+        }
+    }
+}
+
+/// <summary>
+/// JSON structure for container runtime version output.
+/// </summary>
+internal sealed class ContainerVersionJson
+{
+    [JsonPropertyName("Client")]
+    public ContainerClientJson? Client { get; set; }
+
+    [JsonPropertyName("Server")]
+    public ContainerServerJson? Server { get; set; }
+}
+
+internal sealed class ContainerClientJson
+{
+    [JsonPropertyName("Version")]
+    public string? Version { get; set; }
+
+    [JsonPropertyName("Context")]
+    public string? Context { get; set; }
+}
+
+internal sealed class ContainerServerJson
+{
+    [JsonPropertyName("Version")]
+    public string? Version { get; set; }
+
+    [JsonPropertyName("Os")]
+    public string? Os { get; set; }
 }

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DeprecatedWorkloadCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DeprecatedWorkloadCheck.cs
@@ -111,8 +111,9 @@ internal sealed class DeprecatedWorkloadCheck(ILogger<DeprecatedWorkloadCheck> l
         {
             var trimmedLine = line.Trim();
 
-            // Skip header lines and separator lines
+            // Skip header lines, separator lines, and informational lines
             if (trimmedLine.StartsWith("Installed", StringComparison.OrdinalIgnoreCase) ||
+                trimmedLine.StartsWith("Workload version:", StringComparison.OrdinalIgnoreCase) ||
                 trimmedLine.StartsWith("---") ||
                 trimmedLine.StartsWith("Use", StringComparison.OrdinalIgnoreCase) ||
                 string.IsNullOrWhiteSpace(trimmedLine))

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DeprecatedWorkloadCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DeprecatedWorkloadCheck.cs
@@ -1,0 +1,134 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Utils.EnvironmentChecker;
+
+/// <summary>
+/// Checks if the deprecated 'aspire' workload is installed.
+/// </summary>
+/// <remarks>
+/// The 'aspire' workload has been deprecated and should be uninstalled.
+/// Users with this workload installed may encounter conflicts or confusion.
+/// </remarks>
+internal sealed class DeprecatedWorkloadCheck(ILogger<DeprecatedWorkloadCheck> logger) : IEnvironmentCheck
+{
+    private static readonly TimeSpan s_processTimeout = TimeSpan.FromSeconds(10);
+
+    public int Order => 32; // After SDK check (30), before dev certs (35)
+
+    public async Task<IReadOnlyList<EnvironmentCheckResult>> CheckAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var processInfo = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = "workload list",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = Process.Start(processInfo);
+            if (process is null)
+            {
+                logger.LogDebug("Failed to start dotnet workload list process");
+                // Don't fail the check if we can't run the command - the SDK check will catch SDK issues
+                return [];
+            }
+
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(s_processTimeout);
+
+            string output;
+            try
+            {
+                output = await process.StandardOutput.ReadToEndAsync(timeoutCts.Token);
+                await process.WaitForExitAsync(timeoutCts.Token);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                process.Kill();
+                logger.LogDebug("dotnet workload list timed out");
+                return [];
+            }
+
+            if (process.ExitCode != 0)
+            {
+                logger.LogDebug("dotnet workload list exited with code {ExitCode}", process.ExitCode);
+                return [];
+            }
+
+            // Check if the deprecated 'aspire' workload is installed
+            // The output format is typically:
+            // Installed Workload Id      Manifest Version       Installation Source
+            // --------------------------------------------------------------------
+            // aspire                     8.0.0/8.0.100          SDK 8.0.100
+            if (IsAspireWorkloadInstalled(output))
+            {
+                return [new EnvironmentCheckResult
+                {
+                    Category = "sdk",
+                    Name = "aspire-workload",
+                    Status = EnvironmentCheckStatus.Fail,
+                    Message = "Deprecated 'aspire' workload is installed",
+                    Details = "The 'aspire' workload has been deprecated and causes conflicts with modern Aspire projects.",
+                    Fix = "Run: dotnet workload uninstall aspire",
+                    Link = "https://aka.ms/aspire-prerequisites"
+                }];
+            }
+
+            // Workload not installed - this is the expected state, no need to report anything
+            return [];
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Error checking for aspire workload");
+            // Don't fail the check if we can't verify - just skip it
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Checks if the 'aspire' workload is present in the output of 'dotnet workload list'.
+    /// </summary>
+    internal static bool IsAspireWorkloadInstalled(string output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+        {
+            return false;
+        }
+
+        // Parse each line looking for the 'aspire' workload
+        // The format is whitespace-separated columns, with the first column being the workload ID
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (var line in lines)
+        {
+            var trimmedLine = line.Trim();
+
+            // Skip header lines and separator lines
+            if (trimmedLine.StartsWith("Installed", StringComparison.OrdinalIgnoreCase) ||
+                trimmedLine.StartsWith("---") ||
+                trimmedLine.StartsWith("Use", StringComparison.OrdinalIgnoreCase) ||
+                string.IsNullOrWhiteSpace(trimmedLine))
+            {
+                continue;
+            }
+
+            // The workload ID is the first column
+            var columns = trimmedLine.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries);
+            if (columns.Length > 0 &&
+                string.Equals(columns[0], "aspire", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -105,6 +105,7 @@ internal static class CliTestHelper
         services.AddSingleton(options.GitRepositoryFactory);
         services.AddSingleton<IEnvironmentCheck, WslEnvironmentCheck>();
         services.AddSingleton<IEnvironmentCheck, DotNetSdkCheck>();
+        services.AddSingleton<IEnvironmentCheck, DeprecatedWorkloadCheck>();
         services.AddSingleton<IEnvironmentCheck, DevCertsCheck>();
         services.AddSingleton<IEnvironmentCheck, ContainerRuntimeCheck>();
         services.AddSingleton<IEnvironmentChecker, EnvironmentChecker>();

--- a/tests/Aspire.Cli.Tests/Utils/ContainerRuntimeCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/ContainerRuntimeCheckTests.cs
@@ -13,13 +13,14 @@ public class ContainerRuntimeCheckTests
         // Real Docker version -f json output with both client and server
         var input = """{"Client":{"Platform":{"Name":"Docker Engine - Community"},"Version":"28.0.4","ApiVersion":"1.48","DefaultAPIVersion":"1.48","GitCommit":"b8034c0","GoVersion":"go1.23.7","Os":"linux","Arch":"amd64","BuildTime":"Tue Mar 25 15:07:16 2025","Context":"default"},"Server":{"Platform":{"Name":"Docker Engine - Community"},"Components":[{"Name":"Engine","Version":"28.0.4"}],"Version":"28.0.4","ApiVersion":"1.48"}}""";
 
-        var (clientVersion, serverVersion, context) = ContainerRuntimeCheck.ParseVersionFromJsonOutput(input);
+        var (clientVersion, serverVersion, context, serverOs) = ContainerVersionInfo.Parse(input);
 
         Assert.NotNull(clientVersion);
         Assert.Equal(new Version(28, 0, 4), clientVersion);
         Assert.NotNull(serverVersion);
         Assert.Equal(new Version(28, 0, 4), serverVersion);
         Assert.Equal("default", context);
+        Assert.Null(serverOs);
     }
 
     [Fact]
@@ -28,13 +29,14 @@ public class ContainerRuntimeCheckTests
         // Docker Desktop on macOS JSON output
         var input = """{"Client":{"Version":"28.5.1","ApiVersion":"1.51","DefaultAPIVersion":"1.51","GitCommit":"e180ab8","GoVersion":"go1.24.8","Os":"darwin","Arch":"arm64","BuildTime":"Wed Oct  8 12:16:17 2025","Context":"desktop-linux"},"Server":{"Platform":{"Name":"Docker Desktop 4.49.0 (208700)"},"Components":[{"Name":"Engine","Version":"28.5.1"}],"Version":"28.5.1","ApiVersion":"1.51","MinAPIVersion":"1.24","GitCommit":"f8215cc","GoVersion":"go1.24.8","Os":"linux","Arch":"arm64","KernelVersion":"6.10.14-linuxkit","BuildTime":"2025-10-08T12:18:25.000000000+00:00"}}""";
 
-        var (clientVersion, serverVersion, context) = ContainerRuntimeCheck.ParseVersionFromJsonOutput(input);
+        var (clientVersion, serverVersion, context, serverOs) = ContainerVersionInfo.Parse(input);
 
         Assert.NotNull(clientVersion);
         Assert.Equal(new Version(28, 5, 1), clientVersion);
         Assert.NotNull(serverVersion);
         Assert.Equal(new Version(28, 5, 1), serverVersion);
         Assert.Equal("desktop-linux", context);
+        Assert.Equal("linux", serverOs);
     }
 
     [Fact]
@@ -43,13 +45,14 @@ public class ContainerRuntimeCheckTests
         // Docker Engine (Linux) JSON output
         var input = """{"Client":{"Platform":{"Name":"Docker Engine - Community"},"Version":"29.1.3","ApiVersion":"1.52","DefaultAPIVersion":"1.52","GitCommit":"f52814d","GoVersion":"go1.25.5","Os":"linux","Arch":"amd64","BuildTime":"Fri Dec 12 14:49:37 2025","Context":"default"},"Server":{"Platform":{"Name":"Docker Engine - Community"},"Version":"29.1.3","ApiVersion":"1.52","MinAPIVersion":"1.44","Os":"linux","Arch":"amd64","Components":[{"Name":"Engine","Version":"29.1.3"}],"GitCommit":"fbf3ed2","GoVersion":"go1.25.5","KernelVersion":"5.15.0-113-generic","BuildTime":"2025-12-12T14:49:37.000000000+00:00"}}""";
 
-        var (clientVersion, serverVersion, context) = ContainerRuntimeCheck.ParseVersionFromJsonOutput(input);
+        var (clientVersion, serverVersion, context, serverOs) = ContainerVersionInfo.Parse(input);
 
         Assert.NotNull(clientVersion);
         Assert.Equal(new Version(29, 1, 3), clientVersion);
         Assert.NotNull(serverVersion);
         Assert.Equal(new Version(29, 1, 3), serverVersion);
         Assert.Equal("default", context);
+        Assert.Equal("linux", serverOs);
     }
 
     [Fact]
@@ -58,12 +61,13 @@ public class ContainerRuntimeCheckTests
         // Real Podman version -f json output (no Server section)
         var input = """{"Client":{"APIVersion":"4.9.3","Version":"4.9.3","GoVersion":"go1.22.2","GitCommit":"","BuiltTime":"Thu Jan  1 00:00:00 1970","Built":0,"OsArch":"linux/amd64","Os":"linux"}}""";
 
-        var (clientVersion, serverVersion, context) = ContainerRuntimeCheck.ParseVersionFromJsonOutput(input);
+        var (clientVersion, serverVersion, context, serverOs) = ContainerVersionInfo.Parse(input);
 
         Assert.NotNull(clientVersion);
         Assert.Equal(new Version(4, 9, 3), clientVersion);
         Assert.Null(serverVersion);
         Assert.Null(context);
+        Assert.Null(serverOs);
     }
 
     [Fact]
@@ -72,12 +76,13 @@ public class ContainerRuntimeCheckTests
         // Docker Desktop on Windows may have Server:null if daemon is not running
         var input = """{"Client":{"Version":"29.1.3","ApiVersion":"1.52","DefaultAPIVersion":"1.52","GitCommit":"f52814d","GoVersion":"go1.25.5","Os":"windows","Arch":"amd64","BuildTime":"Fri Dec 12 14:51:52 2025","Context":"desktop-linux"},"Server":null}""";
 
-        var (clientVersion, serverVersion, context) = ContainerRuntimeCheck.ParseVersionFromJsonOutput(input);
+        var (clientVersion, serverVersion, context, serverOs) = ContainerVersionInfo.Parse(input);
 
         Assert.NotNull(clientVersion);
         Assert.Equal(new Version(29, 1, 3), clientVersion);
         Assert.Null(serverVersion);
         Assert.Equal("desktop-linux", context);
+        Assert.Null(serverOs);
     }
 
     [Fact]
@@ -85,12 +90,13 @@ public class ContainerRuntimeCheckTests
     {
         var input = """{"Client":{"Version":"19.03.15","ApiVersion":"1.40"},"Server":null}""";
 
-        var (clientVersion, serverVersion, context) = ContainerRuntimeCheck.ParseVersionFromJsonOutput(input);
+        var (clientVersion, serverVersion, context, serverOs) = ContainerVersionInfo.Parse(input);
 
         Assert.NotNull(clientVersion);
         Assert.Equal(new Version(19, 3, 15), clientVersion);
         Assert.Null(serverVersion);
         Assert.Null(context);
+        Assert.Null(serverOs);
     }
 
     [Fact]
@@ -98,12 +104,13 @@ public class ContainerRuntimeCheckTests
     {
         var input = """{"Client":{"Version":"20.10","ApiVersion":"1.41"}}""";
 
-        var (clientVersion, serverVersion, context) = ContainerRuntimeCheck.ParseVersionFromJsonOutput(input);
+        var (clientVersion, serverVersion, context, serverOs) = ContainerVersionInfo.Parse(input);
 
         Assert.NotNull(clientVersion);
         Assert.Equal(new Version(20, 10), clientVersion);
         Assert.Null(serverVersion);
         Assert.Null(context);
+        Assert.Null(serverOs);
     }
 
     [Theory]
@@ -115,11 +122,12 @@ public class ContainerRuntimeCheckTests
     [InlineData("""{"Client":{}}""")]
     public void ParseVersionFromJsonOutput_WithInvalidInput_ReturnsNullVersions(string? input)
     {
-        var (clientVersion, serverVersion, context) = ContainerRuntimeCheck.ParseVersionFromJsonOutput(input!);
+        var (clientVersion, serverVersion, context, serverOs) = ContainerVersionInfo.Parse(input!);
 
         Assert.Null(clientVersion);
         Assert.Null(serverVersion);
         Assert.Null(context);
+        Assert.Null(serverOs);
     }
 
     [Fact]
@@ -128,12 +136,13 @@ public class ContainerRuntimeCheckTests
         // Edge case: only server version present (unusual but possible)
         var input = """{"Server":{"Version":"1.0.0"}}""";
 
-        var (clientVersion, serverVersion, context) = ContainerRuntimeCheck.ParseVersionFromJsonOutput(input);
+        var (clientVersion, serverVersion, context, serverOs) = ContainerVersionInfo.Parse(input);
 
         Assert.Null(clientVersion);
         Assert.NotNull(serverVersion);
         Assert.Equal(new Version(1, 0, 0), serverVersion);
         Assert.Null(context);
+        Assert.Null(serverOs);
     }
 
     [Fact]
@@ -141,11 +150,12 @@ public class ContainerRuntimeCheckTests
     {
         var input = """{"Client":{"Version":"not-a-version"}}""";
 
-        var (clientVersion, serverVersion, context) = ContainerRuntimeCheck.ParseVersionFromJsonOutput(input);
+        var (clientVersion, serverVersion, context, serverOs) = ContainerVersionInfo.Parse(input);
 
         Assert.Null(clientVersion);
         Assert.Null(serverVersion);
         Assert.Null(context);
+        Assert.Null(serverOs);
     }
 
     [Fact]
@@ -153,11 +163,12 @@ public class ContainerRuntimeCheckTests
     {
         var input = "{\"Client\":{\"Version\":\"28.0.4\""; // Missing closing braces
 
-        var (clientVersion, serverVersion, context) = ContainerRuntimeCheck.ParseVersionFromJsonOutput(input);
+        var (clientVersion, serverVersion, context, serverOs) = ContainerVersionInfo.Parse(input);
 
         Assert.Null(clientVersion);
         Assert.Null(serverVersion);
         Assert.Null(context);
+        Assert.Null(serverOs);
     }
 
     [Fact]
@@ -166,13 +177,30 @@ public class ContainerRuntimeCheckTests
         // Hypothetical case where client and server versions differ
         var input = """{"Client":{"Version":"28.0.4"},"Server":{"Version":"27.5.1"}}""";
 
-        var (clientVersion, serverVersion, context) = ContainerRuntimeCheck.ParseVersionFromJsonOutput(input);
+        var (clientVersion, serverVersion, context, serverOs) = ContainerVersionInfo.Parse(input);
 
         Assert.NotNull(clientVersion);
         Assert.Equal(new Version(28, 0, 4), clientVersion);
         Assert.NotNull(serverVersion);
         Assert.Equal(new Version(27, 5, 1), serverVersion);
         Assert.Null(context);
+        Assert.Null(serverOs);
+    }
+
+    [Fact]
+    public void ParseVersionFromJsonOutput_WithWindowsContainerMode_ReturnsWindowsServerOs()
+    {
+        // Docker running in Windows container mode
+        var input = """{"Client":{"Version":"28.0.4","Context":"default"},"Server":{"Version":"28.0.4","Os":"windows"}}""";
+
+        var (clientVersion, serverVersion, context, serverOs) = ContainerVersionInfo.Parse(input);
+
+        Assert.NotNull(clientVersion);
+        Assert.Equal(new Version(28, 0, 4), clientVersion);
+        Assert.NotNull(serverVersion);
+        Assert.Equal(new Version(28, 0, 4), serverVersion);
+        Assert.Equal("default", context);
+        Assert.Equal("windows", serverOs);
     }
 
     [Theory]

--- a/tests/Aspire.Cli.Tests/Utils/DeprecatedWorkloadCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DeprecatedWorkloadCheckTests.cs
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Utils.EnvironmentChecker;
+
+namespace Aspire.Cli.Tests.Utils;
+
+public class DeprecatedWorkloadCheckTests
+{
+    [Fact]
+    public void IsAspireWorkloadInstalled_WithAspireWorkload_ReturnsTrue()
+    {
+        var output = """
+            Installed Workload Id      Manifest Version       Installation Source
+            --------------------------------------------------------------------
+            aspire                     8.0.0/8.0.100          SDK 8.0.100
+            maui                       8.0.0/8.0.100          SDK 8.0.100
+
+            Use `dotnet workload search` to find additional workloads to install.
+            """;
+
+        var result = DeprecatedWorkloadCheck.IsAspireWorkloadInstalled(output);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsAspireWorkloadInstalled_WithoutAspireWorkload_ReturnsFalse()
+    {
+        var output = """
+            Installed Workload Id      Manifest Version       Installation Source
+            --------------------------------------------------------------------
+            maui                       8.0.0/8.0.100          SDK 8.0.100
+            android                    33.0.0/8.0.100         SDK 8.0.100
+
+            Use `dotnet workload search` to find additional workloads to install.
+            """;
+
+        var result = DeprecatedWorkloadCheck.IsAspireWorkloadInstalled(output);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsAspireWorkloadInstalled_WithNoWorkloads_ReturnsFalse()
+    {
+        var output = """
+            Installed Workload Id      Manifest Version       Installation Source
+            --------------------------------------------------------------------
+
+            Use `dotnet workload search` to find additional workloads to install.
+            """;
+
+        var result = DeprecatedWorkloadCheck.IsAspireWorkloadInstalled(output);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsAspireWorkloadInstalled_WithEmptyOutput_ReturnsFalse()
+    {
+        var result = DeprecatedWorkloadCheck.IsAspireWorkloadInstalled("");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsAspireWorkloadInstalled_WithNullOutput_ReturnsFalse()
+    {
+        var result = DeprecatedWorkloadCheck.IsAspireWorkloadInstalled(null!);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsAspireWorkloadInstalled_WithWhitespaceOutput_ReturnsFalse()
+    {
+        var result = DeprecatedWorkloadCheck.IsAspireWorkloadInstalled("   \n   \n   ");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsAspireWorkloadInstalled_IsCaseInsensitive()
+    {
+        var output = """
+            Installed Workload Id      Manifest Version       Installation Source
+            --------------------------------------------------------------------
+            ASPIRE                     8.0.0/8.0.100          SDK 8.0.100
+            """;
+
+        var result = DeprecatedWorkloadCheck.IsAspireWorkloadInstalled(output);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsAspireWorkloadInstalled_WithAspireAsPartOfOtherName_ReturnsFalse()
+    {
+        // Ensure we only match the exact workload name, not partial matches
+        var output = """
+            Installed Workload Id      Manifest Version       Installation Source
+            --------------------------------------------------------------------
+            aspire-components          8.0.0/8.0.100          SDK 8.0.100
+            """;
+
+        var result = DeprecatedWorkloadCheck.IsAspireWorkloadInstalled(output);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsAspireWorkloadInstalled_WithTabSeparatedColumns_ReturnsTrue()
+    {
+        var output = "Installed Workload Id\tManifest Version\tInstallation Source\n" +
+                     "------------------------------------------------------------\n" +
+                     "aspire\t8.0.0/8.0.100\tSDK 8.0.100\n";
+
+        var result = DeprecatedWorkloadCheck.IsAspireWorkloadInstalled(output);
+
+        Assert.True(result);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Utils/DeprecatedWorkloadCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DeprecatedWorkloadCheckTests.cs
@@ -120,4 +120,71 @@ public class DeprecatedWorkloadCheckTests
 
         Assert.True(result);
     }
+
+    /// <summary>
+    /// This test validates the exact format from 'dotnet workload list' command.
+    /// If this test fails, the output format may have changed and the parser needs updating.
+    /// </summary>
+    [Fact]
+    public void IsAspireWorkloadInstalled_WithRealWorldFormat_ParsesCorrectly()
+    {
+        // This is the actual output format from 'dotnet workload list' as of .NET 8/9/10
+        // The format is: WorkloadId (whitespace) ManifestVersion (whitespace) InstallationSource
+        // If Microsoft changes this format, this test should fail and alert us to update the parser
+        var realWorldOutput = """
+            Workload version: 10.0.101.1
+
+            Installed Workload Id      Manifest Version      Installation Source
+            --------------------------------------------------------------------
+            aspire                     8.2.2/8.0.100         SDK 8.0.400
+
+            Use `dotnet workload search` to find additional workloads to install.
+            """;
+
+        var result = DeprecatedWorkloadCheck.IsAspireWorkloadInstalled(realWorldOutput);
+
+        Assert.True(result);
+    }
+
+    /// <summary>
+    /// Validates that newer format with 'Workload version:' header line is handled.
+    /// </summary>
+    [Fact]
+    public void IsAspireWorkloadInstalled_WithWorkloadVersionHeader_ParsesCorrectly()
+    {
+        var output = """
+            Workload version: 8.0.100-manifests.abcd1234
+
+            Installed Workload Id      Manifest Version      Installation Source
+            --------------------------------------------------------------------
+            aspire                     8.0.0/8.0.100         SDK 8.0.100
+            """;
+
+        var result = DeprecatedWorkloadCheck.IsAspireWorkloadInstalled(output);
+
+        Assert.True(result);
+    }
+
+    /// <summary>
+    /// Validates that header and metadata lines are properly skipped and don't cause false positives.
+    /// </summary>
+    [Fact]
+    public void IsAspireWorkloadInstalled_WithNoAspireWorkload_SkipsHeaderLines()
+    {
+        // This tests that "Workload version:", "Installed Workload Id", "Use `dotnet...",
+        // and separator lines are all properly skipped when aspire is NOT installed
+        var output = """
+            Workload version: 10.0.101.1
+
+            Installed Workload Id      Manifest Version      Installation Source
+            --------------------------------------------------------------------
+            maui                       8.0.0/8.0.100         SDK 8.0.100
+
+            Use `dotnet workload search` to find additional workloads to install.
+            """;
+
+        var result = DeprecatedWorkloadCheck.IsAspireWorkloadInstalled(output);
+
+        Assert.False(result);
+    }
 }


### PR DESCRIPTION
- Implement DeprecatedWorkloadCheck to identify if the deprecated 'aspire' workload is installed.
- Update ContainerRuntimeCheck to handle Windows container mode and parse additional server OS information.
- Introduce ContainerVersionInfo for improved version parsing from container runtime output.
- Add tests for DeprecatedWorkloadCheck and update existing tests for ContainerRuntimeCheck.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
