### PR TITLE
Addition of Durable Task Scheduler resources to Azure Functions host library

### DIFF
--- a/Aspire.slnx
+++ b/Aspire.slnx
@@ -133,6 +133,10 @@
     <Project Path="playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/AzureFunctionsEndToEnd.AppHost.csproj" />
     <Project Path="playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj" />
   </Folder>
+  <Folder Name="/playground/AzureFunctionsWithDts/">
+    <Project Path="playground/AzureFunctionsWithDts/AzureFunctionsWithDts.AppHost/AzureFunctionsWithDts.AppHost.csproj" />
+    <Project Path="playground/AzureFunctionsWithDts/AzureFunctionsWithDts.Functions/AzureFunctionsWithDts.Functions.csproj" />
+  </Folder>
   <Folder Name="/playground/AzureKusto/">
     <Project Path="playground/AzureKusto/AzureKusto.AppHost/AzureKusto.AppHost.csproj" />
     <Project Path="playground/AzureKusto/AzureKusto.Worker/AzureKusto.Worker.csproj" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -158,6 +158,9 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.1.0-preview6" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5" />
     <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
+    <!-- playground apps dependencies for AzureFunctionsWithDts -->
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.11.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="1.0.1" />
     <!-- playground apps dependencies for javascript -->
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <!-- Pinned versions for Component Governance - Remove when root dependencies are updated -->

--- a/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.AppHost/AzureFunctionsWithDts.AppHost.csproj
+++ b/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.AppHost/AzureFunctionsWithDts.AppHost.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
+    <UserSecretsId>DC3A64A6-3991-41E2-956F-BFACC8091EC1</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.Functions" />
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.Storage" />
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.AppHost" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AzureFunctionsWithDts.Functions\AzureFunctionsWithDts.Functions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.AppHost/Program.cs
+++ b/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.AppHost/Program.cs
@@ -1,19 +1,17 @@
+using Azure.Hosting;
+
 var builder = DistributedApplication.CreateBuilder(args);
 
 var storage = builder.AddAzureStorage("storage").RunAsEmulator();
 
-var dts = builder.AddContainer("dts", "mcr.microsoft.com/dts/dts-emulator", "latest")
-    .WithEndpoint(name: "grpc", targetPort: 8080)
-    .WithEndpoint(name: "http", targetPort: 8082);
+var dts = builder.AddDurableTaskScheduler("dts").RunAsEmulator();
 
-var grpcEndpoint = dts.GetEndpoint("grpc");
-
-ReferenceExpression dtsConnectionString = ReferenceExpression.Create($"Endpoint=http://{grpcEndpoint.Property(EndpointProperty.Host)}:{grpcEndpoint.Property(EndpointProperty.Port)};Authentication=None");
+var taskHub = dts.AddTaskHub("default");
 
 builder.AddAzureFunctionsProject<Projects.AzureFunctionsWithDts_Functions>("funcapp")
     .WithHostStorage(storage)
     .WaitFor(dts)
-    .WithEnvironment("DURABLE_TASK_SCHEDULER_CONNECTION_STRING", dtsConnectionString)
-    .WithEnvironment("TASKHUB_NAME", "default");
+    .WithEnvironment("DURABLE_TASK_SCHEDULER_CONNECTION_STRING", dts)
+    .WithEnvironment("TASKHUB_NAME", taskHub.Resource.Name);
 
 builder.Build().Run();

--- a/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.AppHost/Program.cs
+++ b/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.AppHost/Program.cs
@@ -1,0 +1,19 @@
+var builder = DistributedApplication.CreateBuilder(args);
+
+var storage = builder.AddAzureStorage("storage").RunAsEmulator();
+
+var dts = builder.AddContainer("dts", "mcr.microsoft.com/dts/dts-emulator", "latest")
+    .WithEndpoint(name: "grpc", targetPort: 8080)
+    .WithEndpoint(name: "http", targetPort: 8082);
+
+var grpcEndpoint = dts.GetEndpoint("grpc");
+
+ReferenceExpression dtsConnectionString = ReferenceExpression.Create($"Endpoint=http://{grpcEndpoint.Property(EndpointProperty.Host)}:{grpcEndpoint.Property(EndpointProperty.Port)};Authentication=None");
+
+builder.AddAzureFunctionsProject<Projects.AzureFunctionsWithDts_Functions>("funcapp")
+    .WithHostStorage(storage)
+    .WaitFor(dts)
+    .WithEnvironment("DURABLE_TASK_SCHEDULER_CONNECTION_STRING", dtsConnectionString)
+    .WithEnvironment("TASKHUB_NAME", "default");
+
+builder.Build().Run();

--- a/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.AppHost/Program.cs
+++ b/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.AppHost/Program.cs
@@ -1,17 +1,14 @@
-using Azure.Hosting;
-
 var builder = DistributedApplication.CreateBuilder(args);
 
 var storage = builder.AddAzureStorage("storage").RunAsEmulator();
 
-var dts = builder.AddDurableTaskScheduler("dts").RunAsEmulator();
+var scheduler = builder.AddDurableTaskScheduler("scheduler").RunAsEmulator();
 
-var taskHub = dts.AddTaskHub("default");
+var taskHub = scheduler.AddTaskHub("taskhub");
 
 builder.AddAzureFunctionsProject<Projects.AzureFunctionsWithDts_Functions>("funcapp")
     .WithHostStorage(storage)
-    .WaitFor(dts)
-    .WithEnvironment("DURABLE_TASK_SCHEDULER_CONNECTION_STRING", dts)
-    .WithEnvironment("TASKHUB_NAME", taskHub.Resource.Name);
+    .WithEnvironment("DURABLE_TASK_SCHEDULER_CONNECTION_STRING", scheduler)
+    .WithEnvironment("TASKHUB_NAME", taskHub.Resource.TaskHubName);
 
 builder.Build().Run();

--- a/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.AppHost/Properties/launchSettings.json
+++ b/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.AppHost/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17244;http://localhost:15054",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21003",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22110"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15054",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19010",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20125"
+      }
+    },
+    "generate-manifest": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "commandLineArgs": "--publisher manifest --output-path aspire-manifest.json",
+      "applicationUrl": "http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175"
+      }
+    }
+  }
+}

--- a/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.Functions/AzureFunctionsWithDts.Functions.csproj
+++ b/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.Functions/AzureFunctionsWithDts.Functions.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Playground.ServiceDefaults\Playground.ServiceDefaults.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <AspireProjectOrPackageReference Include="Aspire.Azure.Storage.Blobs" />
+    <AspireProjectOrPackageReference Include="Aspire.Azure.Storage.Queues" />
+    <AspireProjectOrPackageReference Include="Aspire.Azure.Messaging.EventHubs" />
+    <AspireProjectOrPackageReference Include="Aspire.Azure.Messaging.ServiceBus" />
+  </ItemGroup>
+
+</Project>

--- a/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.Functions/MyOrchestrationTrigger.cs
+++ b/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.Functions/MyOrchestrationTrigger.cs
@@ -1,0 +1,29 @@
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.DurableTask;
+using Microsoft.Extensions.Logging;
+
+public class MyOrchestrationTrigger
+{
+    [Function("Chaining")]
+    public static async Task<object> Run(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        ILogger logger = context.CreateReplaySafeLogger(nameof(MyOrchestrationTrigger));
+        logger.LogInformation("Saying hello.");
+        var outputs = new List<string>();
+
+        // Replace name and input with values relevant for your Durable Functions Activity
+        outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "Tokyo"));
+        outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "Seattle"));
+        outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "London"));
+
+        // returns ["Hello Tokyo!", "Hello Seattle!", "Hello London!"]
+        return outputs;
+    }
+
+    [Function(nameof(SayHello))]
+    public static string SayHello([ActivityTrigger] string name, FunctionContext executionContext)
+    {
+        return $"Hello {name}!";
+    }
+}

--- a/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.Functions/Program.cs
+++ b/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.Functions/Program.cs
@@ -1,0 +1,12 @@
+using Microsoft.Azure.Functions.Worker.Builder;
+using Microsoft.Extensions.Hosting;
+
+var builder = FunctionsApplication.CreateBuilder(args);
+
+builder.AddServiceDefaults();
+
+builder.ConfigureFunctionsWebApplication();
+
+var host = builder.Build();
+
+host.Run();

--- a/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.Functions/Properties/launchSettings.json
+++ b/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.Functions/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "AzureFunctionsEndToEnd_Functions": {
+      "commandName": "Project",
+      "commandLineArgs": "--port 7071",
+      "launchBrowser": false
+    }
+  }
+}

--- a/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.Functions/Properties/launchSettings.json
+++ b/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.Functions/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "AzureFunctionsEndToEnd_Functions": {
+    "AzureFunctionsWithDts_Functions": {
       "commandName": "Project",
       "commandLineArgs": "--port 7071",
       "launchBrowser": false

--- a/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.Functions/host.json
+++ b/playground/AzureFunctionsWithDts/AzureFunctionsWithDts.Functions/host.json
@@ -1,0 +1,22 @@
+{
+    "version": "2.0",
+    "logging": {
+        "applicationInsights": {
+            "samplingSettings": {
+                "isEnabled": true,
+                "excludedTypes": "Request"
+            },
+            "enableLiveMetricsFilters": true
+        }
+    },
+    "extensions": {
+        "durableTask": {
+            "hubName": "%TASKHUB_NAME%",
+            "storageProvider": {
+                "type": "azureManaged",
+                "connectionStringName": "DURABLE_TASK_SCHEDULER_CONNECTION_STRING"
+            }
+        }
+    },
+    "telemetryMode": "openTelemetry"
+}

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskHubNameAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskHubNameAnnotation.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure.DurableTask;
+
+/// <summary>
+/// Annotation that supplies the name for an existing Durable Task hub resource.
+/// </summary>
+/// <param name="hubName">The name of the existing Durable Task hub.</param>
+internal sealed class DurableTaskHubNameAnnotation(object hubName) : IResourceAnnotation
+{
+    /// <summary>
+    /// Gets the name of the existing Durable Task hub.
+    /// </summary>
+    public object HubName { get; } = hubName;
+}

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskHubResource.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskHubResource.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure.DurableTask;
+
+/// <summary>
+/// Represents a Durable Task hub resource. A Task Hub groups durable orchestrations and activities.
+/// This resource extends the scheduler connection string with the TaskHub name so that clients can
+/// connect to the correct hub.
+/// </summary>
+/// <param name="name">The logical name of the Task Hub (used as the TaskHub value).</param>
+/// <param name="scheduler">The durable task scheduler resource whose connection string is the base for this hub.</param>
+public sealed class DurableTaskHubResource(string name, DurableTaskSchedulerResource scheduler) : Resource(name), IResourceWithConnectionString
+{
+    /// <summary>
+    /// Gets the connection string expression composed of the scheduler connection string and the TaskHub name.
+    /// </summary>
+    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{scheduler.ConnectionStringExpression};TaskHub={Name}");
+}

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskHubResource.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskHubResource.cs
@@ -12,10 +12,16 @@ namespace Aspire.Hosting.Azure.DurableTask;
 /// </summary>
 /// <param name="name">The logical name of the Task Hub (used as the TaskHub value).</param>
 /// <param name="scheduler">The durable task scheduler resource whose connection string is the base for this hub.</param>
-public sealed class DurableTaskHubResource(string name, DurableTaskSchedulerResource scheduler) : Resource(name), IResourceWithConnectionString
+public sealed class DurableTaskHubResource(string name, DurableTaskSchedulerResource scheduler)
+    : Resource(name), IResourceWithConnectionString, IResourceWithParent<DurableTaskSchedulerResource>
 {
     /// <summary>
     /// Gets the connection string expression composed of the scheduler connection string and the TaskHub name.
     /// </summary>
-    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{scheduler.ConnectionStringExpression};TaskHub={Name}");
+    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{Parent.ConnectionStringExpression};TaskHub={Name}");
+
+    /// <summary>
+    /// Gets the parent durable task scheduler resource that provides the base connection string.
+    /// </summary>
+    public DurableTaskSchedulerResource Parent => scheduler;
 }

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskHubResource.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskHubResource.cs
@@ -12,16 +12,22 @@ namespace Aspire.Hosting.Azure.DurableTask;
 /// </summary>
 /// <param name="name">The logical name of the Task Hub (used as the TaskHub value).</param>
 /// <param name="scheduler">The durable task scheduler resource whose connection string is the base for this hub.</param>
-public sealed class DurableTaskHubResource(string name, DurableTaskSchedulerResource scheduler)
+/// <param name="taskHubName">The name of the Task Hub. If not provided, the logical name is used.</param>
+public sealed class DurableTaskHubResource(string name, DurableTaskSchedulerResource scheduler, string? taskHubName = null)
     : Resource(name), IResourceWithConnectionString, IResourceWithParent<DurableTaskSchedulerResource>
 {
     /// <summary>
     /// Gets the connection string expression composed of the scheduler connection string and the TaskHub name.
     /// </summary>
-    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{Parent.ConnectionStringExpression};TaskHub={Name}");
+    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{Parent.ConnectionStringExpression};TaskHub={TaskHubName}");
 
     /// <summary>
     /// Gets the parent durable task scheduler resource that provides the base connection string.
     /// </summary>
     public DurableTaskSchedulerResource Parent => scheduler;
+
+    /// <summary>
+    /// Gets the name of the Task Hub. If not provided, the logical name of this resource is returned.
+    /// </summary>
+    public string TaskHubName => taskHubName ?? Name;
 }

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
@@ -91,35 +91,38 @@ public static class DurableTaskResourceExtensions
 
         var emulatorResource = new DurableTaskSchedulerEmulatorResource(builder.Resource);
 
-        var surrogateBuilder = builder.ApplicationBuilder.CreateResourceBuilder(emulatorResource)
-        .WithEnvironment(
-            context =>
-            {
-                ReferenceExpressionBuilder builder1 = new();
-
-                var durableTaskHubNames = builder.ApplicationBuilder
-                    .Resources
-                    .OfType<DurableTaskHubResource>()
-                    .Where(th => th.Parent == builder.Resource)
-                    .Select(th => th.TaskHubName)
-                    .ToList();
-
-                for (int i = 0; i < durableTaskHubNames.Count; i++)
-                {
-                    if (i == 0)
+        var surrogateBuilder =
+            builder
+                .ApplicationBuilder
+                .CreateResourceBuilder(emulatorResource)
+                .WithEnvironment(
+                    context =>
                     {
-                        builder1.AppendFormatted(durableTaskHubNames[i]);
-                    }
-                    else
-                    {
-                        builder1.AppendFormatted($", {durableTaskHubNames[i]}");
-                    }
-                }
+                        ReferenceExpressionBuilder namesBuilder = new();
 
-                ReferenceExpression referenceExpression = builder1.Build();
+                        var durableTaskHubNames =
+                            builder
+                                .ApplicationBuilder
+                                .Resources
+                                .OfType<DurableTaskHubResource>()
+                                .Where(th => th.Parent == builder.Resource)
+                                .Select(th => th.TaskHubName)
+                                .ToList();
 
-                context.EnvironmentVariables["DTS_TASK_HUB_NAMES"] = referenceExpression;
-            });
+                        for (int i = 0; i < durableTaskHubNames.Count; i++)
+                        {
+                            if (i == 0)
+                            {
+                                namesBuilder.AppendFormatted(durableTaskHubNames[i]);
+                            }
+                            else
+                            {
+                                namesBuilder.AppendFormatted($", {durableTaskHubNames[i]}");
+                            }
+                        }
+
+                        context.EnvironmentVariables["DTS_TASK_HUB_NAMES"] = namesBuilder.Build();
+                    });
 
         configureContainer?.Invoke(surrogateBuilder);
 

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
@@ -103,11 +103,11 @@ public static class DurableTaskResourceExtensions
     /// </summary>
     /// <param name="builder">The scheduler resource builder.</param>
     /// <param name="name">The logical name of the task hub resource.</param>
+    /// <param name="taskHubName">The name of the Task Hub. If not provided, the logical name is used.</param>
     /// <returns>An <see cref="IResourceBuilder{TResource}"/> for the task hub resource.</returns>
-    public static IResourceBuilder<DurableTaskHubResource> AddTaskHub(this IResourceBuilder<DurableTaskSchedulerResource> builder, string name)
+    public static IResourceBuilder<DurableTaskHubResource> AddTaskHub(this IResourceBuilder<DurableTaskSchedulerResource> builder, string name, string? taskHubName = null)
     {
-        var hub = new DurableTaskHubResource(name, builder.Resource);
-
+        var hub = new DurableTaskHubResource(name, builder.Resource, taskHubName);
         var hubBuilder = builder.ApplicationBuilder.AddResource(hub);
 
         if (builder.Resource.IsEmulator)

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
@@ -21,6 +21,9 @@ public static class DurableTaskResourceExtensions
     public static IResourceBuilder<DurableTaskSchedulerResource> AddDurableTaskScheduler(this IDistributedApplicationBuilder builder, string name)
     {
         var scheduler = new DurableTaskSchedulerResource(name);
+
+        scheduler.Annotations.Add(ManifestPublishingCallbackAnnotation.Ignore);
+
         return builder.AddResource(scheduler);
     }
 
@@ -138,6 +141,9 @@ public static class DurableTaskResourceExtensions
     public static IResourceBuilder<DurableTaskHubResource> AddTaskHub(this IResourceBuilder<DurableTaskSchedulerResource> builder, string name)
     {
         var hub = new DurableTaskHubResource(name, builder.Resource);
+
+        hub.Annotations.Add(ManifestPublishingCallbackAnnotation.Ignore);
+
         var hubBuilder = builder.ApplicationBuilder.AddResource(hub);
 
         if (builder.Resource.IsEmulator)

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
@@ -54,7 +54,7 @@ public static class DurableTaskResourceExtensions
     {
         if (!builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
         {
-            builder.WithAnnotation(new DurableTaskSchedulerConnectionStringAnnotation(connectionString));
+            builder.WithAnnotation(new DurableTaskSchedulerConnectionStringAnnotation(connectionString.Resource));
         }
 
         return builder;
@@ -103,11 +103,10 @@ public static class DurableTaskResourceExtensions
     /// </summary>
     /// <param name="builder">The scheduler resource builder.</param>
     /// <param name="name">The logical name of the task hub resource.</param>
-    /// <param name="taskHubName">The name of the Task Hub. If not provided, the logical name is used.</param>
     /// <returns>An <see cref="IResourceBuilder{TResource}"/> for the task hub resource.</returns>
-    public static IResourceBuilder<DurableTaskHubResource> AddTaskHub(this IResourceBuilder<DurableTaskSchedulerResource> builder, string name, string? taskHubName = null)
+    public static IResourceBuilder<DurableTaskHubResource> AddTaskHub(this IResourceBuilder<DurableTaskSchedulerResource> builder, string name)
     {
-        var hub = new DurableTaskHubResource(name, builder.Resource, taskHubName);
+        var hub = new DurableTaskHubResource(name, builder.Resource);
         var hubBuilder = builder.ApplicationBuilder.AddResource(hub);
 
         if (builder.Resource.IsEmulator)
@@ -128,5 +127,27 @@ public static class DurableTaskResourceExtensions
         }
 
         return hubBuilder;
+    }
+
+    /// <summary>
+    /// Sets the name of the Durable Task hub.
+    /// </summary>
+    /// <param name="builder">The task hub resource builder.</param>
+    /// <param name="taskHubName">The name of the Task Hub.</param>
+    /// <returns>The same <see cref="IResourceBuilder{DurableTaskHubResource}"/> instance for fluent chaining.</returns>
+    public static IResourceBuilder<DurableTaskHubResource> WithTaskHubName(this IResourceBuilder<DurableTaskHubResource> builder, string taskHubName)
+    {
+        return builder.WithAnnotation(new DurableTaskHubNameAnnotation(taskHubName));
+    }
+
+    /// <summary>
+    /// Sets the name of the Durable Task hub using a parameter resource.
+    /// </summary>
+    /// <param name="builder">The task hub resource builder.</param>
+    /// <param name="taskHubName">A parameter resource that resolves to the Task Hub name.</param>
+    /// <returns>The same <see cref="IResourceBuilder{DurableTaskHubResource}"/> instance for fluent chaining.</returns>
+    public static IResourceBuilder<DurableTaskHubResource> WithTaskHubName(this IResourceBuilder<DurableTaskHubResource> builder, IResourceBuilder<ParameterResource> taskHubName)
+    {
+        return builder.WithAnnotation(new DurableTaskHubNameAnnotation(taskHubName.Resource));
     }
 }

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
@@ -26,6 +26,24 @@ public static class DurableTaskResourceExtensions
     }
 
     /// <summary>
+    /// Configures the Durable Task scheduler to use an existing scheduler instance referenced by the provided connection string.
+    /// No new scheduler resource is provisioned.
+    /// </summary>
+    /// <param name="builder">The scheduler resource builder.</param>
+    /// <param name="connectionString">The connection string referencing the existing Durable Task scheduler instance.</param>
+    /// <returns>The same <see cref="IResourceBuilder{DurableTaskSchedulerResource}"/> instance for fluent chaining.</returns>
+    /// <remarks>The existing resource annotation is only applied when the execution context is not in publish mode.</remarks>
+    public static IResourceBuilder<DurableTaskSchedulerResource> RunAsExisting(this IResourceBuilder<DurableTaskSchedulerResource> builder, string connectionString)
+    {
+        if (!builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
+        {
+            builder.WithAnnotation(new DurableTaskSchedulerConnectionStringAnnotation(connectionString));
+        }
+
+        return builder;
+    }
+
+    /// <summary>
     /// Configures the Durable Task scheduler to run using the local emulator (only in non-publish modes).
     /// </summary>
     /// <param name="builder">The resource builder for the scheduler.</param>

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure.DurableTask;
+
+namespace Azure.Hosting;
+
+/// <summary>
+/// Extension methods for adding and configuring Durable Task resources within a distributed application.
+/// </summary>
+public static class DurableTaskResourceExtensions
+{
+    /// <summary>
+    /// Adds a Durable Task scheduler resource to the distributed application.
+    /// </summary>
+    /// <param name="builder">The distributed application builder.</param>
+    /// <param name="name">The logical name of the scheduler resource.</param>
+    /// <returns>An <see cref="IResourceBuilder{TResource}"/> for the scheduler resource.</returns>
+    public static IResourceBuilder<DurableTaskSchedulerResource> AddDurableTaskScheduler(this IDistributedApplicationBuilder builder, string name)
+    {
+        var scheduler = new DurableTaskSchedulerResource(name);
+        return builder.AddResource(scheduler);
+    }
+
+    /// <summary>
+    /// Configures the Durable Task scheduler to run using the local emulator (only in non-publish modes).
+    /// </summary>
+    /// <param name="builder">The resource builder for the scheduler.</param>
+    /// <returns>The same <see cref="IResourceBuilder{DurableTaskSchedulerResource}"/> instance for chaining.</returns>
+    public static IResourceBuilder<DurableTaskSchedulerResource> RunAsEmulator(this IResourceBuilder<DurableTaskSchedulerResource> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
+        {
+            return builder;
+        }
+
+        // Mark this resource as an emulator for consistent resource identification and tooling support
+        builder.WithAnnotation(new EmulatorResourceAnnotation());
+
+        builder.WithEndpoint(name: "grpc", targetPort: 8080)
+               .WithHttpEndpoint(name: "http", targetPort: 8081)
+               .WithHttpEndpoint(name: "dashboard", targetPort: 8082)
+               .WithAnnotation(new ContainerImageAnnotation
+               {
+                   Registry = DurableTaskSchedulerEmulatorContainerImageTags.Registry,
+                   Image = DurableTaskSchedulerEmulatorContainerImageTags.Image,
+                   Tag = DurableTaskSchedulerEmulatorContainerImageTags.Tag
+               });
+
+        var emulatorResource = new DurableTaskSchedulerEmulatorResource(builder.Resource);
+
+        builder.ApplicationBuilder.CreateResourceBuilder(emulatorResource);
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a Durable Task hub resource associated with the specified scheduler.
+    /// </summary>
+    /// <param name="builder">The scheduler resource builder.</param>
+    /// <param name="name">The logical name of the task hub resource.</param>
+    /// <returns>An <see cref="IResourceBuilder{TResource}"/> for the task hub resource.</returns>
+    public static IResourceBuilder<DurableTaskHubResource> AddTaskHub(this IResourceBuilder<DurableTaskSchedulerResource> builder, string name)
+    {
+        var hub = new DurableTaskHubResource(name, builder.Resource);
+        return builder.ApplicationBuilder.AddResource(hub);
+    }
+}

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
@@ -18,6 +18,15 @@ public static class DurableTaskResourceExtensions
     /// <param name="builder">The distributed application builder.</param>
     /// <param name="name">The logical name of the scheduler resource.</param>
     /// <returns>An <see cref="IResourceBuilder{TResource}"/> for the scheduler resource.</returns>
+    /// <remarks>
+    /// <example>
+    /// Add a Durable Task scheduler resource:
+    /// <code>
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    /// var scheduler = builder.AddDurableTaskScheduler("scheduler");
+    /// </code>
+    /// </example>
+    /// </remarks>
     public static IResourceBuilder<DurableTaskSchedulerResource> AddDurableTaskScheduler(this IDistributedApplicationBuilder builder, string name)
     {
         var scheduler = new DurableTaskSchedulerResource(name);
@@ -34,7 +43,19 @@ public static class DurableTaskResourceExtensions
     /// <param name="builder">The scheduler resource builder.</param>
     /// <param name="connectionString">The connection string referencing the existing Durable Task scheduler instance.</param>
     /// <returns>The same <see cref="IResourceBuilder{DurableTaskSchedulerResource}"/> instance for fluent chaining.</returns>
-    /// <remarks>The existing resource annotation is only applied when the execution context is not in publish mode.</remarks>
+    /// <remarks>
+    /// <para>
+    /// The existing resource annotation is only applied when the execution context is not in publish mode.
+    /// </para>
+    /// <example>
+    /// Use an existing scheduler instead of provisioning a new one:
+    /// <code>
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    /// var scheduler = builder.AddDurableTaskScheduler("scheduler")
+    ///     .RunAsExisting("Endpoint=https://example;...;");
+    /// </code>
+    /// </example>
+    /// </remarks>
     public static IResourceBuilder<DurableTaskSchedulerResource> RunAsExisting(this IResourceBuilder<DurableTaskSchedulerResource> builder, string connectionString)
     {
         if (!builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
@@ -52,7 +73,21 @@ public static class DurableTaskResourceExtensions
     /// <param name="builder">The scheduler resource builder.</param>
     /// <param name="connectionString">The connection string parameter referencing the existing Durable Task scheduler instance.</param>
     /// <returns>The same <see cref="IResourceBuilder{DurableTaskSchedulerResource}"/> instance for fluent chaining.</returns>
-    /// <remarks>The existing resource annotation is only applied when the execution context is not in publish mode.</remarks>
+    /// <remarks>
+    /// <para>
+    /// The existing resource annotation is only applied when the execution context is not in publish mode.
+    /// </para>
+    /// <example>
+    /// Use an existing scheduler where the connection string is supplied via a parameter:
+    /// <code>
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    /// var schedulerConnectionString = builder.AddParameter("schedulerConnectionString");
+    ///
+    /// var scheduler = builder.AddDurableTaskScheduler("scheduler")
+    ///     .RunAsExisting(schedulerConnectionString);
+    /// </code>
+    /// </example>
+    /// </remarks>
     public static IResourceBuilder<DurableTaskSchedulerResource> RunAsExisting(this IResourceBuilder<DurableTaskSchedulerResource> builder, IResourceBuilder<ParameterResource> connectionString)
     {
         if (!builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
@@ -69,6 +104,16 @@ public static class DurableTaskResourceExtensions
     /// <param name="builder">The resource builder for the scheduler.</param>
     /// <param name="configureContainer">Callback that exposes underlying container used for emulation to allow for customization.</param>
     /// <returns>The same <see cref="IResourceBuilder{DurableTaskSchedulerResource}"/> instance for chaining.</returns>
+    /// <remarks>
+    /// <example>
+    /// Run the scheduler locally using the emulator:
+    /// <code>
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    /// var scheduler = builder.AddDurableTaskScheduler("scheduler")
+    ///     .RunAsEmulator();
+    /// </code>
+    /// </example>
+    /// </remarks>
     public static IResourceBuilder<DurableTaskSchedulerResource> RunAsEmulator(this IResourceBuilder<DurableTaskSchedulerResource> builder, Action<IResourceBuilder<DurableTaskSchedulerEmulatorResource>>? configureContainer = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -136,6 +181,18 @@ public static class DurableTaskResourceExtensions
     /// <param name="builder">The scheduler resource builder.</param>
     /// <param name="name">The logical name of the task hub resource.</param>
     /// <returns>An <see cref="IResourceBuilder{TResource}"/> for the task hub resource.</returns>
+    /// <remarks>
+    /// <example>
+    /// Add a task hub under a scheduler:
+    /// <code>
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    /// var scheduler = builder.AddDurableTaskScheduler("scheduler").RunAsEmulator();
+    ///
+    /// var hub = scheduler.AddTaskHub("hub")
+    ///     .WithTaskHubName("MyTaskHub");
+    /// </code>
+    /// </example>
+    /// </remarks>
     public static IResourceBuilder<DurableTaskHubResource> AddTaskHub(this IResourceBuilder<DurableTaskSchedulerResource> builder, string name)
     {
         var hub = new DurableTaskHubResource(name, builder.Resource);
@@ -170,6 +227,16 @@ public static class DurableTaskResourceExtensions
     /// <param name="builder">The task hub resource builder.</param>
     /// <param name="taskHubName">The name of the Task Hub.</param>
     /// <returns>The same <see cref="IResourceBuilder{DurableTaskHubResource}"/> instance for fluent chaining.</returns>
+    /// <remarks>
+    /// <example>
+    /// Set the task hub name:
+    /// <code>
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    /// var scheduler = builder.AddDurableTaskScheduler("scheduler").RunAsEmulator();
+    /// var hub = scheduler.AddTaskHub("hub").WithTaskHubName("MyTaskHub");
+    /// </code>
+    /// </example>
+    /// </remarks>
     public static IResourceBuilder<DurableTaskHubResource> WithTaskHubName(this IResourceBuilder<DurableTaskHubResource> builder, string taskHubName)
     {
         return builder.WithAnnotation(new DurableTaskHubNameAnnotation(taskHubName));
@@ -181,6 +248,18 @@ public static class DurableTaskResourceExtensions
     /// <param name="builder">The task hub resource builder.</param>
     /// <param name="taskHubName">A parameter resource that resolves to the Task Hub name.</param>
     /// <returns>The same <see cref="IResourceBuilder{DurableTaskHubResource}"/> instance for fluent chaining.</returns>
+    /// <remarks>
+    /// <example>
+    /// Set the task hub name from a parameter:
+    /// <code>
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    /// var taskHubName = builder.AddParameter("taskHubName");
+    ///
+    /// var scheduler = builder.AddDurableTaskScheduler("scheduler").RunAsEmulator();
+    /// var hub = scheduler.AddTaskHub("hub").WithTaskHubName(taskHubName);
+    /// </code>
+    /// </example>
+    /// </remarks>
     public static IResourceBuilder<DurableTaskHubResource> WithTaskHubName(this IResourceBuilder<DurableTaskHubResource> builder, IResourceBuilder<ParameterResource> taskHubName)
     {
         return builder.WithAnnotation(new DurableTaskHubNameAnnotation(taskHubName.Resource));

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
@@ -213,7 +213,9 @@ public static class DurableTaskResourceExtensions
                     await notifications.PublishUpdateAsync(r, snapshot => snapshot with
                     {
                         State = KnownResourceStates.Running,
-                        Urls = [new("dashboard", url ?? throw new InvalidOperationException("URL cannot be null"), false) { DisplayProperties = new() { DisplayName = "Task Hub Dashboard" } }]
+                        Urls = url is not null
+                            ? [new("dashboard", url, false) { DisplayProperties = new() { DisplayName = "Task Hub Dashboard" } }]
+                            : []
                     }).ConfigureAwait(false);
                 });
         }

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
@@ -18,7 +18,6 @@ public static class DurableTaskResourceExtensions
     /// <param name="builder">The distributed application builder.</param>
     /// <param name="name">The logical name of the scheduler resource.</param>
     /// <returns>An <see cref="IResourceBuilder{TResource}"/> for the scheduler resource.</returns>
-    /// <remarks>
     /// <example>
     /// Add a Durable Task scheduler resource:
     /// <code>
@@ -26,7 +25,6 @@ public static class DurableTaskResourceExtensions
     /// var scheduler = builder.AddDurableTaskScheduler("scheduler");
     /// </code>
     /// </example>
-    /// </remarks>
     public static IResourceBuilder<DurableTaskSchedulerResource> AddDurableTaskScheduler(this IDistributedApplicationBuilder builder, string name)
     {
         var scheduler = new DurableTaskSchedulerResource(name);
@@ -44,9 +42,8 @@ public static class DurableTaskResourceExtensions
     /// <param name="connectionString">The connection string referencing the existing Durable Task scheduler instance.</param>
     /// <returns>The same <see cref="IResourceBuilder{DurableTaskSchedulerResource}"/> instance for fluent chaining.</returns>
     /// <remarks>
-    /// <para>
     /// The existing resource annotation is only applied when the execution context is not in publish mode.
-    /// </para>
+    /// </remarks>
     /// <example>
     /// Use an existing scheduler instead of provisioning a new one:
     /// <code>
@@ -55,7 +52,6 @@ public static class DurableTaskResourceExtensions
     ///     .RunAsExisting("Endpoint=https://example;...;");
     /// </code>
     /// </example>
-    /// </remarks>
     public static IResourceBuilder<DurableTaskSchedulerResource> RunAsExisting(this IResourceBuilder<DurableTaskSchedulerResource> builder, string connectionString)
     {
         if (!builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
@@ -74,9 +70,8 @@ public static class DurableTaskResourceExtensions
     /// <param name="connectionString">The connection string parameter referencing the existing Durable Task scheduler instance.</param>
     /// <returns>The same <see cref="IResourceBuilder{DurableTaskSchedulerResource}"/> instance for fluent chaining.</returns>
     /// <remarks>
-    /// <para>
     /// The existing resource annotation is only applied when the execution context is not in publish mode.
-    /// </para>
+    /// </remarks>
     /// <example>
     /// Use an existing scheduler where the connection string is supplied via a parameter:
     /// <code>
@@ -87,7 +82,6 @@ public static class DurableTaskResourceExtensions
     ///     .RunAsExisting(schedulerConnectionString);
     /// </code>
     /// </example>
-    /// </remarks>
     public static IResourceBuilder<DurableTaskSchedulerResource> RunAsExisting(this IResourceBuilder<DurableTaskSchedulerResource> builder, IResourceBuilder<ParameterResource> connectionString)
     {
         if (!builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
@@ -104,7 +98,6 @@ public static class DurableTaskResourceExtensions
     /// <param name="builder">The resource builder for the scheduler.</param>
     /// <param name="configureContainer">Callback that exposes underlying container used for emulation to allow for customization.</param>
     /// <returns>The same <see cref="IResourceBuilder{DurableTaskSchedulerResource}"/> instance for chaining.</returns>
-    /// <remarks>
     /// <example>
     /// Run the scheduler locally using the emulator:
     /// <code>
@@ -113,7 +106,6 @@ public static class DurableTaskResourceExtensions
     ///     .RunAsEmulator();
     /// </code>
     /// </example>
-    /// </remarks>
     public static IResourceBuilder<DurableTaskSchedulerResource> RunAsEmulator(this IResourceBuilder<DurableTaskSchedulerResource> builder, Action<IResourceBuilder<DurableTaskSchedulerEmulatorResource>>? configureContainer = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -181,7 +173,6 @@ public static class DurableTaskResourceExtensions
     /// <param name="builder">The scheduler resource builder.</param>
     /// <param name="name">The logical name of the task hub resource.</param>
     /// <returns>An <see cref="IResourceBuilder{TResource}"/> for the task hub resource.</returns>
-    /// <remarks>
     /// <example>
     /// Add a task hub under a scheduler:
     /// <code>
@@ -192,7 +183,6 @@ public static class DurableTaskResourceExtensions
     ///     .WithTaskHubName("MyTaskHub");
     /// </code>
     /// </example>
-    /// </remarks>
     public static IResourceBuilder<DurableTaskHubResource> AddTaskHub(this IResourceBuilder<DurableTaskSchedulerResource> builder, string name)
     {
         var hub = new DurableTaskHubResource(name, builder.Resource);
@@ -229,7 +219,6 @@ public static class DurableTaskResourceExtensions
     /// <param name="builder">The task hub resource builder.</param>
     /// <param name="taskHubName">The name of the Task Hub.</param>
     /// <returns>The same <see cref="IResourceBuilder{DurableTaskHubResource}"/> instance for fluent chaining.</returns>
-    /// <remarks>
     /// <example>
     /// Set the task hub name:
     /// <code>
@@ -238,7 +227,6 @@ public static class DurableTaskResourceExtensions
     /// var hub = scheduler.AddTaskHub("hub").WithTaskHubName("MyTaskHub");
     /// </code>
     /// </example>
-    /// </remarks>
     public static IResourceBuilder<DurableTaskHubResource> WithTaskHubName(this IResourceBuilder<DurableTaskHubResource> builder, string taskHubName)
     {
         return builder.WithAnnotation(new DurableTaskHubNameAnnotation(taskHubName));
@@ -250,7 +238,6 @@ public static class DurableTaskResourceExtensions
     /// <param name="builder">The task hub resource builder.</param>
     /// <param name="taskHubName">A parameter resource that resolves to the Task Hub name.</param>
     /// <returns>The same <see cref="IResourceBuilder{DurableTaskHubResource}"/> instance for fluent chaining.</returns>
-    /// <remarks>
     /// <example>
     /// Set the task hub name from a parameter:
     /// <code>
@@ -261,7 +248,6 @@ public static class DurableTaskResourceExtensions
     /// var hub = scheduler.AddTaskHub("hub").WithTaskHubName(taskHubName);
     /// </code>
     /// </example>
-    /// </remarks>
     public static IResourceBuilder<DurableTaskHubResource> WithTaskHubName(this IResourceBuilder<DurableTaskHubResource> builder, IResourceBuilder<ParameterResource> taskHubName)
     {
         return builder.WithAnnotation(new DurableTaskHubNameAnnotation(taskHubName.Resource));

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
@@ -114,14 +114,12 @@ public static class DurableTaskResourceExtensions
 
                         for (int i = 0; i < durableTaskHubNames.Count; i++)
                         {
-                            if (i == 0)
+                            if (i > 0)
                             {
-                                namesBuilder.AppendFormatted(durableTaskHubNames[i]);
+                                namesBuilder.AppendLiteral(", ");
                             }
-                            else
-                            {
-                                namesBuilder.AppendFormatted($", {durableTaskHubNames[i]}");
-                            }
+
+                            namesBuilder.AppendFormatted(durableTaskHubNames[i]);
                         }
 
                         context.EnvironmentVariables["DTS_TASK_HUB_NAMES"] = namesBuilder.Build();

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerConnectionStringAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerConnectionStringAnnotation.cs
@@ -9,7 +9,7 @@ namespace Aspire.Hosting.Azure.DurableTask;
 /// Annotation that supplies the connection string for an existing Durable Task scheduler resource.
 /// </summary>
 /// <param name="connectionString">The connection string of the existing Durable Task scheduler.</param>
-public sealed class DurableTaskSchedulerConnectionStringAnnotation(object connectionString) : IResourceAnnotation
+internal sealed class DurableTaskSchedulerConnectionStringAnnotation(object connectionString) : IResourceAnnotation
 {
     /// <summary>
     /// Gets the connection string of the existing Durable Task scheduler.

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerConnectionStringAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerConnectionStringAnnotation.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure.DurableTask;
+
+/// <summary>
+/// Annotation that supplies the connection string for an existing Durable Task scheduler resource.
+/// </summary>
+/// <param name="connectionString">The connection string of the existing Durable Task scheduler.</param>
+public sealed class DurableTaskSchedulerConnectionStringAnnotation(object connectionString) : IResourceAnnotation
+{
+    /// <summary>
+    /// Gets the connection string of the existing Durable Task scheduler.
+    /// </summary>
+    public object ConnectionString { get; } = connectionString;
+}

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerEmulatorContainerImageTags.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerEmulatorContainerImageTags.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure.DurableTask;
+
+internal static class DurableTaskSchedulerEmulatorContainerImageTags
+{
+    /// <remarks>mcr.microsoft.com</remarks>
+    public const string Registry = "mcr.microsoft.com";
+
+    /// <remarks>dts/dts-emulator</remarks>
+    public const string Image = "dts/dts-emulator";
+
+    /// <remarks>latest</remarks>
+    public const string Tag = "latest";
+}

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerEmulatorResource.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerEmulatorResource.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure.DurableTask;
+
+/// <summary>
+/// Represents the containerized emulator resource for a <see cref="DurableTaskSchedulerResource"/>.
+/// This is used to host the Durable Task scheduler logic when running locally (e.g. with an Azure Functions emulator).
+/// </summary>
+/// <param name="scheduler">The underlying durable task scheduler resource that provides naming and annotations.</param>
+/// <remarks>
+/// The emulator resource delegates its annotation collection to the underlying scheduler so that configuration
+/// and metadata remain consistent across both representations.
+/// </remarks>
+public sealed class DurableTaskSchedulerEmulatorResource(DurableTaskSchedulerResource scheduler) : ContainerResource(scheduler.Name)
+{
+    /// <inheritdoc />
+    public override ResourceAnnotationCollection Annotations => scheduler.Annotations;
+}

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerResource.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerResource.cs
@@ -34,6 +34,15 @@ public sealed class DurableTaskSchedulerResource(string name) : Resource(name), 
             return ReferenceExpression.Create($"Endpoint=http://{grpcEndpoint.Property(EndpointProperty.Host)}:{grpcEndpoint.Property(EndpointProperty.Port)};Authentication=None");
         }
 
+        static ReferenceExpression CreateReferenceExpression(object? value) => value is IResourceBuilder<ParameterResource> parameterResource
+            ? ReferenceExpression.Create($"{parameterResource}")
+            : ReferenceExpression.Create($"{value?.ToString() ?? String.Empty}");
+
+        if (this.TryGetLastAnnotation<DurableTaskSchedulerConnectionStringAnnotation>(out var connectionStringAnnotation))
+        {
+            return CreateReferenceExpression(connectionStringAnnotation.ConnectionString);
+        }
+
         throw new NotImplementedException();
     }
 

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerResource.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerResource.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure.DurableTask;
+
+/// <summary>
+/// Represents a Durable Task scheduler resource used in Aspire hosting that provides endpoints
+/// and a connection string for Durable Task orchestration scheduling.
+/// </summary>
+/// <param name="name">The unique resource name.</param>
+public sealed class DurableTaskSchedulerResource(string name) : Resource(name), IResourceWithEndpoints, IResourceWithConnectionString
+{
+    /// <summary>
+    /// Gets the expression that resolves to the connection string for the Durable Task scheduler.
+    /// </summary>
+    public ReferenceExpression ConnectionStringExpression => CreateConnectionString();
+
+    private ReferenceExpression CreateConnectionString()
+    {
+        if (this.IsContainer())
+        {
+            var grpcEndpoint = new EndpointReference(this, "grpc");
+
+            return ReferenceExpression.Create($"Endpoint=http://{grpcEndpoint.Property(EndpointProperty.Host)}:{grpcEndpoint.Property(EndpointProperty.Port)};Authentication=None");
+        }
+
+        throw new NotImplementedException();
+    }
+}

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerResource.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerResource.cs
@@ -17,13 +17,33 @@ public sealed class DurableTaskSchedulerResource(string name) : Resource(name), 
     /// </summary>
     public ReferenceExpression ConnectionStringExpression => CreateConnectionString();
 
+    internal ReferenceExpression EmulatorDashboardEndpoint => CreateDashboardEndpoint();
+
+    /// <summary>
+    /// Gets a value indicating whether the Durable Task scheduler is running using the local
+    /// emulator (container) instead of a cloud-hosted service.
+    /// </summary>
+    public bool IsEmulator => this.IsContainer();
+
     private ReferenceExpression CreateConnectionString()
     {
-        if (this.IsContainer())
+        if (IsEmulator)
         {
             var grpcEndpoint = new EndpointReference(this, "grpc");
 
             return ReferenceExpression.Create($"Endpoint=http://{grpcEndpoint.Property(EndpointProperty.Host)}:{grpcEndpoint.Property(EndpointProperty.Port)};Authentication=None");
+        }
+
+        throw new NotImplementedException();
+    }
+
+    private ReferenceExpression CreateDashboardEndpoint()
+    {
+        if (IsEmulator)
+        {
+            var dashboardEndpoint = new EndpointReference(this, "dashboard");
+
+            return ReferenceExpression.Create($"http://{dashboardEndpoint.Property(EndpointProperty.Host)}:{dashboardEndpoint.Property(EndpointProperty.Port)}");
         }
 
         throw new NotImplementedException();

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerResource.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerResource.cs
@@ -44,7 +44,7 @@ public sealed class DurableTaskSchedulerResource(string name) : Resource(name), 
             };
         }
 
-        throw new InvalidOperationException("Unable to create the Durable Task Scheduler connection string.");
+        throw new InvalidOperationException($"Unable to resolve the Durable Task Scheduler connection string. Configure the scheduler using {nameof(DurableTaskResourceExtensions.RunAsEmulator)}() or {nameof(DurableTaskResourceExtensions.RunAsExisting)}(connectionString) before accessing {nameof(ConnectionStringExpression)}.");
     }
 
     private ReferenceExpression CreateDashboardEndpoint()

--- a/src/Aspire.Hosting.Azure.Functions/README.md
+++ b/src/Aspire.Hosting.Azure.Functions/README.md
@@ -47,6 +47,60 @@ var app = builder.Build();
 app.Run();
 ```
 
+## Durable Task Scheduler (Durable Functions)
+
+The Azure Functions hosting library also provides resource APIs for using the Durable Task Scheduler (DTS) with Durable Functions.
+
+In the _AppHost.cs_ file of `AppHost`, add a Scheduler resource, create one or more Task Hubs, and pass the connection string and hub name to your Functions project:
+
+```csharp
+using Aspire.Hosting;
+using Aspire.Hosting.Azure;
+using Aspire.Hosting.Azure.Functions;
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+var storage = builder.AddAzureStorage("storage").RunAsEmulator();
+
+var scheduler = builder.AddDurableTaskScheduler("scheduler")
+    .RunAsEmulator();
+
+var taskHub = scheduler.AddTaskHub("taskhub");
+
+builder.AddAzureFunctionsProject<Projects.Company_FunctionApp>("funcapp")
+    .WithHostStorage(storage)
+    .WithEnvironment("DURABLE_TASK_SCHEDULER_CONNECTION_STRING", scheduler)
+    .WithEnvironment("TASKHUB_NAME", taskHub.Resource.TaskHubName);
+
+builder.Build().Run();
+```
+
+### Use the DTS emulator
+
+`RunAsEmulator()` starts a local container running the Durable Task Scheduler emulator.
+
+When a Scheduler runs as an emulator, Aspire automatically provides:
+
+* A "Scheduler Dashboard" URL for the scheduler resource.
+* A "Task Hub Dashboard" URL for each Task Hub resource.
+* A `DTS_TASK_HUB_NAMES` environment variable on the emulator container listing the Task Hub names associated with that scheduler.
+
+### Use an existing Scheduler
+
+If you already have a Scheduler instance, configure the resource using its connection string:
+
+```csharp
+var schedulerConnectionString = builder.AddParameter(
+    "dts-connection-string",
+    "Endpoint=https://existing-scheduler.durabletask.io;Authentication=DefaultAzure");
+
+var scheduler = builder.AddDurableTaskScheduler("scheduler")
+    .RunAsExisting(schedulerConnectionString);
+
+var taskHubName = builder.AddParameter("taskhub-name", "mytaskhub");
+var taskHub = scheduler.AddTaskHub("taskhub").WithTaskHubName(taskHubName);
+```
+
 ## Feedback & contributing
 
 https://github.com/dotnet/aspire

--- a/src/Aspire.Hosting.Azure.Functions/README.md
+++ b/src/Aspire.Hosting.Azure.Functions/README.md
@@ -81,9 +81,9 @@ builder.Build().Run();
 
 When a Scheduler runs as an emulator, Aspire automatically provides:
 
-* A "Scheduler Dashboard" URL for the scheduler resource.
-* A "Task Hub Dashboard" URL for each Task Hub resource.
-* A `DTS_TASK_HUB_NAMES` environment variable on the emulator container listing the Task Hub names associated with that scheduler.
+- A "Scheduler Dashboard" URL for the scheduler resource.
+- A "Task Hub Dashboard" URL for each Task Hub resource.
+- A `DTS_TASK_HUB_NAMES` environment variable on the emulator container listing the Task Hub names associated with that scheduler.
 
 ### Use an existing Scheduler
 
@@ -100,6 +100,10 @@ var scheduler = builder.AddDurableTaskScheduler("scheduler")
 var taskHubName = builder.AddParameter("taskhub-name", "mytaskhub");
 var taskHub = scheduler.AddTaskHub("taskhub").WithTaskHubName(taskHubName);
 ```
+## Additional documentation
+
+- https://learn.microsoft.com/azure/azure-functions
+- https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler
 
 ## Feedback & contributing
 

--- a/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
@@ -62,12 +62,13 @@ public class DurableTaskResourceExtensionsTests
         Assert.Equal(expectedConnectionString, connectionString);
     }
 
-    [Fact]
-    public async Task AddDurableTaskHub_RunAsExisting_ResolvedConnectionStringParameter()
+    [Theory]
+    [InlineData(null, "mytaskhub")]
+    [InlineData("myrealtaskhub", "myrealtaskhub")]
+    public async Task AddDurableTaskHub_RunAsExisting_ResolvedConnectionStringParameter(string? taskHubName, string expectedTaskHubName)
     {
         string dtsConnectionString = "Endpoint=https://existing-scheduler.durabletask.io;Authentication=DefaultAzure";
-        string expectedConnectionString = $"{dtsConnectionString};TaskHub=mytaskhub";
-
+        string expectedConnectionString = $"{dtsConnectionString};TaskHub={expectedTaskHubName}";
         using var builder = TestDistributedApplicationBuilder.Create();
 
         var connectionStringParameter = builder.AddParameter("dts-connection-string", expectedConnectionString);
@@ -76,7 +77,7 @@ public class DurableTaskResourceExtensionsTests
             .AddDurableTaskScheduler("dts")
             .RunAsExisting(dtsConnectionString);
 
-        var taskHub = dts.AddTaskHub("mytaskhub");
+        var taskHub = dts.AddTaskHub("mytaskhub", taskHubName);
 
         var connectionString = await taskHub.Resource.ConnectionStringExpression.GetValueAsync(default);
 

--- a/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
@@ -77,7 +77,12 @@ public class DurableTaskResourceExtensionsTests
             .AddDurableTaskScheduler("dts")
             .RunAsExisting(dtsConnectionString);
 
-        var taskHub = dts.AddTaskHub("mytaskhub", taskHubName);
+        var taskHub = dts.AddTaskHub("mytaskhub");
+        
+        if (taskHubName is not null)
+        {
+            taskHub = taskHub.WithTaskHubName(taskHubName);   
+        }
 
         var connectionString = await taskHub.Resource.ConnectionStringExpression.GetValueAsync(default);
 

--- a/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting.Azure.Tests;
+
+public class DurableTaskResourceExtensionsTests
+{
+    [Fact]
+    public async Task AddDurableTaskScheduler_RunAsEmulator_ResolvedConnectionString()
+    {
+        string expectedConnectionString = "Endpoint=http://localhost:8080;Authentication=None";
+
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var dts = builder
+            .AddDurableTaskScheduler("dts")
+            .RunAsEmulator(e =>
+            {
+                e.WithEndpoint("grpc", e => e.AllocatedEndpoint = new(e, "localhost", 8080));
+                e.WithEndpoint("http", e => e.AllocatedEndpoint = new(e, "localhost", 8081));
+                e.WithEndpoint("dashboard", e => e.AllocatedEndpoint = new(e, "localhost", 8082));
+            });
+
+        var connectionString = await dts.Resource.ConnectionStringExpression.GetValueAsync(default);
+
+        Assert.Equal(expectedConnectionString, connectionString);
+    }
+
+    [Fact]
+    public async Task AddDurableTaskScheduler_RunAsExisting_ResolvedConnectionString()
+    {
+        string expectedConnectionString = "Endpoint=https://existing-scheduler.durabletask.io;Authentication=DefaultAzure";
+
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var dts = builder
+            .AddDurableTaskScheduler("dts")
+            .RunAsExisting(expectedConnectionString);
+
+        var connectionString = await dts.Resource.ConnectionStringExpression.GetValueAsync(default);
+
+        Assert.Equal(expectedConnectionString, connectionString);
+    }
+
+    [Fact]
+    public async Task AddDurableTaskScheduler_RunAsExisting_ResolvedConnectionStringParameter()
+    {
+        string expectedConnectionString = "Endpoint=https://existing-scheduler.durabletask.io;Authentication=DefaultAzure";
+
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var connectionStringParameter = builder.AddParameter("dts-connection-string", expectedConnectionString);
+
+        var dts = builder
+            .AddDurableTaskScheduler("dts")
+            .RunAsExisting(connectionStringParameter);
+
+        var connectionString = await dts.Resource.ConnectionStringExpression.GetValueAsync(default);
+
+        Assert.Equal(expectedConnectionString, connectionString);
+    }
+
+    [Fact]
+    public async Task AddDurableTaskHub_RunAsExisting_ResolvedConnectionStringParameter()
+    {
+        string dtsConnectionString = "Endpoint=https://existing-scheduler.durabletask.io;Authentication=DefaultAzure";
+        string expectedConnectionString = $"{dtsConnectionString};TaskHub=mytaskhub";
+
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var connectionStringParameter = builder.AddParameter("dts-connection-string", expectedConnectionString);
+
+        var dts = builder
+            .AddDurableTaskScheduler("dts")
+            .RunAsExisting(dtsConnectionString);
+
+        var taskHub = dts.AddTaskHub("mytaskhub");
+
+        var connectionString = await taskHub.Resource.ConnectionStringExpression.GetValueAsync(default);
+
+        Assert.Equal(expectedConnectionString, connectionString);
+    }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
@@ -126,7 +126,7 @@ public class DurableTaskResourceExtensionsTests
         Assert.True(dts.ApplicationBuilder.ExecutionContext.IsPublishMode);
 
         var ex = Assert.Throws<InvalidOperationException>(() => _ = dts.Resource.ConnectionStringExpression);
-        Assert.Contains("Unable to create the Durable Task Scheduler connection string", ex.Message);
+        Assert.Contains("Unable to resolve the Durable Task Scheduler connection string", ex.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.Azure.Tests;
@@ -87,5 +89,170 @@ public class DurableTaskResourceExtensionsTests
         var connectionString = await taskHub.Resource.ConnectionStringExpression.GetValueAsync(default);
 
         Assert.Equal(expectedConnectionString, connectionString);
+    }
+
+    [Fact]
+    public void AddDurableTaskScheduler_IsExcludedFromPublishingManifest()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var dts = builder.AddDurableTaskScheduler("dts");
+
+        Assert.True(dts.Resource.TryGetAnnotationsOfType<ManifestPublishingCallbackAnnotation>(out var manifestAnnotations));
+        var annotation = Assert.Single(manifestAnnotations);
+        Assert.Equal(ManifestPublishingCallbackAnnotation.Ignore, annotation);
+    }
+
+    [Fact]
+    public void AddDurableTaskHub_IsExcludedFromPublishingManifest()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var dts = builder.AddDurableTaskScheduler("dts").RunAsExisting("Endpoint=https://existing-scheduler.durabletask.io;Authentication=DefaultAzure");
+        var taskHub = dts.AddTaskHub("hub");
+
+        Assert.True(taskHub.Resource.TryGetAnnotationsOfType<ManifestPublishingCallbackAnnotation>(out var manifestAnnotations));
+        var annotation = Assert.Single(manifestAnnotations);
+        Assert.Equal(ManifestPublishingCallbackAnnotation.Ignore, annotation);
+    }
+
+    [Fact]
+    public void RunAsExisting_InPublishMode_DoesNotApplyConnectionStringAnnotation()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var dts = builder.AddDurableTaskScheduler("dts")
+            .RunAsExisting("Endpoint=https://existing-scheduler.durabletask.io;Authentication=DefaultAzure");
+
+        Assert.False(dts.ApplicationBuilder.ExecutionContext.IsRunMode);
+        Assert.True(dts.ApplicationBuilder.ExecutionContext.IsPublishMode);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => _ = dts.Resource.ConnectionStringExpression);
+        Assert.Contains("Unable to create the Durable Task Scheduler connection string", ex.Message);
+    }
+
+    [Fact]
+    public void RunAsEmulator_InPublishMode_IsNoOp()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var dts = builder.AddDurableTaskScheduler("dts")
+            .RunAsEmulator();
+
+        Assert.False(dts.Resource.IsEmulator);
+        Assert.DoesNotContain(dts.Resource.Annotations, a => a is EmulatorResourceAnnotation);
+
+        Assert.Throws<InvalidOperationException>(() => _ = dts.Resource.ConnectionStringExpression);
+    }
+
+    [Fact]
+    public void RunAsEmulator_AddsEmulatorAnnotationContainerImageAndEndpoints()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var dts = builder.AddDurableTaskScheduler("dts")
+            .RunAsEmulator();
+
+        Assert.True(dts.Resource.IsEmulator);
+
+        var emulatorAnnotation = dts.Resource.Annotations.OfType<EmulatorResourceAnnotation>().SingleOrDefault();
+        Assert.NotNull(emulatorAnnotation);
+
+        var containerImageAnnotation = dts.Resource.Annotations.OfType<ContainerImageAnnotation>().SingleOrDefault();
+        Assert.NotNull(containerImageAnnotation);
+        Assert.Equal("mcr.microsoft.com", containerImageAnnotation.Registry);
+        Assert.Equal("dts/dts-emulator", containerImageAnnotation.Image);
+        Assert.Equal("latest", containerImageAnnotation.Tag);
+
+        var endpointAnnotations = dts.Resource.Annotations.OfType<EndpointAnnotation>().ToList();
+
+        var grpc = endpointAnnotations.SingleOrDefault(e => e.Name == "grpc");
+        Assert.NotNull(grpc);
+        Assert.Equal(8080, grpc.TargetPort);
+
+        var http = endpointAnnotations.SingleOrDefault(e => e.Name == "http");
+        Assert.NotNull(http);
+        Assert.Equal(8081, http.TargetPort);
+        Assert.Equal("http", http.UriScheme);
+
+        var dashboard = endpointAnnotations.SingleOrDefault(e => e.Name == "dashboard");
+        Assert.NotNull(dashboard);
+        Assert.Equal(8082, dashboard.TargetPort);
+        Assert.Equal("http", dashboard.UriScheme);
+    }
+
+    [Fact]
+    public async Task RunAsEmulator_SetsSingleDtsTaskHubNamesEnvironmentVariable()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var dts = builder.AddDurableTaskScheduler("dts").RunAsEmulator();
+
+        _ = dts.AddTaskHub("hub1").WithTaskHubName("realhub1");
+
+        var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dts.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("realhub1", env["DTS_TASK_HUB_NAMES"]);
+    }
+
+    [Fact]
+    public async Task RunAsEmulator_SetsMultipleDtsTaskHubNamesEnvironmentVariable()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var dts = builder.AddDurableTaskScheduler("dts").RunAsEmulator();
+
+        _ = dts.AddTaskHub("hub1");
+        _ = dts.AddTaskHub("hub2").WithTaskHubName("realhub2");
+
+        var env = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dts.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("hub1, realhub2", env["DTS_TASK_HUB_NAMES"]);
+    }
+
+    [Fact]
+    public async Task RunAsEmulator_DtsTaskHubNamesOnlyIncludesHubsForSameScheduler()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var dts1 = builder.AddDurableTaskScheduler("dts1").RunAsEmulator();
+        var dts2 = builder.AddDurableTaskScheduler("dts2").RunAsEmulator();
+
+        _ = dts1.AddTaskHub("hub1");
+        _ = dts2.AddTaskHub("hub2");
+
+        var env1 = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dts1.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+        var env2 = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dts2.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("hub1", env1["DTS_TASK_HUB_NAMES"]);
+        Assert.Equal("hub2", env2["DTS_TASK_HUB_NAMES"]);
+    }
+
+    [Fact]
+    public async Task WithTaskHubName_Parameter_ResolvedConnectionString()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        const string dtsConnectionString = "Endpoint=https://existing-scheduler.durabletask.io;Authentication=DefaultAzure";
+        var hubNameParameter = builder.AddParameter("hub-name", "parameterHub");
+
+        var dts = builder.AddDurableTaskScheduler("dts")
+            .RunAsExisting(dtsConnectionString);
+
+        var hub = dts.AddTaskHub("ignored").WithTaskHubName(hubNameParameter);
+
+        var connectionString = await hub.Resource.ConnectionStringExpression.GetValueAsync(default);
+        Assert.Equal($"{dtsConnectionString};TaskHub=parameterHub", connectionString);
+    }
+
+    [Fact]
+    public void DurableTaskSchedulerResource_WithoutEmulatorOrExistingConnectionString_Throws()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var dts = builder.AddDurableTaskScheduler("dts");
+
+        var ex = Assert.Throws<InvalidOperationException>(() => _ = dts.Resource.ConnectionStringExpression);
+        Assert.Contains("Unable to create the Durable Task Scheduler connection string", ex.Message);
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
@@ -73,8 +73,6 @@ public class DurableTaskResourceExtensionsTests
         string expectedConnectionString = $"{dtsConnectionString};TaskHub={expectedTaskHubName}";
         using var builder = TestDistributedApplicationBuilder.Create();
 
-        var connectionStringParameter = builder.AddParameter("dts-connection-string", expectedConnectionString);
-
         var dts = builder
             .AddDurableTaskScheduler("dts")
             .RunAsExisting(dtsConnectionString);

--- a/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/DurableTaskResourceExtensionsTests.cs
@@ -251,6 +251,6 @@ public class DurableTaskResourceExtensionsTests
         var dts = builder.AddDurableTaskScheduler("dts");
 
         var ex = Assert.Throws<InvalidOperationException>(() => _ = dts.Resource.ConnectionStringExpression);
-        Assert.Contains("Unable to create the Durable Task Scheduler connection string", ex.Message);
+        Assert.Contains("Unable to resolve the Durable Task Scheduler connection string", ex.Message);
     }
 }


### PR DESCRIPTION
## Description

Adds resources related to the Durable Task Scheduler to the Azure Functions host library.  Allows customers to start the Durable Task Scheduler emulator (or specify a connection string to an existing one) and then pass along connection strings to Azure Functions or other applications.

Replaces #9294 which had languished for too long and a fresh start was needed.

Note that this PR does *not* cover:

 - Support for DTS in the manifest
 - Support for DTS as part of a deployment
 - Client integration for consuming/configuring DTS

The intent is that these features would be added incrementally as time/demand allows.

Fixes #8926

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship. (This PR represents the minimal feature set needed to use DTS with Aspire but more features can be incrementally added as time/demand allow.)
  - [ ] No. Follow-up changes expected. 
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [microsoft/aspire.dev#214](https://github.com/microsoft/aspire.dev/issues/214): Update Azure Functions docs with examples for use of Durable Task Scheduler
  - [ ] No
