### PR TITLE
Fix recommendation numbering in CreateAgentInstructionsAsync

### DIFF
--- a/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
+++ b/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
@@ -97,9 +97,9 @@ internal static class CommonAgentApplicators
 
         ## General recommendations for working with Aspire
         1. Before making any changes always run the apphost using `aspire run` and inspect the state of resources to make sure you are building from a known state.
-        1. Changes to the _apphost.cs_ file will require a restart of the application to take effect.
-        2. Make changes incrementally and run the aspire application using the `aspire run` command to validate changes.
-        3. Use the Aspire MCP tools to check the status of resources and debug issues.
+        2. Changes to the _apphost.cs_ file will require a restart of the application to take effect.
+        3. Make changes incrementally and run the aspire application using the `aspire run` command to validate changes.
+        4. Use the Aspire MCP tools to check the status of resources and debug issues.
 
         ## Running the application
         To run the application run the following command:


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

## Description

This pull request makes a minor update to the agent instructions when created with Aspire CLI. The main change is a correction to the numbering in the list of general recommendations, ensuring the steps are sequential and clear.

- Documentation update:
  * Fixed the numbering in the general recommendations list to be sequential, changing the second item from "1." to "2." and incrementing the following items accordingly in the agent instructions section of `CommonAgentApplicators.cs`.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
