### PR TITLE
Improvements to `ResourceNotificationService.WaitFor` exceptions

### DIFF
--- a/Aspire.slnx
+++ b/Aspire.slnx
@@ -314,6 +314,9 @@
     <Project Path="playground/Stress/Stress.Empty/Stress.Empty.csproj" />
     <Project Path="playground/Stress/Stress.TelemetryService/Stress.TelemetryService.csproj" />
   </Folder>
+  <Folder Name="/playground/Testing/">
+    <Project Path="playground/Testing/Testing.Tests/Testing.Tests.csproj" />
+  </Folder>
   <Folder Name="/playground/TestShop/">
     <Project Path="playground/TestShop/BasketService/BasketService.csproj" />
     <Project Path="playground/TestShop/CatalogDb/CatalogDb.csproj" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -141,6 +141,8 @@
     <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Archives" Version="$(MicrosoftDotNetBuildTasksArchivesVersion)" />
     <PackageVersion Include="Microsoft.DotNet.GenAPI.Task" Version="9.0.103-servicing.25065.25" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0" />
+    <!-- test dependencies shared with playground -->
+    <PackageVersion Include="xunit.v3.assert" Version="$(XunitV3Version)" />     
     <!-- playground apps dependencies -->
     <PackageVersion Include="Microsoft.Orleans.Clustering.AzureStorage" Version="9.2.1" />
     <PackageVersion Include="Microsoft.Orleans.Persistence.AzureStorage" Version="9.2.1" />

--- a/playground/Testing/Testing.Tests/Properties/AssemblyInfo.cs
+++ b/playground/Testing/Testing.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using Xunit;
+
+[assembly: CaptureConsole]
+[assembly: CaptureTrace]

--- a/playground/Testing/Testing.Tests/Testing.Tests.csproj
+++ b/playground/Testing/Testing.Tests/Testing.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
+    <IsAspireHost>true</IsAspireHost>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.AppHost" />
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.Testing" />
+
+    <PackageReference Include="xunit.v3.assert"/>
+  </ItemGroup>
+
+</Project>

--- a/playground/Testing/Testing.Tests/WaitFailures.cs
+++ b/playground/Testing/Testing.Tests/WaitFailures.cs
@@ -50,7 +50,7 @@ public class WaitFailures
         }
     }
 
-    public class WaitForResoruce
+    public class WaitForResource
     {
         [Fact]
         public async Task WaitForResourceThatNeverCompletes()

--- a/playground/Testing/Testing.Tests/WaitFailures.cs
+++ b/playground/Testing/Testing.Tests/WaitFailures.cs
@@ -1,0 +1,261 @@
+using Xunit;
+using Aspire.Hosting.Testing;
+using Aspire.Hosting;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Testing.Tests;
+
+// These tests cover various scenarios in which a wait operation fails to see how helpful the
+// resulting errors / logs are
+public class WaitFailures
+{
+    private static CancellationTokenSource DefaultCancellationTokenSource()
+    {
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(TimeSpan.FromMinutes(1));
+        return cts;
+    }
+
+    public class WaitForExplicitStartResources
+    {
+
+        [Fact]
+        public async Task Container()
+        {
+            var cts = DefaultCancellationTokenSource();
+            await using var builder = DistributedApplicationTestingBuilder.Create();
+
+            var nginx = builder.AddContainer("nginx", "nginx", "")
+                .WithExplicitStart();
+
+            await using var app = builder.Build();
+            await app.StartAsync(cts.Token);
+
+            await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, cancellationToken: cts.Token);
+        }
+
+        [Fact]
+        public async Task Executable()
+        {
+            var cts = DefaultCancellationTokenSource();
+            await using var builder = DistributedApplicationTestingBuilder.Create();
+
+            var pwsh = builder.AddExecutable("pwsh", "pwsh", "")
+                .WithExplicitStart();
+
+            await using var app = builder.Build();
+            await app.StartAsync(cts.Token);
+
+            await app.ResourceNotifications.WaitForResourceAsync(pwsh.Resource.Name, cancellationToken: cts.Token);
+        }
+    }
+
+    public class WaitForResoruce
+    {
+        [Fact]
+        public async Task WaitForResourceThatNeverCompletes()
+        {
+            var cts = DefaultCancellationTokenSource();
+            await using var builder = DistributedApplicationTestingBuilder.Create();
+
+            var nginx = builder.AddContainer("nginx", "nginx");
+
+            await using var app = builder.Build();
+            await app.StartAsync(cts.Token);
+
+            _ = Task.Run(async () =>
+            {
+                await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, cancellationToken: cts.Token);
+                cts.Cancel();
+            });
+
+            await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.TerminalStates, cancellationToken: cts.Token);
+        }
+
+        [Fact]
+        public async Task WaitForResourceThatNeverHitsState()
+        {
+            var cts = DefaultCancellationTokenSource();
+            await using var builder = DistributedApplicationTestingBuilder.Create();
+
+            var nginx = builder.AddContainer("nginx", "nginx");
+
+            await using var app = builder.Build();
+            await app.StartAsync(cts.Token);
+
+            cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+            await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, "StateThatIsNeverUsed", cts.Token);
+        }
+
+        [Fact]
+        public async Task WaitForResourceThatNeverHitsStates()
+        {
+            var cts = DefaultCancellationTokenSource();
+            await using var builder = DistributedApplicationTestingBuilder.Create();
+
+            var nginx = builder.AddContainer("nginx", "nginx");
+
+            await using var app = builder.Build();
+            await app.StartAsync(cts.Token);
+
+            cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+            await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, ["States", "That", "Are", "Never", "Used"], cts.Token);
+        }
+
+        [Fact]
+        public async Task WaitForResourceThatNeverHitsPredicate()
+        {
+            var cts = DefaultCancellationTokenSource();
+            await using var builder = DistributedApplicationTestingBuilder.Create();
+
+            var nginx = builder.AddContainer("nginx", "nginx");
+
+            await using var app = builder.Build();
+            await app.StartAsync(cts.Token);
+
+            cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+            await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, x => false, cts.Token);
+        }
+    }
+
+    public class WaitForResourceHealthyAsync
+    {
+        [Fact]
+        public async Task WaitForHealthyOnResourceThatNeverStarts()
+        {
+            var cts = DefaultCancellationTokenSource();
+            await using var builder = DistributedApplicationTestingBuilder.Create();
+
+            var nginx = builder.AddContainer("nginx", "nginx")
+                .WithExplicitStart();
+
+            await using var app = builder.Build();
+            await app.StartAsync(cts.Token);
+
+            cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+            await app.ResourceNotifications.WaitForResourceHealthyAsync(nginx.Resource.Name, cts.Token);
+        }
+
+        [Fact]
+        public async Task WaitForHealthyOnResourceThatStartsButNeverGoesHealthy()
+        {
+            var cts = DefaultCancellationTokenSource();
+            await using var builder = DistributedApplicationTestingBuilder.Create();
+
+            var nginx = builder.AddContainer("nginx", "nginx")
+                .WithHttpEndpoint(targetPort: 80)
+                .WithHttpEndpoint(name: "fake", targetPort: 1234)
+                .WithHttpHealthCheck("/does-not-exist")
+                .WithHttpHealthCheck("/throws-exception", endpointName: "fake");
+
+            await using var app = builder.Build();
+            await app.StartAsync(cts.Token);
+
+            _ = Task.Run(async () =>
+            {
+                await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, x => x.Snapshot.HealthReports.All(x => x.Status.HasValue), cts.Token);
+                cts.Cancel();
+            });
+            await app.ResourceNotifications.WaitForResourceHealthyAsync(nginx.Resource.Name, cts.Token);
+        }
+
+        [Fact]
+        public async Task WaitForHealthyOnResourceThatGoesHealthyButNeverCompletesResourceReady()
+        {
+            var cts = DefaultCancellationTokenSource();
+            await using var builder = DistributedApplicationTestingBuilder.Create();
+
+            var nginx = builder.AddContainer("nginx", "nginx")
+                .OnResourceReady((_, _, token) => Task.Delay(Timeout.Infinite, token));
+
+            await using var app = builder.Build();
+            await app.StartAsync(cts.Token);
+
+            _ = Task.Run(async () =>
+            {
+                await app.ResourceNotifications.WaitForResourceAsync(nginx.Resource.Name, x => x.Snapshot.HealthStatus == HealthStatus.Healthy, cts.Token);
+                cts.Cancel();
+            });
+
+            await app.ResourceNotifications.WaitForResourceHealthyAsync(nginx.Resource.Name, cts.Token);
+        }
+    }
+
+    public class WaitForDependencies
+    {
+        [Fact]
+        public async Task DependencyNeverStarts()
+        {
+            var cts = DefaultCancellationTokenSource();
+            await using var builder = DistributedApplicationTestingBuilder.Create();
+
+            var dependency = builder.AddContainer("dependency", "nginx")
+                .WithExplicitStart();
+
+            var consumer = builder.AddContainer("consumer", "nginx")
+                .WaitForStart(dependency);
+
+            await using var app = builder.Build();
+
+            // Chicken and egg problem - need `WaitFor` to test `WaitForDependenciesAsync`
+            // but adding `WaitFor` causes `StartAsync` to block until all resource dependencies are started
+            // But I'm trying to test what happens when the waits are not complete.
+            _ = app.StartAsync(cts.Token);
+
+            cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+            await app.ResourceNotifications.WaitForDependenciesAsync(consumer.Resource, cts.Token);
+        }
+
+        [Fact]
+        public async Task DependencyNeverGoesHealthy()
+        {
+            var cts = DefaultCancellationTokenSource();
+
+            await using var builder = DistributedApplicationTestingBuilder.Create();
+
+            var dependency = builder.AddContainer("dependency", "nginx")
+                .WithHttpEndpoint(targetPort: 80)
+                .WithHttpHealthCheck("/does-not-exist");
+
+            var consumer = builder.AddContainer("consumer", "nginx")
+                .WaitFor(dependency);
+
+            await using var app = builder.Build();
+            _ = app.StartAsync(cts.Token);
+
+            _ = Task.Run(async () =>
+            {
+                await app.ResourceNotifications.WaitForResourceAsync(dependency.Resource.Name, cancellationToken: cts.Token);
+                cts.Cancel();
+            });
+
+            await app.ResourceNotifications.WaitForDependenciesAsync(consumer.Resource, cts.Token);
+        }
+
+        [Fact]
+        public async Task DependencyNeverCompletes()
+        {
+            var cts = DefaultCancellationTokenSource();
+
+            await using var builder = DistributedApplicationTestingBuilder.Create();
+
+            var dependency = builder.AddContainer("dependency", "nginx");
+
+            var consumer = builder.AddContainer("consumer", "nginx")
+                .WaitForCompletion(dependency);
+
+            await using var app = builder.Build();
+            _ = app.StartAsync(cts.Token);
+
+            _ = Task.Run(async () =>
+            {
+                await app.ResourceNotifications.WaitForResourceAsync(dependency.Resource.Name, cancellationToken: cts.Token);
+                cts.Cancel();
+            });
+
+            await app.ResourceNotifications.WaitForDependenciesAsync(consumer.Resource, cancellationToken: cts.Token);
+        }
+
+    }
+}

--- a/playground/Testing/Testing.Tests/WaitFailures.cs
+++ b/playground/Testing/Testing.Tests/WaitFailures.cs
@@ -19,7 +19,6 @@ public class WaitFailures
 
     public class WaitForExplicitStartResources
     {
-
         [Fact]
         public async Task Container()
         {

--- a/playground/Testing/Testing.Tests/WaitFailures.cs
+++ b/playground/Testing/Testing.Tests/WaitFailures.cs
@@ -255,6 +255,5 @@ public class WaitFailures
 
             await app.ResourceNotifications.WaitForDependenciesAsync(consumer.Resource, cancellationToken: cts.Token);
         }
-
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -133,7 +133,6 @@ public class ResourceNotificationService : IDisposable
 
         var finalState = resourceEvent.Snapshot.State!.Text!;
         _logger.LogDebug("Finished waiting for resource '{ResourceName}'. Resource state is '{State}'.", resourceName, finalState);
-        
         return finalState;
     }
 

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -884,20 +884,19 @@ public class ResourceNotificationService : IDisposable
 
         if (TryGetCurrentState(resourceName, out var evt) && evt.Snapshot != null)
         {
-            var state = evt.Snapshot;
             var snapshot = evt.Snapshot;
 
-            WriteValue("Current State", state.State?.Text);
+            WriteValue("Current State", snapshot.State?.Text);
             WriteValue("Creation Time", snapshot.CreationTimeStamp);
             WriteValueIfNotNull("Start Time", snapshot.StartTimeStamp);
             WriteValueIfNotNull("Stop Time", snapshot.StopTimeStamp);
             WriteValueIfNotNull("Exit Code", snapshot.ExitCode);
-            WriteValue("Current Health", state.HealthStatus);
+            WriteValue("Current Health", snapshot.HealthStatus);
 
-            if (state.HealthReports.Length > 0)
+            if (snapshot.HealthReports.Length > 0)
             {
                 error.AppendLine("- Health Reports:");
-                foreach (var report in state.HealthReports)
+                foreach (var report in snapshot.HealthReports)
                 {
                     error.Append(CultureInfo.InvariantCulture, $"  - {report.Name}: {report.Status?.ToString() ?? "Unknown"}");
                     if (report.LastRunAt.HasValue)

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -125,20 +125,16 @@ public class ResourceNotificationService : IDisposable
             _logger.LogDebug("Waiting for resource '{ResourceName}' to enter one of the target state: {TargetStates}", resourceName, string.Join(", ", targetStates));
         }
 
-        using var watchCts = CancellationTokenSource.CreateLinkedTokenSource(_disposing.Token, cancellationToken);
-        var watchToken = watchCts.Token;
-        await foreach (var resourceEvent in WatchAsync(watchToken).ConfigureAwait(false))
-        {
-            if (string.Equals(resourceName, resourceEvent.Resource.Name, StringComparisons.ResourceName)
-                && resourceEvent.Snapshot.State?.Text is { Length: > 0 } stateText
-                && targetStates.Contains(stateText, StringComparers.ResourceState))
-            {
-                _logger.LogDebug("Finished waiting for resource '{ResourceName}'. Resource state is '{State}'.", resourceName, stateText);
-                return stateText;
-            }
-        }
+        var resourceEvent = await WaitForResourceCoreAsync(
+            resourceName,
+            re => re.Snapshot.State?.Text is { Length: > 0 } stateText && targetStates.Contains(stateText, StringComparers.ResourceState),
+            $"Resource '{resourceName}' failed to reach one of the target states: [{string.Join(", ", targetStates)}] before the operation was cancelled.",
+            cancellationToken).ConfigureAwait(false);
 
-        throw new OperationCanceledException($"The operation was cancelled before the resource reached one of the target states: [{string.Join(", ", targetStates)}]");
+        var finalState = resourceEvent.Snapshot.State!.Text!;
+        _logger.LogDebug("Finished waiting for resource '{ResourceName}'. Resource state is '{State}'.", resourceName, finalState);
+        
+        return finalState;
     }
 
     private async Task WaitUntilHealthyAsync(IResource resource, IResource dependency, WaitBehavior waitBehavior, CancellationToken cancellationToken)
@@ -150,12 +146,20 @@ public class ResourceNotificationService : IDisposable
             if (dependency.TryGetAnnotationsOfType<HealthCheckAnnotation>(out var _))
             {
                 resourceLogger.LogInformation("Waiting for resource '{ResourceName}' to become healthy.", displayName);
-                await WaitForResourceCoreAsync(dependency.Name, re => re.ResourceId == resourceId && re.Snapshot.HealthStatus == HealthStatus.Healthy, cancellationToken).ConfigureAwait(false);
+                await WaitForResourceCoreAsync(
+                    dependency.Name,
+                    re => re.ResourceId == resourceId && re.Snapshot.HealthStatus == HealthStatus.Healthy,
+                    $"Resource '{displayName}' failed to become healthy before the operation was cancelled.",
+                    cancellationToken).ConfigureAwait(false);
             }
 
             // Now wait for the resource ready event to be executed.
             resourceLogger.LogInformation("Waiting for resource ready to execute for '{ResourceName}'.", displayName);
-            resourceEvent = await WaitForResourceCoreAsync(dependency.Name, re => re.ResourceId == resourceId && re.Snapshot.ResourceReadyEvent is not null, cancellationToken: cancellationToken).ConfigureAwait(false);
+            resourceEvent = await WaitForResourceCoreAsync(
+                dependency.Name,
+                re => re.ResourceId == resourceId && re.Snapshot.ResourceReadyEvent is not null,
+                $"Resource '{displayName}' failed to execute the resource ready event before the operation was cancelled.",
+                cancellationToken: cancellationToken).ConfigureAwait(false);
 
             // Observe the result of the resource ready event task
             await resourceEvent.Snapshot.ResourceReadyEvent!.EventTask.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -219,7 +223,11 @@ public class ResourceNotificationService : IDisposable
     public async Task<ResourceEvent> WaitForResourceHealthyAsync(string resourceName, WaitBehavior waitBehavior, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Waiting for resource '{ResourceName}' to enter the '{State}' state.", resourceName, HealthStatus.Healthy);
-        var resourceEvent = await WaitForResourceCoreAsync(resourceName, re => ShouldYield(waitBehavior, re.Snapshot), cancellationToken: cancellationToken).ConfigureAwait(false);
+        var resourceEvent = await WaitForResourceCoreAsync(
+            resourceName,
+            re => ShouldYield(waitBehavior, re.Snapshot),
+            $"Resource '{resourceName}' failed to become healthy before the operation was cancelled.",
+            cancellationToken: cancellationToken).ConfigureAwait(false);
 
         if (resourceEvent.Snapshot.HealthStatus != HealthStatus.Healthy)
         {
@@ -229,7 +237,11 @@ public class ResourceNotificationService : IDisposable
 
         // Now wait for the resource ready event to be executed (matching behavior of WaitUntilHealthyAsync).
         _logger.LogDebug("Waiting for resource ready to execute for '{ResourceName}'.", resourceName);
-        resourceEvent = await WaitForResourceCoreAsync(resourceName, re => re.ResourceId == resourceEvent.ResourceId && re.Snapshot.ResourceReadyEvent is not null, cancellationToken: cancellationToken).ConfigureAwait(false);
+        resourceEvent = await WaitForResourceCoreAsync(
+            resourceName,
+            re => re.ResourceId == resourceEvent.ResourceId && re.Snapshot.ResourceReadyEvent is not null,
+            $"Resource '{resourceName}' failed to execute the resource ready event before the operation was cancelled.",
+            cancellationToken: cancellationToken).ConfigureAwait(false);
 
         // Observe the result of the resource ready event task
         await resourceEvent.Snapshot.ResourceReadyEvent!.EventTask.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -272,7 +284,11 @@ public class ResourceNotificationService : IDisposable
 
         async Task Core(string displayName, string resourceId)
         {
-            var resourceEvent = await WaitForResourceCoreAsync(dependency.Name, re => re.ResourceId == resourceId && IsKnownTerminalState(re.Snapshot), cancellationToken: cancellationToken).ConfigureAwait(false);
+            var resourceEvent = await WaitForResourceCoreAsync(
+                dependency.Name,
+                re => re.ResourceId == resourceId && IsKnownTerminalState(re.Snapshot),
+                $"Resource '{displayName}' failed to reach a terminal state before the operation was cancelled.",
+                cancellationToken: cancellationToken).ConfigureAwait(false);
             var snapshot = resourceEvent.Snapshot;
 
             if (snapshot.State?.Text == KnownResourceStates.FailedToStart)
@@ -327,7 +343,11 @@ public class ResourceNotificationService : IDisposable
 
         async Task Core(string displayName, string resourceId)
         {
-            var resourceEvent = await WaitForResourceCoreAsync(dependency.Name, re => re.ResourceId == resourceId && IsContinuableState(waitBehavior, re.Snapshot), cancellationToken: cancellationToken).ConfigureAwait(false);
+            var resourceEvent = await WaitForResourceCoreAsync(
+                dependency.Name,
+                re => re.ResourceId == resourceId && IsContinuableState(waitBehavior, re.Snapshot),
+                $"Resource '{displayName}' failed to reach the 'Running' state before the operation was cancelled.",
+                cancellationToken: cancellationToken).ConfigureAwait(false);
             var snapshot = resourceEvent.Snapshot;
 
             if (waitBehavior == WaitBehavior.StopOnResourceUnavailable)
@@ -438,25 +458,37 @@ public class ResourceNotificationService : IDisposable
     public async Task<ResourceEvent> WaitForResourceAsync(string resourceName, Func<ResourceEvent, bool> predicate, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Waiting for resource '{ResourceName}' to match predicate.", resourceName);
-        var resourceEvent = await WaitForResourceCoreAsync(resourceName, predicate, cancellationToken).ConfigureAwait(false);
+        var resourceEvent = await WaitForResourceCoreAsync(
+            resourceName,
+            predicate,
+            $"Resource '{resourceName}' failed to meet the predicate condition before the operation was cancelled.",
+            cancellationToken).ConfigureAwait(false);
         _logger.LogDebug("Finished waiting for resource '{ResourceName}'.", resourceName);
 
         return resourceEvent;
     }
 
-    private async Task<ResourceEvent> WaitForResourceCoreAsync(string resourceName, Func<ResourceEvent, bool> predicate, CancellationToken cancellationToken = default)
+    private async Task<ResourceEvent> WaitForResourceCoreAsync(string resourceName, Func<ResourceEvent, bool> predicate, string cancellationMessage, CancellationToken cancellationToken = default)
     {
-        using var watchCts = CancellationTokenSource.CreateLinkedTokenSource(_disposing.Token, cancellationToken);
-        var watchToken = watchCts.Token;
-        await foreach (var resourceEvent in WatchAsync(watchToken).ConfigureAwait(false))
+        try
         {
-            if (string.Equals(resourceName, resourceEvent.Resource.Name, StringComparisons.ResourceName) && predicate(resourceEvent))
+            using var watchCts = CancellationTokenSource.CreateLinkedTokenSource(_disposing.Token, cancellationToken);
+            var watchToken = watchCts.Token;
+            await foreach (var resourceEvent in WatchAsync(watchToken).ConfigureAwait(false))
             {
-                return resourceEvent;
+                if (string.Equals(resourceName, resourceEvent.Resource.Name, StringComparisons.ResourceName) && predicate(resourceEvent))
+                {
+                    return resourceEvent;
+                }
             }
         }
+        catch (OperationCanceledException ex)
+        {
+            var errorMessage = BuildCancellationErrorMessage(cancellationMessage, resourceName);
+            throw new OperationCanceledException(errorMessage, ex, ex.CancellationToken);
+        }
 
-        throw new OperationCanceledException($"The operation was cancelled before the resource met the predicate condition.");
+        throw new OperationCanceledException(BuildCancellationErrorMessage(cancellationMessage, resourceName));
     }
 
     private readonly object _onResourceUpdatedLock = new();
@@ -828,6 +860,71 @@ public class ResourceNotificationService : IDisposable
 
     private ResourceNotificationState GetResourceNotificationState(string resourceId, IResource resource) =>
         _resourceNotificationStates.GetOrAdd(resourceId, _ => new ResourceNotificationState(resource));
+
+    private string BuildCancellationErrorMessage(string cancellationMessage, string resourceName)
+    {
+        var error = new System.Text.StringBuilder()
+            .AppendLine(cancellationMessage);
+
+        void WriteValue(string label, object? value)
+        {
+            error.Append("- ")
+                .Append(label)
+                .Append(": ")
+                .AppendLine(value?.ToString() ?? "(null)");
+        }
+
+        void WriteValueIfNotNull(string label, object? value)
+        {
+            if (value != null)
+            {
+                WriteValue(label, value);
+            }
+        }
+
+        if (TryGetCurrentState(resourceName, out var evt) && evt.Snapshot != null)
+        {
+            var state = evt.Snapshot;
+            var snapshot = evt.Snapshot;
+
+            WriteValue("Current State", state.State?.Text);
+            WriteValue("Creation Time", snapshot.CreationTimeStamp);
+            WriteValueIfNotNull("Start Time", snapshot.StartTimeStamp);
+            WriteValueIfNotNull("Stop Time", snapshot.StopTimeStamp);
+            WriteValueIfNotNull("Exit Code", snapshot.ExitCode);
+            WriteValue("Current Health", state.HealthStatus);
+
+            if (state.HealthReports.Length > 0)
+            {
+                error.AppendLine("- Health Reports:");
+                foreach (var report in state.HealthReports)
+                {
+                    error.Append(CultureInfo.InvariantCulture, $"  - {report.Name}: {report.Status?.ToString() ?? "Unknown"}");
+                    if (report.LastRunAt.HasValue)
+                    {
+                        error.Append(CultureInfo.InvariantCulture, $" @ {report.LastRunAt.Value:yyyy-MM-dd HH:mm:ss}");
+                    }
+                    error.AppendLine();
+
+                    if (!string.IsNullOrEmpty(report.ExceptionText))
+                    {
+                        // Indent the exception text
+                        var lines = report.ExceptionText.Split('\n');
+                        foreach (var line in lines)
+                        {
+                            error.AppendLine(CultureInfo.InvariantCulture, $"    {line.TrimEnd()}");
+                        }
+                    }
+                }
+            }
+        }
+        else
+        {
+            error.AppendLine(CultureInfo.InvariantCulture, $"Unable to retrieve current state for resource '{resourceName}'.");
+        }
+
+        return error.ToString().TrimEnd();
+    }
 
     /// <inheritdoc/>
     public void Dispose()

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -196,7 +196,12 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
         // This is to reduce log noise when we activate health checks for resources which may not yet be
         // fully initialized. For example a database which is not yet created.
-        _innerBuilder.Logging.AddFilter("Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService", LogLevel.None);
+        // Only suppress these logs when the dashboard is enabled, as the dashboard provides visibility into health check failures.
+        // When the dashboard is disabled (e.g., in tests), these logs are valuable for troubleshooting.
+        if (options.DashboardEnabled)
+        {
+            _innerBuilder.Logging.AddFilter("Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService", LogLevel.None);
+        }
 
         // This is so that we can see certificate errors in the resource server in the console logs.
         // See: https://github.com/dotnet/aspire/issues/2914

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -24,6 +24,5 @@
     <PackageVersion Include="Testcontainers" Version="$(TestcontainersPackageVersion)" />
     <PackageVersion Include="Verify.XunitV3" Version="31.1.0" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="$(XunitV3Version)" />
-    <PackageVersion Include="xunit.v3.assert" Version="$(XunitV3Version)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

- Updated `DistributedApplicationBuilder` to not disable health check logging when the dashboard is disabled.
- Updated `WaitFor` methods in `ResourceNotificationService` to return error messages with more details about the current state of a resource when a wait is cancelled.
- Add playground test project
- Added some tests to explore how wait failures come across to a user

Fixes parts 2 and 3 from #13714.

More specifically, when a `WaitForXYZ` method gets cancelled, rather than getting a general "Operation has timed out" error, you'll get something more like:

```
System.OperationCanceledException : Resource 'nginx' failed to become healthy before the operation was cancelled.
  - Current State: Running
  - Creation Time: 02/01/2026 15:38:40
  - Start Time: 02/01/2026 15:38:44
  - Current Health: Unhealthy
  - Health Reports:
    - nginx_http_/does-not-exist_200_check: Unhealthy @ 2026-01-02 15:38:50
    - nginx_fake_/throws-exception_200_check: Unhealthy @ 2026-01-02 15:38:50
      System.Net.Http.HttpRequestException: An error occurred while sending the request.
       ---> System.Net.Http.HttpIOException: The response ended prematurely. (ResponseEnded)
         at System.Net.Http.HttpConnection.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
         --- End of inner exception stack trace ---
         <SNIP>...</SNIP>
  ---- System.OperationCanceledException : The operation was canceled.
    at Aspire.Hosting.ApplicationModel.ResourceNotificationService.WaitForResourceCoreAsync(String resourceName, Func`2 predicate, String cancellationMessage, CancellationToken cancellationToken) in S:\aspire\src\Aspire.Hosting\ApplicationModel\ResourceNotificationService.cs:488
    at Aspire.Hosting.ApplicationModel.ResourceNotificationService.WaitForResourceHealthyAsync(String resourceName, WaitBehavior waitBehavior, CancellationToken cancellationToken) in S:\aspire\src\Aspire.Hosting\ApplicationModel\ResourceNotificationService.cs:226
         <SNIP>...</SNIP>
```

Attached is the full output from running the playground tests to see some fuller examples of how this shows up
[Testing.Tests_net8.0_x64.log](https://github.com/user-attachments/files/24409511/Testing.Tests_net8.0_x64.log)


## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] No
- Did you add public API?
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [X] No
- Does the change require an update in our Aspire docs?
  - [X] No
