### PR TITLE
Expose 'Never' image pull policy and update tests to validate it

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ContainerPullPolicyAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerPullPolicyAnnotation.cs
@@ -22,6 +22,10 @@ public enum ImagePullPolicy
     /// Pull the image only if it does not already exist.
     /// </summary>
     Missing,
+    /// <summary>
+    /// Never pull the image from the registry even if it is missing locally.
+    /// </summary>
+    Never,
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1804,6 +1804,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                     ImagePullPolicy.Default => null,
                     ImagePullPolicy.Always => ContainerPullPolicy.Always,
                     ImagePullPolicy.Missing => ContainerPullPolicy.Missing,
+                    ImagePullPolicy.Never => ContainerPullPolicy.Never,
                     _ => throw new InvalidOperationException($"Unknown pull policy '{Enum.GetName(typeof(ImagePullPolicy), pullPolicy)}' for container '{container.Name}'")
                 };
             }

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -1251,6 +1251,7 @@ public class DcpExecutorTests
         builder.AddContainer("ExplicitDefault", "container").WithImagePullPolicy(ImagePullPolicy.Default);
         builder.AddContainer("ExplicitAlways", "container").WithImagePullPolicy(ImagePullPolicy.Always);
         builder.AddContainer("ExplicitMissing", "container").WithImagePullPolicy(ImagePullPolicy.Missing);
+        builder.AddContainer("ExplicitNever", "container").WithImagePullPolicy(ImagePullPolicy.Never);
 
         var kubernetesService = new TestKubernetesService();
 
@@ -1263,7 +1264,7 @@ public class DcpExecutorTests
         await appExecutor.RunApplicationAsync();
 
         // Assert
-        Assert.Equal(4, kubernetesService.CreatedResources.OfType<Container>().Count());
+        Assert.Equal(5, kubernetesService.CreatedResources.OfType<Container>().Count());
         var implicitDefaultContainer = Assert.Single(kubernetesService.CreatedResources.OfType<Container>(), c => c.AppModelResourceName == "ImplicitDefault");
         Assert.Null(implicitDefaultContainer.Spec.PullPolicy);
 
@@ -1275,6 +1276,9 @@ public class DcpExecutorTests
 
         var explicitMissingContainer = Assert.Single(kubernetesService.CreatedResources.OfType<Container>(), c => c.AppModelResourceName == "ExplicitMissing");
         Assert.Equal(ContainerPullPolicy.Missing, explicitMissingContainer.Spec.PullPolicy);
+
+        var explicitNeverContainer = Assert.Single(kubernetesService.CreatedResources.OfType<Container>(), c => c.AppModelResourceName == "ExplicitNever");
+        Assert.Equal(ContainerPullPolicy.Never, explicitNeverContainer.Spec.PullPolicy);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Expose `Never` image pull policy and update tests to validate it

Fixes #10573

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
- Did you add public API?
  - [X] Yes
    - If yes, did you have an API Review for it?
      - [X] No
- Does the change make any security assumptions or guarantees?
  - [X] No
- Does the change require an update in our Aspire docs?
  - [X] No
