### PR TITLE
Add a `Logger` property to `IDistributedApplicationResourceEvent`

### DIFF
--- a/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
@@ -734,9 +734,4 @@ public static partial class DevTunnelsResourceBuilderExtensions
 
     [GeneratedRegex(@"^[\w\-=_]{1,50}$")]
     private static partial Regex LabelRegex();
-
-    private sealed class DevTunnelResourceStartedEvent(DevTunnelResource tunnel) : IDistributedApplicationResourceEvent
-    {
-        public IResource Resource { get; } = tunnel;
-    }
 }

--- a/src/Aspire.Hosting/ApplicationModel/BeforeResourceStartedEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/BeforeResourceStartedEvent.cs
@@ -18,8 +18,6 @@ public class BeforeResourceStartedEvent(IResource resource, IServiceProvider ser
     /// <inheritdoc />
     public IResource Resource { get; } = resource;
 
-    /// <summary>
-    /// The <see cref="IServiceProvider"/> for the app host.
-    /// </summary>
+    /// <inheritdoc />
     public IServiceProvider Services { get; } = services;
 }

--- a/src/Aspire.Hosting/ApplicationModel/ConnectionStringAvailableEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ConnectionStringAvailableEvent.cs
@@ -15,8 +15,6 @@ public class ConnectionStringAvailableEvent(IResource resource, IServiceProvider
     /// <inheritdoc />
     public IResource Resource => resource;
 
-    /// <summary>
-    /// The <see cref="IServiceProvider"/> for the app host.
-    /// </summary>
+    /// <inheritdoc />
     public IServiceProvider Services => services;
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceEndpointsAllocatedEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceEndpointsAllocatedEvent.cs
@@ -16,8 +16,6 @@ public class ResourceEndpointsAllocatedEvent(IResource resource, IServiceProvide
     /// <inheritdoc />
     public IResource Resource { get; } = resource;
 
-    /// <summary>
-    /// The <see cref="IServiceProvider"/> instance.
-    /// </summary>
+    /// <inheritdoc />
     public IServiceProvider Services { get; } = services;
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceReadyEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceReadyEvent.cs
@@ -20,8 +20,6 @@ public class ResourceReadyEvent(IResource resource, IServiceProvider services) :
     /// </summary>
     public IResource Resource => resource;
 
-    /// <summary>
-    /// The service provider for the app host.
-    /// </summary>
+    /// <inheritdoc />
     public IServiceProvider Services => services;
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceStoppedEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceStoppedEvent.cs
@@ -19,9 +19,7 @@ public class ResourceStoppedEvent(IResource resource, IServiceProvider services,
     /// <inheritdoc />
     public IResource Resource { get; } = resource;
 
-    /// <summary>
-    /// The <see cref="IServiceProvider"/> for the app host.
-    /// </summary>
+    /// <inheritdoc />
     public IServiceProvider Services { get; } = services;
 
     /// <summary>

--- a/src/Aspire.Hosting/Eventing/IDistributedApplicationEvent.cs
+++ b/src/Aspire.Hosting/Eventing/IDistributedApplicationEvent.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Eventing;
 
@@ -21,4 +23,14 @@ public interface IDistributedApplicationResourceEvent : IDistributedApplicationE
     /// Resource associated with this event.
     /// </summary>
     IResource Resource { get; }
+
+    /// <summary>
+    /// The <see cref="IServiceProvider"/> instance.
+    /// </summary>
+    IServiceProvider Services => throw new NotImplementedException();
+
+    /// <summary>
+    /// An instance of <see cref="ILogger"/> that can be used to log messages for the resource.
+    /// </summary>
+    ILogger Logger => Services.GetRequiredService<ResourceLoggerService>().GetLogger(Resource);
 }


### PR DESCRIPTION
## Description

- Add `IServiceProvider Services` to `IDistributedApplicationResourceEvent`.  All existing implementations already had this property, so it doesn't really change anything, but provided a default interface method to maintain backwards compatibility.
- Add an ILogger property to `IDistributedApplicationResourceEvent`, with a default implementation using  `IDistributedApplicationEvent.Services` to get the resource logger
- Update xml docs of existing Service properties to inherit from the parent interface

Fixes #7531.

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] No
- Did you add public API?
  - [X] Yes
    - If yes, did you have an API Review for it?
      - [X] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [X] Yes
- Does the change make any security assumptions or guarantees?
  - [X] No
- Does the change require an update in our Aspire docs?
  - [X] No
