### PR TITLE
Add WithBun() support for Vite apps

### DIFF
--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -723,6 +723,7 @@ public static class JavaScriptHostingExtensions
     /// Bun forwards script arguments without requiring the <c>--</c> command separator, so this method configures the resource to omit it.
     /// When publishing and a bun lockfile (<c>bun.lock</c> or <c>bun.lockb</c>) is present, <c>--frozen-lockfile</c> is used by default.
     /// Publishing to a container requires Bun to be present in the build image. This method configures a Bun build image when one is not already specified.
+    /// To use a specific Bun version, configure a custom build image (for example, <c>oven/bun:&lt;tag&gt;</c>) using <see cref="ContainerResourceBuilderExtensions.WithDockerfileBaseImage{T}(IResourceBuilder{T}, string?, string?)"/>.
     /// </remarks>
     /// <example>
     /// Run a Vite app using Bun as the package manager:
@@ -730,7 +731,8 @@ public static class JavaScriptHostingExtensions
     /// var builder = DistributedApplication.CreateBuilder(args);
     ///
     /// builder.AddViteApp("frontend", "./frontend")
-    ///        .WithBun();
+    ///        .WithBun()
+    ///        .WithDockerfileBaseImage(buildImage: "oven/bun:latest"); // To use a specific Bun image
     ///
     /// builder.Build().Run();
     /// </code>

--- a/tests/Aspire.Hosting.JavaScript.Tests/PackageInstallationTests.cs
+++ b/tests/Aspire.Hosting.JavaScript.Tests/PackageInstallationTests.cs
@@ -546,6 +546,21 @@ public class PackageInstallationTests
         Assert.Equal(["install", "--frozen-lockfile"], installCommand.Args);
     }
 
+    [Fact]
+    public void WithBun_DefaultsArgsInPublishMode()
+    {
+        using var tempDir = new TestTempDirectory();
+        File.WriteAllText(Path.Combine(tempDir.Path, "bun.lock"), "empty");
+
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var app = builder.AddViteApp("test-app", tempDir.Path)
+            .WithBun();
+
+        Assert.True(app.Resource.TryGetLastAnnotation<JavaScriptInstallCommandAnnotation>(out var installCommand));
+        Assert.Equal(["install", "--frozen-lockfile"], installCommand.Args);
+    }
+
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "ExecuteBeforeStartHooksAsync")]
     private static extern Task ExecuteBeforeStartHooksAsync(DistributedApplication app, CancellationToken cancellationToken);
 }


### PR DESCRIPTION
## Description

This PR adds native `bun` support for Vite/JavaScript resources via a new `WithBun()` extension method, enabling `bun install` and `bun run <script>` flows similar to existing `WithNpm()`, `WithYarn()`, and `WithPnpm()` support.

### Changes

- Added `WithBun()` for `JavaScriptAppResource`-based resources.
- Uses bun executable and run script command (`bun run <script> ...`).
- Does not inject the `--` command separator (bun forwards script flags without it).
- Copies package.json + bun lockfile(s) for Docker layer caching (`bun.lock` / `bun.lockb` when present).
- Sets bun cache mount for Dockerfile generation (`/root/.bun/install/cache`).
- Ensures publish-mode Dockerfile generation can execute bun by overriding the build base image to `oven/bun:1` when not already specified (assuming using `latest` isn't recommended here? Unsure.)

Fixes #13686

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue: https://github.com/dotnet/docs-aspire/issues/6091
  - [ ] No
