### PR TITLE
Apply launch.json debuggers.apphost settings to apphost configuration

### DIFF
--- a/extension/src/dcp/types.ts
+++ b/extension/src/dcp/types.ts
@@ -55,6 +55,13 @@ export interface RunSessionPayload {
     args?: string[];
 }
 
+export interface DebugLaunchSettings {
+    env?: { [key: string]: string };
+    args?: string[];
+    launchProfile?: string;
+    disableLaunchProfile?: boolean;
+}
+
 export interface DcpServerConnectionInfo {
     address: string;
     token: string;
@@ -118,7 +125,7 @@ export interface AspireExtendedDebugConfiguration extends vscode.DebugConfigurat
 }
 
 interface AspireDebuggersConfiguration {
-    [key: string]: Record<string, any>;
+    [key: string]: DebugLaunchSettings;
 }
 
 export interface RunSessionInfo {

--- a/extension/src/debugger/languages/dotnet.ts
+++ b/extension/src/debugger/languages/dotnet.ts
@@ -228,7 +228,7 @@ interface RunApiOutput {
     env?: { [key: string]: string };
 }
 
-function getRunApiConfigFromOutput(runApiOutput: string, debugConfiguration: AspireResourceExtendedDebugConfiguration): RunApiOutput {
+function getRunApiConfigFromOutput(runApiOutput: string): RunApiOutput {
     const parsed = JSON.parse(runApiOutput);
     if (parsed.$type === 'Error') {
         throw new Error(`dotnet run-api failed: ${parsed.Message}`);
@@ -276,7 +276,15 @@ export function createProjectDebuggerExtension(dotNetServiceProducer: (debugSess
                 throw new Error(invalidLaunchConfiguration(projectPath));
             }
 
-            const { profile: baseProfile, profileName } = determineBaseLaunchProfile(launchConfig, launchSettings);
+            // For apphost, read launch profile settings from debugConfiguration (from launch.json)
+            // For resources, read from launchConfig (from payload)
+            const effectiveLaunchConfig: ProjectLaunchConfiguration = launchOptions.isApphost ? {
+                ...launchConfig,
+                disable_launch_profile: debugConfiguration.disableLaunchProfile,
+                launch_profile: debugConfiguration.launchProfile
+            } : launchConfig;
+
+            const { profile: baseProfile, profileName } = determineBaseLaunchProfile(effectiveLaunchConfig, launchSettings);
 
             extensionLogOutputChannel.info(profileName
                 ? `Using launch profile '${profileName}' for project: ${projectPath}`
@@ -300,17 +308,27 @@ export function createProjectDebuggerExtension(dotNetServiceProducer: (debugSess
                     await dotNetService.buildDotNetProject(projectPath);
                 }
 
+
                 debugConfiguration.program = outputPath;
-                debugConfiguration.env = Object.fromEntries(mergeEnvironmentVariables(baseProfile?.environmentVariables, env));
+                debugConfiguration.env = Object.fromEntries(mergeEnvironmentVariables(
+                    baseProfile?.environmentVariables,
+                    debugConfiguration.env,
+                    env
+                ));
             }
             else {
                 // Single file apps should always be built
                 await dotNetService.buildDotNetProject(projectPath);
                 const runApiOutput = await dotNetService.getDotNetRunApiOutput(projectPath);
-                const runApiConfig = getRunApiConfigFromOutput(runApiOutput, debugConfiguration);
+                const runApiConfig = getRunApiConfigFromOutput(runApiOutput);
                 debugConfiguration.program = runApiConfig.executablePath;
 
-                debugConfiguration.env = Object.fromEntries(mergeEnvironmentVariables(baseProfile?.environmentVariables, env, runApiConfig.env));
+                debugConfiguration.env = Object.fromEntries(mergeEnvironmentVariables(
+                    baseProfile?.environmentVariables,
+                    debugConfiguration.env,
+                    env,
+                    runApiConfig.env
+                ));
             }
 
             // Set DOTNET_LAUNCH_PROFILE

--- a/extension/src/debugger/languages/dotnet.ts
+++ b/extension/src/debugger/languages/dotnet.ts
@@ -308,7 +308,6 @@ export function createProjectDebuggerExtension(dotNetServiceProducer: (debugSess
                     await dotNetService.buildDotNetProject(projectPath);
                 }
 
-
                 debugConfiguration.program = outputPath;
                 debugConfiguration.env = Object.fromEntries(mergeEnvironmentVariables(
                     baseProfile?.environmentVariables,

--- a/extension/src/debugger/launchProfiles.ts
+++ b/extension/src/debugger/launchProfiles.ts
@@ -119,16 +119,23 @@ export function determineBaseLaunchProfile(
  * Run session variables take precedence over launch profile variables
  */
 export function mergeEnvironmentVariables(
-    baseProfileEnv: { [key: string]: string } | undefined,
+    launchProfileEnv: { [key: string]: string } | undefined,
+    debugConfigEnv : { [key: string]: string } | undefined,
     runSessionEnv: EnvVar[],
     runApiEnv?: { [key: string]: string }
 ): [string, string][] {
     const merged: { [key: string]: string } = {};
 
     // Start with base profile environment variables
-    if (baseProfileEnv) {
-        Object.assign(merged, baseProfileEnv);
+    if (launchProfileEnv) {
+        Object.assign(merged, launchProfileEnv);
     }
+
+    // Override with debug configuration environment variables
+    if (debugConfigEnv) {
+        Object.assign(merged, debugConfigEnv);
+    }
+
 
     // Override with run API environment variables
     if (runApiEnv) {

--- a/extension/src/debugger/launchProfiles.ts
+++ b/extension/src/debugger/launchProfiles.ts
@@ -136,7 +136,6 @@ export function mergeEnvironmentVariables(
         Object.assign(merged, debugConfigEnv);
     }
 
-
     // Override with run API environment variables
     if (runApiEnv) {
         Object.assign(merged, runApiEnv);

--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -40,15 +40,56 @@ export interface IInteractionService {
 
 type CSLogLevel = 'Trace' | 'Debug' | 'Information' | 'Warn' | 'Error' | 'Critical';
 
+// Support both PascalCase (old) and camelCase (new) for backwards compatibility
+// with different versions of the CLI/AppHost.
+//
+// BREAKING CHANGE: ModelContextProtocol package was updated from an older version to 0.2.0-preview.1
+// (and later to 0.4.0-preview.3), which changed the default JSON serialization to use camelCase
+// (via JsonNamingPolicy.CamelCase) to comply with the MCP specification.
+//
+// This type definition supports both formats to maintain compatibility with:
+// - Older CLI/AppHost versions that serialize with PascalCase
+// - Newer CLI/AppHost versions (with ModelContextProtocol 0.2.0+) that serialize with camelCase
 type DashboardUrls = {
-    BaseUrlWithLoginToken: string;
-    CodespacesUrlWithLoginToken: string | null;
+    // New camelCase format (ModelContextProtocol 0.2.0+)
+    dashboardHealthy?: boolean;
+    baseUrlWithLoginToken?: string;
+    codespacesUrlWithLoginToken?: string | null;
+    // Old PascalCase format (pre-ModelContextProtocol 0.2.0)
+    DashboardHealthy?: boolean;
+    BaseUrlWithLoginToken?: string;
+    CodespacesUrlWithLoginToken?: string | null;
 };
 
+// Helper to access DashboardUrls properties in a case-insensitive way.
+// Prefers the new camelCase format but falls back to PascalCase for backwards compatibility.
+function getDashboardUrlProperty(urls: DashboardUrls, property: 'baseUrl' | 'codespacesUrl'): string {
+    if (property === 'baseUrl') {
+        // Try camelCase first (new format), then PascalCase (old format)
+        return urls.baseUrlWithLoginToken ?? urls.BaseUrlWithLoginToken ?? '';
+    } else {
+        // Try camelCase first (new format), then PascalCase (old format)
+        return urls.codespacesUrlWithLoginToken ?? urls.CodespacesUrlWithLoginToken ?? '';
+    }
+}
+
+// Support both PascalCase (old) and camelCase (new) for backwards compatibility.
+// DisplayLineState is serialized with ModelContextProtocol.McpJsonUtilities.DefaultOptions
+// which changed to camelCase in version 0.2.0+
 type ConsoleLine = {
-    Stream: 'stdout' | 'stderr';
-    Line: string;
+    // New camelCase format (ModelContextProtocol 0.2.0+)
+    stream?: 'stdout' | 'stderr';
+    line?: string;
+    // Old PascalCase format (pre-ModelContextProtocol 0.2.0)
+    Stream?: 'stdout' | 'stderr';
+    Line?: string;
 };
+
+// Helper to access ConsoleLine properties in a case-insensitive way.
+// Prefers the new camelCase format but falls back to PascalCase for backwards compatibility.
+function getConsoleLineText(line: ConsoleLine): string {
+    return line.line ?? line.Line ?? '';
+}
 
 export class InteractionService implements IInteractionService {
     private _getAspireDebugSession: () => AspireDebugSession | null;
@@ -251,10 +292,13 @@ export class InteractionService implements IInteractionService {
     async displayDashboardUrls(dashboardUrls: DashboardUrls) {
         extensionLogOutputChannel.info(`Displaying dashboard URLs: ${JSON.stringify(dashboardUrls)}`);
 
-        this.writeDebugSessionMessage(dashboard + ': ' + dashboardUrls.BaseUrlWithLoginToken, true, AnsiColors.Green);
+        const baseUrl = getDashboardUrlProperty(dashboardUrls, 'baseUrl');
+        const codespacesUrl = getDashboardUrlProperty(dashboardUrls, 'codespacesUrl');
 
-        if (dashboardUrls.CodespacesUrlWithLoginToken) {
-            this.writeDebugSessionMessage(codespaces + ': ' + dashboardUrls.CodespacesUrlWithLoginToken, true, AnsiColors.Green);
+        this.writeDebugSessionMessage(dashboard + ': ' + baseUrl, true, AnsiColors.Green);
+
+        if (codespacesUrl) {
+            this.writeDebugSessionMessage(codespaces + ': ' + codespacesUrl, true, AnsiColors.Green);
         }
 
         //  If aspire.enableAspireDashboardAutoLaunch is true, the dashboard will be launched automatically and we do not need
@@ -262,7 +306,7 @@ export class InteractionService implements IInteractionService {
         const enableDashboardAutoLaunch = vscode.workspace.getConfiguration('aspire').get<boolean>('enableAspireDashboardAutoLaunch', true);
         if (enableDashboardAutoLaunch) {
             // Open the dashboard URL in an external browser. Prefer codespaces URL if available.
-            const urlToOpen = dashboardUrls.CodespacesUrlWithLoginToken ?? dashboardUrls.BaseUrlWithLoginToken;
+            const urlToOpen = codespacesUrl ?? baseUrl;
             vscode.env.openExternal(vscode.Uri.parse(urlToOpen));
             return;
         }
@@ -271,7 +315,7 @@ export class InteractionService implements IInteractionService {
             { title: directLink }
         ];
 
-        if (dashboardUrls.CodespacesUrlWithLoginToken) {
+        if (codespacesUrl) {
             actions.push({ title: codespacesLink });
         }
 
@@ -289,18 +333,18 @@ export class InteractionService implements IInteractionService {
                 extensionLogOutputChannel.info(`Selected action: ${selected.title}`);
 
                 if (selected.title === directLink) {
-                    vscode.env.openExternal(vscode.Uri.parse(dashboardUrls.BaseUrlWithLoginToken));
+                    vscode.env.openExternal(vscode.Uri.parse(baseUrl));
                 }
-                else if (selected.title === codespacesLink && dashboardUrls.CodespacesUrlWithLoginToken) {
-                    vscode.env.openExternal(vscode.Uri.parse(dashboardUrls.CodespacesUrlWithLoginToken));
+                else if (selected.title === codespacesLink && codespacesUrl) {
+                    vscode.env.openExternal(vscode.Uri.parse(codespacesUrl));
                 }
             });
         }, 1000);
     }
 
     async displayLines(lines: ConsoleLine[]) {
-        const displayText = lines.map(line => line.Line).join('\n');
-        lines.forEach(line => extensionLogOutputChannel.info(formatText(line.Line)));
+        const displayText = lines.map(line => getConsoleLineText(line)).join('\n');
+        lines.forEach(line => extensionLogOutputChannel.info(formatText(getConsoleLineText(line))));
 
         // Open a new temp file with the displayText
         const doc = await vscode.workspace.openTextDocument({ content: displayText, language: 'plaintext' });

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -110,8 +110,9 @@ public class Program
 #endif
 
         var debugMode = args?.Any(a => a == "--debug" || a == "-d") ?? false;
+        var extensionEndpoint = builder.Configuration[KnownConfigNames.ExtensionEndpoint];
 
-        if (debugMode && !isMcpStartCommand)
+        if (debugMode && !isMcpStartCommand && extensionEndpoint is null)
         {
             builder.Logging.AddFilter("Aspire.Cli", LogLevel.Debug);
             builder.Logging.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.Warning); // Reduce noise from hosting lifecycle


### PR DESCRIPTION
## Description

**Problem:** 
When users configured `debuggers.apphost` section in their `launch.json` (including `env`, `launchProfile`, and `disableLaunchProfile`), these settings were ignored for the apphost. Only resource-specific debugger settings worked.

**Root Cause:**
The code was reading apphost configuration from `launchConfig` (the protocol layer) instead of `debugConfiguration` (the user's launch.json settings).

Fixes #13741 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] Maybe (added launchProfile & disableLaunchProfile as settings in launch.json)
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
