### PR TITLE
Fix exporting metrics data points

### DIFF
--- a/src/Aspire.Dashboard/Otlp/Model/OtlpAggregationTemporality.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpAggregationTemporality.cs
@@ -6,6 +6,9 @@ namespace Aspire.Dashboard.Otlp.Model;
 /// <summary>
 /// Defines how a metric aggregator reports aggregated values.
 /// </summary>
+/// <remarks>
+/// Values map to <c>OpenTelemetry.Proto.Metrics.V1.AggregationTemporality</c>.
+/// </remarks>
 public enum OtlpAggregationTemporality
 {
     /// <summary>

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpAggregationTemporality.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpAggregationTemporality.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Otlp.Model;
+
+/// <summary>
+/// Defines how a metric aggregator reports aggregated values.
+/// </summary>
+public enum OtlpAggregationTemporality
+{
+    /// <summary>
+    /// The default value, indicating the aggregation temporality is not specified.
+    /// </summary>
+    Unspecified = 0,
+
+    /// <summary>
+    /// Reports changes since the last report time.
+    /// </summary>
+    Delta = 1,
+
+    /// <summary>
+    /// Reports changes since a fixed start time.
+    /// </summary>
+    Cumulative = 2
+}

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
@@ -17,6 +17,7 @@ public class OtlpInstrumentSummary
     public required string Description { get; init; }
     public required string Unit { get; init; }
     public required OtlpInstrumentType Type { get; init; }
+    public required OtlpAggregationTemporality AggregationTemporality { get; init; }
     public required OtlpScope Parent { get; init; }
 
     public OtlpInstrumentKey GetKey() => new(Parent.Name, Name);

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs
@@ -98,6 +98,7 @@ public class OtlpResource
                                     Description = metric.Description,
                                     Unit = metric.Unit,
                                     Type = MapMetricType(metric.DataCase),
+                                    AggregationTemporality = MapAggregationTemporality(metric),
                                     Parent = scope
                                 },
                                 Context = Context
@@ -221,6 +222,17 @@ public class OtlpResource
             Metric.DataOneofCase.Sum => OtlpInstrumentType.Sum,
             Metric.DataOneofCase.Histogram => OtlpInstrumentType.Histogram,
             _ => OtlpInstrumentType.Unsupported
+        };
+    }
+
+    private static OtlpAggregationTemporality MapAggregationTemporality(Metric metric)
+    {
+        return metric.DataCase switch
+        {
+            Metric.DataOneofCase.Sum => (OtlpAggregationTemporality)metric.Sum.AggregationTemporality,
+            Metric.DataOneofCase.Histogram => (OtlpAggregationTemporality)metric.Histogram.AggregationTemporality,
+            Metric.DataOneofCase.ExponentialHistogram => (OtlpAggregationTemporality)metric.ExponentialHistogram.AggregationTemporality,
+            _ => OtlpAggregationTemporality.Unspecified
         };
     }
 

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpanKind.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpanKind.cs
@@ -3,6 +3,12 @@
 
 namespace Aspire.Dashboard.Otlp.Model;
 
+/// <summary>
+/// Specifies the relationship between a span and its parent/children in a trace.
+/// </summary>
+/// <remarks>
+/// Values map to <c>OpenTelemetry.Proto.Trace.V1.Span.Types.SpanKind</c>.
+/// </remarks>
 public enum OtlpSpanKind
 {
     /// <summary>

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpanStatusCode.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpanStatusCode.cs
@@ -3,6 +3,12 @@
 
 namespace Aspire.Dashboard.Otlp.Model;
 
+/// <summary>
+/// Indicates the status of a span.
+/// </summary>
+/// <remarks>
+/// Values map to <c>OpenTelemetry.Proto.Trace.V1.Status.Types.StatusCode</c>.
+/// </remarks>
 public enum OtlpSpanStatusCode
 {
     /// <summary>

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
@@ -64,7 +64,8 @@ public class PlotlyChartTests : DashboardTestContext
                 Unit = "Unit-<b>Bold</b>",
                 Description = "Description-<b>Bold</b>",
                 Parent = new OtlpScope("Parent-Name-<b>Bold</b>", string.Empty, []),
-                Type = OtlpInstrumentType.Sum
+                Type = OtlpInstrumentType.Sum,
+                AggregationTemporality = OtlpAggregationTemporality.Cumulative
             },
             Context = context
         };

--- a/tests/Aspire.Dashboard.Tests/Model/DefaultInstrumentUnitResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DefaultInstrumentUnitResolverTests.cs
@@ -30,7 +30,8 @@ public sealed class DefaultInstrumentUnitResolverTests
             Name = name,
             Parent = TelemetryTestHelpers.CreateOtlpScope(TelemetryTestHelpers.CreateContext(), name: "meter_name"),
             Type = OtlpInstrumentType.Gauge,
-            Unit = unit
+            Unit = unit,
+            AggregationTemporality = OtlpAggregationTemporality.Cumulative
         };
 
         // Act


### PR DESCRIPTION
## Description

The dashboard recently added support for exporting telemetry. However, metrics data wasn't correctly exported.

For metrics, only the instrument summary (name, description, etc) was exported. Actual data points for instruments were missing. Fixed in this PR.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
