### PR TITLE
Manage telemetry and console logs dialog

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -13,78 +13,92 @@
                     GridTemplateColumns="2fr 1fr"
                     TGridItem="ManageDataGridItem"
                     RowClass="@GetRowClass"
-                    OnRowClick="@OnRowClicked">
+                    OnRowClick="@OnRowClicked"
+                    ShowHover="true"
+                    ItemKey="@(item => GetItemKey(item))"
+                    Class="enable-row-click">
         <ChildContent>
             <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]">
                 <HeaderCellItemTemplate>
-                    <FluentButton Appearance="Appearance.Lightweight"
-                                  IconEnd="@GetHeaderCheckboxIcon()"
-                                  OnClick="OnSelectAllClicked"
-                                  style="margin-right: 8px;" />
-                    @ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]
+                    <div style="display: flex; justify-content: flex-start;">
+                        <div class="col-title" style="width: calc(100% - 10px);">
+                            <div class="col-title-text name-title-text">
+                                <FluentButton Appearance="Appearance.Lightweight"
+                                              IconEnd="@GetHeaderCheckboxIcon()"
+                                              OnClick="OnSelectAllClicked"
+                                              style="margin-right: 8px;" />
+                                @ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]
+                            </div>
+                        </div>
+                    </div>
+
                 </HeaderCellItemTemplate>
                 <ChildContent>
-                @{
-                    var indent = context.Depth * 48;
-                }
-                <span class="resources-name-container" style="margin-left: @(indent)px;">
-                    @if (context.IsResourceRow && context.ResourceRow is not null)
-                    {
-                        <span @onclick:stopPropagation="true" class="main-grid-expand-container @(context.ResourceRow.IsExpanded ? "main-grid-expanded" : "main-grid-collapsed")">
-                            @if (context.ResourceRow.Data.Count > 0)
-                            {
-                                <FluentButton Appearance="Appearance.Lightweight"
-                                              Class="main-grid-expand-button"
-                                              OnClick="@(() => OnToggleExpand(context.ResourceRow))"
-                                              aria-label="@ControlsStringsLoc[nameof(ControlsStrings.ToggleNesting)]">
-                                    <FluentIcon Icon="Icons.Regular.Size12.ChevronRight" Color="Color.Neutral" />
-                                </FluentButton>
-                            }
-                        </span>
-                        <FluentButton Appearance="Appearance.Lightweight"
-                                      IconEnd="@GetResourceCheckboxIcon(context.ResourceRow)"
-                                      OnClick="@(() => OnSelectRowClicked(context.ResourceRow))"
-                                      style="margin-right: 8px;" />
-                        @if (context.ResourceRow.Resource is not null)
+                    @{
+                        var indent = context.Depth * 48;
+                    }
+                    <span class="resources-name-container" style="margin-left: @(indent)px;">
+                        @if (context.IsResourceRow && context.ResourceRow is not null)
                         {
-                            <ResourceNameDisplay Resource="context.ResourceRow.Resource" FilterText="" FormatName="GetResourceName" />
-                        }
-                        else
-                        {
-                            @* Telemetry-only resource - display with default icon *@
-                            <span class="resource-name-container">
-                                <FluentIcon Width="16px"
-                                            Class="resource-icon"
-                                            Color="Color.Custom"
-                                            CustomColor="@ColorGenerator.Instance.GetColorVariableByKey(context.ResourceRow.DisplayName)"
-                                            Value="@GetDefaultResourceIcon()" />
-                                <span class="resource-name-text">@context.ResourceRow.DisplayName</span>
+                            <span @onclick:stopPropagation="true" class="main-grid-expand-container @(context.ResourceRow.IsExpanded ? "main-grid-expanded" : "main-grid-collapsed")">
+                                @if (context.ResourceRow.Data.Count > 0)
+                                {
+                                    <FluentButton Appearance="Appearance.Lightweight"
+                                                  Class="main-grid-expand-button"
+                                                  OnClick="@(() => OnToggleExpand(context.ResourceRow))"
+                                                  aria-label="@ControlsStringsLoc[nameof(ControlsStrings.ToggleNesting)]">
+                                        <FluentIcon Icon="Icons.Regular.Size12.ChevronRight" Color="Color.Neutral" />
+                                    </FluentButton>
+                                }
                             </span>
+                            <span @onclick:stopPropagation="true">
+                                <FluentButton Appearance="Appearance.Lightweight"
+                                              IconEnd="@GetResourceCheckboxIcon(context.ResourceRow)"
+                                              OnClick="@(() => OnSelectRowClicked(context.ResourceRow))"
+                                              style="margin-right: 8px;" />
+                            </span>
+                            @if (context.ResourceRow.Resource is not null)
+                            {
+                                <ResourceNameDisplay Resource="context.ResourceRow.Resource" FilterText="" FormatName="GetResourceName" />
+                            }
+                            else
+                            {
+                                @* Telemetry-only resource - display with default icon *@
+                                <span class="resource-name-container">
+                                    <FluentIcon Width="16px"
+                                                Class="resource-icon"
+                                                Color="Color.Custom"
+                                                CustomColor="@ColorGenerator.Instance.GetColorVariableByKey(context.ResourceRow.DisplayName)"
+                                                Value="@GetDefaultResourceIcon()" />
+                                    <span class="resource-name-text">@context.ResourceRow.DisplayName</span>
+                                </span>
+                            }
                         }
-                    }
-                    else if (context.IsNestedRow && context.NestedRow is not null)
-                    {
-                        <FluentButton Appearance="Appearance.Lightweight"
-                                      IconEnd="@(context.NestedRow.Selected ? _iconSelectedMultiple : _iconUnselectedMultiple)"
-                                      OnClick="@(() => OnSelectDataRowClicked(context.NestedRow))"
-                                      style="margin-right: 8px;" />
-                        <span class="cellText">@context.NestedRow.Name</span>
-                    }
-                </span>
+                        else if (context.IsNestedRow && context.NestedRow is not null)
+                        {
+                            <span @onclick:stopPropagation="true">
+                                <FluentButton Appearance="Appearance.Lightweight"
+                                              IconEnd="@(context.NestedRow.Selected ? _iconSelectedMultiple : _iconUnselectedMultiple)"
+                                              OnClick="@(() => OnSelectDataRowClicked(context.NestedRow))"
+                                              style="margin-right: 8px;" />
+                            </span>
+                            <span class="cellText">@context.NestedRow.DisplayName</span>
+                        }
+                    </span>
                 </ChildContent>
             </TemplateColumn>
-            <TemplateColumn Title="@Loc[nameof(Dialogs.ManageDataInfoColumnHeader)]">
+            <TemplateColumn Title="@Loc[nameof(Dialogs.ManageDataSummaryColumnHeader)]">
                 @if (context.IsResourceRow && context.ResourceRow is not null)
                 {
-                    <span class="cellText">@GetSourceInfo(context.ResourceRow)</span>
-                }
-                else if (context.IsNestedRow)
-                {
-                    <FluentIcon Icon="Icons.Filled.Size16.CheckboxChecked" Color="Color.Success" style="margin-right: 4px;" />
-                    if (context.NestedRow?.DataCount is { } dataCount)
-                    {
-                        <span class="cellText">@dataCount</span>
-                    }
+                    <span @onclick:stopPropagation="true">
+                        @foreach (var dataRow in context.ResourceRow.Data)
+                        {
+                            <FluentButton Appearance="Appearance.Lightweight"
+                                          IconEnd="@dataRow.Icon"
+                                          OnClick="@(() => NavigateToDataPage(dataRow))"
+                                          Style="margin-right: 4px;" />
+                        }
+                    </span>
                 }
             </TemplateColumn>
         </ChildContent>
@@ -96,14 +110,14 @@
 
 <div style="margin-top: 16px;">
     <FluentButton IconStart="@(new Icons.Regular.Size16.ArrowDownload())"
-                  OnClick="ExportAllAsync"
+                  OnClick="ExportSelectedAsync"
                   Loading="@_isExporting"
                   Title="@Loc[nameof(Dialogs.ManageDataExportButtonText)]"
                   aria-label="@Loc[nameof(Dialogs.ManageDataExportButtonText)]">
         @Loc[nameof(Dialogs.ManageDataExportButtonText)]
     </FluentButton>
     <FluentButton IconStart="@(new Icons.Regular.Size16.Delete())"
-                  OnClick="RemoveAllAsync"
+                  OnClick="RemoveSelectedAsync"
                   Title="@Loc[nameof(Dialogs.ManageDataRemoveButtonText)]"
                   aria-label="@Loc[nameof(Dialogs.ManageDataRemoveButtonText)]">
         @Loc[nameof(Dialogs.ManageDataRemoveButtonText)]

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -3,6 +3,7 @@
 @using Aspire.Dashboard.Resources
 @using Aspire.Dashboard.Components.Controls.Grid
 @using Aspire.Dashboard.Model
+@using Aspire.Dashboard.Model.ManageData
 @using Resources = Aspire.Dashboard.Resources.Resources
 @using Dialogs = Aspire.Dashboard.Resources.Dialogs
 

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -40,7 +40,7 @@
                     <span class="resources-name-container" style="margin-left: @(indent)px;">
                         @if (context.IsResourceRow && context.ResourceRow is not null)
                         {
-                            <span @onclick:stopPropagation="true" class="main-grid-expand-container @(IsResourceExpanded(context.ResourceRow.DisplayName) ? "main-grid-expanded" : "main-grid-collapsed")">
+                            <span @onclick:stopPropagation="true" class="main-grid-expand-container @(IsResourceExpanded(context.ResourceRow.Name) ? "main-grid-expanded" : "main-grid-collapsed")">
                                 @if (context.ResourceRow.Data.Count > 0)
                                 {
                                     <FluentButton Appearance="Appearance.Lightweight"
@@ -68,9 +68,9 @@
                                     <FluentIcon Width="16px"
                                                 Class="resource-icon"
                                                 Color="Color.Custom"
-                                                CustomColor="@ColorGenerator.Instance.GetColorVariableByKey(context.ResourceRow.DisplayName)"
-                                                Value="@GetDefaultResourceIcon()" />
-                                    <span class="resource-name-text">@context.ResourceRow.DisplayName</span>
+                                                CustomColor="@ColorGenerator.Instance.GetColorVariableByKey(context.ResourceRow.Name)"
+                                                Value="@(new Icons.Regular.Size16.Apps())" />
+                                    <span class="resource-name-text">@context.ResourceRow.Name</span>
                                 </span>
                             }
                         }
@@ -82,7 +82,7 @@
                                               OnClick="@(() => OnSelectDataRowClicked(context.ParentResourceName, context.NestedRow.DataType))"
                                               style="margin-right: 8px;" />
                             </span>
-                            <span class="cellText">@context.NestedRow.DisplayName</span>
+                            <span class="cellText">@GetDataTypeDisplayName(context.NestedRow.DataType)</span>
                         }
                     </span>
                 </ChildContent>
@@ -103,7 +103,7 @@
             </TemplateColumn>
         </ChildContent>
         <EmptyContent>
-            <FluentIcon Icon="Icons.Regular.Size24.Apps" />&nbsp;@ResourcesLoc[nameof(Resources.ResourcesNoResources)]
+            <FluentIcon Icon="Icons.Regular.Size24.Apps" />&nbsp;@Loc[nameof(Dialogs.ManageDataNoResources)]
         </EmptyContent>
     </FluentDataGrid>
 </div>

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -6,26 +6,26 @@
 @using Resources = Aspire.Dashboard.Resources.Resources
 @using Dialogs = Aspire.Dashboard.Resources.Dialogs
 
-@inject IStringLocalizer<Dialogs> Loc
-@inject IStringLocalizer<ControlsStrings> ControlsStringsLoc
-@inject IStringLocalizer<Resources> ResourcesLoc
-
 <div style="max-height: 44vh; overflow-y: auto;">
     <FluentDataGrid @ref="_dataGrid"
                     Items="@GetGridItems()"
                     RowSize="DataGridRowSize.Medium"
-                    GridTemplateColumns="auto 2fr 1fr"
+                    GridTemplateColumns="2fr 1fr"
                     TGridItem="ManageDataGridItem"
-                    RowClass="@GetRowClass">
+                    RowClass="@GetRowClass"
+                    OnRowClick="@OnRowClicked">
         <ChildContent>
-            <SelectColumn TGridItem="ManageDataGridItem"
-                          SelectMode="DataGridSelectMode.Multiple"
-                          SelectFromEntireRow="false"
-                          Property="@(item => item.IsResourceRow && item.ResourceRow is not null ? item.ResourceRow.Selected : false)"
-                          OnSelect="@OnSelectItem" />
             <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]">
+                <HeaderCellItemTemplate>
+                    <FluentButton Appearance="Appearance.Lightweight"
+                                  IconEnd="@GetHeaderCheckboxIcon()"
+                                  OnClick="OnSelectAllClicked"
+                                  style="margin-right: 8px;" />
+                    @ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]
+                </HeaderCellItemTemplate>
+                <ChildContent>
                 @{
-                    var indent = context.Depth * 24;
+                    var indent = context.Depth * 48;
                 }
                 <span class="resources-name-container" style="margin-left: @(indent)px;">
                     @if (context.IsResourceRow && context.ResourceRow is not null)
@@ -41,6 +41,10 @@
                                 </FluentButton>
                             }
                         </span>
+                        <FluentButton Appearance="Appearance.Lightweight"
+                                      IconEnd="@GetResourceCheckboxIcon(context.ResourceRow)"
+                                      OnClick="@(() => OnSelectRowClicked(context.ResourceRow))"
+                                      style="margin-right: 8px;" />
                         @if (context.ResourceRow.Resource is not null)
                         {
                             <ResourceNameDisplay Resource="context.ResourceRow.Resource" FilterText="" FormatName="GetResourceName" />
@@ -60,14 +64,27 @@
                     }
                     else if (context.IsNestedRow && context.NestedRow is not null)
                     {
+                        <FluentButton Appearance="Appearance.Lightweight"
+                                      IconEnd="@(context.NestedRow.Selected ? _iconSelectedMultiple : _iconUnselectedMultiple)"
+                                      OnClick="@(() => OnSelectDataRowClicked(context.NestedRow))"
+                                      style="margin-right: 8px;" />
                         <span class="cellText">@context.NestedRow.Name</span>
                     }
                 </span>
+                </ChildContent>
             </TemplateColumn>
-            <TemplateColumn Title="@ResourcesLoc[nameof(Resources.ResourcesStateColumnHeader)]">
-                @if (context.IsResourceRow && context.ResourceRow?.Resource is not null)
+            <TemplateColumn Title="@Loc[nameof(Dialogs.ManageDataInfoColumnHeader)]">
+                @if (context.IsResourceRow && context.ResourceRow is not null)
                 {
-                    <StateColumnDisplay Resource="@context.ResourceRow.Resource" UnviewedErrorCounts="@null" />
+                    <span class="cellText">@GetSourceInfo(context.ResourceRow)</span>
+                }
+                else if (context.IsNestedRow)
+                {
+                    <FluentIcon Icon="Icons.Filled.Size16.CheckboxChecked" Color="Color.Success" style="margin-right: 4px;" />
+                    if (context.NestedRow?.DataCount is { } dataCount)
+                    {
+                        <span class="cellText">@dataCount</span>
+                    }
                 }
             </TemplateColumn>
         </ChildContent>
@@ -92,23 +109,3 @@
         @Loc[nameof(Dialogs.ManageDataRemoveButtonText)]
     </FluentButton>
 </div>
-
-@code {
-    private string GetRowClass(ManageDataGridItem item)
-    {
-        return item.IsNestedRow ? "nested-data-row" : "resource-data-row";
-    }
-
-    private void OnSelectItem((ManageDataGridItem Item, bool Selected) args)
-    {
-        if (args.Item.IsResourceRow && args.Item.ResourceRow is not null)
-        {
-            args.Item.ResourceRow.Selected = args.Selected;
-        }
-    }
-
-    private Icon GetDefaultResourceIcon()
-    {
-        return IconResolver.ResolveIconName("Apps", IconSize.Size16, IconVariant.Filled) ?? new Icons.Filled.Size16.Apps();
-    }
-}

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -13,7 +13,6 @@
                     RowSize="DataGridRowSize.Medium"
                     GridTemplateColumns="2fr 1fr"
                     TGridItem="ManageDataGridItem"
-                    RowClass="@GetRowClass"
                     OnRowClick="@OnRowClicked"
                     ShowHover="true"
                     ItemKey="@(item => GetItemKey(item))"
@@ -41,7 +40,7 @@
                     <span class="resources-name-container" style="margin-left: @(indent)px;">
                         @if (context.IsResourceRow && context.ResourceRow is not null)
                         {
-                            <span @onclick:stopPropagation="true" class="main-grid-expand-container @(context.ResourceRow.IsExpanded ? "main-grid-expanded" : "main-grid-collapsed")">
+                            <span @onclick:stopPropagation="true" class="main-grid-expand-container @(IsResourceExpanded(context.ResourceRow.DisplayName) ? "main-grid-expanded" : "main-grid-collapsed")">
                                 @if (context.ResourceRow.Data.Count > 0)
                                 {
                                     <FluentButton Appearance="Appearance.Lightweight"
@@ -75,12 +74,12 @@
                                 </span>
                             }
                         }
-                        else if (context.IsNestedRow && context.NestedRow is not null)
+                        else if (context.IsNestedRow && context.NestedRow is not null && context.ParentResourceName is not null)
                         {
                             <span @onclick:stopPropagation="true">
                                 <FluentButton Appearance="Appearance.Lightweight"
-                                              IconEnd="@(context.NestedRow.Selected ? _iconSelectedMultiple : _iconUnselectedMultiple)"
-                                              OnClick="@(() => OnSelectDataRowClicked(context.NestedRow))"
+                                              IconEnd="@(IsDataRowSelected(context.ParentResourceName, context.NestedRow.DataType) ? _iconSelectedMultiple : _iconUnselectedMultiple)"
+                                              OnClick="@(() => OnSelectDataRowClicked(context.ParentResourceName, context.NestedRow.DataType))"
                                               style="margin-right: 8px;" />
                             </span>
                             <span class="cellText">@context.NestedRow.DisplayName</span>

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -1,26 +1,114 @@
 ﻿@using Aspire.Dashboard.Components.Controls.Chart
+@using Aspire.Dashboard.Components.ResourcesGridColumns
 @using Aspire.Dashboard.Resources
 @using Aspire.Dashboard.Components.Controls.Grid
+@using Aspire.Dashboard.Model
+@using Resources = Aspire.Dashboard.Resources.Resources
 @using Dialogs = Aspire.Dashboard.Resources.Dialogs
 
 @inject IStringLocalizer<Dialogs> Loc
+@inject IStringLocalizer<ControlsStrings> ControlsStringsLoc
+@inject IStringLocalizer<Resources> ResourcesLoc
 
 <div style="max-height: 44vh; overflow-y: auto;">
-    <FluentDataGrid Items="@MetricView"
+    <FluentDataGrid @ref="_dataGrid"
+                    Items="@GetGridItems()"
                     RowSize="DataGridRowSize.Medium"
-                    GridTemplateColumns="2fr 1fr 1fr 1fr"
-                    TGridItem="DataRow">
+                    GridTemplateColumns="auto 2fr 1fr"
+                    TGridItem="ManageDataGridItem"
+                    RowClass="@GetRowClass">
         <ChildContent>
-            <SelectColumn TGridItem="DataRow"
+            <SelectColumn TGridItem="ManageDataGridItem"
                           SelectMode="DataGridSelectMode.Multiple"
-                          SelectFromEntireRow="true"
-                          @bind-SelectedItems="@SelectedItems" />
-            <TemplateColumn Title="@Loc[nameof(Dialogs.ExemplarsDialogTraceColumnHeader)]" TooltipText="@(context => "Test")" Tooltip="true">
-                @context.Name
+                          SelectFromEntireRow="false"
+                          Property="@(item => item.IsResourceRow && item.ResourceRow is not null ? item.ResourceRow.Selected : false)"
+                          OnSelect="@OnSelectItem" />
+            <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]">
+                @{
+                    var indent = context.Depth * 24;
+                }
+                <span class="resources-name-container" style="margin-left: @(indent)px;">
+                    @if (context.IsResourceRow && context.ResourceRow is not null)
+                    {
+                        <span @onclick:stopPropagation="true" class="main-grid-expand-container @(context.ResourceRow.IsExpanded ? "main-grid-expanded" : "main-grid-collapsed")">
+                            @if (context.ResourceRow.Data.Count > 0)
+                            {
+                                <FluentButton Appearance="Appearance.Lightweight"
+                                              Class="main-grid-expand-button"
+                                              OnClick="@(() => OnToggleExpand(context.ResourceRow))"
+                                              aria-label="@ControlsStringsLoc[nameof(ControlsStrings.ToggleNesting)]">
+                                    <FluentIcon Icon="Icons.Regular.Size12.ChevronRight" Color="Color.Neutral" />
+                                </FluentButton>
+                            }
+                        </span>
+                        @if (context.ResourceRow.Resource is not null)
+                        {
+                            <ResourceNameDisplay Resource="context.ResourceRow.Resource" FilterText="" FormatName="GetResourceName" />
+                        }
+                        else
+                        {
+                            @* Telemetry-only resource - display with default icon *@
+                            <span class="resource-name-container">
+                                <FluentIcon Width="16px"
+                                            Class="resource-icon"
+                                            Color="Color.Custom"
+                                            CustomColor="@ColorGenerator.Instance.GetColorVariableByKey(context.ResourceRow.DisplayName)"
+                                            Value="@GetDefaultResourceIcon()" />
+                                <span class="resource-name-text">@context.ResourceRow.DisplayName</span>
+                            </span>
+                        }
+                    }
+                    else if (context.IsNestedRow && context.NestedRow is not null)
+                    {
+                        <span class="cellText">@context.NestedRow.Name</span>
+                    }
+                </span>
+            </TemplateColumn>
+            <TemplateColumn Title="@ResourcesLoc[nameof(Resources.ResourcesStateColumnHeader)]">
+                @if (context.IsResourceRow && context.ResourceRow?.Resource is not null)
+                {
+                    <StateColumnDisplay Resource="@context.ResourceRow.Resource" UnviewedErrorCounts="@null" />
+                }
             </TemplateColumn>
         </ChildContent>
         <EmptyContent>
-            <FluentIcon Icon="Icons.Regular.Size24.ChartMultiple" />&nbsp;@Loc[nameof(ControlsStrings.MetricTableNoMetricsFound)]
+            <FluentIcon Icon="Icons.Regular.Size24.Apps" />&nbsp;@ResourcesLoc[nameof(Resources.ResourcesNoResources)]
         </EmptyContent>
     </FluentDataGrid>
 </div>
+
+<div style="margin-top: 16px;">
+    <FluentButton IconStart="@(new Icons.Regular.Size16.ArrowDownload())"
+                  OnClick="ExportAllAsync"
+                  Loading="@_isExporting"
+                  Title="@Loc[nameof(Dialogs.ManageDataExportButtonText)]"
+                  aria-label="@Loc[nameof(Dialogs.ManageDataExportButtonText)]">
+        @Loc[nameof(Dialogs.ManageDataExportButtonText)]
+    </FluentButton>
+    <FluentButton IconStart="@(new Icons.Regular.Size16.Delete())"
+                  OnClick="RemoveAllAsync"
+                  Title="@Loc[nameof(Dialogs.ManageDataRemoveButtonText)]"
+                  aria-label="@Loc[nameof(Dialogs.ManageDataRemoveButtonText)]">
+        @Loc[nameof(Dialogs.ManageDataRemoveButtonText)]
+    </FluentButton>
+</div>
+
+@code {
+    private string GetRowClass(ManageDataGridItem item)
+    {
+        return item.IsNestedRow ? "nested-data-row" : "resource-data-row";
+    }
+
+    private void OnSelectItem((ManageDataGridItem Item, bool Selected) args)
+    {
+        if (args.Item.IsResourceRow && args.Item.ResourceRow is not null)
+        {
+            args.Item.ResourceRow.Selected = args.Selected;
+        }
+    }
+
+    private Icon GetDefaultResourceIcon()
+    {
+        return IconResolver.ResolveIconName("Apps", IconSize.Size16, IconVariant.Filled) ?? new Icons.Filled.Size16.Apps();
+    }
+}

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -1,0 +1,26 @@
+﻿@using Aspire.Dashboard.Components.Controls.Chart
+@using Aspire.Dashboard.Resources
+@using Aspire.Dashboard.Components.Controls.Grid
+@using Dialogs = Aspire.Dashboard.Resources.Dialogs
+
+@inject IStringLocalizer<Dialogs> Loc
+
+<div style="max-height: 44vh; overflow-y: auto;">
+    <FluentDataGrid Items="@MetricView"
+                    RowSize="DataGridRowSize.Medium"
+                    GridTemplateColumns="2fr 1fr 1fr 1fr"
+                    TGridItem="DataRow">
+        <ChildContent>
+            <SelectColumn TGridItem="DataRow"
+                          SelectMode="DataGridSelectMode.Multiple"
+                          SelectFromEntireRow="true"
+                          @bind-SelectedItems="@SelectedItems" />
+            <TemplateColumn Title="@Loc[nameof(Dialogs.ExemplarsDialogTraceColumnHeader)]" TooltipText="@(context => "Test")" Tooltip="true">
+                @context.Name
+            </TemplateColumn>
+        </ChildContent>
+        <EmptyContent>
+            <FluentIcon Icon="Icons.Regular.Size24.ChartMultiple" />&nbsp;@Loc[nameof(ControlsStrings.MetricTableNoMetricsFound)]
+        </EmptyContent>
+    </FluentDataGrid>
+</div>

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -107,7 +107,7 @@
             </TemplateColumn>
         </ChildContent>
         <EmptyContent>
-            <FluentIcon Icon="Icons.Regular.Size24.Apps" />&nbsp;@Loc[nameof(Dialogs.ManageDataNoResources)]
+            <FluentIcon Icon="Icons.Regular.Size24.AppGeneric" />&nbsp;@Loc[nameof(Dialogs.ManageDataNoResources)]
         </EmptyContent>
     </FluentDataGrid>
 </div>

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -7,10 +7,12 @@
 @using Resources = Aspire.Dashboard.Resources.Resources
 @using Dialogs = Aspire.Dashboard.Resources.Dialogs
 
-<div style="max-height: 44vh; overflow-y: auto;">
+<div style="height: 44vh; overflow-y: auto;">
     <FluentDataGrid @ref="_dataGrid"
                     Items="@GetGridItems()"
-                    RowSize="DataGridRowSize.Medium"
+                    ItemSize="46"
+                    Virtualize="true"
+                    GenerateHeader="GenerateHeaderOption.Sticky"
                     GridTemplateColumns="2fr 1fr"
                     TGridItem="ManageDataGridItem"
                     OnRowClick="@OnRowClicked"
@@ -21,8 +23,8 @@
             <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]">
                 <HeaderCellItemTemplate>
                     <div style="display: flex; justify-content: flex-start;">
-                        <div class="col-title" style="width: calc(100% - 10px);">
-                            <div class="col-title-text name-title-text">
+                        <div style="width: calc(100% - 10px);">
+                            <div class="name-title-text">
                                 <FluentButton Appearance="Appearance.Lightweight"
                                               IconEnd="@GetHeaderCheckboxIcon()"
                                               OnClick="OnSelectAllClicked"
@@ -41,7 +43,7 @@
                         @if (context.IsResourceRow && context.ResourceRow is not null)
                         {
                             <span @onclick:stopPropagation="true" class="main-grid-expand-container @(IsResourceExpanded(context.ResourceRow.Name) ? "main-grid-expanded" : "main-grid-collapsed")">
-                                @if (context.ResourceRow.Data.Count > 0)
+                                @if (context.ResourceRow.TelemetryData.Count > 0)
                                 {
                                     <FluentButton Appearance="Appearance.Lightweight"
                                                   Class="main-grid-expand-button"
@@ -91,11 +93,13 @@
                 @if (context.IsResourceRow && context.ResourceRow is not null)
                 {
                     <span @onclick:stopPropagation="true">
-                        @foreach (var dataRow in context.ResourceRow.Data)
+                        @foreach (var dataRow in context.ResourceRow.TelemetryData)
                         {
                             <FluentButton Appearance="Appearance.Lightweight"
                                           IconEnd="@dataRow.Icon"
                                           OnClick="@(() => NavigateToDataPage(dataRow))"
+                                          Title="@GetDataTypeDisplayName(dataRow.DataType)"
+                                          aria-label="@GetDataTypeDisplayName(dataRow.DataType)"
                                           Style="margin-right: 4px;" />
                         }
                     </span>

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Components.Controls.Chart;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Utils;
+using Microsoft.AspNetCore.Components;
+using Microsoft.FluentUI.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Components.Dialogs;
+
+public class DataRow
+{
+    public required string Name { get; set; }
+    public bool Selected { get; set; }
+}
+
+public partial class ManageDataDialog : IDialogContentComponent, IDisposable
+{
+    [Inject]
+    public required BrowserTimeProvider TimeProvider { get; init; }
+
+    [Inject]
+    public required IDialogService DialogService { get; init; }
+
+    [Inject]
+    public required NavigationManager NavigationManager { get; init; }
+
+    [Inject]
+    public required TelemetryRepository TelemetryRepository { get; init; }
+
+    private readonly List<DataRow> _dataRows = new()
+    {
+        new DataRow { Name = "#1", Selected = true },
+        new DataRow { Name = "#2", Selected = false },
+        new DataRow { Name = "#3", Selected = true },
+    };
+
+    public IEnumerable<DataRow> SelectedItems { get; set; } = Enumerable.Empty<DataRow>();
+
+    public IQueryable<DataRow> MetricView => _dataRows.AsQueryable();
+
+    private readonly CancellationTokenSource _cts = new();
+
+    protected override void OnInitialized()
+    {
+        SelectedItems = _dataRows.Where(p => p.Selected);
+    }
+
+    public async Task OnViewDetailsAsync(ChartExemplar exemplar)
+    {
+        var available = await TraceLinkHelpers.WaitForSpanToBeAvailableAsync(
+            traceId: exemplar.TraceId,
+            spanId: exemplar.SpanId,
+            getSpan: TelemetryRepository.GetSpan,
+            DialogService,
+            InvokeAsync,
+            Loc,
+            _cts.Token).ConfigureAwait(false);
+
+        if (available)
+        {
+            NavigationManager.NavigateTo(DashboardUrls.TraceDetailUrl(exemplar.TraceId, spanId: exemplar.SpanId));
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _cts.Dispose();
+    }
+}

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
@@ -1,22 +1,72 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using Aspire.Dashboard.Components.Controls.Chart;
+using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
+using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components.Dialogs;
 
-public class DataRow
+/// <summary>
+/// Represents a row in the manage data grid, containing resource information and nested data rows.
+/// </summary>
+public sealed class ResourceDataRow
 {
-    public required string Name { get; set; }
+    /// <summary>
+    /// The ResourceViewModel from the dashboard client. May be null for telemetry-only resources.
+    /// </summary>
+    public ResourceViewModel? Resource { get; init; }
+
+    /// <summary>
+    /// The OtlpResource from telemetry. May be null if no telemetry data exists yet.
+    /// </summary>
+    public OtlpResource? OtlpResource { get; init; }
+
+    /// <summary>
+    /// The display name for this resource row.
+    /// </summary>
+    public required string DisplayName { get; init; }
+
+    public bool IsExpanded { get; set; }
     public bool Selected { get; set; }
+    public List<DataRow> Data { get; set; } = [];
+
+    /// <summary>
+    /// Gets whether this resource is telemetry-only (no corresponding ResourceViewModel).
+    /// </summary>
+    public bool IsTelemetryOnly => Resource is null && OtlpResource is not null;
 }
 
-public partial class ManageDataDialog : IDialogContentComponent, IDisposable
+/// <summary>
+/// Represents a nested data row within a resource row.
+/// </summary>
+public sealed class DataRow
+{
+    public required string Name { get; init; }
+}
+
+/// <summary>
+/// Represents an item in the manage data grid, which can be either a resource row or a nested data row.
+/// </summary>
+public sealed class ManageDataGridItem
+{
+    public ResourceDataRow? ResourceRow { get; init; }
+    public DataRow? NestedRow { get; init; }
+    public ResourceViewModel? ParentResource { get; init; }
+    public int Depth { get; init; }
+
+    public bool IsResourceRow => ResourceRow is not null;
+    public bool IsNestedRow => NestedRow is not null;
+}
+
+public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposable
 {
     [Inject]
     public required BrowserTimeProvider TimeProvider { get; init; }
@@ -30,22 +80,232 @@ public partial class ManageDataDialog : IDialogContentComponent, IDisposable
     [Inject]
     public required TelemetryRepository TelemetryRepository { get; init; }
 
-    private readonly List<DataRow> _dataRows = new()
-    {
-        new DataRow { Name = "#1", Selected = true },
-        new DataRow { Name = "#2", Selected = false },
-        new DataRow { Name = "#3", Selected = true },
-    };
+    [Inject]
+    public required IDashboardClient DashboardClient { get; init; }
 
-    public IEnumerable<DataRow> SelectedItems { get; set; } = Enumerable.Empty<DataRow>();
+    [Inject]
+    public required IconResolver IconResolver { get; init; }
 
-    public IQueryable<DataRow> MetricView => _dataRows.AsQueryable();
+    [Inject]
+    public required ConsoleLogsManager ConsoleLogsManager { get; init; }
 
+    [Inject]
+    public required TelemetryExportService TelemetryExportService { get; init; }
+
+    [Inject]
+    public required IJSRuntime JS { get; init; }
+
+    private readonly ConcurrentDictionary<string, ResourceViewModel> _resourceByName = new(StringComparers.ResourceName);
+    private readonly Dictionary<string, ResourceDataRow> _resourceDataRows = new(StringComparers.ResourceName);
+    private readonly HashSet<string> _expandedResourceNames = new(StringComparers.ResourceName);
     private readonly CancellationTokenSource _cts = new();
+    private Task? _resourceSubscriptionTask;
+    private FluentDataGrid<ManageDataGridItem>? _dataGrid;
+    private bool _isExporting;
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
-        SelectedItems = _dataRows.Where(p => p.Selected);
+        if (DashboardClient.IsEnabled)
+        {
+            await SubscribeResourcesAsync();
+        }
+    }
+
+    private async Task SubscribeResourcesAsync()
+    {
+        var (snapshot, subscription) = await DashboardClient.SubscribeResourcesAsync(_cts.Token);
+
+        // Apply snapshot.
+        foreach (var resource in snapshot)
+        {
+            _resourceByName[resource.Name] = resource;
+            _resourceDataRows[resource.Name] = CreateResourceDataRow(resource);
+        }
+
+        // Listen for updates and apply.
+        _resourceSubscriptionTask = Task.Run(async () =>
+        {
+            await foreach (var changes in subscription.WithCancellation(_cts.Token).ConfigureAwait(false))
+            {
+                foreach (var (changeType, resource) in changes)
+                {
+                    if (changeType == ResourceViewModelChangeType.Upsert)
+                    {
+                        _resourceByName[resource.Name] = resource;
+                        if (_resourceDataRows.TryGetValue(resource.Name, out var existingRow))
+                        {
+                            // Preserve expanded state
+                            var wasExpanded = existingRow.IsExpanded;
+                            _resourceDataRows[resource.Name] = CreateResourceDataRow(resource);
+                            _resourceDataRows[resource.Name].IsExpanded = wasExpanded;
+                        }
+                        else
+                        {
+                            _resourceDataRows[resource.Name] = CreateResourceDataRow(resource);
+                        }
+                    }
+                    else if (changeType == ResourceViewModelChangeType.Delete)
+                    {
+                        _resourceByName.TryRemove(resource.Name, out _);
+                        _resourceDataRows.Remove(resource.Name);
+                        _expandedResourceNames.Remove(resource.Name);
+                    }
+                }
+
+                await InvokeAsync(async () =>
+                {
+                    if (_dataGrid is not null)
+                    {
+                        await _dataGrid.SafeRefreshDataAsync();
+                    }
+                    StateHasChanged();
+                });
+            }
+        });
+    }
+
+    private ResourceDataRow CreateResourceDataRow(ResourceViewModel resource)
+    {
+        var data = new List<DataRow>();
+
+        var otlpResource = TelemetryRepository.GetResourceByCompositeName(resource.Name);
+        if (otlpResource is not null)
+        {
+            PopulateDataRows(data, otlpResource.ResourceKey);
+        }
+
+        return new ResourceDataRow
+        {
+            Resource = resource,
+            OtlpResource = otlpResource,
+            DisplayName = resource.Name,
+            Data = data
+        };
+    }
+
+    private ResourceDataRow CreateTelemetryOnlyResourceDataRow(OtlpResource otlpResource)
+    {
+        var data = new List<DataRow>();
+        PopulateDataRows(data, otlpResource.ResourceKey);
+
+        return new ResourceDataRow
+        {
+            Resource = null,
+            OtlpResource = otlpResource,
+            DisplayName = otlpResource.ResourceKey.GetCompositeName(),
+            Data = data
+        };
+    }
+
+    private void PopulateDataRows(List<DataRow> data, ResourceKey resourceKey)
+    {
+        // Check for logs
+        var logsResult = TelemetryRepository.GetLogs(new GetLogsContext
+        {
+            ResourceKey = resourceKey,
+            StartIndex = 0,
+            Count = 0,
+            Filters = []
+        });
+        if (logsResult.TotalItemCount > 0)
+        {
+            data.Add(new DataRow { Name = "Logs" });
+        }
+
+        // Check for traces
+        var tracesResult = TelemetryRepository.GetTraces(new GetTracesRequest
+        {
+            ResourceKey = resourceKey,
+            StartIndex = 0,
+            Count = 0,
+            FilterText = "",
+            Filters = []
+        });
+        if (tracesResult.PagedResult.TotalItemCount > 0)
+        {
+            data.Add(new DataRow { Name = "Traces" });
+        }
+
+        // Check for metrics (instruments)
+        var instruments = TelemetryRepository.GetInstrumentsSummaries(resourceKey);
+        if (instruments.Count > 0)
+        {
+            data.Add(new DataRow { Name = "Metrics" });
+        }
+    }
+
+    private IQueryable<ManageDataGridItem> GetGridItems()
+    {
+        // Merge telemetry-only resources into the data rows
+        MergeTelemetryOnlyResources();
+
+        var items = new List<ManageDataGridItem>();
+
+        // Sort by display name (works for both ResourceViewModel resources and telemetry-only resources)
+        foreach (var resourceRow in _resourceDataRows.Values.OrderBy(r => r.DisplayName, StringComparers.ResourceName))
+        {
+            // Add the resource row
+            items.Add(new ManageDataGridItem
+            {
+                ResourceRow = resourceRow,
+                Depth = 0
+            });
+
+            // If expanded, add nested data rows
+            if (resourceRow.IsExpanded)
+            {
+                foreach (var dataRow in resourceRow.Data)
+                {
+                    items.Add(new ManageDataGridItem
+                    {
+                        NestedRow = dataRow,
+                        ParentResource = resourceRow.Resource,
+                        Depth = 1
+                    });
+                }
+            }
+        }
+
+        return items.AsQueryable();
+    }
+
+    private void MergeTelemetryOnlyResources()
+    {
+        // Get all telemetry resources
+        var telemetryResources = TelemetryRepository.GetResources();
+
+        foreach (var otlpResource in telemetryResources)
+        {
+            var compositeName = otlpResource.ResourceKey.GetCompositeName();
+
+            // Check if this resource already exists in our dictionary
+            if (!_resourceDataRows.ContainsKey(compositeName))
+            {
+                // This is a telemetry-only resource, add it
+                var row = CreateTelemetryOnlyResourceDataRow(otlpResource);
+                if (_expandedResourceNames.Contains(compositeName))
+                {
+                    row.IsExpanded = true;
+                }
+                _resourceDataRows[compositeName] = row;
+            }
+        }
+    }
+
+    private void OnToggleExpand(ResourceDataRow resourceRow)
+    {
+        resourceRow.IsExpanded = !resourceRow.IsExpanded;
+
+        if (resourceRow.IsExpanded)
+        {
+            _expandedResourceNames.Add(resourceRow.DisplayName);
+        }
+        else
+        {
+            _expandedResourceNames.Remove(resourceRow.DisplayName);
+        }
+
+        StateHasChanged();
     }
 
     public async Task OnViewDetailsAsync(ChartExemplar exemplar)
@@ -65,9 +325,56 @@ public partial class ManageDataDialog : IDialogContentComponent, IDisposable
         }
     }
 
-    public void Dispose()
+    private string GetResourceName(ResourceViewModel resource) => ResourceViewModel.GetResourceName(resource, _resourceByName);
+
+    private async Task RemoveAllAsync()
     {
-        _cts.Cancel();
+        TelemetryRepository.ClearAllSignals();
+
+        await ConsoleLogsManager.UpdateFiltersAsync(new ConsoleLogsFilters { FilterAllLogsDate = TimeProvider.GetUtcNow().UtcDateTime });
+    }
+
+    private async Task ExportAllAsync()
+    {
+        if (_isExporting)
+        {
+            return;
+        }
+
+        _isExporting = true;
+        StateHasChanged();
+
+        try
+        {
+            using var memoryStream = await TelemetryExportService.ExportAllAsync(CancellationToken.None);
+            var fileName = $"aspire-telemetry-export-{DateTime.UtcNow:yyyyMMdd-HHmmss}.zip";
+
+            using var streamRef = new DotNetStreamReference(memoryStream, leaveOpen: false);
+            await JS.InvokeVoidAsync("downloadStreamAsFile", fileName, streamRef);
+        }
+        finally
+        {
+            _isExporting = false;
+            StateHasChanged();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _cts.CancelAsync();
+
+        if (_resourceSubscriptionTask is not null)
+        {
+            try
+            {
+                await _resourceSubscriptionTask;
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected when cancelling
+            }
+        }
+
         _cts.Dispose();
     }
 }

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using Aspire.Dashboard.Components.Controls.Chart;
 using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Model.ManageData;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
@@ -17,80 +18,6 @@ using CoreIcons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 namespace Aspire.Dashboard.Components.Dialogs;
-
-/// <summary>
-/// Represents a row in the manage data grid, containing resource information and nested data rows.
-/// </summary>
-public sealed class ResourceDataRow
-{
-    /// <summary>
-    /// The ResourceViewModel from the dashboard client. May be null for telemetry-only resources.
-    /// </summary>
-    public ResourceViewModel? Resource { get; init; }
-
-    /// <summary>
-    /// The OtlpResource from telemetry. May be null if no telemetry data exists yet.
-    /// </summary>
-    public OtlpResource? OtlpResource { get; init; }
-
-    /// <summary>
-    /// The display name for this resource row.
-    /// </summary>
-    public required string DisplayName { get; init; }
-
-    public bool IsExpanded { get; set; }
-    public bool Selected { get; set; }
-    public List<DataRow> Data { get; set; } = [];
-
-    /// <summary>
-    /// Gets whether this resource is telemetry-only (no corresponding ResourceViewModel).
-    /// </summary>
-    public bool IsTelemetryOnly => Resource is null && OtlpResource is not null;
-}
-
-/// <summary>
-/// Represents a nested data row within a resource row.
-/// </summary>
-public sealed class DataRow
-{
-    public required string DisplayName { get; init; }
-
-    /// <summary>
-    /// The type of data this row represents.
-    /// </summary>
-    public required AspireDataType DataType { get; init; }
-
-    /// <summary>
-    /// The total count of items (logs, traces, or metrics). Null if count is not available.
-    /// </summary>
-    public int? DataCount { get; init; }
-
-    /// <summary>
-    /// The icon representing this data type.
-    /// </summary>
-    public required Icon Icon { get; init; }
-
-    /// <summary>
-    /// The URL to navigate to when clicking on this data row.
-    /// </summary>
-    public required string Url { get; init; }
-
-    public bool Selected { get; set; }
-}
-
-/// <summary>
-/// Represents an item in the manage data grid, which can be either a resource row or a nested data row.
-/// </summary>
-public sealed class ManageDataGridItem
-{
-    public ResourceDataRow? ResourceRow { get; init; }
-    public DataRow? NestedRow { get; init; }
-    public ResourceViewModel? ParentResource { get; init; }
-    public int Depth { get; init; }
-
-    public bool IsResourceRow => ResourceRow is not null;
-    public bool IsNestedRow => NestedRow is not null;
-}
 
 public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposable
 {

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
@@ -86,7 +86,7 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
             // Recreate all data rows from _resourceByName with updated telemetry counts
             foreach (var (resourceName, resource) in _resourceByName)
             {
-                if (_resourceDataRows.TryGetValue(resourceName, out var existingRow))
+                if (_resourceDataRows.TryGetValue(resourceName, out _))
                 {
                     var newRow = CreateResourceDataRow(resource);
                     _resourceDataRows[resourceName] = newRow;

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.css
@@ -2,6 +2,7 @@
     display: flex;
     align-items: center;
     margin-left: 34px;
+    user-select: none;
 }
 
 ::deep .resources-name-container {

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.css
@@ -1,0 +1,10 @@
+::deep .name-title-text {
+    display: flex;
+    align-items: center;
+    margin-left: 34px;
+}
+
+::deep .resources-name-container {
+    display: flex;
+    align-items: center;
+}

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -41,19 +41,6 @@
                               aria-label="@Loc[nameof(Dialogs.ManageDataManageButtonText)]">
                     @Loc[nameof(Dialogs.ManageDataManageButtonText)]
                 </FluentButton>
-                <FluentButton IconStart="@(new Icons.Regular.Size16.Delete())"
-                              OnClick="ClearAllSignals"
-                              Title="@Loc[nameof(Dialogs.SettingsRemoveAllButtonText)]"
-                              aria-label="@Loc[nameof(Dialogs.SettingsRemoveAllButtonText)]">
-                    @Loc[nameof(Dialogs.SettingsRemoveAllButtonText)]
-                </FluentButton>
-                <FluentButton IconStart="@(new Icons.Regular.Size16.ArrowDownload())"
-                              OnClick="ExportAllAsync"
-                              Loading="@_isExporting"
-                              Title="@Loc[nameof(Dialogs.SettingsExportAllButtonText)]"
-                              aria-label="@Loc[nameof(Dialogs.SettingsExportAllButtonText)]">
-                    @Loc[nameof(Dialogs.SettingsExportAllButtonText)]
-                </FluentButton>
             </div>
         </div>
 

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -36,6 +36,12 @@
             <span class="setting-title">@Loc[nameof(Dialogs.SettingsDialogDashboardLogsAndTelemetry)]</span>
             <div>
                 <FluentButton IconStart="@(new Icons.Regular.Size16.Delete())"
+                              OnClick="LaunchManageData"
+                              Title="@Loc[nameof(Dialogs.SettingsRemoveAllButtonText)]"
+                              aria-label="@Loc[nameof(Dialogs.SettingsRemoveAllButtonText)]">
+                    @Loc[nameof(Dialogs.SettingsRemoveAllButtonText)]
+                </FluentButton>
+                <FluentButton IconStart="@(new Icons.Regular.Size16.Delete())"
                               OnClick="ClearAllSignals"
                               Title="@Loc[nameof(Dialogs.SettingsRemoveAllButtonText)]"
                               aria-label="@Loc[nameof(Dialogs.SettingsRemoveAllButtonText)]">

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -35,11 +35,11 @@
         <div>
             <span class="setting-title">@Loc[nameof(Dialogs.SettingsDialogDashboardLogsAndTelemetry)]</span>
             <div>
-                <FluentButton IconStart="@(new Icons.Regular.Size16.Delete())"
-                              OnClick="LaunchManageData"
-                              Title="@Loc[nameof(Dialogs.SettingsRemoveAllButtonText)]"
-                              aria-label="@Loc[nameof(Dialogs.SettingsRemoveAllButtonText)]">
-                    @Loc[nameof(Dialogs.SettingsRemoveAllButtonText)]
+                <FluentButton IconStart="@(new Icons.Regular.Size16.Settings())"
+                              OnClick="LaunchManageDataAsync"
+                              Title="@Loc[nameof(Dialogs.ManageDataManageButtonText)]"
+                              aria-label="@Loc[nameof(Dialogs.ManageDataManageButtonText)]">
+                    @Loc[nameof(Dialogs.ManageDataManageButtonText)]
                 </FluentButton>
                 <FluentButton IconStart="@(new Icons.Regular.Size16.Delete())"
                               OnClick="ClearAllSignals"

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -140,14 +140,14 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
     {
         var parameters = new DialogParameters
         {
-            Title = Loc[nameof(Dashboard.Resources.Dialogs.ExemplarsDialogTitle)],
+            Title = Loc[nameof(Dashboard.Resources.Dialogs.ManageDataDialogTitle)],
             PrimaryAction = Loc[nameof(Dashboard.Resources.Dialogs.DialogCloseButtonText)],
             DismissTitle = Loc[nameof(Dashboard.Resources.Dialogs.DialogCloseButtonText)],
             SecondaryAction = string.Empty,
             Width = "800px",
             Height = "auto"
         };
-        await DialogService.ShowDialogAsync<ExemplarsDialog>(parameters);
+        await DialogService.ShowDialogAsync<ManageDataDialog>(parameters);
     }
 
     public void Dispose()

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -3,12 +3,10 @@
 
 using System.Globalization;
 using Aspire.Dashboard.Model;
-using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Telemetry;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
-using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components.Dialogs;
 
@@ -17,7 +15,6 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
     private string? _currentSetting;
     private List<CultureInfo> _languageOptions = null!;
     private CultureInfo? _selectedUiCulture;
-    private bool _isExporting;
 
     private IDisposable? _themeChangedSubscription;
 
@@ -25,25 +22,10 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
     public required ThemeManager ThemeManager { get; init; }
 
     [Inject]
-    public required TelemetryRepository TelemetryRepository { get; init; }
-
-    [Inject]
     public required NavigationManager NavigationManager { get; init; }
 
     [Inject]
-    public required ConsoleLogsManager ConsoleLogsManager { get; init; }
-
-    [Inject]
-    public required BrowserTimeProvider TimeProvider { get; init; }
-
-    [Inject]
     public required DashboardTelemetryService TelemetryService { get; init; }
-
-    [Inject]
-    public required TelemetryExportService TelemetryExportService { get; init; }
-
-    [Inject]
-    public required IJSRuntime JS { get; init; }
 
     [Inject]
     public required IDialogService DialogService { get; init; }
@@ -102,38 +84,6 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
     private static void ValueChanged(string? value)
     {
         // Do nothing. Required for FluentUI Blazor to trigger SelectedOptionChanged.
-    }
-
-    private async Task ClearAllSignals()
-    {
-        TelemetryRepository.ClearAllSignals();
-
-        await ConsoleLogsManager.UpdateFiltersAsync(new ConsoleLogsFilters { FilterAllLogsDate = TimeProvider.GetUtcNow().UtcDateTime });
-    }
-
-    private async Task ExportAllAsync()
-    {
-        if (_isExporting)
-        {
-            return;
-        }
-
-        _isExporting = true;
-        StateHasChanged();
-
-        try
-        {
-            using var memoryStream = await TelemetryExportService.ExportAllAsync(CancellationToken.None);
-            var fileName = $"aspire-telemetry-export-{DateTime.UtcNow:yyyyMMdd-HHmmss}.zip";
-
-            using var streamRef = new DotNetStreamReference(memoryStream, leaveOpen: false);
-            await JS.InvokeVoidAsync("downloadStreamAsFile", fileName, streamRef);
-        }
-        finally
-        {
-            _isExporting = false;
-            StateHasChanged();
-        }
     }
 
     private async Task LaunchManageDataAsync()

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -45,6 +45,9 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
     [Inject]
     public required IJSRuntime JS { get; init; }
 
+    [Inject]
+    public required IDialogService DialogService { get; init; }
+
     protected override void OnInitialized()
     {
         _languageOptions = GlobalizationHelpers.OrderedLocalizedCultures;
@@ -131,6 +134,20 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
             _isExporting = false;
             StateHasChanged();
         }
+    }
+
+    private async Task LaunchManageDataAsync()
+    {
+        var parameters = new DialogParameters
+        {
+            Title = Loc[nameof(Dashboard.Resources.Dialogs.ExemplarsDialogTitle)],
+            PrimaryAction = Loc[nameof(Dashboard.Resources.Dialogs.DialogCloseButtonText)],
+            DismissTitle = Loc[nameof(Dashboard.Resources.Dialogs.DialogCloseButtonText)],
+            SecondaryAction = string.Empty,
+            Width = "800px",
+            Height = "auto"
+        };
+        await DialogService.ShowDialogAsync<ExemplarsDialog>(parameters);
     }
 
     public void Dispose()

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -220,7 +220,7 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
 
         if (_openPageDialog is not null)
         {
-            if (Equals(_openPageDialog.Id, McpDialogId))
+            if (Equals(_openPageDialog.Id, McpDialogId) && !_openPageDialog.Result.IsCompleted)
             {
                 return;
             }
@@ -251,7 +251,7 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
 
         if (_openPageDialog is not null)
         {
-            if (Equals(_openPageDialog.Id, HelpDialogId))
+            if (Equals(_openPageDialog.Id, HelpDialogId) && !_openPageDialog.Result.IsCompleted)
             {
                 return;
             }
@@ -286,7 +286,7 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
 
         if (_openPageDialog is not null)
         {
-            if (Equals(_openPageDialog.Id, SettingsDialogId))
+            if (Equals(_openPageDialog.Id, SettingsDialogId) && !_openPageDialog.Result.IsCompleted)
             {
                 return;
             }

--- a/src/Aspire.Dashboard/Model/AspireDataType.cs
+++ b/src/Aspire.Dashboard/Model/AspireDataType.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Model;
+
+/// <summary>
+/// Represents the type of data in an Aspire resource.
+/// </summary>
+public enum AspireDataType
+{
+    /// <summary>
+    /// Console logs from resource stdout/stderr.
+    /// </summary>
+    ConsoleLogs,
+
+    /// <summary>
+    /// Structured logs from OpenTelemetry.
+    /// </summary>
+    StructuredLogs,
+
+    /// <summary>
+    /// Distributed traces from OpenTelemetry.
+    /// </summary>
+    Traces,
+
+    /// <summary>
+    /// Metrics from OpenTelemetry.
+    /// </summary>
+    Metrics
+}

--- a/src/Aspire.Dashboard/Model/ManageData/DataRow.cs
+++ b/src/Aspire.Dashboard/Model/ManageData/DataRow.cs
@@ -10,8 +10,6 @@ namespace Aspire.Dashboard.Model.ManageData;
 /// </summary>
 public sealed class DataRow
 {
-    public required string DisplayName { get; init; }
-
     /// <summary>
     /// The type of data this row represents.
     /// </summary>

--- a/src/Aspire.Dashboard/Model/ManageData/DataRow.cs
+++ b/src/Aspire.Dashboard/Model/ManageData/DataRow.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.FluentUI.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Model.ManageData;
+
+/// <summary>
+/// Represents a nested data row within a resource row.
+/// </summary>
+public sealed class DataRow
+{
+    public required string DisplayName { get; init; }
+
+    /// <summary>
+    /// The type of data this row represents.
+    /// </summary>
+    public required AspireDataType DataType { get; init; }
+
+    /// <summary>
+    /// The total count of items (logs, traces, or metrics). Null if count is not available.
+    /// </summary>
+    public int? DataCount { get; init; }
+
+    /// <summary>
+    /// The icon representing this data type.
+    /// </summary>
+    public required Icon Icon { get; init; }
+
+    /// <summary>
+    /// The URL to navigate to when clicking on this data row.
+    /// </summary>
+    public required string Url { get; init; }
+
+    public bool Selected { get; set; }
+}

--- a/src/Aspire.Dashboard/Model/ManageData/DataRow.cs
+++ b/src/Aspire.Dashboard/Model/ManageData/DataRow.cs
@@ -31,6 +31,4 @@ public sealed class DataRow
     /// The URL to navigate to when clicking on this data row.
     /// </summary>
     public required string Url { get; init; }
-
-    public bool Selected { get; set; }
 }

--- a/src/Aspire.Dashboard/Model/ManageData/ManageDataGridItem.cs
+++ b/src/Aspire.Dashboard/Model/ManageData/ManageDataGridItem.cs
@@ -10,8 +10,8 @@ public sealed class ManageDataGridItem
 {
     public ResourceDataRow? ResourceRow { get; init; }
     public DataRow? NestedRow { get; init; }
-    public ResourceViewModel? ParentResource { get; init; }
     public string? ParentResourceName { get; init; }
+
     public int Depth { get; init; }
 
     public bool IsResourceRow => ResourceRow is not null;

--- a/src/Aspire.Dashboard/Model/ManageData/ManageDataGridItem.cs
+++ b/src/Aspire.Dashboard/Model/ManageData/ManageDataGridItem.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Model.ManageData;
+
+/// <summary>
+/// Represents an item in the manage data grid, which can be either a resource row or a nested data row.
+/// </summary>
+public sealed class ManageDataGridItem
+{
+    public ResourceDataRow? ResourceRow { get; init; }
+    public DataRow? NestedRow { get; init; }
+    public ResourceViewModel? ParentResource { get; init; }
+    public int Depth { get; init; }
+
+    public bool IsResourceRow => ResourceRow is not null;
+    public bool IsNestedRow => NestedRow is not null;
+}

--- a/src/Aspire.Dashboard/Model/ManageData/ManageDataGridItem.cs
+++ b/src/Aspire.Dashboard/Model/ManageData/ManageDataGridItem.cs
@@ -9,7 +9,7 @@ namespace Aspire.Dashboard.Model.ManageData;
 public sealed class ManageDataGridItem
 {
     public ResourceDataRow? ResourceRow { get; init; }
-    public DataRow? NestedRow { get; init; }
+    public TelemetryDataRow? NestedRow { get; init; }
     public string? ParentResourceName { get; init; }
 
     public int Depth { get; init; }

--- a/src/Aspire.Dashboard/Model/ManageData/ManageDataGridItem.cs
+++ b/src/Aspire.Dashboard/Model/ManageData/ManageDataGridItem.cs
@@ -11,6 +11,7 @@ public sealed class ManageDataGridItem
     public ResourceDataRow? ResourceRow { get; init; }
     public DataRow? NestedRow { get; init; }
     public ResourceViewModel? ParentResource { get; init; }
+    public string? ParentResourceName { get; init; }
     public int Depth { get; init; }
 
     public bool IsResourceRow => ResourceRow is not null;

--- a/src/Aspire.Dashboard/Model/ManageData/ResourceDataRow.cs
+++ b/src/Aspire.Dashboard/Model/ManageData/ResourceDataRow.cs
@@ -23,7 +23,7 @@ public sealed class ResourceDataRow
     /// <summary>
     /// The display name for this resource row.
     /// </summary>
-    public required string DisplayName { get; init; }
+    public required string Name { get; init; }
 
     public List<DataRow> Data { get; set; } = [];
 

--- a/src/Aspire.Dashboard/Model/ManageData/ResourceDataRow.cs
+++ b/src/Aspire.Dashboard/Model/ManageData/ResourceDataRow.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Model;
+
+namespace Aspire.Dashboard.Model.ManageData;
+
+/// <summary>
+/// Represents a row in the manage data grid, containing resource information and nested data rows.
+/// </summary>
+public sealed class ResourceDataRow
+{
+    /// <summary>
+    /// The ResourceViewModel from the dashboard client. May be null for telemetry-only resources.
+    /// </summary>
+    public ResourceViewModel? Resource { get; init; }
+
+    /// <summary>
+    /// The OtlpResource from telemetry. May be null if no telemetry data exists yet.
+    /// </summary>
+    public OtlpResource? OtlpResource { get; init; }
+
+    /// <summary>
+    /// The display name for this resource row.
+    /// </summary>
+    public required string DisplayName { get; init; }
+
+    public bool IsExpanded { get; set; }
+    public bool Selected { get; set; }
+    public List<DataRow> Data { get; set; } = [];
+
+    /// <summary>
+    /// Gets whether this resource is telemetry-only (no corresponding ResourceViewModel).
+    /// </summary>
+    public bool IsTelemetryOnly => Resource is null && OtlpResource is not null;
+}

--- a/src/Aspire.Dashboard/Model/ManageData/ResourceDataRow.cs
+++ b/src/Aspire.Dashboard/Model/ManageData/ResourceDataRow.cs
@@ -25,7 +25,10 @@ public sealed class ResourceDataRow
     /// </summary>
     public required string Name { get; init; }
 
-    public List<DataRow> Data { get; set; } = [];
+    /// <summary>
+    /// Gets telemetry data for this resource row.
+    /// </summary>
+    public List<TelemetryDataRow> TelemetryData { get; set; } = [];
 
     /// <summary>
     /// Gets whether this resource is telemetry-only (no corresponding ResourceViewModel).

--- a/src/Aspire.Dashboard/Model/ManageData/ResourceDataRow.cs
+++ b/src/Aspire.Dashboard/Model/ManageData/ResourceDataRow.cs
@@ -25,8 +25,6 @@ public sealed class ResourceDataRow
     /// </summary>
     public required string DisplayName { get; init; }
 
-    public bool IsExpanded { get; set; }
-    public bool Selected { get; set; }
     public List<DataRow> Data { get; set; } = [];
 
     /// <summary>

--- a/src/Aspire.Dashboard/Model/ManageData/TelemetryDataRow.cs
+++ b/src/Aspire.Dashboard/Model/ManageData/TelemetryDataRow.cs
@@ -6,9 +6,9 @@ using Microsoft.FluentUI.AspNetCore.Components;
 namespace Aspire.Dashboard.Model.ManageData;
 
 /// <summary>
-/// Represents a nested data row within a resource row.
+/// Represents a nested telemetry data row within a resource row.
 /// </summary>
-public sealed class DataRow
+public sealed class TelemetryDataRow
 {
     /// <summary>
     /// The type of data this row represents.

--- a/src/Aspire.Dashboard/Model/TelemetryExportService.cs
+++ b/src/Aspire.Dashboard/Model/TelemetryExportService.cs
@@ -30,36 +30,6 @@ public sealed class TelemetryExportService
     }
 
     /// <summary>
-    /// Exports all telemetry and console logs as a zip archive stream.
-    /// </summary>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A memory stream containing the zip archive.</returns>
-    public async Task<MemoryStream> ExportAllAsync(CancellationToken cancellationToken)
-    {
-        var memoryStream = new MemoryStream();
-
-        using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Create, leaveOpen: true))
-        {
-            var resources = _telemetryRepository.GetResources();
-
-            // Export console logs
-            await ExportConsoleLogsAsync(archive, cancellationToken).ConfigureAwait(false);
-
-            // Export structured logs (OTLP JSON)
-            ExportStructuredLogs(archive, resources);
-
-            // Export traces (OTLP JSON)
-            ExportTraces(archive, resources);
-
-            // Export metrics (OTLP JSON)
-            ExportMetrics(archive, resources);
-        }
-
-        memoryStream.Position = 0;
-        return memoryStream;
-    }
-
-    /// <summary>
     /// Exports selected telemetry and console logs as a zip archive stream.
     /// </summary>
     /// <param name="selectedResources">Dictionary mapping resource names to the data types to export.</param>
@@ -118,11 +88,6 @@ public sealed class TelemetryExportService
 
         memoryStream.Position = 0;
         return memoryStream;
-    }
-
-    private async Task ExportConsoleLogsAsync(ZipArchive archive, CancellationToken cancellationToken)
-    {
-        await ExportConsoleLogsAsync(archive, resourceFilter: null, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task ExportConsoleLogsAsync(ZipArchive archive, HashSet<string>? resourceFilter, CancellationToken cancellationToken)

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -1220,5 +1220,32 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ManageDataRemoveButtonText", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Info.
+        /// </summary>
+        public static string ManageDataInfoColumnHeader {
+            get {
+                return ResourceManager.GetString("ManageDataInfoColumnHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Aspire.
+        /// </summary>
+        public static string ManageDataSourceAspire {
+            get {
+                return ResourceManager.GetString("ManageDataSourceAspire", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OpenTelemetry.
+        /// </summary>
+        public static string ManageDataSourceOpenTelemetry {
+            get {
+                return ResourceManager.GetString("ManageDataSourceOpenTelemetry", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -1229,23 +1229,5 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ManageDataSummaryColumnHeader", resourceCulture);
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Aspire.
-        /// </summary>
-        public static string ManageDataSourceAspire {
-            get {
-                return ResourceManager.GetString("ManageDataSourceAspire", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to OpenTelemetry.
-        /// </summary>
-        public static string ManageDataSourceOpenTelemetry {
-            get {
-                return ResourceManager.GetString("ManageDataSourceOpenTelemetry", resourceCulture);
-            }
-        }
     }
 }

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -1184,5 +1184,41 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("TextVisualizerSelectFormatType", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resource logs and telemetry.
+        /// </summary>
+        public static string ManageDataDialogTitle {
+            get {
+                return ResourceManager.GetString("ManageDataDialogTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Manage.
+        /// </summary>
+        public static string ManageDataManageButtonText {
+            get {
+                return ResourceManager.GetString("ManageDataManageButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Export.
+        /// </summary>
+        public static string ManageDataExportButtonText {
+            get {
+                return ResourceManager.GetString("ManageDataExportButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove.
+        /// </summary>
+        public static string ManageDataRemoveButtonText {
+            get {
+                return ResourceManager.GetString("ManageDataRemoveButtonText", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -1186,7 +1186,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Resource logs and telemetry.
+        ///   Looks up a localized string similar to Manage logs and telemetry.
         /// </summary>
         public static string ManageDataDialogTitle {
             get {
@@ -1204,7 +1204,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Export.
+        ///   Looks up a localized string similar to Export selected.
         /// </summary>
         public static string ManageDataExportButtonText {
             get {
@@ -1213,7 +1213,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove.
+        ///   Looks up a localized string similar to Remove selected.
         /// </summary>
         public static string ManageDataRemoveButtonText {
             get {
@@ -1222,11 +1222,11 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Info.
+        ///   Looks up a localized string similar to Summary.
         /// </summary>
-        public static string ManageDataInfoColumnHeader {
+        public static string ManageDataSummaryColumnHeader {
             get {
-                return ResourceManager.GetString("ManageDataInfoColumnHeader", resourceCulture);
+                return ResourceManager.GetString("ManageDataSummaryColumnHeader", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -1195,6 +1195,42 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Console logs.
+        /// </summary>
+        public static string ManageDataConsoleLogs {
+            get {
+                return ResourceManager.GetString("ManageDataConsoleLogs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Metrics.
+        /// </summary>
+        public static string ManageDataMetrics {
+            get {
+                return ResourceManager.GetString("ManageDataMetrics", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Structured logs.
+        /// </summary>
+        public static string ManageDataStructuredLogs {
+            get {
+                return ResourceManager.GetString("ManageDataStructuredLogs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Traces.
+        /// </summary>
+        public static string ManageDataTraces {
+            get {
+                return ResourceManager.GetString("ManageDataTraces", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Manage.
         /// </summary>
         public static string ManageDataManageButtonText {
@@ -1209,6 +1245,15 @@ namespace Aspire.Dashboard.Resources {
         public static string ManageDataExportButtonText {
             get {
                 return ResourceManager.GetString("ManageDataExportButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No resources found.
+        /// </summary>
+        public static string ManageDataNoResources {
+            get {
+                return ResourceManager.GetString("ManageDataNoResources", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -507,16 +507,31 @@
   <data name="ManageDataDialogTitle" xml:space="preserve">
     <value>Manage logs and telemetry</value>
   </data>
-  <data name="ManageDataManageButtonText" xml:space="preserve">
-    <value>Manage</value>
+  <data name="ManageDataConsoleLogs" xml:space="preserve">
+    <value>Console logs</value>
   </data>
   <data name="ManageDataExportButtonText" xml:space="preserve">
     <value>Export selected</value>
   </data>
+  <data name="ManageDataManageButtonText" xml:space="preserve">
+    <value>Manage</value>
+  </data>
+  <data name="ManageDataMetrics" xml:space="preserve">
+    <value>Metrics</value>
+  </data>
+  <data name="ManageDataNoResources" xml:space="preserve">
+    <value>No resources found</value>
+  </data>
   <data name="ManageDataRemoveButtonText" xml:space="preserve">
     <value>Remove selected</value>
   </data>
+  <data name="ManageDataStructuredLogs" xml:space="preserve">
+    <value>Structured logs</value>
+  </data>
   <data name="ManageDataSummaryColumnHeader" xml:space="preserve">
     <value>Summary</value>
+  </data>
+  <data name="ManageDataTraces" xml:space="preserve">
+    <value>Traces</value>
   </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -516,4 +516,13 @@
   <data name="ManageDataRemoveButtonText" xml:space="preserve">
     <value>Remove</value>
   </data>
+  <data name="ManageDataInfoColumnHeader" xml:space="preserve">
+    <value>Info</value>
+  </data>
+  <data name="ManageDataSourceAspire" xml:space="preserve">
+    <value>Aspire</value>
+  </data>
+  <data name="ManageDataSourceOpenTelemetry" xml:space="preserve">
+    <value>OpenTelemetry</value>
+  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -504,4 +504,16 @@
   <data name="McpServerDialogCliInstructionsBelow" xml:space="preserve">
     <value>The &lt;code&gt;aspire mcp init&lt;/code&gt; command writes MCP JSON to your local workspace. Alternatively, configure your local AI development tools using instructions below.</value>
   </data>
+  <data name="ManageDataDialogTitle" xml:space="preserve">
+    <value>Resource logs and telemetry</value>
+  </data>
+  <data name="ManageDataManageButtonText" xml:space="preserve">
+    <value>Manage</value>
+  </data>
+  <data name="ManageDataExportButtonText" xml:space="preserve">
+    <value>Export</value>
+  </data>
+  <data name="ManageDataRemoveButtonText" xml:space="preserve">
+    <value>Remove</value>
+  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -519,10 +519,4 @@
   <data name="ManageDataSummaryColumnHeader" xml:space="preserve">
     <value>Summary</value>
   </data>
-  <data name="ManageDataSourceAspire" xml:space="preserve">
-    <value>Aspire</value>
-  </data>
-  <data name="ManageDataSourceOpenTelemetry" xml:space="preserve">
-    <value>OpenTelemetry</value>
-  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -505,19 +505,19 @@
     <value>The &lt;code&gt;aspire mcp init&lt;/code&gt; command writes MCP JSON to your local workspace. Alternatively, configure your local AI development tools using instructions below.</value>
   </data>
   <data name="ManageDataDialogTitle" xml:space="preserve">
-    <value>Resource logs and telemetry</value>
+    <value>Manage logs and telemetry</value>
   </data>
   <data name="ManageDataManageButtonText" xml:space="preserve">
     <value>Manage</value>
   </data>
   <data name="ManageDataExportButtonText" xml:space="preserve">
-    <value>Export</value>
+    <value>Export selected</value>
   </data>
   <data name="ManageDataRemoveButtonText" xml:space="preserve">
-    <value>Remove</value>
+    <value>Remove selected</value>
   </data>
-  <data name="ManageDataInfoColumnHeader" xml:space="preserve">
-    <value>Info</value>
+  <data name="ManageDataSummaryColumnHeader" xml:space="preserve">
+    <value>Summary</value>
   </data>
   <data name="ManageDataSourceAspire" xml:space="preserve">
     <value>Aspire</value>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -387,6 +387,11 @@
         <target state="new">Export</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataInfoColumnHeader">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -395,6 +400,16 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove</source>
         <target state="new">Remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceAspire">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceOpenTelemetry">
+        <source>OpenTelemetry</source>
+        <target state="new">OpenTelemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -382,6 +382,11 @@
         <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataConsoleLogs">
+        <source>Console logs</source>
+        <target state="new">Console logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
         <source>Export selected</source>
         <target state="new">Export selected</target>
@@ -392,14 +397,34 @@
         <target state="new">Manage</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataMetrics">
+        <source>Metrics</source>
+        <target state="new">Metrics</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataNoResources">
+        <source>No resources found</source>
+        <target state="new">No resources found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataStructuredLogs">
+        <source>Structured logs</source>
+        <target state="new">Structured logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -378,18 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
-        <source>Resource logs and telemetry</source>
-        <target state="new">Resource logs and telemetry</target>
+        <source>Manage logs and telemetry</source>
+        <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
-        <source>Export</source>
-        <target state="new">Export</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataInfoColumnHeader">
-        <source>Info</source>
-        <target state="new">Info</target>
+        <source>Export selected</source>
+        <target state="new">Export selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
@@ -398,8 +393,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
-        <source>Remove</source>
-        <target state="new">Remove</target>
+        <source>Remove selected</source>
+        <target state="new">Remove selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataSourceAspire">
@@ -410,6 +405,11 @@
       <trans-unit id="ManageDataSourceOpenTelemetry">
         <source>OpenTelemetry</source>
         <target state="new">OpenTelemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSummaryColumnHeader">
+        <source>Summary</source>
+        <target state="new">Summary</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -377,6 +377,26 @@
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDialogTitle">
+        <source>Resource logs and telemetry</source>
+        <target state="new">Resource logs and telemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataExportButtonText">
+        <source>Export</source>
+        <target state="new">Export</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataManageButtonText">
+        <source>Manage</source>
+        <target state="new">Manage</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveButtonText">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">
         <source>Aspire MCP API key</source>
         <target state="translated">Klíč rozhraní API Aspirovat MCP</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -397,16 +397,6 @@
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataSourceAspire">
-        <source>Aspire</source>
-        <target state="new">Aspire</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSourceOpenTelemetry">
-        <source>OpenTelemetry</source>
-        <target state="new">OpenTelemetry</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -387,6 +387,11 @@
         <target state="new">Export</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataInfoColumnHeader">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -395,6 +400,16 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove</source>
         <target state="new">Remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceAspire">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceOpenTelemetry">
+        <source>OpenTelemetry</source>
+        <target state="new">OpenTelemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -382,6 +382,11 @@
         <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataConsoleLogs">
+        <source>Console logs</source>
+        <target state="new">Console logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
         <source>Export selected</source>
         <target state="new">Export selected</target>
@@ -392,14 +397,34 @@
         <target state="new">Manage</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataMetrics">
+        <source>Metrics</source>
+        <target state="new">Metrics</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataNoResources">
+        <source>No resources found</source>
+        <target state="new">No resources found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataStructuredLogs">
+        <source>Structured logs</source>
+        <target state="new">Structured logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -377,6 +377,26 @@
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDialogTitle">
+        <source>Resource logs and telemetry</source>
+        <target state="new">Resource logs and telemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataExportButtonText">
+        <source>Export</source>
+        <target state="new">Export</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataManageButtonText">
+        <source>Manage</source>
+        <target state="new">Manage</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveButtonText">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">
         <source>Aspire MCP API key</source>
         <target state="translated">Aspire MCP-API-Schlüssel</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -378,18 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
-        <source>Resource logs and telemetry</source>
-        <target state="new">Resource logs and telemetry</target>
+        <source>Manage logs and telemetry</source>
+        <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
-        <source>Export</source>
-        <target state="new">Export</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataInfoColumnHeader">
-        <source>Info</source>
-        <target state="new">Info</target>
+        <source>Export selected</source>
+        <target state="new">Export selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
@@ -398,8 +393,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
-        <source>Remove</source>
-        <target state="new">Remove</target>
+        <source>Remove selected</source>
+        <target state="new">Remove selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataSourceAspire">
@@ -410,6 +405,11 @@
       <trans-unit id="ManageDataSourceOpenTelemetry">
         <source>OpenTelemetry</source>
         <target state="new">OpenTelemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSummaryColumnHeader">
+        <source>Summary</source>
+        <target state="new">Summary</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -397,16 +397,6 @@
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataSourceAspire">
-        <source>Aspire</source>
-        <target state="new">Aspire</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSourceOpenTelemetry">
-        <source>OpenTelemetry</source>
-        <target state="new">OpenTelemetry</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -387,6 +387,11 @@
         <target state="new">Export</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataInfoColumnHeader">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -395,6 +400,16 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove</source>
         <target state="new">Remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceAspire">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceOpenTelemetry">
+        <source>OpenTelemetry</source>
+        <target state="new">OpenTelemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -377,6 +377,26 @@
         <target state="translated">Aceptar</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDialogTitle">
+        <source>Resource logs and telemetry</source>
+        <target state="new">Resource logs and telemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataExportButtonText">
+        <source>Export</source>
+        <target state="new">Export</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataManageButtonText">
+        <source>Manage</source>
+        <target state="new">Manage</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveButtonText">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">
         <source>Aspire MCP API key</source>
         <target state="translated">Clave API de Aspire MCP</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -382,6 +382,11 @@
         <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataConsoleLogs">
+        <source>Console logs</source>
+        <target state="new">Console logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
         <source>Export selected</source>
         <target state="new">Export selected</target>
@@ -392,14 +397,34 @@
         <target state="new">Manage</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataMetrics">
+        <source>Metrics</source>
+        <target state="new">Metrics</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataNoResources">
+        <source>No resources found</source>
+        <target state="new">No resources found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataStructuredLogs">
+        <source>Structured logs</source>
+        <target state="new">Structured logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -378,18 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
-        <source>Resource logs and telemetry</source>
-        <target state="new">Resource logs and telemetry</target>
+        <source>Manage logs and telemetry</source>
+        <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
-        <source>Export</source>
-        <target state="new">Export</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataInfoColumnHeader">
-        <source>Info</source>
-        <target state="new">Info</target>
+        <source>Export selected</source>
+        <target state="new">Export selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
@@ -398,8 +393,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
-        <source>Remove</source>
-        <target state="new">Remove</target>
+        <source>Remove selected</source>
+        <target state="new">Remove selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataSourceAspire">
@@ -410,6 +405,11 @@
       <trans-unit id="ManageDataSourceOpenTelemetry">
         <source>OpenTelemetry</source>
         <target state="new">OpenTelemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSummaryColumnHeader">
+        <source>Summary</source>
+        <target state="new">Summary</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -397,16 +397,6 @@
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataSourceAspire">
-        <source>Aspire</source>
-        <target state="new">Aspire</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSourceOpenTelemetry">
-        <source>OpenTelemetry</source>
-        <target state="new">OpenTelemetry</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -387,6 +387,11 @@
         <target state="new">Export</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataInfoColumnHeader">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -395,6 +400,16 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove</source>
         <target state="new">Remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceAspire">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceOpenTelemetry">
+        <source>OpenTelemetry</source>
+        <target state="new">OpenTelemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -382,6 +382,11 @@
         <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataConsoleLogs">
+        <source>Console logs</source>
+        <target state="new">Console logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
         <source>Export selected</source>
         <target state="new">Export selected</target>
@@ -392,14 +397,34 @@
         <target state="new">Manage</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataMetrics">
+        <source>Metrics</source>
+        <target state="new">Metrics</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataNoResources">
+        <source>No resources found</source>
+        <target state="new">No resources found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataStructuredLogs">
+        <source>Structured logs</source>
+        <target state="new">Structured logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -377,6 +377,26 @@
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDialogTitle">
+        <source>Resource logs and telemetry</source>
+        <target state="new">Resource logs and telemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataExportButtonText">
+        <source>Export</source>
+        <target state="new">Export</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataManageButtonText">
+        <source>Manage</source>
+        <target state="new">Manage</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveButtonText">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">
         <source>Aspire MCP API key</source>
         <target state="translated">Clé API Aspire MCP</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -378,18 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
-        <source>Resource logs and telemetry</source>
-        <target state="new">Resource logs and telemetry</target>
+        <source>Manage logs and telemetry</source>
+        <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
-        <source>Export</source>
-        <target state="new">Export</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataInfoColumnHeader">
-        <source>Info</source>
-        <target state="new">Info</target>
+        <source>Export selected</source>
+        <target state="new">Export selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
@@ -398,8 +393,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
-        <source>Remove</source>
-        <target state="new">Remove</target>
+        <source>Remove selected</source>
+        <target state="new">Remove selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataSourceAspire">
@@ -410,6 +405,11 @@
       <trans-unit id="ManageDataSourceOpenTelemetry">
         <source>OpenTelemetry</source>
         <target state="new">OpenTelemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSummaryColumnHeader">
+        <source>Summary</source>
+        <target state="new">Summary</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -397,16 +397,6 @@
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataSourceAspire">
-        <source>Aspire</source>
-        <target state="new">Aspire</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSourceOpenTelemetry">
-        <source>OpenTelemetry</source>
-        <target state="new">OpenTelemetry</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -387,6 +387,11 @@
         <target state="new">Export</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataInfoColumnHeader">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -395,6 +400,16 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove</source>
         <target state="new">Remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceAspire">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceOpenTelemetry">
+        <source>OpenTelemetry</source>
+        <target state="new">OpenTelemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -382,6 +382,11 @@
         <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataConsoleLogs">
+        <source>Console logs</source>
+        <target state="new">Console logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
         <source>Export selected</source>
         <target state="new">Export selected</target>
@@ -392,14 +397,34 @@
         <target state="new">Manage</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataMetrics">
+        <source>Metrics</source>
+        <target state="new">Metrics</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataNoResources">
+        <source>No resources found</source>
+        <target state="new">No resources found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataStructuredLogs">
+        <source>Structured logs</source>
+        <target state="new">Structured logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -377,6 +377,26 @@
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDialogTitle">
+        <source>Resource logs and telemetry</source>
+        <target state="new">Resource logs and telemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataExportButtonText">
+        <source>Export</source>
+        <target state="new">Export</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataManageButtonText">
+        <source>Manage</source>
+        <target state="new">Manage</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveButtonText">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">
         <source>Aspire MCP API key</source>
         <target state="translated">Chiave API di Aspire MCP</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -378,18 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
-        <source>Resource logs and telemetry</source>
-        <target state="new">Resource logs and telemetry</target>
+        <source>Manage logs and telemetry</source>
+        <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
-        <source>Export</source>
-        <target state="new">Export</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataInfoColumnHeader">
-        <source>Info</source>
-        <target state="new">Info</target>
+        <source>Export selected</source>
+        <target state="new">Export selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
@@ -398,8 +393,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
-        <source>Remove</source>
-        <target state="new">Remove</target>
+        <source>Remove selected</source>
+        <target state="new">Remove selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataSourceAspire">
@@ -410,6 +405,11 @@
       <trans-unit id="ManageDataSourceOpenTelemetry">
         <source>OpenTelemetry</source>
         <target state="new">OpenTelemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSummaryColumnHeader">
+        <source>Summary</source>
+        <target state="new">Summary</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -397,16 +397,6 @@
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataSourceAspire">
-        <source>Aspire</source>
-        <target state="new">Aspire</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSourceOpenTelemetry">
-        <source>OpenTelemetry</source>
-        <target state="new">OpenTelemetry</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -387,6 +387,11 @@
         <target state="new">Export</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataInfoColumnHeader">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -395,6 +400,16 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove</source>
         <target state="new">Remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceAspire">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceOpenTelemetry">
+        <source>OpenTelemetry</source>
+        <target state="new">OpenTelemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -382,6 +382,11 @@
         <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataConsoleLogs">
+        <source>Console logs</source>
+        <target state="new">Console logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
         <source>Export selected</source>
         <target state="new">Export selected</target>
@@ -392,14 +397,34 @@
         <target state="new">Manage</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataMetrics">
+        <source>Metrics</source>
+        <target state="new">Metrics</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataNoResources">
+        <source>No resources found</source>
+        <target state="new">No resources found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataStructuredLogs">
+        <source>Structured logs</source>
+        <target state="new">Structured logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -377,6 +377,26 @@
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDialogTitle">
+        <source>Resource logs and telemetry</source>
+        <target state="new">Resource logs and telemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataExportButtonText">
+        <source>Export</source>
+        <target state="new">Export</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataManageButtonText">
+        <source>Manage</source>
+        <target state="new">Manage</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveButtonText">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">
         <source>Aspire MCP API key</source>
         <target state="translated">Aspire MCP API キー</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -378,18 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
-        <source>Resource logs and telemetry</source>
-        <target state="new">Resource logs and telemetry</target>
+        <source>Manage logs and telemetry</source>
+        <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
-        <source>Export</source>
-        <target state="new">Export</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataInfoColumnHeader">
-        <source>Info</source>
-        <target state="new">Info</target>
+        <source>Export selected</source>
+        <target state="new">Export selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
@@ -398,8 +393,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
-        <source>Remove</source>
-        <target state="new">Remove</target>
+        <source>Remove selected</source>
+        <target state="new">Remove selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataSourceAspire">
@@ -410,6 +405,11 @@
       <trans-unit id="ManageDataSourceOpenTelemetry">
         <source>OpenTelemetry</source>
         <target state="new">OpenTelemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSummaryColumnHeader">
+        <source>Summary</source>
+        <target state="new">Summary</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -397,16 +397,6 @@
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataSourceAspire">
-        <source>Aspire</source>
-        <target state="new">Aspire</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSourceOpenTelemetry">
-        <source>OpenTelemetry</source>
-        <target state="new">OpenTelemetry</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -387,6 +387,11 @@
         <target state="new">Export</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataInfoColumnHeader">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -395,6 +400,16 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove</source>
         <target state="new">Remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceAspire">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceOpenTelemetry">
+        <source>OpenTelemetry</source>
+        <target state="new">OpenTelemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -382,6 +382,11 @@
         <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataConsoleLogs">
+        <source>Console logs</source>
+        <target state="new">Console logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
         <source>Export selected</source>
         <target state="new">Export selected</target>
@@ -392,14 +397,34 @@
         <target state="new">Manage</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataMetrics">
+        <source>Metrics</source>
+        <target state="new">Metrics</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataNoResources">
+        <source>No resources found</source>
+        <target state="new">No resources found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataStructuredLogs">
+        <source>Structured logs</source>
+        <target state="new">Structured logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -378,18 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
-        <source>Resource logs and telemetry</source>
-        <target state="new">Resource logs and telemetry</target>
+        <source>Manage logs and telemetry</source>
+        <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
-        <source>Export</source>
-        <target state="new">Export</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataInfoColumnHeader">
-        <source>Info</source>
-        <target state="new">Info</target>
+        <source>Export selected</source>
+        <target state="new">Export selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
@@ -398,8 +393,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
-        <source>Remove</source>
-        <target state="new">Remove</target>
+        <source>Remove selected</source>
+        <target state="new">Remove selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataSourceAspire">
@@ -410,6 +405,11 @@
       <trans-unit id="ManageDataSourceOpenTelemetry">
         <source>OpenTelemetry</source>
         <target state="new">OpenTelemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSummaryColumnHeader">
+        <source>Summary</source>
+        <target state="new">Summary</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -377,6 +377,26 @@
         <target state="translated">확인</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDialogTitle">
+        <source>Resource logs and telemetry</source>
+        <target state="new">Resource logs and telemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataExportButtonText">
+        <source>Export</source>
+        <target state="new">Export</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataManageButtonText">
+        <source>Manage</source>
+        <target state="new">Manage</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveButtonText">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">
         <source>Aspire MCP API key</source>
         <target state="translated">Aspire MCP API 키</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -397,16 +397,6 @@
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataSourceAspire">
-        <source>Aspire</source>
-        <target state="new">Aspire</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSourceOpenTelemetry">
-        <source>OpenTelemetry</source>
-        <target state="new">OpenTelemetry</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -387,6 +387,11 @@
         <target state="new">Export</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataInfoColumnHeader">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -395,6 +400,16 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove</source>
         <target state="new">Remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceAspire">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceOpenTelemetry">
+        <source>OpenTelemetry</source>
+        <target state="new">OpenTelemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -382,6 +382,11 @@
         <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataConsoleLogs">
+        <source>Console logs</source>
+        <target state="new">Console logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
         <source>Export selected</source>
         <target state="new">Export selected</target>
@@ -392,14 +397,34 @@
         <target state="new">Manage</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataMetrics">
+        <source>Metrics</source>
+        <target state="new">Metrics</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataNoResources">
+        <source>No resources found</source>
+        <target state="new">No resources found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataStructuredLogs">
+        <source>Structured logs</source>
+        <target state="new">Structured logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -378,18 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
-        <source>Resource logs and telemetry</source>
-        <target state="new">Resource logs and telemetry</target>
+        <source>Manage logs and telemetry</source>
+        <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
-        <source>Export</source>
-        <target state="new">Export</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataInfoColumnHeader">
-        <source>Info</source>
-        <target state="new">Info</target>
+        <source>Export selected</source>
+        <target state="new">Export selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
@@ -398,8 +393,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
-        <source>Remove</source>
-        <target state="new">Remove</target>
+        <source>Remove selected</source>
+        <target state="new">Remove selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataSourceAspire">
@@ -410,6 +405,11 @@
       <trans-unit id="ManageDataSourceOpenTelemetry">
         <source>OpenTelemetry</source>
         <target state="new">OpenTelemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSummaryColumnHeader">
+        <source>Summary</source>
+        <target state="new">Summary</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -377,6 +377,26 @@
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDialogTitle">
+        <source>Resource logs and telemetry</source>
+        <target state="new">Resource logs and telemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataExportButtonText">
+        <source>Export</source>
+        <target state="new">Export</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataManageButtonText">
+        <source>Manage</source>
+        <target state="new">Manage</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveButtonText">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">
         <source>Aspire MCP API key</source>
         <target state="translated">Klucz interfejsu API Aspire MCP</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -397,16 +397,6 @@
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataSourceAspire">
-        <source>Aspire</source>
-        <target state="new">Aspire</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSourceOpenTelemetry">
-        <source>OpenTelemetry</source>
-        <target state="new">OpenTelemetry</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -387,6 +387,11 @@
         <target state="new">Export</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataInfoColumnHeader">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -395,6 +400,16 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove</source>
         <target state="new">Remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceAspire">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceOpenTelemetry">
+        <source>OpenTelemetry</source>
+        <target state="new">OpenTelemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -377,6 +377,26 @@
         <target state="translated">OK</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDialogTitle">
+        <source>Resource logs and telemetry</source>
+        <target state="new">Resource logs and telemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataExportButtonText">
+        <source>Export</source>
+        <target state="new">Export</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataManageButtonText">
+        <source>Manage</source>
+        <target state="new">Manage</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveButtonText">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">
         <source>Aspire MCP API key</source>
         <target state="translated">Chave de API do Aspire MCP</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -382,6 +382,11 @@
         <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataConsoleLogs">
+        <source>Console logs</source>
+        <target state="new">Console logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
         <source>Export selected</source>
         <target state="new">Export selected</target>
@@ -392,14 +397,34 @@
         <target state="new">Manage</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataMetrics">
+        <source>Metrics</source>
+        <target state="new">Metrics</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataNoResources">
+        <source>No resources found</source>
+        <target state="new">No resources found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataStructuredLogs">
+        <source>Structured logs</source>
+        <target state="new">Structured logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -378,18 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
-        <source>Resource logs and telemetry</source>
-        <target state="new">Resource logs and telemetry</target>
+        <source>Manage logs and telemetry</source>
+        <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
-        <source>Export</source>
-        <target state="new">Export</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataInfoColumnHeader">
-        <source>Info</source>
-        <target state="new">Info</target>
+        <source>Export selected</source>
+        <target state="new">Export selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
@@ -398,8 +393,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
-        <source>Remove</source>
-        <target state="new">Remove</target>
+        <source>Remove selected</source>
+        <target state="new">Remove selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataSourceAspire">
@@ -410,6 +405,11 @@
       <trans-unit id="ManageDataSourceOpenTelemetry">
         <source>OpenTelemetry</source>
         <target state="new">OpenTelemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSummaryColumnHeader">
+        <source>Summary</source>
+        <target state="new">Summary</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -397,16 +397,6 @@
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataSourceAspire">
-        <source>Aspire</source>
-        <target state="new">Aspire</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSourceOpenTelemetry">
-        <source>OpenTelemetry</source>
-        <target state="new">OpenTelemetry</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -387,6 +387,11 @@
         <target state="new">Export</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataInfoColumnHeader">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -395,6 +400,16 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove</source>
         <target state="new">Remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceAspire">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceOpenTelemetry">
+        <source>OpenTelemetry</source>
+        <target state="new">OpenTelemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -382,6 +382,11 @@
         <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataConsoleLogs">
+        <source>Console logs</source>
+        <target state="new">Console logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
         <source>Export selected</source>
         <target state="new">Export selected</target>
@@ -392,14 +397,34 @@
         <target state="new">Manage</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataMetrics">
+        <source>Metrics</source>
+        <target state="new">Metrics</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataNoResources">
+        <source>No resources found</source>
+        <target state="new">No resources found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataStructuredLogs">
+        <source>Structured logs</source>
+        <target state="new">Structured logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -377,6 +377,26 @@
         <target state="translated">ОК</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDialogTitle">
+        <source>Resource logs and telemetry</source>
+        <target state="new">Resource logs and telemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataExportButtonText">
+        <source>Export</source>
+        <target state="new">Export</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataManageButtonText">
+        <source>Manage</source>
+        <target state="new">Manage</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveButtonText">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">
         <source>Aspire MCP API key</source>
         <target state="translated">Ключ API Aspire MCP</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -378,18 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
-        <source>Resource logs and telemetry</source>
-        <target state="new">Resource logs and telemetry</target>
+        <source>Manage logs and telemetry</source>
+        <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
-        <source>Export</source>
-        <target state="new">Export</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataInfoColumnHeader">
-        <source>Info</source>
-        <target state="new">Info</target>
+        <source>Export selected</source>
+        <target state="new">Export selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
@@ -398,8 +393,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
-        <source>Remove</source>
-        <target state="new">Remove</target>
+        <source>Remove selected</source>
+        <target state="new">Remove selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataSourceAspire">
@@ -410,6 +405,11 @@
       <trans-unit id="ManageDataSourceOpenTelemetry">
         <source>OpenTelemetry</source>
         <target state="new">OpenTelemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSummaryColumnHeader">
+        <source>Summary</source>
+        <target state="new">Summary</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -397,16 +397,6 @@
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataSourceAspire">
-        <source>Aspire</source>
-        <target state="new">Aspire</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSourceOpenTelemetry">
-        <source>OpenTelemetry</source>
-        <target state="new">OpenTelemetry</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -387,6 +387,11 @@
         <target state="new">Export</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataInfoColumnHeader">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -395,6 +400,16 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove</source>
         <target state="new">Remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceAspire">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceOpenTelemetry">
+        <source>OpenTelemetry</source>
+        <target state="new">OpenTelemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -377,6 +377,26 @@
         <target state="translated">Tamam</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDialogTitle">
+        <source>Resource logs and telemetry</source>
+        <target state="new">Resource logs and telemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataExportButtonText">
+        <source>Export</source>
+        <target state="new">Export</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataManageButtonText">
+        <source>Manage</source>
+        <target state="new">Manage</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveButtonText">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">
         <source>Aspire MCP API key</source>
         <target state="translated">Aspire MCP API anahtarı</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -378,18 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
-        <source>Resource logs and telemetry</source>
-        <target state="new">Resource logs and telemetry</target>
+        <source>Manage logs and telemetry</source>
+        <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
-        <source>Export</source>
-        <target state="new">Export</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataInfoColumnHeader">
-        <source>Info</source>
-        <target state="new">Info</target>
+        <source>Export selected</source>
+        <target state="new">Export selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
@@ -398,8 +393,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
-        <source>Remove</source>
-        <target state="new">Remove</target>
+        <source>Remove selected</source>
+        <target state="new">Remove selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataSourceAspire">
@@ -410,6 +405,11 @@
       <trans-unit id="ManageDataSourceOpenTelemetry">
         <source>OpenTelemetry</source>
         <target state="new">OpenTelemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSummaryColumnHeader">
+        <source>Summary</source>
+        <target state="new">Summary</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -397,16 +397,6 @@
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataSourceAspire">
-        <source>Aspire</source>
-        <target state="new">Aspire</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSourceOpenTelemetry">
-        <source>OpenTelemetry</source>
-        <target state="new">OpenTelemetry</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -377,6 +377,11 @@
         <target state="translated">Tamam</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataConsoleLogs">
+        <source>Console logs</source>
+        <target state="new">Console logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="new">Manage logs and telemetry</target>
@@ -392,14 +397,34 @@
         <target state="new">Manage</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataMetrics">
+        <source>Metrics</source>
+        <target state="new">Metrics</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataNoResources">
+        <source>No resources found</source>
+        <target state="new">No resources found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataStructuredLogs">
+        <source>Structured logs</source>
+        <target state="new">Structured logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -387,6 +387,11 @@
         <target state="new">Export</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataInfoColumnHeader">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -395,6 +400,16 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove</source>
         <target state="new">Remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceAspire">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceOpenTelemetry">
+        <source>OpenTelemetry</source>
+        <target state="new">OpenTelemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -377,6 +377,26 @@
         <target state="translated">确定</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDialogTitle">
+        <source>Resource logs and telemetry</source>
+        <target state="new">Resource logs and telemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataExportButtonText">
+        <source>Export</source>
+        <target state="new">Export</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataManageButtonText">
+        <source>Manage</source>
+        <target state="new">Manage</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveButtonText">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">
         <source>Aspire MCP API key</source>
         <target state="translated">Aspire MCP API 密钥</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -378,18 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
-        <source>Resource logs and telemetry</source>
-        <target state="new">Resource logs and telemetry</target>
+        <source>Manage logs and telemetry</source>
+        <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
-        <source>Export</source>
-        <target state="new">Export</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataInfoColumnHeader">
-        <source>Info</source>
-        <target state="new">Info</target>
+        <source>Export selected</source>
+        <target state="new">Export selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
@@ -398,8 +393,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
-        <source>Remove</source>
-        <target state="new">Remove</target>
+        <source>Remove selected</source>
+        <target state="new">Remove selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataSourceAspire">
@@ -410,6 +405,11 @@
       <trans-unit id="ManageDataSourceOpenTelemetry">
         <source>OpenTelemetry</source>
         <target state="new">OpenTelemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSummaryColumnHeader">
+        <source>Summary</source>
+        <target state="new">Summary</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -397,16 +397,6 @@
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataSourceAspire">
-        <source>Aspire</source>
-        <target state="new">Aspire</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSourceOpenTelemetry">
-        <source>OpenTelemetry</source>
-        <target state="new">OpenTelemetry</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -377,6 +377,11 @@
         <target state="translated">确定</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataConsoleLogs">
+        <source>Console logs</source>
+        <target state="new">Console logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="new">Manage logs and telemetry</target>
@@ -392,14 +397,34 @@
         <target state="new">Manage</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataMetrics">
+        <source>Metrics</source>
+        <target state="new">Metrics</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataNoResources">
+        <source>No resources found</source>
+        <target state="new">No resources found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataStructuredLogs">
+        <source>Structured logs</source>
+        <target state="new">Structured logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -387,6 +387,11 @@
         <target state="new">Export</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataInfoColumnHeader">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
         <source>Manage</source>
         <target state="new">Manage</target>
@@ -395,6 +400,16 @@
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove</source>
         <target state="new">Remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceAspire">
+        <source>Aspire</source>
+        <target state="new">Aspire</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSourceOpenTelemetry">
+        <source>OpenTelemetry</source>
+        <target state="new">OpenTelemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -378,18 +378,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
-        <source>Resource logs and telemetry</source>
-        <target state="new">Resource logs and telemetry</target>
+        <source>Manage logs and telemetry</source>
+        <target state="new">Manage logs and telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataExportButtonText">
-        <source>Export</source>
-        <target state="new">Export</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataInfoColumnHeader">
-        <source>Info</source>
-        <target state="new">Info</target>
+        <source>Export selected</source>
+        <target state="new">Export selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataManageButtonText">
@@ -398,8 +393,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
-        <source>Remove</source>
-        <target state="new">Remove</target>
+        <source>Remove selected</source>
+        <target state="new">Remove selected</target>
         <note />
       </trans-unit>
       <trans-unit id="ManageDataSourceAspire">
@@ -410,6 +405,11 @@
       <trans-unit id="ManageDataSourceOpenTelemetry">
         <source>OpenTelemetry</source>
         <target state="new">OpenTelemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataSummaryColumnHeader">
+        <source>Summary</source>
+        <target state="new">Summary</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -397,16 +397,6 @@
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManageDataSourceAspire">
-        <source>Aspire</source>
-        <target state="new">Aspire</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ManageDataSourceOpenTelemetry">
-        <source>OpenTelemetry</source>
-        <target state="new">OpenTelemetry</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -377,6 +377,11 @@
         <target state="translated">確定</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataConsoleLogs">
+        <source>Console logs</source>
+        <target state="new">Console logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataDialogTitle">
         <source>Manage logs and telemetry</source>
         <target state="new">Manage logs and telemetry</target>
@@ -392,14 +397,34 @@
         <target state="new">Manage</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataMetrics">
+        <source>Metrics</source>
+        <target state="new">Metrics</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataNoResources">
+        <source>No resources found</source>
+        <target state="new">No resources found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataRemoveButtonText">
         <source>Remove selected</source>
         <target state="new">Remove selected</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataStructuredLogs">
+        <source>Structured logs</source>
+        <target state="new">Structured logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManageDataSummaryColumnHeader">
         <source>Summary</source>
         <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataTraces">
+        <source>Traces</source>
+        <target state="new">Traces</target>
         <note />
       </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -377,6 +377,26 @@
         <target state="translated">確定</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManageDataDialogTitle">
+        <source>Resource logs and telemetry</source>
+        <target state="new">Resource logs and telemetry</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataExportButtonText">
+        <source>Export</source>
+        <target state="new">Export</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataManageButtonText">
+        <source>Manage</source>
+        <target state="new">Manage</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManageDataRemoveButtonText">
+        <source>Remove</source>
+        <target state="new">Remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpServerDialogApiKeyLabel">
         <source>Aspire MCP API key</source>
         <target state="translated">Aspire MCP API 金鑰</target>

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryRepositoryTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryRepositoryTests.cs
@@ -18,6 +18,8 @@ namespace Aspire.Dashboard.Tests.TelemetryRepositoryTests;
 
 public class TelemetryRepositoryTests
 {
+    private static readonly DateTime s_testTime = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
     [Fact]
     public void AddData_WhilePaused_IsDiscarded()
     {
@@ -195,5 +197,207 @@ public class TelemetryRepositoryTests
 
         // Assert
         await tcs.Task.DefaultTimeout();
+    }
+
+    [Fact]
+    public void ClearSelectedSignals_ClearsSelectedDataTypes_ForSpecificResources()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        AddTestData(repository, "resource1", "123");
+        AddTestData(repository, "resource2", "456");
+
+        // Act - Clear only structured logs for resource1
+        var selectedResources = new Dictionary<string, HashSet<AspireDataType>>
+        {
+            ["resource1-123"] = [AspireDataType.StructuredLogs]
+        };
+        repository.ClearSelectedSignals(selectedResources);
+
+        // Assert - resource1 logs cleared, but traces and metrics remain
+        var logs = repository.GetLogs(new GetLogsContext { ResourceKey = null, StartIndex = 0, Count = 10, Filters = [] });
+        Assert.Single(logs.Items);
+        Assert.Equal("log-resource2-456", logs.Items[0].Message);
+
+        var traces = repository.GetTraces(new GetTracesRequest { ResourceKey = null, FilterText = string.Empty, StartIndex = 0, Count = 10, Filters = [] });
+        Assert.Equal(2, traces.PagedResult.TotalItemCount);
+
+        var resource1Metrics = repository.GetInstrumentsSummaries(new ResourceKey("resource1", "123"));
+        Assert.Single(resource1Metrics);
+
+        // Assert - resource2 data is unaffected
+        var resource2Key = new ResourceKey("resource2", "456");
+        var resource2Logs = repository.GetLogs(new GetLogsContext { ResourceKey = resource2Key, StartIndex = 0, Count = 10, Filters = [] });
+        Assert.Single(resource2Logs.Items);
+        Assert.Equal("log-resource2-456", resource2Logs.Items[0].Message);
+
+        var resource2Traces = repository.GetTraces(new GetTracesRequest { ResourceKey = resource2Key, FilterText = string.Empty, StartIndex = 0, Count = 10, Filters = [] });
+        Assert.Single(resource2Traces.PagedResult.Items);
+
+        var resource2Metrics = repository.GetInstrumentsSummaries(new ResourceKey("resource2", "456"));
+        Assert.Single(resource2Metrics);
+    }
+
+    [Fact]
+    public void ClearSelectedSignals_OtherResourcesRemainUnaffected()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        AddTestData(repository, "resource1", "111");
+        AddTestData(repository, "resource2", "222");
+        AddTestData(repository, "resource3", "333");
+
+        // Act - Clear all data types for resource2 only
+        var selectedResources = new Dictionary<string, HashSet<AspireDataType>>
+        {
+            ["resource2-222"] = [AspireDataType.StructuredLogs, AspireDataType.Traces, AspireDataType.Metrics]
+        };
+        repository.ClearSelectedSignals(selectedResources);
+
+        // Assert - resource1 and resource3 data is unaffected
+        var logs = repository.GetLogs(new GetLogsContext { ResourceKey = null, StartIndex = 0, Count = 10, Filters = [] });
+        Assert.Equal(2, logs.TotalItemCount);
+        Assert.Contains(logs.Items, l => l.Message == "log-resource1-111");
+        Assert.Contains(logs.Items, l => l.Message == "log-resource3-333");
+        Assert.DoesNotContain(logs.Items, l => l.Message == "log-resource2-222");
+
+        var traces = repository.GetTraces(new GetTracesRequest { ResourceKey = null, FilterText = string.Empty, StartIndex = 0, Count = 10, Filters = [] });
+        Assert.Equal(2, traces.PagedResult.TotalItemCount);
+
+        var resource1Metrics = repository.GetInstrumentsSummaries(new ResourceKey("resource1", "111"));
+        Assert.Single(resource1Metrics);
+
+        var resource3Metrics = repository.GetInstrumentsSummaries(new ResourceKey("resource3", "333"));
+        Assert.Single(resource3Metrics);
+
+        // Assert - resource2 is removed from the repository since all data types were cleared
+        var resource2 = repository.GetResource(new ResourceKey("resource2", "222"));
+        Assert.Null(resource2);
+    }
+
+    [Fact]
+    public void ClearSelectedSignals_ResourceRemovedWhenAllDataTypesCleared()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        AddTestData(repository, "resource1", "123");
+
+        // Verify resource exists before clearing
+        var resourceBefore = repository.GetResource(new ResourceKey("resource1", "123"));
+        Assert.NotNull(resourceBefore);
+
+        // Act - Clear all data types for resource1
+        var selectedResources = new Dictionary<string, HashSet<AspireDataType>>
+        {
+            ["resource1-123"] = [AspireDataType.StructuredLogs, AspireDataType.Traces, AspireDataType.Metrics]
+        };
+        repository.ClearSelectedSignals(selectedResources);
+
+        // Assert - Resource is removed from the repository
+        var resourceAfter = repository.GetResource(new ResourceKey("resource1", "123"));
+        Assert.Null(resourceAfter);
+
+        // Assert - All telemetry data is cleared
+        var logs = repository.GetLogs(new GetLogsContext { ResourceKey = null, StartIndex = 0, Count = 10, Filters = [] });
+        Assert.Empty(logs.Items);
+
+        var traces = repository.GetTraces(new GetTracesRequest { ResourceKey = null, FilterText = string.Empty, StartIndex = 0, Count = 10, Filters = [] });
+        Assert.Empty(traces.PagedResult.Items);
+
+        // Assert - Resources list is empty
+        var resources = repository.GetResources();
+        Assert.Empty(resources);
+    }
+
+    [Fact]
+    public void ClearSelectedSignals_PartialClear_ResourceNotRemoved()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        AddTestData(repository, "resource1", "123");
+
+        // Act - Clear only logs and traces for resource1 (not metrics)
+        var selectedResources = new Dictionary<string, HashSet<AspireDataType>>
+        {
+            ["resource1-123"] = [AspireDataType.StructuredLogs, AspireDataType.Traces]
+        };
+        repository.ClearSelectedSignals(selectedResources);
+
+        // Assert - Resource still exists because not all data types were cleared
+        var resourceAfter = repository.GetResource(new ResourceKey("resource1", "123"));
+        Assert.NotNull(resourceAfter);
+
+        // Assert - Logs and traces are cleared, but metrics remain
+        var logs = repository.GetLogs(new GetLogsContext { ResourceKey = null, StartIndex = 0, Count = 10, Filters = [] });
+        Assert.Empty(logs.Items);
+
+        var traces = repository.GetTraces(new GetTracesRequest { ResourceKey = null, FilterText = string.Empty, StartIndex = 0, Count = 10, Filters = [] });
+        Assert.Empty(traces.PagedResult.Items);
+
+        var metrics = repository.GetInstrumentsSummaries(new ResourceKey("resource1", "123"));
+        Assert.Single(metrics);
+    }
+
+    private static void AddTestData(TelemetryRepository repository, string resourceName, string instanceId)
+    {
+        var compositeName = $"{resourceName}-{instanceId}";
+
+        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>()
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: resourceName, instanceId: instanceId),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords = { CreateLogRecord(time: s_testTime.AddMinutes(1), message: $"log-{compositeName}") }
+                    }
+                }
+            }
+        });
+
+        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: resourceName, instanceId: instanceId),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: compositeName, spanId: $"{compositeName}-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10))
+                        }
+                    }
+                }
+            }
+        });
+
+        repository.AddMetrics(new AddContext(), new RepeatedField<ResourceMetrics>()
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(name: resourceName, instanceId: instanceId),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            CreateSumMetric(metricName: $"metric-{compositeName}", value: 1, startTime: s_testTime.AddMinutes(1))
+                        }
+                    }
+                }
+            }
+        });
     }
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/dotnet/aspire/issues/11770

Background: Previous PRs add support for exporting dashboard data. And it will soon be possible to [import dashboard data](https://github.com/dotnet/aspire/pull/13682). There should be an improved way to manage what data is in the dashboard without deleting everything.

This PR adds a new "Manage telemetry and console logs". It displays a list of resources with checkboxes to selectively remove and export data from the dashboard. Also part of this change is a way to completely remove telemetry resource instances when clearing all their data. If logs, traces and metrics are selected for a resource, the resource is also removed.

In the future a lot of the UI will be reused for importing data. It will allow you to upload a zip file of data and then selectively choose what data to import.

<img width="1271" height="909" alt="image" src="https://github.com/user-attachments/assets/5a4c0ca6-df27-4e2a-9152-78a57b5485d0" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
