### PR TITLE
Fall back to process execution if IDE execution fails (local app run)

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpVersion.cs
+++ b/src/Aspire.Hosting/Dcp/DcpVersion.cs
@@ -5,7 +5,7 @@ namespace Aspire.Hosting.Dcp;
 
 internal static class DcpVersion
 {
-    public static Version MinimumVersionInclusive = new Version(0, 18, 6); // Aspire 13 release
+    public static Version MinimumVersionInclusive = new Version(0, 21, 0); // Aspire 13.2 release
 
     /// <summary>
     /// Development build version proxy, considered always "current" and supporting latest features. 

--- a/src/Aspire.Hosting/Dcp/DcpVersion.cs
+++ b/src/Aspire.Hosting/Dcp/DcpVersion.cs
@@ -5,7 +5,7 @@ namespace Aspire.Hosting.Dcp;
 
 internal static class DcpVersion
 {
-    public static Version MinimumVersionInclusive = new Version(0, 21, 0); // Aspire 13.2 release
+    public static Version MinimumVersionInclusive = new Version(0, 21, 1); // Aspire 13.2 release
 
     /// <summary>
     /// Development build version proxy, considered always "current" and supporting latest features. 

--- a/src/Aspire.Hosting/Dcp/Model/Executable.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Executable.cs
@@ -46,6 +46,12 @@ internal sealed class ExecutableSpec
     public string? ExecutionType { get; set; }
 
     /// <summary>
+    /// Fallback execution types in case the primary execution type is not supported or startup fails.
+    /// </summary>
+    [JsonPropertyName("fallbackExecutionTypes")]
+    public List<string>? FallbackExecutionTypes { get; set; }
+
+    /// <summary>
     /// Health probes to be run for the Executable.
     /// </summary>
     [JsonPropertyName("healthProbes")]


### PR DESCRIPTION
## Description

Pretty much what the title says
Fixes https://github.com/dotnet/aspire/issues/12522

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No (but we have tests on DCP side for this)
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
