### PR TITLE
Remove quarantined attribute from SpecifyingEnvPortInEndpointFlowsToEnv

### DIFF
--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -1137,7 +1137,6 @@ public class DistributedApplicationTests
 
     [Fact]
     [RequiresDocker]
-    [QuarantinedTest("https://github.com/dotnet/aspire/issues/8871")]
     public async Task SpecifyingEnvPortInEndpointFlowsToEnv()
     {
         const string testName = "ports-flow-to-env";


### PR DESCRIPTION
The last set of DCP updates seems to have finally stabilized this test.

Fixes https://github.com/dotnet/aspire/issues/8871