### PR TITLE
Fix WithHttpCommand flaky tests

### DIFF
--- a/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
+using Aspire.Hosting.Testing;
 using Aspire.Hosting.Utils;
-using Aspire.TestUtilities;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
 
 namespace Aspire.Hosting.Tests;
 
@@ -35,7 +37,7 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     public void WithHttpCommand_Throws_WhenEndpointByNameIsNotHttp()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateTestDistributedApplicationBuilder();
 
         var container = builder.AddContainer("name", "image")
                 .WithEndpoint(targetPort: 9999, scheme: "tcp", name: "nonhttp");
@@ -57,7 +59,7 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     public void WithHttpCommand_Throws_WhenEndpointIsNotHttp()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateTestDistributedApplicationBuilder();
 
         var container = builder.AddContainer("name", "image")
                 .WithEndpoint(targetPort: 9999, scheme: "tcp", name: "nonhttp");
@@ -79,7 +81,7 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     public void WithHttpCommand_AddsResourceCommandAnnotation_WithDefaultValues()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateTestDistributedApplicationBuilder();
         var resourceBuilder = builder.AddContainer("name", "image")
             .WithHttpEndpoint()
             .WithHttpCommand("/some-path", "Do The Thing");
@@ -103,7 +105,7 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     public void WithHttpCommand_AddsResourceCommandAnnotation_WithCustomValues()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateTestDistributedApplicationBuilder();
         var resourceBuilder = builder.AddContainer("name", "image")
             .WithHttpEndpoint()
             .WithHttpCommand("/some-path", "Do The Thing",
@@ -135,7 +137,7 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     public void WithHttpCommand_AddsResourceCommandAnnotations_WithUniqueCommandNames()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateTestDistributedApplicationBuilder();
         var resourceBuilder = builder.AddContainer("name", "image")
             .WithHttpEndpoint()
             .WithHttpEndpoint(name: "custom-endpoint")
@@ -173,23 +175,28 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     [InlineData(403, false)]
     [InlineData(404, false)]
     [InlineData(500, false)]
-    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9670")]
     [Theory]
     public async Task WithHttpCommand_ResultsInExpectedResultForStatusCode(int statusCode, bool expectSuccess)
     {
-        // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
-        var resourceBuilder = builder.AddProject<Projects.ServiceA>("servicea")
-            .WithHttpCommand($"/status/{statusCode}", "Do The Thing", commandName: "mycommand");
+        using var builder = CreateTestDistributedApplicationBuilder();
+
+        var fakeHandler = new FakeHttpMessageHandler((HttpStatusCode)statusCode);
+        builder.Services.AddHttpClient("commandclient")
+            .ConfigurePrimaryHttpMessageHandler(() => fakeHandler);
+
+        var service = CreateResourceWithAllocatedEndpoint(builder, "service");
+        service.WithHttpCommand($"/status/{statusCode}", "Do The Thing", commandName: "mycommand", commandOptions: new() { HttpClientName = "commandclient" });
 
         // Act
-        var app = builder.Build();
-        await app.StartAsync();
-        await app.ResourceNotifications.WaitForResourceHealthyAsync("servicea").DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
 
-        var result = await app.ResourceCommands.ExecuteCommandAsync(resourceBuilder.Resource, "mycommand");
+        await MoveResourceToRunningStateAsync(app, service.Resource);
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(service.Resource, "mycommand").DefaultTimeout();
 
         // Assert
+        Assert.True(fakeHandler.Called, "Expected the HTTP handler to be called");
         Assert.Equal(expectSuccess, result.Success);
     }
 
@@ -197,123 +204,169 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     [InlineData("get", true)]
     [InlineData("post", false)]
     [Theory]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/9725")]
     public async Task WithHttpCommand_ResultsInExpectedResultForHttpMethod(string? httpMethod, bool expectSuccess)
     {
         // Arrange
         var method = httpMethod is not null ? new HttpMethod(httpMethod) : HttpCommandOptions.Default.Method;
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
-        var resourceBuilder = builder.AddProject<Projects.ServiceA>("servicea")
-            .WithHttpCommand("/get-only", "Do The Thing", commandName: "mycommand", commandOptions: new() { Method = method });
+        using var builder = CreateTestDistributedApplicationBuilder();
+
+        // Return 405 Method Not Allowed for POST, 200 OK for GET
+        var fakeHandler = new FakeHttpMessageHandler(expectSuccess ? HttpStatusCode.OK : HttpStatusCode.MethodNotAllowed);
+        builder.Services.AddHttpClient("commandclient")
+            .ConfigurePrimaryHttpMessageHandler(() => fakeHandler)
+            .AddStandardResilienceHandler(options =>
+            {
+                // Disable retries to make test faster and deterministic
+                options.Retry.ShouldHandle = _ => ValueTask.FromResult(false);
+            });
+
+        var service = CreateResourceWithAllocatedEndpoint(builder, "service");
+        service.WithHttpCommand("/get-only", "Do The Thing", commandName: "mycommand", commandOptions: new() { Method = method, HttpClientName = "commandclient" });
 
         // Act
-        var app = builder.Build();
-        await app.StartAsync();
-        await app.ResourceNotifications.WaitForResourceHealthyAsync("servicea").DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
 
-        var result = await app.ResourceCommands.ExecuteCommandAsync(resourceBuilder.Resource, "mycommand");
+        await MoveResourceToRunningStateAsync(app, service.Resource);
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(service.Resource, "mycommand").DefaultTimeout();
 
         // Assert
+        Assert.True(fakeHandler.Called, "Expected the HTTP handler to be called");
         Assert.Equal(expectSuccess, result.Success);
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9800")]
     public async Task WithHttpCommand_UsesNamedHttpClient()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
-        var trackingMessageHandler = new TrackingHttpMessageHandler();
+        using var builder = CreateTestDistributedApplicationBuilder();
+        var fakeHandler = new FakeHttpMessageHandler(HttpStatusCode.OK);
         builder.Services.AddHttpClient("commandclient")
-            .AddHttpMessageHandler((sp) => trackingMessageHandler);
-        var resourceBuilder = builder.AddProject<Projects.ServiceA>("servicea")
-            .WithHttpCommand("/get-only", "Do The Thing", commandName: "mycommand", commandOptions: new() { HttpClientName = "commandclient" });
+            .ConfigurePrimaryHttpMessageHandler(() => fakeHandler)
+            .AddStandardResilienceHandler(options =>
+            {
+                // Disable retries to make test faster and deterministic
+                options.Retry.ShouldHandle = _ => ValueTask.FromResult(false);
+            });
+
+        var service = CreateResourceWithAllocatedEndpoint(builder, "service");
+        service.WithHttpCommand("/get-only", "Do The Thing", commandName: "mycommand", commandOptions: new() { HttpClientName = "commandclient" });
 
         // Act
-        var app = builder.Build();
-        await app.StartAsync();
-        await app.ResourceNotifications.WaitForResourceHealthyAsync("servicea").DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
 
-        var result = await app.ResourceCommands.ExecuteCommandAsync(resourceBuilder.Resource, "mycommand");
+        await MoveResourceToRunningStateAsync(app, service.Resource);
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(service.Resource, "mycommand").DefaultTimeout();
 
         // Assert
-        Assert.True(trackingMessageHandler.Called);
+        Assert.True(fakeHandler.Called);
     }
 
-    private sealed class TrackingHttpMessageHandler : DelegatingHandler
+    private sealed class FakeHttpMessageHandler(HttpStatusCode statusCode) : HttpMessageHandler
     {
         public bool Called { get; private set; }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             Called = true;
-            return base.SendAsync(request, cancellationToken);
+            return Task.FromResult(new HttpResponseMessage(statusCode));
         }
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9818")]
     public async Task WithHttpCommand_UsesEndpointSelector()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateTestDistributedApplicationBuilder();
 
-        var serviceA = builder.AddProject<Projects.ServiceA>("servicea");
+        var fakeHandler = new FakeHttpMessageHandler(HttpStatusCode.OK);
+        builder.Services.AddHttpClient("commandclient")
+            .ConfigurePrimaryHttpMessageHandler(() => fakeHandler)
+            .AddStandardResilienceHandler(options =>
+            {
+                // Disable retries to make test faster and deterministic
+                options.Retry.ShouldHandle = _ => ValueTask.FromResult(false);
+            });
+
+        var serviceA = CreateResourceWithAllocatedEndpoint(builder, "servicea");
         var callbackCalled = false;
-        var serviceB = builder.AddProject<Projects.ServiceA>("serviceb")
+        var serviceB = builder.AddResource(new CustomResource("serviceb"))
+            .WithHttpEndpoint(targetPort: 8081)
             .WithHttpCommand("/status/200", "Do The Thing", commandName: "mycommand",
                 endpointSelector: () =>
                 {
                     callbackCalled = true;
                     return serviceA.GetEndpoint("http");
-                });
+                },
+                commandOptions: new() { HttpClientName = "commandclient" });
 
         // Act
-        var app = builder.Build();
-        await app.StartAsync();
-        await app.ResourceNotifications.WaitForResourceHealthyAsync("servicea").DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
 
-        var result = await app.ResourceCommands.ExecuteCommandAsync(serviceB.Resource, "mycommand");
+        // Move serviceA to running (which the command's endpoint selector points to)
+        await app.ResourceNotifications.PublishUpdateAsync(serviceA.Resource, s => s with
+        {
+            State = KnownResourceStates.Running
+        }).DefaultTimeout();
+        await app.ResourceNotifications.WaitForResourceAsync(serviceA.Resource.Name, KnownResourceStates.Running).DefaultTimeout();
+
+        // Move serviceB to running and wait for command to become enabled
+        await MoveResourceToRunningStateAsync(app, serviceB.Resource);
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(serviceB.Resource, "mycommand").DefaultTimeout();
 
         // Assert
         Assert.True(callbackCalled);
+        Assert.True(fakeHandler.Called);
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9789")]
     public async Task WithHttpCommand_CallsPrepareRequestCallback_BeforeSendingRequest()
     {
         // Arrange
         var callbackCalled = false;
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateTestDistributedApplicationBuilder();
 
-        string resolvedResourceName = null!;
-        var resourceBuilder = builder.AddProject<Projects.ServiceA>("servicea")
-            .WithHttpCommand("/status/200", "Do The Thing",
-                commandName: "mycommand",
-                commandOptions: new()
+        var fakeHandler = new FakeHttpMessageHandler(HttpStatusCode.OK);
+        builder.Services.AddHttpClient("commandclient")
+            .ConfigurePrimaryHttpMessageHandler(() => fakeHandler)
+            .AddStandardResilienceHandler(options =>
+            {
+                // Disable retries to make test faster and deterministic
+                options.Retry.ShouldHandle = _ => ValueTask.FromResult(false);
+            });
+
+        var service = CreateResourceWithAllocatedEndpoint(builder, "service");
+        service.WithHttpCommand("/status/200", "Do The Thing",
+            commandName: "mycommand",
+            commandOptions: new()
+            {
+                HttpClientName = "commandclient",
+                PrepareRequest = requestContext =>
                 {
-                    PrepareRequest = requestContext =>
-                    {
-                        Assert.NotNull(requestContext);
-                        Assert.NotNull(requestContext.ServiceProvider);
-                        Assert.Equal(resolvedResourceName, requestContext.ResourceName);
-                        Assert.NotNull(requestContext.Endpoint);
-                        Assert.NotNull(requestContext.HttpClient);
-                        Assert.NotNull(requestContext.Request);
+                    Assert.NotNull(requestContext);
+                    Assert.NotNull(requestContext.ServiceProvider);
+                    Assert.Equal(service.Resource.Name, requestContext.ResourceName);
+                    Assert.NotNull(requestContext.Endpoint);
+                    Assert.NotNull(requestContext.HttpClient);
+                    Assert.NotNull(requestContext.Request);
 
-                        callbackCalled = true;
-                        return Task.CompletedTask;
-                    }
-                });
+                    callbackCalled = true;
+                    return Task.CompletedTask;
+                }
+            });
 
         // Act
-        var app = builder.Build();
-        await app.StartAsync();
-        await app.ResourceNotifications.WaitForResourceHealthyAsync("servicea").DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
-        resolvedResourceName = resourceBuilder.Resource.GetResolvedResourceNames().Single();
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
 
-        var result = await app.ResourceCommands.ExecuteCommandAsync(resourceBuilder.Resource, "mycommand");
+        await MoveResourceToRunningStateAsync(app, service.Resource);
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(service.Resource, "mycommand").DefaultTimeout();
 
         // Assert
         Assert.True(callbackCalled);
@@ -321,40 +374,43 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9772")]
     public async Task WithHttpCommand_CallsGetResponseCallback_AfterSendingRequest()
     {
         // Arrange
         var callbackCalled = false;
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateTestDistributedApplicationBuilder();
 
-        string resolvedResourceName = null!;
-        var resourceBuilder = builder.AddProject<Projects.ServiceA>("servicea")
-            .WithHttpCommand("/status/200", "Do The Thing",
-                commandName: "mycommand",
-                commandOptions: new()
+        var fakeHandler = new FakeHttpMessageHandler(HttpStatusCode.OK);
+        builder.Services.AddHttpClient("commandclient")
+            .ConfigurePrimaryHttpMessageHandler(() => fakeHandler);
+
+        var service = CreateResourceWithAllocatedEndpoint(builder, "service");
+        service.WithHttpCommand("/status/200", "Do The Thing",
+            commandName: "mycommand",
+            commandOptions: new()
+            {
+                HttpClientName = "commandclient",
+                GetCommandResult = resultContext =>
                 {
-                    GetCommandResult = resultContext =>
-                    {
-                        Assert.NotNull(resultContext);
-                        Assert.NotNull(resultContext.ServiceProvider);
-                        Assert.Equal(resolvedResourceName, resultContext.ResourceName);
-                        Assert.NotNull(resultContext.Endpoint);
-                        Assert.NotNull(resultContext.HttpClient);
-                        Assert.NotNull(resultContext.Response);
+                    Assert.NotNull(resultContext);
+                    Assert.NotNull(resultContext.ServiceProvider);
+                    Assert.Equal(service.Resource.Name, resultContext.ResourceName);
+                    Assert.NotNull(resultContext.Endpoint);
+                    Assert.NotNull(resultContext.HttpClient);
+                    Assert.NotNull(resultContext.Response);
 
-                        callbackCalled = true;
-                        return Task.FromResult(CommandResults.Failure("A test error message"));
-                    }
-                });
+                    callbackCalled = true;
+                    return Task.FromResult(CommandResults.Failure("A test error message"));
+                }
+            });
 
         // Act
-        var app = builder.Build();
-        await app.StartAsync();
-        await app.ResourceNotifications.WaitForResourceHealthyAsync("servicea").DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
-        resolvedResourceName = resourceBuilder.Resource.GetResolvedResourceNames().Single();
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
 
-        var result = await app.ResourceCommands.ExecuteCommandAsync(resourceBuilder.Resource, "mycommand");
+        await MoveResourceToRunningStateAsync(app, service.Resource);
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(service.Resource, "mycommand").DefaultTimeout();
 
         // Assert
         Assert.True(callbackCalled);
@@ -363,11 +419,10 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspire/issues/8101")]
     public async Task WithHttpCommand_EnablesCommandOnceResourceIsRunning()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateTestDistributedApplicationBuilder();
 
         builder.Configuration["CODESPACES"] = "false";
 
@@ -376,57 +431,42 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
             .WithHttpCommand("/dothing", "Do The Thing", commandName: "mycommand");
 
         using var app = builder.Build();
-        ResourceCommandState? commandState = null;
-        var watchTcs = new TaskCompletionSource();
-        var watchCts = new CancellationTokenSource();
-        var watchTask = Task.Run(async () =>
-        {
-            await foreach (var resourceEvent in app.ResourceNotifications.WatchAsync(watchCts.Token).WithCancellation(watchCts.Token))
-            {
-                var commandSnapshot = resourceEvent.Snapshot.Commands.First(c => c.Name == "mycommand");
-                commandState = commandSnapshot.State;
-                if (commandState == ResourceCommandState.Enabled)
-                {
-                    watchTcs.TrySetResult();
-                }
-            }
-        }, watchCts.Token);
+        await app.StartAsync().DefaultTimeout();
 
-        // Act/Assert
-        await app.StartAsync();
-
-        // Move the resource to the starting state
+        // Move the resource to the starting state and verify command is disabled
         await app.ResourceNotifications.PublishUpdateAsync(service.Resource, s => s with
         {
             State = KnownResourceStates.Starting
-        });
-        await app.ResourceNotifications.WaitForResourceAsync(service.Resource.Name, KnownResourceStates.Starting).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        }).DefaultTimeout();
 
-        // Veriy the command is disabled
-        Assert.Equal(ResourceCommandState.Disabled, commandState);
+        var startingEvent = await app.ResourceNotifications.WaitForResourceAsync(
+            service.Resource.Name,
+            e => e.Snapshot.State?.Text == KnownResourceStates.Starting).DefaultTimeout();
+
+        Assert.Equal(ResourceCommandState.Disabled, startingEvent.Snapshot.Commands.First(c => c.Name == "mycommand").State);
 
         // Move the resource to the running state
         await app.ResourceNotifications.PublishUpdateAsync(service.Resource, s => s with
         {
             State = KnownResourceStates.Running
-        });
-        await app.ResourceNotifications.WaitForResourceAsync(service.Resource.Name, KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
-        await watchTcs.Task.DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        }).DefaultTimeout();
 
-        // Verify the command is enabled
-        Assert.Equal(ResourceCommandState.Enabled, commandState);
+        // Wait for the command to become enabled (this happens after resource becomes ready)
+        var runningEvent = await app.ResourceNotifications.WaitForResourceAsync(
+            service.Resource.Name,
+            e => e.Snapshot.State?.Text == KnownResourceStates.Running &&
+                 e.Snapshot.Commands.First(c => c.Name == "mycommand").State == ResourceCommandState.Enabled).DefaultTimeout();
 
-        // Clean up
-        watchCts.Cancel();
-        await app.StopAsync();
+        Assert.Equal(ResourceCommandState.Enabled, runningEvent.Snapshot.Commands.First(c => c.Name == "mycommand").State);
+
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9811")]
     public async Task WithHttpCommand_EnablesCommandUsingCustomUpdateStateCallback()
     {
         // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        using var builder = CreateTestDistributedApplicationBuilder();
 
         builder.Configuration["CODESPACES"] = "false";
 
@@ -446,50 +486,93 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
                 });
 
         using var app = builder.Build();
-        ResourceCommandState? commandState = null;
-        var watchTcs = new TaskCompletionSource();
-        var watchCts = new CancellationTokenSource();
-        var watchTask = Task.Run(async () =>
-        {
-            await foreach (var resourceEvent in app.ResourceNotifications.WatchAsync(watchCts.Token).WithCancellation(watchCts.Token))
-            {
-                var commandSnapshot = resourceEvent.Snapshot.Commands.First(c => c.Name == "mycommand");
-                commandState = commandSnapshot.State;
-                if (commandState == ResourceCommandState.Enabled)
-                {
-                    watchTcs.TrySetResult();
-                }
-            }
-        }, watchCts.Token);
-
-        // Act/Assert
-        await app.StartAsync();
+        await app.StartAsync().DefaultTimeout();
 
         // Move the resource to the running state
         await app.ResourceNotifications.PublishUpdateAsync(service.Resource, s => s with
         {
             State = KnownResourceStates.Running
-        });
-        await app.ResourceNotifications.WaitForResourceAsync(service.Resource.Name, KnownResourceStates.Running).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        }).DefaultTimeout();
 
-        // Veriy the command is hidden despite the resource being running
-        Assert.Equal(ResourceCommandState.Hidden, commandState);
+        // Wait for the resource to be running and verify command is hidden (custom UpdateState returns Hidden)
+        var runningEvent = await app.ResourceNotifications.WaitForResourceAsync(
+            service.Resource.Name,
+            e => e.Snapshot.State?.Text == KnownResourceStates.Running &&
+                 e.Snapshot.Commands.First(c => c.Name == "mycommand").State == ResourceCommandState.Hidden).DefaultTimeout();
 
-        // Publish an update to force reevaluation of the command state
+        Assert.Equal(ResourceCommandState.Hidden, runningEvent.Snapshot.Commands.First(c => c.Name == "mycommand").State);
+
+        // Enable the command and publish an update to force reevaluation
         enableCommand = true;
         await app.ResourceNotifications.PublishUpdateAsync(service.Resource, s => s with
         {
             State = KnownResourceStates.Running
-        });
-        await watchTcs.Task.DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
+        }).DefaultTimeout();
 
-        // Verify the callback was called and the command is enabled
+        // Wait for the command to become enabled
+        var enabledEvent = await app.ResourceNotifications.WaitForResourceAsync(
+            service.Resource.Name,
+            e => e.Snapshot.Commands.First(c => c.Name == "mycommand").State == ResourceCommandState.Enabled).DefaultTimeout();
+
         Assert.True(callbackCalled);
-        Assert.Equal(ResourceCommandState.Enabled, commandState);
+        Assert.Equal(ResourceCommandState.Enabled, enabledEvent.Snapshot.Commands.First(c => c.Name == "mycommand").State);
 
-        // Clean up
-        watchCts.Cancel();
-        await app.StopAsync();
+        await app.StopAsync().DefaultTimeout();
+    }
+
+    private IDistributedApplicationTestingBuilder CreateTestDistributedApplicationBuilder()
+    {
+        // Arrange
+        var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        // Disable retries for the commandclient HTTP client to make test faster and deterministic.
+        // TestDistributedApplicationBuilder adds a default resilience handler via ConfigureHttpClientDefaults.
+        // The handler pipeline is named "{clientName}-standard" so for "commandclient" it's "commandclient-standard".
+        builder.Services.Configure<HttpStandardResilienceOptions>("commandclient-standard", options =>
+        {
+            options.Retry.ShouldHandle = _ => ValueTask.FromResult(false);
+        });
+        builder.Services.Configure<HttpStandardResilienceOptions>("-standard", options =>
+        {
+            options.Retry.ShouldHandle = _ => ValueTask.FromResult(false);
+        });
+        return builder;
+    }
+
+    /// <summary>
+    /// Moves a resource to the running state and waits for the HTTP command to become enabled.
+    /// </summary>
+    private static async Task MoveResourceToRunningStateAsync(DistributedApplication app, IResource resource, string commandName = "mycommand")
+    {
+        await app.ResourceNotifications.PublishUpdateAsync(resource, s => s with
+        {
+            State = KnownResourceStates.Running
+        }).DefaultTimeout();
+
+        // Wait for resource to be running AND for the command to become enabled
+        // The command state is updated asynchronously by a WatchAsync loop, so we need to wait for both conditions
+        // Use a longer timeout because the WatchAsync loop may take time to process the state change
+        using var cts = new CancellationTokenSource(TestConstants.LongTimeoutTimeSpan);
+        await app.ResourceNotifications.WaitForResourceAsync(
+            resource.Name,
+            e => e.Snapshot.State?.Text == KnownResourceStates.Running &&
+                 e.Snapshot.Commands.FirstOrDefault(c => c.Name == commandName)?.State == ResourceCommandState.Enabled,
+            cts.Token).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Creates a CustomResource with an HTTP endpoint and pre-allocates the endpoint
+    /// so HTTP commands can resolve the URL without requiring DCP allocation.
+    /// </summary>
+    private static IResourceBuilder<CustomResource> CreateResourceWithAllocatedEndpoint(IDistributedApplicationBuilder builder, string name, int port = 8080)
+    {
+        var service = builder.AddResource(new CustomResource(name))
+            .WithHttpEndpoint(targetPort: port);
+
+        var endpointAnnotation = service.Resource.Annotations.OfType<EndpointAnnotation>().Single();
+        endpointAnnotation.AllocatedEndpoint = new AllocatedEndpoint(endpointAnnotation, "localhost", port);
+
+        return service;
     }
 
     private sealed class CustomResource(string name) : Resource(name), IResourceWithEndpoints, IResourceWithWaitSupport

--- a/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
@@ -506,7 +506,6 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
 
     private IDistributedApplicationTestingBuilder CreateTestDistributedApplicationBuilder()
     {
-        // Arrange
         var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
 
         // Disable retries for the commandclient HTTP client to make test faster and deterministic.

--- a/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
@@ -533,8 +533,8 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
         }).DefaultTimeout();
 
         // Wait for resource to be running AND for the command to become enabled
-        // The command state is updated asynchronously by a WatchAsync loop, so we need to wait for both conditions
-        // Use a longer timeout because the WatchAsync loop may take time to process the state change
+        // The command state is updated synchronously when PublishUpdateAsync is called, but we still need to wait
+        // for the notification to propagate through the ResourceNotificationService event system
         using var cts = new CancellationTokenSource(TestConstants.LongTimeoutTimeSpan);
         await app.ResourceNotifications.WaitForResourceAsync(
             resource.Name,

--- a/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
@@ -535,12 +535,10 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
         // Wait for resource to be running AND for the command to become enabled
         // The command state is updated synchronously when PublishUpdateAsync is called, but we still need to wait
         // for the notification to propagate through the ResourceNotificationService event system
-        using var cts = new CancellationTokenSource(TestConstants.LongTimeoutTimeSpan);
         await app.ResourceNotifications.WaitForResourceAsync(
             resource.Name,
             e => e.Snapshot.State?.Text == KnownResourceStates.Running &&
-                 e.Snapshot.Commands.FirstOrDefault(c => c.Name == commandName)?.State == ResourceCommandState.Enabled,
-            cts.Token).ConfigureAwait(false);
+                 e.Snapshot.Commands.FirstOrDefault(c => c.Name == commandName)?.State == ResourceCommandState.Enabled).DefaultTimeout();
     }
 
     /// <summary>

--- a/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
@@ -271,6 +271,7 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9818")]
     public async Task WithHttpCommand_UsesEndpointSelector()
     {
         // Arrange
@@ -314,6 +315,7 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9789")]
     public async Task WithHttpCommand_CallsPrepareRequestCallback_BeforeSendingRequest()
     {
         // Arrange
@@ -358,6 +360,7 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9772")]
     public async Task WithHttpCommand_CallsGetResponseCallback_AfterSendingRequest()
     {
         // Arrange
@@ -403,6 +406,7 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/8101")]
     public async Task WithHttpCommand_EnablesCommandOnceResourceIsRunning()
     {
         // Arrange
@@ -447,6 +451,7 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspire/issues/9811")]
     public async Task WithHttpCommand_EnablesCommandUsingCustomUpdateStateCallback()
     {
         // Arrange


### PR DESCRIPTION
Should fix https://github.com/dotnet/aspire/issues/9670
Should fix https://github.com/dotnet/aspire/issues/9725
Should fix https://github.com/dotnet/aspire/issues/9800
Should fix https://github.com/dotnet/aspire/issues/9818
Should fix https://github.com/dotnet/aspire/issues/9789
Should fix https://github.com/dotnet/aspire/issues/9772
Should fix https://github.com/dotnet/aspire/issues/8101
Should fix https://github.com/dotnet/aspire/issues/9811

Various issues:
- The tests relied on DCP to build and launch projects. However I've found DCP to be a point of flaky failure in tests. I think this is the biggest problem of these tests. PR updates all tests to use a custom resource and a fake HttpHandler. No more building .NET project over and over, or sending HTTP. More reliable and faster.
- The logic for `UpdateState` was odd. There was a background task looking at the resource state and then using that to update the command state the next time the resource was updated (maybe it would update immediately, may it would wait for the next update before the state was it. It was a race). The problem is if the resource was never updated again then the command state would never change. Caused one flaky test. The fix is to use the resource status from the context which is much simpler. @DamianEdwards is there a reason why `UpdateState` was written this way?
- Resilency retry logic caused the test that returned a 500 status to retry over and over. It took forever. Fixed by disabling resilience retries in tests.