### PR TITLE
Concurrency pwd generation issue

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/UserSecretsParameterDefault.cs
+++ b/src/Aspire.Hosting/ApplicationModel/UserSecretsParameterDefault.cs
@@ -21,16 +21,9 @@ internal sealed class UserSecretsParameterDefault(string applicationName, string
     /// <inheritdoc/>
     public override string GetDefaultValue()
     {
-        var value = parameterDefault.GetDefaultValue();
         var configurationKey = $"Parameters:{parameterName}";
 
-        if (!userSecretsManager.TrySetSecret(configurationKey, value))
-        {
-            // This is a best-effort operation, so we don't throw if it fails. Common reason for failure is that the user secrets ID is not set
-            // in the application's assembly. Note there's no ILogger available this early in the application lifecycle.
-            Debug.WriteLine($"Failed to set value for parameter '{parameterName}' in application '{applicationName}' to user secrets.");
-        }
-        return value;
+        return userSecretsManager.GetOrSetSecret(configurationKey, parameterDefault.GetDefaultValue);
     }
 
     /// <inheritdoc/>

--- a/src/Aspire.Hosting/ApplicationModel/UserSecretsParameterDefault.cs
+++ b/src/Aspire.Hosting/ApplicationModel/UserSecretsParameterDefault.cs
@@ -23,6 +23,7 @@ internal sealed class UserSecretsParameterDefault(string applicationName, string
     {
         var configurationKey = $"Parameters:{parameterName}";
 
+        Debug.WriteLine($"UserSecretsParameterDefault: applicationName: {applicationName}, parameterName: {parameterName}");
         return userSecretsManager.GetOrSetSecret(configurationKey, parameterDefault.GetDefaultValue);
     }
 

--- a/src/Aspire.Hosting/UserSecrets/IUserSecretsManager.cs
+++ b/src/Aspire.Hosting/UserSecrets/IUserSecretsManager.cs
@@ -43,6 +43,14 @@ public interface IUserSecretsManager
     void GetOrSetSecret(IConfigurationManager configuration, string name, Func<string> valueGenerator);
 
     /// <summary>
+    /// Gets a secret value from the store or creates it using the generator if it doesn't exist.
+    /// </summary>
+    /// <param name="name">The name of the secret.</param>
+    /// <param name="valueGenerator">Function to generate the value if it doesn't exist.</param>
+    /// <returns>The existing or generated secret value.</returns>
+    string GetOrSetSecret(string name, Func<string> valueGenerator);
+
+    /// <summary>
     /// Saves state to user secrets asynchronously (for deployment state manager).
     /// If multiple callers save state concurrently, the last write wins.
     /// </summary>

--- a/src/Aspire.Hosting/UserSecrets/NoopUserSecretsManager.cs
+++ b/src/Aspire.Hosting/UserSecrets/NoopUserSecretsManager.cs
@@ -37,6 +37,12 @@ internal sealed class NoopUserSecretsManager : IUserSecretsManager
         configuration.AddInMemoryCollection(new Dictionary<string, string?> { [name] = value });
     }
 
+    public string GetOrSetSecret(string name, Func<string> valueGenerator)
+    {
+        Debug.WriteLine($"User secrets are not enabled. Generating secret '{name}'.");
+        return valueGenerator();
+    }
+
     public Task SaveStateAsync(JsonObject state, CancellationToken cancellationToken = default)
     {
         Debug.WriteLine("User secrets are not enabled. Cannot save state.");

--- a/src/Aspire.Hosting/UserSecrets/UserSecretsManagerFactory.cs
+++ b/src/Aspire.Hosting/UserSecrets/UserSecretsManagerFactory.cs
@@ -6,7 +6,9 @@
 
 using System.Diagnostics;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Hosting.Pipelines.Internal;
@@ -129,6 +131,77 @@ internal sealed class UserSecretsManagerFactory
                 if (!TrySetSecret(name, value))
                 {
                     Debug.WriteLine($"Failed to save value to application user secrets.");
+                }
+            }
+        }
+
+        public string GetOrSetSecret(string name, Func<string> valueGenerator)
+        {
+            // Create a named mutex based on the file path to coordinate across processes
+            var mutexName = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(FilePath)));
+            
+            // On Windows, limits on mutex names may apply, but hex string of SHA256 is 64 chars, which is safe.
+            // We use global scope on Windows to ensure it works across sessions if needed, though for tests it's usually same session.
+            // On Linux, the name is used for file locking in /tmp.
+            using var mutex = new Mutex(false, mutexName);
+
+            var hasHandle = false;
+            try
+            {
+                try
+                {
+                    hasHandle = mutex.WaitOne(TimeSpan.FromSeconds(5));
+                }
+                catch (AbandonedMutexException)
+                {
+                    hasHandle = true;
+                }
+
+                _semaphore.Wait();
+                try
+                {
+                    // Reload inside the lock to get the latest state
+                    Dictionary<string, string?> secrets;
+                    try 
+                    {
+                        secrets = Load();
+                    }
+                    catch
+                    {
+                        // If loading fails, we assume empty secrets to allow proceeding with generation
+                        secrets = new Dictionary<string, string?>();
+                    }
+
+                    if (secrets.TryGetValue(name, out var value) && value is not null)
+                    {
+                        return value;
+                    }
+
+                    var newValue = valueGenerator();
+                    secrets[name] = newValue;
+                    
+                    try
+                    {
+                        Save(secrets);
+                    }
+                    catch (Exception)
+                    {
+                        // Best effort - allow returning value even if persistence fails
+                        Debug.WriteLine("Failed to save user secrets.");
+                    }
+                    
+                    return newValue;
+                }
+                finally
+                {
+                    _semaphore.Release();
+                }
+            }
+            finally
+            {
+                if (hasHandle)
+                {
+                    mutex.ReleaseMutex();
                 }
             }
         }

--- a/src/Aspire.Hosting/UserSecrets/UserSecretsManagerFactory.cs
+++ b/src/Aspire.Hosting/UserSecrets/UserSecretsManagerFactory.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Hosting.Pipelines.Internal;
@@ -139,7 +138,7 @@ internal sealed class UserSecretsManagerFactory
         {
             // Create a named mutex based on the file path to coordinate across processes
             var mutexName = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(FilePath)));
-            
+
             // On Windows, limits on mutex names may apply, but hex string of SHA256 is 64 chars, which is safe.
             // We use global scope on Windows to ensure it works across sessions if needed, though for tests it's usually same session.
             // On Linux, the name is used for file locking in /tmp.
@@ -162,7 +161,7 @@ internal sealed class UserSecretsManagerFactory
                 {
                     // Reload inside the lock to get the latest state
                     Dictionary<string, string?> secrets;
-                    try 
+                    try
                     {
                         secrets = Load();
                     }
@@ -179,7 +178,7 @@ internal sealed class UserSecretsManagerFactory
 
                     var newValue = valueGenerator();
                     secrets[name] = newValue;
-                    
+
                     try
                     {
                         Save(secrets);
@@ -189,7 +188,7 @@ internal sealed class UserSecretsManagerFactory
                         // Best effort - allow returning value even if persistence fails
                         Debug.WriteLine("Failed to save user secrets.");
                     }
-                    
+
                     return newValue;
                 }
                 finally

--- a/src/Aspire.Hosting/UserSecrets/UserSecretsManagerFactory.cs
+++ b/src/Aspire.Hosting/UserSecrets/UserSecretsManagerFactory.cs
@@ -154,6 +154,7 @@ internal sealed class UserSecretsManagerFactory
                 }
                 catch (AbandonedMutexException)
                 {
+                    // The wait completed because a thread exited without releasing a mutex.
                     hasHandle = true;
                 }
 

--- a/src/Aspire.Hosting/UserSecrets/UserSecretsManagerFactory.cs
+++ b/src/Aspire.Hosting/UserSecrets/UserSecretsManagerFactory.cs
@@ -149,6 +149,7 @@ internal sealed class UserSecretsManagerFactory
             {
                 try
                 {
+                    // Wait up to timeout. If timeout is exceeded then continue anyway.
                     hasHandle = mutex.WaitOne(TimeSpan.FromSeconds(5));
                 }
                 catch (AbandonedMutexException)

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -1185,6 +1185,12 @@ public class ParameterProcessorTests
             // Mock implementation - do nothing
         }
 
+        public string GetOrSetSecret(string name, Func<string> valueGenerator)
+        {
+            // Mock implementation - return generate value immediately
+            return valueGenerator();
+        }
+
         public Task SaveStateAsync(JsonObject state, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;

--- a/tests/Aspire.Hosting.Tests/UserSecretsParameterDefaultTests.cs
+++ b/tests/Aspire.Hosting.Tests/UserSecretsParameterDefaultTests.cs
@@ -330,7 +330,7 @@ public class UserSecretsParameterDefaultTests
             new("TestAssembly"), AssemblyBuilderAccess.RunAndCollect, [new CustomAttributeBuilder(s_userSecretsIdAttrCtor, [userSecretsId])]);
 
         var tasks = new List<Task<string>>();
-        for (int i = 0; i < 10; i++)
+        for (var i = 0; i < 10; i++)
         {
             tasks.Add(Task.Run(() => 
             {


### PR DESCRIPTION
## Description

This PR addresses a race condition when multiple DistributedApplicationTestingBuilder instances are initialized concurrently (e.g., during parallel integration tests).
It's a pretty passive solution that uses simple mutexes to prevent that rare case.

**The Problem**
Previously, the logic for handling auto-generated parameters (like passwords) followed this flow:

1. Generate a new value immediately (e.g., Thread A generates Pass1, Thread B generates Pass2).
2. Lock the user secrets store.
3. Save the value.

By the time the lock was acquired, the value was already generated. This caused a "last-writer-wins" scenario where:

- Thread A persists Pass1 and starts its container.
- Thread B overwrites secrets with Pass2.
- Thread A (or dependent services) tries to read the secret, gets Pass2 (the wrong password), and fails authentication against the container running with Pass1.

**The Solution**
I've introduced a new 
GetOrSetSecret
 pattern that inverts this flow to be atomic. The new flow is:

1. Lock (using a system-wide Mutex to handle cross-process locking).
2. Reload the secrets from disk.
3. Check if the value already exists.
 - If yes: Return the existing value (Thread B now sees Pass1 and uses it).
 - If no: Generate and Save the new value.

**Implementation Details**
Added 
`GetOrSetSecret`
 to 
`IUserSecretsManager`

Implemented a Mutex based on the file path hash in 
`UserSecretsManagerFactory`
 to ensure we coordinate writes effectively across test processes, not just threads.
Added resilience: if locking fails (timeout) or file IO fails, we degrade gracefully to the generated value to prevent the test suite from crashing, though the race condition might technically persist in that specific failure edge case.
This ensures both test instances agree on the same shared secret (e.g., Redis password) and containers start/connect successfully.

Fixes #13720

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
