### PR TITLE
Add a new Tls EndpointProperty

### DIFF
--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -91,7 +91,7 @@ public static class RedisBuilderExtensions
         builder.Services.AddHealthChecks().AddRedis(sp => connectionString ?? throw new InvalidOperationException("Connection string is unavailable"), name: healthCheckKey);
 
         var redisBuilder = builder.AddResource(redis)
-            .WithEndpoint(port: port, targetPort: 6379, name: RedisResource.PrimaryEndpointName)
+            .WithEndpoint(port: port, targetPort: 6379, name: RedisResource.PrimaryEndpointName, scheme: "redis")
             .WithImage(RedisContainerImageTags.Image, RedisContainerImageTags.Tag)
             .WithImageRegistry(RedisContainerImageTags.Registry)
             .WithHealthCheck(healthCheckKey)
@@ -197,7 +197,12 @@ public static class RedisBuilderExtensions
                     // If a TLS certificate is configured, ensure the YARP resource has an HTTPS endpoint and
                     // configure the environment variables to use it.
                     redisBuilder
-                        .WithEndpoint(targetPort: 6380, name: RedisResource.SecondaryEndpointName)
+                        .WithEndpoint(targetPort: 6380, name: RedisResource.SecondaryEndpointName, scheme: "redis")
+                        .WithEndpoint(RedisResource.PrimaryEndpointName, ep =>
+                        {
+                            ep.UriScheme = "rediss";
+                            ep.Tls = true;
+                        })
                         .WithArgs(ctx =>
                         {
                             ctx.Args.Add("--tls-port");

--- a/src/Aspire.Hosting.Redis/RedisResource.cs
+++ b/src/Aspire.Hosting.Redis/RedisResource.cs
@@ -124,7 +124,7 @@ public class RedisResource(string name) : ContainerResource(name), IResourceWith
         get
         {
             var builder = new ReferenceExpressionBuilder();
-            builder.Append($"{PrimaryEndpoint.Scheme}://");
+            builder.Append($"{PrimaryEndpoint.Property(EndpointProperty.Scheme)}://");
 
             if (PasswordParameter is not null)
             {

--- a/src/Aspire.Hosting.Redis/RedisResource.cs
+++ b/src/Aspire.Hosting.Redis/RedisResource.cs
@@ -72,10 +72,7 @@ public class RedisResource(string name) : ContainerResource(name), IResourceWith
             builder.Append($",password={PasswordParameter}");
         }
 
-        if (TlsEnabled)
-        {
-            builder.Append($",ssl=true");
-        }
+        builder.Append($",ssl={PrimaryEndpoint.Property(EndpointProperty.Tls)}");
 
         return builder.Build();
     }
@@ -127,14 +124,7 @@ public class RedisResource(string name) : ContainerResource(name), IResourceWith
         get
         {
             var builder = new ReferenceExpressionBuilder();
-            if (TlsEnabled)
-            {
-                builder.AppendLiteral("rediss://");
-            }
-            else
-            {
-                builder.AppendLiteral("redis://");
-            }
+            builder.Append($"{PrimaryEndpoint.Scheme}://");
 
             if (PasswordParameter is not null)
             {

--- a/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
@@ -22,6 +22,7 @@ public sealed class EndpointAnnotation : IResourceAnnotation
     private bool _portSetToNull;
     private int? _targetPort;
     private bool _targetPortSetToNull;
+    private bool? _isTls;
     private readonly NetworkIdentifier _networkID;
 
     /// <summary>
@@ -168,6 +169,15 @@ public sealed class EndpointAnnotation : IResourceAnnotation
     {
         get => _transport ?? (UriScheme == "http" || UriScheme == "https" ? "http" : Protocol.ToString().ToLowerInvariant());
         set => _transport = value;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the endpoint uses TLS.
+    /// </summary>
+    public bool Tls
+    {
+        get => _isTls ?? (UriScheme == "https");
+        set => _isTls = value;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -100,6 +100,7 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
             EndpointProperty.Scheme => Binding("scheme"),
             EndpointProperty.TargetPort => Binding("targetPort"),
             EndpointProperty.HostAndPort => $"{Binding("host")}:{Binding("port")}",
+            EndpointProperty.Tls => Tls.ToString().ToLowerInvariant(),
             _ => throw new InvalidOperationException($"The property '{property}' is not supported for the endpoint '{EndpointName}'.")
         };
 
@@ -140,6 +141,11 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
     /// Gets the URL for this endpoint.
     /// </summary>
     public string Url => AllocatedEndpoint.UriString;
+
+    /// <summary>
+    /// Gets a value indicating whether the endpoint uses TLS.
+    /// </summary>
+    public bool Tls => EndpointAnnotation.Tls;
 
     internal ValueSnapshot<AllocatedEndpoint> AllocatedEndpointSnapshot =>
         EndpointAnnotation.AllocatedEndpointSnapshot;
@@ -302,6 +308,7 @@ public class EndpointReferenceExpression(EndpointReference endpointReference, En
             EndpointProperty.Scheme => new(Endpoint.Scheme),
             EndpointProperty.IPV4Host when networkContext == KnownNetworkIdentifiers.LocalhostNetwork => "127.0.0.1",
             EndpointProperty.TargetPort when Endpoint.TargetPort is int port => new(port.ToString(CultureInfo.InvariantCulture)),
+            EndpointProperty.Tls => new(Endpoint.Tls.ToString().ToLowerInvariant()),
             _ => await ResolveValueWithAllocatedAddress().ConfigureAwait(false)
         };
 
@@ -357,22 +364,27 @@ public enum EndpointProperty
     /// The entire URL of the endpoint.
     /// </summary>
     Url,
+
     /// <summary>
     /// The host of the endpoint.
     /// </summary>
     Host,
+
     /// <summary>
     /// The IPv4 address of the endpoint.
     /// </summary>
     IPV4Host,
+
     /// <summary>
     /// The port of the endpoint.
     /// </summary>
     Port,
+
     /// <summary>
     /// The scheme of the endpoint.
     /// </summary>
     Scheme,
+
     /// <summary>
     /// The target port of the endpoint.
     /// </summary>
@@ -381,5 +393,10 @@ public enum EndpointProperty
     /// <summary>
     /// The host and port of the endpoint in the format `{Host}:{Port}`.
     /// </summary>
-    HostAndPort
+    HostAndPort,
+
+    /// <summary>
+    /// Indicates whether the endpoint uses TLS.
+    /// </summary>
+    Tls,
 }

--- a/src/Schema/aspire-13.0.json
+++ b/src/Schema/aspire-13.0.json
@@ -1,0 +1,852 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/aspire-13.0.json",
+  "type": "object",
+  "description": "Defines the .NET Aspire 8.0 deployment manifest JSON schema.",
+  "required": ["resources"],
+  "properties": {
+    "resources": {
+      "type": "object",
+      "description": "Contains the set of resources deployable as part of this manifest. Each property is a distinct resource.",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["type"],
+        "properties": {
+          "type": {
+            "type": "string"
+          }
+        },
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "A resource that represents a Dockerfile that will be built into a container during deployment.",
+            "required": [ "type", "path", "context" ],
+            "properties": {
+              "type": {
+                "const": "dockerfile.v0"
+              },
+              "path": {
+                "type": "string",
+                "description": "The file path to the Dockerfile to be built into a container image."
+              },
+              "context": {
+                "type": "string",
+                "description": "A directory path used as the context for building the Dockerfile into a container image."
+              },
+              "env": {
+                "$ref": "#/definitions/env"
+              },
+              "bindings": {
+                "$ref": "#/definitions/bindings"
+              },
+              "buildArgs": {
+                "$ref": "#/definitions/buildArgs"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "description": "A generic container resource.",
+            "required": [ "type", "image" ],
+            "properties": {
+              "type": {
+                "const": "container.v0"
+              },
+              "image": {
+                "type": "string",
+                "description": "A string representing the container image to be used."
+              },
+              "entrypoint": {
+                "type": "string",
+                "description": "The entrypoint to use for the container image when executed."
+              },
+              "args": {
+                "$ref": "#/definitions/args"
+              },
+              "connectionString": {
+                "$ref": "#/definitions/connectionString"
+              },
+              "containerFiles": {
+                "type": "object",
+                "description": "Container files to be copied from other resources into this container's image.",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "destination": {
+                      "type": "string",
+                      "description": "The destination path within this container where files will be copied."
+                    },
+                    "sources": {
+                      "type": "array",
+                      "description": "The source paths within the source container to copy from.",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [ "destination" ]
+                }
+              },
+              "env": {
+                "$ref": "#/definitions/env"
+              },
+              "bindings": {
+                "$ref": "#/definitions/bindings"
+              },
+              "bindMounts": {
+                "$ref": "#/definitions/bindMounts"
+              },
+              "volumes": {
+                "$ref": "#/definitions/volumes"
+              },
+              "build": false
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "description": "A generic container resource.",
+            "oneOf": [
+              {
+                "required": [ "type", "build" ]
+              },
+              {
+                "required": [ "type", "image" ]
+              }
+            ],
+            "properties": {
+              "type": {
+                "const": "container.v1"
+              },
+              "image": {
+                "type": "string",
+                "description": "A string representing the container image to be used."
+              },
+              "entrypoint": {
+                "type": "string",
+                "description": "The entrypoint to use for the container image when executed."
+              },
+              "deployment": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/resource.azure.bicep.v0"
+                  },
+                  {
+                    "$ref": "#/definitions/resource.azure.bicep.v1"
+                  }
+                ]
+              },
+              "args": {
+                "$ref": "#/definitions/args"
+              },
+              "build": {
+                "$ref": "#/definitions/build"
+              },
+              "connectionString": {
+                "$ref": "#/definitions/connectionString"
+              },
+              "containerFiles": {
+                "type": "object",
+                "description": "Container files to be copied from other resources into this container's image.",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "destination": {
+                      "type": "string",
+                      "description": "The destination path within this container where files will be copied."
+                    },
+                    "sources": {
+                      "type": "array",
+                      "description": "The source paths within the source container to copy from.",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [ "destination" ]
+                }
+              },
+              "env": {
+                "$ref": "#/definitions/env"
+              },
+              "bindings": {
+                "$ref": "#/definitions/bindings"
+              },
+              "bindMounts": {
+                "$ref": "#/definitions/bindMounts"
+              },
+              "volumes": {
+                "$ref": "#/definitions/volumes"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "description": "Represents a .NET project resource.",
+            "required": [ "type", "path" ],
+            "properties": {
+              "type": {
+                "const": "project.v0"
+              },
+              "path": {
+                "type": "string",
+                "description": "The path to the project file. Relative paths are interpreted as being relative to the location of the manifest file."
+              },
+              "containerFiles": {
+                "type": "object",
+                "description": "Container files to be copied from other resources into this project's container image.",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "destination": {
+                      "type": "string",
+                      "description": "The destination path within this container where files will be copied."
+                    },
+                    "sources": {
+                      "type": "array",
+                      "description": "The source paths within the source container to copy from.",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [ "destination" ]
+                }
+              },
+              "args": {
+                "$ref": "#/definitions/args"
+              },
+              "env": {
+                "$ref": "#/definitions/env"
+              },
+              "bindings": {
+                "$ref": "#/definitions/bindings"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "description": "Represents a .NET project resource.",
+            "required": [ "type", "path" ],
+            "properties": {
+              "type": {
+                "const": "project.v1"
+              },
+              "path": {
+                "type": "string",
+                "description": "The path to the project file. Relative paths are interpreted as being relative to the location of the manifest file."
+              },
+              "deployment": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/resource.azure.bicep.v0"
+                  },
+                  {
+                    "$ref": "#/definitions/resource.azure.bicep.v1"
+                  }
+                ]
+              },
+              "containerFiles": {
+                "type": "object",
+                "description": "Container files to be copied from other resources into this project's container image.",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "destination": {
+                      "type": "string",
+                      "description": "The destination path within this container where files will be copied."
+                    },
+                    "sources": {
+                      "type": "array",
+                      "description": "The source paths within the source container to copy from.",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [ "destination" ]
+                }
+              },
+              "args": {
+                "$ref": "#/definitions/args"
+              },
+              "env": {
+                "$ref": "#/definitions/env"
+              },
+              "bindings": {
+                "$ref": "#/definitions/bindings"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "description": "Represents an executable resource.",
+            "required": [ "type", "command", "workingDirectory" ],
+            "properties": {
+              "type": {
+                "const": "executable.v0"
+              },
+              "workingDirectory": {
+                "type": "string",
+                "description": "The path to the working directory. Should be interpreted as being relative to the AppHost directory."
+              },
+              "command": {
+                "type": "string",
+                "description": "The path to the command. Should be interpreted as being relative to the AppHost directory."
+              },
+              "containerFiles": {
+                "type": "object",
+                "description": "Container files to be copied from other resources into this executable's container image.",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "destination": {
+                      "type": "string",
+                      "description": "The destination path within this container where files will be copied."
+                    },
+                    "sources": {
+                      "type": "array",
+                      "description": "The source paths within the source container to copy from.",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [ "destination" ]
+                }
+              },
+              "args": {
+                "$ref": "#/definitions/args"
+              },
+              "env": {
+                "$ref": "#/definitions/env"
+              },
+              "bindings": {
+                "$ref": "#/definitions/bindings"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [ "connectionString" ],
+            "description": "Represents a value resource. Typically used to perform string concatenation (e.g. for connection strings).",
+            "properties": {
+              "type": {
+                "const": "value.v0"
+              },
+              "connectionString": {
+                "$ref": "#/definitions/connectionString"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "description": "Represents a parameter resource. Parameter resources are used to represent external configuration values that should be provided at deployment time.",
+            "required": [ "value", "inputs" ],
+            "properties": {
+              "type": {
+                "const": "parameter.v0"
+              },
+              "value": {
+                "$ref": "#/definitions/value"
+              },
+              "connectionString": {
+                "$ref": "#/definitions/connectionString"
+              },
+              "inputs": {
+                "type": "object",
+                "description": "Defines a set of input values which need to be either generated or prompted by the deployment tool. This is typically used for environment specific configuration values or secrets.",
+                "additionalProperties": {
+                  "type": "object",
+                  "required": [ "type" ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "description": "The type of the value to be prompted or generated. Currently only 'string'' is supported.",
+                      "enum": [ "string" ]
+                    },
+                    "secret": {
+                      "type": "boolean",
+                      "description": "Flag indicating whether the value should be treated as a secret. Deployment tools should note this value to take appropriate precautions when prompting, storing, and transmitting this value."
+                    },
+                    "default": {
+                      "type": "object",
+                      "oneOf": [
+                        {
+                          "required": [ "generate" ],
+                          "properties": {
+                            "generate": {
+                              "type": "object",
+                              "required": [ "minLength" ],
+                              "properties": {
+                                "minLength": {
+                                  "type": "number",
+                                  "description": "The minimum length of the generated value."
+                                },
+                                "lower": {
+                                  "type": "boolean",
+                                  "description": "Indicates whether lower case characters are allowed in the generated value."
+                                },
+                                "upper": {
+                                  "type": "boolean",
+                                  "description": "Indicates whether upper case characters are allowed in the generated value."
+                                },
+                                "numeric": {
+                                  "type": "boolean",
+                                  "description": "Indicates whether numeric characters are allowed in the generated value."
+                                },
+                                "special": {
+                                  "type": "boolean",
+                                  "description": "Indicates whether special characters are allowed in the generated value."
+                                },
+                                "minLower": {
+                                  "type": "number",
+                                  "description": "Specifies the minimum number of lower case characters that must appear in the generated value."
+                                },
+                                "minUpper": {
+                                  "type": "number",
+                                  "description": "Specifies the minimum number of upper case characters that must appear in the generated value."
+                                },
+                                "minNumeric": {
+                                  "type": "number",
+                                  "description": "Specifies the minimum number of numeric characters that must appear in the generated value."
+                                },
+                                "minSpecial": {
+                                  "type": "number",
+                                  "description": "Specifies the minimum number of special characters that must appear in the generated value."
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        {
+                          "required": [ "value" ],
+                          "properties": {
+                            "value": {
+                              "type": "string",
+                              "description": "The default value to use if the parameter is not provided at deployment time."
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "description": "Represents a formatted projection of a parameter value, produced by applying the specified filter to the parameter.",
+            "required": [ "type", "value", "filter" ],
+            "properties": {
+              "type": {
+                "const": "annotated.string"
+              },
+              "value": {
+                "$ref": "#/definitions/value"
+              },
+              "filter": {
+                "$ref": "#/definitions/annotatedStringFilter"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "description": "Represents a Dapr resource in the manifest.",
+            "required": [ "dapr" ],
+            "properties": {
+              "type": {
+                "const": "dapr.v0"
+              },
+              "dapr": {
+                "type": "object",
+                "description": "Dapr specific configuration.",
+                "required": [ "application", "appId", "components" ],
+                "properties": {
+                  "application": {
+                    "type": "string"
+                  },
+                  "appId": {
+                    "type": "string"
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [ "daprComponent" ],
+            "properties": {
+              "type": {
+                "const": "dapr.component.v0"
+              },
+              "daprComponent": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "$ref": "#/definitions/resource.azure.bicep.v0"
+          },
+          {
+            "$ref": "#/definitions/resource.azure.bicep.v1"
+          },
+          {
+            "type": "object",
+            "required": [ "type", "stack-name" ],
+            "properties": {
+              "type": {
+                "const": "aws.cloudformation.stack.v0"
+              },
+              "stack-name": {
+                "type": "string"
+              },
+              "references": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "target-resource": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [ "type", "stack-name", "template-path" ],
+            "properties": {
+              "type": {
+                "const": "aws.cloudformation.template.v0"
+              },
+              "stack-name": {
+                "type": "string"
+              },
+              "template-path": {
+                "type": "string"
+              },
+              "references": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "target-resource": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "description": "Represents extensions. Any object with a 'type' field that is not captured above will pass.",
+            "required": [ "type" ],
+            "not": {
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "parameter.v0",
+                    "annotated.string",
+                    "container.v0",
+                    "container.v1",
+                    "dockerfile.v0",
+                    "project.v0",
+                    "project.v1",
+                    "value.v0",
+                    "executable.v0",
+                    "azure.bicep.v0",
+                    "azure.bicep.v1",
+                    "aws.cloudformation.template.v0",
+                    "aws.cloudformation.stack.v0",
+                    "dapr.component.v0",
+                    "dapr.v0"
+                  ]
+                }
+              }
+            },
+            "properties": {
+              "type": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "resource.azure.bicep.v0": {
+      "type": "object",
+      "description": "Represents a resource that is deployed using Azure Bicep.",
+      "required": [ "path" ],
+      "properties": {
+        "type": {
+          "const": "azure.bicep.v0"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to the Bicep file to be used for deployment."
+        },
+        "connectionString": {
+          "$ref": "#/definitions/connectionString"
+        },
+        "params": {
+          "type": "object",
+          "description": "A list of parameters which are passed to Azure deployment.",
+          "additionalProperties": {
+            "oneOf": [
+              { "type": "array" },
+              { "type": "boolean" },
+              { "type": "number" },
+              { "type": "object" },
+              { "type": "string" }
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "resource.azure.bicep.v1": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/resource.azure.bicep.v0"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "azure.bicep.v1"
+            },
+            "scope": {
+              "type": "object",
+              "properties": {
+                "resourceGroup": {
+                  "type": "string",
+                  "description": "The name of the resource group to deploy the resource to."
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "connectionString": {
+      "type": "string",
+      "description": "A connection string that can be used to connect to this resource."
+    },
+    "value": {
+      "type": "string",
+      "description": "A value that can be referenced via an expression in the manifest"
+    },
+    "annotatedStringFilter": {
+      "type": "string",
+      "description": "Identifies the filter to apply to the referenced parameter value (for example, 'uri').",
+      "enum": [ "uri" ]
+    },
+    "args": {
+      "type": "array",
+      "description": "List of arguments to used when launched.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "build": {
+      "type": "object",
+      "description": "An object that captures properties that control the building of a container image.",
+      "required": [ "context", "dockerfile" ],
+      "properties": {
+        "context": {
+          "type": "string",
+          "description": "The path to the context directory for the container build. Can be relative of absolute. If relative it is relative to the location of the manifest file."
+        },
+        "dockerfile": {
+          "type": "string",
+          "description": "The path to the Dockerfile. Can be relative or absolute. If relative it is relative to the manifest file."
+        },
+        "stage": {
+          "type": "string",
+          "description": "The name of the build stage to use for multi-stage Dockerfiles."
+        },
+        "buildOnly": {
+          "type": "boolean",
+          "description": "Indicates whether this container is built only to provide files for other containers and should not be deployed as a running service."
+        },
+        "args": {
+          "type": "object",
+          "description": "A list of build arguments which are used during container build.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "secrets": {
+          "type": "object",
+          "description": "A list of build arguments which are used during container build.",
+          "additionalProperties": {
+            "type": "object",
+            "required": [ "type" ],
+            "oneOf": [
+              {
+                "required": [ "type", "value" ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "env"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "If provided use as the value for the environment variable when docker build is run."
+                  }
+                }
+              },
+              {
+                "required": [ "type", "source" ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "file"
+                  },
+                  "source": {
+                    "type": "string",
+                    "description": "Path to secret file. If relative, the path is relative to the manifest file."
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "buildArgs": {
+      "type": "object",
+      "description": "A list of build arguments which are used during container build (for dockerfile.v0 resource type).",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "bindings": {
+      "type": "object",
+      "description": "A list of port bindings for the resource when it is deployed.",
+      "additionalProperties": {
+        "type": "object",
+        "required": [ "scheme", "protocol", "transport" ],
+        "properties": {
+          "scheme": {
+            "type": "string",
+            "description": "The scheme used in URIs for this binding."
+          },
+          "protocol": {
+            "type": "string",
+            "description": "The protocol used for this binding (only 'tcp' or 'udp' are valid).",
+            "enum": [ "tcp", "udp" ]
+          },
+          "transport": {
+            "type": "string",
+            "description": "Additional information describing the transport (e.g. HTTP/2).",
+            "enum": [ "http", "http2", "tcp" ]
+          },
+          "external": {
+            "type": "boolean",
+            "description": "A flag indicating whether this binding is exposed externally when deployed."
+          },
+          "targetPort": {
+            "type": "number",
+            "description": "The port that the workload (e.g. container) is listening on."
+          },
+          "port": {
+            "type": "number",
+            "description": "The port that the workload (e.g. container) is exposed as to other resources and externally."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "env": {
+      "type": "object",
+      "description": "A list of environment variables which are inserted into the resource at runtime.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "volumes": {
+      "type": "array",
+      "description": "A list of volumes associated with this resource when deployed.",
+      "items": {
+        "type": "object",
+        "required": [ "name", "target", "readOnly" ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the volume."
+          },
+          "target": {
+            "type": "string",
+            "description": "The target within the container where the volume is mounted."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Flag indicating whether the mount is read-only."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "bindMounts": {
+      "type": "array",
+      "description": "A list of bind mounts associated with this resource when deployed.",
+      "items": {
+        "type": "object",
+        "required": [ "source", "target", "readOnly" ],
+        "properties": {
+          "source": {
+            "type": "string",
+            "description": "The source path on the host which is mounted into the container."
+          },
+          "target": {
+            "type": "string",
+            "description": "The target within the container where the volume is mounted."
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Flag indicating whether the mount is read-only."
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/src/Shared/SchemaUtils.cs
+++ b/src/Shared/SchemaUtils.cs
@@ -5,5 +5,5 @@ namespace Aspire.Hosting.Utils;
 
 internal static class SchemaUtils
 {
-    public const string SchemaVersion = "https://json.schemastore.org/aspire-8.0.json";
+    public const string SchemaVersion = "https://json.schemastore.org/aspire-13.0.json";
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -1119,7 +1119,7 @@ public class AzureContainerAppsTests
 
         var ex = await Assert.ThrowsAsync<NotSupportedException>(() => ExecuteBeforeStartHooksAsync(app, default));
 
-        Assert.Equal("The endpoint(s) 'foo' specify an unsupported protocol. Only TCP endpoints are supported in Azure Container Apps.", ex.Message);
+        Assert.Equal("The endpoint(s) 'udp' specify an unsupported protocol. Only TCP endpoints are supported in Azure Container Apps.", ex.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -7,6 +7,7 @@
 #pragma warning disable ASPIREDOCKERFILEBUILDER001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIREPIPELINES001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
+using System.Net.Sockets;
 using System.Text.Json.Nodes;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.AppContainers;
@@ -1103,14 +1104,14 @@ public class AzureContainerAppsTests
     }
 
     [Fact]
-    public async Task NonTcpHttpOrUdpSchemeThrows()
+    public async Task NonTcpProtocolThrows()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
         builder.AddAzureContainerAppEnvironment("env");
 
         builder.AddContainer("api", "myimage")
-            .WithEndpoint(scheme: "foo");
+            .WithEndpoint(protocol: ProtocolType.Udp);
 
         using var app = builder.Build();
 
@@ -1118,7 +1119,7 @@ public class AzureContainerAppsTests
 
         var ex = await Assert.ThrowsAsync<NotSupportedException>(() => ExecuteBeforeStartHooksAsync(app, default));
 
-        Assert.Equal("The endpoint(s) 'foo' specify an unsupported scheme. The supported schemes are 'http', 'https', and 'tcp'.", ex.Message);
+        Assert.Equal("The endpoint(s) 'foo' specify an unsupported protocol. Only TCP endpoints are supported in Azure Container Apps.", ex.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureManagedRedisExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureManagedRedisExtensionsTests.cs
@@ -95,7 +95,7 @@ public class AzureManagedRedisExtensionsTests
         Assert.True(redis.Resource.IsContainer(), "The resource should now be a container resource.");
 
         Assert.NotNull(redisResource?.PasswordParameter);
-        Assert.Equal($"localhost:12455,password=p@ssw0rd1", await redis.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None));
+        Assert.Equal($"localhost:12455,password=p@ssw0rd1,ssl=false", await redis.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None));
 
         // Test the new reference properties
         Assert.NotNull(redis.Resource.HostName);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureManagedRedisExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureManagedRedisExtensionsTests.cs
@@ -4,6 +4,7 @@
 using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
+using Kusto.Cloud.Platform.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
@@ -59,10 +60,8 @@ public class AzureManagedRedisExtensionsTests
 
         Assert.True(redis.Resource.IsContainer(), "The resource should now be a container resource.");
 
-        var sslArg = redisResource?.TlsEnabled == true ? ",ssl=true" : "";
-
         Assert.NotNull(redisResource?.PasswordParameter);
-        Assert.Equal($"localhost:12455,password={await redisResource.PasswordParameter.GetValueAsync(CancellationToken.None)}{sslArg}", await redis.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None));
+        Assert.Equal($"localhost:12455,password={await redisResource.PasswordParameter.GetValueAsync(CancellationToken.None)},ssl={(redisResource?.TlsEnabled == true).ToStringLowercase()}", await redis.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None));
     }
 
     [Fact]
@@ -91,7 +90,7 @@ public class AzureManagedRedisExtensionsTests
         Assert.Equal(12455, endpoint.Port);
         Assert.Equal(ProtocolType.Tcp, endpoint.Protocol);
         Assert.Equal("tcp", endpoint.Transport);
-        Assert.Equal("tcp", endpoint.UriScheme);
+        Assert.Equal("redis", endpoint.UriScheme);
 
         Assert.True(redis.Resource.IsContainer(), "The resource should now be a container resource.");
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
@@ -105,7 +105,7 @@ public class AzureRedisExtensionsTests
 
         Assert.NotNull(redisResource?.PasswordParameter);
 #pragma warning disable CS0618 // Type or member is obsolete
-        Assert.Equal($"localhost:12455,password={redisResource.PasswordParameter.Value}", await redis.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None));
+        Assert.Equal($"localhost:12455,password={redisResource.PasswordParameter.Value},ssl=false", await redis.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None));
 #pragma warning restore CS0618 // Type or member is obsolete
     }
 
@@ -135,12 +135,12 @@ public class AzureRedisExtensionsTests
         Assert.Equal(12455, endpoint.Port);
         Assert.Equal(ProtocolType.Tcp, endpoint.Protocol);
         Assert.Equal("tcp", endpoint.Transport);
-        Assert.Equal("tcp", endpoint.UriScheme);
+        Assert.Equal("redis", endpoint.UriScheme);
 
         Assert.True(redis.Resource.IsContainer(), "The resource should now be a container resource.");
 
         Assert.NotNull(redisResource?.PasswordParameter);
-        Assert.Equal($"localhost:12455,password=p@ssw0rd1", await redis.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None));
+        Assert.Equal($"localhost:12455,password=p@ssw0rd1,ssl=false", await redis.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None));
 
         // Test the new reference properties
         Assert.NotNull(redis.Resource.HostName);
@@ -197,11 +197,11 @@ public class AzureRedisExtensionsTests
         // Even with auto-generated password, Password and HostName should be available
         Assert.NotNull(redis.Resource.HostName);
         Assert.NotNull(redis.Resource.Password);
-        
+
         // Validate the values can be resolved
         var hostValue = await redis.Resource.HostName.GetValueAsync(CancellationToken.None);
         Assert.Equal("localhost:6379", hostValue);
-        
+
         var passwordValue = await redis.Resource.Password.GetValueAsync(CancellationToken.None);
         Assert.NotNull(passwordValue);
         Assert.NotEmpty(passwordValue);
@@ -245,7 +245,7 @@ public class AzureRedisExtensionsTests
         Assert.NotNull(redis.Resource.PasswordParameter);
 
 #pragma warning disable CS0618 // Type or member is obsolete
-        Assert.Equal($"localhost:12455,password={redis.Resource.PasswordParameter.Value}", await redis.Resource.GetConnectionStringAsync());
+        Assert.Equal($"localhost:12455,password={redis.Resource.PasswordParameter.Value},ssl=false", await redis.Resource.GetConnectionStringAsync());
 #pragma warning restore CS0618 // Type or member is obsolete
 
         var manifest = await AzureManifestUtils.GetManifestWithBicep(redis.Resource);
@@ -324,7 +324,7 @@ public class AzureRedisExtensionsTests
         // Assert - Verify that the SecretOwner is set to the Redis resource
         Assert.NotNull(redis.Resource.ConnectionStringSecretOutput);
         Assert.Same(redis.Resource, redis.Resource.ConnectionStringSecretOutput.SecretOwner);
-        
+
         // Also verify that References includes both the KeyVault and the Redis resource
         var references = ((IValueWithReferences)redis.Resource.ConnectionStringSecretOutput).References.ToList();
         Assert.Contains(redis.Resource, references);

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.MultipleAzureAppServiceEnvironmentsSupported.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.MultipleAzureAppServiceEnvironmentsSupported.verified.json
@@ -1,5 +1,5 @@
-{
-  "$schema": "https://json.schemastore.org/aspire-8.0.json",
+﻿{
+  "$schema": "https://json.schemastore.org/aspire-13.0.json",
   "resources": {
     "env1-acr": {
       "type": "azure.bicep.v0",

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.MultipleAzureContainerAppEnvironmentsSupported.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.MultipleAzureContainerAppEnvironmentsSupported.verified.json
@@ -1,5 +1,5 @@
 ﻿{
-  "$schema": "https://json.schemastore.org/aspire-8.0.json",
+  "$schema": "https://json.schemastore.org/aspire-13.0.json",
   "resources": {
     "env1-acr": {
       "type": "azure.bicep.v0",

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -162,6 +162,7 @@ export enum EndpointProperty {
     Scheme = "Scheme",
     TargetPort = "TargetPort",
     HostAndPort = "HostAndPort",
+    Tls = "Tls",
 }
 
 /** Enum type for IconVariant */
@@ -704,6 +705,16 @@ export class EndpointReference {
         get: async (): Promise<string> => {
             return await this._client.invokeCapability<string>(
                 'Aspire.Hosting.ApplicationModel/EndpointReference.url',
+                { context: this._handle }
+            );
+        },
+    };
+
+    /** Gets the Tls property */
+    tls = {
+        get: async (): Promise<boolean> => {
+            return await this._client.invokeCapability<boolean>(
+                'Aspire.Hosting.ApplicationModel/EndpointReference.tls',
                 { context: this._handle }
             );
         },

--- a/tests/Aspire.Hosting.Containers.Tests/Snapshots/WithDockerfileTests.ManifestPublishingWritesDockerfileToResourceSpecificPath.verified.json
+++ b/tests/Aspire.Hosting.Containers.Tests/Snapshots/WithDockerfileTests.ManifestPublishingWritesDockerfileToResourceSpecificPath.verified.json
@@ -1,5 +1,5 @@
 ﻿{
-  "$schema": "https://json.schemastore.org/aspire-8.0.json",
+  "$schema": "https://json.schemastore.org/aspire-13.0.json",
   "resources": {
     "testcontainer": {
       "type": "container.v1",

--- a/tests/Aspire.Hosting.Redis.Tests/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/AddRedisTests.cs
@@ -44,7 +44,7 @@ public class AddRedisTests(ITestOutputHelper testOutputHelper)
         Assert.Null(endpoint.Port);
         Assert.Equal(ProtocolType.Tcp, endpoint.Protocol);
         Assert.Equal("tcp", endpoint.Transport);
-        Assert.Equal("tcp", endpoint.UriScheme);
+        Assert.Equal("redis", endpoint.UriScheme);
 
         var containerAnnotation = Assert.Single(containerResource.Annotations.OfType<ContainerImageAnnotation>());
         Assert.Equal(RedisContainerImageTags.Tag, containerAnnotation.Tag);
@@ -72,7 +72,7 @@ public class AddRedisTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(9813, endpoint.Port);
         Assert.Equal(ProtocolType.Tcp, endpoint.Protocol);
         Assert.Equal("tcp", endpoint.Transport);
-        Assert.Equal("tcp", endpoint.UriScheme);
+        Assert.Equal("redis", endpoint.UriScheme);
 
         var containerAnnotation = Assert.Single(containerResource.Annotations.OfType<ContainerImageAnnotation>());
         Assert.Equal(RedisContainerImageTags.Tag, containerAnnotation.Tag);
@@ -94,7 +94,7 @@ public class AddRedisTests(ITestOutputHelper testOutputHelper)
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<IResourceWithConnectionString>());
-        Assert.Equal("{myRedis.bindings.tcp.host}:{myRedis.bindings.tcp.port},password={pass.value}", connectionStringResource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{myRedis.bindings.tcp.host}:{myRedis.bindings.tcp.port},password={pass.value},ssl=false", connectionStringResource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -111,7 +111,7 @@ public class AddRedisTests(ITestOutputHelper testOutputHelper)
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<IResourceWithConnectionString>());
-        Assert.Equal("{myRedis.bindings.tcp.host}:{myRedis.bindings.tcp.port},password={pass.value}", connectionStringResource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{myRedis.bindings.tcp.host}:{myRedis.bindings.tcp.port},password={pass.value},ssl=false", connectionStringResource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -127,7 +127,7 @@ public class AddRedisTests(ITestOutputHelper testOutputHelper)
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<IResourceWithConnectionString>());
         var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
-        Assert.Equal("{myRedis.bindings.tcp.host}:{myRedis.bindings.tcp.port},password={myRedis-password.value}", connectionStringResource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{myRedis.bindings.tcp.host}:{myRedis.bindings.tcp.port},password={myRedis-password.value},ssl=false", connectionStringResource.ConnectionStringExpression.ValueExpression);
         Assert.StartsWith("localhost:2000", connectionString);
     }
 
@@ -142,7 +142,7 @@ public class AddRedisTests(ITestOutputHelper testOutputHelper)
         var expectedManifest = $$"""
             {
               "type": "container.v0",
-              "connectionString": "{redis.bindings.tcp.host}:{redis.bindings.tcp.port},password={redis-password.value}",
+              "connectionString": "{redis.bindings.tcp.host}:{redis.bindings.tcp.port},password={redis-password.value},ssl=false",
               "image": "{{RedisContainerImageTags.Registry}}/{{RedisContainerImageTags.Image}}:{{RedisContainerImageTags.Tag}}",
               "entrypoint": "/bin/sh",
               "args": [
@@ -154,7 +154,7 @@ public class AddRedisTests(ITestOutputHelper testOutputHelper)
               },
               "bindings": {
                 "tcp": {
-                  "scheme": "tcp",
+                  "scheme": "redis",
                   "protocol": "tcp",
                   "transport": "tcp",
                   "targetPort": 6379
@@ -176,7 +176,7 @@ public class AddRedisTests(ITestOutputHelper testOutputHelper)
         var expectedManifest = $$"""
             {
               "type": "container.v0",
-              "connectionString": "{redis.bindings.tcp.host}:{redis.bindings.tcp.port}",
+              "connectionString": "{redis.bindings.tcp.host}:{redis.bindings.tcp.port},ssl=false",
               "image": "{{RedisContainerImageTags.Registry}}/{{RedisContainerImageTags.Image}}:{{RedisContainerImageTags.Tag}}",
               "entrypoint": "/bin/sh",
               "args": [
@@ -185,7 +185,7 @@ public class AddRedisTests(ITestOutputHelper testOutputHelper)
               ],
               "bindings": {
                 "tcp": {
-                  "scheme": "tcp",
+                  "scheme": "redis",
                   "protocol": "tcp",
                   "transport": "tcp",
                   "targetPort": 6379
@@ -211,7 +211,7 @@ public class AddRedisTests(ITestOutputHelper testOutputHelper)
         var expectedManifest = $$"""
             {
               "type": "container.v0",
-              "connectionString": "{redis.bindings.tcp.host}:{redis.bindings.tcp.port},password={pass.value}",
+              "connectionString": "{redis.bindings.tcp.host}:{redis.bindings.tcp.port},password={pass.value},ssl=false",
               "image": "{{RedisContainerImageTags.Registry}}/{{RedisContainerImageTags.Image}}:{{RedisContainerImageTags.Tag}}",
               "entrypoint": "/bin/sh",
               "args": [
@@ -223,7 +223,7 @@ public class AddRedisTests(ITestOutputHelper testOutputHelper)
               },
               "bindings": {
                 "tcp": {
-                  "scheme": "tcp",
+                  "scheme": "redis",
                   "protocol": "tcp",
                   "transport": "tcp",
                   "targetPort": 6379
@@ -246,7 +246,7 @@ public class AddRedisTests(ITestOutputHelper testOutputHelper)
         var expectedManifest = $$"""
             {
               "type": "container.v0",
-              "connectionString": "{redis.bindings.tcp.host}:{redis.bindings.tcp.port},password={pass.value}",
+              "connectionString": "{redis.bindings.tcp.host}:{redis.bindings.tcp.port},password={pass.value},ssl=false",
               "image": "{{RedisContainerImageTags.Registry}}/{{RedisContainerImageTags.Image}}:{{RedisContainerImageTags.Tag}}",
               "entrypoint": "/bin/sh",
               "args": [
@@ -258,7 +258,7 @@ public class AddRedisTests(ITestOutputHelper testOutputHelper)
               },
               "bindings": {
                 "tcp": {
-                  "scheme": "tcp",
+                  "scheme": "redis",
                   "protocol": "tcp",
                   "transport": "tcp",
                   "targetPort": 6379
@@ -476,13 +476,13 @@ public class AddRedisTests(ITestOutputHelper testOutputHelper)
         var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
         if (withPassword)
         {
-            Assert.Equal("{myRedis.bindings.tcp.host}:{myRedis.bindings.tcp.port},password={pass.value}", connectionStringResource.ConnectionStringExpression.ValueExpression);
-            Assert.Equal($"localhost:5001,password={password}", connectionString);
+            Assert.Equal("{myRedis.bindings.tcp.host}:{myRedis.bindings.tcp.port},password={pass.value},ssl=false", connectionStringResource.ConnectionStringExpression.ValueExpression);
+            Assert.Equal($"localhost:5001,password={password},ssl=false", connectionString);
         }
         else
         {
-            Assert.Equal("{myRedis.bindings.tcp.host}:{myRedis.bindings.tcp.port}", connectionStringResource.ConnectionStringExpression.ValueExpression);
-            Assert.Equal($"localhost:5001", connectionString);
+            Assert.Equal("{myRedis.bindings.tcp.host}:{myRedis.bindings.tcp.port},ssl=false", connectionStringResource.ConnectionStringExpression.ValueExpression);
+            Assert.Equal($"localhost:5001,ssl=false", connectionString);
         }
     }
 
@@ -703,7 +703,7 @@ public class AddRedisTests(ITestOutputHelper testOutputHelper)
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<IResourceWithConnectionString>());
         var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
-        Assert.Equal("{myRedis.bindings.tcp.host}:{myRedis.bindings.tcp.port},password={pass.value}", connectionStringResource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{myRedis.bindings.tcp.host}:{myRedis.bindings.tcp.port},password={pass.value},ssl=false", connectionStringResource.ConnectionStringExpression.ValueExpression);
         Assert.StartsWith($"localhost:5001,password={password}", connectionString);
     }
 

--- a/tests/Aspire.Hosting.Redis.Tests/ConnectionPropertiesTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/ConnectionPropertiesTests.cs
@@ -10,7 +10,7 @@ public class ConnectionPropertiesTests
     [Fact]
     public void RedisResourceGetConnectionPropertiesReturnsExpectedValues()
     {
-    var password = new ParameterResource("password", _ => "p@ssw0rd1", secret: true);
+        var password = new ParameterResource("password", _ => "p@ssw0rd1", secret: true);
         var resource = new RedisResource("redis", password);
 
         var properties = ((IResourceWithConnectionString)resource).GetConnectionProperties().ToArray();
@@ -34,7 +34,7 @@ public class ConnectionPropertiesTests
             property =>
             {
                 Assert.Equal("Uri", property.Key);
-                Assert.Equal("redis://:{password.value}@{redis.bindings.tcp.host}:{redis.bindings.tcp.port}", property.Value.ValueExpression);
+                Assert.Equal("{redis.bindings.tcp.scheme}://:{password.value}@{redis.bindings.tcp.host}:{redis.bindings.tcp.port}", property.Value.ValueExpression);
             });
     }
 }

--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -51,7 +51,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="$(RepoRoot)src\Schema\aspire-8.0.json" Link="Schema\aspire-8.0.json">
+    <Content Include="$(RepoRoot)src\Schema\aspire-13.0.json" Link="Schema\aspire-13.0.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -229,7 +229,7 @@ public class ManifestGenerationTests(ITestOutputHelper testOutputHelper)
 
         var container = resources.GetProperty("rediscontainer");
         Assert.Equal("container.v0", container.GetProperty("type").GetString());
-        Assert.Equal("{rediscontainer.bindings.tcp.host}:{rediscontainer.bindings.tcp.port},password={rediscontainer-password.value}", container.GetProperty("connectionString").GetString());
+        Assert.Equal("{rediscontainer.bindings.tcp.host}:{rediscontainer.bindings.tcp.port},password={rediscontainer-password.value},ssl=false", container.GetProperty("connectionString").GetString());
     }
 
     [Fact]
@@ -406,7 +406,7 @@ public class ManifestGenerationTests(ITestOutputHelper testOutputHelper)
                 },
                 "redis": {
                   "type": "container.v0",
-                  "connectionString": "{redis.bindings.tcp.host}:{redis.bindings.tcp.port},password={redis-password.value}",
+                  "connectionString": "{redis.bindings.tcp.host}:{redis.bindings.tcp.port},password={redis-password.value},ssl=false",
                   "image": "{{ComponentTestConstants.AspireTestContainerRegistry}}/{{RedisContainerImageTags.Image}}:{{RedisContainerImageTags.Tag}}",
                   "entrypoint": "/bin/sh",
                   "args": [
@@ -557,10 +557,10 @@ public class ManifestGenerationTests(ITestOutputHelper testOutputHelper)
 
         // Create a destination container with ContainerFilesDestinationAnnotation
         var destContainer = builder.AddContainer("dest", "nginx:alpine")
-            .WithAnnotation(new ContainerFilesDestinationAnnotation 
-            { 
-                Source = sourceContainer.Resource, 
-                DestinationPath = "/usr/share/nginx/html" 
+            .WithAnnotation(new ContainerFilesDestinationAnnotation
+            {
+                Source = sourceContainer.Resource,
+                DestinationPath = "/usr/share/nginx/html"
             });
 
         builder.Build().Run();
@@ -600,10 +600,10 @@ public class ManifestGenerationTests(ITestOutputHelper testOutputHelper)
 
         // Create a destination container with ContainerFilesDestinationAnnotation
         var destContainer = builder.AddContainer("dest", "nginx:alpine")
-            .WithAnnotation(new ContainerFilesDestinationAnnotation 
-            { 
-                Source = sourceContainer.Resource, 
-                DestinationPath = "/usr/share/nginx/html" 
+            .WithAnnotation(new ContainerFilesDestinationAnnotation
+            {
+                Source = sourceContainer.Resource,
+                DestinationPath = "/usr/share/nginx/html"
             });
 
         builder.Build().Run();
@@ -646,15 +646,15 @@ public class ManifestGenerationTests(ITestOutputHelper testOutputHelper)
 
         // Create a destination container with multiple ContainerFilesDestinationAnnotations
         var destContainer = builder.AddContainer("dest", "nginx:alpine")
-            .WithAnnotation(new ContainerFilesDestinationAnnotation 
-            { 
-                Source = source1.Resource, 
-                DestinationPath = "/usr/share/nginx/html" 
+            .WithAnnotation(new ContainerFilesDestinationAnnotation
+            {
+                Source = source1.Resource,
+                DestinationPath = "/usr/share/nginx/html"
             })
-            .WithAnnotation(new ContainerFilesDestinationAnnotation 
-            { 
-                Source = source2.Resource, 
-                DestinationPath = "/usr/share/nginx/assets" 
+            .WithAnnotation(new ContainerFilesDestinationAnnotation
+            {
+                Source = source2.Resource,
+                DestinationPath = "/usr/share/nginx/assets"
             });
 
         builder.Build().Run();

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -381,7 +381,7 @@ public class ManifestGenerationTests(ITestOutputHelper testOutputHelper)
                     "REDIS_HOST": "{redis.bindings.tcp.host}",
                     "REDIS_PORT": "{redis.bindings.tcp.port}",
                     "REDIS_PASSWORD": "{redis-password.value}",
-                    "REDIS_URI": "redis://:{redis-password-uri-encoded.value}@{redis.bindings.tcp.host}:{redis.bindings.tcp.port}",
+                    "REDIS_URI": "{redis.bindings.tcp.scheme}://:{redis-password-uri-encoded.value}@{redis.bindings.tcp.host}:{redis.bindings.tcp.port}",
                     "ConnectionStrings__postgresdb": "{postgresdb.connectionString}",
                     "POSTGRESDB_HOST": "{postgres.bindings.tcp.host}",
                     "POSTGRESDB_PORT": "{postgres.bindings.tcp.port}",
@@ -418,7 +418,7 @@ public class ManifestGenerationTests(ITestOutputHelper testOutputHelper)
                   },
                   "bindings": {
                     "tcp": {
-                      "scheme": "tcp",
+                      "scheme": "redis",
                       "protocol": "tcp",
                       "transport": "tcp",
                       "targetPort": 6379

--- a/tests/Aspire.Hosting.Tests/Schema/SchemaTests.cs
+++ b/tests/Aspire.Hosting.Tests/Schema/SchemaTests.cs
@@ -215,7 +215,7 @@ public class SchemaTests
     {
         if (s_schema == null)
         {
-            var relativePath = Path.Combine("Schema", "aspire-8.0.json");
+            var relativePath = Path.Combine("Schema", "aspire-13.0.json");
             var schemaPath = Path.GetFullPath(relativePath);
             s_schema = JsonSchema.FromFile(schemaPath);
         }


### PR DESCRIPTION
## Description

Introduce a new `Tls` `EndpointProperty` to enable resolving whether an endpoint is TLS enabled via `ReferenceExpression` (resolves to `true` or `false` depending on whether an endpoint is TLS enabled). HTTPS endpoints are automatically considered TLS enabled, while non-HTTP TCP endpoints require TLS to be explicitly enabled on the endpoint.

This is a bit of a brute force approach, but several different connection strings need a boolean value to indicate whether a connection uses TLS or not, but there's currently timing issues where we may not know if an endpoint is actually TLS terminated when a connection string is requested. We need some kind of value provider to correctly populate connection strings in these cases.

I also took the opportunity to update the redis connection string to use `redis` and `rediss` schemes instead of `tcp` to make generating URI style connection strings more straightforward.

Fixes #13645