### PR TITLE
Fix race in RabbitMQEventSourceListener

### DIFF
--- a/src/Components/Aspire.RabbitMQ.Client/RabbitMQEventSourceLogForwarder.cs
+++ b/src/Components/Aspire.RabbitMQ.Client/RabbitMQEventSourceLogForwarder.cs
@@ -127,7 +127,8 @@ internal sealed class RabbitMQEventSourceLogForwarder : IDisposable
     /// </summary>
     private sealed class RabbitMQEventSourceListener : EventListener
     {
-        private readonly List<EventSource> _eventSources = new List<EventSource>();
+        // This must be initialized here so it is available before the base constructor is called.
+        private readonly List<EventSource> _eventSources = [];
 
         private readonly Action<EventWrittenEventArgs> _log;
         private readonly EventLevel _level;
@@ -137,6 +138,7 @@ internal sealed class RabbitMQEventSourceLogForwarder : IDisposable
             _log = log;
             _level = level;
 
+            // Enable any event sources that were created before this listener.
             foreach (EventSource eventSource in _eventSources)
             {
                 OnEventSourceCreated(eventSource);
@@ -145,13 +147,17 @@ internal sealed class RabbitMQEventSourceLogForwarder : IDisposable
             _eventSources.Clear();
         }
 
+        // This is called from the base constructor and so _log and _level may not be initialized yet.
+        // https://github.com/dotnet/runtime/blob/15663b5a44d507e0c120f88b6e2e96f977ceac90/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs#L4153-L4158
         protected sealed override void OnEventSourceCreated(EventSource eventSource)
         {
             base.OnEventSourceCreated(eventSource);
 
+            // Log will be null during base constructor call. Store registered event source to enable later when class is initialized.
             if (_log == null)
             {
                 _eventSources.Add(eventSource);
+                return;
             }
 
             if (eventSource.Name == "rabbitmq-dotnet-client" || eventSource.Name == "rabbitmq-client")

--- a/src/Components/Aspire.RabbitMQ.Client/RabbitMQEventSourceLogForwarder.cs
+++ b/src/Components/Aspire.RabbitMQ.Client/RabbitMQEventSourceLogForwarder.cs
@@ -151,6 +151,12 @@ internal sealed class RabbitMQEventSourceLogForwarder : IDisposable
         // https://github.com/dotnet/runtime/blob/15663b5a44d507e0c120f88b6e2e96f977ceac90/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs#L4153-L4158
         protected sealed override void OnEventSourceCreated(EventSource eventSource)
         {
+            // Defensive check for being passed a event source.
+            if (eventSource == null)
+            {
+                return;
+            }
+
             base.OnEventSourceCreated(eventSource);
 
             // Log will be null during base constructor call. Store registered event source to enable later when class is initialized.

--- a/src/Components/Aspire.RabbitMQ.Client/RabbitMQEventSourceLogForwarder.cs
+++ b/src/Components/Aspire.RabbitMQ.Client/RabbitMQEventSourceLogForwarder.cs
@@ -138,7 +138,7 @@ internal sealed class RabbitMQEventSourceLogForwarder : IDisposable
             _log = log;
             _level = level;
 
-            // Enable any event sources that were created before this listener.
+            // Enable any event sources that were created before this listener. Safe to do now that _level is set.
             foreach (EventSource eventSource in _eventSources)
             {
                 OnEventSourceCreated(eventSource);


### PR DESCRIPTION
## Description

I had a build fail with this error:

```
System.NullReferenceException : Object reference not set to an instance of an object.   at Aspire.RabbitMQ.Client.RabbitMQEventSourceLogForwarder.RabbitMQEventSourceListener.OnEventSourceCreated(EventSource eventSource) in /_/src/Components/Aspire.RabbitMQ.Client/RabbitMQEventSourceLogForwarder.cs:line 157
   at Aspire.RabbitMQ.Client.RabbitMQEventSourceLogForwarder.RabbitMQEventSourceListener..ctor(Action`1 log, EventLevel level) in /_/src/Components/Aspire.RabbitMQ.Client/RabbitMQEventSourceLogForwarder.cs:line 142
   at Aspire.RabbitMQ.Client.RabbitMQEventSourceLogForwarder.Start() in /_/src/Components/Aspire.RabbitMQ.Client/RabbitMQEventSourceLogForwarder.cs:line 28
   at Aspire.RabbitMQ.Client.Tests.AspireRabbitMQLoggingTests.TestExceptionWithInnerException() in /_/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs:line 162
   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```

I'm not 100% certain what the cause is, it seems like the EventSource is null, but that shouldn't be possible. I did notice that EnableEvents was being called before the type was full initialized. PR to fix.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
