### PR TITLE
Include logging with CLI test output

### DIFF
--- a/tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj
+++ b/tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <Compile Include="$(TestsSharedDir)TestModuleInitializer.cs" Link="shared/TestModuleInitializer.cs" />
+    <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" Link="shared/AsyncTestHelpers.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -13,6 +13,7 @@ using Aspire.Cli.Templating;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.TestUtilities;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
@@ -40,8 +41,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     public async Task NewCommandInteractiveFlowSmokeTest()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options => {
-
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
             // Set of options that we'll give when prompted.
             options.NewCommandPrompterFactory = (sp) =>
             {
@@ -75,7 +76,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var command = provider.GetRequiredService<NewCommand>();
         var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
 
-        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(0, exitCode);
     }
 

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -396,7 +396,7 @@ internal sealed class TestOutputTextWriter : TextWriter
 
     public override void WriteLine(string? message)
     {
-        _outputHelper.WriteLine("CLI stdout: " + message);
+        _outputHelper.WriteLine(message!);
         if (message is not null)
         {
             Logs.Add(message);

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -67,7 +67,7 @@ internal static class CliTestHelper
         var configuration = configBuilder.Build();
         services.AddSingleton<IConfiguration>(configuration);
 
-        services.AddLogging().AddXunitLogging(outputHelper);
+        services.AddLogging(b => b.SetMinimumLevel(LogLevel.Trace)).AddXunitLogging(outputHelper);
 
         services.AddMemoryCache();
 

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -67,7 +67,7 @@ internal static class CliTestHelper
         var configuration = configBuilder.Build();
         services.AddSingleton<IConfiguration>(configuration);
 
-        services.AddLogging();
+        services.AddLogging().AddXunitLogging(outputHelper);
 
         services.AddMemoryCache();
 
@@ -396,7 +396,7 @@ internal sealed class TestOutputTextWriter : TextWriter
 
     public override void WriteLine(string? message)
     {
-        _outputHelper.WriteLine(message!);
+        _outputHelper.WriteLine("CLI stdout: " + message);
         if (message is not null)
         {
             Logs.Add(message);


### PR DESCRIPTION
Minor change to include logger messages in test output. It's kind of messy because it is mixed together with CLI stdout but the CLI stdout is already messy from ANSI control codes 🤷

@davidfowl @mitchdenny I noticed all the tests use `WaitAsync(CliTestConstants.DefaultTimeout)` instead of `DefaultTimeout()`. Any objections with replacing them all with `DefaultTimeout()`? It has a longer delay for CLI, prints out line information, and doesn't timeout when the debugger is attached.