### PR TITLE
Add utility method to compute resource dependencies

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceDependencyDiscoveryMode.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceDependencyDiscoveryMode.cs
@@ -12,7 +12,7 @@ public enum ResourceDependencyDiscoveryMode
     /// Discover the full transitive closure of all dependencies.
     /// This includes direct dependencies and all dependencies of those dependencies, recursively.
     /// </summary>
-    TransitiveClosure,
+    Recursive,
 
     /// <summary>
     /// Discover only direct dependencies.

--- a/src/Aspire.Hosting/ApplicationModel/ResourceDependencyDiscoveryMode.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceDependencyDiscoveryMode.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Specifies how resource dependencies are discovered.
+/// </summary>
+public enum ResourceDependencyDiscoveryMode
+{
+    /// <summary>
+    /// Discover the full transitive closure of all dependencies.
+    /// This includes direct dependencies and all dependencies of those dependencies, recursively.
+    /// </summary>
+    TransitiveClosure,
+
+    /// <summary>
+    /// Discover only direct dependencies.
+    /// This includes dependencies from annotations (parent, wait, connection string redirect)
+    /// and from environment variables and command-line arguments, but does not recurse
+    /// into the dependencies of those dependencies.
+    /// </summary>
+    DirectOnly
+}

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -1192,4 +1192,223 @@ public static class ResourceExtensions
         var resourceLoggerService = serviceProvider.GetRequiredService<ResourceLoggerService>();
         return resourceLoggerService.GetLogger(resource);
     }
+
+    /// <summary>
+    /// Computes the set of resources that the specified <paramref name="resource"/> depends on.
+    /// </summary>
+    /// <param name="resource">The resource to compute dependencies for.</param>
+    /// <param name="executionContext">The execution context for resolving environment variables and arguments.</param>
+    /// <param name="mode">Specifies whether to discover only direct dependencies or the full transitive closure.</param>
+    /// <param name="cancellationToken">A cancellation token to observe while computing dependencies.</param>
+    /// <returns>A set of all resources that the specified resource depends on.</returns>
+    /// <remarks>
+    /// <para>
+    /// Dependencies are computed from multiple sources:
+    /// <list type="bullet">
+    /// <item>Parent resources via <see cref="IResourceWithParent"/></item>
+    /// <item>Wait dependencies via <see cref="WaitAnnotation"/></item>
+    /// <item>Connection string redirects via <see cref="ConnectionStringRedirectAnnotation"/></item>
+    /// <item>References to endpoints in environment variables and command-line arguments (via <see cref="IValueWithReferences"/>)</item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// When <paramref name="mode"/> is <see cref="ResourceDependencyDiscoveryMode.DirectOnly"/>, only the immediate
+    /// dependencies are returned. When <paramref name="mode"/> is <see cref="ResourceDependencyDiscoveryMode.TransitiveClosure"/>,
+    /// all transitive dependencies are included.
+    /// </para>
+    /// <para>
+    /// This method invokes environment variable and command-line argument callbacks to discover all references. The context resource (<paramref name="resource"/>) is not considered a dependency (even if it is transitively referenced).
+    /// </para>
+    /// </remarks>
+    public static async Task<IReadOnlySet<IResource>> GetResourceDependenciesAsync(
+        this IResource resource,
+        DistributedApplicationExecutionContext executionContext,
+        ResourceDependencyDiscoveryMode mode = ResourceDependencyDiscoveryMode.TransitiveClosure,
+        CancellationToken cancellationToken = default)
+    {
+        var dependencies = await GatherDirectDependenciesAsync(resource, [], executionContext, cancellationToken).ConfigureAwait(false);
+
+        if (mode == ResourceDependencyDiscoveryMode.TransitiveClosure)
+        {
+            // Compute transitive closure by recursively processing dependencies
+            var toProcess = new Queue<IResource>(dependencies);
+            while (toProcess.Count > 0)
+            {
+                var dep = toProcess.Dequeue();
+
+                var newDependencies = await GatherDirectDependenciesAsync(dep, dependencies, executionContext, cancellationToken).ConfigureAwait(false);
+
+                foreach (var newDep in newDependencies)
+                {
+                    if (newDep != resource)
+                    {
+                        toProcess.Enqueue(newDep);
+                    }
+                }
+            }
+        }
+
+        // Ensure the input resource is not in its own dependency set, even if referenced transitively.
+        dependencies.Remove(resource);
+
+        return dependencies;
+    }
+
+    /// <summary>
+    /// Gathers direct dependencies of a given resource.
+    /// </summary>
+    /// <returns>
+    /// Newly discovered dependencies (not already in <paramref name="dependencies"/>).
+    /// </returns>
+    private static async Task<HashSet<IResource>> GatherDirectDependenciesAsync(
+        IResource resource,
+        HashSet<IResource> dependencies,
+        DistributedApplicationExecutionContext executionContext,
+        CancellationToken cancellationToken)
+    {
+        var visited = new HashSet<object>();
+
+        // Collect direct dependencies from annotations
+        var newDependencies = CollectAnnotationDependencies(resource, dependencies);
+
+        // Collect raw (unresolved) environment variable and argument values
+        var rawValues = await GatherRawEnvironmentAndArgumentValuesAsync(resource, executionContext, cancellationToken).ConfigureAwait(false);
+
+        foreach (var value in rawValues)
+        {
+            newDependencies.UnionWith(CollectDependenciesFromValue(value, dependencies, visited));
+        }
+
+        return newDependencies;
+    }
+
+    /// <summary>
+    /// Gathers raw (unresolved) environment variable and argument values from a resource.
+    /// </summary>
+    private static async Task<List<object>> GatherRawEnvironmentAndArgumentValuesAsync(
+        IResource resource,
+        DistributedApplicationExecutionContext executionContext,
+        CancellationToken cancellationToken)
+    {
+        var rawValues = new List<object>();
+
+        // Gather environment variable values
+        if (resource.TryGetEnvironmentVariables(out var environmentCallbacks))
+        {
+            var envVars = new Dictionary<string, object>();
+            var context = new EnvironmentCallbackContext(executionContext, resource, envVars, cancellationToken);
+
+            foreach (var callback in environmentCallbacks)
+            {
+                await callback.Callback(context).ConfigureAwait(false);
+            }
+
+            rawValues.AddRange(envVars.Values);
+        }
+
+        // Gather command-line argument values
+        if (resource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var argsCallbacks))
+        {
+            var args = new List<object>();
+            var context = new CommandLineArgsCallbackContext(args, resource, cancellationToken)
+            {
+                ExecutionContext = executionContext
+            };
+
+            foreach (var callback in argsCallbacks)
+            {
+                await callback.Callback(context).ConfigureAwait(false);
+            }
+
+            rawValues.AddRange(args);
+        }
+
+        return rawValues;
+    }
+
+    /// <summary>
+    /// Collects dependencies from resource annotations (parent, wait, connection string redirect).
+    /// </summary>
+    /// <returns>A set of newly collected dependencies added to <paramref name="dependencies"/>.</returns>
+    private static HashSet<IResource> CollectAnnotationDependencies(IResource resource, HashSet<IResource> dependencies)
+    {
+        var newDependencies = new HashSet<IResource>();
+
+        // Parent relationship
+        if (resource is IResourceWithParent resourceWithParent)
+        {
+            if (dependencies.Add(resourceWithParent.Parent))
+            {
+                newDependencies.Add(resourceWithParent.Parent);
+            }
+        }
+
+        // Wait annotations
+        if (resource.TryGetAnnotationsOfType<WaitAnnotation>(out var waitAnnotations))
+        {
+            foreach (var waitAnnotation in waitAnnotations)
+            {
+                if (dependencies.Add(waitAnnotation.Resource))
+                {
+                    newDependencies.Add(waitAnnotation.Resource);
+                }
+            }
+        }
+
+        // Connection string redirect
+        if (resource.TryGetLastAnnotation<ConnectionStringRedirectAnnotation>(out var redirectAnnotation))
+        {
+            if (dependencies.Add(redirectAnnotation.Resource))
+            {
+                newDependencies.Add(redirectAnnotation.Resource);
+            }
+        }
+
+        return newDependencies;
+    }
+
+    /// <summary>
+    /// Recursively collects resource dependencies from a value using <see cref="IValueWithReferences"/>.
+    /// </summary>
+    private static HashSet<IResource> CollectDependenciesFromValue(object? value, HashSet<IResource> dependencies, HashSet<object> visited)
+    {
+        if (value is null || !visited.Add(value))
+        {
+            return [];
+        }
+
+        var newDependencies = new HashSet<IResource>();
+
+        // Direct resource references
+        if (value is IResource resource)
+        {
+            if (dependencies.Add(resource))
+            {
+                newDependencies.Add(resource);
+            }
+            newDependencies.UnionWith(CollectAnnotationDependencies(resource, dependencies));
+        }
+
+        // Resource builder wrapping a resource
+        if (value is IResourceBuilder<IResource> resourceBuilder)
+        {
+            if (dependencies.Add(resourceBuilder.Resource))
+            {
+                newDependencies.Add(resourceBuilder.Resource);
+            }
+            newDependencies.UnionWith(CollectAnnotationDependencies(resourceBuilder.Resource, dependencies));
+            value = resourceBuilder.Resource;
+        }
+
+        // Recurse through IValueWithReferences
+        if (value is IValueWithReferences valueWithReferences)
+        {
+            foreach (var reference in valueWithReferences.References)
+            {
+                newDependencies.UnionWith(CollectDependenciesFromValue(reference, dependencies, visited));
+            }
+        }
+
+        return newDependencies;
+    }
 }

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -132,7 +132,7 @@ public sealed class ParameterProcessor(
                 continue;
             }
 
-            var dependencies = await resource.GetResourceDependenciesAsync(executionContext, ResourceDependencyDiscoveryMode.TransitiveClosure, cancellationToken).ConfigureAwait(false);
+            var dependencies = await resource.GetResourceDependenciesAsync(executionContext, ResourceDependencyDiscoveryMode.Recursive, cancellationToken).ConfigureAwait(false);
             foreach (var parameter in dependencies.OfType<ParameterResource>())
             {
                 referencedParameters.TryAdd(parameter.Name, parameter);

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -103,9 +103,8 @@ public sealed class ParameterProcessor(
     public async Task InitializeParametersAsync(DistributedApplicationModel model, bool waitForResolution = false, CancellationToken cancellationToken = default)
     {
         var referencedParameters = new Dictionary<string, ParameterResource>();
-        var currentDependencySet = new HashSet<object?>();
 
-        await CollectDependentParameterResourcesAsync(model, referencedParameters, currentDependencySet, cancellationToken).ConfigureAwait(false);
+        await CollectDependentParameterResourcesAsync(model, referencedParameters, cancellationToken).ConfigureAwait(false);
 
         // Combine explicit parameters with dependent parameters
         var explicitParameters = model.Resources.OfType<ParameterResource>();
@@ -124,7 +123,7 @@ public sealed class ParameterProcessor(
         }
     }
 
-    private async Task CollectDependentParameterResourcesAsync(DistributedApplicationModel model, Dictionary<string, ParameterResource> referencedParameters, HashSet<object?> currentDependencySet, CancellationToken cancellationToken)
+    private async Task CollectDependentParameterResourcesAsync(DistributedApplicationModel model, Dictionary<string, ParameterResource> referencedParameters, CancellationToken cancellationToken)
     {
         foreach (var resource in model.Resources)
         {
@@ -133,41 +132,11 @@ public sealed class ParameterProcessor(
                 continue;
             }
 
-            await ProcessResourceDependenciesAsync(resource, executionContext, referencedParameters, currentDependencySet, cancellationToken).ConfigureAwait(false);
-        }
-    }
-
-    private async Task ProcessResourceDependenciesAsync(IResource resource, DistributedApplicationExecutionContext executionContext, Dictionary<string, ParameterResource> referencedParameters, HashSet<object?> currentDependencySet, CancellationToken cancellationToken)
-    {
-        // Process the resource's execution configuration to find referenced parameters
-        var executionConfgiuration = await ExecutionConfigurationBuilder.Create(resource)
-            .WithArgumentsConfig()
-            .WithEnvironmentVariablesConfig()
-            .BuildAsync(executionContext, logger, cancellationToken).ConfigureAwait(false);
-
-        foreach (var reference in executionConfgiuration.References)
-        {
-            TryAddDependentParameters(reference, referencedParameters, currentDependencySet);
-        }
-    }
-
-    private static void TryAddDependentParameters(object? value, Dictionary<string, ParameterResource> referencedParameters, HashSet<object?> currentDependencySet)
-    {
-        if (value is ParameterResource parameter)
-        {
-            referencedParameters.TryAdd(parameter.Name, parameter);
-        }
-        else if (value is IValueWithReferences objectWithReferences)
-        {
-            currentDependencySet.Add(value);
-            foreach (var dependency in objectWithReferences.References)
+            var dependencies = await resource.GetResourceDependenciesAsync(executionContext, ResourceDependencyDiscoveryMode.TransitiveClosure, cancellationToken).ConfigureAwait(false);
+            foreach (var parameter in dependencies.OfType<ParameterResource>())
             {
-                if (!currentDependencySet.Contains(dependency))
-                {
-                    TryAddDependentParameters(dependency, referencedParameters, currentDependencySet);
-                }
+                referencedParameters.TryAdd(parameter.Name, parameter);
             }
-            currentDependencySet.Remove(value);
         }
     }
 

--- a/tests/Aspire.Hosting.Tests/ResourceDependencyTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceDependencyTests.cs
@@ -1,0 +1,547 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting.Tests;
+
+public class ResourceDependencyTests
+{
+    [Fact]
+    public async Task DirectReferenceViaWithReferenceIsIncluded()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var redis = builder.AddRedis("redis");
+        var container = builder.AddContainer("container", "alpine")
+            .WithReference(redis);
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await container.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(redis.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task EndpointReferenceViaWithEnvironmentIsIncluded()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var api = builder.AddContainer("api", "alpine")
+            .WithHttpEndpoint(5000, 5000, "http");
+
+        var frontend = builder.AddContainer("frontend", "alpine")
+            .WithEnvironment("API_URL", api.GetEndpoint("http"));
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await frontend.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(api.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task EndpointPropertyReferenceIsIncluded()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var api = builder.AddContainer("api", "alpine")
+            .WithHttpEndpoint(5000, 5000, "http");
+
+        var frontend = builder.AddContainer("frontend", "alpine")
+            .WithEnvironment("API_PORT", api.GetEndpoint("http").Property(EndpointProperty.Port));
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await frontend.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(api.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task ConnectionStringReferenceIsIncluded()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var postgres = builder.AddPostgres("postgres");
+        var db = postgres.AddDatabase("db");
+
+        var container = builder.AddContainer("container", "alpine")
+            .WithReference(db);
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await container.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(db.Resource, dependencies);
+        Assert.Contains(postgres.Resource, dependencies); // Parent of db
+    }
+
+    [Fact]
+    public async Task ConnectionStringRedirectIsIncluded()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var redis = builder.AddRedis("redis");
+        var redirect = builder.AddRedis("redirect")
+            .WithConnectionStringRedirection(redis.Resource);
+
+        var container = builder.AddContainer("container", "alpine")
+            .WithReference(redirect);
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await container.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(redirect.Resource, dependencies);
+        Assert.Contains(redis.Resource, dependencies); // The redirect target
+    }
+
+    [Fact]
+    public async Task ParentRelationshipIsIncluded()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var postgres = builder.AddPostgres("postgres");
+        var db = postgres.AddDatabase("db");
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await db.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(postgres.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task WaitForDependencyIsIncluded()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var redis = builder.AddRedis("redis");
+        var container = builder.AddContainer("container", "alpine")
+            .WaitFor(redis);
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await container.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(redis.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task WaitForCompletionDependencyIsIncluded()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var initContainer = builder.AddContainer("init", "alpine");
+        var mainContainer = builder.AddContainer("main", "alpine")
+            .WaitForCompletion(initContainer);
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await mainContainer.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(initContainer.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task ParameterInEnvironmentIsIncluded()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var param = builder.AddParameter("apiKey");
+        var container = builder.AddContainer("container", "alpine")
+            .WithEnvironment("API_KEY", param);
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await container.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(param.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task ParameterInArgsIsIncluded()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var param = builder.AddParameter("config");
+        var exe = builder.AddExecutable("app", "myapp", ".")
+            .WithArgs(param);
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await exe.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(param.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task ReferenceExpressionWithMultipleResourcesIncludesAll()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var host = builder.AddParameter("host");
+        var port = builder.AddParameter("port");
+        var password = builder.AddParameter("password", secret: true);
+
+        var container = builder.AddContainer("container", "alpine")
+            .WithEnvironment("CONNECTION", ReferenceExpression.Create($"Host={host};Port={port};Password={password}"));
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await container.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(host.Resource, dependencies);
+        Assert.Contains(port.Resource, dependencies);
+        Assert.Contains(password.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task TransitiveDependenciesAreIncluded()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // A -> B -> C via WaitFor
+        var c = builder.AddRedis("c");
+        var b = builder.AddContainer("b", "alpine")
+            .WaitFor(c);
+        var a = builder.AddContainer("a", "alpine")
+            .WaitFor(b);
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await a.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(b.Resource, dependencies);
+        Assert.Contains(c.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task TransitiveDependenciesUsingArgsAreInclude()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // A -> B -> C via Args
+        var c = builder.AddRedis("c");
+        var b = builder.AddContainer("b", "alpine")
+            .WithArgs(c);
+        var a = builder.AddContainer("a", "alpine")
+            .WithArgs(b);
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await a.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(b.Resource, dependencies);
+        Assert.Contains(c.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task TransitiveDependenciesUsingEnvironmentAreIncluded()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // A -> B -> C via Environment
+        var c = builder.AddRedis("c")
+            .WithHttpEndpoint(6379, 6379, "redisc");
+        var b = builder.AddContainer("b", "alpine")
+            .WithHttpEndpoint(8080, 8080, "httpb")
+            .WithEnvironment("C_HOST", c.GetEndpoint("redisc"));
+        var a = builder.AddContainer("a", "alpine")
+            .WithEnvironment("B_HOST", b.GetEndpoint("httpb"));
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await a.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(b.Resource, dependencies);
+        Assert.Contains(c.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task DiamondDependenciesAreDeduplicatedAndIncludeAll()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // A -> B -> D, A -> C -> D via WaitFor
+        var d = builder.AddContainer("d", "alpine");
+        var b = builder.AddContainer("b", "alpine").WaitFor(d);
+        var c = builder.AddContainer("c", "alpine").WaitFor(d);
+        var a = builder.AddContainer("a", "alpine")
+            .WaitFor(b)
+            .WaitFor(c);
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await a.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(b.Resource, dependencies);
+        Assert.Contains(c.Resource, dependencies);
+        Assert.Contains(d.Resource, dependencies);
+        Assert.Equal(3, dependencies.Count); // D only appears once
+    }
+
+    [Fact]
+    public async Task DeepChainDependenciesAreIncluded()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // A -> B -> C -> D -> E via WaitFor
+        var e = builder.AddRedis("e");
+        var d = builder.AddContainer("d", "alpine").WaitFor(e);
+        var c = builder.AddContainer("c", "alpine").WaitFor(d);
+        var b = builder.AddContainer("b", "alpine").WaitFor(c);
+        var a = builder.AddContainer("a", "alpine").WaitFor(b);
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await a.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(b.Resource, dependencies);
+        Assert.Contains(c.Resource, dependencies);
+        Assert.Contains(d.Resource, dependencies);
+        Assert.Contains(e.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task MixedReferenceTypesToSameResourceIsDeduplicatedAndIncluded()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // Use a container instead of Redis to avoid auto-generated password parameter
+        var backend = builder.AddContainer("backend", "alpine")
+            .WithHttpEndpoint(8080, 8080, "http");
+
+        var frontend = builder.AddContainer("frontend", "alpine")
+            .WithEnvironment("BACKEND_URL", backend.GetEndpoint("http"))  // Endpoint reference
+            .WaitFor(backend);                                            // Also wait for it
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await frontend.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(backend.Resource, dependencies);
+        Assert.Single(dependencies); // Backend should only appear once despite multiple reference types
+    }
+
+    [Fact]
+    public async Task WaitForChildAlsoIncludesParent()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var postgres = builder.AddPostgres("postgres");
+        var db = postgres.AddDatabase("db");
+
+        var container = builder.AddContainer("container", "alpine")
+            .WaitFor(db);
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await container.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(db.Resource, dependencies);
+        Assert.Contains(postgres.Resource, dependencies); // Parent included due to transitive dependency
+    }
+
+    [Fact]
+    public async Task UnrelatedResourceIsNotIncluded()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var redis = builder.AddRedis("redis");
+        var unrelatedResource = builder.AddRedis("unrelated");
+        var container = builder.AddContainer("container", "alpine")
+            .WithReference(redis);
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await container.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.DoesNotContain(unrelatedResource.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task InputResourceIsExcludedFromOwnDependencies()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var container = builder.AddContainer("container", "alpine");
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await container.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.DoesNotContain(container.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task ResourceThatDependsOnInputIsNotIncluded()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var container = builder.AddContainer("container", "alpine")
+            .WithHttpEndpoint(5000, 5000, "http");
+        var dependentContainer = builder.AddContainer("dependent", "alpine")
+            .WithReference(container.GetEndpoint("http")); // Reverse direction
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await container.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.DoesNotContain(dependentContainer.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task SiblingResourceUnderSameParentIsNotIncluded()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var postgres = builder.AddPostgres("postgres");
+        var db1 = postgres.AddDatabase("db1");
+        var db2 = postgres.AddDatabase("db2");
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await db1.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.DoesNotContain(db2.Resource, dependencies);
+        Assert.Contains(postgres.Resource, dependencies); // Parent IS included
+    }
+
+    [Fact]
+    public async Task ResourceOnlyReferencedByThirdResourceIsNotIncluded()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // A references B, C references D. D should not be in A's dependencies.
+        var d = builder.AddRedis("d");
+        var c = builder.AddContainer("c", "alpine").WithReference(d);
+        var b = builder.AddRedis("b");
+        var a = builder.AddContainer("a", "alpine").WithReference(b);
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await a.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(b.Resource, dependencies);
+        Assert.DoesNotContain(c.Resource, dependencies);
+        Assert.DoesNotContain(d.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task ResourceWithZeroDependenciesReturnsEmptySet()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var container = builder.AddContainer("container", "alpine");
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await container.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Empty(dependencies);
+    }
+
+    [Fact]
+    public async Task MultipleWaitAnnotationsForSameTargetAreDeduplicatedAndIncluded()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var redis = builder.AddContainer("redis", "redis");
+        var container = builder.AddContainer("container", "alpine")
+            .WaitFor(redis)
+            .WaitFor(redis); // Add wait twice
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await container.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(redis.Resource, dependencies);
+        Assert.Single(dependencies);
+    }
+
+    [Fact]
+    public async Task DirectOnlyExcludesTransitiveDependencies()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // Chain: A -> B -> C
+        var c = builder.AddRedis("c");
+        var b = builder.AddContainer("b", "alpine")
+            .WithHttpEndpoint(5000, 5000, "http")
+            .WithReference(c);
+        var a = builder.AddContainer("a", "alpine")
+            .WithReference(b.GetEndpoint("http"));
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await a.Resource.GetResourceDependenciesAsync(executionContext, ResourceDependencyDiscoveryMode.DirectOnly);
+
+        Assert.Contains(b.Resource, dependencies);
+        Assert.DoesNotContain(c.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task TransitiveClosureIncludesAllDependencies()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // Chain: A -> B -> C
+        var c = builder.AddRedis("c");
+        var b = builder.AddContainer("b", "alpine")
+            .WithHttpEndpoint(5000, 5000, "http")
+            .WithReference(c);
+        var a = builder.AddContainer("a", "alpine")
+            .WithReference(b.GetEndpoint("http"));
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await a.Resource.GetResourceDependenciesAsync(executionContext, ResourceDependencyDiscoveryMode.TransitiveClosure);
+
+        Assert.Contains(b.Resource, dependencies);
+        Assert.Contains(c.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task DirectOnlyWithDeepChainOnlyIncludesDirectDependency()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // Chain: A -> B -> C -> D -> E
+        var e = builder.AddRedis("e");
+        var d = builder.AddContainer("d", "alpine")
+            .WithHttpEndpoint(5003, 5003, "http")
+            .WithReference(e);
+        var c = builder.AddContainer("c", "alpine")
+            .WithHttpEndpoint(5002, 5002, "http")
+            .WithReference(d.GetEndpoint("http"));
+        var b = builder.AddContainer("b", "alpine")
+            .WithHttpEndpoint(5001, 5001, "http")
+            .WithReference(c.GetEndpoint("http"));
+        var a = builder.AddContainer("a", "alpine")
+            .WithReference(b.GetEndpoint("http"));
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await a.Resource.GetResourceDependenciesAsync(executionContext, ResourceDependencyDiscoveryMode.DirectOnly);
+
+        Assert.Single(dependencies);
+        Assert.Contains(b.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task DirectOnlyIncludesReferencedResourcesFromConnectionString()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // A references database, which has postgres as parent.
+        // The database's connection string expression references postgres.
+        var postgres = builder.AddPostgres("postgres");
+        var db = postgres.AddDatabase("db");
+        var a = builder.AddContainer("a", "alpine").WithReference(db);
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await a.Resource.GetResourceDependenciesAsync(executionContext, ResourceDependencyDiscoveryMode.DirectOnly);
+
+        // With DirectOnly, we get both db and postgres because db's ConnectionStringExpression
+        // references postgres, and that reference is discovered while traversing a's environment.
+        Assert.Contains(db.Resource, dependencies);
+        Assert.Contains(postgres.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task DefaultOverloadUsesTransitiveClosure()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // Chain: A -> B -> C
+        var c = builder.AddRedis("c");
+        var b = builder.AddContainer("b", "alpine")
+            .WithHttpEndpoint(5000, 5000, "http")
+            .WithReference(c);
+        var a = builder.AddContainer("a", "alpine")
+            .WithReference(b.GetEndpoint("http"));
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+
+        // Default overload should include transitive dependencies
+        var dependencies = await a.Resource.GetResourceDependenciesAsync(executionContext);
+
+        Assert.Contains(b.Resource, dependencies);
+        Assert.Contains(c.Resource, dependencies);
+    }
+}


### PR DESCRIPTION
## Description

Adds a utility method to compute transitive closure of resource dependencies (resources that given resource depends on). This is something that I need for upcoming improvements to container tunnel, but I think it is universally useful, and also changes the core of Azure publisher, so a separate PR is warranted.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes (probably--although doc comments should be sufficient as a start)
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
