### PR TITLE
Redact sensitive trace logs

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -664,8 +664,8 @@ public class ResourceNotificationService : IDisposable
                     newState.ResourceReadyEvent is not null,
                     newState.ExitCode,
                     string.Join(" ", newState.Urls.Select(u => $"{u.Name} = {u.Url}")),
-                    string.Join(" ", newState.EnvironmentVariables.Where(e => e.IsFromSpec).Select(e => $"{e.Name} = {e.Value}")),
-                    string.Join(" ", newState.Properties.Select(p => $"{p.Name} = {Stringify(p.Value)}")),
+                    string.Join(" ", newState.EnvironmentVariables.Where(e => e.IsFromSpec).Select(e => $"{e.Name} = {(e.Value is null ? "(null)" : "***")}")),
+                    string.Join(" ", newState.Properties.Select(p => $"{p.Name} = {(p.IsSensitive ? "***" : Stringify(p.Value))}")),
                     string.Join(" ", newState.HealthReports.Select(p => $"{p.Name} = {Stringify(p.Status)}")),
                     string.Join(" ", newState.Commands.Select(c => $"{c.Name} ({c.DisplayName}) = {Stringify(c.State)}")));
 


### PR DESCRIPTION
## Description

Prevent sensitive information from being logged in local development when users opt-in for trace level logs.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [x] Yes - https://github.com/microsoft/aspire.dev/issues/235
  - [ ] No
