### PR TITLE
Fix flaky DeployCommandTests tests

### DIFF
--- a/src/Aspire.Cli/Commands/DeployCommand.cs
+++ b/src/Aspire.Cli/Commands/DeployCommand.cs
@@ -9,6 +9,8 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
 
 namespace Aspire.Cli.Commands;
 
@@ -16,8 +18,8 @@ internal sealed class DeployCommand : PipelineCommandBase
 {
     private readonly Option<bool> _clearCacheOption;
 
-    public DeployCommand(IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory)
-        : base("deploy", DeployCommandStrings.Description, runner, interactionService, projectLocator, telemetry, sdkInstaller, features, updateNotifier, executionContext, hostEnvironment, projectFactory)
+    public DeployCommand(IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory, ILogger<DeployCommand> logger, IAnsiConsole ansiConsole)
+        : base("deploy", DeployCommandStrings.Description, runner, interactionService, projectLocator, telemetry, sdkInstaller, features, updateNotifier, executionContext, hostEnvironment, projectFactory, logger, ansiConsole)
     {
         _clearCacheOption = new Option<bool>("--clear-cache")
         {

--- a/src/Aspire.Cli/Commands/DoCommand.cs
+++ b/src/Aspire.Cli/Commands/DoCommand.cs
@@ -9,6 +9,8 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
 
 namespace Aspire.Cli.Commands;
 
@@ -16,8 +18,8 @@ internal sealed class DoCommand : PipelineCommandBase
 {
     private readonly Argument<string> _stepArgument;
 
-    public DoCommand(IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory)
-        : base("do", DoCommandStrings.Description, runner, interactionService, projectLocator, telemetry, sdkInstaller, features, updateNotifier, executionContext, hostEnvironment, projectFactory)
+    public DoCommand(IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory, ILogger<DoCommand> logger, IAnsiConsole ansiConsole)
+        : base("do", DoCommandStrings.Description, runner, interactionService, projectLocator, telemetry, sdkInstaller, features, updateNotifier, executionContext, hostEnvironment, projectFactory, logger, ansiConsole)
     {
         _stepArgument = new Argument<string>("step")
         {

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -11,6 +11,7 @@ using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
+using Microsoft.Extensions.Logging;
 using Aspire.Cli.Utils;
 using Aspire.Hosting;
 using Spectre.Console;
@@ -30,6 +31,8 @@ internal abstract class PipelineCommandBase : BaseCommand
 
     private readonly IFeatures _features;
     private readonly ICliHostEnvironment _hostEnvironment;
+    private readonly ILogger _logger;
+    private readonly IAnsiConsole _ansiConsole;
 
     protected readonly Option<string?> _logLevelOption = new("--log-level")
     {
@@ -58,7 +61,7 @@ internal abstract class PipelineCommandBase : BaseCommand
     private static bool IsCompletionStateWarning(string completionState) =>
         completionState == CompletionStates.CompletedWithWarning;
 
-    protected PipelineCommandBase(string name, string description, IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory)
+    protected PipelineCommandBase(string name, string description, IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory, ILogger logger, IAnsiConsole ansiConsole)
         : base(name, description, features, updateNotifier, executionContext, interactionService)
     {
         ArgumentNullException.ThrowIfNull(runner);
@@ -68,6 +71,8 @@ internal abstract class PipelineCommandBase : BaseCommand
         ArgumentNullException.ThrowIfNull(hostEnvironment);
         ArgumentNullException.ThrowIfNull(features);
         ArgumentNullException.ThrowIfNull(projectFactory);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(ansiConsole);
 
         _runner = runner;
         _projectLocator = projectLocator;
@@ -76,6 +81,8 @@ internal abstract class PipelineCommandBase : BaseCommand
         _hostEnvironment = hostEnvironment;
         _features = features;
         _projectFactory = projectFactory;
+        _logger = logger;
+        _ansiConsole = ansiConsole;
 
         var projectOption = new Option<FileInfo?>("--project")
         {
@@ -232,10 +239,11 @@ internal abstract class PipelineCommandBase : BaseCommand
             // Both apphost exit code and backchannel indicate success
             return ExitCodeConstants.Success;
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException ex)
         {
             // Send terminal progress bar stop sequence on cancellation
             StopTerminalProgressBar();
+            _logger.LogDebug(ex, "Operation was cancelled.");
             InteractionService.DisplayError(GetCanceledMessage());
             return ExitCodeConstants.FailedToBuildArtifacts;
         }
@@ -243,12 +251,14 @@ internal abstract class PipelineCommandBase : BaseCommand
         {
             // Send terminal progress bar stop sequence on exception
             StopTerminalProgressBar();
+            _logger.LogError(ex, "Failed to locate project.");
             return HandleProjectLocatorException(ex, InteractionService);
         }
         catch (AppHostIncompatibleException ex)
         {
             // Send terminal progress bar stop sequence on exception
             StopTerminalProgressBar();
+            _logger.LogError(ex, "AppHost is incompatible. Required version: {RequiredVersion}", appHostCompatibilityCheck?.AspireHostingVersion);
             InteractionService.DisplayError(ex.Message);
             return ExitCodeConstants.AppHostIncompatible;
         }
@@ -256,6 +266,7 @@ internal abstract class PipelineCommandBase : BaseCommand
         {
             // Send terminal progress bar stop sequence on exception
             StopTerminalProgressBar();
+            _logger.LogError(ex, "Failed to connect to AppHost backchannel.");
             InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ErrorConnectingToAppHost, ex.Message));
             if (publishContext?.OutputCollector is { } outputCollector)
             {
@@ -267,6 +278,7 @@ internal abstract class PipelineCommandBase : BaseCommand
         {
             // Occurs if the apphost RPC channel is lost unexpectedly.
             StopTerminalProgressBar();
+            _logger.LogError(ex, "Connection to AppHost was lost unexpectedly.");
             InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.AppHostConnectionLost, ex.Message));
             if (publishContext?.OutputCollector is { } outputCollector)
             {
@@ -278,6 +290,7 @@ internal abstract class PipelineCommandBase : BaseCommand
         {
             // Send terminal progress bar stop sequence on exception
             StopTerminalProgressBar();
+            _logger.LogError(ex, "An unexpected error occurred during pipeline execution.");
             InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message));
             if (publishContext?.OutputCollector is { } outputCollector)
             {
@@ -409,7 +422,7 @@ internal abstract class PipelineCommandBase : BaseCommand
     {
         var stepCounter = 1;
         var steps = new Dictionary<string, StepInfo>();
-        var logger = new ConsoleActivityLogger(_hostEnvironment, isDebugOrTraceLoggingEnabled);
+        var logger = new ConsoleActivityLogger(_ansiConsole, _hostEnvironment, isDebugOrTraceLoggingEnabled);
         logger.StartSpinner();
         PublishingActivity? publishingActivity = null;
 

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -258,7 +258,7 @@ internal abstract class PipelineCommandBase : BaseCommand
         {
             // Send terminal progress bar stop sequence on exception
             StopTerminalProgressBar();
-            _logger.LogError(ex, "AppHost is incompatible. Required version: {RequiredVersion}", appHostCompatibilityCheck?.AspireHostingVersion);
+            _logger.LogError(ex, "AppHost is incompatible. Required capability: {RequiredCapability}", ex.RequiredCapability);
             InteractionService.DisplayError(ex.Message);
             return ExitCodeConstants.AppHostIncompatible;
         }

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -9,6 +9,8 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
 
 namespace Aspire.Cli.Commands;
 
@@ -34,8 +36,8 @@ internal sealed class PublishCommand : PipelineCommandBase
 {
     private readonly IPublishCommandPrompter _prompter;
 
-    public PublishCommand(IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator, IPublishCommandPrompter prompter, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory)
-        : base("publish", PublishCommandStrings.Description, runner, interactionService, projectLocator, telemetry, sdkInstaller, features, updateNotifier, executionContext, hostEnvironment, projectFactory)
+    public PublishCommand(IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator, IPublishCommandPrompter prompter, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory, ILogger<PublishCommand> logger, IAnsiConsole ansiConsole)
+        : base("publish", PublishCommandStrings.Description, runner, interactionService, projectLocator, telemetry, sdkInstaller, features, updateNotifier, executionContext, hostEnvironment, projectFactory, logger, ansiConsole)
     {
         ArgumentNullException.ThrowIfNull(prompter);
         _prompter = prompter;

--- a/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
+++ b/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
@@ -17,6 +17,7 @@ namespace Aspire.Cli.Utils;
 /// </summary>
 internal sealed class ConsoleActivityLogger
 {
+    private readonly IAnsiConsole _console;
     private readonly bool _enableColor;
     private readonly ICliHostEnvironment _hostEnvironment;
     private readonly bool _isDebugOrTraceLoggingEnabled;
@@ -48,8 +49,9 @@ internal sealed class ConsoleActivityLogger
     private const string InProgressSymbol = "→";
     private const string InfoSymbol = "i";
 
-    public ConsoleActivityLogger(ICliHostEnvironment hostEnvironment, bool isDebugOrTraceLoggingEnabled = false, bool? forceColor = null)
+    public ConsoleActivityLogger(IAnsiConsole console, ICliHostEnvironment hostEnvironment, bool isDebugOrTraceLoggingEnabled = false, bool? forceColor = null)
     {
+        _console = console;
         _hostEnvironment = hostEnvironment;
         _enableColor = forceColor ?? _hostEnvironment.SupportsAnsi;
         _isDebugOrTraceLoggingEnabled = isDebugOrTraceLoggingEnabled;
@@ -106,7 +108,7 @@ internal sealed class ConsoleActivityLogger
         _spinning = true;
         _spinnerTask = Task.Run(async () =>
         {
-            AnsiConsole.Cursor.Hide();
+            _console.Cursor.Hide();
 
             try
             {
@@ -115,8 +117,8 @@ internal sealed class ConsoleActivityLogger
                     var spinChar = _spinnerChars[_spinnerIndex % _spinnerChars.Length];
 
                     // Write then move back so nothing can write between these events (hopefully)
-                    AnsiConsole.Write(CultureInfo.InvariantCulture, spinChar);
-                    AnsiConsole.Cursor.MoveLeft();
+                    _console.Write(spinChar.ToString());
+                    _console.Cursor.MoveLeft();
 
                     _spinnerIndex++;
                     await Task.Delay(120).ConfigureAwait(false);
@@ -125,9 +127,9 @@ internal sealed class ConsoleActivityLogger
             finally
             {
                 // Clear spinner character
-                AnsiConsole.Write(CultureInfo.InvariantCulture, ' ');
-                AnsiConsole.Cursor.MoveLeft();
-                AnsiConsole.Cursor.Show();
+                _console.Write(" ");
+                _console.Cursor.MoveLeft();
+                _console.Cursor.Show();
             }
         });
     }
@@ -190,8 +192,8 @@ internal sealed class ConsoleActivityLogger
             const string continuationPrefix = "  ";
             foreach (var line in SplitLinesPreserve(message))
             {
-                Console.Write(continuationPrefix);
-                Console.WriteLine(line);
+                _console.Write(continuationPrefix);
+                _console.WriteLine(line);
             }
         }
     }
@@ -202,7 +204,7 @@ internal sealed class ConsoleActivityLogger
         {
             var totalSeconds = _stopwatch.Elapsed.TotalSeconds;
             var line = new string('-', 60);
-            AnsiConsole.MarkupLine(line);
+            _console.MarkupLine(line);
             var totalSteps = _stepStates.Count;
             // Derive per-step outcome counts from _stepStates (not task-level counters) for accurate X/Y display.
             var succeededSteps = _stepStates.Values.Count(v => v == ActivityState.Success);
@@ -235,12 +237,12 @@ internal sealed class ConsoleActivityLogger
                 }
             }
             summaryParts.Add($"Total time: {DurationFormatter.FormatDuration(TimeSpan.FromSeconds(totalSeconds), CultureInfo.InvariantCulture, DecimalDurationDisplay.Fixed)}");
-            AnsiConsole.MarkupLine(string.Join(" • ", summaryParts));
+            _console.MarkupLine(string.Join(" • ", summaryParts));
 
             if (_durationRecords is { Count: > 0 })
             {
-                AnsiConsole.WriteLine();
-                AnsiConsole.MarkupLine("Steps Summary:");
+                _console.WriteLine();
+                _console.MarkupLine("Steps Summary:");
                 foreach (var rec in _durationRecords)
                 {
                     // PadLeft(10) accommodates split units like "2h 30m", decimal units like "1.5s", and very long durations like "999d 23h"
@@ -262,15 +264,15 @@ internal sealed class ConsoleActivityLogger
                         .Append(symbol).Append(' ')
                         .Append("[dim]").Append(name).Append("[/]")
                         .Append(reason);
-                    AnsiConsole.MarkupLine(lineSb.ToString());
+                    _console.MarkupLine(lineSb.ToString());
                 }
-                AnsiConsole.WriteLine();
+                _console.WriteLine();
             }
 
             // If a caller provided a final status line via SetFinalResult, print it now
             if (!string.IsNullOrEmpty(_finalStatusHeader))
             {
-                AnsiConsole.MarkupLine(_finalStatusHeader!);
+                _console.MarkupLine(_finalStatusHeader!);
                 
                 // If pipeline failed and not already in debug/trace mode, show help message about using --log-level debug
                 if (!_pipelineSucceeded && !_isDebugOrTraceLoggingEnabled)
@@ -278,11 +280,11 @@ internal sealed class ConsoleActivityLogger
                     var helpMessage = _enableColor
                         ? "[dim]For more details, add --log-level debug/trace to the command.[/]"
                         : "For more details, add --log-level debug/trace to the command.";
-                    AnsiConsole.MarkupLine(helpMessage);
+                    _console.MarkupLine(helpMessage);
                 }
             }
-            AnsiConsole.MarkupLine(line);
-            AnsiConsole.WriteLine(); // Ensure final newline after deployment summary
+            _console.MarkupLine(line);
+            _console.WriteLine(); // Ensure final newline after deployment summary
         }
     }
 
@@ -362,7 +364,7 @@ internal sealed class ConsoleActivityLogger
                 {
                     markup.Append(symbol).Append(' ').Append(highlightedLine);
                 }
-                AnsiConsole.MarkupLine(markup.ToString());
+                _console.MarkupLine(markup.ToString());
             }
         }
     }

--- a/tests/Aspire.Cli.Tests/Commands/DeployCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DeployCommandTests.cs
@@ -10,6 +10,7 @@ using Aspire.Cli.Tests.TestServices;
 using Microsoft.Extensions.DependencyInjection;
 using Aspire.Cli.Utils;
 using Aspire.TestUtilities;
+using Microsoft.AspNetCore.InternalTesting;
 
 namespace Aspire.Cli.Tests.Commands;
 
@@ -26,7 +27,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("deploy --help");
 
-        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(0, exitCode);
     }
 
@@ -56,7 +57,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
 
         // Act
         var result = command.Parse("deploy --project invalid.csproj");
-        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
         Assert.Equal(ExitCodeConstants.FailedToFindProject, exitCode); // Ensure the command fails
@@ -90,7 +91,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
 
         // Act
         var result = command.Parse("deploy --project valid.csproj");
-        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
         Assert.Equal(ExitCodeConstants.AppHostIncompatible, exitCode); // Ensure the command fails
@@ -124,7 +125,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
 
         // Act
         var result = command.Parse("deploy --project valid.csproj");
-        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
         Assert.Equal(ExitCodeConstants.FailedToBuildArtifacts, exitCode); // Ensure the command fails
@@ -192,7 +193,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
 
         // Act
         var result = command.Parse("deploy");
-        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
         Assert.Equal(0, exitCode); // Ensure the command succeeds
@@ -261,7 +262,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
 
         // Act
         var result = command.Parse("deploy");
-        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
         Assert.Equal(0, exitCode); // Ensure the command succeeds
@@ -272,6 +273,9 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
     public async Task DeployCommandIncludesDeployFlagInArguments()
     {
         using var tempRepo = TemporaryWorkspace.Create(outputHelper);
+
+        // Use a cross-platform path for testing
+        var testOutputPath = Path.Combine(Path.GetTempPath(), "test");
 
         // Arrange
         var services = CliTestHelper.CreateServiceCollection(tempRepo, outputHelper, options =>
@@ -298,7 +302,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
                             Assert.Contains("publish", args);
                             // When output path is explicitly provided, it should be included
                             Assert.Contains("--output-path", args);
-                            Assert.Contains("/tmp/test", args);
+                            Assert.Contains(testOutputPath, args);
                             // Verify that --step deploy is passed by default
                             Assert.Contains("--step", args);
                             Assert.Contains("deploy", args);
@@ -329,8 +333,8 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
         var command = provider.GetRequiredService<RootCommand>();
 
         // Act
-        var result = command.Parse("deploy --output-path /tmp/test");
-        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+        var result = command.Parse($"deploy --output-path {testOutputPath}");
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
         Assert.Equal(0, exitCode);
@@ -390,7 +394,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
 
         // Act
         var result = command.Parse("deploy");
-        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
         Assert.Equal(ExitCodeConstants.FailedToBuildArtifacts, exitCode); // Ensure the command returns a non-zero exit code


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspire/issues/11217
Addresses https://github.com/dotnet/aspire/issues/9870

The problem is `ConsoleActivityLogger` used the static `AnsiConsole`, not a test instance. Any operation delay would cause `ConsoleActivityLogger` to display a spinner in the console. A spinner involves doing interactive console stuff like changing the cursor position, which would blow up the test.

This PR:
- Uses DefaultTimeout in tests so they don't timeout while debugging
- Adds some logging to pipeline commands
- Injects test console into ConsoleActivityLogger so tests don't fail while writing to the console
- Fixes asserting path. It was resolved to a windows path on window, e.g. `c:\tmp\test`