### PR TITLE
Fix flaky CLI output tests

### DIFF
--- a/src/Aspire.Cli/Commands/ExtensionInternalCommand.cs
+++ b/src/Aspire.Cli/Commands/ExtensionInternalCommand.cs
@@ -49,11 +49,12 @@ internal sealed class ExtensionInternalCommand : BaseCommand
             {
                 var result = await _projectLocator.UseOrFindAppHostProjectFileAsync(null, MultipleAppHostProjectsFoundBehavior.None, createSettingsFile: false, cancellationToken);
 
-                Console.WriteLine(JsonSerializer.Serialize(new AppHostProjectSearchResultPoco
+                var json = JsonSerializer.Serialize(new AppHostProjectSearchResultPoco
                 {
                     SelectedProjectFile = result.SelectedProjectFile?.FullName,
                     AllProjectFileCandidates = result.AllProjectFileCandidates.Select(f => f.FullName).ToList()
-                }, BackchannelJsonSerializerContext.Default.AppHostProjectSearchResultPoco));
+                }, BackchannelJsonSerializerContext.Default.AppHostProjectSearchResultPoco);
+                InteractionService.DisplayRawText(json);
                 return ExitCodeConstants.Success;
             }
             catch

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -180,6 +180,12 @@ internal class ConsoleInteractionService : IInteractionService
         _ansiConsole.WriteLine(message);
     }
 
+    public void DisplayRawText(string text)
+    {
+        // Write raw text directly to avoid console wrapping
+        _ansiConsole.Profile.Out.Writer.WriteLine(text);
+    }
+
     public void DisplayMarkdown(string markdown)
     {
         var spectreMarkup = MarkdownToSpectreConverter.ConvertToSpectre(markdown);

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -299,6 +299,13 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         _consoleInteractionService.DisplayPlainText(text);
     }
 
+    public void DisplayRawText(string text)
+    {
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayPlainTextAsync(text, _cancellationToken));
+        Debug.Assert(result);
+        _consoleInteractionService.DisplayRawText(text);
+    }
+
     public void DisplayMarkdown(string markdown)
     {
         // Send raw markdown to extension (it can handle markdown natively)

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -18,6 +18,7 @@ internal interface IInteractionService
     void DisplayError(string errorMessage);
     void DisplayMessage(string emoji, string message);
     void DisplayPlainText(string text);
+    void DisplayRawText(string text);
     void DisplayMarkdown(string markdown);
     void DisplaySuccess(string message);
     void DisplaySubtleMessage(string message, bool escapeMarkup = true);

--- a/tests/Aspire.Cli.Tests/Commands/ExtensionInternalCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ExtensionInternalCommandTests.cs
@@ -74,22 +74,19 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
         Assert.Equal(ExitCodeConstants.Success, exitCode);
 
-        // Find the JSON output from captured logs (it should be the line containing valid JSON)
-        var jsonOutput = capturedOutput.Logs.FirstOrDefault(log => log.TrimStart().StartsWith('{'));
-        Assert.NotNull(jsonOutput);
+        // Join all captured output and deserialize
+        var allOutput = string.Join(string.Empty, capturedOutput.Logs);
 
         // Verify JSON is valid and deserializable
         AppHostProjectSearchResultPoco? searchResult;
         try
         {
-            searchResult = JsonSerializer.Deserialize<AppHostProjectSearchResultPoco>(
-                jsonOutput,
-                BackchannelJsonSerializerContext.Default.AppHostProjectSearchResultPoco);
+            searchResult = JsonSerializer.Deserialize(allOutput, BackchannelJsonSerializerContext.Default.AppHostProjectSearchResultPoco);
         }
         catch (JsonException ex)
         {
-            outputHelper.WriteLine($"Failed to deserialize JSON. Raw output: {jsonOutput}");
-            throw new JsonException($"Failed to deserialize JSON: {jsonOutput}", ex);
+            outputHelper.WriteLine($"Failed to deserialize JSON. Raw output: {allOutput}");
+            throw new JsonException($"Failed to deserialize JSON: {allOutput}", ex);
         }
 
         Assert.NotNull(searchResult);
@@ -120,22 +117,19 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
         Assert.Equal(ExitCodeConstants.Success, exitCode);
 
-        // Find the JSON output from captured logs (it should be the line containing valid JSON)
-        var jsonOutput = capturedOutput.Logs.FirstOrDefault(log => log.TrimStart().StartsWith('{'));
-        Assert.NotNull(jsonOutput);
+        // Join all captured output and deserialize
+        var allOutput = string.Join(string.Empty, capturedOutput.Logs);
 
         // Verify JSON is valid and deserializable
         AppHostProjectSearchResultPoco? searchResult;
         try
         {
-            searchResult = JsonSerializer.Deserialize<AppHostProjectSearchResultPoco>(
-                jsonOutput,
-                BackchannelJsonSerializerContext.Default.AppHostProjectSearchResultPoco);
+            searchResult = JsonSerializer.Deserialize(allOutput, BackchannelJsonSerializerContext.Default.AppHostProjectSearchResultPoco);
         }
         catch (JsonException ex)
         {
-            outputHelper.WriteLine($"Failed to deserialize JSON. Raw output: {jsonOutput}");
-            throw new JsonException($"Failed to deserialize JSON: {jsonOutput}", ex);
+            outputHelper.WriteLine($"Failed to deserialize JSON. Raw output: {allOutput}");
+            throw new JsonException($"Failed to deserialize JSON: {allOutput}", ex);
         }
 
         Assert.NotNull(searchResult);

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -912,6 +912,7 @@ internal sealed class OrderTrackingInteractionService(List<string> operationOrde
     public void DisplaySubtleMessage(string message, bool escapeMarkup = true) { }
     public void DisplayEmptyLine() { }
     public void DisplayPlainText(string text) { }
+    public void DisplayRawText(string text) { }
     public void DisplayMarkdown(string markdown) { }
     public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false) { }
     public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null) { }

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -992,6 +992,7 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
     public void DisplayCancellationMessage() { }
     public void DisplayEmptyLine() { }
     public void DisplayPlainText(string text) { }
+    public void DisplayRawText(string text) { }
     public void DisplayMarkdown(string markdown) { }
 
     public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null) { }

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -962,6 +962,7 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
     public void DisplayError(string errorMessage) => _innerService.DisplayError(errorMessage);
     public void DisplayMessage(string emoji, string message) => _innerService.DisplayMessage(emoji, message);
     public void DisplayPlainText(string text) => _innerService.DisplayPlainText(text);
+    public void DisplayRawText(string text) => _innerService.DisplayRawText(text);
     public void DisplayMarkdown(string markdown) => _innerService.DisplayMarkdown(markdown);
     public void DisplaySuccess(string message) => _innerService.DisplaySuccess(message);
     public void DisplaySubtleMessage(string message, bool escapeMarkup = true) => _innerService.DisplaySubtleMessage(message, escapeMarkup);

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -423,6 +423,7 @@ public class DotNetTemplateFactoryTests
         public void DisplayCancellationMessage() { }
         public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;
         public void DisplayPlainText(string text) { }
+        public void DisplayRawText(string text) { }
         public void DisplayMarkdown(string markdown) { }
         public void DisplaySubtleMessage(string message, bool escapeMarkup = true) { }
         public void DisplayEmptyLine() { }

--- a/tests/Aspire.Cli.Tests/TestServices/TestConsoleInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestConsoleInteractionService.cs
@@ -113,6 +113,10 @@ internal sealed class TestConsoleInteractionService : IInteractionService
     {
     }
 
+    public void DisplayRawText(string text)
+    {
+    }
+
     public void DisplayMarkdown(string markdown)
     {
     }

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -126,6 +126,10 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
     {
     }
 
+    public void DisplayRawText(string text)
+    {
+    }
+
     public void DisplayMarkdown(string markdown)
     {
     }

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -160,14 +160,17 @@ internal sealed class CliServiceCollectionTestOptions
     public string[] EnabledFeatures { get; set; } = Array.Empty<string>();
     public string[] DisabledFeatures { get; set; } = Array.Empty<string>();
 
+    public TestOutputTextWriter? OutputTextWriter { get; set; }
+
     public Func<IServiceProvider, IAnsiConsole> AnsiConsoleFactory => (IServiceProvider serviceProvider) =>
     {
+        var textWriter = OutputTextWriter ?? new TestOutputTextWriter(_outputHelper);
         AnsiConsoleSettings settings = new AnsiConsoleSettings()
         {
             Ansi = AnsiSupport.Yes,
             Interactive = InteractionSupport.Yes,
             ColorSystem = ColorSystemSupport.Standard,
-            Out = new AnsiConsoleOutput(new TestOutputTextWriter(_outputHelper))
+            Out = new AnsiConsoleOutput(textWriter)
         };
         var ansiConsole = AnsiConsole.Create(settings);
         return ansiConsole;


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspire/issues/12304
Addresses https://github.com/dotnet/aspire/issues/12300

I believe these tests were flaky because they wrote and read from the console, which is static across tests. Fix by writing to scoped output and assert that output.