### PR TITLE
Fix flaky CLI orphan detector tests

### DIFF
--- a/src/Aspire.Hosting/Cli/CliOrphanDetector.cs
+++ b/src/Aspire.Hosting/Cli/CliOrphanDetector.cs
@@ -4,10 +4,11 @@
 using System.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Cli;
 
-internal sealed class CliOrphanDetector(IConfiguration configuration, IHostApplicationLifetime lifetime, TimeProvider timeProvider) : BackgroundService
+internal sealed class CliOrphanDetector(IConfiguration configuration, IHostApplicationLifetime lifetime, TimeProvider timeProvider, ILogger<CliOrphanDetector> logger) : BackgroundService
 {
     internal Func<int, bool> IsProcessRunning { get; set; } = (int pid) =>
     {
@@ -31,7 +32,7 @@ internal sealed class CliOrphanDetector(IConfiguration configuration, IHostAppli
             {
                 return false;
             }
-            
+
             // Check if the process start time matches the expected start time exactly.
             var actualStartTimeUnix = ((DateTimeOffset)process.StartTime).ToUnixTimeSeconds();
             return actualStartTimeUnix == expectedStartTimeUnix;
@@ -46,29 +47,38 @@ internal sealed class CliOrphanDetector(IConfiguration configuration, IHostAppli
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        if (configuration[KnownConfigNames.CliProcessId] is not { } pidString || !int.TryParse(pidString, out var pid))
+        {
+            // If there is no PID environment variable, we assume that the process is not a child process
+            // of the .NET Aspire CLI and we won't continue monitoring.
+            logger.LogDebug("No CLI process ID configured. Orphan detection disabled.");
+            return;
+        }
+
+        logger.LogDebug("Starting orphan detection for CLI process {Pid}.", pid);
+
+        // Try to get the CLI process start time for robust orphan detection
+        long? expectedStartTimeUnix = null;
+        if (configuration[KnownConfigNames.CliProcessStarted] is { } startTimeString &&
+            long.TryParse(startTimeString, out var startTimeUnix))
+        {
+            expectedStartTimeUnix = startTimeUnix;
+            logger.LogDebug("Using start time verification. Expected start time: {StartTime}.", expectedStartTimeUnix);
+        }
+        else
+        {
+            logger.LogDebug("No valid start time configured. Using PID-only detection.");
+        }
+
+        using var periodic = new PeriodicTimer(TimeSpan.FromSeconds(1), timeProvider);
+
+        logger.LogDebug("Starting detection loop.");
         try
         {
-            if (configuration[KnownConfigNames.CliProcessId] is not { } pidString || !int.TryParse(pidString, out var pid))
-            {
-                // If there is no PID environment variable, we assume that the process is not a child process
-                // of the .NET Aspire CLI and we won't continue monitoring.
-                return;
-            }
-
-            // Try to get the CLI process start time for robust orphan detection
-            long? expectedStartTimeUnix = null;
-            if (configuration[KnownConfigNames.CliProcessStarted] is { } startTimeString && 
-                long.TryParse(startTimeString, out var startTimeUnix))
-            {
-                expectedStartTimeUnix = startTimeUnix;
-            }
-
-            using var periodic = new PeriodicTimer(TimeSpan.FromSeconds(1), timeProvider);
-
             do
             {
                 bool isProcessStillRunning;
-                
+
                 if (expectedStartTimeUnix.HasValue)
                 {
                     // Use robust process checking with start time verification
@@ -82,6 +92,7 @@ internal sealed class CliOrphanDetector(IConfiguration configuration, IHostAppli
 
                 if (!isProcessStillRunning)
                 {
+                    logger.LogDebug("CLI process {Pid} is no longer running. Stopping application.", pid);
                     lifetime.StopApplication();
                     return;
                 }
@@ -90,6 +101,7 @@ internal sealed class CliOrphanDetector(IConfiguration configuration, IHostAppli
         catch (TaskCanceledException)
         {
             // This is expected when the app is shutting down.
+            logger.LogDebug("Orphan detection cancelled.");
         }
     }
 }

--- a/tests/Aspire.Cli.Tests/Hosting/CliOrphanDetectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Hosting/CliOrphanDetectorTests.cs
@@ -257,7 +257,7 @@ public class CliOrphanDetectorTests(ITestOutputHelper testOutputHelper)
         // Wait until the apphost is spun up and then kill off the stub
         // process so everything is torn down.
         await resourcesCreatedTcs.Task.DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
-        fakeCliProcess.Process.Kill();
+        fakeCliProcess.Kill();
 
         await pendingRun.DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
     }


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspire/issues/12710

This PR:
- Adds logging to `CliOrphanDetector`.
- Fixes flaky tests by calling `ReadAsync` instead of `WaitToReadAsync`. I think the intention of the tests is to wait until the callbacks are called, but calling `WaitToReadAsync` and then not reading the value doesn't do that.
- General test clean up.

I don't like that `CliOrphanDetector` is a bunch of func properties that can be set during tests to change behavior. That doesn't seem like the best way to make it testable. But refactoring the type can happen in a future PR.