### PR TITLE
Bump the microsoft_docker_images group across 3 directories with 1 update

### DIFF
--- a/playground/publishers/Publishers.AppHost/qots/Dockerfile
+++ b/playground/publishers/Publishers.AppHost/qots/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN go build qots.go
 
 # Stage 2: Run the Go program
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20251206
 WORKDIR /app
 COPY --from=builder /app/qots .
 CMD ["./qots"]

--- a/playground/withdockerfile/WithDockerfile.AppHost/dynamic-async.Dockerfile
+++ b/playground/withdockerfile/WithDockerfile.AppHost/dynamic-async.Dockerfile
@@ -3,6 +3,6 @@ WORKDIR /app
 COPY . .
 RUN go build -o qots .
 
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20251206
 COPY --from=builder /app/qots /qots
 ENTRYPOINT ["/qots"]

--- a/playground/withdockerfile/WithDockerfile.AppHost/dynamic-sync.Dockerfile
+++ b/playground/withdockerfile/WithDockerfile.AppHost/dynamic-sync.Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN echo "Built at 20251217162400" > /build-info.txt
 RUN go build -o qots .
 
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20251206
 COPY --from=builder /app/qots /qots
 COPY --from=builder /build-info.txt /build-info.txt
 ENTRYPOINT ["/qots"]

--- a/playground/withdockerfile/WithDockerfile.AppHost/qots/Dockerfile
+++ b/playground/withdockerfile/WithDockerfile.AppHost/qots/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN go build qots.go
 
 # Stage 2: Run the Go program
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20251206
 WORKDIR /app
 RUN --mount=type=secret,id=SECRET_ASENV cp /run/secrets/SECRET_ASENV /app/SECRET_ASENV
 COPY --from=builder /app/qots .


### PR DESCRIPTION
## Description

Bumps the microsoft_docker_images group with 1 update in the /playground/withdockerfile/WithDockerfile.AppHost/qots directory: cbl-mariner/base/core.
Bumps the microsoft_docker_images group with 1 update in the /playground/publishers/Publishers.AppHost/qots directory: cbl-mariner/base/core.
Bumps the microsoft_docker_images group with 1 update in the /playground/withdockerfile/WithDockerfile.AppHost directory: cbl-mariner/base/core.


Updates `cbl-mariner/base/core` from 2.0 to 2.0.20251206

Updates `cbl-mariner/base/core` from 2.0 to 2.0.20251206

Updates `cbl-mariner/base/core` from 2.0 to 2.0.20251206

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
