### PR TITLE
Rename WithSecretBuildArg from Exception to WithBuildSecret

### DIFF
--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -1059,7 +1059,7 @@ public static class ContainerResourceBuilderExtensions
 
         if (value.Resource.Secret)
         {
-            throw new InvalidOperationException("Cannot add secret parameter as a build argument. Use WithSecretBuildArg instead.");
+            throw new InvalidOperationException("Cannot add secret parameter as a build argument. Use WithBuildSecret instead.");
         }
 
         return builder.WithBuildArg(name, value.Resource);
@@ -1108,7 +1108,7 @@ public static class ContainerResourceBuilderExtensions
 
         if (annotation is null)
         {
-            throw new InvalidOperationException("The resource does not have a Dockerfile build annotation. Call WithDockerfile before calling WithSecretBuildArg.");
+            throw new InvalidOperationException("The resource does not have a Dockerfile build annotation. Call WithDockerfile before calling WithBuildSecret.");
         }
 
         annotation.BuildSecrets[name] = value.Resource;


### PR DESCRIPTION
## Description

While deploying a custom Docker image for one of my services, I've noticed that the exception when referencing a secret in a build arg, as in 

```csharp
var nugetUsername = builder.AddParameter("nugetUsername", secret: true);
var nugetPassword = builder.AddParameter("nugetPassword", secret: true);
builder
    .AddDockerfile(
        "<name>",
        "<context>",
        "<Dockerfile>")
    .WithBuildArg("Nuget_UserName", nugetUsername)
    .WithBuildArg("Nuget_Password", nugetPassword)
```

uses a wrong variable name `WithSecretBuildArg`. The docs are already updated. 

https://aspire.dev/de/app-host/withdockerfile/

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
