### PR TITLE
Remove relationship attribute from GetResourceDependenciesAsync

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -1232,10 +1232,6 @@ public static class ResourceExtensions
 
         if (mode == ResourceDependencyDiscoveryMode.Recursive)
         {
-            // Relationship annotations represent both direct and indirect dependencies,
-            // we only collect dependencies from them in Recursive mode.
-            CollectRelationshipAnnotationDependencies(resource, dependencies, newDependencies);
-
             // Compute transitive closure by recursively processing dependencies
             var toProcess = new Queue<IResource>(dependencies);
             while (toProcess.Count > 0)
@@ -1244,7 +1240,6 @@ public static class ResourceExtensions
                 newDependencies.Clear();
 
                 await GatherDirectDependenciesAsync(dep, dependencies, newDependencies, executionContext, cancellationToken).ConfigureAwait(false);
-                CollectRelationshipAnnotationDependencies(dep, dependencies, newDependencies);
 
                 foreach (var newDep in newDependencies)
                 {

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -1366,23 +1366,6 @@ public static class ResourceExtensions
     }
 
     /// <summary>
-    /// Collects dependencies from resource relationship annotations.
-    /// </summary>
-    private static void CollectRelationshipAnnotationDependencies(IResource resource, HashSet<IResource> dependencies, HashSet<IResource> newDependencies)
-    {
-        if (resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationshipAnnotations))
-        {
-            foreach (var relationshipAnnotation in relationshipAnnotations)
-            {
-                if (dependencies.Add(relationshipAnnotation.Resource))
-                {
-                    newDependencies.Add(relationshipAnnotation.Resource);
-                }
-            }
-        }
-    }
-
-    /// <summary>
     /// Recursively collects resource dependencies from a value using <see cref="IValueWithReferences"/>.
     /// </summary>
     private static void CollectDependenciesFromValue(object? value, HashSet<IResource> dependencies, HashSet<IResource> newDependencies, HashSet<object> visitedValues)


### PR DESCRIPTION
Follow up to https://github.com/dotnet/aspire/pull/13798

@karolz-ms I didn't realize that the relationship attribute mixed recursive and direct. Since this is weird, and the relationship attribute is focused on UI, I think it's best to leave it out until people ask for it. What do you think?