### PR TITLE
Fail publish when Azure App Service normalizes envs

### DIFF
--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceComputeResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceComputeResourceExtensions.cs
@@ -65,10 +65,10 @@ public static class AzureAppServiceComputeResourceExtensions
     /// Skips validation for environment variable names that Azure App Service may not support.
     /// </summary>
     /// <remarks>
-    /// When running on Azure App Service, environment variable names can't contains hyphens.
+    /// When running on Azure App Service, environment variable names can't contain hyphens.
     /// This can cause Aspire client integrations that rely on the original environment variable names to fail.
     /// By default, Aspire performs validation to ensure environment variable names are compatible with Azure App Service,
-    /// failing to publish any invalid names are found.
+    /// failing to publish if any invalid names are found.
     /// </remarks>
     /// <typeparam name="T">The type of the compute resource.</typeparam>
     /// <param name="builder">The compute resource builder.</param>

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
@@ -230,7 +230,7 @@ public class AzureAppServiceEnvironmentResource :
         }
 
         var sb = new StringBuilder();
-        sb.AppendLine("Resource '" + resource.Name + "' is being published to Azure App Service, but it defines connection string app settings with '-' in the key name.");
+        sb.AppendLine("Resource '" + resource.Name + "' cannot be published to Azure App Service because it has environment variables with '-' in the name.");
         sb.AppendLine();
         sb.AppendLine("Azure App Service removes '-' characters from environment variable names at runtime.");
         sb.AppendLine("This will change the keys and can prevent Aspire client integrations from finding the expected connection string.");

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
@@ -4,12 +4,15 @@
 #pragma warning disable ASPIREPIPELINES001
 #pragma warning disable ASPIREAZURE001
 
+using System.Text;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure.AppService;
 using Aspire.Hosting.Pipelines;
 using Azure.Provisioning;
 using Azure.Provisioning.AppService;
 using Azure.Provisioning.Expressions;
 using Azure.Provisioning.Primitives;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Azure;
 
@@ -34,6 +37,19 @@ public class AzureAppServiceEnvironmentResource :
         {
             var model = factoryContext.PipelineContext.Model;
             var steps = new List<PipelineStep>();
+
+            // Add validation step that checks for environment variable name issues
+            // This runs early and provides user-friendly error messages through the activity reporter
+            var validateStep = new PipelineStep
+            {
+                Name = $"validate-appservice-config-{name}",
+                Description = $"Validates Azure App Service configuration for {name}.",
+                Action = ctx => ValidateAppServiceConfigurationAsync(ctx, model),
+                RequiredBySteps = [WellKnownPipelineSteps.Publish],
+                DependsOnSteps = [WellKnownPipelineSteps.PublishPrereq]
+            };
+
+            steps.Add(validateStep);
 
             // Add print-dashboard-url step
             var printDashboardUrlStep = new PipelineStep
@@ -130,6 +146,109 @@ public class AzureAppServiceEnvironmentResource :
             $"Dashboard available at [{dashboardUri}]({dashboardUri})",
             CompletionState.Completed,
             context.CancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task ValidateAppServiceConfigurationAsync(PipelineStepContext context, DistributedApplicationModel model)
+    {
+        // Check for validation errors in all app service contexts
+        if (!this.TryGetLastAnnotation<AzureAppServiceEnvironmentContextAnnotation>(out var contextAnnotation))
+        {
+            await context.ReportingStep.CompleteAsync(
+                "App Service configuration validated",
+                CompletionState.Completed,
+                context.CancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        var errors = new List<string>();
+
+        foreach (var computeResource in model.GetComputeResources())
+        {
+            var deploymentTarget = computeResource.GetDeploymentTargetAnnotation(this)?.DeploymentTarget;
+            if (deploymentTarget is null)
+            {
+                continue;
+            }
+
+            // Get the app service context for this resource and validate
+            try
+            {
+                var appServiceContext = contextAnnotation.EnvironmentContext.GetAppServiceContext(computeResource);
+                var validationError = ValidateEnvironmentVariableNames(computeResource, appServiceContext);
+                if (validationError is not null)
+                {
+                    errors.Add(validationError);
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // Context not found for this resource - skip
+            }
+        }
+
+        if (errors.Count > 0)
+        {
+            // Report each error through the activity reporter for user-friendly display
+            foreach (var error in errors)
+            {
+                context.ReportingStep.Log(LogLevel.Error, error, enableMarkdown: false);
+            }
+
+            await context.ReportingStep.CompleteAsync(
+                "App Service configuration validation failed",
+                CompletionState.CompletedWithError,
+                context.CancellationToken).ConfigureAwait(false);
+
+            // Throw to stop the pipeline - the error has already been reported through the activity reporter
+            throw new DistributedApplicationException("App Service configuration validation failed. See errors above.");
+        }
+
+        await context.ReportingStep.CompleteAsync(
+            "App Service configuration validated",
+            CompletionState.Completed,
+            context.CancellationToken).ConfigureAwait(false);
+    }
+
+    private static string? ValidateEnvironmentVariableNames(IResource resource, AzureAppServiceWebsiteContext appServiceContext)
+    {
+        if (resource.HasAnnotationOfType<AzureAppServiceIgnoreEnvironmentVariableChecksAnnotation>())
+        {
+            return null;
+        }
+
+        // Azure App Service removes '-' from environment variable names at runtime.
+        // This breaks configuration binding for connection strings that use dashed names.
+        var problematicKeys = appServiceContext.EnvironmentVariables.Keys
+            .Where(static k => k.Contains('-', StringComparison.Ordinal))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static k => k, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (problematicKeys.Length == 0)
+        {
+            return null;
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine("Resource '" + resource.Name + "' is being published to Azure App Service, but it defines connection string app settings with '-' in the key name.");
+        sb.AppendLine();
+        sb.AppendLine("Azure App Service removes '-' characters from environment variable names at runtime.");
+        sb.AppendLine("This will change the keys and can prevent Aspire client integrations from finding the expected connection string.");
+        sb.AppendLine();
+        sb.AppendLine("Affected setting(s):");
+
+        foreach (var key in problematicKeys)
+        {
+            var normalized = key.Replace("-", string.Empty, StringComparison.Ordinal);
+            sb.AppendLine("  - " + key + " (becomes " + normalized + ")");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("Fix options:");
+        sb.AppendLine("  - Use a dash-free connection name in the AppHost (e.g. WithReference(resource, connectionName: \"mydb\")).");
+        sb.AppendLine($"  - Call {nameof(AzureAppServiceComputeResourceExtensions.SkipEnvironmentVariableNameChecks)}() on this resource to bypass this validation.");
+
+        return sb.ToString();
     }
 
     // We don't want these to be public if we end up with an app service

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceIgnoreEnvironmentVariableChecksAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceIgnoreEnvironmentVariableChecksAnnotation.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Represents an annotation that disables validation for environment variable names that Azure App Service normalizes.
+/// </summary>
+internal sealed class AzureAppServiceIgnoreEnvironmentVariableChecksAnnotation : IResourceAnnotation;

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithAzureResourceDependencies_DoesNotHang_step=diagnostics.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithAzureResourceDependencies_DoesNotHang_step=diagnostics.verified.txt
@@ -5,7 +5,7 @@ PIPELINE DEPENDENCY GRAPH DIAGNOSTICS
 This diagnostic output shows the complete pipeline dependency graph structure.
 Use this to understand step relationships and troubleshoot execution issues.
 
-Total steps defined: 29
+Total steps defined: 30
 
 Analysis for full pipeline execution (showing all steps and their relationships)
 
@@ -40,9 +40,10 @@ Steps with no dependencies run first, followed by steps that depend on them.
  24. diagnostics
  25. publish-prereq
  26. publish-azure634f9
- 27. publish
- 28. publish-manifest
- 29. push
+ 27. validate-appservice-config-env
+ 28. publish
+ 29. publish-manifest
+ 30. push
 
 DETAILED STEP ANALYSIS
 ======================
@@ -156,7 +157,7 @@ Step: provision-kv
 
 Step: publish
     Description: Aggregation step for all publish operations. All publish steps should be required by this step.
-    Dependencies: ✓ publish-azure634f9
+    Dependencies: ✓ publish-azure634f9, ✓ validate-appservice-config-env
 
 Step: publish-azure634f9
     Description: Publishes the Azure environment configuration for azure634f9.
@@ -188,6 +189,11 @@ Step: update-api-provisionable-resource
     Dependencies: ✓ check-api-exists, ✓ create-provisioning-context
     Resource: api-website (AzureAppServiceWebSiteResource)
     Tags: update-website-provisionable-resource
+
+Step: validate-appservice-config-env
+    Description: Validates Azure App Service configuration for env.
+    Dependencies: ✓ publish-prereq
+    Resource: env (AzureAppServiceEnvironmentResource)
 
 Step: validate-azure-login
     Description: Validates Azure CLI authentication before deployment.
@@ -424,12 +430,12 @@ If targeting 'provision-kv':
     [4] provision-kv
 
 If targeting 'publish':
-  Direct dependencies: publish-azure634f9
-  Total steps: 4
+  Direct dependencies: publish-azure634f9, validate-appservice-config-env
+  Total steps: 5
   Execution order:
     [0] process-parameters
     [1] publish-prereq
-    [2] publish-azure634f9
+    [2] publish-azure634f9 | validate-appservice-config-env (parallel)
     [3] publish
 
 If targeting 'publish-azure634f9':
@@ -502,6 +508,14 @@ If targeting 'update-api-provisionable-resource':
     [3] create-provisioning-context
     [4] check-api-exists
     [5] update-api-provisionable-resource
+
+If targeting 'validate-appservice-config-env':
+  Direct dependencies: publish-prereq
+  Total steps: 3
+  Execution order:
+    [0] process-parameters
+    [1] publish-prereq
+    [2] validate-appservice-config-env
 
 If targeting 'validate-azure-login':
   Direct dependencies: deploy-prereq

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRedisAccessKeyAuthentication_CreatesCorrectDependencies.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRedisAccessKeyAuthentication_CreatesCorrectDependencies.verified.txt
@@ -5,7 +5,7 @@ PIPELINE DEPENDENCY GRAPH DIAGNOSTICS
 This diagnostic output shows the complete pipeline dependency graph structure.
 Use this to understand step relationships and troubleshoot execution issues.
 
-Total steps defined: 36
+Total steps defined: 37
 
 Analysis for full pipeline execution (showing all steps and their relationships)
 
@@ -47,9 +47,10 @@ Steps with no dependencies run first, followed by steps that depend on them.
  31. diagnostics
  32. publish-prereq
  33. publish-azure634f9
- 34. publish
- 35. publish-manifest
- 36. push
+ 34. validate-appservice-config-env
+ 35. publish
+ 36. publish-manifest
+ 37. push
 
 DETAILED STEP ANALYSIS
 ======================
@@ -205,7 +206,7 @@ Step: provision-pg-kv
 
 Step: publish
     Description: Aggregation step for all publish operations. All publish steps should be required by this step.
-    Dependencies: ✓ publish-azure634f9
+    Dependencies: ✓ publish-azure634f9, ✓ validate-appservice-config-env
 
 Step: publish-azure634f9
     Description: Publishes the Azure environment configuration for azure634f9.
@@ -237,6 +238,11 @@ Step: update-api-provisionable-resource
     Dependencies: ✓ check-api-exists, ✓ create-provisioning-context
     Resource: api-website (AzureAppServiceWebSiteResource)
     Tags: update-website-provisionable-resource
+
+Step: validate-appservice-config-env
+    Description: Validates Azure App Service configuration for env.
+    Dependencies: ✓ publish-prereq
+    Resource: env (AzureAppServiceEnvironmentResource)
 
 Step: validate-azure-login
     Description: Validates Azure CLI authentication before deployment.
@@ -548,12 +554,12 @@ If targeting 'provision-pg-kv':
     [4] provision-pg-kv
 
 If targeting 'publish':
-  Direct dependencies: publish-azure634f9
-  Total steps: 4
+  Direct dependencies: publish-azure634f9, validate-appservice-config-env
+  Total steps: 5
   Execution order:
     [0] process-parameters
     [1] publish-prereq
-    [2] publish-azure634f9
+    [2] publish-azure634f9 | validate-appservice-config-env (parallel)
     [3] publish
 
 If targeting 'publish-azure634f9':
@@ -626,6 +632,14 @@ If targeting 'update-api-provisionable-resource':
     [3] create-provisioning-context
     [4] check-api-exists
     [5] update-api-provisionable-resource
+
+If targeting 'validate-appservice-config-env':
+  Direct dependencies: publish-prereq
+  Total steps: 3
+  Execution order:
+    [0] process-parameters
+    [1] publish-prereq
+    [2] validate-appservice-config-env
 
 If targeting 'validate-azure-login':
   Direct dependencies: deploy-prereq


### PR DESCRIPTION
## Description

Prevent publish when the App Service contains dashes in ENVs. Optionally disable the verification.
Fixes #13047

<img width="1007" height="392" alt="image" src="https://github.com/user-attachments/assets/b4b436e8-7e52-421e-adee-6719e1aab575" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
