### PR TITLE
Fix flaky ProcessParametersStep_ValidatesBehavior test

### DIFF
--- a/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
+++ b/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
@@ -2050,7 +2050,7 @@ public class DistributedApplicationPipelineTests(ITestOutputHelper testOutputHel
         PipelineStep? buildPrereqStep = null;
         PipelineStep? publishPrereqStep = null;
         
-        // Track execution order using the activity reporter callback when steps are created/started
+        // Track execution order using the activity reporter callback when steps are created
         activityReporter.OnStepCreated = (stepTitle) =>
         {
             lock (lockObject)

--- a/tests/Shared/TestPipelineActivityReporter.cs
+++ b/tests/Shared/TestPipelineActivityReporter.cs
@@ -131,9 +131,9 @@ internal sealed class TestPipelineActivityReporter : IPipelineActivityReporter
         lock (CreatedSteps)
         {
             CreatedSteps.Add(title);
+            OnStepCreated?.Invoke(title);
+            _testOutputHelper.WriteLine($"[CreateStep] {title}");
         }
-        OnStepCreated?.Invoke(title);
-        _testOutputHelper.WriteLine($"[CreateStep] {title}");
 
         return Task.FromResult<IReportingStep>(new TestReportingStep(this, title, _testOutputHelper));
     }
@@ -158,11 +158,9 @@ internal sealed class TestPipelineActivityReporter : IPipelineActivityReporter
             lock (_reporter.CompletedSteps)
             {
                 _reporter.CompletedSteps.Add((_title, completionText, completionState));
+                _reporter.OnStepCompleted?.Invoke(_title, completionText, completionState);
+                _testOutputHelper.WriteLine($"  [CompleteStep:{_title}] {completionText} (State: {completionState})");
             }
-
-            _reporter.OnStepCompleted?.Invoke(_title, completionText, completionState);
-
-            _testOutputHelper.WriteLine($"  [CompleteStep:{_title}] {completionText} (State: {completionState})");
 
             return Task.CompletedTask;
         }
@@ -172,8 +170,8 @@ internal sealed class TestPipelineActivityReporter : IPipelineActivityReporter
             lock (_reporter.CreatedTasks)
             {
                 _reporter.CreatedTasks.Add((_title, statusText));
+                _testOutputHelper.WriteLine($"    [CreateTask:{_title}] {statusText}");
             }
-            _testOutputHelper.WriteLine($"    [CreateTask:{_title}] {statusText}");
 
             return Task.FromResult<IReportingTask>(new TestReportingTask(_reporter, statusText, _testOutputHelper));
         }
@@ -183,8 +181,8 @@ internal sealed class TestPipelineActivityReporter : IPipelineActivityReporter
             lock (_reporter.LoggedMessages)
             {
                 _reporter.LoggedMessages.Add((_title, logLevel, message));
+                _testOutputHelper.WriteLine($"    [{logLevel}:{_title}] {message}");
             }
-            _testOutputHelper.WriteLine($"    [{logLevel}:{_title}] {message}");
         }
     }
 
@@ -208,8 +206,8 @@ internal sealed class TestPipelineActivityReporter : IPipelineActivityReporter
             lock (_reporter.CompletedTasks)
             {
                 _reporter.CompletedTasks.Add((_initialStatusText, completionMessage, completionState));
+                _testOutputHelper.WriteLine($"      [CompleteTask:{_initialStatusText}] {completionMessage} (State: {completionState})");
             }
-            _testOutputHelper.WriteLine($"      [CompleteTask:{_initialStatusText}] {completionMessage} (State: {completionState})");
 
             return Task.CompletedTask;
         }
@@ -219,8 +217,8 @@ internal sealed class TestPipelineActivityReporter : IPipelineActivityReporter
             lock (_reporter.UpdatedTasks)
             {
                 _reporter.UpdatedTasks.Add((_initialStatusText, statusText));
+                _testOutputHelper.WriteLine($"      [UpdateTask:{_initialStatusText}] {statusText}");
             }
-            _testOutputHelper.WriteLine($"      [UpdateTask:{_initialStatusText}] {statusText}");
 
             return Task.CompletedTask;
         }

--- a/tests/Shared/TestPipelineActivityReporter.cs
+++ b/tests/Shared/TestPipelineActivityReporter.cs
@@ -56,6 +56,16 @@ internal sealed class TestPipelineActivityReporter : IPipelineActivityReporter
     public List<(string StepTitle, LogLevel LogLevel, string Message)> LoggedMessages { get; } = [];
 
     /// <summary>
+    /// Gets or sets a callback that is invoked when a step is created.
+    /// </summary>
+    public Action<string>? OnStepCreated { get; set; }
+
+    /// <summary>
+    /// Gets or sets a callback that is invoked when a step completes.
+    /// </summary>
+    public Action<string, string, CompletionState>? OnStepCompleted { get; set; }
+
+    /// <summary>
     /// Gets a value indicating whether <see cref="CompletePublishAsync"/> has been called.
     /// </summary>
     public bool CompletePublishCalled { get; private set; }
@@ -122,6 +132,7 @@ internal sealed class TestPipelineActivityReporter : IPipelineActivityReporter
         {
             CreatedSteps.Add(title);
         }
+        OnStepCreated?.Invoke(title);
         _testOutputHelper.WriteLine($"[CreateStep] {title}");
 
         return Task.FromResult<IReportingStep>(new TestReportingStep(this, title, _testOutputHelper));
@@ -148,6 +159,8 @@ internal sealed class TestPipelineActivityReporter : IPipelineActivityReporter
             {
                 _reporter.CompletedSteps.Add((_title, completionText, completionState));
             }
+
+            _reporter.OnStepCompleted?.Invoke(_title, completionText, completionState);
 
             _testOutputHelper.WriteLine($"  [CompleteStep:{_title}] {completionText} (State: {completionState})");
 


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspire/issues/13083

This test was flaky I think because the order of the additional steps didn't guarantee they would run in the expected order. One says it is after parameter processing, the other says it is after deployment. What is stopping them following that requirement but after deployment step executing first?

Fix is to assert order of the actual steps using the pipeline activity reporter.