### PR TITLE
Fix CLI E2E recording workflow to paginate artifacts

### DIFF
--- a/.github/workflows/cli-e2e-recording-comment.yml
+++ b/.github/workflows/cli-e2e-recording-comment.yml
@@ -90,15 +90,22 @@ jobs:
             
             const runId = ${{ steps.run-info.outputs.run_id }};
             
-            // List artifacts for the workflow run
-            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: runId
-            });
+            // List ALL artifacts for the workflow run using pagination
+            // (without pagination we only get the first page and miss CLI E2E artifacts)
+            const allArtifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+                per_page: 100
+              }
+            );
+            
+            console.log(`Total artifacts found: ${allArtifacts.length}`);
             
             // Filter for CLI E2E test logs (they contain recordings)
-            const cliE2eArtifacts = artifacts.data.artifacts.filter(a => 
+            const cliE2eArtifacts = allArtifacts.filter(a => 
               a.name.startsWith('logs-') && 
               a.name.includes('Tests-ubuntu-latest') &&
               (a.name.includes('SmokeTests') || 


### PR DESCRIPTION
## Problem

The CLI E2E recording comment workflow was never finding the CLI E2E test artifacts. Investigation showed that CI runs have 200+ artifacts, but the workflow was only fetching the first page (default 30 items).

Looking at the CI run for PR #13902:
- Total artifacts: 295
- CLI E2E artifacts (SmokeTests, DockerDeploymentTests, etc.) were on page 3

## Fix

Use `github.paginate()` to fetch all artifacts across all pages instead of a single API call.

## Testing

After this fix, the workflow will:
1. Log total artifacts found (helpful for debugging)
2. Properly find CLI E2E test artifacts regardless of pagination
3. Download, extract, and upload recordings to asciinema
4. Post/update a comment on the PR with recording links