### PR TITLE
Improve polyglot project UX

### DIFF
--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -124,9 +124,10 @@ internal sealed class AddCommand : BaseCommand
                     }
 
                     // If there are hives (PR build directories), include all channels.
+                    // If a channel is configured in settings.json, use that (already filtered above).
                     // Otherwise, only use the implicit/default channel to avoid prompting.
                     var hasHives = ExecutionContext.GetPrHiveCount() > 0;
-                    var channels = hasHives
+                    var channels = hasHives || !string.IsNullOrEmpty(configuredChannel)
                         ? allChannels
                         : allChannels.Where(c => c.Type is PackageChannelType.Implicit);
 

--- a/src/Aspire.Cli/Packaging/TemporaryNuGetConfig.cs
+++ b/src/Aspire.Cli/Packaging/TemporaryNuGetConfig.cs
@@ -21,7 +21,7 @@ internal sealed class TemporaryNuGetConfig : IDisposable
     {
         var tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         Directory.CreateDirectory(tempDirectory);
-        var tempFilePath = Path.Combine(tempDirectory, "NuGet.config");
+        var tempFilePath = Path.Combine(tempDirectory, "nuget.config");
         var configFile = new FileInfo(tempFilePath);
         await GenerateNuGetConfigAsync(mappings, configFile);
         return new TemporaryNuGetConfig(configFile);

--- a/src/Aspire.Cli/Projects/AppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerProject.cs
@@ -75,8 +75,6 @@ internal sealed class AppHostServerProject
         return version;
     }
 
-    public static string? LocalPackagePath = Environment.GetEnvironmentVariable("ASPIRE_POLYGLOT_PACKAGE_SOURCE");
-
     /// <summary>
     /// Path to local Aspire repo root (e.g., /path/to/aspire).
     /// When set, uses direct project references instead of NuGet packages.
@@ -169,6 +167,7 @@ internal sealed class AppHostServerProject
         // Create appsettings.json with the list of ATS assemblies
         // These are the assemblies that will be scanned for [AspireExport] capabilities
         // Include all packages since any package could contribute capabilities via [AspireExport]
+        // The code generation package for the language is already included in packages
         var atsAssemblies = new List<string> { "Aspire.Hosting" };
         foreach (var pkg in packages)
         {
@@ -177,8 +176,6 @@ internal sealed class AppHostServerProject
                 atsAssemblies.Add(pkg.Name);
             }
         }
-        // Add the TypeScript code generator assembly for code generation support
-        atsAssemblies.Add("Aspire.Hosting.CodeGeneration.TypeScript");
 
         var assembliesJson = string.Join(",\n      ", atsAssemblies.Select(a => $"\"{a}\""));
         var appSettingsJson = $$"""
@@ -199,278 +196,60 @@ internal sealed class AppHostServerProject
         var appSettingsJsonPath = Path.Combine(_projectModelPath, "appsettings.json");
         File.WriteAllText(appSettingsJsonPath, appSettingsJson);
 
-        // Handle NuGet.config:
-        // 1. If local package source is specified (dev scenario), create a config that includes it
-        // 2. Otherwise, use NuGetConfigMerger to create/update config based on channel (same pattern as aspire new/init)
+        // Handle NuGet.config - copy user's config and merge channel sources
         var nugetConfigPath = Path.Combine(_projectModelPath, "NuGet.config");
         string? channelName = null;
 
-        if (LocalPackagePath is not null)
+        // First, copy user's NuGet.config if it exists (to preserve private feeds/auth)
+        var userNugetConfig = FindNuGetConfig(_appPath);
+        if (userNugetConfig is not null)
         {
-            var nugetConfig = $"""
-                <?xml version="1.0" encoding="utf-8"?>
-                <configuration>
-                    <packageSources>
-                        <add key="local" value="{LocalPackagePath.Replace("\\", "/")}" />
-                    </packageSources>
-                </configuration>
-                """;
-            File.WriteAllText(nugetConfigPath, nugetConfig);
+            File.Copy(userNugetConfig, nugetConfigPath, overwrite: true);
+        }
+
+        // Get the appropriate channel from the packaging service (same logic as aspire new/init)
+        var channels = await _packagingService.GetChannelsAsync(cancellationToken);
+
+        // Check for global channel setting (same as aspire new/init)
+        var configuredChannelName = await _configurationService.GetConfigurationAsync("channel", cancellationToken);
+
+        PackageChannel? channel;
+        if (!string.IsNullOrEmpty(configuredChannelName))
+        {
+            // Use the configured channel if specified
+            channel = channels.FirstOrDefault(c => string.Equals(c.Name, configuredChannelName, StringComparison.OrdinalIgnoreCase));
         }
         else
         {
-            // First, copy user's NuGet.config if it exists (to preserve private feeds/auth)
-            var userNugetConfig = FindNuGetConfig(_appPath);
-            if (userNugetConfig is not null)
-            {
-                File.Copy(userNugetConfig, nugetConfigPath, overwrite: true);
-            }
+            // Fall back to first explicit channel (staging/PR)
+            channel = channels.FirstOrDefault(c => c.Type == PackageChannelType.Explicit);
+        }
 
-            // Get the appropriate channel from the packaging service (same logic as aspire new/init)
-            var channels = await _packagingService.GetChannelsAsync(cancellationToken);
+        // NuGetConfigMerger creates or updates the config with channel sources/mappings
+        if (channel is not null)
+        {
+            await NuGetConfigMerger.CreateOrUpdateAsync(
+                new DirectoryInfo(_projectModelPath),
+                channel,
+                cancellationToken: cancellationToken);
 
-            // Check for global channel setting (same as aspire new/init)
-            var configuredChannelName = await _configurationService.GetConfigurationAsync("channel", cancellationToken);
-
-            PackageChannel? channel;
-            if (!string.IsNullOrEmpty(configuredChannelName))
-            {
-                // Use the configured channel if specified
-                channel = channels.FirstOrDefault(c => string.Equals(c.Name, configuredChannelName, StringComparison.OrdinalIgnoreCase));
-            }
-            else
-            {
-                // Fall back to first explicit channel (staging/PR)
-                channel = channels.FirstOrDefault(c => c.Type == PackageChannelType.Explicit);
-            }
-
-            // NuGetConfigMerger creates or updates the config with channel sources/mappings
-            if (channel is not null)
-            {
-                await NuGetConfigMerger.CreateOrUpdateAsync(
-                    new DirectoryInfo(_projectModelPath),
-                    channel,
-                    cancellationToken: cancellationToken);
-
-                // Track the channel name to return to caller
-                channelName = channel.Name;
-            }
+            // Track the channel name to return to caller
+            channelName = channel.Name;
         }
 
         // Note: We don't create launchSettings.json here. Environment variables
         // (ports, OTLP endpoints, etc.) are read from the user's apphost.run.json
         // and passed directly to Run() at runtime.
 
-        // Create the project file
-        string template;
-
+        // Create the project file based on mode (local dev vs production)
+        XDocument doc;
         if (LocalAspirePath is not null)
         {
-            // Local build: use project references like the playground
-            var repoRoot = Path.GetFullPath(LocalAspirePath) + Path.DirectorySeparatorChar;
-
-            // Determine OS/architecture for DCP package name (matches Directory.Build.props logic)
-            var (buildOs, buildArch) = GetBuildPlatform();
-            var dcpPackageName = $"microsoft.developercontrolplane.{buildOs}-{buildArch}";
-
-            // Read DCP version from eng/Versions.props in the repo
-            var dcpVersion = GetDcpVersionFromRepo(repoRoot, buildOs, buildArch);
-
-            template = $"""
-                <Project Sdk="Microsoft.NET.Sdk">
-
-                    <PropertyGroup>
-                        <OutputType>exe</OutputType>
-                        <TargetFramework>{TargetFramework}</TargetFramework>
-                        <AssemblyName>{AssemblyName}</AssemblyName>
-                        <OutDir>{BuildFolder}</OutDir>
-                        <UserSecretsId>{_userSecretsId}</UserSecretsId>
-                        <IsAspireHost>true</IsAspireHost>
-                        <IsPublishable>false</IsPublishable>
-                        <SelfContained>false</SelfContained>
-                        <ImplicitUsings>enable</ImplicitUsings>
-                        <Nullable>enable</Nullable>
-                        <WarningLevel>0</WarningLevel>
-                        <EnableNETAnalyzers>false</EnableNETAnalyzers>
-                        <EnableRoslynAnalyzers>false</EnableRoslynAnalyzers>
-                        <RunAnalyzers>false</RunAnalyzers>
-                        <NoWarn>$(NoWarn);1701;1702;1591;CS8019;CS1591;CS1573;CS0168;CS0219;CS8618;CS8625;CS1998;CS1999</NoWarn>
-                        <!-- Properties for in-repo building (from Aspire.RepoTesting.targets) -->
-                        <RepoRoot>{repoRoot}</RepoRoot>
-                        <SkipValidateAspireHostProjectResources>true</SkipValidateAspireHostProjectResources>
-                        <SkipAddAspireDefaultReferences>true</SkipAddAspireDefaultReferences>
-                        <AspireHostingSDKVersion>42.42.42</AspireHostingSDKVersion>
-                        <!-- DCP and Dashboard paths for local development (same as Directory.Build.props) -->
-                        <DcpDir>$(NuGetPackageRoot){dcpPackageName}/{dcpVersion}/tools/</DcpDir>
-                        <AspireDashboardDir>{repoRoot}artifacts/bin/Aspire.Dashboard/Debug/net8.0/</AspireDashboardDir>
-                    </PropertyGroup>
-                    <ItemGroup>
-                        <PackageReference Include="StreamJsonRpc" Version="2.22.23" />
-                        <!-- Pin Google.Protobuf to match Aspire.Hosting's version to avoid conflicts -->
-                        <PackageReference Include="Google.Protobuf" Version="3.33.0" />
-                    </ItemGroup>
-                </Project>
-                """;
+            doc = CreateDevModeProjectFile(packages);
         }
         else
         {
-            // Standard NuGet flow with Aspire.AppHost.Sdk
-            template = $"""
-                <Project Sdk="Microsoft.NET.Sdk">
-
-                    <Sdk Name="Aspire.AppHost.Sdk" Version="{sdkVersion}" />
-
-                    <PropertyGroup>
-                        <OutputType>exe</OutputType>
-                        <TargetFramework>{TargetFramework}</TargetFramework>
-                        <AssemblyName>{AssemblyName}</AssemblyName>
-                        <OutDir>{BuildFolder}</OutDir>
-                        <UserSecretsId>{_userSecretsId}</UserSecretsId>
-                        <IsAspireHost>true</IsAspireHost>
-                        <IsPublishable>true</IsPublishable>
-                        <SelfContained>true</SelfContained>
-                        <ImplicitUsings>enable</ImplicitUsings>
-                        <Nullable>enable</Nullable>
-                        <WarningLevel>0</WarningLevel>
-                        <EnableNETAnalyzers>false</EnableNETAnalyzers>
-                        <EnableRoslynAnalyzers>false</EnableRoslynAnalyzers>
-                        <RunAnalyzers>false</RunAnalyzers>
-                        <NoWarn>$(NoWarn);1701;1702;1591;CS8019;CS1591;CS1573;CS0168;CS0219;CS8618;CS8625;CS1998;CS1999</NoWarn>
-                    </PropertyGroup>
-                    <ItemGroup>
-                        <PackageReference Include="StreamJsonRpc" Version="2.22.23" />
-                    </ItemGroup>
-                    <!-- Disable Aspire SDK code generation - we don't need project metadata for the AppHost server -->
-                    <Target Name="_CSharpWriteHostProjectMetadataSources" />
-                    <Target Name="_CSharpWriteProjectMetadataSources" />
-                </Project>
-                """;
-        }
-
-        var doc = XDocument.Parse(template);
-
-        // Check if using local build (project references for faster dev loop)
-        if (LocalAspirePath is not null)
-        {
-            var repoRoot = Path.GetFullPath(LocalAspirePath);
-
-            var projectRefGroup = new XElement("ItemGroup");
-            var addedProjects = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            var otherPackages = new List<(string Name, string Version)>();
-
-            foreach (var pkg in packages)
-            {
-                if (!pkg.Name.StartsWith("Aspire.Hosting", StringComparison.OrdinalIgnoreCase))
-                {
-                    otherPackages.Add(pkg);
-                    continue;
-                }
-
-                // Skip if already added
-                if (addedProjects.Contains(pkg.Name))
-                {
-                    continue;
-                }
-
-                // Look for the project in src/ or src/Components/ (same as AspireProjectOrPackageReference)
-                var candidatePaths = new[]
-                {
-                    Path.Combine(repoRoot, "src", "Components", pkg.Name, $"{pkg.Name}.csproj"),
-                    Path.Combine(repoRoot, "src", pkg.Name, $"{pkg.Name}.csproj")
-                };
-
-                var projectPath = candidatePaths.FirstOrDefault(File.Exists);
-                if (projectPath is not null)
-                {
-                    addedProjects.Add(pkg.Name);
-                    projectRefGroup.Add(new XElement("ProjectReference",
-                        new XAttribute("Include", projectPath),
-                        new XElement("IsAspireProjectResource", "false")));
-                }
-                else
-                {
-                    // Fallback to NuGet package if project not found
-                    _logger.LogWarning("Could not find local project for {PackageName}, falling back to NuGet", pkg.Name);
-                    otherPackages.Add(pkg);
-                }
-            }
-
-            if (projectRefGroup.HasElements)
-            {
-                doc.Root!.Add(projectRefGroup);
-            }
-
-            if (otherPackages.Count > 0)
-            {
-                doc.Root!.Add(new XElement("ItemGroup",
-                    otherPackages.Select(p => new XElement("PackageReference",
-                        new XAttribute("Include", p.Name),
-                        new XAttribute("Version", p.Version)))));
-            }
-
-            // Add imports for in-repo AppHost building (from Aspire.RepoTesting.targets)
-            var appHostInTargets = Path.Combine(repoRoot, "src", "Aspire.Hosting.AppHost", "build", "Aspire.Hosting.AppHost.in.targets");
-            var sdkInTargets = Path.Combine(repoRoot, "src", "Aspire.AppHost.Sdk", "SDK", "Sdk.in.targets");
-
-            if (File.Exists(appHostInTargets))
-            {
-                doc.Root!.Add(new XElement("Import", new XAttribute("Project", appHostInTargets)));
-            }
-            if (File.Exists(sdkInTargets))
-            {
-                doc.Root!.Add(new XElement("Import", new XAttribute("Project", sdkInTargets)));
-            }
-
-            // Add Dashboard project reference (like playground does)
-            var dashboardProject = Path.Combine(repoRoot, "src", "Aspire.Dashboard", "Aspire.Dashboard.csproj");
-            if (File.Exists(dashboardProject))
-            {
-                doc.Root!.Add(new XElement("ItemGroup",
-                    new XElement("ProjectReference",
-                        new XAttribute("Include", dashboardProject))));
-            }
-
-            // Add Aspire.Hosting.RemoteHost project reference
-            var remoteHostProject = Path.Combine(repoRoot, "src", "Aspire.Hosting.RemoteHost", "Aspire.Hosting.RemoteHost.csproj");
-            if (File.Exists(remoteHostProject))
-            {
-                doc.Root!.Add(new XElement("ItemGroup",
-                    new XElement("ProjectReference",
-                        new XAttribute("Include", remoteHostProject))));
-            }
-
-            // Add Aspire.Hosting.CodeGeneration.TypeScript project reference for code generation
-            var typeScriptCodeGenProject = Path.Combine(repoRoot, "src", "Aspire.Hosting.CodeGeneration.TypeScript", "Aspire.Hosting.CodeGeneration.TypeScript.csproj");
-            if (File.Exists(typeScriptCodeGenProject))
-            {
-                doc.Root!.Add(new XElement("ItemGroup",
-                    new XElement("ProjectReference",
-                        new XAttribute("Include", typeScriptCodeGenProject))));
-            }
-
-            // Disable Aspire SDK code generation - we don't need project metadata for the AppHost server
-            // These must come after the imports to override the targets defined there
-            doc.Root!.Add(new XElement("Target", new XAttribute("Name", "_CSharpWriteHostProjectMetadataSources")));
-            doc.Root!.Add(new XElement("Target", new XAttribute("Name", "_CSharpWriteProjectMetadataSources")));
-        }
-        else
-        {
-            // Add package references (standard NuGet flow)
-            var packageRefs = packages.Select(p => new XElement("PackageReference",
-                new XAttribute("Include", p.Name),
-                new XAttribute("Version", p.Version))).ToList();
-
-            // Add Aspire.Hosting.RemoteHost package reference
-            packageRefs.Add(new XElement("PackageReference",
-                new XAttribute("Include", "Aspire.Hosting.RemoteHost"),
-                new XAttribute("Version", sdkVersion)));
-
-            // Add Aspire.Hosting.CodeGeneration.TypeScript package for code generation
-            packageRefs.Add(new XElement("PackageReference",
-                new XAttribute("Include", "Aspire.Hosting.CodeGeneration.TypeScript"),
-                new XAttribute("Version", sdkVersion)));
-
-            doc.Root!.Add(new XElement("ItemGroup", packageRefs));
+            doc = CreateProductionProjectFile(sdkVersion, packages);
         }
 
         // Add appsettings.json to be copied to output directory
@@ -484,6 +263,178 @@ internal sealed class AppHostServerProject
         doc.Save(projectFileName);
 
         return (projectFileName, channelName);
+    }
+
+    /// <summary>
+    /// Creates a project file for local development using project references.
+    /// Used when ASPIRE_REPO_ROOT is set.
+    /// </summary>
+    private XDocument CreateDevModeProjectFile(IEnumerable<(string Name, string Version)> packages)
+    {
+        var repoRoot = Path.GetFullPath(LocalAspirePath!) + Path.DirectorySeparatorChar;
+
+        // Determine OS/architecture for DCP package name (matches Directory.Build.props logic)
+        var (buildOs, buildArch) = GetBuildPlatform();
+        var dcpPackageName = $"microsoft.developercontrolplane.{buildOs}-{buildArch}";
+        var dcpVersion = GetDcpVersionFromRepo(repoRoot, buildOs, buildArch);
+
+        var template = $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <OutputType>exe</OutputType>
+                    <TargetFramework>{TargetFramework}</TargetFramework>
+                    <AssemblyName>{AssemblyName}</AssemblyName>
+                    <OutDir>{BuildFolder}</OutDir>
+                    <UserSecretsId>{_userSecretsId}</UserSecretsId>
+                    <IsAspireHost>true</IsAspireHost>
+                    <IsPublishable>false</IsPublishable>
+                    <SelfContained>false</SelfContained>
+                    <ImplicitUsings>enable</ImplicitUsings>
+                    <Nullable>enable</Nullable>
+                    <WarningLevel>0</WarningLevel>
+                    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+                    <EnableRoslynAnalyzers>false</EnableRoslynAnalyzers>
+                    <RunAnalyzers>false</RunAnalyzers>
+                    <NoWarn>$(NoWarn);1701;1702;1591;CS8019;CS1591;CS1573;CS0168;CS0219;CS8618;CS8625;CS1998;CS1999</NoWarn>
+                    <!-- Properties for in-repo building -->
+                    <RepoRoot>{repoRoot}</RepoRoot>
+                    <SkipValidateAspireHostProjectResources>true</SkipValidateAspireHostProjectResources>
+                    <SkipAddAspireDefaultReferences>true</SkipAddAspireDefaultReferences>
+                    <AspireHostingSDKVersion>42.42.42</AspireHostingSDKVersion>
+                    <!-- DCP and Dashboard paths for local development -->
+                    <DcpDir>$(NuGetPackageRoot){dcpPackageName}/{dcpVersion}/tools/</DcpDir>
+                    <AspireDashboardDir>{repoRoot}artifacts/bin/Aspire.Dashboard/Debug/net8.0/</AspireDashboardDir>
+                </PropertyGroup>
+                <ItemGroup>
+                    <PackageReference Include="StreamJsonRpc" Version="2.22.23" />
+                    <PackageReference Include="Google.Protobuf" Version="3.33.0" />
+                </ItemGroup>
+            </Project>
+            """;
+
+        var doc = XDocument.Parse(template);
+
+        // Add project references for Aspire.Hosting.* packages, NuGet for others
+        var projectRefGroup = new XElement("ItemGroup");
+        var addedProjects = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var otherPackages = new List<(string Name, string Version)>();
+
+        foreach (var pkg in packages)
+        {
+            if (!pkg.Name.StartsWith("Aspire.Hosting", StringComparison.OrdinalIgnoreCase))
+            {
+                otherPackages.Add(pkg);
+                continue;
+            }
+
+            if (addedProjects.Contains(pkg.Name))
+            {
+                continue;
+            }
+
+            // Look for the project in src/
+            var projectPath = Path.Combine(repoRoot, "src", pkg.Name, $"{pkg.Name}.csproj");
+            if (File.Exists(projectPath))
+            {
+                addedProjects.Add(pkg.Name);
+                projectRefGroup.Add(new XElement("ProjectReference",
+                    new XAttribute("Include", projectPath),
+                    new XElement("IsAspireProjectResource", "false")));
+            }
+            else
+            {
+                _logger.LogWarning("Could not find local project for {PackageName}, falling back to NuGet", pkg.Name);
+                otherPackages.Add(pkg);
+            }
+        }
+
+        if (projectRefGroup.HasElements)
+        {
+            doc.Root!.Add(projectRefGroup);
+        }
+
+        if (otherPackages.Count > 0)
+        {
+            doc.Root!.Add(new XElement("ItemGroup",
+                otherPackages.Select(p => new XElement("PackageReference",
+                    new XAttribute("Include", p.Name),
+                    new XAttribute("Version", p.Version)))));
+        }
+
+        // Add imports for in-repo AppHost building
+        var appHostInTargets = Path.Combine(repoRoot, "src", "Aspire.Hosting.AppHost", "build", "Aspire.Hosting.AppHost.in.targets");
+        var sdkInTargets = Path.Combine(repoRoot, "src", "Aspire.AppHost.Sdk", "SDK", "Sdk.in.targets");
+
+        if (File.Exists(appHostInTargets))
+        {
+            doc.Root!.Add(new XElement("Import", new XAttribute("Project", appHostInTargets)));
+        }
+        if (File.Exists(sdkInTargets))
+        {
+            doc.Root!.Add(new XElement("Import", new XAttribute("Project", sdkInTargets)));
+        }
+
+        // Add Dashboard and RemoteHost project references
+        var dashboardProject = Path.Combine(repoRoot, "src", "Aspire.Dashboard", "Aspire.Dashboard.csproj");
+        if (File.Exists(dashboardProject))
+        {
+            doc.Root!.Add(new XElement("ItemGroup",
+                new XElement("ProjectReference", new XAttribute("Include", dashboardProject))));
+        }
+
+        var remoteHostProject = Path.Combine(repoRoot, "src", "Aspire.Hosting.RemoteHost", "Aspire.Hosting.RemoteHost.csproj");
+        if (File.Exists(remoteHostProject))
+        {
+            doc.Root!.Add(new XElement("ItemGroup",
+                new XElement("ProjectReference", new XAttribute("Include", remoteHostProject))));
+        }
+
+        // Disable Aspire SDK code generation (must come after imports)
+        doc.Root!.Add(new XElement("Target", new XAttribute("Name", "_CSharpWriteHostProjectMetadataSources")));
+        doc.Root!.Add(new XElement("Target", new XAttribute("Name", "_CSharpWriteProjectMetadataSources")));
+
+        return doc;
+    }
+
+    /// <summary>
+    /// Creates a project file for production using NuGet packages.
+    /// </summary>
+    private XDocument CreateProductionProjectFile(string sdkVersion, IEnumerable<(string Name, string Version)> packages)
+    {
+        var template = $"""
+            <Project Sdk="Aspire.AppHost.Sdk/{sdkVersion}">
+                <PropertyGroup>
+                    <OutputType>exe</OutputType>
+                    <TargetFramework>{TargetFramework}</TargetFramework>
+                    <AssemblyName>{AssemblyName}</AssemblyName>
+                    <OutDir>{BuildFolder}</OutDir>
+                    <UserSecretsId>{_userSecretsId}</UserSecretsId>
+                    <IsAspireHost>true</IsAspireHost>
+                </PropertyGroup>
+                <!-- Disable Aspire SDK code generation -->
+                <Target Name="_CSharpWriteHostProjectMetadataSources" />
+                <Target Name="_CSharpWriteProjectMetadataSources" />
+            </Project>
+            """;
+
+        var doc = XDocument.Parse(template);
+
+        // Add package references - SDK provides Aspire.Hosting.AppHost (which brings Aspire.Hosting)
+        // We need to add: RemoteHost, code gen package, and any integration packages
+        var explicitPackages = packages
+            .Where(p => !p.Name.Equals("Aspire.Hosting", StringComparison.OrdinalIgnoreCase) &&
+                        !p.Name.Equals("Aspire.Hosting.AppHost", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        // Always add RemoteHost - required for the RPC server
+        explicitPackages.Add(("Aspire.Hosting.RemoteHost", sdkVersion));
+
+        var packageRefs = explicitPackages.Select(p => new XElement("PackageReference",
+            new XAttribute("Include", p.Name),
+            new XAttribute("Version", p.Version)));
+        doc.Root!.Add(new XElement("ItemGroup", packageRefs));
+
+        return doc;
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -918,6 +918,11 @@ internal sealed class GuestAppHostProject : IAppHostProject
         {
             config.SdkVersion = newSdkVersion;
         }
+        // Update channel if it's an explicit channel (not the implicit/default one)
+        if (context.Channel.Type == Packaging.PackageChannelType.Explicit)
+        {
+            config.Channel = context.Channel.Name;
+        }
         foreach (var (packageId, _, newVersion) in updates)
         {
             config.AddOrUpdatePackage(packageId, newVersion);

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -73,7 +73,9 @@ internal sealed class ScaffoldingService : IScaffoldingService
         var appHostServerProject = _appHostServerProjectFactory.Create(directory.FullName);
         var socketPath = appHostServerProject.GetSocketPath();
 
-        var (buildSuccess, buildOutput, channelName) = await BuildAppHostServerAsync(appHostServerProject, config.SdkVersion!, packages, cancellationToken);
+        var (buildSuccess, buildOutput, channelName) = await _interactionService.ShowStatusAsync(
+            ":gear:  Preparing Aspire server...",
+            () => BuildAppHostServerAsync(appHostServerProject, config.SdkVersion!, packages, cancellationToken));
         if (!buildSuccess)
         {
             _interactionService.DisplayLines(buildOutput.GetLines());
@@ -111,7 +113,9 @@ internal sealed class ScaffoldingService : IScaffoldingService
             _logger.LogDebug("Wrote {Count} scaffold files", scaffoldFiles.Count);
 
             // Step 5: Install dependencies using GuestRuntime
-            var installResult = await InstallDependenciesAsync(directory, language, rpcClient, cancellationToken);
+            var installResult = await _interactionService.ShowStatusAsync(
+                $":package:  Installing {language.DisplayName} dependencies...",
+                () => InstallDependenciesAsync(directory, language, rpcClient, cancellationToken));
             if (installResult != 0)
             {
                 return;

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
@@ -835,7 +835,7 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
 
         // Generate internal async method for fluent builder methods
         WriteLine($"    /** @internal */");
-        Write($"    async {internalMethodName}(");
+        Write($"    private async {internalMethodName}(");
         Write(internalParamsString);
         Write($"): Promise<{builder.BuilderClassName}> {{");
         WriteLine();

--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
@@ -1,0 +1,450 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Xml.Linq;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Tests.Mcp;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Projects;
+
+public class AppHostServerProjectTests(ITestOutputHelper outputHelper) : IDisposable
+{
+    private readonly TemporaryWorkspace _workspace = TemporaryWorkspace.Create(outputHelper);
+
+    public void Dispose()
+    {
+        _workspace.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private AppHostServerProject CreateProject(string? appPath = null)
+    {
+        appPath ??= _workspace.WorkspaceRoot.FullName;
+        var runner = new TestDotNetCliRunner();
+        var packagingService = new MockPackagingService();
+        var configurationService = new TrackingConfigurationService();
+        var logger = NullLogger<AppHostServerProject>.Instance;
+
+        return new AppHostServerProject(appPath, runner, packagingService, configurationService, logger);
+    }
+
+    /// <summary>
+    /// Normalizes a generated csproj for snapshot comparison by replacing dynamic values.
+    /// </summary>
+    private static string NormalizeCsprojForSnapshot(string csprojContent, AppHostServerProject project)
+    {
+        // Replace dynamic UserSecretsId with placeholder
+        return csprojContent.Replace(project.UserSecretsId, "{USER_SECRETS_ID}");
+    }
+
+    [Fact]
+    public async Task CreateProjectFiles_ProductionCsproj_MatchesSnapshot()
+    {
+        // Arrange
+        var project = CreateProject();
+        var packages = new List<(string Name, string Version)>
+        {
+            ("Aspire.Hosting", "13.1.0"),
+            ("Aspire.Hosting.AppHost", "13.1.0"),
+            ("Aspire.Hosting.Redis", "13.1.0"),
+            ("Aspire.Hosting.PostgreSQL", "13.1.0"),
+            ("Aspire.Hosting.CodeGeneration.TypeScript", "13.1.0")
+        };
+
+        // Act
+        var (projectPath, _) = await project.CreateProjectFilesAsync("13.1.0", packages);
+
+        // Assert
+        var csprojContent = await File.ReadAllTextAsync(projectPath);
+        var normalized = NormalizeCsprojForSnapshot(csprojContent, project);
+
+        await Verify(normalized, extension: "xml")
+            .UseFileName("AppHostServerProject_ProductionCsproj");
+    }
+
+    [Fact]
+    public async Task CreateProjectFiles_AppSettingsJson_MatchesSnapshot()
+    {
+        // Arrange
+        var project = CreateProject();
+        var packages = new List<(string Name, string Version)>
+        {
+            ("Aspire.Hosting", "13.1.0"),
+            ("Aspire.Hosting.Redis", "13.1.0"),
+            ("Aspire.Hosting.PostgreSQL", "13.1.0"),
+            ("Aspire.Hosting.CodeGeneration.TypeScript", "13.1.0")
+        };
+
+        // Act
+        await project.CreateProjectFilesAsync("13.1.0", packages);
+
+        // Assert
+        var appSettingsPath = Path.Combine(project.ProjectModelPath, "appsettings.json");
+        var content = await File.ReadAllTextAsync(appSettingsPath);
+
+        await Verify(content, extension: "json")
+            .UseFileName("AppHostServerProject_AppSettingsJson");
+    }
+
+    [Fact]
+    public async Task CreateProjectFiles_ProgramCs_MatchesSnapshot()
+    {
+        // Arrange
+        var project = CreateProject();
+        var packages = new List<(string Name, string Version)>
+        {
+            ("Aspire.Hosting", "13.1.0")
+        };
+
+        // Act
+        await project.CreateProjectFilesAsync("13.1.0", packages);
+
+        // Assert
+        var programCsPath = Path.Combine(project.ProjectModelPath, "Program.cs");
+        var content = await File.ReadAllTextAsync(programCsPath);
+
+        // Use .txt extension to avoid compilation of snapshot file
+        await Verify(content, extension: "txt")
+            .UseFileName("AppHostServerProject_ProgramCs");
+    }
+
+    [Fact]
+    public async Task CreateProjectFiles_GeneratesProductionCsproj_WithAspireSdk()
+    {
+        // Arrange
+        var project = CreateProject();
+        var packages = new List<(string Name, string Version)>
+        {
+            ("Aspire.Hosting", "13.1.0"),
+            ("Aspire.Hosting.AppHost", "13.1.0"),
+            ("Aspire.Hosting.Redis", "13.1.0"),
+            ("Aspire.Hosting.CodeGeneration.TypeScript", "13.1.0")
+        };
+
+        // Act
+        var (projectPath, _) = await project.CreateProjectFilesAsync("13.1.0", packages);
+
+        // Assert
+        Assert.True(File.Exists(projectPath));
+        var doc = XDocument.Load(projectPath);
+
+        // Verify SDK attribute
+        var sdkAttr = doc.Root?.Attribute("Sdk")?.Value;
+        Assert.Equal("Aspire.AppHost.Sdk/13.1.0", sdkAttr);
+    }
+
+    [Fact]
+    public async Task CreateProjectFiles_ProductionMode_FiltersOutImplicitPackages()
+    {
+        // Arrange
+        var project = CreateProject();
+        var packages = new List<(string Name, string Version)>
+        {
+            ("Aspire.Hosting", "13.1.0"),
+            ("Aspire.Hosting.AppHost", "13.1.0"),
+            ("Aspire.Hosting.Redis", "13.1.0"),
+            ("Aspire.Hosting.PostgreSQL", "13.1.0"),
+            ("Aspire.Hosting.CodeGeneration.TypeScript", "13.1.0")
+        };
+
+        // Act
+        var (projectPath, _) = await project.CreateProjectFilesAsync("13.1.0", packages);
+
+        // Assert
+        var doc = XDocument.Load(projectPath);
+        var packageRefs = doc.Descendants("PackageReference")
+            .Select(e => e.Attribute("Include")?.Value)
+            .Where(v => v is not null)
+            .ToList();
+
+        // Aspire.Hosting and Aspire.Hosting.AppHost should NOT be in package references (SDK provides them)
+        Assert.DoesNotContain("Aspire.Hosting", packageRefs);
+        Assert.DoesNotContain("Aspire.Hosting.AppHost", packageRefs);
+
+        // Integration packages and code gen should be present
+        Assert.Contains("Aspire.Hosting.Redis", packageRefs);
+        Assert.Contains("Aspire.Hosting.PostgreSQL", packageRefs);
+        Assert.Contains("Aspire.Hosting.CodeGeneration.TypeScript", packageRefs);
+
+        // RemoteHost should always be added
+        Assert.Contains("Aspire.Hosting.RemoteHost", packageRefs);
+    }
+
+    [Theory]
+    [InlineData("Aspire.Hosting", false)]
+    [InlineData("Aspire.Hosting.AppHost", false)]
+    [InlineData("Aspire.Hosting.Redis", true)]
+    [InlineData("Aspire.Hosting.PostgreSQL", true)]
+    [InlineData("Aspire.Hosting.RemoteHost", true)]
+    [InlineData("Aspire.Hosting.CodeGeneration.TypeScript", true)]
+    [InlineData("Aspire.Hosting.CodeGeneration.Python", true)]
+    public async Task CreateProjectFiles_ProductionMode_CorrectlyFiltersPackages(string packageName, bool shouldBeIncluded)
+    {
+        // Arrange
+        var project = CreateProject();
+        var packages = new List<(string Name, string Version)>
+        {
+            ("Aspire.Hosting", "13.1.0"),
+            ("Aspire.Hosting.AppHost", "13.1.0"),
+            (packageName, "13.1.0")
+        };
+
+        // Act
+        var (projectPath, _) = await project.CreateProjectFilesAsync("13.1.0", packages);
+
+        // Assert
+        var doc = XDocument.Load(projectPath);
+        var packageRefs = doc.Descendants("PackageReference")
+            .Select(e => e.Attribute("Include")?.Value)
+            .Where(v => v is not null)
+            .ToList();
+
+        if (shouldBeIncluded)
+        {
+            Assert.Contains(packageName, packageRefs);
+        }
+        else
+        {
+            Assert.DoesNotContain(packageName, packageRefs);
+        }
+    }
+
+    [Fact]
+    public async Task CreateProjectFiles_ProductionMode_AlwaysAddsRemoteHost()
+    {
+        // Arrange
+        var project = CreateProject();
+        var packages = new List<(string Name, string Version)>
+        {
+            ("Aspire.Hosting", "13.1.0"),
+            ("Aspire.Hosting.AppHost", "13.1.0")
+        };
+
+        // Act
+        var (projectPath, _) = await project.CreateProjectFilesAsync("13.1.0", packages);
+
+        // Assert
+        var doc = XDocument.Load(projectPath);
+        var packageRefs = doc.Descendants("PackageReference")
+            .Select(e => e.Attribute("Include")?.Value)
+            .Where(v => v is not null)
+            .ToList();
+
+        // RemoteHost should always be present even if not in input packages
+        Assert.Contains("Aspire.Hosting.RemoteHost", packageRefs);
+    }
+
+    [Fact]
+    public async Task CreateProjectFiles_GeneratesProgramCs()
+    {
+        // Arrange
+        var project = CreateProject();
+        var packages = new List<(string Name, string Version)>
+        {
+            ("Aspire.Hosting", "13.1.0")
+        };
+
+        // Act
+        await project.CreateProjectFilesAsync("13.1.0", packages);
+
+        // Assert
+        var programCs = Path.Combine(project.ProjectModelPath, "Program.cs");
+        Assert.True(File.Exists(programCs));
+
+        var content = await File.ReadAllTextAsync(programCs);
+        Assert.Contains("RemoteHostServer.RunAsync", content);
+    }
+
+    [Fact]
+    public async Task CreateProjectFiles_GeneratesAppSettingsJson_WithAtsAssemblies()
+    {
+        // Arrange
+        var project = CreateProject();
+        var packages = new List<(string Name, string Version)>
+        {
+            ("Aspire.Hosting", "13.1.0"),
+            ("Aspire.Hosting.Redis", "13.1.0"),
+            ("Aspire.Hosting.CodeGeneration.TypeScript", "13.1.0")
+        };
+
+        // Act
+        await project.CreateProjectFilesAsync("13.1.0", packages);
+
+        // Assert
+        var appSettingsPath = Path.Combine(project.ProjectModelPath, "appsettings.json");
+        Assert.True(File.Exists(appSettingsPath));
+
+        var content = await File.ReadAllTextAsync(appSettingsPath);
+        Assert.Contains("AtsAssemblies", content);
+        Assert.Contains("Aspire.Hosting", content);
+        Assert.Contains("Aspire.Hosting.Redis", content);
+        Assert.Contains("Aspire.Hosting.CodeGeneration.TypeScript", content);
+    }
+
+    [Fact]
+    public async Task CreateProjectFiles_ProductionMode_HasMinimalProperties()
+    {
+        // Arrange
+        var project = CreateProject();
+        var packages = new List<(string Name, string Version)>
+        {
+            ("Aspire.Hosting", "13.1.0")
+        };
+
+        // Act
+        var (projectPath, _) = await project.CreateProjectFilesAsync("13.1.0", packages);
+
+        // Assert
+        var doc = XDocument.Load(projectPath);
+
+        // Should have minimal property group
+        var propertyGroup = doc.Descendants("PropertyGroup").First();
+
+        Assert.NotNull(propertyGroup.Element("OutputType"));
+        Assert.NotNull(propertyGroup.Element("TargetFramework"));
+        Assert.NotNull(propertyGroup.Element("AssemblyName"));
+        Assert.NotNull(propertyGroup.Element("OutDir"));
+        Assert.NotNull(propertyGroup.Element("UserSecretsId"));
+        Assert.NotNull(propertyGroup.Element("IsAspireHost"));
+
+        // Should NOT have dev-mode only properties
+        Assert.Null(propertyGroup.Element("IsPublishable"));
+        Assert.Null(propertyGroup.Element("SelfContained"));
+        Assert.Null(propertyGroup.Element("NoWarn"));
+        Assert.Null(propertyGroup.Element("RepoRoot"));
+    }
+
+    [Fact]
+    public async Task CreateProjectFiles_ProductionMode_DisablesCodeGeneration()
+    {
+        // Arrange
+        var project = CreateProject();
+        var packages = new List<(string Name, string Version)>
+        {
+            ("Aspire.Hosting", "13.1.0")
+        };
+
+        // Act
+        var (projectPath, _) = await project.CreateProjectFilesAsync("13.1.0", packages);
+
+        // Assert
+        var doc = XDocument.Load(projectPath);
+
+        // Should have empty targets to disable code generation
+        var targets = doc.Descendants("Target").ToList();
+        Assert.Contains(targets, t => t.Attribute("Name")?.Value == "_CSharpWriteHostProjectMetadataSources");
+        Assert.Contains(targets, t => t.Attribute("Name")?.Value == "_CSharpWriteProjectMetadataSources");
+    }
+
+    [Fact]
+    public async Task CreateProjectFiles_CopiesAppSettingsToOutput()
+    {
+        // Arrange
+        var project = CreateProject();
+        var packages = new List<(string Name, string Version)>
+        {
+            ("Aspire.Hosting", "13.1.0")
+        };
+
+        // Act
+        var (projectPath, _) = await project.CreateProjectFilesAsync("13.1.0", packages);
+
+        // Assert
+        var doc = XDocument.Load(projectPath);
+
+        var noneElement = doc.Descendants("None")
+            .FirstOrDefault(e => e.Attribute("Include")?.Value == "appsettings.json");
+
+        Assert.NotNull(noneElement);
+        Assert.Equal("PreserveNewest", noneElement.Attribute("CopyToOutputDirectory")?.Value);
+    }
+
+    [Fact]
+    public void DefaultSdkVersion_ReturnsValidVersion()
+    {
+        // Act
+        var version = AppHostServerProject.DefaultSdkVersion;
+
+        // Assert
+        Assert.NotNull(version);
+        Assert.NotEmpty(version);
+        // Should not contain '+' (commit hash should be stripped)
+        Assert.DoesNotContain("+", version);
+    }
+
+    [Fact]
+    public void ProjectModelPath_IsStableForSameAppPath()
+    {
+        // Arrange
+        var appPath = _workspace.WorkspaceRoot.FullName;
+
+        // Act
+        var project1 = CreateProject(appPath);
+        var project2 = CreateProject(appPath);
+
+        // Assert - same app path should result in same project model path
+        Assert.Equal(project1.ProjectModelPath, project2.ProjectModelPath);
+    }
+
+    [Fact]
+    public void UserSecretsId_IsStableForSameAppPath()
+    {
+        // Arrange
+        var appPath = _workspace.WorkspaceRoot.FullName;
+
+        // Act
+        var project1 = CreateProject(appPath);
+        var project2 = CreateProject(appPath);
+
+        // Assert - same app path should result in same user secrets ID
+        Assert.Equal(project1.UserSecretsId, project2.UserSecretsId);
+    }
+
+    [Fact]
+    public async Task CreateProjectFiles_UsesSdkVersionInPackageAttribute()
+    {
+        // Arrange
+        var project = CreateProject();
+        var packages = new List<(string Name, string Version)>
+        {
+            ("Aspire.Hosting", "13.2.0")
+        };
+
+        // Act
+        var (projectPath, _) = await project.CreateProjectFilesAsync("13.2.0", packages);
+
+        // Assert
+        var doc = XDocument.Load(projectPath);
+        var sdkAttr = doc.Root?.Attribute("Sdk")?.Value;
+        Assert.Equal("Aspire.AppHost.Sdk/13.2.0", sdkAttr);
+    }
+
+    [Fact]
+    public async Task CreateProjectFiles_PackageVersionsMatchSdkVersion()
+    {
+        // Arrange
+        var project = CreateProject();
+        var sdkVersion = "13.3.0";
+        var packages = new List<(string Name, string Version)>
+        {
+            ("Aspire.Hosting", sdkVersion),
+            ("Aspire.Hosting.Redis", sdkVersion)
+        };
+
+        // Act
+        var (projectPath, _) = await project.CreateProjectFilesAsync(sdkVersion, packages);
+
+        // Assert
+        var doc = XDocument.Load(projectPath);
+
+        // RemoteHost should use SDK version
+        var remoteHostRef = doc.Descendants("PackageReference")
+            .FirstOrDefault(e => e.Attribute("Include")?.Value == "Aspire.Hosting.RemoteHost");
+
+        Assert.NotNull(remoteHostRef);
+        Assert.Equal(sdkVersion, remoteHostRef.Attribute("Version")?.Value);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
@@ -516,8 +516,35 @@ public class AppHostServerProjectTests(ITestOutputHelper outputHelper) : IDispos
         // Assert - verify NuGet.config uses the correct channel
         var nugetConfigPath = Path.Combine(project.ProjectModelPath, "NuGet.config");
         
+        // Build diagnostic info for assertion failure
+        var diagnosticInfo = new System.Text.StringBuilder();
+        diagnosticInfo.AppendLine($"appPath: {appPath}");
+        diagnosticInfo.AppendLine($"settingsJson path: {settingsJson}");
+        diagnosticInfo.AppendLine($"settingsJson exists: {File.Exists(settingsJson)}");
+        if (File.Exists(settingsJson))
+        {
+            diagnosticInfo.AppendLine($"settingsJson content: {File.ReadAllText(settingsJson)}");
+        }
+        diagnosticInfo.AppendLine($"project.ProjectModelPath: {project.ProjectModelPath}");
+        diagnosticInfo.AppendLine($"nugetConfigPath: {nugetConfigPath}");
+        diagnosticInfo.AppendLine($"nugetConfigPath exists: {File.Exists(nugetConfigPath)}");
+        
+        // List files in project model path
+        if (Directory.Exists(project.ProjectModelPath))
+        {
+            diagnosticInfo.AppendLine("Files in ProjectModelPath:");
+            foreach (var file in Directory.GetFiles(project.ProjectModelPath))
+            {
+                diagnosticInfo.AppendLine($"  - {Path.GetFileName(file)}");
+            }
+        }
+        else
+        {
+            diagnosticInfo.AppendLine("ProjectModelPath does not exist!");
+        }
+        
         // The NuGet.config should exist
-        Assert.True(File.Exists(nugetConfigPath), "NuGet.config should be created");
+        Assert.True(File.Exists(nugetConfigPath), $"NuGet.config should be created\n\nDiagnostics:\n{diagnosticInfo}");
         
         var nugetConfigContent = await File.ReadAllTextAsync(nugetConfigPath);
 

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -1,0 +1,225 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Tests.Utils;
+
+namespace Aspire.Cli.Tests.Projects;
+
+public class GuestAppHostProjectTests(ITestOutputHelper outputHelper) : IDisposable
+{
+    private readonly TemporaryWorkspace _workspace = TemporaryWorkspace.Create(outputHelper);
+
+    public void Dispose()
+    {
+        _workspace.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void AspireJsonConfiguration_LoadOrCreate_SetsDefaultSdkVersion()
+    {
+        // Arrange
+        var directory = _workspace.WorkspaceRoot.FullName;
+
+        // Act
+        var config = AspireJsonConfiguration.LoadOrCreate(directory, "13.1.0");
+
+        // Assert
+        Assert.Equal("13.1.0", config.SdkVersion);
+    }
+
+    [Fact]
+    public void AspireJsonConfiguration_LoadOrCreate_PreservesExistingSdkVersion()
+    {
+        // Arrange - create settings.json with existing SDK version
+        var settingsDir = _workspace.CreateDirectory(".aspire");
+        var settingsPath = Path.Combine(settingsDir.FullName, "settings.json");
+        File.WriteAllText(settingsPath, """
+            {
+                "sdkVersion": "12.0.0",
+                "language": "typescript"
+            }
+            """);
+
+        // Act
+        var config = AspireJsonConfiguration.LoadOrCreate(_workspace.WorkspaceRoot.FullName, "13.1.0");
+
+        // Assert - should preserve existing version, not override with default
+        Assert.Equal("12.0.0", config.SdkVersion);
+    }
+
+    [Fact]
+    public void AspireJsonConfiguration_Save_UpdatesSdkVersion()
+    {
+        // Arrange - create initial settings.json
+        var settingsDir = _workspace.CreateDirectory(".aspire");
+        var settingsPath = Path.Combine(settingsDir.FullName, "settings.json");
+        File.WriteAllText(settingsPath, """
+            {
+                "sdkVersion": "12.0.0",
+                "language": "typescript",
+                "packages": {
+                    "Aspire.Hosting.Redis": "12.0.0"
+                }
+            }
+            """);
+
+        // Act - load, update SDK version, and save
+        var config = AspireJsonConfiguration.Load(_workspace.WorkspaceRoot.FullName);
+        Assert.NotNull(config);
+        config.SdkVersion = "13.1.0";
+        config.Save(_workspace.WorkspaceRoot.FullName);
+
+        // Assert - reload and verify
+        var reloaded = AspireJsonConfiguration.Load(_workspace.WorkspaceRoot.FullName);
+        Assert.NotNull(reloaded);
+        Assert.Equal("13.1.0", reloaded.SdkVersion);
+        Assert.Equal("typescript", reloaded.Language);
+        Assert.NotNull(reloaded.Packages);
+        Assert.Equal("12.0.0", reloaded.Packages["Aspire.Hosting.Redis"]);
+    }
+
+    [Fact]
+    public void AspireJsonConfiguration_AddOrUpdatePackage_AddsNewPackage()
+    {
+        // Arrange
+        var config = new AspireJsonConfiguration
+        {
+            SdkVersion = "13.1.0",
+            Language = "typescript"
+        };
+
+        // Act
+        config.AddOrUpdatePackage("Aspire.Hosting.Redis", "13.1.0");
+
+        // Assert
+        Assert.NotNull(config.Packages);
+        Assert.Single(config.Packages);
+        Assert.Equal("13.1.0", config.Packages["Aspire.Hosting.Redis"]);
+    }
+
+    [Fact]
+    public void AspireJsonConfiguration_AddOrUpdatePackage_UpdatesExistingPackage()
+    {
+        // Arrange
+        var config = new AspireJsonConfiguration
+        {
+            SdkVersion = "13.1.0",
+            Language = "typescript",
+            Packages = new Dictionary<string, string>
+            {
+                ["Aspire.Hosting.Redis"] = "12.0.0"
+            }
+        };
+
+        // Act
+        config.AddOrUpdatePackage("Aspire.Hosting.Redis", "13.1.0");
+
+        // Assert
+        Assert.NotNull(config.Packages);
+        Assert.Single(config.Packages);
+        Assert.Equal("13.1.0", config.Packages["Aspire.Hosting.Redis"]);
+    }
+
+    [Fact]
+    public void AspireJsonConfiguration_GetAllPackages_IncludesBasePackages()
+    {
+        // Arrange
+        var config = new AspireJsonConfiguration
+        {
+            SdkVersion = "13.1.0",
+            Language = "typescript",
+            Packages = new Dictionary<string, string>
+            {
+                ["Aspire.Hosting.Redis"] = "13.1.0"
+            }
+        };
+
+        // Act
+        var packages = config.GetAllPackages().ToList();
+
+        // Assert - should include base packages plus explicit packages
+        Assert.Contains(packages, p => p.Name == "Aspire.Hosting" && p.Version == "13.1.0");
+        Assert.Contains(packages, p => p.Name == "Aspire.Hosting.AppHost" && p.Version == "13.1.0");
+        Assert.Contains(packages, p => p.Name == "Aspire.Hosting.Redis" && p.Version == "13.1.0");
+    }
+
+    [Fact]
+    public void AspireJsonConfiguration_GetAllPackages_WithNoExplicitPackages_ReturnsBasePackagesOnly()
+    {
+        // Arrange
+        var config = new AspireJsonConfiguration
+        {
+            SdkVersion = "13.1.0",
+            Language = "typescript"
+        };
+
+        // Act
+        var packages = config.GetAllPackages().ToList();
+
+        // Assert - should include base packages only
+        Assert.Equal(2, packages.Count);
+        Assert.Contains(packages, p => p.Name == "Aspire.Hosting" && p.Version == "13.1.0");
+        Assert.Contains(packages, p => p.Name == "Aspire.Hosting.AppHost" && p.Version == "13.1.0");
+    }
+
+    [Fact]
+    public void AspireJsonConfiguration_Save_PreservesExtensionData()
+    {
+        // Arrange - create settings.json with extra properties
+        var settingsDir = _workspace.CreateDirectory(".aspire");
+        var settingsPath = Path.Combine(settingsDir.FullName, "settings.json");
+        File.WriteAllText(settingsPath, """
+            {
+                "sdkVersion": "13.1.0",
+                "language": "typescript",
+                "features": {
+                    "experimental": true
+                },
+                "customProperty": "customValue"
+            }
+            """);
+
+        // Act - load, modify, and save
+        var config = AspireJsonConfiguration.Load(_workspace.WorkspaceRoot.FullName);
+        Assert.NotNull(config);
+        config.SdkVersion = "13.2.0";
+        config.Save(_workspace.WorkspaceRoot.FullName);
+
+        // Assert - reload and verify extension data is preserved
+        var json = File.ReadAllText(settingsPath);
+        Assert.Contains("features", json);
+        Assert.Contains("experimental", json);
+        Assert.Contains("customProperty", json);
+        Assert.Contains("customValue", json);
+    }
+
+    [Fact]
+    public async Task AspireJsonConfiguration_MatchesSnapshot()
+    {
+        // Arrange - create a full settings.json
+        var config = new AspireJsonConfiguration
+        {
+            Schema = "https://json.schemastore.org/aspire-settings.json",
+            AppHostPath = "apphost.ts",
+            Language = "typescript",
+            SdkVersion = "13.1.0",
+            Packages = new Dictionary<string, string>
+            {
+                ["Aspire.Hosting.Redis"] = "13.1.0",
+                ["Aspire.Hosting.PostgreSQL"] = "13.1.0"
+            }
+        };
+
+        // Act
+        config.Save(_workspace.WorkspaceRoot.FullName);
+
+        // Assert
+        var settingsPath = AspireJsonConfiguration.GetFilePath(_workspace.WorkspaceRoot.FullName);
+        var content = await File.ReadAllTextAsync(settingsPath);
+
+        await Verify(content, extension: "json")
+            .UseFileName("AspireJsonConfiguration_SettingsJson");
+    }
+}

--- a/tests/Aspire.Cli.Tests/Snapshots/AppHostServerProject_AppSettingsJson.verified.json
+++ b/tests/Aspire.Cli.Tests/Snapshots/AppHostServerProject_AppSettingsJson.verified.json
@@ -1,0 +1,15 @@
+﻿{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  },
+  "AtsAssemblies": [
+    "Aspire.Hosting",
+      "Aspire.Hosting.Redis",
+      "Aspire.Hosting.PostgreSQL",
+      "Aspire.Hosting.CodeGeneration.TypeScript"
+  ]
+}

--- a/tests/Aspire.Cli.Tests/Snapshots/AppHostServerProject_NuGetConfig_UsesProjectLocalChannel.verified.xml
+++ b/tests/Aspire.Cli.Tests/Snapshots/AppHostServerProject_NuGetConfig_UsesProjectLocalChannel.verified.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="{PR_NEW_HIVE}" value="{PR_NEW_HIVE}" />
+    <add key="https://api.nuget.org/v3/index.json" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="{PR_NEW_HIVE}">
+      <package pattern="Aspire*" />
+    </packageSource>
+    <packageSource key="https://api.nuget.org/v3/index.json">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/tests/Aspire.Cli.Tests/Snapshots/AppHostServerProject_ProductionCsproj.verified.xml
+++ b/tests/Aspire.Cli.Tests/Snapshots/AppHostServerProject_ProductionCsproj.verified.xml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Aspire.AppHost.Sdk/13.1.0">
+  <PropertyGroup>
+    <OutputType>exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>AppHostServer</AssemblyName>
+    <OutDir>build</OutDir>
+    <UserSecretsId>{USER_SECRETS_ID}</UserSecretsId>
+    <IsAspireHost>true</IsAspireHost>
+  </PropertyGroup>
+  <!-- Disable Aspire SDK code generation -->
+  <Target Name="_CSharpWriteHostProjectMetadataSources" />
+  <Target Name="_CSharpWriteProjectMetadataSources" />
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.1.0" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.1.0" />
+    <PackageReference Include="Aspire.Hosting.CodeGeneration.TypeScript" Version="13.1.0" />
+    <PackageReference Include="Aspire.Hosting.RemoteHost" Version="13.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/tests/Aspire.Cli.Tests/Snapshots/AppHostServerProject_ProgramCs.verified.txt
+++ b/tests/Aspire.Cli.Tests/Snapshots/AppHostServerProject_ProgramCs.verified.txt
@@ -1,0 +1,1 @@
+﻿await Aspire.Hosting.RemoteHost.RemoteHostServer.RunAsync(args);

--- a/tests/Aspire.Cli.Tests/Snapshots/AspireJsonConfiguration_SettingsJson.verified.json
+++ b/tests/Aspire.Cli.Tests/Snapshots/AspireJsonConfiguration_SettingsJson.verified.json
@@ -1,0 +1,10 @@
+﻿{
+  "$schema": "https://json.schemastore.org/aspire-settings.json",
+  "appHostPath": "apphost.ts",
+  "language": "typescript",
+  "sdkVersion": "13.1.0",
+  "packages": {
+    "Aspire.Hosting.Redis": "13.1.0",
+    "Aspire.Hosting.PostgreSQL": "13.1.0"
+  }
+}

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/AtsGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/AtsGeneratedAspire.verified.ts
@@ -425,7 +425,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withPersistenceInternal(mode?: TestPersistenceMode): Promise<TestRedisResource> {
+    private async _withPersistenceInternal(mode?: TestPersistenceMode): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (mode !== undefined) rpcArgs.mode = mode;
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
@@ -442,7 +442,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<TestRedisResource> {
+    private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (value !== undefined) rpcArgs.value = value;
         if (enabled !== undefined) rpcArgs.enabled = enabled;
@@ -461,7 +461,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withConfigInternal(config: TestConfigDto): Promise<TestRedisResource> {
+    private async _withConfigInternal(config: TestConfigDto): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, config };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withConfig',
@@ -494,7 +494,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withConnectionStringInternal(connectionString: ReferenceExpression): Promise<TestRedisResource> {
+    private async _withConnectionStringInternal(connectionString: ReferenceExpression): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, connectionString };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withConnectionString',
@@ -509,7 +509,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _testWithEnvironmentCallbackInternal(callback: (arg: TestEnvironmentContext) => Promise<void>): Promise<TestRedisResource> {
+    private async _testWithEnvironmentCallbackInternal(callback: (arg: TestEnvironmentContext) => Promise<void>): Promise<TestRedisResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestEnvironmentContextHandle;
             const arg = new TestEnvironmentContext(argHandle, this._client);
@@ -529,7 +529,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withCreatedAtInternal(createdAt: string): Promise<TestRedisResource> {
+    private async _withCreatedAtInternal(createdAt: string): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, createdAt };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withCreatedAt',
@@ -544,7 +544,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withModifiedAtInternal(modifiedAt: string): Promise<TestRedisResource> {
+    private async _withModifiedAtInternal(modifiedAt: string): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, modifiedAt };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withModifiedAt',
@@ -559,7 +559,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withCorrelationIdInternal(correlationId: string): Promise<TestRedisResource> {
+    private async _withCorrelationIdInternal(correlationId: string): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, correlationId };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withCorrelationId',
@@ -574,7 +574,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withOptionalCallbackInternal(callback?: (arg: TestCallbackContext) => Promise<void>): Promise<TestRedisResource> {
+    private async _withOptionalCallbackInternal(callback?: (arg: TestCallbackContext) => Promise<void>): Promise<TestRedisResource> {
         const callbackId = callback ? registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestCallbackContextHandle;
             const arg = new TestCallbackContext(argHandle, this._client);
@@ -596,7 +596,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withStatusInternal(status: TestResourceStatus): Promise<TestRedisResource> {
+    private async _withStatusInternal(status: TestResourceStatus): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, status };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withStatus',
@@ -611,7 +611,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withNestedConfigInternal(config: TestNestedDto): Promise<TestRedisResource> {
+    private async _withNestedConfigInternal(config: TestNestedDto): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, config };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withNestedConfig',
@@ -626,7 +626,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withValidatorInternal(validator: (arg: TestResourceContext) => Promise<boolean>): Promise<TestRedisResource> {
+    private async _withValidatorInternal(validator: (arg: TestResourceContext) => Promise<boolean>): Promise<TestRedisResource> {
         const validatorId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestResourceContextHandle;
             const arg = new TestResourceContext(argHandle, this._client);
@@ -646,7 +646,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _testWaitForInternal(dependency: ResourceBuilderBase): Promise<TestRedisResource> {
+    private async _testWaitForInternal(dependency: ResourceBuilderBase): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/testWaitFor',
@@ -670,7 +670,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withConnectionStringDirectInternal(connectionString: string): Promise<TestRedisResource> {
+    private async _withConnectionStringDirectInternal(connectionString: string): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, connectionString };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withConnectionStringDirect',
@@ -685,7 +685,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withRedisSpecificInternal(option: string): Promise<TestRedisResource> {
+    private async _withRedisSpecificInternal(option: string): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, option };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withRedisSpecific',
@@ -700,7 +700,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withDependencyInternal(dependency: ResourceBuilderBase): Promise<TestRedisResource> {
+    private async _withDependencyInternal(dependency: ResourceBuilderBase): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withDependency',
@@ -715,7 +715,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withEndpointsInternal(endpoints: string[]): Promise<TestRedisResource> {
+    private async _withEndpointsInternal(endpoints: string[]): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, endpoints };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withEndpoints',
@@ -730,7 +730,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withEnvironmentVariablesInternal(variables: Record<string, string>): Promise<TestRedisResource> {
+    private async _withEnvironmentVariablesInternal(variables: Record<string, string>): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, variables };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withEnvironmentVariables',
@@ -757,7 +757,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<TestRedisResource> {
+    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<TestRedisResource> {
         const operationId = registerCallback(async (argData: unknown) => {
             const arg = wrapIfHandle(argData) as AbortSignal;
             await operation(arg);
@@ -936,7 +936,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<Resource> {
+    private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (value !== undefined) rpcArgs.value = value;
         if (enabled !== undefined) rpcArgs.enabled = enabled;
@@ -955,7 +955,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withConfigInternal(config: TestConfigDto): Promise<Resource> {
+    private async _withConfigInternal(config: TestConfigDto): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, config };
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withConfig',
@@ -970,7 +970,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withCreatedAtInternal(createdAt: string): Promise<Resource> {
+    private async _withCreatedAtInternal(createdAt: string): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, createdAt };
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withCreatedAt',
@@ -985,7 +985,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withModifiedAtInternal(modifiedAt: string): Promise<Resource> {
+    private async _withModifiedAtInternal(modifiedAt: string): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, modifiedAt };
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withModifiedAt',
@@ -1000,7 +1000,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withCorrelationIdInternal(correlationId: string): Promise<Resource> {
+    private async _withCorrelationIdInternal(correlationId: string): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, correlationId };
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withCorrelationId',
@@ -1015,7 +1015,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withOptionalCallbackInternal(callback?: (arg: TestCallbackContext) => Promise<void>): Promise<Resource> {
+    private async _withOptionalCallbackInternal(callback?: (arg: TestCallbackContext) => Promise<void>): Promise<Resource> {
         const callbackId = callback ? registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestCallbackContextHandle;
             const arg = new TestCallbackContext(argHandle, this._client);
@@ -1037,7 +1037,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withStatusInternal(status: TestResourceStatus): Promise<Resource> {
+    private async _withStatusInternal(status: TestResourceStatus): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, status };
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withStatus',
@@ -1052,7 +1052,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withNestedConfigInternal(config: TestNestedDto): Promise<Resource> {
+    private async _withNestedConfigInternal(config: TestNestedDto): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, config };
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withNestedConfig',
@@ -1067,7 +1067,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withValidatorInternal(validator: (arg: TestResourceContext) => Promise<boolean>): Promise<Resource> {
+    private async _withValidatorInternal(validator: (arg: TestResourceContext) => Promise<boolean>): Promise<Resource> {
         const validatorId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestResourceContextHandle;
             const arg = new TestResourceContext(argHandle, this._client);
@@ -1087,7 +1087,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _testWaitForInternal(dependency: ResourceBuilderBase): Promise<Resource> {
+    private async _testWaitForInternal(dependency: ResourceBuilderBase): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/testWaitFor',
@@ -1102,7 +1102,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withDependencyInternal(dependency: ResourceBuilderBase): Promise<Resource> {
+    private async _withDependencyInternal(dependency: ResourceBuilderBase): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withDependency',
@@ -1117,7 +1117,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withEndpointsInternal(endpoints: string[]): Promise<Resource> {
+    private async _withEndpointsInternal(endpoints: string[]): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, endpoints };
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withEndpoints',
@@ -1132,7 +1132,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<Resource> {
+    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<Resource> {
         const operationId = registerCallback(async (argData: unknown) => {
             const arg = wrapIfHandle(argData) as AbortSignal;
             await operation(arg);
@@ -1244,7 +1244,7 @@ export class ResourceWithConnectionString extends ResourceBuilderBase<IResourceW
     }
 
     /** @internal */
-    async _withConnectionStringInternal(connectionString: ReferenceExpression): Promise<ResourceWithConnectionString> {
+    private async _withConnectionStringInternal(connectionString: ReferenceExpression): Promise<ResourceWithConnectionString> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, connectionString };
         const result = await this._client.invokeCapability<IResourceWithConnectionStringHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withConnectionString',
@@ -1259,7 +1259,7 @@ export class ResourceWithConnectionString extends ResourceBuilderBase<IResourceW
     }
 
     /** @internal */
-    async _withConnectionStringDirectInternal(connectionString: string): Promise<ResourceWithConnectionString> {
+    private async _withConnectionStringDirectInternal(connectionString: string): Promise<ResourceWithConnectionString> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, connectionString };
         const result = await this._client.invokeCapability<IResourceWithConnectionStringHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withConnectionStringDirect',
@@ -1312,7 +1312,7 @@ export class ResourceWithEnvironment extends ResourceBuilderBase<IResourceWithEn
     }
 
     /** @internal */
-    async _testWithEnvironmentCallbackInternal(callback: (arg: TestEnvironmentContext) => Promise<void>): Promise<ResourceWithEnvironment> {
+    private async _testWithEnvironmentCallbackInternal(callback: (arg: TestEnvironmentContext) => Promise<void>): Promise<ResourceWithEnvironment> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestEnvironmentContextHandle;
             const arg = new TestEnvironmentContext(argHandle, this._client);
@@ -1332,7 +1332,7 @@ export class ResourceWithEnvironment extends ResourceBuilderBase<IResourceWithEn
     }
 
     /** @internal */
-    async _withEnvironmentVariablesInternal(variables: Record<string, string>): Promise<ResourceWithEnvironment> {
+    private async _withEnvironmentVariablesInternal(variables: Record<string, string>): Promise<ResourceWithEnvironment> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, variables };
         const result = await this._client.invokeCapability<IResourceWithEnvironmentHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withEnvironmentVariables',

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -1066,7 +1066,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withEnvironmentInternal(name: string, value: string): Promise<ContainerResource> {
+    private async _withEnvironmentInternal(name: string, value: string): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting/withEnvironment',
@@ -1081,7 +1081,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withEnvironmentExpressionInternal(name: string, value: ReferenceExpression): Promise<ContainerResource> {
+    private async _withEnvironmentExpressionInternal(name: string, value: ReferenceExpression): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting/withEnvironmentExpression',
@@ -1096,7 +1096,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withEnvironmentCallbackInternal(callback: (obj: EnvironmentCallbackContext) => Promise<void>): Promise<ContainerResource> {
+    private async _withEnvironmentCallbackInternal(callback: (obj: EnvironmentCallbackContext) => Promise<void>): Promise<ContainerResource> {
         const callbackId = registerCallback(async (objData: unknown) => {
             const objHandle = wrapIfHandle(objData) as EnvironmentCallbackContextHandle;
             const obj = new EnvironmentCallbackContext(objHandle, this._client);
@@ -1116,7 +1116,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withEnvironmentCallbackAsyncInternal(callback: (arg: EnvironmentCallbackContext) => Promise<void>): Promise<ContainerResource> {
+    private async _withEnvironmentCallbackAsyncInternal(callback: (arg: EnvironmentCallbackContext) => Promise<void>): Promise<ContainerResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as EnvironmentCallbackContextHandle;
             const arg = new EnvironmentCallbackContext(argHandle, this._client);
@@ -1136,7 +1136,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withArgsInternal(args: string[]): Promise<ContainerResource> {
+    private async _withArgsInternal(args: string[]): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, args };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting/withArgs',
@@ -1151,7 +1151,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withReferenceInternal(source: ResourceBuilderBase, connectionName?: string, optional?: boolean): Promise<ContainerResource> {
+    private async _withReferenceInternal(source: ResourceBuilderBase, connectionName?: string, optional?: boolean): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, source };
         if (connectionName !== undefined) rpcArgs.connectionName = connectionName;
         if (optional !== undefined) rpcArgs.optional = optional;
@@ -1170,7 +1170,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withServiceReferenceInternal(source: ResourceBuilderBase): Promise<ContainerResource> {
+    private async _withServiceReferenceInternal(source: ResourceBuilderBase): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, source };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting/withServiceReference',
@@ -1185,7 +1185,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withHttpEndpointInternal(port?: number, targetPort?: number, name?: string, env?: string, isProxied?: boolean): Promise<ContainerResource> {
+    private async _withHttpEndpointInternal(port?: number, targetPort?: number, name?: string, env?: string, isProxied?: boolean): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (port !== undefined) rpcArgs.port = port;
         if (targetPort !== undefined) rpcArgs.targetPort = targetPort;
@@ -1210,7 +1210,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withExternalHttpEndpointsInternal(): Promise<ContainerResource> {
+    private async _withExternalHttpEndpointsInternal(): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting/withExternalHttpEndpoints',
@@ -1234,7 +1234,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _waitForInternal(dependency: ResourceBuilderBase): Promise<ContainerResource> {
+    private async _waitForInternal(dependency: ResourceBuilderBase): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting/waitFor',
@@ -1249,7 +1249,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _waitForCompletionInternal(dependency: ResourceBuilderBase, exitCode?: number): Promise<ContainerResource> {
+    private async _waitForCompletionInternal(dependency: ResourceBuilderBase, exitCode?: number): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         if (exitCode !== undefined) rpcArgs.exitCode = exitCode;
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
@@ -1266,7 +1266,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withHttpHealthCheckInternal(path?: string, statusCode?: number, endpointName?: string): Promise<ContainerResource> {
+    private async _withHttpHealthCheckInternal(path?: string, statusCode?: number, endpointName?: string): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (path !== undefined) rpcArgs.path = path;
         if (statusCode !== undefined) rpcArgs.statusCode = statusCode;
@@ -1287,7 +1287,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<ContainerResource> {
+    private async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, parent };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting/withParentRelationship',
@@ -1311,7 +1311,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<ContainerResource> {
+    private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (value !== undefined) rpcArgs.value = value;
         if (enabled !== undefined) rpcArgs.enabled = enabled;
@@ -1330,7 +1330,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withConfigInternal(config: TestConfigDto): Promise<ContainerResource> {
+    private async _withConfigInternal(config: TestConfigDto): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, config };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withConfig',
@@ -1345,7 +1345,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _testWithEnvironmentCallbackInternal(callback: (arg: TestEnvironmentContext) => Promise<void>): Promise<ContainerResource> {
+    private async _testWithEnvironmentCallbackInternal(callback: (arg: TestEnvironmentContext) => Promise<void>): Promise<ContainerResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestEnvironmentContextHandle;
             const arg = new TestEnvironmentContext(argHandle, this._client);
@@ -1365,7 +1365,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withCreatedAtInternal(createdAt: string): Promise<ContainerResource> {
+    private async _withCreatedAtInternal(createdAt: string): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, createdAt };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withCreatedAt',
@@ -1380,7 +1380,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withModifiedAtInternal(modifiedAt: string): Promise<ContainerResource> {
+    private async _withModifiedAtInternal(modifiedAt: string): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, modifiedAt };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withModifiedAt',
@@ -1395,7 +1395,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withCorrelationIdInternal(correlationId: string): Promise<ContainerResource> {
+    private async _withCorrelationIdInternal(correlationId: string): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, correlationId };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withCorrelationId',
@@ -1410,7 +1410,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withOptionalCallbackInternal(callback?: (arg: TestCallbackContext) => Promise<void>): Promise<ContainerResource> {
+    private async _withOptionalCallbackInternal(callback?: (arg: TestCallbackContext) => Promise<void>): Promise<ContainerResource> {
         const callbackId = callback ? registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestCallbackContextHandle;
             const arg = new TestCallbackContext(argHandle, this._client);
@@ -1432,7 +1432,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withStatusInternal(status: TestResourceStatus): Promise<ContainerResource> {
+    private async _withStatusInternal(status: TestResourceStatus): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, status };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withStatus',
@@ -1447,7 +1447,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withNestedConfigInternal(config: TestNestedDto): Promise<ContainerResource> {
+    private async _withNestedConfigInternal(config: TestNestedDto): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, config };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withNestedConfig',
@@ -1462,7 +1462,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withValidatorInternal(validator: (arg: TestResourceContext) => Promise<boolean>): Promise<ContainerResource> {
+    private async _withValidatorInternal(validator: (arg: TestResourceContext) => Promise<boolean>): Promise<ContainerResource> {
         const validatorId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestResourceContextHandle;
             const arg = new TestResourceContext(argHandle, this._client);
@@ -1482,7 +1482,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _testWaitForInternal(dependency: ResourceBuilderBase): Promise<ContainerResource> {
+    private async _testWaitForInternal(dependency: ResourceBuilderBase): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/testWaitFor',
@@ -1497,7 +1497,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withDependencyInternal(dependency: ResourceBuilderBase): Promise<ContainerResource> {
+    private async _withDependencyInternal(dependency: ResourceBuilderBase): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withDependency',
@@ -1512,7 +1512,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withEndpointsInternal(endpoints: string[]): Promise<ContainerResource> {
+    private async _withEndpointsInternal(endpoints: string[]): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, endpoints };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withEndpoints',
@@ -1527,7 +1527,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withEnvironmentVariablesInternal(variables: Record<string, string>): Promise<ContainerResource> {
+    private async _withEnvironmentVariablesInternal(variables: Record<string, string>): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, variables };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withEnvironmentVariables',
@@ -1542,7 +1542,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<ContainerResource> {
+    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<ContainerResource> {
         const operationId = registerCallback(async (argData: unknown) => {
             const arg = wrapIfHandle(argData) as AbortSignal;
             await operation(arg);
@@ -1739,7 +1739,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withEnvironmentInternal(name: string, value: string): Promise<ExecutableResource> {
+    private async _withEnvironmentInternal(name: string, value: string): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting/withEnvironment',
@@ -1754,7 +1754,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withEnvironmentExpressionInternal(name: string, value: ReferenceExpression): Promise<ExecutableResource> {
+    private async _withEnvironmentExpressionInternal(name: string, value: ReferenceExpression): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting/withEnvironmentExpression',
@@ -1769,7 +1769,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withEnvironmentCallbackInternal(callback: (obj: EnvironmentCallbackContext) => Promise<void>): Promise<ExecutableResource> {
+    private async _withEnvironmentCallbackInternal(callback: (obj: EnvironmentCallbackContext) => Promise<void>): Promise<ExecutableResource> {
         const callbackId = registerCallback(async (objData: unknown) => {
             const objHandle = wrapIfHandle(objData) as EnvironmentCallbackContextHandle;
             const obj = new EnvironmentCallbackContext(objHandle, this._client);
@@ -1789,7 +1789,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withEnvironmentCallbackAsyncInternal(callback: (arg: EnvironmentCallbackContext) => Promise<void>): Promise<ExecutableResource> {
+    private async _withEnvironmentCallbackAsyncInternal(callback: (arg: EnvironmentCallbackContext) => Promise<void>): Promise<ExecutableResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as EnvironmentCallbackContextHandle;
             const arg = new EnvironmentCallbackContext(argHandle, this._client);
@@ -1809,7 +1809,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withArgsInternal(args: string[]): Promise<ExecutableResource> {
+    private async _withArgsInternal(args: string[]): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, args };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting/withArgs',
@@ -1824,7 +1824,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withReferenceInternal(source: ResourceBuilderBase, connectionName?: string, optional?: boolean): Promise<ExecutableResource> {
+    private async _withReferenceInternal(source: ResourceBuilderBase, connectionName?: string, optional?: boolean): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, source };
         if (connectionName !== undefined) rpcArgs.connectionName = connectionName;
         if (optional !== undefined) rpcArgs.optional = optional;
@@ -1843,7 +1843,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withServiceReferenceInternal(source: ResourceBuilderBase): Promise<ExecutableResource> {
+    private async _withServiceReferenceInternal(source: ResourceBuilderBase): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, source };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting/withServiceReference',
@@ -1858,7 +1858,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withHttpEndpointInternal(port?: number, targetPort?: number, name?: string, env?: string, isProxied?: boolean): Promise<ExecutableResource> {
+    private async _withHttpEndpointInternal(port?: number, targetPort?: number, name?: string, env?: string, isProxied?: boolean): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (port !== undefined) rpcArgs.port = port;
         if (targetPort !== undefined) rpcArgs.targetPort = targetPort;
@@ -1883,7 +1883,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withExternalHttpEndpointsInternal(): Promise<ExecutableResource> {
+    private async _withExternalHttpEndpointsInternal(): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting/withExternalHttpEndpoints',
@@ -1907,7 +1907,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _waitForInternal(dependency: ResourceBuilderBase): Promise<ExecutableResource> {
+    private async _waitForInternal(dependency: ResourceBuilderBase): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting/waitFor',
@@ -1922,7 +1922,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _waitForCompletionInternal(dependency: ResourceBuilderBase, exitCode?: number): Promise<ExecutableResource> {
+    private async _waitForCompletionInternal(dependency: ResourceBuilderBase, exitCode?: number): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         if (exitCode !== undefined) rpcArgs.exitCode = exitCode;
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
@@ -1939,7 +1939,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withHttpHealthCheckInternal(path?: string, statusCode?: number, endpointName?: string): Promise<ExecutableResource> {
+    private async _withHttpHealthCheckInternal(path?: string, statusCode?: number, endpointName?: string): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (path !== undefined) rpcArgs.path = path;
         if (statusCode !== undefined) rpcArgs.statusCode = statusCode;
@@ -1960,7 +1960,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<ExecutableResource> {
+    private async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, parent };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting/withParentRelationship',
@@ -1984,7 +1984,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<ExecutableResource> {
+    private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (value !== undefined) rpcArgs.value = value;
         if (enabled !== undefined) rpcArgs.enabled = enabled;
@@ -2003,7 +2003,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withConfigInternal(config: TestConfigDto): Promise<ExecutableResource> {
+    private async _withConfigInternal(config: TestConfigDto): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, config };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withConfig',
@@ -2018,7 +2018,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _testWithEnvironmentCallbackInternal(callback: (arg: TestEnvironmentContext) => Promise<void>): Promise<ExecutableResource> {
+    private async _testWithEnvironmentCallbackInternal(callback: (arg: TestEnvironmentContext) => Promise<void>): Promise<ExecutableResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestEnvironmentContextHandle;
             const arg = new TestEnvironmentContext(argHandle, this._client);
@@ -2038,7 +2038,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withCreatedAtInternal(createdAt: string): Promise<ExecutableResource> {
+    private async _withCreatedAtInternal(createdAt: string): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, createdAt };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withCreatedAt',
@@ -2053,7 +2053,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withModifiedAtInternal(modifiedAt: string): Promise<ExecutableResource> {
+    private async _withModifiedAtInternal(modifiedAt: string): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, modifiedAt };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withModifiedAt',
@@ -2068,7 +2068,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withCorrelationIdInternal(correlationId: string): Promise<ExecutableResource> {
+    private async _withCorrelationIdInternal(correlationId: string): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, correlationId };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withCorrelationId',
@@ -2083,7 +2083,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withOptionalCallbackInternal(callback?: (arg: TestCallbackContext) => Promise<void>): Promise<ExecutableResource> {
+    private async _withOptionalCallbackInternal(callback?: (arg: TestCallbackContext) => Promise<void>): Promise<ExecutableResource> {
         const callbackId = callback ? registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestCallbackContextHandle;
             const arg = new TestCallbackContext(argHandle, this._client);
@@ -2105,7 +2105,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withStatusInternal(status: TestResourceStatus): Promise<ExecutableResource> {
+    private async _withStatusInternal(status: TestResourceStatus): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, status };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withStatus',
@@ -2120,7 +2120,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withNestedConfigInternal(config: TestNestedDto): Promise<ExecutableResource> {
+    private async _withNestedConfigInternal(config: TestNestedDto): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, config };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withNestedConfig',
@@ -2135,7 +2135,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withValidatorInternal(validator: (arg: TestResourceContext) => Promise<boolean>): Promise<ExecutableResource> {
+    private async _withValidatorInternal(validator: (arg: TestResourceContext) => Promise<boolean>): Promise<ExecutableResource> {
         const validatorId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestResourceContextHandle;
             const arg = new TestResourceContext(argHandle, this._client);
@@ -2155,7 +2155,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _testWaitForInternal(dependency: ResourceBuilderBase): Promise<ExecutableResource> {
+    private async _testWaitForInternal(dependency: ResourceBuilderBase): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/testWaitFor',
@@ -2170,7 +2170,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withDependencyInternal(dependency: ResourceBuilderBase): Promise<ExecutableResource> {
+    private async _withDependencyInternal(dependency: ResourceBuilderBase): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withDependency',
@@ -2185,7 +2185,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withEndpointsInternal(endpoints: string[]): Promise<ExecutableResource> {
+    private async _withEndpointsInternal(endpoints: string[]): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, endpoints };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withEndpoints',
@@ -2200,7 +2200,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withEnvironmentVariablesInternal(variables: Record<string, string>): Promise<ExecutableResource> {
+    private async _withEnvironmentVariablesInternal(variables: Record<string, string>): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, variables };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withEnvironmentVariables',
@@ -2215,7 +2215,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<ExecutableResource> {
+    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<ExecutableResource> {
         const operationId = registerCallback(async (argData: unknown) => {
             const arg = wrapIfHandle(argData) as AbortSignal;
             await operation(arg);
@@ -2412,7 +2412,7 @@ export class ParameterResource extends ResourceBuilderBase<ParameterResourceHand
     }
 
     /** @internal */
-    async _withDescriptionInternal(description: string, enableMarkdown?: boolean): Promise<ParameterResource> {
+    private async _withDescriptionInternal(description: string, enableMarkdown?: boolean): Promise<ParameterResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, description };
         if (enableMarkdown !== undefined) rpcArgs.enableMarkdown = enableMarkdown;
         const result = await this._client.invokeCapability<ParameterResourceHandle>(
@@ -2429,7 +2429,7 @@ export class ParameterResource extends ResourceBuilderBase<ParameterResourceHand
     }
 
     /** @internal */
-    async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<ParameterResource> {
+    private async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<ParameterResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, parent };
         const result = await this._client.invokeCapability<ParameterResourceHandle>(
             'Aspire.Hosting/withParentRelationship',
@@ -2453,7 +2453,7 @@ export class ParameterResource extends ResourceBuilderBase<ParameterResourceHand
     }
 
     /** @internal */
-    async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<ParameterResource> {
+    private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<ParameterResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (value !== undefined) rpcArgs.value = value;
         if (enabled !== undefined) rpcArgs.enabled = enabled;
@@ -2472,7 +2472,7 @@ export class ParameterResource extends ResourceBuilderBase<ParameterResourceHand
     }
 
     /** @internal */
-    async _withConfigInternal(config: TestConfigDto): Promise<ParameterResource> {
+    private async _withConfigInternal(config: TestConfigDto): Promise<ParameterResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, config };
         const result = await this._client.invokeCapability<ParameterResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withConfig',
@@ -2487,7 +2487,7 @@ export class ParameterResource extends ResourceBuilderBase<ParameterResourceHand
     }
 
     /** @internal */
-    async _withCreatedAtInternal(createdAt: string): Promise<ParameterResource> {
+    private async _withCreatedAtInternal(createdAt: string): Promise<ParameterResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, createdAt };
         const result = await this._client.invokeCapability<ParameterResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withCreatedAt',
@@ -2502,7 +2502,7 @@ export class ParameterResource extends ResourceBuilderBase<ParameterResourceHand
     }
 
     /** @internal */
-    async _withModifiedAtInternal(modifiedAt: string): Promise<ParameterResource> {
+    private async _withModifiedAtInternal(modifiedAt: string): Promise<ParameterResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, modifiedAt };
         const result = await this._client.invokeCapability<ParameterResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withModifiedAt',
@@ -2517,7 +2517,7 @@ export class ParameterResource extends ResourceBuilderBase<ParameterResourceHand
     }
 
     /** @internal */
-    async _withCorrelationIdInternal(correlationId: string): Promise<ParameterResource> {
+    private async _withCorrelationIdInternal(correlationId: string): Promise<ParameterResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, correlationId };
         const result = await this._client.invokeCapability<ParameterResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withCorrelationId',
@@ -2532,7 +2532,7 @@ export class ParameterResource extends ResourceBuilderBase<ParameterResourceHand
     }
 
     /** @internal */
-    async _withOptionalCallbackInternal(callback?: (arg: TestCallbackContext) => Promise<void>): Promise<ParameterResource> {
+    private async _withOptionalCallbackInternal(callback?: (arg: TestCallbackContext) => Promise<void>): Promise<ParameterResource> {
         const callbackId = callback ? registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestCallbackContextHandle;
             const arg = new TestCallbackContext(argHandle, this._client);
@@ -2554,7 +2554,7 @@ export class ParameterResource extends ResourceBuilderBase<ParameterResourceHand
     }
 
     /** @internal */
-    async _withStatusInternal(status: TestResourceStatus): Promise<ParameterResource> {
+    private async _withStatusInternal(status: TestResourceStatus): Promise<ParameterResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, status };
         const result = await this._client.invokeCapability<ParameterResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withStatus',
@@ -2569,7 +2569,7 @@ export class ParameterResource extends ResourceBuilderBase<ParameterResourceHand
     }
 
     /** @internal */
-    async _withNestedConfigInternal(config: TestNestedDto): Promise<ParameterResource> {
+    private async _withNestedConfigInternal(config: TestNestedDto): Promise<ParameterResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, config };
         const result = await this._client.invokeCapability<ParameterResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withNestedConfig',
@@ -2584,7 +2584,7 @@ export class ParameterResource extends ResourceBuilderBase<ParameterResourceHand
     }
 
     /** @internal */
-    async _withValidatorInternal(validator: (arg: TestResourceContext) => Promise<boolean>): Promise<ParameterResource> {
+    private async _withValidatorInternal(validator: (arg: TestResourceContext) => Promise<boolean>): Promise<ParameterResource> {
         const validatorId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestResourceContextHandle;
             const arg = new TestResourceContext(argHandle, this._client);
@@ -2604,7 +2604,7 @@ export class ParameterResource extends ResourceBuilderBase<ParameterResourceHand
     }
 
     /** @internal */
-    async _testWaitForInternal(dependency: ResourceBuilderBase): Promise<ParameterResource> {
+    private async _testWaitForInternal(dependency: ResourceBuilderBase): Promise<ParameterResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<ParameterResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/testWaitFor',
@@ -2619,7 +2619,7 @@ export class ParameterResource extends ResourceBuilderBase<ParameterResourceHand
     }
 
     /** @internal */
-    async _withDependencyInternal(dependency: ResourceBuilderBase): Promise<ParameterResource> {
+    private async _withDependencyInternal(dependency: ResourceBuilderBase): Promise<ParameterResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<ParameterResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withDependency',
@@ -2634,7 +2634,7 @@ export class ParameterResource extends ResourceBuilderBase<ParameterResourceHand
     }
 
     /** @internal */
-    async _withEndpointsInternal(endpoints: string[]): Promise<ParameterResource> {
+    private async _withEndpointsInternal(endpoints: string[]): Promise<ParameterResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, endpoints };
         const result = await this._client.invokeCapability<ParameterResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withEndpoints',
@@ -2649,7 +2649,7 @@ export class ParameterResource extends ResourceBuilderBase<ParameterResourceHand
     }
 
     /** @internal */
-    async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<ParameterResource> {
+    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<ParameterResource> {
         const operationId = registerCallback(async (argData: unknown) => {
             const arg = wrapIfHandle(argData) as AbortSignal;
             await operation(arg);
@@ -2776,7 +2776,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withReplicasInternal(replicas: number): Promise<ProjectResource> {
+    private async _withReplicasInternal(replicas: number): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, replicas };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting/withReplicas',
@@ -2791,7 +2791,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withEnvironmentInternal(name: string, value: string): Promise<ProjectResource> {
+    private async _withEnvironmentInternal(name: string, value: string): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting/withEnvironment',
@@ -2806,7 +2806,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withEnvironmentExpressionInternal(name: string, value: ReferenceExpression): Promise<ProjectResource> {
+    private async _withEnvironmentExpressionInternal(name: string, value: ReferenceExpression): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting/withEnvironmentExpression',
@@ -2821,7 +2821,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withEnvironmentCallbackInternal(callback: (obj: EnvironmentCallbackContext) => Promise<void>): Promise<ProjectResource> {
+    private async _withEnvironmentCallbackInternal(callback: (obj: EnvironmentCallbackContext) => Promise<void>): Promise<ProjectResource> {
         const callbackId = registerCallback(async (objData: unknown) => {
             const objHandle = wrapIfHandle(objData) as EnvironmentCallbackContextHandle;
             const obj = new EnvironmentCallbackContext(objHandle, this._client);
@@ -2841,7 +2841,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withEnvironmentCallbackAsyncInternal(callback: (arg: EnvironmentCallbackContext) => Promise<void>): Promise<ProjectResource> {
+    private async _withEnvironmentCallbackAsyncInternal(callback: (arg: EnvironmentCallbackContext) => Promise<void>): Promise<ProjectResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as EnvironmentCallbackContextHandle;
             const arg = new EnvironmentCallbackContext(argHandle, this._client);
@@ -2861,7 +2861,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withArgsInternal(args: string[]): Promise<ProjectResource> {
+    private async _withArgsInternal(args: string[]): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, args };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting/withArgs',
@@ -2876,7 +2876,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withReferenceInternal(source: ResourceBuilderBase, connectionName?: string, optional?: boolean): Promise<ProjectResource> {
+    private async _withReferenceInternal(source: ResourceBuilderBase, connectionName?: string, optional?: boolean): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, source };
         if (connectionName !== undefined) rpcArgs.connectionName = connectionName;
         if (optional !== undefined) rpcArgs.optional = optional;
@@ -2895,7 +2895,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withServiceReferenceInternal(source: ResourceBuilderBase): Promise<ProjectResource> {
+    private async _withServiceReferenceInternal(source: ResourceBuilderBase): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, source };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting/withServiceReference',
@@ -2910,7 +2910,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withHttpEndpointInternal(port?: number, targetPort?: number, name?: string, env?: string, isProxied?: boolean): Promise<ProjectResource> {
+    private async _withHttpEndpointInternal(port?: number, targetPort?: number, name?: string, env?: string, isProxied?: boolean): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (port !== undefined) rpcArgs.port = port;
         if (targetPort !== undefined) rpcArgs.targetPort = targetPort;
@@ -2935,7 +2935,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withExternalHttpEndpointsInternal(): Promise<ProjectResource> {
+    private async _withExternalHttpEndpointsInternal(): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting/withExternalHttpEndpoints',
@@ -2959,7 +2959,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _waitForInternal(dependency: ResourceBuilderBase): Promise<ProjectResource> {
+    private async _waitForInternal(dependency: ResourceBuilderBase): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting/waitFor',
@@ -2974,7 +2974,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _waitForCompletionInternal(dependency: ResourceBuilderBase, exitCode?: number): Promise<ProjectResource> {
+    private async _waitForCompletionInternal(dependency: ResourceBuilderBase, exitCode?: number): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         if (exitCode !== undefined) rpcArgs.exitCode = exitCode;
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
@@ -2991,7 +2991,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withHttpHealthCheckInternal(path?: string, statusCode?: number, endpointName?: string): Promise<ProjectResource> {
+    private async _withHttpHealthCheckInternal(path?: string, statusCode?: number, endpointName?: string): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (path !== undefined) rpcArgs.path = path;
         if (statusCode !== undefined) rpcArgs.statusCode = statusCode;
@@ -3012,7 +3012,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<ProjectResource> {
+    private async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, parent };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting/withParentRelationship',
@@ -3036,7 +3036,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<ProjectResource> {
+    private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (value !== undefined) rpcArgs.value = value;
         if (enabled !== undefined) rpcArgs.enabled = enabled;
@@ -3055,7 +3055,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withConfigInternal(config: TestConfigDto): Promise<ProjectResource> {
+    private async _withConfigInternal(config: TestConfigDto): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, config };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withConfig',
@@ -3070,7 +3070,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _testWithEnvironmentCallbackInternal(callback: (arg: TestEnvironmentContext) => Promise<void>): Promise<ProjectResource> {
+    private async _testWithEnvironmentCallbackInternal(callback: (arg: TestEnvironmentContext) => Promise<void>): Promise<ProjectResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestEnvironmentContextHandle;
             const arg = new TestEnvironmentContext(argHandle, this._client);
@@ -3090,7 +3090,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withCreatedAtInternal(createdAt: string): Promise<ProjectResource> {
+    private async _withCreatedAtInternal(createdAt: string): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, createdAt };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withCreatedAt',
@@ -3105,7 +3105,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withModifiedAtInternal(modifiedAt: string): Promise<ProjectResource> {
+    private async _withModifiedAtInternal(modifiedAt: string): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, modifiedAt };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withModifiedAt',
@@ -3120,7 +3120,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withCorrelationIdInternal(correlationId: string): Promise<ProjectResource> {
+    private async _withCorrelationIdInternal(correlationId: string): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, correlationId };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withCorrelationId',
@@ -3135,7 +3135,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withOptionalCallbackInternal(callback?: (arg: TestCallbackContext) => Promise<void>): Promise<ProjectResource> {
+    private async _withOptionalCallbackInternal(callback?: (arg: TestCallbackContext) => Promise<void>): Promise<ProjectResource> {
         const callbackId = callback ? registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestCallbackContextHandle;
             const arg = new TestCallbackContext(argHandle, this._client);
@@ -3157,7 +3157,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withStatusInternal(status: TestResourceStatus): Promise<ProjectResource> {
+    private async _withStatusInternal(status: TestResourceStatus): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, status };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withStatus',
@@ -3172,7 +3172,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withNestedConfigInternal(config: TestNestedDto): Promise<ProjectResource> {
+    private async _withNestedConfigInternal(config: TestNestedDto): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, config };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withNestedConfig',
@@ -3187,7 +3187,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withValidatorInternal(validator: (arg: TestResourceContext) => Promise<boolean>): Promise<ProjectResource> {
+    private async _withValidatorInternal(validator: (arg: TestResourceContext) => Promise<boolean>): Promise<ProjectResource> {
         const validatorId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestResourceContextHandle;
             const arg = new TestResourceContext(argHandle, this._client);
@@ -3207,7 +3207,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _testWaitForInternal(dependency: ResourceBuilderBase): Promise<ProjectResource> {
+    private async _testWaitForInternal(dependency: ResourceBuilderBase): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/testWaitFor',
@@ -3222,7 +3222,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withDependencyInternal(dependency: ResourceBuilderBase): Promise<ProjectResource> {
+    private async _withDependencyInternal(dependency: ResourceBuilderBase): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withDependency',
@@ -3237,7 +3237,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withEndpointsInternal(endpoints: string[]): Promise<ProjectResource> {
+    private async _withEndpointsInternal(endpoints: string[]): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, endpoints };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withEndpoints',
@@ -3252,7 +3252,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withEnvironmentVariablesInternal(variables: Record<string, string>): Promise<ProjectResource> {
+    private async _withEnvironmentVariablesInternal(variables: Record<string, string>): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, variables };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withEnvironmentVariables',
@@ -3267,7 +3267,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<ProjectResource> {
+    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<ProjectResource> {
         const operationId = registerCallback(async (argData: unknown) => {
             const arg = wrapIfHandle(argData) as AbortSignal;
             await operation(arg);
@@ -3469,7 +3469,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withBindMountInternal(source: string, target: string, isReadOnly?: boolean): Promise<TestRedisResource> {
+    private async _withBindMountInternal(source: string, target: string, isReadOnly?: boolean): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, source, target };
         if (isReadOnly !== undefined) rpcArgs.isReadOnly = isReadOnly;
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
@@ -3486,7 +3486,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withImageTagInternal(tag: string): Promise<TestRedisResource> {
+    private async _withImageTagInternal(tag: string): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, tag };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting/withImageTag',
@@ -3501,7 +3501,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withImageRegistryInternal(registry: string): Promise<TestRedisResource> {
+    private async _withImageRegistryInternal(registry: string): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, registry };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting/withImageRegistry',
@@ -3516,7 +3516,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withLifetimeInternal(lifetime: ContainerLifetime): Promise<TestRedisResource> {
+    private async _withLifetimeInternal(lifetime: ContainerLifetime): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, lifetime };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting/withLifetime',
@@ -3531,7 +3531,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withEnvironmentInternal(name: string, value: string): Promise<TestRedisResource> {
+    private async _withEnvironmentInternal(name: string, value: string): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting/withEnvironment',
@@ -3546,7 +3546,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withEnvironmentExpressionInternal(name: string, value: ReferenceExpression): Promise<TestRedisResource> {
+    private async _withEnvironmentExpressionInternal(name: string, value: ReferenceExpression): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting/withEnvironmentExpression',
@@ -3561,7 +3561,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withEnvironmentCallbackInternal(callback: (obj: EnvironmentCallbackContext) => Promise<void>): Promise<TestRedisResource> {
+    private async _withEnvironmentCallbackInternal(callback: (obj: EnvironmentCallbackContext) => Promise<void>): Promise<TestRedisResource> {
         const callbackId = registerCallback(async (objData: unknown) => {
             const objHandle = wrapIfHandle(objData) as EnvironmentCallbackContextHandle;
             const obj = new EnvironmentCallbackContext(objHandle, this._client);
@@ -3581,7 +3581,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withEnvironmentCallbackAsyncInternal(callback: (arg: EnvironmentCallbackContext) => Promise<void>): Promise<TestRedisResource> {
+    private async _withEnvironmentCallbackAsyncInternal(callback: (arg: EnvironmentCallbackContext) => Promise<void>): Promise<TestRedisResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as EnvironmentCallbackContextHandle;
             const arg = new EnvironmentCallbackContext(argHandle, this._client);
@@ -3601,7 +3601,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withArgsInternal(args: string[]): Promise<TestRedisResource> {
+    private async _withArgsInternal(args: string[]): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, args };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting/withArgs',
@@ -3616,7 +3616,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withReferenceInternal(source: ResourceBuilderBase, connectionName?: string, optional?: boolean): Promise<TestRedisResource> {
+    private async _withReferenceInternal(source: ResourceBuilderBase, connectionName?: string, optional?: boolean): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, source };
         if (connectionName !== undefined) rpcArgs.connectionName = connectionName;
         if (optional !== undefined) rpcArgs.optional = optional;
@@ -3635,7 +3635,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withServiceReferenceInternal(source: ResourceBuilderBase): Promise<TestRedisResource> {
+    private async _withServiceReferenceInternal(source: ResourceBuilderBase): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, source };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting/withServiceReference',
@@ -3650,7 +3650,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withHttpEndpointInternal(port?: number, targetPort?: number, name?: string, env?: string, isProxied?: boolean): Promise<TestRedisResource> {
+    private async _withHttpEndpointInternal(port?: number, targetPort?: number, name?: string, env?: string, isProxied?: boolean): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (port !== undefined) rpcArgs.port = port;
         if (targetPort !== undefined) rpcArgs.targetPort = targetPort;
@@ -3675,7 +3675,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withExternalHttpEndpointsInternal(): Promise<TestRedisResource> {
+    private async _withExternalHttpEndpointsInternal(): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting/withExternalHttpEndpoints',
@@ -3699,7 +3699,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _waitForInternal(dependency: ResourceBuilderBase): Promise<TestRedisResource> {
+    private async _waitForInternal(dependency: ResourceBuilderBase): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting/waitFor',
@@ -3714,7 +3714,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _waitForCompletionInternal(dependency: ResourceBuilderBase, exitCode?: number): Promise<TestRedisResource> {
+    private async _waitForCompletionInternal(dependency: ResourceBuilderBase, exitCode?: number): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         if (exitCode !== undefined) rpcArgs.exitCode = exitCode;
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
@@ -3731,7 +3731,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withHttpHealthCheckInternal(path?: string, statusCode?: number, endpointName?: string): Promise<TestRedisResource> {
+    private async _withHttpHealthCheckInternal(path?: string, statusCode?: number, endpointName?: string): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (path !== undefined) rpcArgs.path = path;
         if (statusCode !== undefined) rpcArgs.statusCode = statusCode;
@@ -3752,7 +3752,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<TestRedisResource> {
+    private async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, parent };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting/withParentRelationship',
@@ -3767,7 +3767,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withVolumeInternal(target: string, name?: string, isReadOnly?: boolean): Promise<TestRedisResource> {
+    private async _withVolumeInternal(target: string, name?: string, isReadOnly?: boolean): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { resource: this._handle, target };
         if (name !== undefined) rpcArgs.name = name;
         if (isReadOnly !== undefined) rpcArgs.isReadOnly = isReadOnly;
@@ -3795,7 +3795,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withPersistenceInternal(mode?: TestPersistenceMode): Promise<TestRedisResource> {
+    private async _withPersistenceInternal(mode?: TestPersistenceMode): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (mode !== undefined) rpcArgs.mode = mode;
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
@@ -3812,7 +3812,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<TestRedisResource> {
+    private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (value !== undefined) rpcArgs.value = value;
         if (enabled !== undefined) rpcArgs.enabled = enabled;
@@ -3831,7 +3831,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withConfigInternal(config: TestConfigDto): Promise<TestRedisResource> {
+    private async _withConfigInternal(config: TestConfigDto): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, config };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withConfig',
@@ -3864,7 +3864,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withConnectionStringInternal(connectionString: ReferenceExpression): Promise<TestRedisResource> {
+    private async _withConnectionStringInternal(connectionString: ReferenceExpression): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, connectionString };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withConnectionString',
@@ -3879,7 +3879,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _testWithEnvironmentCallbackInternal(callback: (arg: TestEnvironmentContext) => Promise<void>): Promise<TestRedisResource> {
+    private async _testWithEnvironmentCallbackInternal(callback: (arg: TestEnvironmentContext) => Promise<void>): Promise<TestRedisResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestEnvironmentContextHandle;
             const arg = new TestEnvironmentContext(argHandle, this._client);
@@ -3899,7 +3899,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withCreatedAtInternal(createdAt: string): Promise<TestRedisResource> {
+    private async _withCreatedAtInternal(createdAt: string): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, createdAt };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withCreatedAt',
@@ -3914,7 +3914,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withModifiedAtInternal(modifiedAt: string): Promise<TestRedisResource> {
+    private async _withModifiedAtInternal(modifiedAt: string): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, modifiedAt };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withModifiedAt',
@@ -3929,7 +3929,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withCorrelationIdInternal(correlationId: string): Promise<TestRedisResource> {
+    private async _withCorrelationIdInternal(correlationId: string): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, correlationId };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withCorrelationId',
@@ -3944,7 +3944,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withOptionalCallbackInternal(callback?: (arg: TestCallbackContext) => Promise<void>): Promise<TestRedisResource> {
+    private async _withOptionalCallbackInternal(callback?: (arg: TestCallbackContext) => Promise<void>): Promise<TestRedisResource> {
         const callbackId = callback ? registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestCallbackContextHandle;
             const arg = new TestCallbackContext(argHandle, this._client);
@@ -3966,7 +3966,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withStatusInternal(status: TestResourceStatus): Promise<TestRedisResource> {
+    private async _withStatusInternal(status: TestResourceStatus): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, status };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withStatus',
@@ -3981,7 +3981,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withNestedConfigInternal(config: TestNestedDto): Promise<TestRedisResource> {
+    private async _withNestedConfigInternal(config: TestNestedDto): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, config };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withNestedConfig',
@@ -3996,7 +3996,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withValidatorInternal(validator: (arg: TestResourceContext) => Promise<boolean>): Promise<TestRedisResource> {
+    private async _withValidatorInternal(validator: (arg: TestResourceContext) => Promise<boolean>): Promise<TestRedisResource> {
         const validatorId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestResourceContextHandle;
             const arg = new TestResourceContext(argHandle, this._client);
@@ -4016,7 +4016,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _testWaitForInternal(dependency: ResourceBuilderBase): Promise<TestRedisResource> {
+    private async _testWaitForInternal(dependency: ResourceBuilderBase): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/testWaitFor',
@@ -4040,7 +4040,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withConnectionStringDirectInternal(connectionString: string): Promise<TestRedisResource> {
+    private async _withConnectionStringDirectInternal(connectionString: string): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, connectionString };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withConnectionStringDirect',
@@ -4055,7 +4055,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withRedisSpecificInternal(option: string): Promise<TestRedisResource> {
+    private async _withRedisSpecificInternal(option: string): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, option };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withRedisSpecific',
@@ -4070,7 +4070,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withDependencyInternal(dependency: ResourceBuilderBase): Promise<TestRedisResource> {
+    private async _withDependencyInternal(dependency: ResourceBuilderBase): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withDependency',
@@ -4085,7 +4085,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withEndpointsInternal(endpoints: string[]): Promise<TestRedisResource> {
+    private async _withEndpointsInternal(endpoints: string[]): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, endpoints };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withEndpoints',
@@ -4100,7 +4100,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withEnvironmentVariablesInternal(variables: Record<string, string>): Promise<TestRedisResource> {
+    private async _withEnvironmentVariablesInternal(variables: Record<string, string>): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, variables };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withEnvironmentVariables',
@@ -4127,7 +4127,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<TestRedisResource> {
+    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<TestRedisResource> {
         const operationId = registerCallback(async (argData: unknown) => {
             const arg = wrapIfHandle(argData) as AbortSignal;
             await operation(arg);
@@ -4406,7 +4406,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<Resource> {
+    private async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, parent };
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting/withParentRelationship',
@@ -4430,7 +4430,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<Resource> {
+    private async _withOptionalStringInternal(value?: string, enabled?: boolean): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (value !== undefined) rpcArgs.value = value;
         if (enabled !== undefined) rpcArgs.enabled = enabled;
@@ -4449,7 +4449,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withConfigInternal(config: TestConfigDto): Promise<Resource> {
+    private async _withConfigInternal(config: TestConfigDto): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, config };
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withConfig',
@@ -4464,7 +4464,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withCreatedAtInternal(createdAt: string): Promise<Resource> {
+    private async _withCreatedAtInternal(createdAt: string): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, createdAt };
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withCreatedAt',
@@ -4479,7 +4479,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withModifiedAtInternal(modifiedAt: string): Promise<Resource> {
+    private async _withModifiedAtInternal(modifiedAt: string): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, modifiedAt };
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withModifiedAt',
@@ -4494,7 +4494,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withCorrelationIdInternal(correlationId: string): Promise<Resource> {
+    private async _withCorrelationIdInternal(correlationId: string): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, correlationId };
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withCorrelationId',
@@ -4509,7 +4509,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withOptionalCallbackInternal(callback?: (arg: TestCallbackContext) => Promise<void>): Promise<Resource> {
+    private async _withOptionalCallbackInternal(callback?: (arg: TestCallbackContext) => Promise<void>): Promise<Resource> {
         const callbackId = callback ? registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestCallbackContextHandle;
             const arg = new TestCallbackContext(argHandle, this._client);
@@ -4531,7 +4531,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withStatusInternal(status: TestResourceStatus): Promise<Resource> {
+    private async _withStatusInternal(status: TestResourceStatus): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, status };
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withStatus',
@@ -4546,7 +4546,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withNestedConfigInternal(config: TestNestedDto): Promise<Resource> {
+    private async _withNestedConfigInternal(config: TestNestedDto): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, config };
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withNestedConfig',
@@ -4561,7 +4561,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withValidatorInternal(validator: (arg: TestResourceContext) => Promise<boolean>): Promise<Resource> {
+    private async _withValidatorInternal(validator: (arg: TestResourceContext) => Promise<boolean>): Promise<Resource> {
         const validatorId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestResourceContextHandle;
             const arg = new TestResourceContext(argHandle, this._client);
@@ -4581,7 +4581,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _testWaitForInternal(dependency: ResourceBuilderBase): Promise<Resource> {
+    private async _testWaitForInternal(dependency: ResourceBuilderBase): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/testWaitFor',
@@ -4596,7 +4596,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withDependencyInternal(dependency: ResourceBuilderBase): Promise<Resource> {
+    private async _withDependencyInternal(dependency: ResourceBuilderBase): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withDependency',
@@ -4611,7 +4611,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withEndpointsInternal(endpoints: string[]): Promise<Resource> {
+    private async _withEndpointsInternal(endpoints: string[]): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, endpoints };
         const result = await this._client.invokeCapability<IResourceHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withEndpoints',
@@ -4626,7 +4626,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<Resource> {
+    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<Resource> {
         const operationId = registerCallback(async (argData: unknown) => {
             const arg = wrapIfHandle(argData) as AbortSignal;
             await operation(arg);
@@ -4748,7 +4748,7 @@ export class ResourceWithArgs extends ResourceBuilderBase<IResourceWithArgsHandl
     }
 
     /** @internal */
-    async _withArgsInternal(args: string[]): Promise<ResourceWithArgs> {
+    private async _withArgsInternal(args: string[]): Promise<ResourceWithArgs> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, args };
         const result = await this._client.invokeCapability<IResourceWithArgsHandle>(
             'Aspire.Hosting/withArgs',
@@ -4796,7 +4796,7 @@ export class ResourceWithConnectionString extends ResourceBuilderBase<IResourceW
     }
 
     /** @internal */
-    async _withConnectionStringInternal(connectionString: ReferenceExpression): Promise<ResourceWithConnectionString> {
+    private async _withConnectionStringInternal(connectionString: ReferenceExpression): Promise<ResourceWithConnectionString> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, connectionString };
         const result = await this._client.invokeCapability<IResourceWithConnectionStringHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withConnectionString',
@@ -4811,7 +4811,7 @@ export class ResourceWithConnectionString extends ResourceBuilderBase<IResourceW
     }
 
     /** @internal */
-    async _withConnectionStringDirectInternal(connectionString: string): Promise<ResourceWithConnectionString> {
+    private async _withConnectionStringDirectInternal(connectionString: string): Promise<ResourceWithConnectionString> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, connectionString };
         const result = await this._client.invokeCapability<IResourceWithConnectionStringHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withConnectionStringDirect',
@@ -4864,7 +4864,7 @@ export class ResourceWithEndpoints extends ResourceBuilderBase<IResourceWithEndp
     }
 
     /** @internal */
-    async _withHttpEndpointInternal(port?: number, targetPort?: number, name?: string, env?: string, isProxied?: boolean): Promise<ResourceWithEndpoints> {
+    private async _withHttpEndpointInternal(port?: number, targetPort?: number, name?: string, env?: string, isProxied?: boolean): Promise<ResourceWithEndpoints> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (port !== undefined) rpcArgs.port = port;
         if (targetPort !== undefined) rpcArgs.targetPort = targetPort;
@@ -4889,7 +4889,7 @@ export class ResourceWithEndpoints extends ResourceBuilderBase<IResourceWithEndp
     }
 
     /** @internal */
-    async _withExternalHttpEndpointsInternal(): Promise<ResourceWithEndpoints> {
+    private async _withExternalHttpEndpointsInternal(): Promise<ResourceWithEndpoints> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         const result = await this._client.invokeCapability<IResourceWithEndpointsHandle>(
             'Aspire.Hosting/withExternalHttpEndpoints',
@@ -4913,7 +4913,7 @@ export class ResourceWithEndpoints extends ResourceBuilderBase<IResourceWithEndp
     }
 
     /** @internal */
-    async _withHttpHealthCheckInternal(path?: string, statusCode?: number, endpointName?: string): Promise<ResourceWithEndpoints> {
+    private async _withHttpHealthCheckInternal(path?: string, statusCode?: number, endpointName?: string): Promise<ResourceWithEndpoints> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (path !== undefined) rpcArgs.path = path;
         if (statusCode !== undefined) rpcArgs.statusCode = statusCode;
@@ -4982,7 +4982,7 @@ export class ResourceWithEnvironment extends ResourceBuilderBase<IResourceWithEn
     }
 
     /** @internal */
-    async _withEnvironmentInternal(name: string, value: string): Promise<ResourceWithEnvironment> {
+    private async _withEnvironmentInternal(name: string, value: string): Promise<ResourceWithEnvironment> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
         const result = await this._client.invokeCapability<IResourceWithEnvironmentHandle>(
             'Aspire.Hosting/withEnvironment',
@@ -4997,7 +4997,7 @@ export class ResourceWithEnvironment extends ResourceBuilderBase<IResourceWithEn
     }
 
     /** @internal */
-    async _withEnvironmentExpressionInternal(name: string, value: ReferenceExpression): Promise<ResourceWithEnvironment> {
+    private async _withEnvironmentExpressionInternal(name: string, value: ReferenceExpression): Promise<ResourceWithEnvironment> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
         const result = await this._client.invokeCapability<IResourceWithEnvironmentHandle>(
             'Aspire.Hosting/withEnvironmentExpression',
@@ -5012,7 +5012,7 @@ export class ResourceWithEnvironment extends ResourceBuilderBase<IResourceWithEn
     }
 
     /** @internal */
-    async _withEnvironmentCallbackInternal(callback: (obj: EnvironmentCallbackContext) => Promise<void>): Promise<ResourceWithEnvironment> {
+    private async _withEnvironmentCallbackInternal(callback: (obj: EnvironmentCallbackContext) => Promise<void>): Promise<ResourceWithEnvironment> {
         const callbackId = registerCallback(async (objData: unknown) => {
             const objHandle = wrapIfHandle(objData) as EnvironmentCallbackContextHandle;
             const obj = new EnvironmentCallbackContext(objHandle, this._client);
@@ -5032,7 +5032,7 @@ export class ResourceWithEnvironment extends ResourceBuilderBase<IResourceWithEn
     }
 
     /** @internal */
-    async _withEnvironmentCallbackAsyncInternal(callback: (arg: EnvironmentCallbackContext) => Promise<void>): Promise<ResourceWithEnvironment> {
+    private async _withEnvironmentCallbackAsyncInternal(callback: (arg: EnvironmentCallbackContext) => Promise<void>): Promise<ResourceWithEnvironment> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as EnvironmentCallbackContextHandle;
             const arg = new EnvironmentCallbackContext(argHandle, this._client);
@@ -5052,7 +5052,7 @@ export class ResourceWithEnvironment extends ResourceBuilderBase<IResourceWithEn
     }
 
     /** @internal */
-    async _withReferenceInternal(source: ResourceBuilderBase, connectionName?: string, optional?: boolean): Promise<ResourceWithEnvironment> {
+    private async _withReferenceInternal(source: ResourceBuilderBase, connectionName?: string, optional?: boolean): Promise<ResourceWithEnvironment> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, source };
         if (connectionName !== undefined) rpcArgs.connectionName = connectionName;
         if (optional !== undefined) rpcArgs.optional = optional;
@@ -5071,7 +5071,7 @@ export class ResourceWithEnvironment extends ResourceBuilderBase<IResourceWithEn
     }
 
     /** @internal */
-    async _withServiceReferenceInternal(source: ResourceBuilderBase): Promise<ResourceWithEnvironment> {
+    private async _withServiceReferenceInternal(source: ResourceBuilderBase): Promise<ResourceWithEnvironment> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, source };
         const result = await this._client.invokeCapability<IResourceWithEnvironmentHandle>(
             'Aspire.Hosting/withServiceReference',
@@ -5086,7 +5086,7 @@ export class ResourceWithEnvironment extends ResourceBuilderBase<IResourceWithEn
     }
 
     /** @internal */
-    async _testWithEnvironmentCallbackInternal(callback: (arg: TestEnvironmentContext) => Promise<void>): Promise<ResourceWithEnvironment> {
+    private async _testWithEnvironmentCallbackInternal(callback: (arg: TestEnvironmentContext) => Promise<void>): Promise<ResourceWithEnvironment> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as TestEnvironmentContextHandle;
             const arg = new TestEnvironmentContext(argHandle, this._client);
@@ -5106,7 +5106,7 @@ export class ResourceWithEnvironment extends ResourceBuilderBase<IResourceWithEn
     }
 
     /** @internal */
-    async _withEnvironmentVariablesInternal(variables: Record<string, string>): Promise<ResourceWithEnvironment> {
+    private async _withEnvironmentVariablesInternal(variables: Record<string, string>): Promise<ResourceWithEnvironment> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, variables };
         const result = await this._client.invokeCapability<IResourceWithEnvironmentHandle>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/withEnvironmentVariables',
@@ -5217,7 +5217,7 @@ export class ResourceWithWaitSupport extends ResourceBuilderBase<IResourceWithWa
     }
 
     /** @internal */
-    async _waitForInternal(dependency: ResourceBuilderBase): Promise<ResourceWithWaitSupport> {
+    private async _waitForInternal(dependency: ResourceBuilderBase): Promise<ResourceWithWaitSupport> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<IResourceWithWaitSupportHandle>(
             'Aspire.Hosting/waitFor',
@@ -5232,7 +5232,7 @@ export class ResourceWithWaitSupport extends ResourceBuilderBase<IResourceWithWa
     }
 
     /** @internal */
-    async _waitForCompletionInternal(dependency: ResourceBuilderBase, exitCode?: number): Promise<ResourceWithWaitSupport> {
+    private async _waitForCompletionInternal(dependency: ResourceBuilderBase, exitCode?: number): Promise<ResourceWithWaitSupport> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         if (exitCode !== undefined) rpcArgs.exitCode = exitCode;
         const result = await this._client.invokeCapability<IResourceWithWaitSupportHandle>(


### PR DESCRIPTION
- Add status spinners for scaffold/init operations
- Update sdkVersion in settings.json during aspire update
- Show Aspire SDK update line instead of implicit packages
- Use Preparing Aspire server instead of Building app host

feat: Add asynchronous package retrieval and update project file generation

- Implemented `GetAllPackagesAsync` method to retrieve all packages including the code generation package for the current language.
- Updated `BuildAndGenerateSdkAsync`, `RunAsync`, and `PublishAsync` methods to use the new asynchronous package retrieval method.
- Added comprehensive unit tests for `AppHostServerProject` and `GuestAppHostProject` to ensure correct project file generation and configuration handling.
- Created snapshots for generated project files and configuration settings to validate output against expected results.

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
