### PR TITLE
[CI] Use 8-core-ubuntu-latest only on tests and package build jobs

### DIFF
--- a/.github/workflows/build-cli-native-archives.yml
+++ b/.github/workflows/build-cli-native-archives.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         targets:
-          - os: 8-core-ubuntu-latest
+          - os: ubuntu-latest
             rids: linux-x64
           - os: windows-latest
             rids: win-x64

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -107,7 +107,7 @@ jobs:
     name: Upload arch-specific NuGets
     needs: build_packages
     if: ${{ needs.build_packages.outputs.arch_rids != '[]' }}
-    runs-on: 8-core-ubuntu-latest
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
 
   prepare_for_ci:
-    runs-on: 8-core-ubuntu-latest
+    runs-on: ubuntu-latest
     name: Prepare for CI
     if: ${{ github.repository_owner == 'dotnet' }}
     outputs:
@@ -92,7 +92,7 @@ jobs:
   # This job is used for branch protection. It fails if any of the dependent jobs failed
   results:
     if: ${{ always() && github.repository_owner == 'dotnet' }}
-    runs-on: 8-core-ubuntu-latest
+    runs-on: ubuntu-latest
     name: Final Results
     needs: [prepare_for_ci, tests, build_cli_archives]
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -6,7 +6,7 @@ on: workflow_dispatch
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
-    runs-on: 8-core-ubuntu-latest
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -47,7 +47,7 @@ on:
       os:
         required: false
         type: string
-        default: "8-core-ubuntu-latest"
+        default: "ubuntu-latest"
       # When true, ignores test failures and checks if .trx files have nonzero test count
       ignoreTestFailures:
         required: false
@@ -76,7 +76,7 @@ jobs:
       # the repo we install system dotnet earlier in the build
 
       - name: Setup vars (Linux)
-        if: ${{ inputs.os == '8-core-ubuntu-latest' || inputs.os == 'macos-latest' }}
+        if: ${{ inputs.os == '8-core-ubuntu-latest' || inputs.os == 'ubuntu-latest' || inputs.os == 'macos-latest' }}
         run: |
           echo "DOTNET_SCRIPT=./dotnet.sh" >> $GITHUB_ENV
           echo "BUILD_SCRIPT=./build.sh" >> $GITHUB_ENV
@@ -107,12 +107,12 @@ jobs:
           DOTNET_INSTALL_DIR: ${{ env.DOTNET_ROOT }}
 
       - name: Trust HTTPS development certificate (Linux)
-        if: inputs.os == '8-core-ubuntu-latest'
+        if: inputs.os == '8-core-ubuntu-latest' || inputs.os == 'ubuntu-latest'
         run: ${{ env.DOTNET_SCRIPT }} dev-certs https --trust
 
       - name: Verify Docker is running
         # nested docker containers not supported on windows
-        if: inputs.os == '8-core-ubuntu-latest'
+        if: inputs.os == '8-core-ubuntu-latest' || inputs.os == 'ubuntu-latest'
         run: docker info
 
       - name: Download built nugets
@@ -136,6 +136,7 @@ jobs:
           $os = "${{ inputs.os }}"
           switch ($os) {
             '8-core-ubuntu-latest' { $rid = 'linux-x64' }
+            'ubuntu-latest' { $rid = 'linux-x64' }
             'macos-latest'  { $rid = 'osx-arm64' }
             'windows-latest'{ $rid = 'win-x64' }
             Default { Write-Error "Unknown OS '$os' for RID mapping"; exit 1 }
@@ -180,7 +181,7 @@ jobs:
           /bl:${{ github.workspace }}/artifacts/log/Debug/InstallSdkForTesting.binlog
 
       - name: Install Azure Functions Core Tools
-        if: inputs.os == '8-core-ubuntu-latest' && (inputs.testShortName == 'Playground' || inputs.testShortName == 'Azure')
+        if: (inputs.os == '8-core-ubuntu-latest' || inputs.os == 'ubuntu-latest') && (inputs.testShortName == 'Playground' || inputs.testShortName == 'Azure')
         run: |
           npm i -g azure-functions-core-tools@4 --unsafe-perm true
 
@@ -276,7 +277,7 @@ jobs:
         uses: ./.github/actions/unlock-macos-keychain
 
       - name: Run nuget dependent tests (Linux/macOS)
-        if: ${{ inputs.requiresNugets && (inputs.os == '8-core-ubuntu-latest' || inputs.os == 'macos-latest') }}
+        if: ${{ inputs.requiresNugets && (inputs.os == '8-core-ubuntu-latest' || inputs.os == 'ubuntu-latest' || inputs.os == 'macos-latest') }}
         working-directory: ${{ github.workspace }}/run-tests/
         env:
           ASPIRE__TEST__DCPLOGBASEPATH: ${{ github.workspace }}/testresults/dcp
@@ -351,7 +352,7 @@ jobs:
           }
 
       - name: Run tests (Linux/macOS)
-        if: ${{ ! inputs.requiresNugets && (inputs.os == '8-core-ubuntu-latest' || inputs.os == 'macos-latest') }}
+        if: ${{ ! inputs.requiresNugets && (inputs.os == '8-core-ubuntu-latest' || inputs.os == 'ubuntu-latest' || inputs.os == 'macos-latest') }}
         id: run-tests-unix
         env:
           ASPIRE__TEST__DCPLOGBASEPATH: ${{ github.workspace }}/testresults/dcp
@@ -494,7 +495,7 @@ jobs:
           Write-Host "✓ Test execution completed successfully (found $validFileCount valid .trx file(s))"
 
       - name: Dump docker info
-        if: ${{ always() && inputs.os == '8-core-ubuntu-latest' }}
+        if: ${{ always() && (inputs.os == '8-core-ubuntu-latest' || inputs.os == 'ubuntu-latest') }}
         run: |
           docker container ls --all
           docker container ls --all --format json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
 
   setup_for_tests_lin:
     name: Setup for tests (Linux)
-    runs-on: 8-core-ubuntu-latest
+    runs-on: ubuntu-latest
     outputs:
       integrations_tests_matrix: ${{ steps.generate_tests_matrix.outputs.integrations_tests_matrix }}
       templates_tests_matrix: ${{ steps.generate_tests_matrix.outputs.templates_tests_matrix }}
@@ -75,7 +75,7 @@ jobs:
         ${{ fromJson(needs.setup_for_tests_lin.outputs.integrations_tests_matrix) }}
     with:
       testShortName: ${{ matrix.shortname }}
-      os: "8-core-ubuntu-latest"
+      os: "ubuntu-latest"
       # Docker tests are run on linux, and Hosting tests take longer to finish
       testSessionTimeout: ${{ matrix.shortname == 'Hosting' && '25m' || '15m' }}
       extraTestArgs: "--filter-not-trait \"quarantined=true\" --filter-not-trait \"outerloop=true\""
@@ -118,7 +118,7 @@ jobs:
       matrix: ${{ fromJson(needs.setup_for_tests_lin.outputs.templates_tests_matrix) }}
     with:
       testShortName: ${{ matrix.shortname }}
-      os: "8-core-ubuntu-latest"
+      os: "ubuntu-latest"
       testProjectPath: tests/Aspire.Templates.Tests/Aspire.Templates.Tests.csproj
       testSessionTimeout: 20m
       testHangTimeout: "12m"
@@ -170,7 +170,7 @@ jobs:
     with:
       testShortName: EndToEnd
       # EndToEnd is not run on Windows/macOS due to missing Docker support
-      os: 8-core-ubuntu-latest
+      os: ubuntu-latest
       testProjectPath: tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj
       requiresNugets: true
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
@@ -186,7 +186,7 @@ jobs:
       matrix: ${{ fromJson(needs.setup_for_tests_lin.outputs.cli_e2e_tests_matrix) }}
     with:
       testShortName: ${{ matrix.shortname }}
-      os: "8-core-ubuntu-latest"
+      os: "ubuntu-latest"
       testProjectPath: tests/Aspire.Cli.EndToEndTests/Aspire.Cli.EndToEndTests.csproj
       testSessionTimeout: 20m
       testHangTimeout: "12m"
@@ -220,7 +220,7 @@ jobs:
 
   results:
     if: ${{ always() && github.repository_owner == 'dotnet' }}
-    runs-on: 8-core-ubuntu-latest
+    runs-on: ubuntu-latest
     name: Final Test Results
     needs: [
       cli_e2e_tests,
@@ -239,9 +239,9 @@ jobs:
 
       - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
-          pattern: logs-*-8-core-ubuntu-latest
+          pattern: logs-*-ubuntu-latest
           merge-multiple: true
-          path: ${{ github.workspace }}/testresults/8-core-ubuntu-latest
+          path: ${{ github.workspace }}/testresults/ubuntu-latest
 
       - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
