### PR TITLE
Add polyglot support for TypeScript AppHost tests

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
@@ -246,4 +246,29 @@ internal static class CliE2ETestHelpers
             return true;
         }, TimeSpan.FromSeconds(1));
     }
+
+    /// <summary>
+    /// Enables polyglot support feature flag by setting the features__polyglotSupportEnabled environment variable.
+    /// This allows the CLI to create TypeScript and Python AppHosts.
+    /// </summary>
+    /// <param name="builder">The sequence builder.</param>
+    /// <param name="counter">The sequence counter for prompt detection.</param>
+    /// <returns>The builder for chaining.</returns>
+    internal static Hex1bTerminalInputSequenceBuilder EnablePolyglotSupport(
+        this Hex1bTerminalInputSequenceBuilder builder,
+        SequenceCounter counter)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return builder
+                .Type("$env:features__polyglotSupportEnabled='true'")
+                .Enter()
+                .WaitForSuccessPrompt(counter);
+        }
+
+        return builder
+            .Type("export features__polyglotSupportEnabled=true")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+    }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
@@ -248,7 +248,7 @@ internal static class CliE2ETestHelpers
     }
 
     /// <summary>
-    /// Enables polyglot support feature flag by setting the features__polyglotSupportEnabled environment variable.
+    /// Enables polyglot support feature flag using the aspire config set command.
     /// This allows the CLI to create TypeScript and Python AppHosts.
     /// </summary>
     /// <param name="builder">The sequence builder.</param>
@@ -258,16 +258,8 @@ internal static class CliE2ETestHelpers
         this Hex1bTerminalInputSequenceBuilder builder,
         SequenceCounter counter)
     {
-        if (OperatingSystem.IsWindows())
-        {
-            return builder
-                .Type("$env:features__polyglotSupportEnabled='true'")
-                .Enter()
-                .WaitForSuccessPrompt(counter);
-        }
-
         return builder
-            .Type("export features__polyglotSupportEnabled=true")
+            .Type("aspire config set features.polyglotSupportEnabled true")
             .Enter()
             .WaitForSuccessPrompt(counter);
     }

--- a/tests/Aspire.Cli.EndToEndTests/TypeScriptPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEndTests/TypeScriptPolyglotTests.cs
@@ -48,7 +48,7 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
 
         // Pattern for aspire add completion
         var waitingForPackageAdded = new CellPatternSearcher()
-            .Find("Added package");
+            .Find("The package Aspire.Hosting.JavaScript::");
 
         // In CI, aspire add shows a version selection prompt (but aspire new does not when channel is set)
         var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
@@ -121,25 +121,9 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
             sequenceBuilder
                 .WaitUntil(s => waitingForAddVersionSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
                 .WaitUntil(s => waitingForPrVersionSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
-                .Enter(); // select PR channel
-
-            // Second prompt: Select the specific version with short SHA
-            // The version with our commit SHA should appear in the list
-            // Navigate right through options until we find it, then press Enter
-            sequenceBuilder
-                .WaitUntil(s => waitingForAddVersionSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-                // Navigate right to find the version with our SHA (may need multiple presses)
-                .Key(Hex1b.Input.Hex1bKey.RightArrow)
-                .Wait(500)
-                .Key(Hex1b.Input.Hex1bKey.RightArrow)
-                .Wait(500)
-                .Key(Hex1b.Input.Hex1bKey.RightArrow)
-                .Wait(500)
-                .Key(Hex1b.Input.Hex1bKey.RightArrow)
-                .Wait(500)
-                .Key(Hex1b.Input.Hex1bKey.RightArrow)
+                .Enter() // select PR channel
                 .WaitUntil(s => waitingForShaVersionSelected.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter(); // select specific version
+                .Enter();
         }
 
         sequenceBuilder

--- a/tests/Aspire.Cli.EndToEndTests/TypeScriptPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEndTests/TypeScriptPolyglotTests.cs
@@ -83,8 +83,9 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
 
         // Step 2: Create a Vite app using npm create vite
         // Using --template vanilla-ts for a minimal TypeScript Vite app
+        // Use -y to skip npm prompts and -- to pass args to create-vite
         sequenceBuilder
-            .Type("npm create vite@latest viteapp -- --template vanilla-ts")
+            .Type("npm create -y vite@latest viteapp -- --template vanilla-ts")
             .Enter()
             .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
 


### PR DESCRIPTION
Implement polyglot support by enabling a feature flag for creating TypeScript and Python AppHosts. Add end-to-end tests for creating a TypeScript-based AppHost and integrating a Vite application. This enhances the CLI's capabilities for polyglot development.

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No

