### PR TITLE
Update Hex1b packages to 0.47.0

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -9,7 +9,7 @@
 			"type": "stdio",
 			"command": "dnx",
 			"args": [
-				"Hex1b.McpServer@0.45.0",
+				"Hex1b.McpServer@0.47.0",
 				"--yes"
 			]
 		}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -92,7 +92,7 @@
     <PackageVersion Include="Grpc.AspNetCore" Version="2.71.0" />
     <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.71.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.72.0" />
-    <PackageVersion Include="Hex1b" Version="0.45.0" />
+    <PackageVersion Include="Hex1b" Version="0.47.0" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="KubernetesClient" Version="18.0.5" />
     <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />


### PR DESCRIPTION
Updates Hex1b package versions:
- `Hex1b` NuGet package: 0.45.0 → 0.47.0
- `Hex1b.McpServer` in VS Code MCP config: 0.45.0 → 0.47.0