### PR TITLE
Allow trailing commas in launchSettings.json

### DIFF
--- a/src/Shared/LaunchProfiles/LaunchSettingsSerializerContext.cs
+++ b/src/Shared/LaunchProfiles/LaunchSettingsSerializerContext.cs
@@ -7,7 +7,7 @@ using System.Text.Json.Serialization;
 namespace Aspire.Hosting;
 
 [JsonSerializable(typeof(LaunchSettings))]
-[JsonSourceGenerationOptions(ReadCommentHandling = JsonCommentHandling.Skip)]
+[JsonSourceGenerationOptions(ReadCommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true)]
 internal sealed partial class LaunchSettingsSerializerContext : JsonSerializerContext
 {
 

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -36,6 +36,40 @@ public class ProjectResourceTests
 
         // Should not throw - trailing commas are common in hand-edited JSON.
         appBuilder.AddProject("project", projectDetails.ProjectFilePath);
+
+        async static Task<(string ProjectFilePath, string LaunchSettingsFilePath)> PrepareProjectWithTrailingCommasInLaunchSettingsAsync()
+        {
+            var csProjContent = """
+                                <Project Sdk="Microsoft.NET.Sdk.Web">
+                                <!-- Not a real project, just a stub for testing -->
+                                </Project>
+                                """;
+
+            // Note: launchSettings.json is often edited by hand; allow trailing commas.
+            var launchSettingsContent = """
+                                        {
+                                            "profiles": {
+                                                "Development": {
+                                                    "commandName": "Project",
+                                                    "launchBrowser": true,
+                                                },
+                                            },
+                                        }
+                                        """;
+
+            var projectDirectoryPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            var projectFilePath = Path.Combine(projectDirectoryPath, "Project.csproj");
+            var propertiesDirectoryPath = Path.Combine(projectDirectoryPath, "Properties");
+            var launchSettingsFilePath = Path.Combine(propertiesDirectoryPath, "launchSettings.json");
+
+            Directory.CreateDirectory(projectDirectoryPath);
+            await File.WriteAllTextAsync(projectFilePath, csProjContent).DefaultTimeout();
+
+            Directory.CreateDirectory(propertiesDirectoryPath);
+            await File.WriteAllTextAsync(launchSettingsFilePath, launchSettingsContent).DefaultTimeout();
+
+            return (projectFilePath, launchSettingsFilePath);
+        }
     }
 
     [Fact]
@@ -78,40 +112,6 @@ public class ProjectResourceTests
             return (projectFilePath, launchSettingsFilePath);
         }
     }
-
-        private static async Task<(string ProjectFilePath, string LaunchSettingsFilePath)> PrepareProjectWithTrailingCommasInLaunchSettingsAsync()
-        {
-                var csProjContent = """
-                                                        <Project Sdk=\"Microsoft.NET.Sdk.Web\">
-                                                        <!-- Not a real project, just a stub for testing -->
-                                                        </Project>
-                                                        """;
-
-                // Note: launchSettings.json is often edited by hand; allow trailing commas.
-                var launchSettingsContent = """
-                                                                        {
-                                                                            "profiles": {
-                                                                                "Development": {
-                                                                                    "commandName": "Project",
-                                                                                    "launchBrowser": true,
-                                                                                },
-                                                                            },
-                                                                        }
-                                                                        """;
-
-                var projectDirectoryPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-                var projectFilePath = Path.Combine(projectDirectoryPath, "Project.csproj");
-                var propertiesDirectoryPath = Path.Combine(projectDirectoryPath, "Properties");
-                var launchSettingsFilePath = Path.Combine(propertiesDirectoryPath, "launchSettings.json");
-
-                Directory.CreateDirectory(projectDirectoryPath);
-                await File.WriteAllTextAsync(projectFilePath, csProjContent).DefaultTimeout();
-
-                Directory.CreateDirectory(propertiesDirectoryPath);
-                await File.WriteAllTextAsync(launchSettingsFilePath, launchSettingsContent).DefaultTimeout();
-
-                return (projectFilePath, launchSettingsFilePath);
-        }
 
     [Theory]
     [InlineData(KnownConfigNames.DashboardOtlpGrpcEndpointUrl)]


### PR DESCRIPTION
This enables parsing `launchSettings.json` with optional trailing commas so when AI or your linter adds a trailing comma on save you aren't digging through log files trying to figure out why your launch profile isn't applying.

Includes tests covering the new behavior.