### PR TITLE
Fix AppHost.cs incorrectly detected as single-file apphost

### DIFF
--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -142,8 +142,10 @@ internal sealed class DotNetAppHostProject : IAppHostProject
 
         if (isSingleFile)
         {
-            // For single-file apphosts, we just check that it exists
-            return new AppHostValidationResult(IsValid: appHostFile.Exists);
+            // For single-file apphosts, validate that:
+            // 1. No sibling .csproj files exist (otherwise it's part of a project)
+            // 2. The file contains the #:sdk Aspire.AppHost.Sdk directive
+            return new AppHostValidationResult(IsValid: IsValidSingleFileAppHost(appHostFile));
         }
 
         // For project files, check if it's a valid Aspire AppHost using GetAppHostInformationAsync

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostProjectFactory.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostProjectFactory.cs
@@ -152,6 +152,13 @@ internal sealed class TestAppHostProjectFactory : IAppHostProjectFactory
             {
                 return Task.FromResult(_factory.ValidateAppHostCallback(appHostFile));
             }
+
+            // Match production behavior: for .cs files, validate as single-file apphost
+            if (appHostFile.Extension.Equals(".cs", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new AppHostValidationResult(IsValid: IsValidSingleFileAppHost(appHostFile)));
+            }
+
             return Task.FromResult(new AppHostValidationResult(IsValid: true));
         }
 


### PR DESCRIPTION
## Description

     When running `aspire run` on .NET starter templates, both AppHost.csproj
     and AppHost.cs were incorrectly detected as separate apphosts.

     The bug was in ValidateAppHostAsync() which only checked if .cs files
     exist, without validating they are actual single-file apphosts.

     Fix: Use IsValidSingleFileAppHost() to validate .cs files have:
     - No sibling .csproj files (otherwise it's part of a project)
     - The #:sdk Aspire.AppHost.Sdk directive

     Added regression tests to prevent future occurrences.

Fixes https://github.com/dotnet/aspire/issues/13971
Fixes https://github.com/dotnet/aspire/issues/13956

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No


cc: @davidfowl @mitchdenny 