### PR TITLE
Add AspireList support for TypeScript code generation

### DIFF
--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/base.ts
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/base.ts
@@ -188,18 +188,49 @@ export class ResourceBuilderBase<THandle extends Handle = Handle> {
  * ```
  */
 export class AspireList<T> {
+    private _resolvedHandle?: Handle;
+    private _resolvePromise?: Promise<Handle>;
+
     constructor(
-        private readonly _handle: Handle,
+        private readonly _handleOrContext: Handle,
         private readonly _client: AspireClient,
-        private readonly _typeId: string
-    ) {}
+        private readonly _typeId: string,
+        private readonly _getterCapabilityId?: string
+    ) {
+        // If no getter capability, the handle is already the list handle
+        if (!_getterCapabilityId) {
+            this._resolvedHandle = _handleOrContext;
+        }
+    }
+
+    /**
+     * Ensures we have the actual list handle by calling the getter if needed.
+     */
+    private async _ensureHandle(): Promise<Handle> {
+        if (this._resolvedHandle) {
+            return this._resolvedHandle;
+        }
+        if (this._resolvePromise) {
+            return this._resolvePromise;
+        }
+        // Call the getter capability to get the actual list handle
+        this._resolvePromise = (async () => {
+            const result = await this._client.invokeCapability(this._getterCapabilityId!, {
+                context: this._handleOrContext
+            });
+            this._resolvedHandle = result as Handle;
+            return this._resolvedHandle;
+        })();
+        return this._resolvePromise;
+    }
 
     /**
      * Gets the number of elements in the list.
      */
     async count(): Promise<number> {
+        const handle = await this._ensureHandle();
         return await this._client.invokeCapability('Aspire.Hosting/List.length', {
-            list: this._handle
+            list: handle
         }) as number;
     }
 
@@ -207,8 +238,9 @@ export class AspireList<T> {
      * Gets the element at the specified index.
      */
     async get(index: number): Promise<T> {
+        const handle = await this._ensureHandle();
         return await this._client.invokeCapability('Aspire.Hosting/List.get', {
-            list: this._handle,
+            list: handle,
             index
         }) as T;
     }
@@ -217,8 +249,9 @@ export class AspireList<T> {
      * Adds an element to the end of the list.
      */
     async add(item: T): Promise<void> {
+        const handle = await this._ensureHandle();
         await this._client.invokeCapability('Aspire.Hosting/List.add', {
-            list: this._handle,
+            list: handle,
             item
         });
     }
@@ -227,8 +260,9 @@ export class AspireList<T> {
      * Removes the element at the specified index.
      */
     async removeAt(index: number): Promise<void> {
+        const handle = await this._ensureHandle();
         await this._client.invokeCapability('Aspire.Hosting/List.removeAt', {
-            list: this._handle,
+            list: handle,
             index
         });
     }
@@ -237,8 +271,9 @@ export class AspireList<T> {
      * Clears all elements from the list.
      */
     async clear(): Promise<void> {
+        const handle = await this._ensureHandle();
         await this._client.invokeCapability('Aspire.Hosting/List.clear', {
-            list: this._handle
+            list: handle
         });
     }
 
@@ -246,12 +281,18 @@ export class AspireList<T> {
      * Converts the list to an array (creates a copy).
      */
     async toArray(): Promise<T[]> {
+        const handle = await this._ensureHandle();
         return await this._client.invokeCapability('Aspire.Hosting/List.toArray', {
-            list: this._handle
+            list: handle
         }) as T[];
     }
 
-    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+    toJSON(): MarshalledHandle { 
+        if (this._resolvedHandle) {
+            return this._resolvedHandle.toJSON();
+        }
+        return this._handleOrContext.toJSON(); 
+    }
 }
 
 // ============================================================================

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/AtsGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/AtsGeneratedAspire.verified.ts
@@ -29,6 +29,9 @@ import {
 /** Handle to TestCallbackContext */
 type TestCallbackContextHandle = Handle<'Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestCallbackContext'>;
 
+/** Handle to TestCollectionContext */
+type TestCollectionContextHandle = Handle<'Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestCollectionContext'>;
+
 /** Handle to TestEnvironmentContext */
 type TestEnvironmentContextHandle = Handle<'Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestEnvironmentContext'>;
 
@@ -187,6 +190,49 @@ export class TestCallbackContext {
             );
         }
     };
+
+}
+
+// ============================================================================
+// TestCollectionContext
+// ============================================================================
+
+/**
+ * Type class for TestCollectionContext.
+ */
+export class TestCollectionContext {
+    constructor(private _handle: TestCollectionContextHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    /** Gets the Items property */
+    private _items?: AspireList<string>;
+    get items(): AspireList<string> {
+        if (!this._items) {
+            this._items = new AspireList<string>(
+                this._handle,
+                this._client,
+                'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestCollectionContext.items',
+                'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestCollectionContext.items'
+            );
+        }
+        return this._items;
+    }
+
+    /** Gets the Metadata property */
+    private _metadata?: AspireDict<string, string>;
+    get metadata(): AspireDict<string, string> {
+        if (!this._metadata) {
+            this._metadata = new AspireDict<string, string>(
+                this._handle,
+                this._client,
+                'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestCollectionContext.metadata',
+                'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestCollectionContext.metadata'
+            );
+        }
+        return this._metadata;
+    }
 
 }
 
@@ -1480,6 +1526,7 @@ process.on('uncaughtException', (error: Error) => {
 
 // Register wrapper factories for typed handle wrapping in callbacks
 registerHandleWrapper('Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestCallbackContext', (handle, client) => new TestCallbackContext(handle as TestCallbackContextHandle, client));
+registerHandleWrapper('Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestCollectionContext', (handle, client) => new TestCollectionContext(handle as TestCollectionContextHandle, client));
 registerHandleWrapper('Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestEnvironmentContext', (handle, client) => new TestEnvironmentContext(handle as TestEnvironmentContextHandle, client));
 registerHandleWrapper('Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestResourceContext', (handle, client) => new TestResourceContext(handle as TestResourceContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.IDistributedApplicationBuilder', (handle, client) => new DistributedApplicationBuilder(handle as IDistributedApplicationBuilderHandle, client));

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -29,6 +29,9 @@ import {
 /** Handle to TestCallbackContext */
 type TestCallbackContextHandle = Handle<'Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestCallbackContext'>;
 
+/** Handle to TestCollectionContext */
+type TestCollectionContextHandle = Handle<'Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestCollectionContext'>;
+
 /** Handle to TestEnvironmentContext */
 type TestEnvironmentContextHandle = Handle<'Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestEnvironmentContext'>;
 
@@ -428,14 +431,18 @@ export class CommandLineArgsCallbackContext {
     toJSON(): MarshalledHandle { return this._handle.toJSON(); }
 
     /** Gets the Args property */
-    args = {
-        get: async (): Promise<AspireList<any>> => {
-            return await this._client.invokeCapability<AspireList<any>>(
+    private _args?: AspireList<any>;
+    get args(): AspireList<any> {
+        if (!this._args) {
+            this._args = new AspireList<any>(
+                this._handle,
+                this._client,
                 'Aspire.Hosting.ApplicationModel/CommandLineArgsCallbackContext.args',
-                { context: this._handle }
+                'Aspire.Hosting.ApplicationModel/CommandLineArgsCallbackContext.args'
             );
-        },
-    };
+        }
+        return this._args;
+    }
 
     /** Gets the CancellationToken property */
     cancellationToken = {
@@ -892,14 +899,18 @@ export class ResourceUrlsCallbackContext {
     toJSON(): MarshalledHandle { return this._handle.toJSON(); }
 
     /** Gets the Urls property */
-    urls = {
-        get: async (): Promise<AspireList<ResourceUrlAnnotation>> => {
-            return await this._client.invokeCapability<AspireList<ResourceUrlAnnotation>>(
+    private _urls?: AspireList<ResourceUrlAnnotation>;
+    get urls(): AspireList<ResourceUrlAnnotation> {
+        if (!this._urls) {
+            this._urls = new AspireList<ResourceUrlAnnotation>(
+                this._handle,
+                this._client,
                 'Aspire.Hosting.ApplicationModel/ResourceUrlsCallbackContext.urls',
-                { context: this._handle }
+                'Aspire.Hosting.ApplicationModel/ResourceUrlsCallbackContext.urls'
             );
-        },
-    };
+        }
+        return this._urls;
+    }
 
     /** Gets the CancellationToken property */
     cancellationToken = {
@@ -984,6 +995,49 @@ export class TestCallbackContext {
             );
         }
     };
+
+}
+
+// ============================================================================
+// TestCollectionContext
+// ============================================================================
+
+/**
+ * Type class for TestCollectionContext.
+ */
+export class TestCollectionContext {
+    constructor(private _handle: TestCollectionContextHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    /** Gets the Items property */
+    private _items?: AspireList<string>;
+    get items(): AspireList<string> {
+        if (!this._items) {
+            this._items = new AspireList<string>(
+                this._handle,
+                this._client,
+                'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestCollectionContext.items',
+                'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestCollectionContext.items'
+            );
+        }
+        return this._items;
+    }
+
+    /** Gets the Metadata property */
+    private _metadata?: AspireDict<string, string>;
+    get metadata(): AspireDict<string, string> {
+        if (!this._metadata) {
+            this._metadata = new AspireDict<string, string>(
+                this._handle,
+                this._client,
+                'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestCollectionContext.metadata',
+                'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestCollectionContext.metadata'
+            );
+        }
+        return this._metadata;
+    }
 
 }
 
@@ -7809,6 +7863,7 @@ registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.Environmen
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext', (handle, client) => new ExecuteCommandContext(handle as ExecuteCommandContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceUrlsCallbackContext', (handle, client) => new ResourceUrlsCallbackContext(handle as ResourceUrlsCallbackContextHandle, client));
 registerHandleWrapper('Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestCallbackContext', (handle, client) => new TestCallbackContext(handle as TestCallbackContextHandle, client));
+registerHandleWrapper('Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestCollectionContext', (handle, client) => new TestCollectionContext(handle as TestCollectionContextHandle, client));
 registerHandleWrapper('Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestEnvironmentContext', (handle, client) => new TestEnvironmentContext(handle as TestEnvironmentContextHandle, client));
 registerHandleWrapper('Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestResourceContext', (handle, client) => new TestResourceContext(handle as TestResourceContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.IDistributedApplicationBuilder', (handle, client) => new DistributedApplicationBuilder(handle as IDistributedApplicationBuilderHandle, client));

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/base.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/base.verified.ts
@@ -188,18 +188,49 @@ export class ResourceBuilderBase<THandle extends Handle = Handle> {
  * ```
  */
 export class AspireList<T> {
+    private _resolvedHandle?: Handle;
+    private _resolvePromise?: Promise<Handle>;
+
     constructor(
-        private readonly _handle: Handle,
+        private readonly _handleOrContext: Handle,
         private readonly _client: AspireClient,
-        private readonly _typeId: string
-    ) {}
+        private readonly _typeId: string,
+        private readonly _getterCapabilityId?: string
+    ) {
+        // If no getter capability, the handle is already the list handle
+        if (!_getterCapabilityId) {
+            this._resolvedHandle = _handleOrContext;
+        }
+    }
+
+    /**
+     * Ensures we have the actual list handle by calling the getter if needed.
+     */
+    private async _ensureHandle(): Promise<Handle> {
+        if (this._resolvedHandle) {
+            return this._resolvedHandle;
+        }
+        if (this._resolvePromise) {
+            return this._resolvePromise;
+        }
+        // Call the getter capability to get the actual list handle
+        this._resolvePromise = (async () => {
+            const result = await this._client.invokeCapability(this._getterCapabilityId!, {
+                context: this._handleOrContext
+            });
+            this._resolvedHandle = result as Handle;
+            return this._resolvedHandle;
+        })();
+        return this._resolvePromise;
+    }
 
     /**
      * Gets the number of elements in the list.
      */
     async count(): Promise<number> {
+        const handle = await this._ensureHandle();
         return await this._client.invokeCapability('Aspire.Hosting/List.length', {
-            list: this._handle
+            list: handle
         }) as number;
     }
 
@@ -207,8 +238,9 @@ export class AspireList<T> {
      * Gets the element at the specified index.
      */
     async get(index: number): Promise<T> {
+        const handle = await this._ensureHandle();
         return await this._client.invokeCapability('Aspire.Hosting/List.get', {
-            list: this._handle,
+            list: handle,
             index
         }) as T;
     }
@@ -217,8 +249,9 @@ export class AspireList<T> {
      * Adds an element to the end of the list.
      */
     async add(item: T): Promise<void> {
+        const handle = await this._ensureHandle();
         await this._client.invokeCapability('Aspire.Hosting/List.add', {
-            list: this._handle,
+            list: handle,
             item
         });
     }
@@ -227,8 +260,9 @@ export class AspireList<T> {
      * Removes the element at the specified index.
      */
     async removeAt(index: number): Promise<void> {
+        const handle = await this._ensureHandle();
         await this._client.invokeCapability('Aspire.Hosting/List.removeAt', {
-            list: this._handle,
+            list: handle,
             index
         });
     }
@@ -237,8 +271,9 @@ export class AspireList<T> {
      * Clears all elements from the list.
      */
     async clear(): Promise<void> {
+        const handle = await this._ensureHandle();
         await this._client.invokeCapability('Aspire.Hosting/List.clear', {
-            list: this._handle
+            list: handle
         });
     }
 
@@ -246,12 +281,18 @@ export class AspireList<T> {
      * Converts the list to an array (creates a copy).
      */
     async toArray(): Promise<T[]> {
+        const handle = await this._ensureHandle();
         return await this._client.invokeCapability('Aspire.Hosting/List.toArray', {
-            list: this._handle
+            list: handle
         }) as T[];
     }
 
-    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+    toJSON(): MarshalledHandle { 
+        if (this._resolvedHandle) {
+            return this._resolvedHandle.toJSON();
+        }
+        return this._handleOrContext.toJSON(); 
+    }
 }
 
 // ============================================================================

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TestTypes/TestTypes.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TestTypes/TestTypes.cs
@@ -64,6 +64,24 @@ public class TestEnvironmentContext
 }
 
 /// <summary>
+/// Test context with collection properties to verify consistent code generation.
+/// Verifies both List and Dictionary properties generate proper getter patterns.
+/// </summary>
+[AspireExport(ExposeProperties = true)]
+public class TestCollectionContext
+{
+    /// <summary>
+    /// List property - should generate AspireList getter like Dictionary properties.
+    /// </summary>
+    public List<string> Items { get; } = [];
+
+    /// <summary>
+    /// Dictionary property - already works with AspireDict getter.
+    /// </summary>
+    public Dictionary<string, string> Metadata { get; } = [];
+}
+
+/// <summary>
 /// Test DTO with complex nested types.
 /// </summary>
 [AspireDto]


### PR DESCRIPTION
## Description

Adds support for generating `AspireList<T>` properties in the TypeScript code generator for list-type capabilities.

### Changes

- **AtsTypeScriptCodeGenerator.cs**: Added `IsListType()` helper and `GenerateListProperty()` method to generate lazy `AspireList<T>` properties for list-returning getters
- **base.ts**: Added `AspireList<T>` class for handling list operations
- **Tests**: Added test case for list property generation and updated snapshots

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No