### PR TITLE
Add E2E regression test for duplicate apphost detection

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/JsReactTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JsReactTemplateTests.cs
@@ -58,6 +58,12 @@ public sealed class JsReactTemplateTests(ITestOutputHelper output)
         var waitForCtrlCMessage = new CellPatternSearcher()
             .Find($"Press CTRL+C to stop the apphost and exit.");
 
+        // Regression test for https://github.com/dotnet/aspire/issues/13971
+        // If this prompt appears, it means multiple apphosts were incorrectly detected
+        // (e.g., AppHost.cs was incorrectly treated as a single-file apphost)
+        var unexpectedAppHostSelectionPrompt = new CellPatternSearcher()
+            .Find("Select an apphost to use:");
+
         // The purpose of this is to keep track of the number of actual shell commands we have
         // executed. This is important because we customize the shell prompt to show either
         // "[n OK] $ " or "[n ERR:exitcode] $ ". This allows us to deterministically wait for a
@@ -96,7 +102,17 @@ public sealed class JsReactTemplateTests(ITestOutputHelper output)
             .WaitForSuccessPrompt(counter)
             .Type("aspire run")
             .Enter()
-            .WaitUntil(s => waitForCtrlCMessage.Search(s).Count > 0, TimeSpan.FromMinutes(2))
+            .WaitUntil(s =>
+            {
+                // Fail immediately if we see the apphost selection prompt (means duplicate detection)
+                if (unexpectedAppHostSelectionPrompt.Search(s).Count > 0)
+                {
+                    throw new InvalidOperationException(
+                        "Unexpected apphost selection prompt detected! " +
+                        "This indicates multiple apphosts were incorrectly detected.");
+                }
+                return waitForCtrlCMessage.Search(s).Count > 0;
+            }, TimeSpan.FromMinutes(2))
             .Ctrl().Key(Hex1b.Input.Hex1bKey.C)
             .WaitForSuccessPrompt(counter)
             .Type("exit")

--- a/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
@@ -57,6 +57,12 @@ public sealed class SmokeTests(ITestOutputHelper output)
 
         var waitForCtrlCMessage = new CellPatternSearcher()
             .Find($"Press CTRL+C to stop the apphost and exit.");
+
+        // Regression test for https://github.com/dotnet/aspire/issues/13971
+        // If this prompt appears, it means multiple apphosts were incorrectly detected
+        // (e.g., AppHost.cs was incorrectly treated as a single-file apphost)
+        var unexpectedAppHostSelectionPrompt = new CellPatternSearcher()
+            .Find("Select an apphost to use:");
         
         // The purpose of this is to keep track of the number of actual shell commands we have
         // executed. This is important because we customize the shell prompt to show either
@@ -99,7 +105,17 @@ public sealed class SmokeTests(ITestOutputHelper output)
             .WaitForSuccessPrompt(counter)
             .Type("aspire run")
             .Enter()
-            .WaitUntil(s => waitForCtrlCMessage.Search(s).Count > 0, TimeSpan.FromMinutes(2))
+            .WaitUntil(s =>
+            {
+                // Fail immediately if we see the apphost selection prompt (means duplicate detection)
+                if (unexpectedAppHostSelectionPrompt.Search(s).Count > 0)
+                {
+                    throw new InvalidOperationException(
+                        "Unexpected apphost selection prompt detected! " +
+                        "This indicates multiple apphosts were incorrectly detected.");
+                }
+                return waitForCtrlCMessage.Search(s).Count > 0;
+            }, TimeSpan.FromMinutes(2))
             .Ctrl().Key(Hex1b.Input.Hex1bKey.C)
             .WaitForSuccessPrompt(counter)
             .Type("exit")


### PR DESCRIPTION
## Description

Adds a regression test to the CLI E2E tests to catch issues like #13971 where AppHost.cs was incorrectly detected as a single-file apphost alongside AppHost.csproj.

The tests now fail immediately if the "Select an apphost to use:" prompt appears during aspire run, which indicates multiple apphosts were incorrectly detected.

### Changes
- **SmokeTests.cs**: Added check that fails if apphost selection prompt appears
- **JsReactTemplateTests.cs**: Same check added

### Testing
These tests will catch any future regressions in apphost detection logic by verifying that only one apphost is found when running on starter templates.

Fixes validation gap from #13971

cc @mitchdenny for review