### PR TITLE
Add TypeScriptPolyglotTests to CLI E2E recording workflow

### DIFF
--- a/.github/workflows/cli-e2e-recording-comment.yml
+++ b/.github/workflows/cli-e2e-recording-comment.yml
@@ -112,7 +112,8 @@ jobs:
                a.name.includes('EmptyAppHostTemplateTests') ||
                a.name.includes('JsReactTemplateTests') ||
                a.name.includes('PythonReactTemplateTests') ||
-               a.name.includes('DockerDeploymentTests'))
+               a.name.includes('DockerDeploymentTests') ||
+               a.name.includes('TypeScriptPolyglotTests'))
             );
             
             console.log(`Found ${cliE2eArtifacts.length} CLI E2E artifacts`);

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
@@ -1,13 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Cli.EndToEndTests.Helpers;
+using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Tests.Utils;
 using Hex1b;
 using Hex1b.Automation;
 using Xunit;
 
-namespace Aspire.Cli.EndToEndTests;
+namespace Aspire.Cli.EndToEnd.Tests;
 
 /// <summary>
 /// End-to-end tests for Aspire CLI with TypeScript polyglot AppHost.


### PR DESCRIPTION
## Description

Fix TypeScriptPolyglot E2E tests. Wrong assembly name and needs config.
