### PR TITLE
Add aspire agent command for AI-powered development

### DIFF
--- a/src/Aspire.Cli/Agent/AgentContext.cs
+++ b/src/Aspire.Cli/Agent/AgentContext.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Agent;
+
+/// <summary>
+/// Holds the current project context for the agent session.
+/// </summary>
+internal sealed class AgentContext
+{
+    /// <summary>
+    /// Gets the AppHost project file, if available.
+    /// </summary>
+    public FileInfo? AppHostProject { get; init; }
+
+    /// <summary>
+    /// Gets whether we're running in offline mode (no AppHost).
+    /// </summary>
+    public bool IsOfflineMode => AppHostProject is null;
+
+    /// <summary>
+    /// Gets the working directory for the session.
+    /// </summary>
+    public DirectoryInfo WorkingDirectory { get; init; } = new(Environment.CurrentDirectory);
+
+    /// <summary>
+    /// Gets the list of resources discovered from the AppHost.
+    /// </summary>
+    public List<DiscoveredResource> Resources { get; init; } = [];
+
+    /// <summary>
+    /// Gets a summary of the project context for injection into the system prompt.
+    /// </summary>
+    public string GetContextSummary()
+    {
+        if (IsOfflineMode)
+        {
+            return $"""
+                Working directory: {WorkingDirectory.FullName}
+                Mode: Offline (no AppHost detected)
+                Available actions: Create new projects, run diagnostics
+                """;
+        }
+
+        var resourceSummary = Resources.Count > 0
+            ? string.Join("\n", Resources.Select(r => $"  - {r.Name} ({r.Type}): {r.State}"))
+            : "  (no resources discovered yet)";
+
+        return $"""
+            Working directory: {WorkingDirectory.FullName}
+            AppHost: {AppHostProject!.FullName}
+            Mode: Online (AppHost available)
+            Resources:
+            {resourceSummary}
+            """;
+    }
+}
+
+/// <summary>
+/// Represents a resource discovered from the AppHost.
+/// </summary>
+internal sealed record DiscoveredResource(
+    string Name,
+    string Type,
+    string State,
+    IReadOnlyList<string> Endpoints);

--- a/src/Aspire.Cli/Agent/AgentEvent.cs
+++ b/src/Aspire.Cli/Agent/AgentEvent.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Agent;
+
+/// <summary>
+/// Represents an event from the agent during message processing.
+/// </summary>
+internal abstract record AgentEvent;
+
+/// <summary>
+/// Event indicating the assistant is starting to process.
+/// </summary>
+internal sealed record AssistantTurnStartEvent : AgentEvent;
+
+/// <summary>
+/// Event containing a streaming text delta from the assistant.
+/// </summary>
+internal sealed record AssistantMessageDeltaEvent(string Content) : AgentEvent;
+
+/// <summary>
+/// Event containing the complete assistant message.
+/// </summary>
+internal sealed record AssistantMessageEvent(string Content) : AgentEvent;
+
+/// <summary>
+/// Event indicating a tool is starting execution.
+/// </summary>
+internal sealed record ToolExecutionStartEvent(string ToolName, string? Arguments) : AgentEvent;
+
+/// <summary>
+/// Event indicating a tool has completed execution.
+/// </summary>
+internal sealed record ToolExecutionCompleteEvent(string ToolName, string? Result, bool Success) : AgentEvent;
+
+/// <summary>
+/// Event indicating the session is idle (processing complete).
+/// </summary>
+internal sealed record SessionIdleEvent : AgentEvent;
+
+/// <summary>
+/// Event indicating an error occurred.
+/// </summary>
+internal sealed record SessionErrorEvent(string Message) : AgentEvent;

--- a/src/Aspire.Cli/Agent/AgentToolRegistry.cs
+++ b/src/Aspire.Cli/Agent/AgentToolRegistry.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using Aspire.Cli.Agent.Tools;
+using Microsoft.Extensions.AI;
+
+namespace Aspire.Cli.Agent;
+
+/// <summary>
+/// Registry that provides all available agent tools.
+/// </summary>
+internal sealed class AgentToolRegistry : IAgentToolRegistry
+{
+    private readonly IAspireNewTool _newTool;
+    private readonly IAspireAddTool _addTool;
+    private readonly IAspireRunTool _runTool;
+    private readonly IAspireDoctorTool _doctorTool;
+    private readonly IListIntegrationsTool _listIntegrationsTool;
+    private readonly IGetIntegrationDocsTool _getIntegrationDocsTool;
+
+    public AgentToolRegistry(
+        IAspireNewTool newTool,
+        IAspireAddTool addTool,
+        IAspireRunTool runTool,
+        IAspireDoctorTool doctorTool,
+        IListIntegrationsTool listIntegrationsTool,
+        IGetIntegrationDocsTool getIntegrationDocsTool)
+    {
+        _newTool = newTool;
+        _addTool = addTool;
+        _runTool = runTool;
+        _doctorTool = doctorTool;
+        _listIntegrationsTool = listIntegrationsTool;
+        _getIntegrationDocsTool = getIntegrationDocsTool;
+    }
+
+    public IList<AIFunction> GetTools(AgentContext context)
+    {
+        var tools = new List<AIFunction>();
+
+        // Always available tools
+        tools.Add(AIFunctionFactory.Create(
+            async ([Description("The template to use (e.g., 'aspire-starter', 'aspire')")] string template,
+                   [Description("The name for the new project")] string name,
+                   [Description("The output directory (optional)")] string? outputDir) =>
+                await _newTool.ExecuteAsync(template, name, outputDir),
+            "aspire_new",
+            "Create a new Aspire project from a template"));
+
+        tools.Add(AIFunctionFactory.Create(
+            async () => await _doctorTool.ExecuteAsync(),
+            "aspire_doctor",
+            "Run diagnostics to check the Aspire environment (Docker, .NET SDK, certificates, etc.)"));
+
+        tools.Add(AIFunctionFactory.Create(
+            async ([Description("Optional search filter")] string? filter) =>
+                await _listIntegrationsTool.ExecuteAsync(filter),
+            "list_integrations",
+            "List available Aspire integrations with their hosting and client package pairs"));
+
+        tools.Add(AIFunctionFactory.Create(
+            async ([Description("The integration package ID (e.g., 'Aspire.Hosting.Redis')")] string packageId) =>
+                await _getIntegrationDocsTool.ExecuteAsync(packageId),
+            "get_integration_docs",
+            "Get detailed documentation for a specific Aspire integration including usage examples and configuration"));
+
+        // Tools that require an AppHost
+        if (!context.IsOfflineMode)
+        {
+            tools.Add(AIFunctionFactory.Create(
+                async ([Description("The integration to add (e.g., 'redis', 'postgres', 'rabbitmq')")] string integration) =>
+                    await _addTool.ExecuteAsync(integration, context.AppHostProject!.FullName),
+                "aspire_add",
+                "Add an integration to the AppHost project"));
+
+            tools.Add(AIFunctionFactory.Create(
+                async ([Description("Whether to watch for changes")] bool watch) =>
+                    await _runTool.ExecuteAsync(context.AppHostProject!.FullName, watch),
+                "aspire_run",
+                "Run the Aspire AppHost application"));
+        }
+
+        return tools;
+    }
+}

--- a/src/Aspire.Cli/Agent/CopilotAgentSession.cs
+++ b/src/Aspire.Cli/Agent/CopilotAgentSession.cs
@@ -1,0 +1,172 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using GitHub.Copilot.SDK;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Agent;
+
+/// <summary>
+/// Agent session implementation using the GitHub Copilot SDK.
+/// </summary>
+internal sealed class CopilotAgentSession : IAgentSession
+{
+    private readonly IAgentToolRegistry _toolRegistry;
+    private readonly ILogger<CopilotAgentSession> _logger;
+    private CopilotClient? _client;
+    private CopilotSession? _session;
+    private AgentContext _context = new();
+
+    public CopilotAgentSession(
+        IAgentToolRegistry toolRegistry,
+        ILogger<CopilotAgentSession> logger)
+    {
+        _toolRegistry = toolRegistry;
+        _logger = logger;
+    }
+
+    public AgentContext Context => _context;
+
+    public bool IsConnected => _session is not null;
+
+    public async Task InitializeAsync(FileInfo? appHostProject, CancellationToken cancellationToken = default)
+    {
+        _context = new AgentContext
+        {
+            AppHostProject = appHostProject,
+            WorkingDirectory = new DirectoryInfo(Environment.CurrentDirectory)
+        };
+
+        try
+        {
+            _client = new CopilotClient(new CopilotClientOptions
+            {
+                AutoStart = true,
+                Logger = _logger
+            });
+
+            await _client.StartAsync(cancellationToken);
+
+            var tools = _toolRegistry.GetTools(_context);
+
+            _session = await _client.CreateSessionAsync(new SessionConfig
+            {
+                Model = "claude-opus-4",
+                Streaming = true,
+                Tools = tools,
+                SystemMessage = new SystemMessageConfig
+                {
+                    Mode = SystemMessageMode.Append,
+                    Content = GetSystemPrompt()
+                }
+            }, cancellationToken);
+
+            _logger.LogDebug("Agent session initialized with {ToolCount} tools", tools.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to initialize agent session");
+            throw new AgentSessionException("Failed to connect to Copilot CLI. Ensure 'copilot' is installed and you're authenticated with 'gh auth login'.", ex);
+        }
+    }
+
+    public async Task SendMessageAsync(string prompt, Action<AgentEvent> onEvent, CancellationToken cancellationToken = default)
+    {
+        if (_session is null)
+        {
+            throw new AgentSessionException("Session not initialized. Call InitializeAsync first.");
+        }
+
+        var tcs = new TaskCompletionSource();
+
+        using var subscription = _session.On(evt =>
+        {
+            var agentEvent = MapSessionEvent(evt);
+            if (agentEvent is not null)
+            {
+                onEvent(agentEvent);
+            }
+
+            if (agentEvent is SessionIdleEvent or SessionErrorEvent)
+            {
+                tcs.TrySetResult();
+            }
+        });
+
+        await _session.SendAsync(new MessageOptions { Prompt = prompt }, cancellationToken);
+
+        using var registration = cancellationToken.Register(() => tcs.TrySetCanceled());
+        await tcs.Task;
+    }
+
+    public async Task AbortAsync()
+    {
+        if (_session is not null)
+        {
+            await _session.AbortAsync();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_session is not null)
+        {
+            await _session.DisposeAsync();
+            _session = null;
+        }
+
+        if (_client is not null)
+        {
+            await _client.DisposeAsync();
+            _client = null;
+        }
+    }
+
+    private static AgentEvent? MapSessionEvent(GitHub.Copilot.SDK.SessionEvent evt)
+    {
+        return evt switch
+        {
+            GitHub.Copilot.SDK.AssistantTurnStartEvent => new AssistantTurnStartEvent(),
+            GitHub.Copilot.SDK.AssistantMessageDeltaEvent delta => new AssistantMessageDeltaEvent(delta.Data?.DeltaContent ?? ""),
+            GitHub.Copilot.SDK.AssistantMessageEvent msg => new AssistantMessageEvent(msg.Data?.Content ?? ""),
+            GitHub.Copilot.SDK.ToolExecutionStartEvent toolStart => new ToolExecutionStartEvent(toolStart.Data?.ToolName ?? "", toolStart.Data?.Arguments?.ToString()),
+            GitHub.Copilot.SDK.ToolExecutionCompleteEvent toolEnd => new ToolExecutionCompleteEvent(toolEnd.Data?.ToolCallId ?? "", toolEnd.Data?.Result?.Content, toolEnd.Data?.Success == true),
+            GitHub.Copilot.SDK.SessionIdleEvent => new SessionIdleEvent(),
+            GitHub.Copilot.SDK.SessionErrorEvent err => new SessionErrorEvent(err.Data?.Message ?? "Unknown error"),
+            _ => null
+        };
+    }
+
+    private string GetSystemPrompt()
+    {
+        return $"""
+            You are the Aspire Agent, an AI assistant specialized in building Aspire 
+            distributed applications. You help developers:
+
+            - Create new Aspire projects with appropriate templates
+            - Add and configure integrations (databases, caches, message queues, Azure services)
+            - Connect integrations together (e.g., a web app to a database, a worker to a message queue)
+            - Run and debug applications locally
+            - Deploy to Azure and other cloud environments
+            - Troubleshoot issues using logs, traces, and diagnostics
+
+            You have deep knowledge of Aspire integrations:
+            - **Hosting integrations** (AppHost): How to add resources like Redis, PostgreSQL, RabbitMQ, Azure services
+            - **Client integrations** (Service projects): How services consume resources via dependency injection
+            - **Connection patterns**: How WithReference() wires up connection strings and service discovery
+            - **Integration pairs**: Which hosting package pairs with which client package
+
+            Current project context:
+            {_context.GetContextSummary()}
+
+            Guidelines:
+            - Be concise and actionable
+            - Prefer using tools over explaining how to do things manually
+            - When adding integrations, explain BOTH the hosting side (AppHost) AND the client side (service project)
+            - Always show how to wire up connections using WithReference()
+            - When adding resources, verify the AppHost was updated correctly
+            - For troubleshooting, start with `doctor` then check logs/traces
+            - Explain what you're doing before executing tools
+            """;
+    }
+}

--- a/src/Aspire.Cli/Agent/IAgentSession.cs
+++ b/src/Aspire.Cli/Agent/IAgentSession.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Agent;
+
+/// <summary>
+/// Represents a session with the Aspire agent.
+/// </summary>
+internal interface IAgentSession : IAsyncDisposable
+{
+    /// <summary>
+    /// Gets the current project context for the session.
+    /// </summary>
+    AgentContext Context { get; }
+
+    /// <summary>
+    /// Gets whether the session is connected and ready.
+    /// </summary>
+    bool IsConnected { get; }
+
+    /// <summary>
+    /// Initializes the agent session with optional AppHost context.
+    /// </summary>
+    /// <param name="appHostProject">The AppHost project file, or null for offline mode.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task InitializeAsync(FileInfo? appHostProject, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sends a message to the agent and streams the response.
+    /// </summary>
+    /// <param name="prompt">The user prompt.</param>
+    /// <param name="onEvent">Callback for each event received.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task SendMessageAsync(string prompt, Action<AgentEvent> onEvent, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Aborts the current message processing.
+    /// </summary>
+    Task AbortAsync();
+}
+
+/// <summary>
+/// Exception thrown when the agent session encounters an error.
+/// </summary>
+internal sealed class AgentSessionException : Exception
+{
+    public AgentSessionException(string message) : base(message) { }
+    public AgentSessionException(string message, Exception innerException) : base(message, innerException) { }
+}

--- a/src/Aspire.Cli/Agent/IAgentToolRegistry.cs
+++ b/src/Aspire.Cli/Agent/IAgentToolRegistry.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Aspire.Cli.Agent;
+
+/// <summary>
+/// Registry for agent tools that can be exposed to the Copilot SDK.
+/// </summary>
+internal interface IAgentToolRegistry
+{
+    /// <summary>
+    /// Gets all available tools for the current context.
+    /// </summary>
+    /// <param name="context">The agent context.</param>
+    /// <returns>List of AI functions that can be invoked by the model.</returns>
+    IList<AIFunction> GetTools(AgentContext context);
+}

--- a/src/Aspire.Cli/Agent/Tools/AspireCliTools.cs
+++ b/src/Aspire.Cli/Agent/Tools/AspireCliTools.cs
@@ -1,0 +1,179 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Cli.Agent.Tools;
+
+/// <summary>
+/// Implementation of the aspire new tool.
+/// </summary>
+internal sealed class AspireNewTool : IAspireNewTool
+{
+    private readonly CliExecutionContext _executionContext;
+
+    public AspireNewTool(CliExecutionContext executionContext)
+    {
+        _executionContext = executionContext;
+    }
+
+    public async Task<string> ExecuteAsync(string template, string name, string? outputDir)
+    {
+        var args = $"new {template} --name {name}";
+        if (!string.IsNullOrEmpty(outputDir))
+        {
+            args += $" --output \"{outputDir}\"";
+        }
+
+        var result = await RunAspireCommandAsync(args);
+        return result.Success
+            ? $"Successfully created project '{name}' from template '{template}'.\n{result.Output}"
+            : $"Failed to create project: {result.Error}";
+    }
+
+    private async Task<(bool Success, string Output, string Error)> RunAspireCommandAsync(string arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "aspire",
+            Arguments = arguments,
+            WorkingDirectory = _executionContext.WorkingDirectory.FullName,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = new Process { StartInfo = startInfo };
+        process.Start();
+
+        var output = await process.StandardOutput.ReadToEndAsync();
+        var error = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        return (process.ExitCode == 0, output, error);
+    }
+}
+
+/// <summary>
+/// Implementation of the aspire add tool.
+/// </summary>
+internal sealed class AspireAddTool : IAspireAddTool
+{
+    private readonly CliExecutionContext _executionContext;
+
+    public AspireAddTool(CliExecutionContext executionContext)
+    {
+        _executionContext = executionContext;
+    }
+
+    public async Task<string> ExecuteAsync(string integration, string appHostPath)
+    {
+        var args = $"add {integration} --project \"{appHostPath}\" --non-interactive";
+
+        var result = await RunAspireCommandAsync(args);
+        return result.Success
+            ? $"Successfully added '{integration}' to the AppHost.\n{result.Output}"
+            : $"Failed to add integration: {result.Error}";
+    }
+
+    private async Task<(bool Success, string Output, string Error)> RunAspireCommandAsync(string arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "aspire",
+            Arguments = arguments,
+            WorkingDirectory = _executionContext.WorkingDirectory.FullName,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = new Process { StartInfo = startInfo };
+        process.Start();
+
+        var output = await process.StandardOutput.ReadToEndAsync();
+        var error = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        return (process.ExitCode == 0, output, error);
+    }
+}
+
+/// <summary>
+/// Implementation of the aspire run tool.
+/// </summary>
+internal sealed class AspireRunTool : IAspireRunTool
+{
+    private readonly CliExecutionContext _executionContext;
+
+    public AspireRunTool(CliExecutionContext executionContext)
+    {
+        _executionContext = executionContext;
+    }
+
+    public async Task<string> ExecuteAsync(string appHostPath, bool watch)
+    {
+        var args = $"run --project \"{appHostPath}\"";
+        if (watch)
+        {
+            args += " --watch";
+        }
+
+        // For run, we start the process but don't wait for it to complete
+        // Return info about how to stop it
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "aspire",
+            Arguments = args,
+            WorkingDirectory = _executionContext.WorkingDirectory.FullName,
+            UseShellExecute = false,
+            CreateNoWindow = false
+        };
+
+        Process.Start(startInfo);
+
+        await Task.Delay(2000); // Give it time to start
+
+        return $"Started AppHost. The dashboard should be available shortly. Use Ctrl+C in the terminal to stop.";
+    }
+}
+
+/// <summary>
+/// Implementation of the aspire doctor tool.
+/// </summary>
+internal sealed class AspireDoctorTool : IAspireDoctorTool
+{
+    private readonly CliExecutionContext _executionContext;
+
+    public AspireDoctorTool(CliExecutionContext executionContext)
+    {
+        _executionContext = executionContext;
+    }
+
+    public async Task<string> ExecuteAsync()
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "aspire",
+            Arguments = "doctor --non-interactive",
+            WorkingDirectory = _executionContext.WorkingDirectory.FullName,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = new Process { StartInfo = startInfo };
+        process.Start();
+
+        var output = await process.StandardOutput.ReadToEndAsync();
+        var error = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        return process.ExitCode == 0
+            ? $"Environment check completed:\n{output}"
+            : $"Environment check found issues:\n{output}\n{error}";
+    }
+}

--- a/src/Aspire.Cli/Agent/Tools/IAgentTools.cs
+++ b/src/Aspire.Cli/Agent/Tools/IAgentTools.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Agent.Tools;
+
+/// <summary>
+/// Tool for creating new Aspire projects.
+/// </summary>
+internal interface IAspireNewTool
+{
+    Task<string> ExecuteAsync(string template, string name, string? outputDir);
+}
+
+/// <summary>
+/// Tool for adding integrations to an AppHost.
+/// </summary>
+internal interface IAspireAddTool
+{
+    Task<string> ExecuteAsync(string integration, string appHostPath);
+}
+
+/// <summary>
+/// Tool for running the Aspire AppHost.
+/// </summary>
+internal interface IAspireRunTool
+{
+    Task<string> ExecuteAsync(string appHostPath, bool watch);
+}
+
+/// <summary>
+/// Tool for running Aspire diagnostics.
+/// </summary>
+internal interface IAspireDoctorTool
+{
+    Task<string> ExecuteAsync();
+}
+
+/// <summary>
+/// Tool for listing available integrations.
+/// </summary>
+internal interface IListIntegrationsTool
+{
+    Task<string> ExecuteAsync(string? filter);
+}
+
+/// <summary>
+/// Tool for getting integration documentation.
+/// </summary>
+internal interface IGetIntegrationDocsTool
+{
+    Task<string> ExecuteAsync(string packageId);
+}

--- a/src/Aspire.Cli/Agent/Tools/IntegrationTools.cs
+++ b/src/Aspire.Cli/Agent/Tools/IntegrationTools.cs
@@ -1,0 +1,203 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.NuGet;
+
+namespace Aspire.Cli.Agent.Tools;
+
+/// <summary>
+/// Tool for listing available Aspire integrations.
+/// </summary>
+internal sealed class ListIntegrationsTool : IListIntegrationsTool
+{
+    private readonly INuGetPackageCache _packageCache;
+
+    // Well-known integration package pairs
+    private static readonly IReadOnlyList<IntegrationInfo> s_knownIntegrations =
+    [
+        new("Redis", "Aspire.Hosting.Redis", "Aspire.StackExchange.Redis", "AddRedis()", "AddRedisClient()"),
+        new("PostgreSQL", "Aspire.Hosting.PostgreSQL", "Aspire.Npgsql", "AddPostgres().AddDatabase()", "AddNpgsqlDataSource()"),
+        new("PostgreSQL + EF Core", "Aspire.Hosting.PostgreSQL", "Aspire.Npgsql.EntityFrameworkCore.PostgreSQL", "AddPostgres().AddDatabase()", "AddNpgsqlDbContext<T>()"),
+        new("SQL Server", "Aspire.Hosting.SqlServer", "Aspire.Microsoft.Data.SqlClient", "AddSqlServer().AddDatabase()", "AddSqlServerClient()"),
+        new("SQL Server + EF Core", "Aspire.Hosting.SqlServer", "Aspire.Microsoft.EntityFrameworkCore.SqlServer", "AddSqlServer().AddDatabase()", "AddSqlServerDbContext<T>()"),
+        new("MongoDB", "Aspire.Hosting.MongoDB", "Aspire.MongoDB.Driver", "AddMongoDB().AddDatabase()", "AddMongoDBClient()"),
+        new("RabbitMQ", "Aspire.Hosting.RabbitMQ", "Aspire.RabbitMQ.Client", "AddRabbitMQ()", "AddRabbitMQClient()"),
+        new("Kafka", "Aspire.Hosting.Kafka", "Aspire.Confluent.Kafka", "AddKafka()", "AddKafkaProducer()/AddKafkaConsumer()"),
+        new("Azure Storage", "Aspire.Hosting.Azure.Storage", "Aspire.Azure.Storage.Blobs", "AddAzureStorage().AddBlobs()", "AddAzureBlobClient()"),
+        new("Azure Cosmos DB", "Aspire.Hosting.Azure.CosmosDB", "Aspire.Microsoft.Azure.Cosmos", "AddAzureCosmosDB()", "AddAzureCosmosClient()"),
+        new("Azure Service Bus", "Aspire.Hosting.Azure.ServiceBus", "Aspire.Azure.Messaging.ServiceBus", "AddAzureServiceBus()", "AddAzureServiceBusClient()"),
+        new("Azure Key Vault", "Aspire.Hosting.Azure.KeyVault", "Aspire.Azure.Security.KeyVault", "AddAzureKeyVault()", "AddAzureKeyVaultClient()"),
+        new("MySQL", "Aspire.Hosting.MySql", "Aspire.MySqlConnector", "AddMySql().AddDatabase()", "AddMySqlDataSource()"),
+        new("Oracle", "Aspire.Hosting.Oracle", "Aspire.Oracle.EntityFrameworkCore", "AddOracle().AddDatabase()", "AddOracleDbContext<T>()"),
+        new("Elasticsearch", "Aspire.Hosting.Elasticsearch", "Aspire.Elastic.Clients.Elasticsearch", "AddElasticsearch()", "AddElasticsearchClient()"),
+        new("Milvus", "Aspire.Hosting.Milvus", "Aspire.Milvus.Client", "AddMilvus()", "AddMilvusClient()"),
+        new("Qdrant", "Aspire.Hosting.Qdrant", "Aspire.Qdrant.Client", "AddQdrant()", "AddQdrantClient()"),
+        new("Ollama", "Aspire.Hosting.Ollama", null, "AddOllama().AddModel()", null),
+        new("Seq", "Aspire.Hosting.Seq", "Aspire.Seq", "AddSeq()", "builder.Logging.AddSeq()"),
+        new("Garnet", "Aspire.Hosting.Garnet", "Aspire.StackExchange.Redis", "AddGarnet()", "AddRedisClient()"),
+        new("Valkey", "Aspire.Hosting.Valkey", "Aspire.StackExchange.Redis", "AddValkey()", "AddRedisClient()"),
+        new("NATS", "Aspire.Hosting.Nats", "Aspire.NATS.Net", "AddNats()", "AddNatsClient()"),
+    ];
+
+    public ListIntegrationsTool(INuGetPackageCache packageCache)
+    {
+        _packageCache = packageCache;
+    }
+
+    public Task<string> ExecuteAsync(string? filter)
+    {
+        var integrations = s_knownIntegrations.AsEnumerable();
+
+        if (!string.IsNullOrWhiteSpace(filter))
+        {
+            integrations = integrations.Where(i =>
+                i.Name.Contains(filter, StringComparison.OrdinalIgnoreCase) ||
+                i.HostingPackage.Contains(filter, StringComparison.OrdinalIgnoreCase) ||
+                (i.ClientPackage?.Contains(filter, StringComparison.OrdinalIgnoreCase) ?? false));
+        }
+
+        var result = integrations.Select(i =>
+        {
+            var clientInfo = i.ClientPackage is not null
+                ? $"\n  Client: {i.ClientPackage} → {i.ClientMethod}"
+                : "\n  Client: N/A (hosting only)";
+
+            return $"""
+                **{i.Name}**
+                  Hosting: {i.HostingPackage} → {i.HostingMethod}{clientInfo}
+                """;
+        });
+
+        var output = string.Join("\n\n", result);
+        return Task.FromResult($"Available Aspire Integrations:\n\n{output}");
+    }
+
+    private sealed record IntegrationInfo(
+        string Name,
+        string HostingPackage,
+        string? ClientPackage,
+        string HostingMethod,
+        string? ClientMethod);
+}
+
+/// <summary>
+/// Tool for getting detailed integration documentation.
+/// </summary>
+internal sealed class GetIntegrationDocsTool : IGetIntegrationDocsTool
+{
+    private readonly INuGetPackageCache _packageCache;
+
+    public GetIntegrationDocsTool(INuGetPackageCache packageCache)
+    {
+        _packageCache = packageCache;
+    }
+
+    public async Task<string> ExecuteAsync(string packageId)
+    {
+        // Try to get package info from NuGet
+        // For now, return static documentation based on known packages
+        var docs = GetStaticDocs(packageId);
+        if (docs is not null)
+        {
+            return docs;
+        }
+
+        return $"No detailed documentation found for '{packageId}'. Use 'list_integrations' to see available integrations.";
+    }
+
+    private static string? GetStaticDocs(string packageId)
+    {
+        return packageId.ToLowerInvariant() switch
+        {
+            "aspire.hosting.redis" or "redis" => """
+                # Redis Integration
+
+                ## Hosting (AppHost)
+                ```csharp
+                var redis = builder.AddRedis("cache");
+                
+                // With persistence
+                var redis = builder.AddRedis("cache")
+                    .WithDataVolume()
+                    .WithPersistence();
+
+                // Reference from a project
+                builder.AddProject<Projects.MyApi>("api")
+                    .WithReference(redis);
+                ```
+
+                ## Client (Service Project)
+                ```csharp
+                // In Program.cs
+                builder.AddRedisClient("cache");
+
+                // Inject IConnectionMultiplexer or IDatabase
+                public class MyService(IConnectionMultiplexer redis) { }
+                ```
+
+                ## Connection
+                The connection string is automatically configured via WithReference().
+                The service will receive a connection string named "cache".
+                """,
+
+            "aspire.hosting.postgresql" or "postgres" or "postgresql" => """
+                # PostgreSQL Integration
+
+                ## Hosting (AppHost)
+                ```csharp
+                var postgres = builder.AddPostgres("pg")
+                    .AddDatabase("mydb");
+
+                // With pgAdmin for management
+                var postgres = builder.AddPostgres("pg")
+                    .WithPgAdmin()
+                    .AddDatabase("mydb");
+
+                // Reference from a project
+                builder.AddProject<Projects.MyApi>("api")
+                    .WithReference(postgres);
+                ```
+
+                ## Client (Service Project) - Npgsql
+                ```csharp
+                builder.AddNpgsqlDataSource("mydb");
+
+                public class MyService(NpgsqlDataSource dataSource) { }
+                ```
+
+                ## Client (Service Project) - EF Core
+                ```csharp
+                builder.AddNpgsqlDbContext<MyDbContext>("mydb");
+
+                public class MyService(MyDbContext db) { }
+                ```
+                """,
+
+            "aspire.hosting.rabbitmq" or "rabbitmq" => """
+                # RabbitMQ Integration
+
+                ## Hosting (AppHost)
+                ```csharp
+                var rabbitmq = builder.AddRabbitMQ("messaging");
+
+                // With management plugin
+                var rabbitmq = builder.AddRabbitMQ("messaging")
+                    .WithManagementPlugin();
+
+                // Reference from a project
+                builder.AddProject<Projects.MyWorker>("worker")
+                    .WithReference(rabbitmq);
+                ```
+
+                ## Client (Service Project)
+                ```csharp
+                builder.AddRabbitMQClient("messaging");
+
+                public class MyService(IConnection connection) { }
+                ```
+                """,
+
+            _ => null
+        };
+    }
+}

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -15,6 +15,8 @@
     <DefineConstants>$(DefineConstants);CLI</DefineConstants>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
     <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
+    <!-- Disable assembly signing for referencing unsigned SDK during development -->
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <!-- Set the nuget properties when building as a global tool. -->
@@ -46,6 +48,11 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="Semver" />
     <PackageReference Include="ModelContextProtocol" />
+  </ItemGroup>
+
+  <!-- Use local project reference for GitHub Copilot SDK during development -->
+  <ItemGroup>
+    <ProjectReference Include="D:\dev\git\copilot-sdk\dotnet\src\GitHub.Copilot.SDK.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Cli/Commands/AgentCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentCommand.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Utils;
+
+namespace Aspire.Cli.Commands;
+
+/// <summary>
+/// Command for managing the Aspire agent experience.
+/// </summary>
+internal sealed class AgentCommand : BaseCommand
+{
+    public AgentCommand(
+        AgentStartCommand startCommand,
+        IFeatures features,
+        ICliUpdateNotifier updateNotifier,
+        CliExecutionContext executionContext,
+        IInteractionService interactionService)
+        : base("agent", "Start an AI-powered agent for building Aspire applications", features, updateNotifier, executionContext, interactionService)
+    {
+        Subcommands.Add(startCommand);
+    }
+
+    protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        // Show help if no subcommand specified
+        InteractionService.DisplayMessage("🤖", "Use 'aspire agent start' to launch the Aspire agent.");
+        return Task.FromResult(ExitCodeConstants.Success);
+    }
+}

--- a/src/Aspire.Cli/Commands/AgentStartCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentStartCommand.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using Aspire.Cli.Agent;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Tui;
+using Aspire.Cli.Utils;
+
+namespace Aspire.Cli.Commands;
+
+/// <summary>
+/// Starts the Aspire agent for interactive AI-powered development.
+/// </summary>
+internal sealed class AgentStartCommand : BaseCommand
+{
+    private readonly IAgentSession _agentSession;
+    private readonly IAgentTuiRenderer _tuiRenderer;
+    private readonly IProjectLocator _projectLocator;
+
+    public AgentStartCommand(
+        IAgentSession agentSession,
+        IAgentTuiRenderer tuiRenderer,
+        IProjectLocator projectLocator,
+        IFeatures features,
+        ICliUpdateNotifier updateNotifier,
+        CliExecutionContext executionContext,
+        IInteractionService interactionService)
+        : base("start", "Start the Aspire agent", features, updateNotifier, executionContext, interactionService)
+    {
+        _agentSession = agentSession;
+        _tuiRenderer = tuiRenderer;
+        _projectLocator = projectLocator;
+
+        var projectOption = new Option<FileInfo?>("--project", "-p")
+        {
+            Description = "The path to the AppHost project file"
+        };
+
+        Options.Add(projectOption);
+    }
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        var projectFile = parseResult.GetValue<FileInfo?>("--project");
+
+        try
+        {
+            // Try to locate AppHost project for context
+            FileInfo? appHostProject = null;
+            try
+            {
+                appHostProject = projectFile ?? await _projectLocator.UseOrFindAppHostProjectFileAsync(null, createSettingsFile: false, cancellationToken);
+            }
+            catch (ProjectLocatorException)
+            {
+                // No AppHost found - that's OK, we can still run in offline mode
+            }
+
+            // Initialize the agent session
+            await _agentSession.InitializeAsync(appHostProject, cancellationToken);
+
+            // Render the TUI and run the agent loop
+            await _tuiRenderer.RunAsync(_agentSession, cancellationToken);
+
+            return ExitCodeConstants.Success;
+        }
+        catch (AgentSessionException ex)
+        {
+            InteractionService.DisplayError($"Agent error: {ex.Message}");
+            return ExitCodeConstants.FailedToDotnetRunAppHost;
+        }
+        catch (OperationCanceledException)
+        {
+            return ExitCodeConstants.Success;
+        }
+    }
+}

--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -35,6 +35,7 @@ internal sealed class RootCommand : BaseRootCommand
         UpdateCommand updateCommand,
         McpCommand mcpCommand,
         SdkCommand sdkCommand,
+        AgentCommand agentCommand,
         ExtensionInternalCommand extensionInternalCommand,
         IFeatures featureFlags,
         IInteractionService interactionService)
@@ -54,6 +55,7 @@ internal sealed class RootCommand : BaseRootCommand
         ArgumentNullException.ThrowIfNull(execCommand);
         ArgumentNullException.ThrowIfNull(mcpCommand);
         ArgumentNullException.ThrowIfNull(sdkCommand);
+        ArgumentNullException.ThrowIfNull(agentCommand);
         ArgumentNullException.ThrowIfNull(extensionInternalCommand);
         ArgumentNullException.ThrowIfNull(featureFlags);
         ArgumentNullException.ThrowIfNull(interactionService);
@@ -118,6 +120,7 @@ internal sealed class RootCommand : BaseRootCommand
         Subcommands.Add(updateCommand);
         Subcommands.Add(extensionInternalCommand);
         Subcommands.Add(mcpCommand);
+        Subcommands.Add(agentCommand);
 
         if (featureFlags.IsFeatureEnabled(KnownFeatures.ExecCommandEnabled, false))
         {

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -36,6 +36,9 @@ using Spectre.Console;
 using RootCommand = Aspire.Cli.Commands.RootCommand;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Packaging;
+using Aspire.Cli.Agent;
+using Aspire.Cli.Agent.Tools;
+using Aspire.Cli.Tui;
 
 #if DEBUG
 using OpenTelemetry;
@@ -240,8 +243,21 @@ public class Program
         builder.Services.AddTransient<SdkCommand>();
         builder.Services.AddTransient<SdkGenerateCommand>();
         builder.Services.AddTransient<SdkDumpCommand>();
+        builder.Services.AddTransient<AgentCommand>();
+        builder.Services.AddTransient<AgentStartCommand>();
         builder.Services.AddTransient<RootCommand>();
         builder.Services.AddTransient<ExtensionInternalCommand>();
+
+        // Agent services.
+        builder.Services.AddSingleton<IAgentSession, CopilotAgentSession>();
+        builder.Services.AddSingleton<IAgentToolRegistry, AgentToolRegistry>();
+        builder.Services.AddSingleton<IAgentTuiRenderer, AgentTuiRenderer>();
+        builder.Services.AddSingleton<IAspireNewTool, AspireNewTool>();
+        builder.Services.AddSingleton<IAspireAddTool, AspireAddTool>();
+        builder.Services.AddSingleton<IAspireRunTool, AspireRunTool>();
+        builder.Services.AddSingleton<IAspireDoctorTool, AspireDoctorTool>();
+        builder.Services.AddSingleton<IListIntegrationsTool, ListIntegrationsTool>();
+        builder.Services.AddSingleton<IGetIntegrationDocsTool, GetIntegrationDocsTool>();
 
         var app = builder.Build();
         return app;

--- a/src/Aspire.Cli/Tui/AgentTuiRenderer.cs
+++ b/src/Aspire.Cli/Tui/AgentTuiRenderer.cs
@@ -1,0 +1,258 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Text;
+using Aspire.Cli.Agent;
+using Spectre.Console;
+
+namespace Aspire.Cli.Tui;
+
+/// <summary>
+/// Main TUI renderer for the Aspire agent experience.
+/// </summary>
+internal sealed class AgentTuiRenderer : IAgentTuiRenderer
+{
+    private readonly IAnsiConsole _console;
+    private static readonly Style s_aspireStyle = new(Color.MediumPurple1);
+
+    public AgentTuiRenderer(IAnsiConsole console)
+    {
+        _console = console;
+    }
+
+    public async Task RunAsync(IAgentSession session, CancellationToken cancellationToken)
+    {
+        RenderWelcome(session.Context);
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var prompt = await GetUserInputAsync(cancellationToken);
+
+            if (string.IsNullOrWhiteSpace(prompt))
+            {
+                continue;
+            }
+
+            // Handle special commands
+            if (prompt.StartsWith('/'))
+            {
+                if (HandleSpecialCommand(prompt, session))
+                {
+                    continue;
+                }
+                if (prompt.Equals("/quit", StringComparison.OrdinalIgnoreCase) ||
+                    prompt.Equals("/exit", StringComparison.OrdinalIgnoreCase))
+                {
+                    break;
+                }
+            }
+
+            await ProcessMessageAsync(session, prompt, cancellationToken);
+        }
+
+        RenderGoodbye();
+    }
+
+    private void RenderWelcome(AgentContext context)
+    {
+        _console.Clear();
+
+        // Aspire logo/header
+        var header = new FigletText("Aspire Agent")
+            .Color(Color.MediumPurple1);
+
+        _console.Write(header);
+        _console.WriteLine();
+
+        // Status panel
+        var modeText = context.IsOfflineMode
+            ? "[yellow]Offline Mode[/] - No AppHost detected"
+            : $"[green]Online Mode[/] - AppHost: {context.AppHostProject?.Name}";
+
+        var panel = new Panel(new Markup(modeText))
+        {
+            Border = BoxBorder.Rounded,
+            BorderStyle = s_aspireStyle,
+            Header = new PanelHeader(" Status ", Justify.Center)
+        };
+
+        _console.Write(panel);
+        _console.WriteLine();
+
+        // Help text
+        _console.MarkupLine("[dim]Type your message and press Enter. Use [/][cyan]/help[/][dim] for commands, [/][cyan]/quit[/][dim] to exit.[/]");
+        _console.WriteLine();
+    }
+
+    private async Task<string> GetUserInputAsync(CancellationToken cancellationToken)
+    {
+        _console.Markup("[cyan]>[/] ");
+
+        var input = new StringBuilder();
+        var line = await Task.Run(() =>
+        {
+            try
+            {
+                return Console.ReadLine();
+            }
+            catch (OperationCanceledException)
+            {
+                return null;
+            }
+        }, cancellationToken);
+
+        return line ?? string.Empty;
+    }
+
+    private bool HandleSpecialCommand(string command, IAgentSession session)
+    {
+        switch (command.ToLowerInvariant())
+        {
+            case "/help":
+                RenderHelp();
+                return true;
+
+            case "/clear":
+                _console.Clear();
+                RenderWelcome(session.Context);
+                return true;
+
+            case "/status":
+                RenderStatus(session.Context);
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    private void RenderHelp()
+    {
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .BorderColor(Color.MediumPurple1)
+            .AddColumn("Command")
+            .AddColumn("Description");
+
+        table.AddRow("[cyan]/help[/]", "Show this help message");
+        table.AddRow("[cyan]/clear[/]", "Clear the screen");
+        table.AddRow("[cyan]/status[/]", "Show current status");
+        table.AddRow("[cyan]/quit[/]", "Exit the agent");
+
+        _console.WriteLine();
+        _console.Write(table);
+        _console.WriteLine();
+    }
+
+    private void RenderStatus(AgentContext context)
+    {
+        _console.WriteLine();
+
+        var grid = new Grid();
+        grid.AddColumn();
+        grid.AddColumn();
+
+        grid.AddRow("[dim]Working Directory:[/]", context.WorkingDirectory.FullName);
+        grid.AddRow("[dim]Mode:[/]", context.IsOfflineMode ? "[yellow]Offline[/]" : "[green]Online[/]");
+
+        if (!context.IsOfflineMode)
+        {
+            grid.AddRow("[dim]AppHost:[/]", context.AppHostProject!.FullName);
+            grid.AddRow("[dim]Resources:[/]", context.Resources.Count.ToString(CultureInfo.InvariantCulture));
+        }
+
+        _console.Write(new Panel(grid)
+        {
+            Border = BoxBorder.Rounded,
+            BorderStyle = s_aspireStyle,
+            Header = new PanelHeader(" Status ", Justify.Center)
+        });
+
+        _console.WriteLine();
+    }
+
+    private async Task ProcessMessageAsync(IAgentSession session, string prompt, CancellationToken cancellationToken)
+    {
+        _console.WriteLine();
+
+        var responseBuilder = new StringBuilder();
+        var isStreaming = false;
+
+        try
+        {
+            await session.SendMessageAsync(prompt, evt =>
+            {
+                switch (evt)
+                {
+                    case AssistantTurnStartEvent:
+                        // Starting response
+                        break;
+
+                    case AssistantMessageDeltaEvent delta:
+                        if (!isStreaming)
+                        {
+                            _console.Markup("[mediumpurple1]Assistant:[/] ");
+                            isStreaming = true;
+                        }
+                        _console.Write(new Text(delta.Content));
+                        responseBuilder.Append(delta.Content);
+                        break;
+
+                    case AssistantMessageEvent msg:
+                        if (!isStreaming && !string.IsNullOrEmpty(msg.Content))
+                        {
+                            _console.MarkupLine($"[mediumpurple1]Assistant:[/] {msg.Content.EscapeMarkup()}");
+                        }
+                        break;
+
+                    case ToolExecutionStartEvent toolStart:
+                        if (isStreaming)
+                        {
+                            _console.WriteLine();
+                            isStreaming = false;
+                        }
+                        _console.MarkupLine($"[yellow]⚙ Running:[/] [dim]{toolStart.ToolName.EscapeMarkup()}[/]");
+                        break;
+
+                    case ToolExecutionCompleteEvent toolEnd:
+                        var icon = toolEnd.Success ? "[green]✓[/]" : "[red]✗[/]";
+                        _console.MarkupLine($"  {icon} [dim]{toolEnd.ToolName.EscapeMarkup()} completed[/]");
+                        break;
+
+                    case SessionErrorEvent error:
+                        if (isStreaming)
+                        {
+                            _console.WriteLine();
+                            isStreaming = false;
+                        }
+                        _console.MarkupLine($"[red]Error:[/] {error.Message.EscapeMarkup()}");
+                        break;
+
+                    case SessionIdleEvent:
+                        if (isStreaming)
+                        {
+                            _console.WriteLine();
+                        }
+                        break;
+                }
+            }, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            if (isStreaming)
+            {
+                _console.WriteLine();
+            }
+            _console.MarkupLine("[dim]Cancelled[/]");
+        }
+
+        _console.WriteLine();
+    }
+
+    private void RenderGoodbye()
+    {
+        _console.WriteLine();
+        _console.MarkupLine("[mediumpurple1]Goodbye![/]");
+    }
+}

--- a/src/Aspire.Cli/Tui/IAgentTuiRenderer.cs
+++ b/src/Aspire.Cli/Tui/IAgentTuiRenderer.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Agent;
+
+namespace Aspire.Cli.Tui;
+
+/// <summary>
+/// Renderer for the agent TUI experience.
+/// </summary>
+internal interface IAgentTuiRenderer
+{
+    /// <summary>
+    /// Runs the TUI main loop.
+    /// </summary>
+    /// <param name="session">The agent session.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task RunAsync(IAgentSession session, CancellationToken cancellationToken);
+}


### PR DESCRIPTION
## Summary

Introduces the \spire agent start\ command that launches an interactive AI-powered assistant for building Aspire distributed applications.

## Key Features

- **Model:** Uses GitHub Copilot SDK with Claude Opus
- **TUI:** Spectre Console interface with purple Aspire branding
- **Tools:**
  - \spire_new\ - Create new projects from templates
  - \spire_add\ - Add integrations to AppHost
  - \spire_run\ - Run the AppHost
  - \spire_doctor\ - Run environment diagnostics
  - \list_integrations\ - Discover 20+ hosting/client package pairs
  - \get_integration_docs\ - Get detailed integration documentation
- **Modes:** Online (with AppHost context) and offline (scaffolding only)
- **Streaming:** Real-time response rendering with tool execution visualization

## Prerequisites

- \copilot\ CLI must be installed
- GitHub authentication via \gh auth login\

## Usage

\\\ash
# In a directory with an Aspire AppHost
aspire agent start

# Or specify the project explicitly
aspire agent start --project ./src/MyApp.AppHost/MyApp.AppHost.csproj
\\\

## Notes

- This is an experimental feature
- Currently references GitHub Copilot SDK via local project reference (will need package reference when SDK is published)
- Assembly signing is disabled for CLI during development to allow unsigned SDK reference

## TODO

- [ ] Integrate with running AppHost via MCP
- [ ] Add more tools (deploy, stop, connect resource)
- [ ] Session persistence
- [ ] Graceful Ctrl+C handling
