### PR TITLE
Improve flaky test failures from port conflicts

### DIFF
--- a/tests/Aspire.Dashboard.Tests/Integration/ServerRetryHelper.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/ServerRetryHelper.cs
@@ -74,7 +74,7 @@ public static class ServerRetryHelper
                 // Success - exit the retry loop
                 return;
             }
-            catch (Exception ex) when (ex is not TimeoutException and not InvalidOperationException)
+            catch (Exception ex)
             {
                 retryCount++;
 
@@ -82,10 +82,8 @@ public static class ServerRetryHelper
                 {
                     throw;
                 }
-                else
-                {
-                    logger.LogError(ex, "Error running test {retryCount}. Retrying.", retryCount);
-                }
+
+                logger.LogError(ex, "Error running test {retryCount}. Retrying.", retryCount);
             }
             finally
             {

--- a/tests/Aspire.Dashboard.Tests/Integration/ServerRetryHelper.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/ServerRetryHelper.cs
@@ -17,7 +17,9 @@ public static class ServerRetryHelper
     // Named mutex to prevent race conditions when multiple parallel tests (even across processes)
     // try to find and bind ports. Without this, GetAvailablePort can return the same port to
     // multiple tests before any of them bind.
-    private const string PortAllocationMutexName = "Global\\AspireDashboardTestPortAllocation";
+    // Note: Using a session-local mutex (no "Global\" prefix) which is sufficient for tests
+    // running in the same user session and avoids permission issues on some platforms.
+    private const string PortAllocationMutexName = "AspireDashboardTestPortAllocation";
 
     /// <summary>
     /// Retry a func. Useful when a test needs an explicit port and you want to avoid port conflicts.

--- a/tests/Aspire.Dashboard.Tests/Integration/ServerRetryHelper.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/ServerRetryHelper.cs
@@ -68,6 +68,10 @@ public static class ServerRetryHelper
                         {
                             ports.Add(port);
                         }
+                        else
+                        {
+                            logger.LogInformation("Port {port} found to be unavailable during bind check. Continuing search.", port);
+                        }
 
                         // Use a minimum gap of 10 between port allocations to reduce the risk of port collisions.
                         // Allocating consecutive ports (gap of 0) can lead to conflicts if the OS or other processes

--- a/tests/Aspire.Dashboard.Tests/Integration/ServerRetryHelper.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/ServerRetryHelper.cs
@@ -159,11 +159,13 @@ public static class ServerRetryHelper
 
         static bool TryBindPort(int port, ILogger logger)
         {
+            // Since we only bind without calling Listen() or Connect(), we never enter TIME_WAIT.
+            // The port is released immediately on dispose.
             try
             {
                 using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
                 socket.Bind(new IPEndPoint(IPAddress.Loopback, port));
-                // Successfully bound, port is available
+                // Successfully bound, port is available.
                 return true;
             }
             catch (SocketException ex) when (ex.SocketErrorCode == SocketError.AddressAlreadyInUse)


### PR DESCRIPTION
Most dashboard tests bind to port 0. However there are some where that's not possible and a helper method tries to find available ports. I noticed these tests sometimes failed.

PR improves BindPortWithRetry with bind to check port availablity, and adds a mutex to lock around getting ports and using them.