### PR TITLE
Improve MCP AppHost detection reliability

### DIFF
--- a/src/Aspire.Cli/Backchannel/IAuxiliaryBackchannelMonitor.cs
+++ b/src/Aspire.Cli/Backchannel/IAuxiliaryBackchannelMonitor.cs
@@ -30,4 +30,11 @@ internal interface IAuxiliaryBackchannelMonitor
     /// <param name="workingDirectory">The working directory to check against.</param>
     /// <returns>A list of in-scope connections.</returns>
     IReadOnlyList<AppHostAuxiliaryBackchannel> GetConnectionsForWorkingDirectory(DirectoryInfo workingDirectory);
+
+    /// <summary>
+    /// Triggers an immediate scan of the backchannels directory for new/removed AppHosts.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the scan operation.</returns>
+    Task ScanAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Aspire.Cli/Mcp/ListAppHostsTool.cs
+++ b/src/Aspire.Cli/Mcp/ListAppHostsTool.cs
@@ -35,12 +35,14 @@ internal sealed class ListAppHostsTool(IAuxiliaryBackchannelMonitor auxiliaryBac
         return JsonDocument.Parse("{ \"type\": \"object\", \"properties\": {} }").RootElement;
     }
 
-    public override ValueTask<CallToolResult> CallToolAsync(ModelContextProtocol.Client.McpClient mcpClient, IReadOnlyDictionary<string, JsonElement>? arguments, CancellationToken cancellationToken)
+    public override async ValueTask<CallToolResult> CallToolAsync(ModelContextProtocol.Client.McpClient mcpClient, IReadOnlyDictionary<string, JsonElement>? arguments, CancellationToken cancellationToken)
     {
         // This tool does not use the MCP client as it operates locally
         _ = mcpClient;
         _ = arguments;
-        _ = cancellationToken;
+
+        // Trigger an immediate scan to ensure we have the latest AppHost connections
+        await auxiliaryBackchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
 
         var workingDirectory = executionContext.WorkingDirectory.FullName;
 
@@ -78,9 +80,9 @@ internal sealed class ListAppHostsTool(IAuxiliaryBackchannelMonitor auxiliaryBac
         var outOfScopeJson = JsonSerializer.Serialize(outOfScopeAppHosts, AppHostListInfoSerializerContext.Default.ListAppHostListInfo);
         responseBuilder.AppendLine(outOfScopeJson);
 
-        return ValueTask.FromResult(new CallToolResult
+        return new CallToolResult
         {
             Content = [new TextContentBlock { Text = responseBuilder.ToString() }]
-        });
+        };
     }
 }

--- a/tests/Aspire.Cli.Tests/Mcp/ListAppHostsToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListAppHostsToolTests.cs
@@ -143,6 +143,26 @@ public class ListAppHostsToolTests(ITestOutputHelper outputHelper)
         Assert.Contains("3333", text);
     }
 
+    [Fact]
+    public async Task ListAppHostsTool_CallsScanAsyncBeforeReturningResults()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var executionContext = CreateCliExecutionContext(workspace.WorkspaceRoot);
+
+        Assert.Equal(0, monitor.ScanCallCount);
+
+        var tool = new ListAppHostsTool(monitor, executionContext);
+        await tool.CallToolAsync(null!, null, CancellationToken.None);
+
+        Assert.Equal(1, monitor.ScanCallCount);
+
+        // Call again to verify it scans each time
+        await tool.CallToolAsync(null!, null, CancellationToken.None);
+
+        Assert.Equal(2, monitor.ScanCallCount);
+    }
+
     private static CliExecutionContext CreateCliExecutionContext(DirectoryInfo workingDirectory)
     {
         var hivesDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "hives"));

--- a/tests/Aspire.Cli.Tests/Mcp/MockPackagingService.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/MockPackagingService.cs
@@ -69,6 +69,8 @@ internal sealed class MockAuxiliaryBackchannelMonitor : IAuxiliaryBackchannelMon
 
     public AppHostAuxiliaryBackchannel? SelectedConnection => null;
 
+    public Task ScanAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
     public IReadOnlyList<AppHostAuxiliaryBackchannel> GetConnectionsForWorkingDirectory(DirectoryInfo workingDirectory)
     {
         // Return empty list by default (no in-scope AppHosts)

--- a/tests/Aspire.Cli.Tests/TestServices/TestAuxiliaryBackchannelMonitor.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAuxiliaryBackchannelMonitor.cs
@@ -13,6 +13,20 @@ internal sealed class TestAuxiliaryBackchannelMonitor : IAuxiliaryBackchannelMon
 
     public string? SelectedAppHostPath { get; set; }
 
+    /// <summary>
+    /// Gets the number of times ScanAsync was called.
+    /// </summary>
+    public int ScanCallCount { get; private set; }
+
+    /// <summary>
+    /// Triggers an immediate scan. In the test implementation, this just increments ScanCallCount.
+    /// </summary>
+    public Task ScanAsync(CancellationToken cancellationToken = default)
+    {
+        ScanCallCount++;
+        return Task.CompletedTask;
+    }
+
     public AppHostAuxiliaryBackchannel? SelectedConnection
     {
         get


### PR DESCRIPTION
## Summary
- Add on-demand AppHost scans for `list_apphosts` and serialize scans with a shared lock
- Keep the backchannel watcher responsive by running connection attempts in parallel while `ScanAsync` awaits results
- Enable polling-based file watching and shorten the socket retry window with exponential backoff
- Avoid blocking scans on disconnect cleanup

## Behavior changes
- `list_apphosts` now waits for connection attempts to complete before returning results
- Background scans remain fire-and-forget to avoid stalling the watcher loop
