### PR TITLE
Treat exit code 143 as equivalent to 0

### DIFF
--- a/extension/src/debugger/adapterTracker.ts
+++ b/extension/src/debugger/adapterTracker.ts
@@ -62,7 +62,7 @@ export function createDebugAdapterTracker(dcpServer: AspireDcpServer, debugAdapt
                         return;
                         }
 
-                        // Exit codes 143 should be treated as normal exits (SIGTERM)
+                        // Exit code 143 should be treated as a normal exit (SIGTERM)
                         if (code === 143) {
                             code = 0;
                         }

--- a/extension/src/debugger/adapterTracker.ts
+++ b/extension/src/debugger/adapterTracker.ts
@@ -62,8 +62,8 @@ export function createDebugAdapterTracker(dcpServer: AspireDcpServer, debugAdapt
                         return;
                         }
 
-                        // Exit codes 143 should be treated as normal exits (SIGTERM)
-                        if (code === 143) {
+                        // Exit codes 143 should be treated as normal exits (SIGTERM) on macOS and Linux
+                        if ((process.platform === 'darwin' || process.platform === 'linux') && code === 143) {
                             code = 0;
                         }
 

--- a/extension/src/debugger/adapterTracker.ts
+++ b/extension/src/debugger/adapterTracker.ts
@@ -62,6 +62,11 @@ export function createDebugAdapterTracker(dcpServer: AspireDcpServer, debugAdapt
                         return;
                         }
 
+                        // Exit codes 143 and 130 should be treated as normal exits (SIGTERM and SIGINT)
+                        if (code === 143 || code === 130) {
+                            code = 0;
+                        }
+
                         const notification: SessionTerminatedNotification = {
                             notification_type: 'sessionTerminated',
                             session_id: session.configuration.runId,

--- a/extension/src/debugger/adapterTracker.ts
+++ b/extension/src/debugger/adapterTracker.ts
@@ -62,8 +62,8 @@ export function createDebugAdapterTracker(dcpServer: AspireDcpServer, debugAdapt
                         return;
                         }
 
-                        // Exit codes 143 and 130 should be treated as normal exits (SIGTERM and SIGINT)
-                        if (code === 143 || code === 130) {
+                        // Exit codes 143 should be treated as normal exits (SIGTERM)
+                        if (code === 143) {
                             code = 0;
                         }
 

--- a/extension/src/test/adapterTracker.test.ts
+++ b/extension/src/test/adapterTracker.test.ts
@@ -1,0 +1,214 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { createDebugAdapterTracker } from '../debugger/adapterTracker';
+import AspireDcpServer from '../dcp/AspireDcpServer';
+import { AspireResourceExtendedDebugConfiguration, SessionTerminatedNotification } from '../dcp/types';
+
+suite('Debug Adapter Tracker Tests', () => {
+    let dcpServer: sinon.SinonStubbedInstance<AspireDcpServer>;
+    let debugSession: vscode.DebugSession;
+    let registerFactoryStub: sinon.SinonStub;
+
+    setup(() => {
+        dcpServer = sinon.createStubInstance(AspireDcpServer);
+
+        // Create a mock debug session with AspireResourceExtendedDebugConfiguration
+        debugSession = {
+            id: 'test-session-1',
+            type: 'coreclr',
+            name: 'Test Session',
+            workspaceFolder: undefined,
+            configuration: {
+                runId: 'run-123',
+                debugSessionId: 'debug-456',
+                type: 'coreclr',
+                name: 'Test Debug Config',
+                request: 'launch'
+            } as AspireResourceExtendedDebugConfiguration,
+            customRequest: sinon.stub(),
+            getDebugProtocolBreakpoint: sinon.stub()
+        };
+
+        // Stub registerDebugAdapterTrackerFactory to record calls and allow .lastCall
+        registerFactoryStub = sinon.stub(vscode.debug, 'registerDebugAdapterTrackerFactory').callsFake((_type, factory) => {
+            // Return a disposable, as expected by the code under test
+            return { dispose: () => {} };
+        });
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('exit code 0 is sent as 0', async () => {
+        const disposable = createDebugAdapterTracker(dcpServer as any, 'coreclr');
+        const factory = registerFactoryStub.lastCall.args[1];
+        const tracker = factory.createDebugAdapterTracker(debugSession);
+
+        // Call onExit with code 0
+        tracker.onExit(0);
+
+        // Verify notification was sent with exit code 0
+        assert.strictEqual(dcpServer.sendNotification.calledOnce, true);
+        const notification = dcpServer.sendNotification.firstCall.args[0] as SessionTerminatedNotification;
+        assert.strictEqual(notification.notification_type, 'sessionTerminated');
+        assert.strictEqual(notification.session_id, 'run-123');
+        assert.strictEqual(notification.dcp_id, 'debug-456');
+        assert.strictEqual(notification.exit_code, 0);
+
+        disposable.dispose();
+    });
+
+    test('exit code 1 is sent as 1', async () => {
+        const disposable = createDebugAdapterTracker(dcpServer as any, 'coreclr');
+        const factory = registerFactoryStub.lastCall.args[1];
+        const tracker = factory.createDebugAdapterTracker(debugSession);
+
+        // Call onExit with code 1
+        tracker.onExit(1);
+
+        // Verify notification was sent with exit code 1
+        assert.strictEqual(dcpServer.sendNotification.calledOnce, true);
+        const notification = dcpServer.sendNotification.firstCall.args[0] as SessionTerminatedNotification;
+        assert.strictEqual(notification.exit_code, 1);
+
+        disposable.dispose();
+    });
+
+    test('exit code 143 on macOS is converted to 0', async () => {
+        // Mock process.platform to return 'darwin'
+        const originalPlatform = process.platform;
+        Object.defineProperty(process, 'platform', {
+            value: 'darwin',
+            configurable: true
+        });
+
+        try {
+            const disposable = createDebugAdapterTracker(dcpServer as any, 'coreclr');
+            const factory = registerFactoryStub.lastCall.args[1];
+            const tracker = factory.createDebugAdapterTracker(debugSession);
+
+            // Call onExit with code 143 (SIGTERM)
+            tracker.onExit(143);
+
+            // Verify notification was sent with exit code 0 (converted from 143)
+            assert.strictEqual(dcpServer.sendNotification.calledOnce, true);
+            const notification = dcpServer.sendNotification.firstCall.args[0] as SessionTerminatedNotification;
+            assert.strictEqual(notification.notification_type, 'sessionTerminated');
+            assert.strictEqual(notification.session_id, 'run-123');
+            assert.strictEqual(notification.dcp_id, 'debug-456');
+            assert.strictEqual(notification.exit_code, 0, 'Exit code 143 should be converted to 0 on macOS');
+
+            disposable.dispose();
+        } finally {
+            // Restore original platform
+            Object.defineProperty(process, 'platform', {
+                value: originalPlatform,
+                configurable: true
+            });
+        }
+    });
+
+    test('exit code 143 on Linux is converted to 0', async () => {
+        // Mock process.platform to return 'linux'
+        const originalPlatform = process.platform;
+        Object.defineProperty(process, 'platform', {
+            value: 'linux',
+            configurable: true
+        });
+
+        try {
+            const disposable = createDebugAdapterTracker(dcpServer as any, 'coreclr');
+            const factory = registerFactoryStub.lastCall.args[1];
+            const tracker = factory.createDebugAdapterTracker(debugSession);
+
+            // Call onExit with code 143 (SIGTERM)
+            tracker.onExit(143);
+
+            // Verify notification was sent with exit code 0 (converted from 143)
+            assert.strictEqual(dcpServer.sendNotification.calledOnce, true);
+            const notification = dcpServer.sendNotification.firstCall.args[0] as SessionTerminatedNotification;
+            assert.strictEqual(notification.exit_code, 0, 'Exit code 143 should be converted to 0 on Linux');
+
+            disposable.dispose();
+        } finally {
+            // Restore original platform
+            Object.defineProperty(process, 'platform', {
+                value: originalPlatform,
+                configurable: true
+            });
+        }
+    });
+
+    test('exit code 143 on Windows is NOT converted', async () => {
+        // Mock process.platform to return 'win32'
+        const originalPlatform = process.platform;
+        Object.defineProperty(process, 'platform', {
+            value: 'win32',
+            configurable: true
+        });
+
+        try {
+            const disposable = createDebugAdapterTracker(dcpServer as any, 'coreclr');
+            const factory = registerFactoryStub.lastCall.args[1];
+            const tracker = factory.createDebugAdapterTracker(debugSession);
+
+            // Call onExit with code 143
+            tracker.onExit(143);
+
+            // Verify notification was sent with exit code 143 (NOT converted on Windows)
+            assert.strictEqual(dcpServer.sendNotification.calledOnce, true);
+            const notification = dcpServer.sendNotification.firstCall.args[0] as SessionTerminatedNotification;
+            assert.strictEqual(notification.exit_code, 143, 'Exit code 143 should NOT be converted to 0 on Windows');
+
+            disposable.dispose();
+        } finally {
+            // Restore original platform
+            Object.defineProperty(process, 'platform', {
+                value: originalPlatform,
+                configurable: true
+            });
+        }
+    });
+
+    test('undefined exit code is sent as 0', async () => {
+        const disposable = createDebugAdapterTracker(dcpServer as any, 'coreclr');
+        const factory = registerFactoryStub.lastCall.args[1];
+        const tracker = factory.createDebugAdapterTracker(debugSession);
+
+        // Call onExit with undefined
+        tracker.onExit(undefined);
+
+        // Verify notification was sent with exit code 0
+        assert.strictEqual(dcpServer.sendNotification.calledOnce, true);
+        const notification = dcpServer.sendNotification.firstCall.args[0] as SessionTerminatedNotification;
+        assert.strictEqual(notification.exit_code, 0);
+
+        disposable.dispose();
+    });
+
+    test('does not send notification if debug session lacks runId', async () => {
+        // Create session without proper configuration
+        const invalidSession = {
+            ...debugSession,
+            configuration: {
+                type: 'coreclr',
+                name: 'Test',
+                request: 'launch'
+            }
+        };
+
+        const disposable = createDebugAdapterTracker(dcpServer as any, 'coreclr');
+        const factory = registerFactoryStub.lastCall.args[1];
+        const tracker = factory.createDebugAdapterTracker(invalidSession);
+
+        // Call onExit
+        tracker.onExit(0);
+
+        // Verify notification was NOT sent
+        assert.strictEqual(dcpServer.sendNotification.called, false);
+
+        disposable.dispose();
+    });
+});

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -2796,6 +2796,11 @@ fs.realpath@^1.0.0:
   resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
+fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/function-bind/-/function-bind-1.1.2.tgz"


### PR DESCRIPTION
## Description

According to [this](https://komodor.com/learn/exit-codes-in-containers-and-kubernetes-the-complete-guide/), graceful termination in the context of Kubernetes indicates success. 

The extension is receiving exit code 143 (seemingly related to https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/10.0/sigterm-signal-handler). The suggestion in the article is to handle SIGTERM at a higher level. In this case, it would be the adapter tracker.

Fixes #12965

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
