### PR TITLE
By default, redact environment variables from debug configuration logging

### DIFF
--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -151,6 +151,9 @@
     <trans-unit id="aspire-vscode.strings.failedToStartProject">
       <source xml:lang="en">Failed to start project: {0}.</source>
     </trans-unit>
+    <trans-unit id="configuration.aspire.enableDebugConfigEnvironmentLogging">
+      <source xml:lang="en">Include environment variables when logging debug session configurations. This can help diagnose environment-related issues but may expose sensitive information in logs.</source>
+    </trans-unit>
     <trans-unit id="command.init">
       <source xml:lang="en">Initialize Aspire</source>
     </trans-unit>

--- a/extension/package.json
+++ b/extension/package.json
@@ -211,6 +211,12 @@
           "default": true,
           "description": "%configuration.aspire.enableAspireDashboardAutoLaunch%",
           "scope": "window"
+        },
+        "aspire.enableDebugConfigEnvironmentLogging": {
+          "type": "boolean",
+          "default": false,
+          "description": "%configuration.aspire.enableDebugConfigEnvironmentLogging%",
+          "scope": "window"
         }
       }
     }

--- a/extension/package.json
+++ b/extension/package.json
@@ -214,7 +214,7 @@
         },
         "aspire.enableDebugConfigEnvironmentLogging": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "%configuration.aspire.enableDebugConfigEnvironmentLogging%",
           "scope": "window"
         }

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -20,6 +20,7 @@
   "configuration.aspire.enableAspireCliDebugLogging": "Enable console debug logging for Aspire CLI commands executed by the extension.",
   "configuration.aspire.enableAspireDcpDebugLogging": "Enable Developer Control Plane (DCP) debug logging for Aspire applications. Logs will be stored in the workspace's .aspire/dcp/logs-{debugSessionId} folder.",
   "configuration.aspire.enableAspireDashboardAutoLaunch": "Enable automatic launch of the Aspire Dashboard when using the Aspire debugger.",
+  "configuration.aspire.enableDebugConfigEnvironmentLogging": "Include environment variables when logging debug session configurations. This can help diagnose environment-related issues but may expose sensitive information in logs.",
   "command.runAppHost": "Run Aspire apphost",
 	"command.debugAppHost": "Debug Aspire apphost",
 	"aspire-vscode.strings.noCsprojFound": "No apphost found in the current workspace.",

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -236,7 +236,10 @@ export class AspireDebugSession implements vscode.DebugAdapter {
 
   async startAndGetDebugSession(debugConfig: AspireResourceExtendedDebugConfiguration): Promise<AspireResourceDebugSession | undefined> {
     return new Promise(async (resolve) => {
-      extensionLogOutputChannel.info(`Starting debug session with configuration: ${JSON.stringify(debugConfig)}`);
+      const logConfig = this._terminalProvider.isDebugConfigEnvironmentLoggingEnabled()
+        ? debugConfig
+        : { ...debugConfig, env: debugConfig.env ? '<redacted>' : undefined };
+      extensionLogOutputChannel.info(`Starting debug session with configuration: ${JSON.stringify(logConfig)}`);
       this.createDebugAdapterTrackerCore(debugConfig.type);
 
       const disposable = vscode.debug.onDidStartDebugSession(session => {

--- a/extension/src/utils/AspireTerminalProvider.ts
+++ b/extension/src/utils/AspireTerminalProvider.ts
@@ -213,4 +213,8 @@ export class AspireTerminalProvider implements vscode.Disposable {
     isCliDebugLoggingEnabled(): boolean {
         return vscode.workspace.getConfiguration('aspire').get<boolean>('enableAspireCliDebugLogging', false);
     }
+
+    isDebugConfigEnvironmentLoggingEnabled(): boolean {
+        return vscode.workspace.getConfiguration('aspire').get<boolean>('enableDebugConfigEnvironmentLogging', false);
+    }
 }


### PR DESCRIPTION
## Description

Environment variables are sensitive and we should make it easier and more comfortable for people to share logs after they run into issues. This setting is off by default but can be turned on.

Fixes #13885 

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
