### PR TITLE
Don't await the app host workspace check in extension

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -80,7 +80,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const getEnableSettingsFileCreationPromptOnStartup = () => vscode.workspace.getConfiguration('aspire').get<boolean>('enableSettingsFileCreationPromptOnStartup', true);
   const setEnableSettingsFileCreationPromptOnStartup = async (value: boolean) => await vscode.workspace.getConfiguration('aspire').update('enableSettingsFileCreationPromptOnStartup', value, vscode.ConfigurationTarget.Workspace);
-  pushNullableSubscription(await checkForExistingAppHostPathInWorkspace(terminalProvider, getEnableSettingsFileCreationPromptOnStartup, setEnableSettingsFileCreationPromptOnStartup), context);
+  checkForExistingAppHostPathInWorkspace(terminalProvider, getEnableSettingsFileCreationPromptOnStartup, setEnableSettingsFileCreationPromptOnStartup);
 
   // Return exported API for tests or other extensions
   return {
@@ -110,11 +110,5 @@ async function tryExecuteCommand(commandName: string, terminalProvider: AspireTe
   }
   catch (error) {
     vscode.window.showErrorMessage(errorMessage(error));
-  }
-}
-
-function pushNullableSubscription(subscription: vscode.Disposable | null, context: vscode.ExtensionContext) {
-  if (subscription) {
-    context.subscriptions.push(subscription);
   }
 }


### PR DESCRIPTION
## Description

Awaiting this call can cause the extension to not load for minutes or seconds, depending on the size of the workspace.

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
