### PR TITLE
Change download JSON button to view JSON. Download or copy from visualizer

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ExceptionDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ExceptionDetails.razor
@@ -29,6 +29,13 @@
 
     private async Task OnExceptionDetailsClickedAsync()
     {
-        await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, Loc[nameof(ControlsStrings.ExceptionDetailsTitle)], ExceptionText, containsSecret: false);
+        await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
+        {
+            ViewportInformation = ViewportInformation,
+            DialogService = DialogService,
+            DialogsLoc = DialogsLoc,
+            ValueDescription = Loc[nameof(ControlsStrings.ExceptionDetailsTitle)],
+            Value = ExceptionText
+        });
     }
 }

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.cs
@@ -160,7 +160,15 @@ public partial class GridValue
 
     private async Task OpenTextVisualizerAsync()
     {
-        await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, ValueDescription, ValueToVisualize ?? Value ?? string.Empty, IsMasked || ContainsSecret);
+        await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
+        {
+            ViewportInformation = ViewportInformation,
+            DialogService = DialogService,
+            DialogsLoc = DialogsLoc,
+            ValueDescription = ValueDescription,
+            Value = ValueToVisualize ?? Value ?? string.Empty,
+            ContainsSecret = IsMasked || ContainsSecret
+        });
     }
 
     private Dictionary<string, object> BuildComponentParameters()

--- a/src/Aspire.Dashboard/Components/Controls/SpanActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanActions.razor.cs
@@ -85,7 +85,7 @@ public partial class SpanActions : ComponentBase
 
         _menuItems.Add(new MenuButtonItem
         {
-            Text = ControlsLoc[nameof(ControlsStrings.SpanJson)],
+            Text = ControlsLoc[nameof(ControlsStrings.ExportJson)],
             Icon = s_bracesIcon,
             OnClick = async () =>
             {

--- a/src/Aspire.Dashboard/Components/Controls/SpanActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanActions.razor.cs
@@ -90,7 +90,15 @@ public partial class SpanActions : ComponentBase
             OnClick = async () =>
             {
                 var result = TelemetryExportHelpers.GetSpanAsJson(SpanViewModel.Span, TelemetryRepository);
-                await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, result.FileName, result.Json, containsSecret: false, result.FileName);
+                await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
+                {
+                    ViewportInformation = ViewportInformation,
+                    DialogService = DialogService,
+                    DialogsLoc = DialogsLoc,
+                    ValueDescription = result.FileName,
+                    Value = result.Json,
+                    DownloadFileName = result.FileName
+                });
             }
         });
 

--- a/src/Aspire.Dashboard/Components/Controls/SpanActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanActions.razor.cs
@@ -90,7 +90,7 @@ public partial class SpanActions : ComponentBase
             OnClick = async () =>
             {
                 var result = TelemetryExportHelpers.GetSpanAsJson(SpanViewModel.Span, TelemetryRepository);
-                await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, ControlsLoc[nameof(ControlsStrings.SpanJson)], result.Json, containsSecret: false, result.FileName);
+                await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, result.FileName, result.Json, containsSecret: false, result.FileName);
             }
         });
 

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Components.Controls.PropertyValues;
+using Aspire.Dashboard.Components.Dialogs;
 using Aspire.Dashboard.Components.Pages;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Assistant;
@@ -21,7 +22,7 @@ namespace Aspire.Dashboard.Components.Controls;
 
 public partial class SpanDetails : IDisposable
 {
-    private static readonly Icon s_downloadIcon = new Icons.Regular.Size16.ArrowDownload();
+    private static readonly Icon s_bracesIcon = new Icons.Regular.Size16.Braces();
     
     [Parameter, EditorRequired]
     public required SpanDetailsViewModel ViewModel { get; set; }
@@ -52,6 +53,9 @@ public partial class SpanDetails : IDisposable
 
     [Inject]
     public required ComponentTelemetryContextProvider TelemetryContextProvider { get; init; }
+
+    [CascadingParameter]
+    public required ViewportInformation ViewportInformation { get; set; }
 
     private IQueryable<TelemetryPropertyViewModel> FilteredItems =>
         ViewModel.Properties.Where(ApplyFilter).AsQueryable();
@@ -130,9 +134,13 @@ public partial class SpanDetails : IDisposable
 
         _spanActionsMenuItems.Add(new MenuButtonItem
         {
-            Text = Loc[nameof(ControlsStrings.DownloadJson)],
-            Icon = s_downloadIcon,
-            OnClick = () => TelemetryExportHelpers.DownloadSpanAsJsonAsync(JS, ViewModel.Span, TelemetryRepository)
+            Text = Loc[nameof(ControlsStrings.SpanJson)],
+            Icon = s_bracesIcon,
+            OnClick = async () =>
+            {
+                var result = TelemetryExportHelpers.GetSpanAsJson(ViewModel.Span, TelemetryRepository);
+                await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, Loc[nameof(ControlsStrings.SpanJson)], result.Json, containsSecret: false, result.FileName);
+            }
         });
     }
 

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
@@ -139,7 +139,7 @@ public partial class SpanDetails : IDisposable
             OnClick = async () =>
             {
                 var result = TelemetryExportHelpers.GetSpanAsJson(ViewModel.Span, TelemetryRepository);
-                await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, Loc[nameof(ControlsStrings.SpanJson)], result.Json, containsSecret: false, result.FileName);
+                await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, result.FileName, result.Json, containsSecret: false, result.FileName);
             }
         });
     }

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
@@ -134,7 +134,7 @@ public partial class SpanDetails : IDisposable
 
         _spanActionsMenuItems.Add(new MenuButtonItem
         {
-            Text = Loc[nameof(ControlsStrings.SpanJson)],
+            Text = Loc[nameof(ControlsStrings.ExportJson)],
             Icon = s_bracesIcon,
             OnClick = async () =>
             {

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
@@ -139,7 +139,15 @@ public partial class SpanDetails : IDisposable
             OnClick = async () =>
             {
                 var result = TelemetryExportHelpers.GetSpanAsJson(ViewModel.Span, TelemetryRepository);
-                await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, result.FileName, result.Json, containsSecret: false, result.FileName);
+                await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
+                {
+                    ViewportInformation = ViewportInformation,
+                    DialogService = DialogService,
+                    DialogsLoc = DialogsLoc,
+                    ValueDescription = result.FileName,
+                    Value = result.Json,
+                    DownloadFileName = result.FileName
+                });
             }
         });
     }

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogActions.razor.cs
@@ -11,7 +11,6 @@ using Aspire.Dashboard.Resources;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
 using Microsoft.FluentUI.AspNetCore.Components;
-using Microsoft.JSInterop;
 using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 namespace Aspire.Dashboard.Components;
@@ -20,8 +19,8 @@ public partial class StructuredLogActions : ComponentBase
 {
     private static readonly Icon s_viewDetailsIcon = new Icons.Regular.Size16.Info();
     private static readonly Icon s_messageOpenIcon = new Icons.Regular.Size16.Open();
+    private static readonly Icon s_bracesIcon = new Icons.Regular.Size16.Braces();
     private static readonly Icon s_gitHubCopilotIcon = new AspireIcons.Size16.GitHubCopilot();
-    private static readonly Icon s_downloadIcon = new Icons.Regular.Size16.ArrowDownload();
 
     private AspireMenuButton? _menuButton;
 
@@ -45,9 +44,6 @@ public partial class StructuredLogActions : ComponentBase
 
     [Inject]
     public required IAIContextProvider AIContextProvider { get; set; }
-
-    [Inject]
-    public required IJSRuntime JS { get; init; }
 
     [Parameter]
     public required EventCallback<string> OnViewDetails { get; set; }
@@ -83,9 +79,13 @@ public partial class StructuredLogActions : ComponentBase
 
         _menuItems.Add(new MenuButtonItem
         {
-            Text = ControlsLoc[nameof(ControlsStrings.DownloadJson)],
-            Icon = s_downloadIcon,
-            OnClick = () => TelemetryExportHelpers.DownloadLogEntryAsJsonAsync(JS, LogEntry)
+            Text = ControlsLoc[nameof(ControlsStrings.LogJson)],
+            Icon = s_bracesIcon,
+            OnClick = async () =>
+            {
+                var result = TelemetryExportHelpers.GetLogEntryAsJson(LogEntry);
+                await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, ControlsLoc[nameof(ControlsStrings.LogJson)], result.Json, containsSecret: false, result.FileName);
+            }
         });
 
         if (AIContextProvider.Enabled)

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogActions.razor.cs
@@ -73,7 +73,14 @@ public partial class StructuredLogActions : ComponentBase
             OnClick = async () =>
             {
                 var header = Loc[nameof(Resources.StructuredLogs.StructuredLogsMessageColumnHeader)];
-                await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, header, LogEntry.Message, containsSecret: false);
+                await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
+                {
+                    ViewportInformation = ViewportInformation,
+                    DialogService = DialogService,
+                    DialogsLoc = DialogsLoc,
+                    ValueDescription = header,
+                    Value = LogEntry.Message
+                });
             }
         });
 
@@ -84,7 +91,15 @@ public partial class StructuredLogActions : ComponentBase
             OnClick = async () =>
             {
                 var result = TelemetryExportHelpers.GetLogEntryAsJson(LogEntry);
-                await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, result.FileName, result.Json, containsSecret: false, result.FileName);
+                await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
+                {
+                    ViewportInformation = ViewportInformation,
+                    DialogService = DialogService,
+                    DialogsLoc = DialogsLoc,
+                    ValueDescription = result.FileName,
+                    Value = result.Json,
+                    DownloadFileName = result.FileName
+                });
             }
         });
 

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogActions.razor.cs
@@ -86,7 +86,7 @@ public partial class StructuredLogActions : ComponentBase
 
         _menuItems.Add(new MenuButtonItem
         {
-            Text = ControlsLoc[nameof(ControlsStrings.LogJson)],
+            Text = ControlsLoc[nameof(ControlsStrings.ExportJson)],
             Icon = s_bracesIcon,
             OnClick = async () =>
             {

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogActions.razor.cs
@@ -84,7 +84,7 @@ public partial class StructuredLogActions : ComponentBase
             OnClick = async () =>
             {
                 var result = TelemetryExportHelpers.GetLogEntryAsJson(LogEntry);
-                await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, ControlsLoc[nameof(ControlsStrings.LogJson)], result.Json, containsSecret: false, result.FileName);
+                await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, result.FileName, result.Json, containsSecret: false, result.FileName);
             }
         });
 

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
@@ -165,7 +165,7 @@ public partial class StructuredLogDetails : IDisposable
             OnClick = async () =>
             {
                 var result = TelemetryExportHelpers.GetLogEntryAsJson(ViewModel.LogEntry);
-                await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, Loc[nameof(ControlsStrings.LogJson)], result.Json, containsSecret: false, result.FileName);
+                await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, result.FileName, result.Json, containsSecret: false, result.FileName);
             }
         });
     }

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
@@ -165,7 +165,15 @@ public partial class StructuredLogDetails : IDisposable
             OnClick = async () =>
             {
                 var result = TelemetryExportHelpers.GetLogEntryAsJson(ViewModel.LogEntry);
-                await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, result.FileName, result.Json, containsSecret: false, result.FileName);
+                await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
+                {
+                    ViewportInformation = ViewportInformation,
+                    DialogService = DialogService,
+                    DialogsLoc = DialogsLoc,
+                    ValueDescription = result.FileName,
+                    Value = result.Json,
+                    DownloadFileName = result.FileName
+                });
             }
         });
     }

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
@@ -160,7 +160,7 @@ public partial class StructuredLogDetails : IDisposable
 
         _logActionsMenuItems.Add(new MenuButtonItem
         {
-            Text = Loc[nameof(ControlsStrings.LogJson)],
+            Text = Loc[nameof(ControlsStrings.ExportJson)],
             Icon = s_bracesIcon,
             OnClick = async () =>
             {

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Components.Controls.PropertyValues;
+using Aspire.Dashboard.Components.Dialogs;
 using Aspire.Dashboard.Components.Pages;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Assistant;
@@ -9,6 +10,7 @@ using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Telemetry;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.JSInterop;
 using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
@@ -17,7 +19,7 @@ namespace Aspire.Dashboard.Components.Controls;
 
 public partial class StructuredLogDetails : IDisposable
 {
-    private static readonly Icon s_downloadIcon = new Icons.Regular.Size16.ArrowDownload();
+    private static readonly Icon s_bracesIcon = new Icons.Regular.Size16.Braces();
 
     [Parameter, EditorRequired]
     public required StructureLogsDetailsViewModel ViewModel { get; set; }
@@ -36,6 +38,15 @@ public partial class StructuredLogDetails : IDisposable
 
     [Inject]
     public required ComponentTelemetryContextProvider TelemetryContextProvider { get; init; }
+
+    [Inject]
+    public required IDialogService DialogService { get; init; }
+
+    [Inject]
+    public required IStringLocalizer<Resources.Dialogs> DialogsLoc { get; init; }
+
+    [CascadingParameter]
+    public required ViewportInformation ViewportInformation { get; set; }
 
     internal IQueryable<TelemetryPropertyViewModel> FilteredItems =>
         _logEntryAttributes.Where(ApplyFilter).AsQueryable();
@@ -149,9 +160,13 @@ public partial class StructuredLogDetails : IDisposable
 
         _logActionsMenuItems.Add(new MenuButtonItem
         {
-            Text = Loc[nameof(ControlsStrings.DownloadJson)],
-            Icon = s_downloadIcon,
-            OnClick = () => TelemetryExportHelpers.DownloadLogEntryAsJsonAsync(JS, ViewModel.LogEntry)
+            Text = Loc[nameof(ControlsStrings.LogJson)],
+            Icon = s_bracesIcon,
+            OnClick = async () =>
+            {
+                var result = TelemetryExportHelpers.GetLogEntryAsJson(ViewModel.LogEntry);
+                await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, Loc[nameof(ControlsStrings.LogJson)], result.Json, containsSecret: false, result.FileName);
+            }
         });
     }
 

--- a/src/Aspire.Dashboard/Components/Controls/TraceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/TraceActions.razor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Components.CustomIcons;
+using Aspire.Dashboard.Components.Dialogs;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Assistant;
 using Aspire.Dashboard.Model.Assistant.Prompts;
@@ -12,7 +13,6 @@ using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
 using Microsoft.FluentUI.AspNetCore.Components;
-using Microsoft.JSInterop;
 using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 namespace Aspire.Dashboard.Components;
@@ -22,7 +22,7 @@ public partial class TraceActions : ComponentBase
     private static readonly Icon s_viewDetailsIcon = new Icons.Regular.Size16.Info();
     private static readonly Icon s_structuredLogsIcon = new Icons.Regular.Size16.SlideTextSparkle();
     private static readonly Icon s_gitHubCopilotIcon = new AspireIcons.Size16.GitHubCopilot();
-    private static readonly Icon s_downloadIcon = new Icons.Regular.Size16.ArrowDownload();
+    private static readonly Icon s_bracesIcon = new Icons.Regular.Size16.Braces();
 
     private AspireMenuButton? _menuButton;
 
@@ -36,19 +36,25 @@ public partial class TraceActions : ComponentBase
     public required IStringLocalizer<Resources.AIPrompts> AIPromptsLoc { get; init; }
 
     [Inject]
+    public required IStringLocalizer<Resources.Dialogs> DialogsLoc { get; init; }
+
+    [Inject]
     public required NavigationManager NavigationManager { get; init; }
 
     [Inject]
     public required IAIContextProvider AIContextProvider { get; init; }
 
     [Inject]
-    public required IJSRuntime JS { get; init; }
+    public required IDialogService DialogService { get; init; }
 
     [Inject]
     public required TelemetryRepository TelemetryRepository { get; init; }
 
     [Parameter]
     public required OtlpTrace Trace { get; set; }
+
+    [CascadingParameter]
+    public required ViewportInformation ViewportInformation { get; set; }
 
     private readonly List<MenuButtonItem> _menuItems = new();
 
@@ -79,9 +85,13 @@ public partial class TraceActions : ComponentBase
 
         _menuItems.Add(new MenuButtonItem
         {
-            Text = ControlsLoc[nameof(ControlsStrings.DownloadJson)],
-            Icon = s_downloadIcon,
-            OnClick = () => TelemetryExportHelpers.DownloadTraceAsJsonAsync(JS, Trace, TelemetryRepository)
+            Text = ControlsLoc[nameof(ControlsStrings.TraceJson)],
+            Icon = s_bracesIcon,
+            OnClick = async () =>
+            {
+                var result = TelemetryExportHelpers.GetTraceAsJson(Trace, TelemetryRepository);
+                await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, ControlsLoc[nameof(ControlsStrings.TraceJson)], result.Json, containsSecret: false, result.FileName);
+            }
         });
 
         if (AIContextProvider.Enabled)

--- a/src/Aspire.Dashboard/Components/Controls/TraceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/TraceActions.razor.cs
@@ -90,7 +90,15 @@ public partial class TraceActions : ComponentBase
             OnClick = async () =>
             {
                 var result = TelemetryExportHelpers.GetTraceAsJson(Trace, TelemetryRepository);
-                await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, result.FileName, result.Json, containsSecret: false, result.FileName);
+                await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
+                {
+                    ViewportInformation = ViewportInformation,
+                    DialogService = DialogService,
+                    DialogsLoc = DialogsLoc,
+                    ValueDescription = result.FileName,
+                    Value = result.Json,
+                    DownloadFileName = result.FileName
+                });
             }
         });
 

--- a/src/Aspire.Dashboard/Components/Controls/TraceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/TraceActions.razor.cs
@@ -90,7 +90,7 @@ public partial class TraceActions : ComponentBase
             OnClick = async () =>
             {
                 var result = TelemetryExportHelpers.GetTraceAsJson(Trace, TelemetryRepository);
-                await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, ControlsLoc[nameof(ControlsStrings.TraceJson)], result.Json, containsSecret: false, result.FileName);
+                await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, result.FileName, result.Json, containsSecret: false, result.FileName);
             }
         });
 

--- a/src/Aspire.Dashboard/Components/Controls/TraceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/TraceActions.razor.cs
@@ -85,7 +85,7 @@ public partial class TraceActions : ComponentBase
 
         _menuItems.Add(new MenuButtonItem
         {
-            Text = ControlsLoc[nameof(ControlsStrings.TraceJson)],
+            Text = ControlsLoc[nameof(ControlsStrings.ExportJson)],
             Icon = s_bracesIcon,
             OnClick = async () =>
             {

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
@@ -58,15 +58,31 @@
                 </FluentButton>
             }
 
-            <FluentButton Id="@_copyButtonId"
-                          Class="text-visualizer-copy"
-                          AdditionalAttributes="@FluentUIExtensions.GetClipboardCopyAdditionalAttributes(TextVisualizerViewModel.FormattedText, ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)], ControlsStringsLoc[nameof(ControlsStrings.GridValueCopied)])">
-                <span slot="start">
-                    <FluentIcon Class="copy-icon" Style="display:inline; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Copy" Slot="start" />
-                    <FluentIcon Class="checkmark-icon" Style="display:none; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Checkmark" Slot="start" />
+            <div class="button-container-right">
+                @if (Content.DownloadFileName is not null)
+                {
+                    <FluentButton Id="@_downloadButtonId"
+                                  Class="text-visualizer-download"
+                                  OnClick="@DownloadAsync"
+                                  Title="@ControlsStringsLoc[nameof(ControlsStrings.Download)]"
+                                  aria-label="@ControlsStringsLoc[nameof(ControlsStrings.Download)]">
+                        <span slot="start">
+                            <FluentIcon Style="display:inline; vertical-align: text-bottom" Icon="Icons.Regular.Size16.ArrowDownload" Slot="start" />
+                        </span>
+                        @ControlsStringsLoc[nameof(ControlsStrings.Download)]
+                    </FluentButton>
+                }
+
+                <FluentButton Id="@_copyButtonId"
+                              Class="text-visualizer-copy"
+                              AdditionalAttributes="@FluentUIExtensions.GetClipboardCopyAdditionalAttributes(TextVisualizerViewModel.FormattedText, ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)], ControlsStringsLoc[nameof(ControlsStrings.GridValueCopied)])">
+                    <span slot="start">
+                        <FluentIcon Class="copy-icon" Style="display:inline; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Copy" Slot="start" />
+                        <FluentIcon Class="checkmark-icon" Style="display:none; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Checkmark" Slot="start" />
                 </span>
                 @ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)]
             </FluentButton>
+            </div>
         </div>
     </div>
 </FluentDialogBody>

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
@@ -61,27 +61,22 @@
             <div class="button-container-right">
                 @if (Content.DownloadFileName is not null)
                 {
-                    <FluentButton Id="@_downloadButtonId"
-                                  Class="text-visualizer-download"
-                                  OnClick="@DownloadAsync"
+                    <FluentButton OnClick="@DownloadAsync"
                                   Title="@ControlsStringsLoc[nameof(ControlsStrings.Download)]"
-                                  aria-label="@ControlsStringsLoc[nameof(ControlsStrings.Download)]">
-                        <span slot="start">
-                            <FluentIcon Style="display:inline; vertical-align: text-bottom" Icon="Icons.Regular.Size16.ArrowDownload" Slot="start" />
-                        </span>
+                                  aria-label="@ControlsStringsLoc[nameof(ControlsStrings.Download)]"
+                                  IconStart="new Icons.Regular.Size16.ArrowDownload()">
                         @ControlsStringsLoc[nameof(ControlsStrings.Download)]
                     </FluentButton>
                 }
 
                 <FluentButton Id="@_copyButtonId"
-                              Class="text-visualizer-copy"
                               AdditionalAttributes="@FluentUIExtensions.GetClipboardCopyAdditionalAttributes(TextVisualizerViewModel.FormattedText, ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)], ControlsStringsLoc[nameof(ControlsStrings.GridValueCopied)])">
                     <span slot="start">
                         <FluentIcon Class="copy-icon" Style="display:inline; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Copy" Slot="start" />
                         <FluentIcon Class="checkmark-icon" Style="display:none; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Checkmark" Slot="start" />
-                </span>
-                @ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)]
-            </FluentButton>
+                    </span>
+                    @ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)]
+                </FluentButton>
             </div>
         </div>
     </div>

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
@@ -14,7 +14,6 @@ namespace Aspire.Dashboard.Components.Dialogs;
 public partial class TextVisualizerDialog : ComponentBase
 {
     private readonly string _copyButtonId = $"copy-{Guid.NewGuid():N}";
-    private readonly string _downloadButtonId = $"download-{Guid.NewGuid():N}";
     private readonly string _openSelectFormatButtonId = $"select-format-{Guid.NewGuid():N}";
 
     private List<SelectViewModel<string>> _options = null!;

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
@@ -5,7 +5,6 @@ using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.Localization;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.JSInterop;
 
@@ -92,22 +91,21 @@ public partial class TextVisualizerDialog : ComponentBase
         TextVisualizerViewModel.UpdateFormat(newFormat ?? DashboardUIHelpers.PlaintextFormat);
     }
 
-    public static async Task OpenDialogAsync(ViewportInformation viewportInformation, IDialogService dialogService,
-        IStringLocalizer<Resources.Dialogs> dialogsLoc, string valueDescription, string value, bool containsSecret, string? downloadFileName = null)
+    public static async Task OpenDialogAsync(OpenTextVisualizerDialogOptions options)
     {
-        var width = viewportInformation.IsDesktop ? "75vw" : "100vw";
+        var width = options.ViewportInformation.IsDesktop ? "75vw" : "100vw";
         var parameters = new DialogParameters
         {
-            Title = valueDescription,
-            DismissTitle = dialogsLoc[nameof(Resources.Dialogs.DialogCloseButtonText)],
+            Title = options.ValueDescription,
+            DismissTitle = options.DialogsLoc[nameof(Resources.Dialogs.DialogCloseButtonText)],
             Width = $"min(1000px, {width})",
             TrapFocus = true,
             Modal = true,
             PreventScroll = true,
         };
 
-        await dialogService.ShowDialogAsync<TextVisualizerDialog>(
-            new TextVisualizerDialogViewModel(value, valueDescription, containsSecret, downloadFileName), parameters);
+        await options.DialogService.ShowDialogAsync<TextVisualizerDialog>(
+            new TextVisualizerDialogViewModel(options.Value, options.ValueDescription, options.ContainsSecret, options.DownloadFileName), parameters);
     }
 
     private async Task DownloadAsync()

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.css
@@ -17,7 +17,9 @@
     margin-left: 0;
 }
 
-.text-visualizer-container ::deep.text-visualizer-copy {
+.text-visualizer-container ::deep.button-container-right {
+    display: flex;
+    gap: 8px;
     margin-left: auto;
 }
 

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -158,7 +158,15 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
                 if (_trace is not null)
                 {
                     var result = TelemetryExportHelpers.GetTraceAsJson(_trace, TelemetryRepository);
-                    await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, result.FileName, result.Json, containsSecret: false, result.FileName);
+                    await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
+                    {
+                        ViewportInformation = ViewportInformation,
+                        DialogService = DialogService,
+                        DialogsLoc = DialogsLoc,
+                        ValueDescription = result.FileName,
+                        Value = result.Json,
+                        DownloadFileName = result.FileName
+                    });
                 }
             },
             IsDisabled = _trace is null

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -25,7 +25,7 @@ namespace Aspire.Dashboard.Components.Pages;
 
 public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisposable
 {
-    private static readonly Icon s_downloadIcon = new Icons.Regular.Size16.ArrowDownload();
+    private static readonly Icon s_bracesIcon = new Icons.Regular.Size16.Braces();
 
     private const string NameColumn = nameof(NameColumn);
     private const string ResourceColumn = nameof(ResourceColumn);
@@ -148,12 +148,19 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
             }
         });
 
-        // Add "Download JSON"
+        // Add "Trace JSON"
         _traceActionsMenuItems.Add(new MenuButtonItem
         {
-            Text = ControlStringsLoc[nameof(ControlsStrings.DownloadJson)],
-            Icon = s_downloadIcon,
-            OnClick = () => _trace is not null ? TelemetryExportHelpers.DownloadTraceAsJsonAsync(JS, _trace, TelemetryRepository) : Task.CompletedTask,
+            Text = ControlStringsLoc[nameof(ControlsStrings.TraceJson)],
+            Icon = s_bracesIcon,
+            OnClick = async () =>
+            {
+                if (_trace is not null)
+                {
+                    var result = TelemetryExportHelpers.GetTraceAsJson(_trace, TelemetryRepository);
+                    await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, ControlStringsLoc[nameof(ControlsStrings.TraceJson)], result.Json, containsSecret: false, result.FileName);
+                }
+            },
             IsDisabled = _trace is null
         });
 

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -151,7 +151,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
         // Add "Trace JSON"
         _traceActionsMenuItems.Add(new MenuButtonItem
         {
-            Text = ControlStringsLoc[nameof(ControlsStrings.TraceJson)],
+            Text = ControlStringsLoc[nameof(ControlsStrings.ExportJson)],
             Icon = s_bracesIcon,
             OnClick = async () =>
             {

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -158,7 +158,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
                 if (_trace is not null)
                 {
                     var result = TelemetryExportHelpers.GetTraceAsJson(_trace, TelemetryRepository);
-                    await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, ControlStringsLoc[nameof(ControlsStrings.TraceJson)], result.Json, containsSecret: false, result.FileName);
+                    await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, DialogsLoc, result.FileName, result.Json, containsSecret: false, result.FileName);
                 }
             },
             IsDisabled = _trace is null

--- a/src/Aspire.Dashboard/Model/OpenTextVisualizerDialogOptions.cs
+++ b/src/Aspire.Dashboard/Model/OpenTextVisualizerDialogOptions.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Localization;
+using Microsoft.FluentUI.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Model;
+
+/// <summary>
+/// Options for opening the text visualizer dialog.
+/// </summary>
+public sealed class OpenTextVisualizerDialogOptions
+{
+    public required ViewportInformation ViewportInformation { get; init; }
+    public required IDialogService DialogService { get; init; }
+    public required IStringLocalizer<Resources.Dialogs> DialogsLoc { get; init; }
+    public required string ValueDescription { get; init; }
+    public required string Value { get; init; }
+    public bool ContainsSecret { get; init; }
+    public string? DownloadFileName { get; init; }
+}

--- a/src/Aspire.Dashboard/Model/TelemetryExportHelpers.cs
+++ b/src/Aspire.Dashboard/Model/TelemetryExportHelpers.cs
@@ -1,12 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
-using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Model;
+
+/// <summary>
+/// Represents the result of exporting telemetry data to JSON.
+/// </summary>
+/// <param name="Json">The JSON representation of the telemetry data.</param>
+/// <param name="FileName">The suggested file name for downloading the JSON.</param>
+internal sealed record TelemetryJsonExportResult(string Json, string FileName);
 
 /// <summary>
 /// Helper methods for exporting telemetry data.
@@ -14,42 +19,42 @@ namespace Aspire.Dashboard.Model;
 internal static class TelemetryExportHelpers
 {
     /// <summary>
-    /// Downloads a span as a JSON file, including associated log entries.
+    /// Gets a span as a JSON export result, including associated log entries.
     /// </summary>
-    /// <param name="js">The JS runtime.</param>
-    /// <param name="span">The span to download.</param>
+    /// <param name="span">The span to convert.</param>
     /// <param name="telemetryRepository">The telemetry repository to fetch logs from.</param>
-    public static Task DownloadSpanAsJsonAsync(IJSRuntime js, OtlpSpan span, TelemetryRepository telemetryRepository)
+    /// <returns>A result containing the JSON representation and suggested file name.</returns>
+    public static TelemetryJsonExportResult GetSpanAsJson(OtlpSpan span, TelemetryRepository telemetryRepository)
     {
         var logs = telemetryRepository.GetLogsForSpan(span.TraceId, span.SpanId);
-        var spanJson = TelemetryExportService.ConvertSpanToJson(span, logs);
+        var json = TelemetryExportService.ConvertSpanToJson(span, logs);
         var fileName = $"span-{OtlpHelpers.ToShortenedId(span.SpanId)}.json";
-        return js.DownloadFileAsync(fileName, spanJson);
+        return new TelemetryJsonExportResult(json, fileName);
     }
 
     /// <summary>
-    /// Downloads a log entry as a JSON file.
+    /// Gets a log entry as a JSON export result.
     /// </summary>
-    /// <param name="js">The JS runtime.</param>
-    /// <param name="logEntry">The log entry to download.</param>
-    public static Task DownloadLogEntryAsJsonAsync(IJSRuntime js, OtlpLogEntry logEntry)
+    /// <param name="logEntry">The log entry to convert.</param>
+    /// <returns>A result containing the JSON representation and suggested file name.</returns>
+    public static TelemetryJsonExportResult GetLogEntryAsJson(OtlpLogEntry logEntry)
     {
-        var logJson = TelemetryExportService.ConvertLogEntryToJson(logEntry);
+        var json = TelemetryExportService.ConvertLogEntryToJson(logEntry);
         var fileName = $"log-{logEntry.InternalId}.json";
-        return js.DownloadFileAsync(fileName, logJson);
+        return new TelemetryJsonExportResult(json, fileName);
     }
 
     /// <summary>
-    /// Downloads all spans in a trace as a JSON file, including associated log entries.
+    /// Gets all spans in a trace as a JSON export result, including associated log entries.
     /// </summary>
-    /// <param name="js">The JS runtime.</param>
-    /// <param name="trace">The trace to download.</param>
+    /// <param name="trace">The trace to convert.</param>
     /// <param name="telemetryRepository">The telemetry repository to fetch logs from.</param>
-    public static Task DownloadTraceAsJsonAsync(IJSRuntime js, OtlpTrace trace, TelemetryRepository telemetryRepository)
+    /// <returns>A result containing the JSON representation and suggested file name.</returns>
+    public static TelemetryJsonExportResult GetTraceAsJson(OtlpTrace trace, TelemetryRepository telemetryRepository)
     {
         var logs = telemetryRepository.GetLogsForTrace(trace.TraceId);
-        var traceJson = TelemetryExportService.ConvertTraceToJson(trace, logs);
+        var json = TelemetryExportService.ConvertTraceToJson(trace, logs);
         var fileName = $"trace-{OtlpHelpers.ToShortenedId(trace.TraceId)}.json";
-        return js.DownloadFileAsync(fileName, traceJson);
+        return new TelemetryJsonExportResult(json, fileName);
     }
 }

--- a/src/Aspire.Dashboard/Model/TextVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/TextVisualizerDialogViewModel.cs
@@ -3,4 +3,11 @@
 
 namespace Aspire.Dashboard.Model;
 
-public record TextVisualizerDialogViewModel(string Text, string Description, bool ContainsSecret);
+/// <summary>
+/// View model for the text visualizer dialog.
+/// </summary>
+/// <param name="Text">The text content to display.</param>
+/// <param name="Description">The description/title for the dialog.</param>
+/// <param name="ContainsSecret">Whether the text contains sensitive data.</param>
+/// <param name="DownloadFileName">Optional file name for downloading the content. If null, download is disabled.</param>
+public record TextVisualizerDialogViewModel(string Text, string Description, bool ContainsSecret, string? DownloadFileName = null);

--- a/src/Aspire.Dashboard/Otlp/Model/Serialization/OtlpLogsJson.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/Serialization/OtlpLogsJson.cs
@@ -11,16 +11,16 @@ namespace Aspire.Dashboard.Otlp.Model.Serialization;
 internal sealed class OtlpResourceLogsJson
 {
     /// <summary>
-    /// The resource for the logs in this message.
-    /// </summary>
-    [JsonPropertyName("resource")]
-    public OtlpResourceJson? Resource { get; set; }
-
-    /// <summary>
     /// A list of ScopeLogs that originate from a resource.
     /// </summary>
     [JsonPropertyName("scopeLogs")]
     public OtlpScopeLogsJson[]? ScopeLogs { get; set; }
+
+    /// <summary>
+    /// The resource for the logs in this message.
+    /// </summary>
+    [JsonPropertyName("resource")]
+    public OtlpResourceJson? Resource { get; set; }
 
     /// <summary>
     /// The Schema URL, if known.

--- a/src/Aspire.Dashboard/Otlp/Model/Serialization/OtlpMetricsJson.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/Serialization/OtlpMetricsJson.cs
@@ -11,16 +11,16 @@ namespace Aspire.Dashboard.Otlp.Model.Serialization;
 internal sealed class OtlpResourceMetricsJson
 {
     /// <summary>
-    /// The resource for the metrics in this message.
-    /// </summary>
-    [JsonPropertyName("resource")]
-    public OtlpResourceJson? Resource { get; set; }
-
-    /// <summary>
     /// A list of metrics that originate from a resource.
     /// </summary>
     [JsonPropertyName("scopeMetrics")]
     public OtlpScopeMetricsJson[]? ScopeMetrics { get; set; }
+
+    /// <summary>
+    /// The resource for the metrics in this message.
+    /// </summary>
+    [JsonPropertyName("resource")]
+    public OtlpResourceJson? Resource { get; set; }
 
     /// <summary>
     /// The Schema URL, if known.

--- a/src/Aspire.Dashboard/Otlp/Model/Serialization/OtlpTraceJson.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/Serialization/OtlpTraceJson.cs
@@ -11,16 +11,16 @@ namespace Aspire.Dashboard.Otlp.Model.Serialization;
 internal sealed class OtlpResourceSpansJson
 {
     /// <summary>
-    /// The resource for the spans in this message.
-    /// </summary>
-    [JsonPropertyName("resource")]
-    public OtlpResourceJson? Resource { get; set; }
-
-    /// <summary>
     /// A list of ScopeSpans that originate from a resource.
     /// </summary>
     [JsonPropertyName("scopeSpans")]
     public OtlpScopeSpansJson[]? ScopeSpans { get; set; }
+
+    /// <summary>
+    /// The resource for the spans in this message.
+    /// </summary>
+    [JsonPropertyName("resource")]
+    public OtlpResourceJson? Resource { get; set; }
 
     /// <summary>
     /// The Schema URL, if known.

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
@@ -268,29 +268,11 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Log JSON.
+        ///   Looks up a localized string similar to Export JSON.
         /// </summary>
-        public static string LogJson {
+        public static string ExportJson {
             get {
-                return ResourceManager.GetString("LogJson", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Span JSON.
-        /// </summary>
-        public static string SpanJson {
-            get {
-                return ResourceManager.GetString("SpanJson", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Trace JSON.
-        /// </summary>
-        public static string TraceJson {
-            get {
-                return ResourceManager.GetString("TraceJson", resourceCulture);
+                return ResourceManager.GetString("ExportJson", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
@@ -268,11 +268,38 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Download JSON.
+        ///   Looks up a localized string similar to Log JSON.
         /// </summary>
-        public static string DownloadJson {
+        public static string LogJson {
             get {
-                return ResourceManager.GetString("DownloadJson", resourceCulture);
+                return ResourceManager.GetString("LogJson", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Span JSON.
+        /// </summary>
+        public static string SpanJson {
+            get {
+                return ResourceManager.GetString("SpanJson", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trace JSON.
+        /// </summary>
+        public static string TraceJson {
+            get {
+                return ResourceManager.GetString("TraceJson", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Download.
+        /// </summary>
+        public static string Download {
+            get {
+                return ResourceManager.GetString("Download", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.resx
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.resx
@@ -519,7 +519,16 @@
   <data name="SpanTypeCloud" xml:space="preserve">
     <value>Cloud</value>
   </data>
-  <data name="DownloadJson" xml:space="preserve">
-    <value>Download JSON</value>
+  <data name="LogJson" xml:space="preserve">
+    <value>Log JSON</value>
+  </data>
+  <data name="SpanJson" xml:space="preserve">
+    <value>Span JSON</value>
+  </data>
+  <data name="TraceJson" xml:space="preserve">
+    <value>Trace JSON</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Download</value>
   </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.resx
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.resx
@@ -519,14 +519,8 @@
   <data name="SpanTypeCloud" xml:space="preserve">
     <value>Cloud</value>
   </data>
-  <data name="LogJson" xml:space="preserve">
-    <value>Log JSON</value>
-  </data>
-  <data name="SpanJson" xml:space="preserve">
-    <value>Span JSON</value>
-  </data>
-  <data name="TraceJson" xml:space="preserve">
-    <value>Trace JSON</value>
+  <data name="ExportJson" xml:space="preserve">
+    <value>Export JSON</value>
   </data>
   <data name="Download" xml:space="preserve">
     <value>Download</value>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -117,14 +117,14 @@
         <target state="translated">Sbalit vše</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadJson">
-        <source>Download JSON</source>
-        <target state="translated">Stáhnout JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DetailsColumnHeader">
         <source>Details</source>
         <target state="translated">Podrobnosti</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Download">
+        <source>Download</source>
+        <target state="new">Download</target>
         <note />
       </trans-unit>
       <trans-unit id="DurationColumnHeader">
@@ -295,6 +295,11 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Načítání…</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LogJson">
+        <source>Log JSON</source>
+        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -537,6 +542,11 @@
         <target state="translated">Čas spuštění: &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanJson">
+        <source>Span JSON</source>
+        <target state="new">Span JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">Cloud</target>
@@ -615,6 +625,11 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">Přepnout vnoření</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TraceJson">
+        <source>Trace JSON</source>
+        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Rozbalit vše</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExportJson">
+        <source>Export JSON</source>
+        <target state="new">Export JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterPlaceholder">
         <source>Filter...</source>
         <target state="translated">Filtrovat…</target>
@@ -295,11 +300,6 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Načítání…</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="LogJson">
-        <source>Log JSON</source>
-        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -542,11 +542,6 @@
         <target state="translated">Čas spuštění: &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
-      <trans-unit id="SpanJson">
-        <source>Span JSON</source>
-        <target state="new">Span JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">Cloud</target>
@@ -625,11 +620,6 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">Přepnout vnoření</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TraceJson">
-        <source>Trace JSON</source>
-        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -117,14 +117,14 @@
         <target state="translated">Alle reduzieren</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadJson">
-        <source>Download JSON</source>
-        <target state="translated">JSON herunterladen</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DetailsColumnHeader">
         <source>Details</source>
         <target state="translated">Details</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Download">
+        <source>Download</source>
+        <target state="new">Download</target>
         <note />
       </trans-unit>
       <trans-unit id="DurationColumnHeader">
@@ -295,6 +295,11 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Wird geladen...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LogJson">
+        <source>Log JSON</source>
+        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -537,6 +542,11 @@
         <target state="translated">Startzeit &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanJson">
+        <source>Span JSON</source>
+        <target state="new">Span JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">Cloud</target>
@@ -615,6 +625,11 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">Verschachtelung umschalten</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TraceJson">
+        <source>Trace JSON</source>
+        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Alle erweitern</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExportJson">
+        <source>Export JSON</source>
+        <target state="new">Export JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterPlaceholder">
         <source>Filter...</source>
         <target state="translated">Filtern...</target>
@@ -295,11 +300,6 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Wird geladen...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="LogJson">
-        <source>Log JSON</source>
-        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -542,11 +542,6 @@
         <target state="translated">Startzeit &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
-      <trans-unit id="SpanJson">
-        <source>Span JSON</source>
-        <target state="new">Span JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">Cloud</target>
@@ -625,11 +620,6 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">Verschachtelung umschalten</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TraceJson">
-        <source>Trace JSON</source>
-        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -117,14 +117,14 @@
         <target state="translated">Contraer todo</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadJson">
-        <source>Download JSON</source>
-        <target state="translated">Descargar JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DetailsColumnHeader">
         <source>Details</source>
         <target state="translated">Detalles</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Download">
+        <source>Download</source>
+        <target state="new">Download</target>
         <note />
       </trans-unit>
       <trans-unit id="DurationColumnHeader">
@@ -295,6 +295,11 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Cargando...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LogJson">
+        <source>Log JSON</source>
+        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -537,6 +542,11 @@
         <target state="translated">Hora de inicio &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanJson">
+        <source>Span JSON</source>
+        <target state="new">Span JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">Nube</target>
@@ -615,6 +625,11 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">Alternar anidamiento</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TraceJson">
+        <source>Trace JSON</source>
+        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Expandir todo</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExportJson">
+        <source>Export JSON</source>
+        <target state="new">Export JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterPlaceholder">
         <source>Filter...</source>
         <target state="translated">Filtrar...</target>
@@ -295,11 +300,6 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Cargando...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="LogJson">
-        <source>Log JSON</source>
-        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -542,11 +542,6 @@
         <target state="translated">Hora de inicio &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
-      <trans-unit id="SpanJson">
-        <source>Span JSON</source>
-        <target state="new">Span JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">Nube</target>
@@ -625,11 +620,6 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">Alternar anidamiento</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TraceJson">
-        <source>Trace JSON</source>
-        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -117,14 +117,14 @@
         <target state="translated">Tout réduire</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadJson">
-        <source>Download JSON</source>
-        <target state="translated">Téléchargez JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DetailsColumnHeader">
         <source>Details</source>
         <target state="translated">Détails</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Download">
+        <source>Download</source>
+        <target state="new">Download</target>
         <note />
       </trans-unit>
       <trans-unit id="DurationColumnHeader">
@@ -295,6 +295,11 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Chargement...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LogJson">
+        <source>Log JSON</source>
+        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -537,6 +542,11 @@
         <target state="translated">&lt;strong&gt;Heure de début : &lt;/strong&gt; {0}</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanJson">
+        <source>Span JSON</source>
+        <target state="new">Span JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">Cloud</target>
@@ -615,6 +625,11 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">Activer/désactiver l’imbrication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TraceJson">
+        <source>Trace JSON</source>
+        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Tout développer</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExportJson">
+        <source>Export JSON</source>
+        <target state="new">Export JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterPlaceholder">
         <source>Filter...</source>
         <target state="translated">Filtrer...</target>
@@ -295,11 +300,6 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Chargement...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="LogJson">
-        <source>Log JSON</source>
-        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -542,11 +542,6 @@
         <target state="translated">&lt;strong&gt;Heure de début : &lt;/strong&gt; {0}</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
-      <trans-unit id="SpanJson">
-        <source>Span JSON</source>
-        <target state="new">Span JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">Cloud</target>
@@ -625,11 +620,6 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">Activer/désactiver l’imbrication</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TraceJson">
-        <source>Trace JSON</source>
-        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -117,14 +117,14 @@
         <target state="translated">Comprimi tutto</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadJson">
-        <source>Download JSON</source>
-        <target state="translated">Scarica JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DetailsColumnHeader">
         <source>Details</source>
         <target state="translated">Dettagli</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Download">
+        <source>Download</source>
+        <target state="new">Download</target>
         <note />
       </trans-unit>
       <trans-unit id="DurationColumnHeader">
@@ -295,6 +295,11 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Caricamento in corso...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LogJson">
+        <source>Log JSON</source>
+        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -537,6 +542,11 @@
         <target state="translated">Ora di inizio &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanJson">
+        <source>Span JSON</source>
+        <target state="new">Span JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">Cloud</target>
@@ -615,6 +625,11 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">Attiva/Disattiva annidamento</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TraceJson">
+        <source>Trace JSON</source>
+        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Espandi tutto</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExportJson">
+        <source>Export JSON</source>
+        <target state="new">Export JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterPlaceholder">
         <source>Filter...</source>
         <target state="translated">Filtro...</target>
@@ -295,11 +300,6 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Caricamento in corso...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="LogJson">
-        <source>Log JSON</source>
-        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -542,11 +542,6 @@
         <target state="translated">Ora di inizio &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
-      <trans-unit id="SpanJson">
-        <source>Span JSON</source>
-        <target state="new">Span JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">Cloud</target>
@@ -625,11 +620,6 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">Attiva/Disattiva annidamento</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TraceJson">
-        <source>Trace JSON</source>
-        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -117,14 +117,14 @@
         <target state="translated">すべて折りたたむ</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadJson">
-        <source>Download JSON</source>
-        <target state="translated">JSON のダウンロード</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DetailsColumnHeader">
         <source>Details</source>
         <target state="translated">詳細</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Download">
+        <source>Download</source>
+        <target state="new">Download</target>
         <note />
       </trans-unit>
       <trans-unit id="DurationColumnHeader">
@@ -295,6 +295,11 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">読み込み中...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LogJson">
+        <source>Log JSON</source>
+        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -537,6 +542,11 @@
         <target state="translated">開始時刻 &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanJson">
+        <source>Span JSON</source>
+        <target state="new">Span JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">クラウド</target>
@@ -615,6 +625,11 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">入れ子の切り替え</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TraceJson">
+        <source>Trace JSON</source>
+        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -152,6 +152,11 @@
         <target state="translated">すべて展開</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExportJson">
+        <source>Export JSON</source>
+        <target state="new">Export JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterPlaceholder">
         <source>Filter...</source>
         <target state="translated">フィルター...</target>
@@ -295,11 +300,6 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">読み込み中...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="LogJson">
-        <source>Log JSON</source>
-        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -542,11 +542,6 @@
         <target state="translated">開始時刻 &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
-      <trans-unit id="SpanJson">
-        <source>Span JSON</source>
-        <target state="new">Span JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">クラウド</target>
@@ -625,11 +620,6 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">入れ子の切り替え</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TraceJson">
-        <source>Trace JSON</source>
-        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -152,6 +152,11 @@
         <target state="translated">모두 확장</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExportJson">
+        <source>Export JSON</source>
+        <target state="new">Export JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterPlaceholder">
         <source>Filter...</source>
         <target state="translated">필터...</target>
@@ -295,11 +300,6 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">로드 중...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="LogJson">
-        <source>Log JSON</source>
-        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -542,11 +542,6 @@
         <target state="translated">시작 시간 &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
-      <trans-unit id="SpanJson">
-        <source>Span JSON</source>
-        <target state="new">Span JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">클라우드</target>
@@ -625,11 +620,6 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">중첩 토글</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TraceJson">
-        <source>Trace JSON</source>
-        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -117,14 +117,14 @@
         <target state="translated">모두 축소</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadJson">
-        <source>Download JSON</source>
-        <target state="translated">JSON 다운로드</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DetailsColumnHeader">
         <source>Details</source>
         <target state="translated">세부 정보</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Download">
+        <source>Download</source>
+        <target state="new">Download</target>
         <note />
       </trans-unit>
       <trans-unit id="DurationColumnHeader">
@@ -295,6 +295,11 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">로드 중...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LogJson">
+        <source>Log JSON</source>
+        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -537,6 +542,11 @@
         <target state="translated">시작 시간 &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanJson">
+        <source>Span JSON</source>
+        <target state="new">Span JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">클라우드</target>
@@ -615,6 +625,11 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">중첩 토글</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TraceJson">
+        <source>Trace JSON</source>
+        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -117,14 +117,14 @@
         <target state="translated">Zwiń wszystko</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadJson">
-        <source>Download JSON</source>
-        <target state="translated">Pobierz plik JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DetailsColumnHeader">
         <source>Details</source>
         <target state="translated">Szczegóły</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Download">
+        <source>Download</source>
+        <target state="new">Download</target>
         <note />
       </trans-unit>
       <trans-unit id="DurationColumnHeader">
@@ -295,6 +295,11 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Trwa ładowanie...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LogJson">
+        <source>Log JSON</source>
+        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -537,6 +542,11 @@
         <target state="translated">Czas rozpoczęcia: &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanJson">
+        <source>Span JSON</source>
+        <target state="new">Span JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">Chmura</target>
@@ -615,6 +625,11 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">Przełącz zagnieżdżanie</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TraceJson">
+        <source>Trace JSON</source>
+        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Rozwiń wszystko</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExportJson">
+        <source>Export JSON</source>
+        <target state="new">Export JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterPlaceholder">
         <source>Filter...</source>
         <target state="translated">Filtruj...</target>
@@ -295,11 +300,6 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Trwa ładowanie...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="LogJson">
-        <source>Log JSON</source>
-        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -542,11 +542,6 @@
         <target state="translated">Czas rozpoczęcia: &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
-      <trans-unit id="SpanJson">
-        <source>Span JSON</source>
-        <target state="new">Span JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">Chmura</target>
@@ -625,11 +620,6 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">Przełącz zagnieżdżanie</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TraceJson">
-        <source>Trace JSON</source>
-        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -117,14 +117,14 @@
         <target state="translated">Recolher todos</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadJson">
-        <source>Download JSON</source>
-        <target state="translated">Baixar JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DetailsColumnHeader">
         <source>Details</source>
         <target state="translated">Detalhes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Download">
+        <source>Download</source>
+        <target state="new">Download</target>
         <note />
       </trans-unit>
       <trans-unit id="DurationColumnHeader">
@@ -295,6 +295,11 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Carregando...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LogJson">
+        <source>Log JSON</source>
+        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -537,6 +542,11 @@
         <target state="translated">Horário de início &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanJson">
+        <source>Span JSON</source>
+        <target state="new">Span JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">Nuvem</target>
@@ -615,6 +625,11 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">Ativar/desativar aninhamento</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TraceJson">
+        <source>Trace JSON</source>
+        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Expandir tudo</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExportJson">
+        <source>Export JSON</source>
+        <target state="new">Export JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterPlaceholder">
         <source>Filter...</source>
         <target state="translated">Filtro...</target>
@@ -295,11 +300,6 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Carregando...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="LogJson">
-        <source>Log JSON</source>
-        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -542,11 +542,6 @@
         <target state="translated">Horário de início &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
-      <trans-unit id="SpanJson">
-        <source>Span JSON</source>
-        <target state="new">Span JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">Nuvem</target>
@@ -625,11 +620,6 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">Ativar/desativar aninhamento</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TraceJson">
-        <source>Trace JSON</source>
-        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Развернуть все</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExportJson">
+        <source>Export JSON</source>
+        <target state="new">Export JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterPlaceholder">
         <source>Filter...</source>
         <target state="translated">Фильтр...</target>
@@ -295,11 +300,6 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Идет загрузка...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="LogJson">
-        <source>Log JSON</source>
-        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -542,11 +542,6 @@
         <target state="translated">&lt;strong&gt;Время начала: &lt;/strong&gt; {0}</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
-      <trans-unit id="SpanJson">
-        <source>Span JSON</source>
-        <target state="new">Span JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">Облако</target>
@@ -625,11 +620,6 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">Переключить вложение</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TraceJson">
-        <source>Trace JSON</source>
-        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -117,14 +117,14 @@
         <target state="translated">Свернуть все</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadJson">
-        <source>Download JSON</source>
-        <target state="translated">Скачать JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DetailsColumnHeader">
         <source>Details</source>
         <target state="translated">Сведения</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Download">
+        <source>Download</source>
+        <target state="new">Download</target>
         <note />
       </trans-unit>
       <trans-unit id="DurationColumnHeader">
@@ -295,6 +295,11 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Идет загрузка...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LogJson">
+        <source>Log JSON</source>
+        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -537,6 +542,11 @@
         <target state="translated">&lt;strong&gt;Время начала: &lt;/strong&gt; {0}</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanJson">
+        <source>Span JSON</source>
+        <target state="new">Span JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">Облако</target>
@@ -615,6 +625,11 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">Переключить вложение</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TraceJson">
+        <source>Trace JSON</source>
+        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Tümünü genişlet</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExportJson">
+        <source>Export JSON</source>
+        <target state="new">Export JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterPlaceholder">
         <source>Filter...</source>
         <target state="translated">Filtrele...</target>
@@ -295,11 +300,6 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Yükleniyor...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="LogJson">
-        <source>Log JSON</source>
-        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -542,11 +542,6 @@
         <target state="translated">Başlangıç zamanı &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
-      <trans-unit id="SpanJson">
-        <source>Span JSON</source>
-        <target state="new">Span JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">Bulut</target>
@@ -625,11 +620,6 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">Yerleştirmeyi aç/kapat</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TraceJson">
-        <source>Trace JSON</source>
-        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -117,14 +117,14 @@
         <target state="translated">Tümünü daralt</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadJson">
-        <source>Download JSON</source>
-        <target state="translated">JSON dosyasını indir</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DetailsColumnHeader">
         <source>Details</source>
         <target state="translated">Ayrıntılar</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Download">
+        <source>Download</source>
+        <target state="new">Download</target>
         <note />
       </trans-unit>
       <trans-unit id="DurationColumnHeader">
@@ -295,6 +295,11 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Yükleniyor...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LogJson">
+        <source>Log JSON</source>
+        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -537,6 +542,11 @@
         <target state="translated">Başlangıç zamanı &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanJson">
+        <source>Span JSON</source>
+        <target state="new">Span JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">Bulut</target>
@@ -615,6 +625,11 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">Yerleştirmeyi aç/kapat</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TraceJson">
+        <source>Trace JSON</source>
+        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -117,14 +117,14 @@
         <target state="translated">全部折叠</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadJson">
-        <source>Download JSON</source>
-        <target state="translated">下载 JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DetailsColumnHeader">
         <source>Details</source>
         <target state="translated">详细信息</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Download">
+        <source>Download</source>
+        <target state="new">Download</target>
         <note />
       </trans-unit>
       <trans-unit id="DurationColumnHeader">
@@ -295,6 +295,11 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">正在加载...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LogJson">
+        <source>Log JSON</source>
+        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -537,6 +542,11 @@
         <target state="translated">开始时间 &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanJson">
+        <source>Span JSON</source>
+        <target state="new">Span JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">云</target>
@@ -615,6 +625,11 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">切换嵌套</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TraceJson">
+        <source>Trace JSON</source>
+        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -152,6 +152,11 @@
         <target state="translated">全部展开</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExportJson">
+        <source>Export JSON</source>
+        <target state="new">Export JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterPlaceholder">
         <source>Filter...</source>
         <target state="translated">筛选...</target>
@@ -295,11 +300,6 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">正在加载...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="LogJson">
-        <source>Log JSON</source>
-        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -542,11 +542,6 @@
         <target state="translated">开始时间 &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
-      <trans-unit id="SpanJson">
-        <source>Span JSON</source>
-        <target state="new">Span JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">云</target>
@@ -625,11 +620,6 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">切换嵌套</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TraceJson">
-        <source>Trace JSON</source>
-        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -117,14 +117,14 @@
         <target state="translated">全部摺疊</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadJson">
-        <source>Download JSON</source>
-        <target state="translated">下載 JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DetailsColumnHeader">
         <source>Details</source>
         <target state="translated">詳細資料</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Download">
+        <source>Download</source>
+        <target state="new">Download</target>
         <note />
       </trans-unit>
       <trans-unit id="DurationColumnHeader">
@@ -295,6 +295,11 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">正在載入...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LogJson">
+        <source>Log JSON</source>
+        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -537,6 +542,11 @@
         <target state="translated">開始時間 &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="SpanJson">
+        <source>Span JSON</source>
+        <target state="new">Span JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">雲端</target>
@@ -615,6 +625,11 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">切換巢狀項目</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TraceJson">
+        <source>Trace JSON</source>
+        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -152,6 +152,11 @@
         <target state="translated">全部展開</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExportJson">
+        <source>Export JSON</source>
+        <target state="new">Export JSON</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FilterPlaceholder">
         <source>Filter...</source>
         <target state="translated">篩選...</target>
@@ -295,11 +300,6 @@
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">正在載入...</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="LogJson">
-        <source>Log JSON</source>
-        <target state="new">Log JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="MetricTableExemplarsColumnHeader">
@@ -542,11 +542,6 @@
         <target state="translated">開始時間 &lt;strong&gt;{0}&lt;/strong&gt;</target>
         <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
-      <trans-unit id="SpanJson">
-        <source>Span JSON</source>
-        <target state="new">Span JSON</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpanTypeCloud">
         <source>Cloud</source>
         <target state="translated">雲端</target>
@@ -625,11 +620,6 @@
       <trans-unit id="ToggleNesting">
         <source>Toggle nesting</source>
         <target state="translated">切換巢狀項目</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TraceJson">
-        <source>Trace JSON</source>
-        <target state="new">Trace JSON</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">


### PR DESCRIPTION
The original community request for exporting JSON copied it to the clipboard. The implementation was problematic so it was changed to a download.

This PR re-enables copying to clipboard by displaying the JSON in the visualizer. It also adds an optional download button to the visualizer, which is used only on the new dialogs for now, to get the best of all worlds:

✅ View JSON in dashboard
✅ Copy to clipboard
✅ Download to file

<img width="788" height="586" alt="image" src="https://github.com/user-attachments/assets/a7e9d37f-abfe-4245-af7a-aff754575c39" />

<img width="1274" height="972" alt="image" src="https://github.com/user-attachments/assets/f65da843-9438-4336-a766-17e631ce305f" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
