### PR TITLE
Upgrade Hex1b to 0.48.0 and add Hex1b.McpServer 0.48.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -92,7 +92,8 @@
     <PackageVersion Include="Grpc.AspNetCore" Version="2.71.0" />
     <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.71.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.72.0" />
-    <PackageVersion Include="Hex1b" Version="0.47.0" />
+    <PackageVersion Include="Hex1b" Version="0.48.0" />
+    <PackageVersion Include="Hex1b.McpServer" Version="0.48.0" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="KubernetesClient" Version="18.0.5" />
     <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />


### PR DESCRIPTION
This PR upgrades the Hex1b package from 0.47.0 to 0.48.0 and adds the Hex1b.McpServer package at version 0.48.0.