### PR TITLE
[CI] Retry for some docker related failures on AzDo/Helix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
           patterns: |
             \.md$
             eng/pipelines/.*
+            eng/test-configuration.json
             \.github/workflows/apply-test-attributes.yml
             \.github/workflows/backport.yml
             \.github/workflows/dogfood-comment.yml

--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -1,10 +1,9 @@
 {
-  "version": 1,
+  "version": 2,
   "defaultOnFailure": "fail",
   "localRerunCount": 1,
+  "remoteRerunCount": 3,
   "retryOnRules": [
-    { "testName": { "contains": "Aspire.Elastic.Clients.Elasticsearch.Tests.ConformanceTests.HealthCheckReportsExpectedStatus" } },
-    { "testAssembly": { "contains": "Aspire.Elastic.Clients.Elasticsearch.Tests" }, "failureMessage": { "contains": "RemoteExecutionException : Half-way through waiting for remote process." } },
-    { "failureMessage" : { "contains" : "MSBUILD : error MSB4166: Child node" } }
+    { "failureMessage" : { "regex" : "open.*docker.*GetImageBlob.*: no such file or directory" }
   ]
 }

--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -4,6 +4,6 @@
   "localRerunCount": 1,
   "remoteRerunCount": 3,
   "retryOnRules": [
-    { "failureMessage" : { "regex" : "open.*docker.*GetImageBlob.*: no such file or directory" }
+    { "failureMessage" : { "regex" : "open.*docker.*GetImageBlob.*: no such file or directory" } }
   ]
 }


### PR DESCRIPTION
Even using `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX=netaspireci.azurecr.io`
failed on some agents. I tried a direct `docker pull` and it fails like:

```
docker pull netaspireci.azurecr.io/testcontainers/ryuk:0.14.0
0.14.0: Pulling from testcontainers/ryuk
c57ba2ec65d2: Pulling fs layer
2d8f392ade3e: Pulling fs layer
open /datadisks/disk1/docker/tmp/GetImageBlob2965270469: no such file or directory
```

As a workaround to get CI green add helix retries[1] for this failure.

And specifically we use `remoteRerunCount` so a *different* agent would
be used to run the work item again.

Issue: https://github.com/dotnet/aspire/issues/11820

--
1. https://github.com/dotnet/arcade/blob/238bb95905161ba32b49ed7b8d6964e578652c19/Documentation/DevWorkflow/Design/Dev-Design-Test-Configuration-Json.md?plain=1#L48-L54
