### PR TITLE
Add VSCODE_CMD env var to start-code scripts

### DIFF
--- a/start-code.cmd
+++ b/start-code.cmd
@@ -2,12 +2,15 @@
 SETLOCAL
 
 :: This command launches a Visual Studio Code with environment variables required to use a local version of the .NET Core SDK.
+:: Set VSCODE_CMD environment variable to use a different VS Code variant (e.g., code-insiders).
 
-FOR /f "delims=" %%a IN ('where.exe code') DO @SET vscode=%%a& GOTO break
+IF ["%VSCODE_CMD%"] == [""] SET VSCODE_CMD=code
+
+FOR /f "delims=" %%a IN ('where.exe %VSCODE_CMD%') DO @SET vscode=%%a& GOTO break
 :break
 
 IF ["%vscode%"] == [""] (
-    echo [41m[ERROR][0m Visual Studio Code is not installed or can't be found.
+    echo [ERROR] %VSCODE_CMD% is not installed or can't be found.
     echo.
     exit /b 1
 )
@@ -23,7 +26,7 @@ SET DOTNET_MULTILEVEL_LOOKUP=0
 SET PATH=%DOTNET_ROOT%;%PATH%
 
 IF NOT EXIST "%DOTNET_ROOT%\dotnet.exe" (
-    echo [41m[ERROR][0m .NET SDK has not yet been installed. Run [93m%~dp0restore.cmd[0m to install.
+    echo [ERROR] .NET SDK has not yet been installed. Run %~dp0restore.cmd to install.
     echo.
     exit /b 1
 )

--- a/start-code.sh
+++ b/start-code.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# This command launches a Visual Studio Code with environment variables required to use a local version of the .NET Core SDK.
+# Set VSCODE_CMD environment variable to use a different VS Code variant (e.g., code-insiders).
+
 set -euo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -24,5 +27,12 @@ then
     set -- '.';
 fi
 
-code-insiders "$@"
+VSCODE_CMD="${VSCODE_CMD:-code}"
+
+if ! command -v "$VSCODE_CMD" &> /dev/null; then
+    echo "[ERROR] $VSCODE_CMD is not installed or can't be found."
+    exit 1
+fi
+
+"$VSCODE_CMD" "$@"
 


### PR DESCRIPTION
Both start-code.sh and start-code.cmd now support configuring which VS Code variant to launch via the VSCODE_CMD environment variable. Defaults to code if not set.