### PR TITLE
Improve backchannel reliability with PID-based socket naming

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -59,6 +59,7 @@
     <Compile Include="$(RepoRoot)src\Aspire.Hosting\Ats\RuntimeSpec.cs" Link="Ats\RuntimeSpec.cs" />
     <Compile Include="$(SharedDir)PackageUpdateHelpers.cs" Link="Utils\PackageUpdateHelpers.cs" />
     <Compile Include="$(SharedDir)PathLookupHelper.cs" Link="Utils\PathLookupHelper.cs" />
+    <Compile Include="$(SharedDir)BackchannelConstants.cs" Link="Backchannel\BackchannelConstants.cs" />
     <Compile Include="$(SharedDir)Mcp\McpIconHelper.cs" Link="Mcp\McpIconHelper.cs" />
     <Compile Include="$(RepoRoot)src\Aspire.Hosting\Utils\X509Certificate2Extensions.cs" Link="Utils\X509Certificate2Extensions.cs" />
   </ItemGroup>

--- a/src/Aspire.Cli/Backchannel/AuxiliaryBackchannelMonitor.cs
+++ b/src/Aspire.Cli/Backchannel/AuxiliaryBackchannelMonitor.cs
@@ -185,11 +185,9 @@ internal sealed class AuxiliaryBackchannelMonitor(
         }
         finally
         {
-            // Clean up all connections
-            foreach (var connection in Connections)
-            {
-                await DisconnectAsync(connection).ConfigureAwait(false);
-            }
+            // Clean up all connections in parallel
+            var disconnectTasks = Connections.Select(DisconnectAsync);
+            await Task.WhenAll(disconnectTasks).ConfigureAwait(false);
             _connectionsByHash.Clear();
         }
     }

--- a/src/Aspire.Cli/Backchannel/AuxiliaryBackchannelMonitor.cs
+++ b/src/Aspire.Cli/Backchannel/AuxiliaryBackchannelMonitor.cs
@@ -25,7 +25,9 @@ internal sealed class AuxiliaryBackchannelMonitor(
 {
     private static readonly TimeSpan s_maxRetryElapsed = TimeSpan.FromSeconds(3);
     private static readonly TimeSpan s_maxRetryDelay = TimeSpan.FromSeconds(1);
-    private readonly ConcurrentDictionary<string, AppHostAuxiliaryBackchannel> _connections = new();
+    
+    // Outer key: hash (prefix), Inner key: socketPath, Value: connection
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, AppHostAuxiliaryBackchannel>> _connectionsByHash = new();
     private readonly string _backchannelsDirectory = GetBackchannelsDirectory();
 
     // Track known socket files to detect additions and removals
@@ -34,9 +36,18 @@ internal sealed class AuxiliaryBackchannelMonitor(
     private readonly TimeProvider _timeProvider = timeProvider;
 
     /// <summary>
-    /// Gets the collection of active AppHost connections.
+    /// Gets all active AppHost connections, flattened from all hashes.
     /// </summary>
-    public IReadOnlyDictionary<string, AppHostAuxiliaryBackchannel> Connections => _connections;
+    public IEnumerable<AppHostAuxiliaryBackchannel> Connections => 
+        _connectionsByHash.Values.SelectMany(d => d.Values);
+
+    /// <summary>
+    /// Gets connections for a specific AppHost hash (prefix).
+    /// </summary>
+    /// <param name="hash">The AppHost hash.</param>
+    /// <returns>All connections for the given hash, or empty if none.</returns>
+    public IEnumerable<AppHostAuxiliaryBackchannel> GetConnectionsByHash(string hash) =>
+        _connectionsByHash.TryGetValue(hash, out var connections) ? connections.Values : [];
 
     /// <summary>
     /// Gets or sets the path to the selected AppHost. When set, this AppHost will be used for MCP operations.
@@ -50,7 +61,7 @@ internal sealed class AuxiliaryBackchannelMonitor(
     {
         get
         {
-            var connections = _connections.Values.ToList();
+            var connections = Connections.ToList();
 
             if (connections.Count == 0)
             {
@@ -91,7 +102,7 @@ internal sealed class AuxiliaryBackchannelMonitor(
     /// </summary>
     public IReadOnlyList<AppHostAuxiliaryBackchannel> GetConnectionsForWorkingDirectory(DirectoryInfo workingDirectory)
     {
-        return _connections.Values
+        return Connections
             .Where(c => IsAppHostInScopeOfDirectory(c.AppHostInfo?.AppHostPath, workingDirectory.FullName))
             .ToList();
     }
@@ -175,11 +186,11 @@ internal sealed class AuxiliaryBackchannelMonitor(
         finally
         {
             // Clean up all connections
-            foreach (var connection in _connections.Values)
+            foreach (var connection in Connections)
             {
                 await DisconnectAsync(connection).ConfigureAwait(false);
             }
-            _connections.Clear();
+            _connectionsByHash.Clear();
         }
     }
 
@@ -221,9 +232,17 @@ internal sealed class AuxiliaryBackchannelMonitor(
             {
                 logger.LogDebug("Socket deleted: {SocketPath}", removedFile);
                 var hash = AppHostHelper.ExtractHashFromSocketPath(removedFile);
-                if (!string.IsNullOrEmpty(hash) && _connections.TryRemove(hash, out var connection))
+                if (!string.IsNullOrEmpty(hash) && 
+                    _connectionsByHash.TryGetValue(hash, out var connectionsForHash) &&
+                    connectionsForHash.TryRemove(removedFile, out var connection))
                 {
                     _ = Task.Run(async () => await DisconnectAsync(connection).ConfigureAwait(false), CancellationToken.None);
+                    
+                    // Clean up empty hash entries
+                    if (connectionsForHash.IsEmpty)
+                    {
+                        _connectionsByHash.TryRemove(hash, out _);
+                    }
                 }
             }
 
@@ -271,10 +290,11 @@ internal sealed class AuxiliaryBackchannelMonitor(
             return;
         }
 
-        // Check if we're already connected
-        if (_connections.ContainsKey(hash))
+        // Check if we're already connected to this specific socket
+        if (_connectionsByHash.TryGetValue(hash, out var existingConnections) && 
+            existingConnections.ContainsKey(socketPath))
         {
-            logger.LogDebug("Already connected to AppHost with hash {Hash}", hash);
+            logger.LogDebug("Already connected to socket: {SocketPath}", socketPath);
             return;
         }
 
@@ -402,23 +422,35 @@ internal sealed class AuxiliaryBackchannelMonitor(
             // Set up disconnect handler
             rpc.Disconnected += (sender, args) =>
             {
-                logger.LogInformation("Disconnected from AppHost {Hash}: {Reason}", hash, args.Reason);
-                if (_connections.TryRemove(hash, out var conn))
+                logger.LogInformation("Disconnected from AppHost at {SocketPath}: {Reason}", socketPath, args.Reason);
+                if (_connectionsByHash.TryGetValue(hash, out var connectionsForHash) &&
+                    connectionsForHash.TryRemove(socketPath, out var conn))
                 {
                     _ = Task.Run(async () => await DisconnectAsync(conn).ConfigureAwait(false));
+                    
+                    // Clean up empty hash entries
+                    if (connectionsForHash.IsEmpty)
+                    {
+                        _connectionsByHash.TryRemove(hash, out _);
+                    }
                 }
             };
 
-            if (_connections.TryAdd(hash, connection))
+            // Get or create the inner dictionary for this hash
+            var connectionsDict = _connectionsByHash.GetOrAdd(hash, _ => new ConcurrentDictionary<string, AppHostAuxiliaryBackchannel>());
+            
+            if (connectionsDict.TryAdd(socketPath, connection))
             {
                 logger.LogInformation(
-                    "Successfully connected to AppHost {Hash}. " +
+                    "Successfully connected to AppHost at {SocketPath}. " +
+                    "Hash: {Hash}, " +
                     "AppHost Path: {AppHostPath}, " +
                     "AppHost PID: {AppHostPid}, " +
                     "CLI PID: {CliPid}, " +
                     "Dashboard URL: {DashboardUrl}, " +
                     "Dashboard Token: {DashboardToken}, " +
                     "In Scope: {InScope}",
+                    socketPath,
                     hash,
                     appHostInfo?.AppHostPath ?? "N/A",
                     appHostInfo?.ProcessId.ToString(CultureInfo.InvariantCulture) ?? "N/A",
@@ -429,7 +461,7 @@ internal sealed class AuxiliaryBackchannelMonitor(
             }
             else
             {
-                logger.LogWarning("Failed to add connection for AppHost {Hash}", hash);
+                logger.LogWarning("Failed to add connection for socket {SocketPath}", socketPath);
                 await DisconnectAsync(connection).ConfigureAwait(false);
             }
         }

--- a/src/Aspire.Cli/Backchannel/IAuxiliaryBackchannelMonitor.cs
+++ b/src/Aspire.Cli/Backchannel/IAuxiliaryBackchannelMonitor.cs
@@ -9,9 +9,16 @@ namespace Aspire.Cli.Backchannel;
 internal interface IAuxiliaryBackchannelMonitor
 {
     /// <summary>
-    /// Gets the collection of active AppHost connections.
+    /// Gets all active AppHost connections.
     /// </summary>
-    IReadOnlyDictionary<string, AppHostAuxiliaryBackchannel> Connections { get; }
+    IEnumerable<AppHostAuxiliaryBackchannel> Connections { get; }
+
+    /// <summary>
+    /// Gets connections for a specific AppHost hash (prefix).
+    /// </summary>
+    /// <param name="hash">The AppHost hash.</param>
+    /// <returns>All connections for the given hash, or empty if none.</returns>
+    IEnumerable<AppHostAuxiliaryBackchannel> GetConnectionsByHash(string hash);
 
     /// <summary>
     /// Gets or sets the path to the selected AppHost. When set, this AppHost will be used for MCP operations.

--- a/src/Aspire.Cli/Commands/McpStartCommand.cs
+++ b/src/Aspire.Cli/Commands/McpStartCommand.cs
@@ -368,12 +368,12 @@ internal sealed class McpStartCommand : BaseCommand
     /// </summary>
     private async Task<AppHostAuxiliaryBackchannel?> GetSelectedConnectionAsync(CancellationToken cancellationToken)
     {
-        var connections = _auxiliaryBackchannelMonitor.Connections.Values.ToList();
+        var connections = _auxiliaryBackchannelMonitor.Connections.ToList();
 
         if (connections.Count == 0)
         {
             await _auxiliaryBackchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
-            connections = _auxiliaryBackchannelMonitor.Connections.Values.ToList();
+            connections = _auxiliaryBackchannelMonitor.Connections.ToList();
             if (connections.Count == 0)
             {
                 return null;

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -68,7 +68,7 @@ internal sealed class PsCommand : BaseCommand
         if (jsonOutput)
         {
             await _backchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
-            connections = _backchannelMonitor.Connections.Values.ToList();
+            connections = _backchannelMonitor.Connections.ToList();
         }
         else
         {
@@ -77,7 +77,7 @@ internal sealed class PsCommand : BaseCommand
                 async () =>
                 {
                     await _backchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
-                    return _backchannelMonitor.Connections.Values.ToList();
+                    return _backchannelMonitor.Connections.ToList();
                 });
         }
 

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -728,8 +728,9 @@ internal sealed class RunCommand : BaseCommand
                     // Trigger a scan and try to connect
                     await _backchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
 
-                    // Check if we can find a connection for this AppHost (keyed by hash)
-                    if (_backchannelMonitor.Connections.TryGetValue(expectedHash, out var connection))
+                    // Check if we can find a connection for this AppHost by hash
+                    var connection = _backchannelMonitor.GetConnectionsByHash(expectedHash).FirstOrDefault();
+                    if (connection is not null)
                     {
                         return connection;
                     }

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -565,24 +565,32 @@ internal sealed class RunCommand : BaseCommand
 
         _logger.LogDebug("Starting AppHost in background: {AppHostPath}", effectiveAppHostFile.FullName);
 
-        // Compute the expected auxiliary socket path hash for this AppHost
-        // The Connections dictionary is keyed by hash, not the full path
-        var expectedSocketPath = AppHostHelper.ComputeAuxiliarySocketPath(
+        // Compute the expected auxiliary socket path prefix for this AppHost.
+        // The hash identifies the AppHost (from project path), while the PID makes each instance unique.
+        // Multiple instances of the same AppHost will have the same hash but different PIDs.
+        var expectedSocketPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(
             effectiveAppHostFile.FullName,
             ExecutionContext.HomeDirectory.FullName);
-        // We know the format is valid since we just computed it with ComputeAuxiliarySocketPath
-        var expectedHash = AppHostHelper.ExtractHashFromSocketPath(expectedSocketPath)!;
+        // We know the format is valid since we just computed it with ComputeAuxiliarySocketPrefix
+        var expectedHash = AppHostHelper.ExtractHashFromSocketPath(expectedSocketPrefix)!;
 
-        _logger.LogDebug("Waiting for socket: {SocketPath}, Hash: {Hash}", expectedSocketPath, expectedHash);
+        _logger.LogDebug("Waiting for socket with prefix: {SocketPrefix}, Hash: {Hash}", expectedSocketPrefix, expectedHash);
 
         // Check for running instance and stop it if found (same behavior as regular run)
         var runningInstanceDetectionEnabled = _features.IsFeatureEnabled(KnownFeatures.RunningInstanceDetectionEnabled, defaultValue: true);
-        if (runningInstanceDetectionEnabled && File.Exists(expectedSocketPath))
+        var existingSockets = AppHostHelper.FindMatchingSockets(
+            effectiveAppHostFile.FullName,
+            ExecutionContext.HomeDirectory.FullName);
+
+        if (runningInstanceDetectionEnabled && existingSockets.Length > 0)
         {
-            _logger.LogDebug("Found running instance for this AppHost, stopping it first");
+            _logger.LogDebug("Found {Count} running instance(s) for this AppHost, stopping them first", existingSockets.Length);
             var manager = new RunningInstanceManager(_logger, _interactionService, _timeProvider);
-            // Don't block on failure - just try to stop
-            await manager.StopRunningInstanceAsync(expectedSocketPath, cancellationToken).ConfigureAwait(false);
+            foreach (var existingSocket in existingSockets)
+            {
+                // Don't block on failure - just try to stop each
+                await manager.StopRunningInstanceAsync(existingSocket, cancellationToken).ConfigureAwait(false);
+            }
         }
 
         // Build the arguments for the child CLI process

--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -92,7 +92,7 @@ internal sealed class StopCommand : BaseCommand
                 async () =>
                 {
                     await _backchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
-                    return _backchannelMonitor.Connections.Values.ToList();
+                    return _backchannelMonitor.Connections.ToList();
                 });
 
             if (connections.Count == 0)

--- a/src/Aspire.Cli/Mcp/ListAppHostsTool.cs
+++ b/src/Aspire.Cli/Mcp/ListAppHostsTool.cs
@@ -46,7 +46,7 @@ internal sealed class ListAppHostsTool(IAuxiliaryBackchannelMonitor auxiliaryBac
 
         var workingDirectory = executionContext.WorkingDirectory.FullName;
 
-        var connections = auxiliaryBackchannelMonitor.Connections.Values.ToList();
+        var connections = auxiliaryBackchannelMonitor.Connections.ToList();
 
         var inScopeAppHosts = connections
             .Where(c => c.IsInScope)

--- a/src/Aspire.Cli/Mcp/SelectAppHostTool.cs
+++ b/src/Aspire.Cli/Mcp/SelectAppHostTool.cs
@@ -69,7 +69,7 @@ internal sealed class SelectAppHostTool(IAuxiliaryBackchannelMonitor auxiliaryBa
         }
 
         // Check if there's a running AppHost with this path
-        var matchingConnection = auxiliaryBackchannelMonitor.Connections.Values
+        var matchingConnection = auxiliaryBackchannelMonitor.Connections
             .FirstOrDefault(c =>
             {
                 if (c.AppHostInfo?.AppHostPath is null)
@@ -83,7 +83,7 @@ internal sealed class SelectAppHostTool(IAuxiliaryBackchannelMonitor auxiliaryBa
         if (matchingConnection == null)
         {
             // List available AppHosts
-            var availableAppHosts = auxiliaryBackchannelMonitor.Connections.Values
+            var availableAppHosts = auxiliaryBackchannelMonitor.Connections
                 .Where(c => c.AppHostInfo?.AppHostPath != null)
                 .Select(c => c.AppHostInfo!.AppHostPath)
                 .ToList();

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -425,15 +425,18 @@ internal sealed class DotNetAppHostProject : IAppHostProject
     /// <inheritdoc />
     public async Task<bool> CheckAndHandleRunningInstanceAsync(FileInfo appHostFile, DirectoryInfo homeDirectory, CancellationToken cancellationToken)
     {
-        var auxiliarySocketPath = AppHostHelper.ComputeAuxiliarySocketPath(appHostFile.FullName, homeDirectory.FullName);
+        var matchingSockets = AppHostHelper.FindMatchingSockets(appHostFile.FullName, homeDirectory.FullName);
 
-        // Check if the socket file exists
-        if (!File.Exists(auxiliarySocketPath))
+        // Check if any socket files exist
+        if (matchingSockets.Length == 0)
         {
             return true; // No running instance, continue
         }
 
-        // Stop the running instance (no prompt per mitchdenny's request)
-        return await _runningInstanceManager.StopRunningInstanceAsync(auxiliarySocketPath, cancellationToken);
+        // Stop all running instances
+        var stopTasks = matchingSockets.Select(socketPath => 
+            _runningInstanceManager.StopRunningInstanceAsync(socketPath, cancellationToken));
+        var results = await Task.WhenAll(stopTasks);
+        return results.All(r => r);
     }
 }

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -962,17 +962,20 @@ internal sealed class GuestAppHostProject : IAppHostProject
         var appHostServerProject = _appHostServerProjectFactory.Create(directory.FullName);
         var genericAppHostPath = appHostServerProject.GetProjectFilePath();
 
-        // Compute socket path based on the AppHost server project path
-        var auxiliarySocketPath = AppHostHelper.ComputeAuxiliarySocketPath(genericAppHostPath, homeDirectory.FullName);
+        // Find matching sockets for this AppHost
+        var matchingSockets = AppHostHelper.FindMatchingSockets(genericAppHostPath, homeDirectory.FullName);
 
-        // Check if the socket file exists
-        if (!File.Exists(auxiliarySocketPath))
+        // Check if any socket files exist
+        if (matchingSockets.Length == 0)
         {
             return true; // No running instance, continue
         }
 
-        // Stop the running instance
-        return await _runningInstanceManager.StopRunningInstanceAsync(auxiliarySocketPath, cancellationToken);
+        // Stop all running instances
+        var stopTasks = matchingSockets.Select(socketPath => 
+            _runningInstanceManager.StopRunningInstanceAsync(socketPath, cancellationToken));
+        var results = await Task.WhenAll(stopTasks);
+        return results.All(r => r);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -43,6 +43,7 @@
     <Compile Include="$(SharedDir)PackageUpdateHelpers.cs" Link="Utils\PackageUpdateHelpers.cs" />
     <Compile Include="$(SharedDir)InteractionHelpers.cs" Link="Utils\InteractionHelpers.cs" />
     <Compile Include="$(SharedDir)LocaleHelpers.cs" Link="Utils\LocaleHelpers.cs" />
+    <Compile Include="$(SharedDir)BackchannelConstants.cs" Link="Backchannel\BackchannelConstants.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Shared/BackchannelConstants.cs
+++ b/src/Shared/BackchannelConstants.cs
@@ -1,0 +1,325 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Aspire.Hosting.Backchannel;
+
+/// <summary>
+/// Shared constants and helpers for backchannel socket communication between
+/// AppHost and CLI. These MUST stay in sync between both components.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Architecture Overview</strong>
+/// </para>
+/// <para>
+/// The backchannel is a Unix domain socket that enables bidirectional communication:
+/// </para>
+/// <list type="bullet">
+/// <item>CLI → AppHost: Commands (stop, get info, etc.)</item>
+/// <item>AppHost → CLI: Status updates, events</item>
+/// </list>
+/// <para>
+/// <strong>Socket File Location</strong>
+/// </para>
+/// <para>
+/// Socket files are stored in: <c>~/.aspire/cli/backchannels/</c>
+/// </para>
+/// <para>
+/// <strong>Socket Naming Format</strong>
+/// </para>
+/// <para>
+/// New format: <c>auxi.sock.{hash}.{pid}</c>
+/// </para>
+/// <list type="bullet">
+/// <item><c>auxi.sock</c> - Prefix (not "aux" because that's reserved on Windows)</item>
+/// <item><c>{hash}</c> - SHA256(AppHost project path)[0:16] - identifies the AppHost project</item>
+/// <item><c>{pid}</c> - Process ID of the AppHost - identifies the specific instance</item>
+/// </list>
+/// <para>
+/// Old format (for backward compatibility): <c>auxi.sock.{hash}</c>
+/// </para>
+/// <para>
+/// <strong>Why PID in the Filename?</strong>
+/// </para>
+/// <list type="bullet">
+/// <item>Multiple instances of the same AppHost can run simultaneously</item>
+/// <item>Orphan detection: if PID doesn't exist, socket is orphaned and can be deleted</item>
+/// <item>Fast cleanup without needing to attempt connection</item>
+/// </list>
+/// <para>
+/// <strong>Backward Compatibility</strong>
+/// </para>
+/// <para>
+/// Old CLI versions use glob pattern <c>aux*.sock.*</c> which matches the new format.
+/// Old CLIs will work with new AppHosts, they just won't benefit from PID-based orphan detection.
+/// </para>
+/// </remarks>
+internal static class BackchannelConstants
+{
+    /// <summary>
+    /// Directory path within ~/.aspire for backchannel sockets.
+    /// </summary>
+    public const string BackchannelsRelativePath = ".aspire/cli/backchannels";
+
+    /// <summary>
+    /// Prefix for auxiliary backchannel sockets.
+    /// </summary>
+    /// <remarks>
+    /// Uses "auxi" instead of "aux" because "aux" is a reserved device name on Windows
+    /// (from DOS days: CON, PRN, AUX, NUL, COM1-9, LPT1-9). Using "aux" causes
+    /// "SocketException: A socket operation encountered a dead network" on Windows.
+    /// </remarks>
+    public const string SocketPrefix = "auxi.sock";
+
+    /// <summary>
+    /// Number of hex characters to use from the SHA256 hash.
+    /// </summary>
+    /// <remarks>
+    /// Using 16 chars (64 bits) balances uniqueness against path length constraints.
+    /// Unix socket paths are limited to ~104 characters on most systems.
+    /// Full path example: ~/.aspire/cli/backchannels/auxi.sock.bc43b855b6848166.46730
+    /// = ~65 characters, well under the limit.
+    /// </remarks>
+    public const int HashLength = 16;
+
+    /// <summary>
+    /// Gets the backchannels directory path for the given home directory.
+    /// </summary>
+    /// <param name="homeDirectory">The user's home directory.</param>
+    /// <returns>The full path to the backchannels directory.</returns>
+    public static string GetBackchannelsDirectory(string homeDirectory)
+        => Path.Combine(homeDirectory, BackchannelsRelativePath);
+
+    /// <summary>
+    /// Computes the hash portion of the socket name from an AppHost path.
+    /// </summary>
+    /// <remarks>
+    /// The hash is case-sensitive. On case-insensitive file systems (Windows, macOS with default settings),
+    /// "C:\App\MyApp.csproj" and "C:\app\myapp.csproj" will produce different hashes even though they
+    /// reference the same file. This is acceptable because the CLI typically uses the exact path provided
+    /// by MSBuild or the user, which should be consistent within a session.
+    /// </remarks>
+    /// <param name="appHostPath">The full path to the AppHost project file.</param>
+    /// <returns>A 16-character lowercase hex string.</returns>
+    public static string ComputeHash(string appHostPath)
+    {
+        var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(appHostPath));
+        return Convert.ToHexString(hashBytes)[..HashLength].ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Computes the full socket path for an AppHost instance.
+    /// </summary>
+    /// <remarks>
+    /// Called by AppHost when creating the socket. Includes the PID to ensure
+    /// uniqueness across multiple instances of the same AppHost.
+    /// </remarks>
+    /// <param name="appHostPath">The full path to the AppHost project file.</param>
+    /// <param name="homeDirectory">The user's home directory.</param>
+    /// <param name="processId">The process ID of the AppHost.</param>
+    /// <returns>The full socket path including PID.</returns>
+    public static string ComputeSocketPath(string appHostPath, string homeDirectory, int processId)
+    {
+        var dir = GetBackchannelsDirectory(homeDirectory);
+        var hash = ComputeHash(appHostPath);
+        return Path.Combine(dir, $"{SocketPrefix}.{hash}.{processId}");
+    }
+
+    /// <summary>
+    /// Computes the socket path prefix for finding sockets (without PID).
+    /// </summary>
+    /// <remarks>
+    /// Called by CLI when searching for sockets. Since the CLI doesn't know the
+    /// AppHost's PID, it uses this prefix with a glob pattern to find matching sockets.
+    /// </remarks>
+    /// <param name="appHostPath">The full path to the AppHost project file.</param>
+    /// <param name="homeDirectory">The user's home directory.</param>
+    /// <returns>The socket path prefix (without PID suffix).</returns>
+    public static string ComputeSocketPrefix(string appHostPath, string homeDirectory)
+    {
+        var dir = GetBackchannelsDirectory(homeDirectory);
+        var hash = ComputeHash(appHostPath);
+        return Path.Combine(dir, $"{SocketPrefix}.{hash}");
+    }
+
+    /// <summary>
+    /// Finds all socket files matching the given AppHost path.
+    /// </summary>
+    /// <remarks>
+    /// Returns all socket files for an AppHost, regardless of PID. This includes
+    /// both old format (<c>auxi.sock.{hash}</c>) and new format (<c>auxi.sock.{hash}.{pid}</c>).
+    /// </remarks>
+    /// <param name="appHostPath">The full path to the AppHost project file.</param>
+    /// <param name="homeDirectory">The user's home directory.</param>
+    /// <returns>An array of socket file paths, or empty if none found.</returns>
+    public static string[] FindMatchingSockets(string appHostPath, string homeDirectory)
+    {
+        var prefix = ComputeSocketPrefix(appHostPath, homeDirectory);
+        var dir = Path.GetDirectoryName(prefix);
+        var prefixFileName = Path.GetFileName(prefix);
+
+        if (dir is null || !Directory.Exists(dir))
+        {
+            return [];
+        }
+
+        // Match both old format (auxi.sock.{hash}) and new format (auxi.sock.{hash}.{pid})
+        // Use pattern with "*" to match optional PID suffix
+        var allMatches = Directory.GetFiles(dir, prefixFileName + "*");
+        
+        // Filter to only include exact match (old format) or .{pid} suffix (new format)
+        // This avoids matching auxi.sock.{hash}abc (different hash that starts with same chars)
+        // and also avoids matching files like auxi.sock.{hash}.12345.bak
+        return allMatches.Where(f =>
+        {
+            var fileName = Path.GetFileName(f);
+            if (fileName == prefixFileName)
+            {
+                return true; // Old format: exact match
+            }
+            if (fileName.StartsWith(prefixFileName + ".", StringComparison.Ordinal) &&
+                int.TryParse(fileName.AsSpan(prefixFileName.Length + 1), NumberStyles.None, CultureInfo.InvariantCulture, out _))
+            {
+                return true; // New format: prefix followed by dot and integer PID
+            }
+            return false;
+        }).ToArray();
+    }
+
+    /// <summary>
+    /// Extracts the hash from a socket filename.
+    /// </summary>
+    /// <remarks>
+    /// Works with both old format (<c>auxi.sock.{hash}</c>) and new format (<c>auxi.sock.{hash}.{pid}</c>).
+    /// </remarks>
+    /// <param name="socketPath">The full socket path or filename.</param>
+    /// <returns>The hash portion, or <c>null</c> if the format is unrecognized.</returns>
+    public static string? ExtractHash(string socketPath)
+    {
+        var fileName = Path.GetFileName(socketPath);
+
+        // Handle new format: auxi.sock.{hash}.{pid}
+        // Handle old format: auxi.sock.{hash}
+        if (fileName.StartsWith($"{SocketPrefix}.", StringComparison.Ordinal))
+        {
+            var afterPrefix = fileName[($"{SocketPrefix}.".Length)..];
+            // If there's another dot, it's new format - return just the hash part
+            var dotIndex = afterPrefix.IndexOf('.');
+            return dotIndex > 0 ? afterPrefix[..dotIndex] : afterPrefix;
+        }
+
+        // Handle legacy format: aux.sock.{hash}
+        if (fileName.StartsWith("aux.sock.", StringComparison.Ordinal))
+        {
+            var afterPrefix = fileName["aux.sock.".Length..];
+            var dotIndex = afterPrefix.IndexOf('.');
+            return dotIndex > 0 ? afterPrefix[..dotIndex] : afterPrefix;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts the PID from a socket filename (new format only).
+    /// </summary>
+    /// <param name="socketPath">The full socket path or filename.</param>
+    /// <returns>The PID if present and valid, or <c>null</c> for old format sockets.</returns>
+    public static int? ExtractPid(string socketPath)
+    {
+        var fileName = Path.GetFileName(socketPath);
+        var lastDot = fileName.LastIndexOf('.');
+        if (lastDot > 0 && int.TryParse(fileName[(lastDot + 1)..], NumberStyles.None, CultureInfo.InvariantCulture, out var pid))
+        {
+            return pid;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Checks if a process with the given PID exists and is running.
+    /// </summary>
+    /// <remarks>
+    /// Used for orphan detection. If the PID from a socket filename doesn't correspond
+    /// to a running process, the socket is orphaned and can be safely deleted.
+    /// </remarks>
+    /// <param name="pid">The process ID to check.</param>
+    /// <returns><c>true</c> if the process exists and is running; otherwise, <c>false</c>.</returns>
+    public static bool ProcessExists(int pid)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(pid);
+            return !process.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            // Process doesn't exist
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            // Process has exited
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Cleans up orphaned socket files for a specific AppHost hash.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Called by AppHost on startup to clean up sockets from previous crashed instances.
+    /// This ensures orphan cleanup happens even if the user has an old CLI that doesn't
+    /// support PID-based orphan detection.
+    /// </para>
+    /// <para>
+    /// <strong>Limitation:</strong> This method only cleans up new format sockets (<c>auxi.sock.{hash}.{pid}</c>)
+    /// because old format sockets (<c>auxi.sock.{hash}</c>) don't have a PID for orphan detection.
+    /// Old format sockets are cleaned up via connection-based detection in the CLI.
+    /// </para>
+    /// </remarks>
+    /// <param name="backchannelsDirectory">The backchannels directory path.</param>
+    /// <param name="hash">The AppHost hash to match.</param>
+    /// <param name="currentPid">The current process ID (to avoid deleting own socket).</param>
+    /// <returns>The number of orphaned sockets deleted.</returns>
+    public static int CleanupOrphanedSockets(string backchannelsDirectory, string hash, int currentPid)
+    {
+        var deleted = 0;
+
+        if (!Directory.Exists(backchannelsDirectory))
+        {
+            return deleted;
+        }
+
+        // Find all sockets for this hash (both old and new format)
+        var pattern = $"{SocketPrefix}.{hash}*";
+        foreach (var socketPath in Directory.GetFiles(backchannelsDirectory, pattern))
+        {
+            var pid = ExtractPid(socketPath);
+            if (pid.HasValue && pid.Value != currentPid && !ProcessExists(pid.Value))
+            {
+                try
+                {
+                    // Double-check before delete to minimize TOCTOU race window
+                    // (A new process could theoretically start with the same PID between our checks)
+                    if (!ProcessExists(pid.Value))
+                    {
+                        File.Delete(socketPath);
+                        deleted++;
+                    }
+                }
+                catch
+                {
+                    // Ignore deletion failures
+                }
+            }
+        }
+
+        return deleted;
+    }
+}

--- a/tests/Aspire.Cli.Tests/Mcp/AppHostConnectionSelectionLogicTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/AppHostConnectionSelectionLogicTests.cs
@@ -25,8 +25,8 @@ public class AppHostConnectionSelectionLogicTests
         var inScope = CreateConnection("hash1", appHostPath: "C:/repo/AppHost1", isInScope: true, processId: 1);
         var outOfScope = CreateConnection("hash2", appHostPath: "C:/other/AppHost2", isInScope: false, processId: 2);
 
-        monitor.AddConnection("hash1", inScope);
-        monitor.AddConnection("hash2", outOfScope);
+        monitor.AddConnection("hash1", "socket.hash1", inScope);
+        monitor.AddConnection("hash2", "socket.hash2", outOfScope);
 
         monitor.SelectedAppHostPath = "C:/other/AppHost2";
 
@@ -40,7 +40,7 @@ public class AppHostConnectionSelectionLogicTests
 
         var inScope = CreateConnection("hash1", appHostPath: "C:/repo/AppHost1", isInScope: true, processId: 1);
 
-        monitor.AddConnection("hash1", inScope);
+        monitor.AddConnection("hash1", "socket.hash1", inScope);
         monitor.SelectedAppHostPath = "C:/missing/AppHost";
 
         var selected = monitor.SelectedConnection;
@@ -57,8 +57,8 @@ public class AppHostConnectionSelectionLogicTests
         var inScope = CreateConnection("hash1", appHostPath: "C:/repo/AppHost1", isInScope: true, processId: 1);
         var outOfScope = CreateConnection("hash2", appHostPath: "C:/other/AppHost2", isInScope: false, processId: 2);
 
-        monitor.AddConnection("hash1", inScope);
-        monitor.AddConnection("hash2", outOfScope);
+        monitor.AddConnection("hash1", "socket.hash1", inScope);
+        monitor.AddConnection("hash2", "socket.hash2", outOfScope);
 
         Assert.Same(inScope, monitor.SelectedConnection);
     }

--- a/tests/Aspire.Cli.Tests/Mcp/ListAppHostsToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListAppHostsToolTests.cs
@@ -51,7 +51,7 @@ public class ListAppHostsToolTests(ITestOutputHelper outputHelper)
             CliProcessId = 5678
         };
         var connection = CreateAppHostConnection("hash1", "/tmp/socket1", appHostInfo, isInScope: true);
-        monitor.AddConnection("hash1", connection);
+        monitor.AddConnection("hash1", "socket.hash1", connection);
 
         var tool = new ListAppHostsTool(monitor, executionContext);
         var result = await tool.CallToolAsync(null!, null, CancellationToken.None);
@@ -83,7 +83,7 @@ public class ListAppHostsToolTests(ITestOutputHelper outputHelper)
             CliProcessId = null
         };
         var connection = CreateAppHostConnection("hash2", "/tmp/socket2", appHostInfo, isInScope: false);
-        monitor.AddConnection("hash2", connection);
+        monitor.AddConnection("hash2", "socket.hash2", connection);
 
         var tool = new ListAppHostsTool(monitor, executionContext);
         var result = await tool.CallToolAsync(null!, null, CancellationToken.None);
@@ -115,7 +115,7 @@ public class ListAppHostsToolTests(ITestOutputHelper outputHelper)
             CliProcessId = 2222
         };
         var inScopeConnection = CreateAppHostConnection("hash1", "/tmp/socket1", inScopeAppHostInfo, isInScope: true);
-        monitor.AddConnection("hash1", inScopeConnection);
+        monitor.AddConnection("hash1", "socket.hash1", inScopeConnection);
 
         // Create out-of-scope connection
         var outOfScopeAppHostPath = "/other/path/OutOfScopeAppHost";
@@ -126,7 +126,7 @@ public class ListAppHostsToolTests(ITestOutputHelper outputHelper)
             CliProcessId = 4444
         };
         var outOfScopeConnection = CreateAppHostConnection("hash2", "/tmp/socket2", outOfScopeAppHostInfo, isInScope: false);
-        monitor.AddConnection("hash2", outOfScopeConnection);
+        monitor.AddConnection("hash2", "socket.hash2", outOfScopeConnection);
 
         var tool = new ListAppHostsTool(monitor, executionContext);
         var result = await tool.CallToolAsync(null!, null, CancellationToken.None);

--- a/tests/Aspire.Cli.Tests/Mcp/MockPackagingService.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/MockPackagingService.cs
@@ -61,9 +61,9 @@ internal static class TestExecutionContextFactory
 
 internal sealed class MockAuxiliaryBackchannelMonitor : IAuxiliaryBackchannelMonitor
 {
-    private readonly Dictionary<string, AppHostAuxiliaryBackchannel> _connections = new();
+    public IEnumerable<AppHostAuxiliaryBackchannel> Connections => [];
 
-    public IReadOnlyDictionary<string, AppHostAuxiliaryBackchannel> Connections => _connections;
+    public IEnumerable<AppHostAuxiliaryBackchannel> GetConnectionsByHash(string hash) => [];
 
     public string? SelectedAppHostPath { get; set; }
 
@@ -74,6 +74,6 @@ internal sealed class MockAuxiliaryBackchannelMonitor : IAuxiliaryBackchannelMon
     public IReadOnlyList<AppHostAuxiliaryBackchannel> GetConnectionsForWorkingDirectory(DirectoryInfo workingDirectory)
     {
         // Return empty list by default (no in-scope AppHosts)
-        return Array.Empty<AppHostAuxiliaryBackchannel>();
+        return [];
     }
 }

--- a/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
@@ -5,44 +5,45 @@ using Aspire.Cli.Utils;
 
 namespace Aspire.Cli.Tests.Utils;
 
-public class AppHostHelperTests
+public class AppHostHelperTests(ITestOutputHelper outputHelper)
 {
     [Fact]
-    public void ComputeAuxiliarySocketPath_UsesAuxiPrefix()
+    public void ComputeAuxiliarySocketPrefix_UsesAuxiPrefix()
     {
         // Arrange
-        var appHostPath = "/path/to/MyApp.AppHost.csproj";
-        var homeDirectory = "/home/user";
+        var appHostPath = Path.Combine("path", "to", "MyApp.AppHost.csproj");
+        var homeDirectory = Path.Combine(Path.GetTempPath(), "testuser");
 
         // Act
-        var socketPath = AppHostHelper.ComputeAuxiliarySocketPath(appHostPath, homeDirectory);
+        var socketPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, homeDirectory);
 
         // Assert
-        var fileName = Path.GetFileName(socketPath);
+        var fileName = Path.GetFileName(socketPrefix);
         Assert.StartsWith("auxi.sock.", fileName);
         
-        // Verify the path structure
-        var expectedDir = Path.Combine(homeDirectory, ".aspire", "cli", "backchannels");
-        Assert.Contains(expectedDir, socketPath);
+        // Verify the directory is under the backchannels folder
+        var dir = Path.GetDirectoryName(socketPrefix);
+        Assert.NotNull(dir);
+        Assert.EndsWith("backchannels", dir);
     }
 
     [Fact]
-    public void ComputeAuxiliarySocketPath_ProducesConsistentHash()
+    public void ComputeAuxiliarySocketPrefix_ProducesConsistentHash()
     {
         // Arrange
         var appHostPath = "/path/to/MyApp.AppHost.csproj";
         var homeDirectory = "/home/user";
 
         // Act
-        var socketPath1 = AppHostHelper.ComputeAuxiliarySocketPath(appHostPath, homeDirectory);
-        var socketPath2 = AppHostHelper.ComputeAuxiliarySocketPath(appHostPath, homeDirectory);
+        var socketPrefix1 = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, homeDirectory);
+        var socketPrefix2 = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, homeDirectory);
 
-        // Assert - Same input should produce same path
-        Assert.Equal(socketPath1, socketPath2);
+        // Assert - Same input should produce same prefix
+        Assert.Equal(socketPrefix1, socketPrefix2);
     }
 
     [Fact]
-    public void ComputeAuxiliarySocketPath_ProducesDifferentHashForDifferentAppHosts()
+    public void ComputeAuxiliarySocketPrefix_ProducesDifferentHashForDifferentAppHosts()
     {
         // Arrange
         var appHostPath1 = "/path/to/App1.AppHost.csproj";
@@ -50,15 +51,15 @@ public class AppHostHelperTests
         var homeDirectory = "/home/user";
 
         // Act
-        var socketPath1 = AppHostHelper.ComputeAuxiliarySocketPath(appHostPath1, homeDirectory);
-        var socketPath2 = AppHostHelper.ComputeAuxiliarySocketPath(appHostPath2, homeDirectory);
+        var socketPrefix1 = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath1, homeDirectory);
+        var socketPrefix2 = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath2, homeDirectory);
 
-        // Assert - Different inputs should produce different paths
-        Assert.NotEqual(socketPath1, socketPath2);
+        // Assert - Different inputs should produce different prefixes
+        Assert.NotEqual(socketPrefix1, socketPrefix2);
     }
 
     [Fact]
-    public void ComputeAuxiliarySocketPath_DoesNotUseReservedWindowsName()
+    public void ComputeAuxiliarySocketPrefix_DoesNotUseReservedWindowsName()
     {
         // This test verifies that the socket path does not use "aux" which is a reserved
         // device name on Windows < 11 (from DOS days: CON, PRN, AUX, NUL, COM1-9, LPT1-9)
@@ -68,13 +69,273 @@ public class AppHostHelperTests
         var homeDirectory = "/home/user";
 
         // Act
-        var socketPath = AppHostHelper.ComputeAuxiliarySocketPath(appHostPath, homeDirectory);
+        var socketPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, homeDirectory);
 
         // Assert
-        var fileName = Path.GetFileName(socketPath);
+        var fileName = Path.GetFileName(socketPrefix);
         
         // Should use "auxi" prefix, not "aux"
         Assert.StartsWith("auxi.sock.", fileName);
         Assert.DoesNotContain("aux.sock.", fileName);
+    }
+
+    [Fact]
+    public void ComputeAuxiliarySocketPrefix_HashIs16Characters()
+    {
+        var appHostPath = "/path/to/MyApp.AppHost.csproj";
+        var homeDirectory = "/home/user";
+
+        var socketPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, homeDirectory);
+
+        // Format is: auxi.sock.{hash} where hash is 16 chars
+        var fileName = Path.GetFileName(socketPrefix);
+        var hash = fileName["auxi.sock.".Length..];
+        Assert.Equal(16, hash.Length);
+        Assert.Matches("^[a-f0-9]+$", hash);
+    }
+
+    [Fact]
+    public void ExtractHashFromSocketPath_ExtractsHashFromNewFormat()
+    {
+        // New format: auxi.sock.{hash}.{pid}
+        var socketPath = "/home/user/.aspire/cli/backchannels/auxi.sock.abc123def4567890.12345";
+        
+        var hash = AppHostHelper.ExtractHashFromSocketPath(socketPath);
+        
+        Assert.Equal("abc123def4567890", hash);
+    }
+
+    [Fact]
+    public void ExtractHashFromSocketPath_ExtractsHashFromOldFormat()
+    {
+        // Old format: auxi.sock.{hash}
+        var socketPath = "/home/user/.aspire/cli/backchannels/auxi.sock.abc123def4567890";
+        
+        var hash = AppHostHelper.ExtractHashFromSocketPath(socketPath);
+        
+        Assert.Equal("abc123def4567890", hash);
+    }
+
+    [Fact]
+    public void ExtractHashFromSocketPath_ExtractsHashFromLegacyAuxFormat()
+    {
+        // Legacy format: aux.sock.{hash}
+        var socketPath = "/home/user/.aspire/cli/backchannels/aux.sock.abc123def4567890";
+        
+        var hash = AppHostHelper.ExtractHashFromSocketPath(socketPath);
+        
+        Assert.Equal("abc123def4567890", hash);
+    }
+
+    [Fact]
+    public void ExtractHashFromSocketPath_ReturnsNullForUnrecognizedFormat()
+    {
+        var socketPath = "/home/user/.aspire/cli/backchannels/unknown.sock.abc123";
+        
+        var hash = AppHostHelper.ExtractHashFromSocketPath(socketPath);
+        
+        Assert.Null(hash);
+    }
+
+    [Fact]
+    public void ExtractPidFromSocketPath_ExtractsPidFromNewFormat()
+    {
+        // New format: auxi.sock.{hash}.{pid}
+        var socketPath = "/home/user/.aspire/cli/backchannels/auxi.sock.abc123def4567890.12345";
+        
+        var pid = AppHostHelper.ExtractPidFromSocketPath(socketPath);
+        
+        Assert.Equal(12345, pid);
+    }
+
+    [Fact]
+    public void ExtractPidFromSocketPath_ReturnsNullForOldFormat()
+    {
+        // Old format: auxi.sock.{hash} - no PID
+        var socketPath = "/home/user/.aspire/cli/backchannels/auxi.sock.abc123def4567890";
+        
+        var pid = AppHostHelper.ExtractPidFromSocketPath(socketPath);
+        
+        Assert.Null(pid);
+    }
+
+    [Fact]
+    public void ExtractPidFromSocketPath_ReturnsNullForInvalidPid()
+    {
+        // Invalid PID (not a number)
+        var socketPath = "/home/user/.aspire/cli/backchannels/auxi.sock.abc123def4567890.notapid";
+        
+        var pid = AppHostHelper.ExtractPidFromSocketPath(socketPath);
+        
+        Assert.Null(pid);
+    }
+
+    [Fact]
+    public void ProcessExists_ReturnsTrueForCurrentProcess()
+    {
+        var currentPid = Environment.ProcessId;
+        
+        var exists = AppHostHelper.ProcessExists(currentPid);
+        
+        Assert.True(exists);
+    }
+
+    [Fact]
+    public void ProcessExists_ReturnsFalseForInvalidPid()
+    {
+        // Use a very high PID that's unlikely to exist
+        var invalidPid = int.MaxValue - 1;
+        
+        var exists = AppHostHelper.ProcessExists(invalidPid);
+        
+        Assert.False(exists);
+    }
+
+    [Fact]
+    public void FindMatchingSockets_ReturnsEmptyForNonExistentDirectory()
+    {
+        var appHostPath = "/path/to/MyApp.AppHost.csproj";
+        var homeDirectory = "/nonexistent/home/directory";
+        
+        var sockets = AppHostHelper.FindMatchingSockets(appHostPath, homeDirectory);
+        
+        Assert.Empty(sockets);
+    }
+
+    [Fact]
+    public void FindMatchingSockets_FindsMatchingSocketFiles()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "backchannels");
+        Directory.CreateDirectory(backchannelsDir);
+
+        var appHostPath = "/path/to/MyApp.AppHost.csproj";
+        
+        // Get the hash by extracting from computed prefix
+        var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, workspace.WorkspaceRoot.FullName);
+        var hash = Path.GetFileName(prefix)["auxi.sock.".Length..];
+        
+        // Create matching socket files (new format with PID)
+        var socket1 = Path.Combine(backchannelsDir, $"auxi.sock.{hash}.12345");
+        var socket2 = Path.Combine(backchannelsDir, $"auxi.sock.{hash}.67890");
+        File.WriteAllText(socket1, "");
+        File.WriteAllText(socket2, "");
+        
+        // Create a non-matching socket file (different hash)
+        var otherSocket = Path.Combine(backchannelsDir, "auxi.sock.differenthash123.99999");
+        File.WriteAllText(otherSocket, "");
+        
+        var sockets = AppHostHelper.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
+        
+        Assert.Equal(2, sockets.Length);
+        Assert.Contains(socket1, sockets);
+        Assert.Contains(socket2, sockets);
+        Assert.DoesNotContain(otherSocket, sockets);
+    }
+
+    [Fact]
+    public void FindMatchingSockets_FindsOldFormatSocketsWithoutPid()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "backchannels");
+        Directory.CreateDirectory(backchannelsDir);
+
+        var appHostPath = "/path/to/MyApp.AppHost.csproj";
+        
+        // Get the hash by extracting from computed prefix
+        var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, workspace.WorkspaceRoot.FullName);
+        var hash = Path.GetFileName(prefix)["auxi.sock.".Length..];
+        
+        // Create old format socket (no PID) - for backward compatibility
+        var oldFormatSocket = Path.Combine(backchannelsDir, $"auxi.sock.{hash}");
+        File.WriteAllText(oldFormatSocket, "");
+        
+        // Create new format socket (with PID)
+        var newFormatSocket = Path.Combine(backchannelsDir, $"auxi.sock.{hash}.12345");
+        File.WriteAllText(newFormatSocket, "");
+        
+        var sockets = AppHostHelper.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
+        
+        // Should find both old and new format
+        Assert.Equal(2, sockets.Length);
+        Assert.Contains(oldFormatSocket, sockets);
+        Assert.Contains(newFormatSocket, sockets);
+    }
+
+    [Fact]
+    public void FindMatchingSockets_DoesNotMatchSimilarHashes()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "backchannels");
+        Directory.CreateDirectory(backchannelsDir);
+
+        var appHostPath = "/path/to/MyApp.AppHost.csproj";
+        
+        // Get the hash by extracting from computed prefix
+        var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, workspace.WorkspaceRoot.FullName);
+        var hash = Path.GetFileName(prefix)["auxi.sock.".Length..];
+        
+        // Create a socket with a hash that starts with the same chars but is different
+        var similarSocket = Path.Combine(backchannelsDir, $"auxi.sock.{hash}xyz.12345");
+        File.WriteAllText(similarSocket, "");
+        
+        var sockets = AppHostHelper.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
+        
+        // Should NOT match the similar hash
+        Assert.Empty(sockets);
+    }
+
+    [Fact]
+    public void FindMatchingSockets_ReturnsEmptyWhenNoMatchingFiles()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "backchannels");
+        Directory.CreateDirectory(backchannelsDir);
+
+        var appHostPath = "/path/to/MyApp.AppHost.csproj";
+        
+        // Create sockets for a DIFFERENT app host
+        var otherSocket = Path.Combine(backchannelsDir, "auxi.sock.differenthash123.99999");
+        File.WriteAllText(otherSocket, "");
+        
+        var sockets = AppHostHelper.FindMatchingSockets(appHostPath, workspace.WorkspaceRoot.FullName);
+        
+        Assert.Empty(sockets);
+    }
+
+    [Fact]
+    public void CleanupOrphanedSockets_CleansUpBothOldAndNewFormatSockets()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var backchannelsDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cli", "backchannels");
+        Directory.CreateDirectory(backchannelsDir);
+
+        var appHostPath = "/path/to/MyApp.AppHost.csproj";
+        
+        // Get the hash
+        var prefix = AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, workspace.WorkspaceRoot.FullName);
+        var hash = AppHostHelper.ExtractHashFromSocketPath(prefix)!;
+        
+        // Create old format socket (no PID) - should NOT be cleaned up (can't detect orphan without PID)
+        var oldFormatSocket = Path.Combine(backchannelsDir, $"auxi.sock.{hash}");
+        File.WriteAllText(oldFormatSocket, "");
+        
+        // Create new format socket with a dead PID (use int.MaxValue - 1 as unlikely to exist)
+        var deadPid = int.MaxValue - 1;
+        var orphanedSocket = Path.Combine(backchannelsDir, $"auxi.sock.{hash}.{deadPid}");
+        File.WriteAllText(orphanedSocket, "");
+        
+        // Create new format socket with current PID (should NOT be deleted)
+        var currentPid = Environment.ProcessId;
+        var liveSocket = Path.Combine(backchannelsDir, $"auxi.sock.{hash}.{currentPid}");
+        File.WriteAllText(liveSocket, "");
+        
+        var deleted = AppHostHelper.CleanupOrphanedSockets(backchannelsDir, hash, currentPid);
+        
+        // Should only delete the orphaned socket (dead PID)
+        Assert.Equal(1, deleted);
+        Assert.True(File.Exists(oldFormatSocket), "Old format socket should still exist (can't detect orphan)");
+        Assert.False(File.Exists(orphanedSocket), "Orphaned socket should be deleted");
+        Assert.True(File.Exists(liveSocket), "Live socket should still exist");
     }
 }


### PR DESCRIPTION
## Description

This PR improves the reliability of the auxiliary backchannel between the CLI and AppHost by including the process ID (PID) in socket filenames.

### Problem
Multiple AppHost instances with the same project path would overwrite each other's sockets, causing:
- "Zombie" sockets that can't accept connections
- Unreliable CLI-to-AppHost communication
- Orphaned socket files that accumulate over time

### Solution
**New socket format:** `auxi.sock.{hash}.{pid}`

Benefits:
- **Unique sockets per instance** - No collisions when running multiple instances of the same AppHost
- **Fast orphan detection** - Check if PID exists before attempting connection
- **Self-healing cleanup** - Both AppHost and CLI clean up orphaned sockets automatically

### Changes
- **New shared code** (`src/Shared/BackchannelConstants.cs`): Centralized helpers for socket naming, hash computation, PID extraction, and orphan cleanup
- **AppHost**: Socket name now includes PID; cleans up orphaned sockets on startup
- **CLI**: Uses `FindMatchingSockets` helper for discovery; PID-based orphan detection before connecting

### Backward Compatibility
| CLI | AppHost | Works? | Notes |
|-----|---------|--------|-------|
| New | New | ✅ | Full orphan detection |
| New | Old | ✅ | Falls back to connection-based detection |
| Old | New | ✅ | AppHost self-cleanup on startup |
| Old | Old | ✅ | No change |

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No