### PR TITLE
Move polyglot validation to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,28 +82,12 @@ jobs:
     with:
       versionOverrideArg: ${{ needs.prepare_for_ci.outputs.VERSION_SUFFIX_OVERRIDE }}
 
-  build_cli_archives:
-    uses: ./.github/workflows/build-cli-native-archives.yml
-    name: Build native CLI archives
-    needs: [prepare_for_ci]
-    if: ${{ github.repository_owner == 'dotnet' && needs.prepare_for_ci.outputs.skip_workflow != 'true' }}
-    with:
-      versionOverrideArg: ${{ needs.prepare_for_ci.outputs.VERSION_SUFFIX_OVERRIDE }}
-
-  polyglot_validation:
-    uses: ./.github/workflows/polyglot-validation.yml
-    name: Polyglot SDK Validation
-    needs: [tests, build_cli_archives]
-    if: ${{ github.repository_owner == 'dotnet' && needs.prepare_for_ci.outputs.skip_workflow != 'true' }}
-    with:
-      versionOverrideArg: ${{ needs.prepare_for_ci.outputs.VERSION_SUFFIX_OVERRIDE }}
-
   # This job is used for branch protection. It fails if any of the dependent jobs failed
   results:
     if: ${{ always() && github.repository_owner == 'dotnet' }}
     runs-on: ubuntu-latest
     name: Final Results
-    needs: [prepare_for_ci, tests, build_cli_archives, polyglot_validation]
+    needs: [prepare_for_ci, tests]
 
     steps:
       - name: Fail if any of the dependent jobs failed
@@ -119,8 +103,6 @@ jobs:
           ${{ always() &&
               needs.prepare_for_ci.outputs.skip_workflow != 'true' &&
               needs.tests.outputs.skip_workflow != 'true' &&
-              needs.build_cli_archives.outputs.skip_workflow != 'true' &&
-              needs.polyglot_validation.outputs.skip_workflow != 'true' &&
               (contains(needs.*.result, 'failure') ||
                contains(needs.*.result, 'cancelled') ||
                contains(needs.*.result, 'skipped')) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,12 +90,20 @@ jobs:
     with:
       versionOverrideArg: ${{ needs.prepare_for_ci.outputs.VERSION_SUFFIX_OVERRIDE }}
 
+  polyglot_validation:
+    uses: ./.github/workflows/polyglot-validation.yml
+    name: Polyglot SDK Validation
+    needs: [tests, build_cli_archives]
+    if: ${{ github.repository_owner == 'dotnet' && needs.prepare_for_ci.outputs.skip_workflow != 'true' }}
+    with:
+      versionOverrideArg: ${{ needs.prepare_for_ci.outputs.VERSION_SUFFIX_OVERRIDE }}
+
   # This job is used for branch protection. It fails if any of the dependent jobs failed
   results:
     if: ${{ always() && github.repository_owner == 'dotnet' }}
     runs-on: ubuntu-latest
     name: Final Results
-    needs: [prepare_for_ci, tests, build_cli_archives]
+    needs: [prepare_for_ci, tests, build_cli_archives, polyglot_validation]
 
     steps:
       - name: Fail if any of the dependent jobs failed
@@ -112,6 +120,7 @@ jobs:
               needs.prepare_for_ci.outputs.skip_workflow != 'true' &&
               needs.tests.outputs.skip_workflow != 'true' &&
               needs.build_cli_archives.outputs.skip_workflow != 'true' &&
+              needs.polyglot_validation.outputs.skip_workflow != 'true' &&
               (contains(needs.*.result, 'failure') ||
                contains(needs.*.result, 'cancelled') ||
                contains(needs.*.result, 'skipped')) }}

--- a/.github/workflows/polyglot-validation.yml
+++ b/.github/workflows/polyglot-validation.yml
@@ -1,7 +1,7 @@
 # Polyglot SDK Validation Tests (Reusable)
 # Validates Python, Go, Java, Rust, and TypeScript AppHost SDKs with Redis integration
 # Uses Dockerfiles from .github/workflows/polyglot-validation/ for reproducible environments
-# Uses dogfood script to install CLI and NuGet packages from the current PR
+# Uses locally built CLI and NuGet packages from the workflow artifacts
 name: Polyglot SDK Validation
 
 on:
@@ -19,6 +19,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Download CLI archive
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: cli-native-archives-linux-x64
+          path: ${{ github.workspace }}/artifacts/cli
+
+      - name: Download NuGet packages
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: built-nugets
+          path: ${{ github.workspace }}/artifacts/nugets
+
       - name: Build Python validation image
         run: |
           docker build \
@@ -27,14 +39,10 @@ jobs:
             .github/workflows/polyglot-validation/
 
       - name: Run Python SDK validation
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e GH_TOKEN="${GH_TOKEN}" \
-            -e PR_NUMBER="${{ github.event.pull_request.number }}" \
             polyglot-python
 
   validate_go:
@@ -44,6 +52,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Download CLI archive
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: cli-native-archives-linux-x64
+          path: ${{ github.workspace }}/artifacts/cli
+
+      - name: Download NuGet packages
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: built-nugets
+          path: ${{ github.workspace }}/artifacts/nugets
+
       - name: Build Go validation image
         run: |
           docker build \
@@ -52,14 +72,10 @@ jobs:
             .github/workflows/polyglot-validation/
 
       - name: Run Go SDK validation
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e GH_TOKEN="${GH_TOKEN}" \
-            -e PR_NUMBER="${{ github.event.pull_request.number }}" \
             polyglot-go
 
   validate_java:
@@ -69,6 +85,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Download CLI archive
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: cli-native-archives-linux-x64
+          path: ${{ github.workspace }}/artifacts/cli
+
+      - name: Download NuGet packages
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: built-nugets
+          path: ${{ github.workspace }}/artifacts/nugets
+
       - name: Build Java validation image
         run: |
           docker build \
@@ -77,14 +105,10 @@ jobs:
             .github/workflows/polyglot-validation/
 
       - name: Run Java SDK validation
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e GH_TOKEN="${GH_TOKEN}" \
-            -e PR_NUMBER="${{ github.event.pull_request.number }}" \
             polyglot-java
 
   validate_rust:
@@ -96,6 +120,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Download CLI archive
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: cli-native-archives-linux-x64
+          path: ${{ github.workspace }}/artifacts/cli
+
+      - name: Download NuGet packages
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: built-nugets
+          path: ${{ github.workspace }}/artifacts/nugets
+
       - name: Build Rust validation image
         run: |
           docker build \
@@ -104,14 +140,10 @@ jobs:
             .github/workflows/polyglot-validation/
 
       - name: Run Rust SDK validation
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e GH_TOKEN="${GH_TOKEN}" \
-            -e PR_NUMBER="${{ github.event.pull_request.number }}" \
             polyglot-rust
 
   validate_typescript:
@@ -121,6 +153,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Download CLI archive
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: cli-native-archives-linux-x64
+          path: ${{ github.workspace }}/artifacts/cli
+
+      - name: Download NuGet packages
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: built-nugets
+          path: ${{ github.workspace }}/artifacts/nugets
+
       - name: Build TypeScript validation image
         run: |
           docker build \
@@ -129,14 +173,10 @@ jobs:
             .github/workflows/polyglot-validation/
 
       - name: Run TypeScript SDK validation
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e GH_TOKEN="${GH_TOKEN}" \
-            -e PR_NUMBER="${{ github.event.pull_request.number }}" \
             polyglot-typescript
 
   results:

--- a/.github/workflows/polyglot-validation.yml
+++ b/.github/workflows/polyglot-validation.yml
@@ -31,6 +31,12 @@ jobs:
           name: built-nugets
           path: ${{ github.workspace }}/artifacts/nugets
 
+      - name: Download RID-specific NuGet packages
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: built-nugets-for-linux-x64
+          path: ${{ github.workspace }}/artifacts/nugets-rid
+
       - name: Build Python validation image
         run: |
           docker build \
@@ -64,6 +70,12 @@ jobs:
           name: built-nugets
           path: ${{ github.workspace }}/artifacts/nugets
 
+      - name: Download RID-specific NuGet packages
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: built-nugets-for-linux-x64
+          path: ${{ github.workspace }}/artifacts/nugets-rid
+
       - name: Build Go validation image
         run: |
           docker build \
@@ -96,6 +108,12 @@ jobs:
         with:
           name: built-nugets
           path: ${{ github.workspace }}/artifacts/nugets
+
+      - name: Download RID-specific NuGet packages
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: built-nugets-for-linux-x64
+          path: ${{ github.workspace }}/artifacts/nugets-rid
 
       - name: Build Java validation image
         run: |
@@ -132,6 +150,12 @@ jobs:
           name: built-nugets
           path: ${{ github.workspace }}/artifacts/nugets
 
+      - name: Download RID-specific NuGet packages
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: built-nugets-for-linux-x64
+          path: ${{ github.workspace }}/artifacts/nugets-rid
+
       - name: Build Rust validation image
         run: |
           docker build \
@@ -164,6 +188,12 @@ jobs:
         with:
           name: built-nugets
           path: ${{ github.workspace }}/artifacts/nugets
+
+      - name: Download RID-specific NuGet packages
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: built-nugets-for-linux-x64
+          path: ${{ github.workspace }}/artifacts/nugets-rid
 
       - name: Build TypeScript validation image
         run: |

--- a/.github/workflows/polyglot-validation/Dockerfile.go
+++ b/.github/workflows/polyglot-validation/Dockerfile.go
@@ -6,9 +6,9 @@
 #   docker run --rm \
 #     -v "$(pwd):/workspace" \
 #     -v /var/run/docker.sock:/var/run/docker.sock \
-#     -e GH_TOKEN \
-#     -e PR_NUMBER=<pr_number> \
 #     polyglot-go
+#
+# Note: Expects CLI and NuGet artifacts to be pre-downloaded to /workspace/artifacts/
 #
 FROM mcr.microsoft.com/devcontainers/go:1-trixie
 
@@ -17,15 +17,6 @@ RUN apt-get update && apt-get install -y \
     wget \
     docker.io \
     jq \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install GitHub CLI (matches inline script installation)
-RUN mkdir -p -m 755 /etc/apt/keyrings \
-    && wget -nv -O- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-    && apt-get update \
-    && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET SDK 10.0
@@ -38,16 +29,14 @@ ENV PATH="/root/.aspire/bin:${PATH}"
 
 WORKDIR /workspace
 
+COPY setup-local-cli.sh /scripts/setup-local-cli.sh
 COPY test-go.sh /scripts/test-go.sh
-RUN chmod +x /scripts/test-go.sh
+RUN chmod +x /scripts/setup-local-cli.sh /scripts/test-go.sh
 
-# Entrypoint: Install Aspire CLI from PR, enable polyglot, run validation
+# Entrypoint: Set up Aspire CLI from local artifacts, enable polyglot, run validation
 ENTRYPOINT ["/bin/bash", "-c", "\
     set -e && \
-    echo '=== Installing Aspire CLI from PR ===' && \
-    chmod +x /workspace/eng/scripts/get-aspire-cli-pr.sh && \
-    /workspace/eng/scripts/get-aspire-cli-pr.sh ${PR_NUMBER} && \
-    aspire --version && \
+    /scripts/setup-local-cli.sh && \
     echo '=== Enabling polyglot support ===' && \
     aspire config set features:polyglotSupportEnabled true --global && \
     echo '=== Running validation ===' && \

--- a/.github/workflows/polyglot-validation/Dockerfile.python
+++ b/.github/workflows/polyglot-validation/Dockerfile.python
@@ -6,9 +6,9 @@
 #   docker run --rm \
 #     -v "$(pwd):/workspace" \
 #     -v /var/run/docker.sock:/var/run/docker.sock \
-#     -e GH_TOKEN \
-#     -e PR_NUMBER=<pr_number> \
 #     polyglot-python
+#
+# Note: Expects CLI and NuGet artifacts to be pre-downloaded to /workspace/artifacts/
 #
 FROM mcr.microsoft.com/devcontainers/python:3.12
 
@@ -17,15 +17,6 @@ RUN apt-get update && apt-get install -y \
     wget \
     docker.io \
     jq \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install GitHub CLI (matches inline script installation)
-RUN mkdir -p -m 755 /etc/apt/keyrings \
-    && wget -nv -O- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-    && apt-get update \
-    && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET SDK 10.0
@@ -42,16 +33,14 @@ ENV PATH="/root/.aspire/bin:${PATH}"
 
 WORKDIR /workspace
 
+COPY setup-local-cli.sh /scripts/setup-local-cli.sh
 COPY test-python.sh /scripts/test-python.sh
-RUN chmod +x /scripts/test-python.sh
+RUN chmod +x /scripts/setup-local-cli.sh /scripts/test-python.sh
 
-# Entrypoint: Install Aspire CLI from PR, enable polyglot, run validation
+# Entrypoint: Set up Aspire CLI from local artifacts, enable polyglot, run validation
 ENTRYPOINT ["/bin/bash", "-c", "\
     set -e && \
-    echo '=== Installing Aspire CLI from PR ===' && \
-    chmod +x /workspace/eng/scripts/get-aspire-cli-pr.sh && \
-    /workspace/eng/scripts/get-aspire-cli-pr.sh ${PR_NUMBER} && \
-    aspire --version && \
+    /scripts/setup-local-cli.sh && \
     echo '=== Enabling polyglot support ===' && \
     aspire config set features:polyglotSupportEnabled true --global && \
     echo '=== Running validation ===' && \

--- a/.github/workflows/polyglot-validation/Dockerfile.rust
+++ b/.github/workflows/polyglot-validation/Dockerfile.rust
@@ -6,9 +6,9 @@
 #   docker run --rm \
 #     -v "$(pwd):/workspace" \
 #     -v /var/run/docker.sock:/var/run/docker.sock \
-#     -e GH_TOKEN \
-#     -e PR_NUMBER=<pr_number> \
 #     polyglot-rust
+#
+# Note: Expects CLI and NuGet artifacts to be pre-downloaded to /workspace/artifacts/
 #
 FROM mcr.microsoft.com/devcontainers/rust:1
 
@@ -17,15 +17,6 @@ RUN apt-get update && apt-get install -y \
     wget \
     docker.io \
     jq \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install GitHub CLI (matches inline script installation)
-RUN mkdir -p -m 755 /etc/apt/keyrings \
-    && wget -nv -O- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-    && apt-get update \
-    && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET SDK 10.0
@@ -38,16 +29,14 @@ ENV PATH="/root/.aspire/bin:${PATH}"
 
 WORKDIR /workspace
 
+COPY setup-local-cli.sh /scripts/setup-local-cli.sh
 COPY test-rust.sh /scripts/test-rust.sh
-RUN chmod +x /scripts/test-rust.sh
+RUN chmod +x /scripts/setup-local-cli.sh /scripts/test-rust.sh
 
-# Entrypoint: Install Aspire CLI from PR, enable polyglot, run validation
+# Entrypoint: Set up Aspire CLI from local artifacts, enable polyglot, run validation
 ENTRYPOINT ["/bin/bash", "-c", "\
     set -e && \
-    echo '=== Installing Aspire CLI from PR ===' && \
-    chmod +x /workspace/eng/scripts/get-aspire-cli-pr.sh && \
-    /workspace/eng/scripts/get-aspire-cli-pr.sh ${PR_NUMBER} && \
-    aspire --version && \
+    /scripts/setup-local-cli.sh && \
     echo '=== Enabling polyglot support ===' && \
     aspire config set features:polyglotSupportEnabled true --global && \
     echo '=== Running validation ===' && \

--- a/.github/workflows/polyglot-validation/Dockerfile.typescript
+++ b/.github/workflows/polyglot-validation/Dockerfile.typescript
@@ -6,9 +6,9 @@
 #   docker run --rm \
 #     -v "$(pwd):/workspace" \
 #     -v /var/run/docker.sock:/var/run/docker.sock \
-#     -e GH_TOKEN \
-#     -e PR_NUMBER=<pr_number> \
 #     polyglot-typescript
+#
+# Note: Expects CLI and NuGet artifacts to be pre-downloaded to /workspace/artifacts/
 #
 FROM mcr.microsoft.com/devcontainers/typescript-node:22
 
@@ -17,15 +17,6 @@ RUN apt-get update && apt-get install -y \
     wget \
     docker.io \
     jq \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install GitHub CLI (matches inline script installation)
-RUN mkdir -p -m 755 /etc/apt/keyrings \
-    && wget -nv -O- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-    && apt-get update \
-    && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET SDK 10.0
@@ -38,16 +29,14 @@ ENV PATH="/root/.aspire/bin:${PATH}"
 
 WORKDIR /workspace
 
+COPY setup-local-cli.sh /scripts/setup-local-cli.sh
 COPY test-typescript.sh /scripts/test-typescript.sh
-RUN chmod +x /scripts/test-typescript.sh
+RUN chmod +x /scripts/setup-local-cli.sh /scripts/test-typescript.sh
 
-# Entrypoint: Install Aspire CLI from PR, enable polyglot, run validation
+# Entrypoint: Set up Aspire CLI from local artifacts, enable polyglot, run validation
 ENTRYPOINT ["/bin/bash", "-c", "\
     set -e && \
-    echo '=== Installing Aspire CLI from PR ===' && \
-    chmod +x /workspace/eng/scripts/get-aspire-cli-pr.sh && \
-    /workspace/eng/scripts/get-aspire-cli-pr.sh ${PR_NUMBER} && \
-    aspire --version && \
+    /scripts/setup-local-cli.sh && \
     echo '=== Enabling polyglot support ===' && \
     aspire config set features:polyglotSupportEnabled true --global && \
     echo '=== Running validation ===' && \

--- a/.github/workflows/polyglot-validation/setup-local-cli.sh
+++ b/.github/workflows/polyglot-validation/setup-local-cli.sh
@@ -7,6 +7,7 @@ set -e
 ARTIFACTS_DIR="/workspace/artifacts"
 CLI_DIR="$ARTIFACTS_DIR/cli"
 NUGETS_DIR="$ARTIFACTS_DIR/nugets"
+NUGETS_RID_DIR="$ARTIFACTS_DIR/nugets-rid"
 ASPIRE_HOME="$HOME/.aspire"
 
 echo "=== Setting up Aspire CLI from local artifacts ==="
@@ -51,6 +52,20 @@ else
     echo "Warning: Could not find NuGet packages directory"
     ls -la "$NUGETS_DIR" 2>/dev/null || echo "Directory does not exist"
 fi
+
+# Copy RID-specific packages (Aspire.Hosting.Orchestration.linux-x64, Aspire.Dashboard.Sdk.linux-x64)
+if [ -d "$NUGETS_RID_DIR" ]; then
+    echo "Copying RID-specific NuGet packages from $NUGETS_RID_DIR to hive"
+    find "$NUGETS_RID_DIR" -name "*.nupkg" -exec cp {} "$HIVE_DIR/" \;
+    RID_PKG_COUNT=$(find "$NUGETS_RID_DIR" -name "*.nupkg" | wc -l)
+    echo "Copied $RID_PKG_COUNT RID-specific packages to hive"
+else
+    echo "Warning: Could not find RID-specific NuGet packages directory at $NUGETS_RID_DIR"
+fi
+
+# Total package count
+TOTAL_PKG_COUNT=$(find "$HIVE_DIR" -name "*.nupkg" | wc -l)
+echo "Total packages in hive: $TOTAL_PKG_COUNT"
 
 # Set the channel to 'local' so CLI uses our hive
 echo "Setting channel to 'local'"

--- a/.github/workflows/polyglot-validation/setup-local-cli.sh
+++ b/.github/workflows/polyglot-validation/setup-local-cli.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# setup-local-cli.sh - Set up Aspire CLI and NuGet packages from local artifacts
+# Used by polyglot validation Dockerfiles to use pre-built artifacts from the workflow
+
+set -e
+
+ARTIFACTS_DIR="/workspace/artifacts"
+CLI_DIR="$ARTIFACTS_DIR/cli"
+NUGETS_DIR="$ARTIFACTS_DIR/nugets"
+ASPIRE_HOME="$HOME/.aspire"
+
+echo "=== Setting up Aspire CLI from local artifacts ==="
+
+# Find and extract the CLI archive
+CLI_ARCHIVE=$(find "$CLI_DIR" -name "aspire-cli-linux-x64*.tar.gz" 2>/dev/null | head -1)
+if [ -z "$CLI_ARCHIVE" ]; then
+    echo "Error: Could not find CLI archive in $CLI_DIR"
+    ls -la "$CLI_DIR" 2>/dev/null || echo "Directory does not exist"
+    exit 1
+fi
+
+echo "Found CLI archive: $CLI_ARCHIVE"
+
+# Create CLI directory and extract
+mkdir -p "$ASPIRE_HOME/bin"
+tar -xzf "$CLI_ARCHIVE" -C "$ASPIRE_HOME/bin"
+chmod +x "$ASPIRE_HOME/bin/aspire"
+
+# Verify CLI works
+echo "CLI version:"
+"$ASPIRE_HOME/bin/aspire" --version
+
+# Set up NuGet hive
+HIVE_DIR="$ASPIRE_HOME/hives/local/packages"
+mkdir -p "$HIVE_DIR"
+
+# Find NuGet packages in the shipping directory
+SHIPPING_DIR="$NUGETS_DIR/Release/Shipping"
+if [ ! -d "$SHIPPING_DIR" ]; then
+    # Try without Release subdirectory
+    SHIPPING_DIR="$NUGETS_DIR"
+fi
+
+if [ -d "$SHIPPING_DIR" ]; then
+    echo "Copying NuGet packages from $SHIPPING_DIR to hive"
+    # Copy all .nupkg files, handling nested directories
+    find "$SHIPPING_DIR" -name "*.nupkg" -exec cp {} "$HIVE_DIR/" \;
+    PKG_COUNT=$(find "$HIVE_DIR" -name "*.nupkg" | wc -l)
+    echo "Copied $PKG_COUNT packages to hive"
+else
+    echo "Warning: Could not find NuGet packages directory"
+    ls -la "$NUGETS_DIR" 2>/dev/null || echo "Directory does not exist"
+fi
+
+# Set the channel to 'local' so CLI uses our hive
+echo "Setting channel to 'local'"
+"$ASPIRE_HOME/bin/aspire" config set channel local --global || true
+
+echo "=== Aspire CLI setup complete ==="

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -175,13 +175,6 @@ jobs:
       requiresNugets: true
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
 
-  polyglot_validation:
-    name: Polyglot SDK Validation
-    uses: ./.github/workflows/polyglot-validation.yml
-    needs: build_packages
-    with:
-      versionOverrideArg: ${{ inputs.versionOverrideArg }}
-
   cli_e2e_tests:
     name: Cli E2E Linux
     # Only run CLI E2E tests during PR builds
@@ -236,7 +229,6 @@ jobs:
       integrations_test_lin,
       integrations_test_macos,
       integrations_test_win,
-      polyglot_validation,
       templates_test_lin,
       templates_test_macos,
       templates_test_win

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,12 @@ jobs:
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
 
+  build_cli_archives:
+    name: Build native CLI archives
+    uses: ./.github/workflows/build-cli-native-archives.yml
+    with:
+      versionOverrideArg: ${{ inputs.versionOverrideArg }}
+
   integrations_test_lin:
     uses: ./.github/workflows/run-tests.yml
     name: Integrations Linux
@@ -180,7 +186,7 @@ jobs:
     # Only run CLI E2E tests during PR builds
     if: ${{ github.event_name == 'pull_request' }}
     uses: ./.github/workflows/run-tests.yml
-    needs: [setup_for_tests_lin, build_packages]
+    needs: [setup_for_tests_lin, build_packages, build_cli_archives]
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup_for_tests_lin.outputs.cli_e2e_tests_matrix) }}
@@ -191,6 +197,13 @@ jobs:
       testSessionTimeout: 20m
       testHangTimeout: "12m"
       extraTestArgs: "--filter-not-trait quarantined=true --filter-not-trait outerloop=true --filter-class Aspire.Cli.EndToEnd.Tests.${{ matrix.shortname }}"
+      versionOverrideArg: ${{ inputs.versionOverrideArg }}
+
+  polyglot_validation:
+    name: Polyglot SDK Validation
+    uses: ./.github/workflows/polyglot-validation.yml
+    needs: [build_packages, build_cli_archives]
+    with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
 
   extension_tests_win:
@@ -223,12 +236,14 @@ jobs:
     runs-on: ubuntu-latest
     name: Final Test Results
     needs: [
+      build_cli_archives,
       cli_e2e_tests,
       endtoend_tests,
       extension_tests_win,
       integrations_test_lin,
       integrations_test_macos,
       integrations_test_win,
+      polyglot_validation,
       templates_test_lin,
       templates_test_macos,
       templates_test_win
@@ -287,6 +302,7 @@ jobs:
                  needs.integrations_test_lin.result == 'skipped' ||
                  needs.integrations_test_macos.result == 'skipped' ||
                  needs.integrations_test_win.result == 'skipped' ||
+                 needs.polyglot_validation.result == 'skipped' ||
                  needs.templates_test_lin.result == 'skipped' ||
                  needs.templates_test_macos.result == 'skipped' ||
                  needs.templates_test_win.result == 'skipped'))) }}


### PR DESCRIPTION
## Description

These tests were using `get-aspire-cli-pr.sh` to get the locally built cli but on `main` this doesn't work (failing the validation steps). These changes move the tests to `ci.yml` in order to run them once `build_cli_archives` is done and packages are available (from tests.yml).

