### PR TITLE
Use test docker registry for polyglot SDK validation

### DIFF
--- a/.github/workflows/polyglot-validation/test-go.sh
+++ b/.github/workflows/polyglot-validation/test-go.sh
@@ -40,7 +40,7 @@ aspire add Aspire.Hosting.Redis --non-interactive 2>&1 || {
 # Insert Redis code into apphost.go
 echo "Configuring apphost.go with Redis..."
 if grep -q "builder.Build()" apphost.go; then
-    sed -i '/builder.Build()/i\// Add Redis cache resource\n\t_, err = builder.AddRedis("cache", 0, nil)\n\tif err != nil {\n\t\tlog.Fatalf("Failed to add Redis: %v", err)\n\t}' apphost.go
+    sed -i '/builder.Build()/i\// Add Redis cache resource\n\tredis, err := builder.AddRedis("cache", 0, nil)\n\tif err != nil {\n\t\tlog.Fatalf("Failed to add Redis: %v", err)\n\t}\n\t_, err = redis.WithImageRegistry("netaspireci.azurecr.io")\n\tif err != nil {\n\t\tlog.Fatalf("Failed to set image registry: %v", err)\n\t}' apphost.go
     echo "✅ Redis configuration added to apphost.go"
 fi
 

--- a/.github/workflows/polyglot-validation/test-java.sh
+++ b/.github/workflows/polyglot-validation/test-java.sh
@@ -40,7 +40,7 @@ aspire add Aspire.Hosting.Redis --non-interactive 2>&1 || {
 # Insert Redis code into AppHost.java
 echo "Configuring AppHost.java with Redis..."
 if grep -q "builder.build()" AppHost.java; then
-    sed -i '/builder.build()/i\            // Add Redis cache resource\n            builder.addRedis("cache", null, null);' AppHost.java
+    sed -i '/builder.build()/i\            // Add Redis cache resource\n            builder.addRedis("cache", null, null).withImageRegistry("netaspireci.azurecr.io");' AppHost.java
     echo "✅ Redis configuration added to AppHost.java"
 fi
 

--- a/.github/workflows/polyglot-validation/test-python.sh
+++ b/.github/workflows/polyglot-validation/test-python.sh
@@ -40,7 +40,7 @@ aspire add Aspire.Hosting.Redis --non-interactive 2>&1 || {
 # Insert Redis line into apphost.py
 echo "Configuring apphost.py with Redis..."
 if grep -q "builder.build().run()" apphost.py; then
-    sed -i '/builder.build().run()/i\# Add Redis cache resource\nredis = builder.add_redis("cache")' apphost.py
+    sed -i '/builder.build().run()/i\# Add Redis cache resource\nredis = builder.add_redis("cache").with_image_registry("netaspireci.azurecr.io")' apphost.py
     echo "✅ Redis configuration added to apphost.py"
 fi
 

--- a/.github/workflows/polyglot-validation/test-rust.sh
+++ b/.github/workflows/polyglot-validation/test-rust.sh
@@ -40,7 +40,7 @@ aspire add Aspire.Hosting.Redis --non-interactive 2>&1 || {
 # Insert Redis code into src/main.rs
 echo "Configuring src/main.rs with Redis..."
 if [ -f "src/main.rs" ] && grep -q "builder.build()" src/main.rs; then
-    sed -i '/builder.build()/i\    // Add Redis cache resource\n    builder.add_redis("cache", None, None)?;' src/main.rs
+    sed -i '/builder.build()/i\    // Add Redis cache resource\n    builder.add_redis("cache", None, None)?.with_image_registry("netaspireci.azurecr.io")?;' src/main.rs
     echo "✅ Redis configuration added to src/main.rs"
 fi
 

--- a/.github/workflows/polyglot-validation/test-typescript.sh
+++ b/.github/workflows/polyglot-validation/test-typescript.sh
@@ -40,7 +40,7 @@ aspire add Aspire.Hosting.Redis --non-interactive 2>&1 || {
 # Insert Redis line into apphost.ts
 echo "Configuring apphost.ts with Redis..."
 if grep -q "builder.build().run()" apphost.ts; then
-    sed -i '/builder.build().run()/i\// Add Redis cache resource\nconst redis = await builder.addRedis("cache");' apphost.ts
+    sed -i '/builder.build().run()/i\// Add Redis cache resource\nconst redis = await builder.addRedis("cache").withImageRegistry("netaspireci.azurecr.io");' apphost.ts
     echo "✅ Redis configuration added to apphost.ts"
 fi
 


### PR DESCRIPTION
Add `.withImageRegistry("netaspireci.azurecr.io")` to all polyglot SDK validation scripts to avoid Docker Hub rate limiting.

Fixes #14113