### PR TITLE
Remove Aspire.Hosting and Aspire.Hosting.Tests from Aspire.Cli.Tests

### DIFF
--- a/tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj
+++ b/tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj
@@ -12,9 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Aspire.Hosting\Aspire.Hosting.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Cli\Aspire.Cli.csproj" />
-    <ProjectReference Include="..\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj
+++ b/tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(TestsSharedDir)Logging\*.cs" LinkBase="shared/Logging" />
     <Compile Include="$(TestsSharedDir)TestModuleInitializer.cs" Link="shared/TestModuleInitializer.cs" />
     <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" Link="shared/AsyncTestHelpers.cs" />
     <Compile Include="$(TestsSharedDir)TemporaryRepo.cs" Link="shared\TemporaryRepo.cs" />

--- a/tests/Aspire.Hosting.Tests/Cli/CliOrphanDetectorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Cli/CliOrphanDetectorTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Threading.Channels;
-using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Cli;
 using Aspire.Hosting.Utils;
 using Aspire.TestUtilities;
@@ -13,7 +12,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Time.Testing;
 
-namespace Aspire.Cli.Tests;
+namespace Aspire.Hosting.Tests;
 
 public class CliOrphanDetectorTests(ITestOutputHelper testOutputHelper)
 {


### PR DESCRIPTION
CliOrphanDetector test was in CLI tests instead of hosts tests. Moving it to hosts tests allows dependencies to be removed.