### PR TITLE
exclude ignorable files from workspace search

### DIFF
--- a/extension/src/test/workspace.test.ts
+++ b/extension/src/test/workspace.test.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { findAspireSettingsFiles, getCommonExcludeGlob } from '../utils/workspace';
+import { getCommonExcludeGlob } from '../utils/workspace';
 
 suite('utils/workspace tests', () => {
     let tempDir: string;

--- a/extension/src/test/workspace.test.ts
+++ b/extension/src/test/workspace.test.ts
@@ -1,0 +1,125 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { findAspireSettingsFiles, getCommonExcludeGlob } from '../utils/workspace';
+
+suite('utils/workspace tests', () => {
+    let tempDir: string;
+
+    setup(async () => {
+        // Create a temporary directory for test workspace
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aspire-test-'));
+    });
+
+    teardown(async () => {
+        // Clean up temp directory
+        if (tempDir && fs.existsSync(tempDir)) {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    test('getCommonExcludeGlob returns valid glob pattern', () => {
+        const glob = getCommonExcludeGlob();
+
+        assert.ok(glob.startsWith('{'), 'Glob should start with {');
+        assert.ok(glob.endsWith('}'), 'Glob should end with }');
+        assert.ok(glob.includes('**/node_modules/**'), 'Glob should include node_modules');
+        assert.ok(glob.includes('**/[Bb]in/**'), 'Glob should include bin');
+        assert.ok(glob.includes('**/[Oo]bj/**'), 'Glob should include obj');
+    });
+
+    test('findAspireSettingsFiles excludes node_modules directory', async function () {
+        this.timeout(10000); // Allow more time for file operations
+
+        // Create a settings.json inside node_modules (should be excluded)
+        const nodeModulesAspireDir = path.join(tempDir, 'node_modules', 'some-package', '.aspire');
+        fs.mkdirSync(nodeModulesAspireDir, { recursive: true });
+        fs.writeFileSync(path.join(nodeModulesAspireDir, 'settings.json'), '{}');
+
+        // Create a settings.json at the root level (should be found)
+        const rootAspireDir = path.join(tempDir, '.aspire');
+        fs.mkdirSync(rootAspireDir, { recursive: true });
+        fs.writeFileSync(path.join(rootAspireDir, 'settings.json'), '{}');
+
+        // Open the temp directory as a workspace folder
+        const workspaceFolder = { uri: vscode.Uri.file(tempDir), name: 'test', index: 0 };
+
+        // We need to actually update the workspace for findFiles to work
+        // Since we can't easily mock vscode.workspace.workspaceFolders in integration tests,
+        // we'll verify the exclude pattern is correctly formed
+        const excludeGlob = getCommonExcludeGlob();
+
+        // Verify the exclude pattern would match node_modules paths
+        assert.ok(excludeGlob.includes('**/node_modules/**'),
+            'Exclude pattern should include node_modules');
+
+        // Verify node_modules path exists
+        const nodeModulesSettingsPath = path.join(nodeModulesAspireDir, 'settings.json');
+        assert.ok(fs.existsSync(nodeModulesSettingsPath),
+            'node_modules settings.json should exist for test');
+
+        // Verify root settings path exists
+        const rootSettingsPath = path.join(rootAspireDir, 'settings.json');
+        assert.ok(fs.existsSync(rootSettingsPath),
+            'Root settings.json should exist for test');
+    });
+
+    test('findAspireSettingsFiles excludes bin directory', async function () {
+        this.timeout(10000);
+
+        // Create a settings.json inside bin (should be excluded)
+        const binAspireDir = path.join(tempDir, 'MyProject', 'bin', 'Debug', '.aspire');
+        fs.mkdirSync(binAspireDir, { recursive: true });
+        fs.writeFileSync(path.join(binAspireDir, 'settings.json'), '{}');
+
+        // Verify the exclude pattern would match bin paths
+        const excludeGlob = getCommonExcludeGlob();
+        assert.ok(excludeGlob.includes('**/[Bb]in/**'),
+            'Exclude pattern should include bin directory');
+
+        // Verify bin path exists
+        const binSettingsPath = path.join(binAspireDir, 'settings.json');
+        assert.ok(fs.existsSync(binSettingsPath),
+            'bin settings.json should exist for test');
+    });
+
+    test('findAspireSettingsFiles excludes obj directory', async function () {
+        this.timeout(10000);
+
+        // Create a settings.json inside obj (should be excluded)
+        const objAspireDir = path.join(tempDir, 'MyProject', 'obj', 'Debug', '.aspire');
+        fs.mkdirSync(objAspireDir, { recursive: true });
+        fs.writeFileSync(path.join(objAspireDir, 'settings.json'), '{}');
+
+        // Verify the exclude pattern would match obj paths
+        const excludeGlob = getCommonExcludeGlob();
+        assert.ok(excludeGlob.includes('**/[Oo]bj/**'),
+            'Exclude pattern should include obj directory');
+
+        // Verify obj path exists
+        const objSettingsPath = path.join(objAspireDir, 'settings.json');
+        assert.ok(fs.existsSync(objSettingsPath),
+            'obj settings.json should exist for test');
+    });
+
+    test('findAspireSettingsFiles excludes artifacts directory', async function () {
+        this.timeout(10000);
+
+        // Create a settings.json inside artifacts (should be excluded)
+        const artifactsAspireDir = path.join(tempDir, 'artifacts', 'bin', '.aspire');
+        fs.mkdirSync(artifactsAspireDir, { recursive: true });
+        fs.writeFileSync(path.join(artifactsAspireDir, 'settings.json'), '{}');
+
+        // Verify the exclude pattern would match artifacts paths
+        const excludeGlob = getCommonExcludeGlob();
+        assert.ok(excludeGlob.includes('**/artifacts/**'),
+            'Exclude pattern should include artifacts directory');
+
+        // Verify artifacts path exists
+        const artifactsSettingsPath = path.join(artifactsAspireDir, 'settings.json');
+        assert.ok(fs.existsSync(artifactsSettingsPath),
+            'artifacts settings.json should exist for test');
+    });
+});

--- a/extension/src/test/workspace.test.ts
+++ b/extension/src/test/workspace.test.ts
@@ -1,24 +1,7 @@
 import * as assert from 'assert';
-import * as vscode from 'vscode';
-import * as path from 'path';
-import * as fs from 'fs';
-import * as os from 'os';
-import { getCommonExcludeGlob } from '../utils/workspace';
+import { getCommonExcludeGlob, findAspireSettingsFiles } from '../utils/workspace';
 
 suite('utils/workspace tests', () => {
-    let tempDir: string;
-
-    setup(async () => {
-        // Create a temporary directory for test workspace
-        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aspire-test-'));
-    });
-
-    teardown(async () => {
-        // Clean up temp directory
-        if (tempDir && fs.existsSync(tempDir)) {
-            fs.rmSync(tempDir, { recursive: true, force: true });
-        }
-    });
 
     test('getCommonExcludeGlob returns valid glob pattern', () => {
         const glob = getCommonExcludeGlob();
@@ -28,95 +11,51 @@ suite('utils/workspace tests', () => {
         assert.ok(glob.includes('**/node_modules/**'), 'Glob should include node_modules');
         assert.ok(glob.includes('**/[Bb]in/**'), 'Glob should include bin');
         assert.ok(glob.includes('**/[Oo]bj/**'), 'Glob should include obj');
+        assert.ok(glob.includes('**/artifacts/**'), 'Glob should include artifacts');
     });
 
-    test('findAspireSettingsFiles excludes node_modules directory', async function () {
-        this.timeout(10000); // Allow more time for file operations
-
-        // Create a settings.json inside node_modules (should be excluded)
-        const nodeModulesAspireDir = path.join(tempDir, 'node_modules', 'some-package', '.aspire');
-        fs.mkdirSync(nodeModulesAspireDir, { recursive: true });
-        fs.writeFileSync(path.join(nodeModulesAspireDir, 'settings.json'), '{}');
-
-        // Create a settings.json at the root level (should be found)
-        const rootAspireDir = path.join(tempDir, '.aspire');
-        fs.mkdirSync(rootAspireDir, { recursive: true });
-        fs.writeFileSync(path.join(rootAspireDir, 'settings.json'), '{}');
-
-        // We need to actually update the workspace for findFiles to work
-        // Since we can't easily mock vscode.workspace.workspaceFolders in integration tests,
-        // we'll verify the exclude pattern is correctly formed
-        const excludeGlob = getCommonExcludeGlob();
-
-        // Verify the exclude pattern would match node_modules paths
-        assert.ok(excludeGlob.includes('**/node_modules/**'),
-            'Exclude pattern should include node_modules');
-
-        // Verify node_modules path exists
-        const nodeModulesSettingsPath = path.join(nodeModulesAspireDir, 'settings.json');
-        assert.ok(fs.existsSync(nodeModulesSettingsPath),
-            'node_modules settings.json should exist for test');
-
-        // Verify root settings path exists
-        const rootSettingsPath = path.join(rootAspireDir, 'settings.json');
-        assert.ok(fs.existsSync(rootSettingsPath),
-            'Root settings.json should exist for test');
-    });
-
-    test('findAspireSettingsFiles excludes bin directory', async function () {
+    test('findAspireSettingsFiles uses correct exclude pattern', async function () {
         this.timeout(10000);
 
-        // Create a settings.json inside bin (should be excluded)
-        const binAspireDir = path.join(tempDir, 'MyProject', 'bin', 'Debug', '.aspire');
-        fs.mkdirSync(binAspireDir, { recursive: true });
-        fs.writeFileSync(path.join(binAspireDir, 'settings.json'), '{}');
+        // Call findAspireSettingsFiles and verify it returns results (may be empty if no settings files exist)
+        // The main point is that it executes without error and uses the exclude pattern
+        const results = await findAspireSettingsFiles();
 
-        // Verify the exclude pattern would match bin paths
+        // Results should be an array (possibly empty)
+        assert.ok(Array.isArray(results), 'findAspireSettingsFiles should return an array');
+
+        // Verify that any results found are not in excluded directories
         const excludeGlob = getCommonExcludeGlob();
-        assert.ok(excludeGlob.includes('**/[Bb]in/**'),
-            'Exclude pattern should include bin directory');
-
-        // Verify bin path exists
-        const binSettingsPath = path.join(binAspireDir, 'settings.json');
-        assert.ok(fs.existsSync(binSettingsPath),
-            'bin settings.json should exist for test');
+        for (const uri of results) {
+            const filePath = uri.fsPath;
+            assert.ok(!filePath.includes('/node_modules/'), `Result should not be in node_modules: ${filePath}`);
+            assert.ok(!filePath.includes('/bin/') && !filePath.includes('/Bin/'), `Result should not be in bin: ${filePath}`);
+            assert.ok(!filePath.includes('/obj/') && !filePath.includes('/Obj/'), `Result should not be in obj: ${filePath}`);
+            assert.ok(!filePath.includes('/artifacts/'), `Result should not be in artifacts: ${filePath}`);
+        }
     });
 
-    test('findAspireSettingsFiles excludes obj directory', async function () {
-        this.timeout(10000);
+    test('getCommonExcludeGlob includes all expected directories', () => {
+        const glob = getCommonExcludeGlob();
 
-        // Create a settings.json inside obj (should be excluded)
-        const objAspireDir = path.join(tempDir, 'MyProject', 'obj', 'Debug', '.aspire');
-        fs.mkdirSync(objAspireDir, { recursive: true });
-        fs.writeFileSync(path.join(objAspireDir, 'settings.json'), '{}');
+        // Build outputs
+        assert.ok(glob.includes('**/artifacts/**'), 'Should exclude artifacts');
+        assert.ok(glob.includes('**/[Bb]in/**'), 'Should exclude bin (case-insensitive)');
+        assert.ok(glob.includes('**/[Oo]bj/**'), 'Should exclude obj (case-insensitive)');
+        assert.ok(glob.includes('**/dist/**'), 'Should exclude dist');
+        assert.ok(glob.includes('**/out/**'), 'Should exclude out');
+        assert.ok(glob.includes('**/build/**'), 'Should exclude build');
+        assert.ok(glob.includes('**/publish/**'), 'Should exclude publish');
 
-        // Verify the exclude pattern would match obj paths
-        const excludeGlob = getCommonExcludeGlob();
-        assert.ok(excludeGlob.includes('**/[Oo]bj/**'),
-            'Exclude pattern should include obj directory');
+        // Dependencies
+        assert.ok(glob.includes('**/node_modules/**'), 'Should exclude node_modules');
+        assert.ok(glob.includes('**/.venv/**'), 'Should exclude .venv');
+        assert.ok(glob.includes('**/packages/**'), 'Should exclude packages');
 
-        // Verify obj path exists
-        const objSettingsPath = path.join(objAspireDir, 'settings.json');
-        assert.ok(fs.existsSync(objSettingsPath),
-            'obj settings.json should exist for test');
-    });
-
-    test('findAspireSettingsFiles excludes artifacts directory', async function () {
-        this.timeout(10000);
-
-        // Create a settings.json inside artifacts (should be excluded)
-        const artifactsAspireDir = path.join(tempDir, 'artifacts', 'bin', '.aspire');
-        fs.mkdirSync(artifactsAspireDir, { recursive: true });
-        fs.writeFileSync(path.join(artifactsAspireDir, 'settings.json'), '{}');
-
-        // Verify the exclude pattern would match artifacts paths
-        const excludeGlob = getCommonExcludeGlob();
-        assert.ok(excludeGlob.includes('**/artifacts/**'),
-            'Exclude pattern should include artifacts directory');
-
-        // Verify artifacts path exists
-        const artifactsSettingsPath = path.join(artifactsAspireDir, 'settings.json');
-        assert.ok(fs.existsSync(artifactsSettingsPath),
-            'artifacts settings.json should exist for test');
+        // IDE/Tool directories
+        assert.ok(glob.includes('**/.vs/**'), 'Should exclude .vs');
+        assert.ok(glob.includes('**/.vscode-test/**'), 'Should exclude .vscode-test');
+        assert.ok(glob.includes('**/.idea/**'), 'Should exclude .idea');
+        assert.ok(glob.includes('**/.git/**'), 'Should exclude .git');
     });
 });

--- a/extension/src/test/workspace.test.ts
+++ b/extension/src/test/workspace.test.ts
@@ -43,9 +43,6 @@ suite('utils/workspace tests', () => {
         fs.mkdirSync(rootAspireDir, { recursive: true });
         fs.writeFileSync(path.join(rootAspireDir, 'settings.json'), '{}');
 
-        // Open the temp directory as a workspace folder
-        const workspaceFolder = { uri: vscode.Uri.file(tempDir), name: 'test', index: 0 };
-
         // We need to actually update the workspace for findFiles to work
         // Since we can't easily mock vscode.workspace.workspaceFolders in integration tests,
         // we'll verify the exclude pattern is correctly formed

--- a/extension/src/utils/workspace.ts
+++ b/extension/src/utils/workspace.ts
@@ -52,6 +52,17 @@ export function getCommonExcludeGlob(): string {
     return `{${commonExcludePatterns.join(',')}}`;
 }
 
+/**
+ * Searches for Aspire settings.json files in the workspace, excluding common build output
+ * and dependency directories.
+ * @returns An array of URIs pointing to found settings.json files
+ */
+export async function findAspireSettingsFiles(): Promise<vscode.Uri[]> {
+    const searchSubpath = '**/.aspire/settings.json';
+    const excludePattern = getCommonExcludeGlob();
+    return vscode.workspace.findFiles(searchSubpath, excludePattern);
+}
+
 export function isWorkspaceOpen(showErrorMessage: boolean = true): boolean {
     const isOpen = !!vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0;
     if (!isOpen && showErrorMessage) {
@@ -117,9 +128,7 @@ export async function checkForExistingAppHostPathInWorkspace(terminalProvider: A
     extensionLogOutputChannel.info(`Checking AppHost settings in workspace: ${rootFolder.name}`);
 
     // Search for settings.json files in any .aspire directory anywhere in the workspace
-    const searchSubpath = '**/.aspire/settings.json';
-    const excludePattern = getCommonExcludeGlob();
-    const settingsFiles = await vscode.workspace.findFiles(searchSubpath, excludePattern);
+    const settingsFiles = await findAspireSettingsFiles();
     const settingsFileExists = settingsFiles.length > 0;
 
     if (settingsFileExists) {


### PR DESCRIPTION
## Description

We don't need to search node_modules, etc when looking through the workspace files for an aspire settings file. It's wasted time

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
