### PR TITLE
Add hourly cleanup workflow for deployment test resources

### DIFF
--- a/.github/workflows/deployment-cleanup.yml
+++ b/.github/workflows/deployment-cleanup.yml
@@ -1,0 +1,224 @@
+# Cleanup workflow for deployment test resources
+#
+# Runs hourly to remove orphaned Azure resource groups from deployment tests.
+# Resource groups older than 3 hours are deleted.
+#
+# Resource group naming format: aspire-e2e-{hash}-{YYYYMMDDHHMMSS}-{runId}
+# The timestamp is parsed to determine age.
+#
+name: Deployment Environment Cleanup
+
+on:
+  schedule:
+    # Run every hour
+    - cron: '0 * * * *'
+
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (list but do not delete)'
+        required: false
+        type: boolean
+        default: false
+      max_age_hours:
+        description: 'Delete RGs older than this many hours'
+        required: false
+        type: number
+        default: 3
+
+# OIDC permissions for Azure login
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write  # For posting PR comments
+
+jobs:
+  cleanup:
+    name: Cleanup Azure Resources
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'dotnet' }}
+    environment: deployment-testing
+
+    steps:
+      - name: Get OIDC token
+        id: oidc
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const token = await core.getIDToken('api://AzureADTokenExchange');
+            core.setOutput('token', token);
+
+      - name: Azure Login (OIDC via CLI)
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
+        run: |
+          az login --service-principal \
+            --username "$AZURE_CLIENT_ID" \
+            --tenant "$AZURE_TENANT_ID" \
+            --federated-token "${{ steps.oidc.outputs.token }}" \
+            --allow-no-subscriptions
+          az account set --subscription "$AZURE_SUBSCRIPTION_ID"
+
+      - name: Cleanup old resource groups
+        id: cleanup
+        env:
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          MAX_AGE_HOURS: ${{ inputs.max_age_hours || '3' }}
+        run: |
+          echo "## Deployment Environment Cleanup" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Max Age:** ${MAX_AGE_HOURS} hours" >> $GITHUB_STEP_SUMMARY
+          echo "**Dry Run:** ${DRY_RUN}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Get current time in seconds since epoch
+          NOW=$(date +%s)
+          MAX_AGE_SECONDS=$((MAX_AGE_HOURS * 3600))
+
+          # List all resource groups matching our prefix
+          RG_LIST=$(az group list --query "[?starts_with(name, 'aspire-e2e-')].name" -o tsv || echo "")
+
+          if [ -z "$RG_LIST" ]; then
+            echo "No resource groups found matching 'aspire-e2e-*' prefix."
+            echo "✅ No resource groups found matching prefix." >> $GITHUB_STEP_SUMMARY
+            echo "deleted_count=0" >> $GITHUB_OUTPUT
+            echo "skipped_count=0" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          DELETED_COUNT=0
+          SKIPPED_COUNT=0
+          DELETED_LIST=""
+          SKIPPED_LIST=""
+
+          echo "### Resource Groups Processed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Resource Group | Age | Action |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------------|-----|--------|" >> $GITHUB_STEP_SUMMARY
+
+          for RG in $RG_LIST; do
+            echo "Processing: $RG"
+
+            # Extract timestamp from RG name (format: aspire-e2e-{hash}-{YYYYMMDDHHMMSS}-{suffix})
+            # Look for 14-digit number in the name
+            TIMESTAMP=$(echo "$RG" | grep -oE '[0-9]{14}' | head -1)
+
+            if [ -z "$TIMESTAMP" ]; then
+              echo "  ⚠️ Could not parse timestamp from: $RG (skipping)"
+              echo "| $RG | Unknown | ⚠️ Skipped (no timestamp) |" >> $GITHUB_STEP_SUMMARY
+              SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+              SKIPPED_LIST="${SKIPPED_LIST}${RG}\n"
+              continue
+            fi
+
+            # Parse timestamp (YYYYMMDDHHMMSS)
+            YEAR=${TIMESTAMP:0:4}
+            MONTH=${TIMESTAMP:4:2}
+            DAY=${TIMESTAMP:6:2}
+            HOUR=${TIMESTAMP:8:2}
+            MIN=${TIMESTAMP:10:2}
+            SEC=${TIMESTAMP:12:2}
+
+            # Convert to epoch seconds (assuming UTC)
+            RG_EPOCH=$(date -u -d "${YEAR}-${MONTH}-${DAY} ${HOUR}:${MIN}:${SEC}" +%s 2>/dev/null || echo "0")
+
+            if [ "$RG_EPOCH" = "0" ]; then
+              echo "  ⚠️ Invalid timestamp format: $TIMESTAMP (skipping)"
+              echo "| $RG | Invalid | ⚠️ Skipped (invalid timestamp) |" >> $GITHUB_STEP_SUMMARY
+              SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+              SKIPPED_LIST="${SKIPPED_LIST}${RG}\n"
+              continue
+            fi
+
+            # Calculate age
+            AGE_SECONDS=$((NOW - RG_EPOCH))
+            AGE_HOURS=$((AGE_SECONDS / 3600))
+            AGE_MINS=$(((AGE_SECONDS % 3600) / 60))
+
+            if [ $AGE_SECONDS -gt $MAX_AGE_SECONDS ]; then
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "  🔍 Would delete: $RG (age: ${AGE_HOURS}h ${AGE_MINS}m)"
+                echo "| $RG | ${AGE_HOURS}h ${AGE_MINS}m | 🔍 Would delete (dry run) |" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "  🗑️ Deleting: $RG (age: ${AGE_HOURS}h ${AGE_MINS}m)"
+                az group delete --name "$RG" --yes --no-wait || echo "  ⚠️ Failed to delete $RG"
+                echo "| $RG | ${AGE_HOURS}h ${AGE_MINS}m | 🗑️ Deleted |" >> $GITHUB_STEP_SUMMARY
+              fi
+              DELETED_COUNT=$((DELETED_COUNT + 1))
+              DELETED_LIST="${DELETED_LIST}${RG}\n"
+            else
+              echo "  ✅ Keeping: $RG (age: ${AGE_HOURS}h ${AGE_MINS}m, under threshold)"
+              echo "| $RG | ${AGE_HOURS}h ${AGE_MINS}m | ✅ Kept (recent) |" >> $GITHUB_STEP_SUMMARY
+              SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+            fi
+          done
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "- **Would delete:** $DELETED_COUNT resource groups" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- **Deleted:** $DELETED_COUNT resource groups" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "- **Kept/Skipped:** $SKIPPED_COUNT resource groups" >> $GITHUB_STEP_SUMMARY
+
+          echo "deleted_count=$DELETED_COUNT" >> $GITHUB_OUTPUT
+          echo "skipped_count=$SKIPPED_COUNT" >> $GITHUB_OUTPUT
+          echo "deleted_list<<EOF" >> $GITHUB_OUTPUT
+          echo -e "$DELETED_LIST" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Find associated PR (if any)
+        id: find_pr
+        if: ${{ steps.cleanup.outputs.deleted_count != '0' }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            // Check if this workflow was triggered by a PR or has associated PRs
+            // For scheduled runs, we won't have a PR context
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${context.repo.owner}:deploy-test/initial-infrastructure`,
+              per_page: 1
+            });
+
+            if (prs.length > 0) {
+              core.setOutput('pr_number', prs[0].number);
+              core.setOutput('has_pr', 'true');
+            } else {
+              core.setOutput('has_pr', 'false');
+            }
+
+      - name: Post cleanup results to PR
+        if: ${{ steps.find_pr.outputs.has_pr == 'true' && steps.cleanup.outputs.deleted_count != '0' }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const prNumber = ${{ steps.find_pr.outputs.pr_number }};
+            const deletedCount = ${{ steps.cleanup.outputs.deleted_count }};
+            const skippedCount = ${{ steps.cleanup.outputs.skipped_count }};
+            const deletedList = `${{ steps.cleanup.outputs.deleted_list }}`.trim();
+
+            let body = `## 🧹 Deployment Environment Cleanup\n\n`;
+            body += `**Deleted:** ${deletedCount} resource groups\n`;
+            body += `**Kept/Skipped:** ${skippedCount} resource groups\n\n`;
+
+            if (deletedList) {
+              body += `### Deleted Resource Groups\n\`\`\`\n${deletedList}\n\`\`\`\n`;
+            }
+
+            body += `\n[View workflow run](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: body
+            });
+
+            console.log(`Posted cleanup results to PR #${prNumber}`);

--- a/.github/workflows/deployment-test-command.yml
+++ b/.github/workflows/deployment-test-command.yml
@@ -1,6 +1,6 @@
 # Trigger deployment tests from PR comments
 #
-# Usage: Comment `/deployment-test` or `/deployment-test scenario-name` on a PR
+# Usage: Comment `/deployment-test` on a PR
 #
 # This workflow validates the commenter is an org member and triggers
 # the deployment-tests.yml workflow with the PR context.
@@ -18,10 +18,10 @@ permissions:
 
 jobs:
   deployment-test:
-    # Only run when the comment starts with /deployment-test on a PR
+    # Only run when the comment is exactly /deployment-test on a PR
     if: >-
       ${{
-        startsWith(github.event.comment.body, '/deployment-test') &&
+        github.event.comment.body == '/deployment-test' &&
         github.event.issue.pull_request &&
         github.repository_owner == 'dotnet'
       }}
@@ -64,24 +64,6 @@ jobs:
               throw error;
             }
 
-      - name: Parse scenario name
-        if: steps.check_membership.outputs.is_member == 'true'
-        id: parse
-        env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
-        run: |
-          # Extract optional scenario name from comment
-          # Format: /deployment-test [scenario-name]
-          SCENARIO=$(echo "$COMMENT_BODY" | sed -n 's|^/deployment-test\s*\(.*\)$|\1|p' | tr -d '\r\n' | xargs)
-          
-          if [ -z "$SCENARIO" ]; then
-            echo "No scenario specified, will run all tests"
-            echo "scenario=" >> $GITHUB_OUTPUT
-          else
-            echo "Scenario: $SCENARIO"
-            echo "scenario=$SCENARIO" >> $GITHUB_OUTPUT
-          fi
-
       - name: Get PR details
         if: steps.check_membership.outputs.is_member == 'true'
         id: pr
@@ -103,14 +85,13 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            const scenario = '${{ steps.parse.outputs.scenario }}' || 'all scenarios';
             const prNumber = ${{ steps.pr.outputs.number }};
             
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `🚀 Starting deployment test for **${scenario}** on PR #${prNumber}...\n\nThis will deploy to real Azure infrastructure. Results will be posted here when complete.\n\n[View workflow run](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/deployment-tests.yml)`
+              body: `🚀 Starting deployment tests on PR #${prNumber}...\n\nThis will deploy to real Azure infrastructure. Results will be posted here when complete.\n\n[View workflow run](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/deployment-tests.yml)`
             });
 
       - name: Trigger deployment tests
@@ -124,7 +105,6 @@ jobs:
               workflow_id: 'deployment-tests.yml',
               ref: '${{ steps.pr.outputs.head_ref }}',
               inputs: {
-                scenario: '${{ steps.parse.outputs.scenario }}',
                 pr_number: '${{ steps.pr.outputs.number }}'
               }
             });

--- a/.github/workflows/deployment-test-command.yml
+++ b/.github/workflows/deployment-test-command.yml
@@ -1,0 +1,132 @@
+# Trigger deployment tests from PR comments
+#
+# Usage: Comment `/deployment-test` or `/deployment-test scenario-name` on a PR
+#
+# This workflow validates the commenter is an org member and triggers
+# the deployment-tests.yml workflow with the PR context.
+#
+name: Deployment Test Command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: write  # To trigger workflows
+
+jobs:
+  deployment-test:
+    # Only run when the comment starts with /deployment-test on a PR
+    if: >-
+      ${{
+        startsWith(github.event.comment.body, '/deployment-test') &&
+        github.event.issue.pull_request &&
+        github.repository_owner == 'dotnet'
+      }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check org membership
+        id: check_membership
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const commenter = context.payload.comment.user.login;
+            
+            try {
+              // Check if user is a member of the dotnet org
+              const { status } = await github.rest.orgs.checkMembershipForUser({
+                org: 'dotnet',
+                username: commenter
+              });
+              
+              if (status === 204 || status === 302) {
+                core.info(`✅ ${commenter} is a member of dotnet org`);
+                core.setOutput('is_member', 'true');
+                return;
+              }
+            } catch (error) {
+              if (error.status === 404) {
+                core.warning(`❌ ${commenter} is not a member of dotnet org`);
+                core.setOutput('is_member', 'false');
+                
+                // Post a comment explaining the restriction
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: `@${commenter} The \`/deployment-test\` command is restricted to dotnet org members for security reasons (it deploys to real Azure infrastructure).`
+                });
+                return;
+              }
+              throw error;
+            }
+
+      - name: Parse scenario name
+        if: steps.check_membership.outputs.is_member == 'true'
+        id: parse
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          # Extract optional scenario name from comment
+          # Format: /deployment-test [scenario-name]
+          SCENARIO=$(echo "$COMMENT_BODY" | sed -n 's|^/deployment-test\s*\(.*\)$|\1|p' | tr -d '\r\n' | xargs)
+          
+          if [ -z "$SCENARIO" ]; then
+            echo "No scenario specified, will run all tests"
+            echo "scenario=" >> $GITHUB_OUTPUT
+          else
+            echo "Scenario: $SCENARIO"
+            echo "scenario=$SCENARIO" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get PR details
+        if: steps.check_membership.outputs.is_member == 'true'
+        id: pr
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            
+            core.setOutput('number', pr.number);
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('head_ref', pr.head.ref);
+
+      - name: Acknowledge command
+        if: steps.check_membership.outputs.is_member == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const scenario = '${{ steps.parse.outputs.scenario }}' || 'all scenarios';
+            const prNumber = ${{ steps.pr.outputs.number }};
+            
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `🚀 Starting deployment test for **${scenario}** on PR #${prNumber}...\n\nThis will deploy to real Azure infrastructure. Results will be posted here when complete.\n\n[View workflow run](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/deployment-tests.yml)`
+            });
+
+      - name: Trigger deployment tests
+        if: steps.check_membership.outputs.is_member == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'deployment-tests.yml',
+              ref: '${{ steps.pr.outputs.head_ref }}',
+              inputs: {
+                scenario: '${{ steps.parse.outputs.scenario }}',
+                pr_number: '${{ steps.pr.outputs.number }}'
+              }
+            });
+            
+            core.info('✅ Triggered deployment-tests.yml workflow');


### PR DESCRIPTION
## Summary

This PR adds infrastructure for cleaning up Azure resources created by deployment E2E tests.

### Changes

**New: Cleanup Workflow (`.github/workflows/deployment-cleanup.yml`)**
- Runs hourly to remove orphaned Azure resource groups
- Deletes resource groups older than 3 hours
- Supports dry-run mode for testing
- Posts cleanup results to associated PR (if any) or workflow summary
- Uses same OIDC authentication as deployment tests

**Improved: Resource Group Naming (`AzureAuthenticationHelpers.cs`)**
- New format: `aspire-e2e-{hash}-{YYYYMMDDHHMMSS}-{runId}`
- Timestamp embedded in name enables age detection without Azure API calls
- Added `ParseResourceGroupTimestamp()` helper method

**Improved: Test Cleanup (`AcaStarterDeploymentTests.cs`)**
- Attempts cleanup of both `aspire-e2e-*` and `rg-aspire-*` patterns
- Best-effort cleanup with graceful failure handling
- Relies on hourly workflow for reliability

### Testing

The cleanup workflow can be tested manually via workflow_dispatch with `dry_run: true`.

### Related

Built on top of the deployment E2E test infrastructure from `deploy-test/initial-infrastructure` branch.