### PR TITLE
Add end-to-end deployment tests infrastructure

### DIFF
--- a/.github/actions/enumerate-tests/action.yml
+++ b/.github/actions/enumerate-tests/action.yml
@@ -13,6 +13,10 @@ inputs:
     required: false
     type: boolean
     default: false
+  includeDeployment:
+    required: false
+    type: boolean
+    default: false
 
 outputs:
   integrations_tests_matrix:
@@ -24,6 +28,9 @@ outputs:
   cli_e2e_tests_matrix:
     description: Cli E2E tests matrix
     value: ${{ steps.generate_cli_e2e_matrix.outputs.cli_e2e_tests_matrix }}
+  deployment_tests_matrix:
+    description: Deployment E2E tests matrix
+    value: ${{ steps.generate_deployment_matrix.outputs.deployment_tests_matrix }}
 runs:
   using: "composite"
   steps:
@@ -67,6 +74,17 @@ runs:
           -p:PrepareForHelix=true
           -p:ExtractTestClassNamesPrefix=Aspire.Cli.EndToEnd.Tests
           -p:InstallBrowsersForPlaywright=false
+
+    - name: Generate list of Deployment E2E tests
+      if: ${{ inputs.includeDeployment }}
+      shell: pwsh
+      run: >
+          dotnet build ${{ github.workspace }}/tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj
+          "/t:Build;ExtractTestClassNames"
+          /bl:${{ github.workspace }}/artifacts/log/Debug/BuildDeploymentEndToEndTests.binlog
+          -p:ExtractTestClassNamesForHelix=true
+          -p:PrepareForHelix=true
+          -p:ExtractTestClassNamesPrefix=Aspire.Deployment.EndToEnd.Tests
 
     - name: Generate tests matrix
       id: generate_integrations_matrix
@@ -121,6 +139,26 @@ runs:
         $jsonString = ConvertTo-Json $jsonObject -Compress
         "cli_e2e_tests_matrix=$jsonString"
         "cli_e2e_tests_matrix=$jsonString" | Out-File -FilePath $env:GITHUB_OUTPUT
+
+    - name: Generate deployment matrix
+      id: generate_deployment_matrix
+      if: ${{ inputs.includeDeployment }}
+      shell: pwsh
+      run: |
+        $inputFilePath = "${{ github.workspace }}/artifacts/helix/deployment-e2e-tests/Aspire.Deployment.EndToEnd.Tests.tests.list"
+        $lines = Get-Content $inputFilePath
+
+        $prefix = "Aspire.Deployment.EndToEnd.Tests."
+        $lines = @(Get-Content $inputFilePath | ForEach-Object {
+            $_ -replace "^$prefix", ""
+        })
+
+        $jsonObject = @{
+            "shortname" = @($lines | Sort-Object)
+        }
+        $jsonString = ConvertTo-Json $jsonObject -Compress
+        "deployment_tests_matrix=$jsonString"
+        "deployment_tests_matrix=$jsonString" | Out-File -FilePath $env:GITHUB_OUTPUT
 
     - name: Upload logs
       if: always()

--- a/.github/skills/deployment-e2e-testing/SKILL.md
+++ b/.github/skills/deployment-e2e-testing/SKILL.md
@@ -1,0 +1,425 @@
+---
+name: deployment-e2e-testing
+description: Guide for writing Aspire deployment end-to-end tests. Use this when asked to create, modify, or debug deployment E2E tests that deploy to Azure.
+---
+
+# Aspire Deployment End-to-End Testing
+
+This skill provides patterns and practices for writing end-to-end tests that deploy Aspire applications to real Azure infrastructure.
+
+## Overview
+
+Deployment E2E tests extend the CLI E2E testing patterns with actual Azure deployments. They use the Hex1b terminal automation library to drive the Aspire CLI and verify that deployed applications work correctly.
+
+**Location**: `tests/Aspire.Deployment.EndToEnd.Tests/`
+
+**Supported Platforms**: Linux only (Hex1b requirement).
+
+**Prerequisites**:
+- Azure subscription with appropriate permissions
+- OIDC authentication (CI) or Azure CLI authentication (local)
+
+## Relationship to CLI E2E Tests
+
+Deployment tests build on the CLI E2E testing skill. Before working with deployment tests, familiarize yourself with:
+
+- [CLI E2E Testing Skill](../cli-e2e-testing/SKILL.md) - Core terminal automation patterns
+
+Key differences from CLI E2E tests:
+
+| Aspect | CLI E2E Tests | Deployment E2E Tests |
+|--------|---------------|----------------------|
+| Duration | 5-15 minutes | 15-45 minutes |
+| Resources | Local only | Azure resources |
+| Authentication | None | Azure OIDC/CLI |
+| Cleanup | Temp directories | Azure resource groups |
+| Triggers | PR, push | Nightly, manual, deploy-test/* |
+
+## Key Components
+
+### Core Classes
+
+- **`DeploymentE2ETestHelpers`** (`Helpers/DeploymentE2ETestHelpers.cs`): Terminal automation helpers
+- **`AzureAuthenticationHelpers`** (`Helpers/AzureAuthenticationHelpers.cs`): Azure auth and resource naming
+- **`DeploymentReporter`** (`Helpers/DeploymentReporter.cs`): GitHub step summary reporting
+- **`SequenceCounter`** (`Helpers/SequenceCounter.cs`): Prompt tracking (same as CLI E2E)
+
+### Test Architecture
+
+Each deployment test:
+
+1. Validates Azure authentication (skip if not available locally)
+2. Generates a unique resource group name
+3. Creates a project using `aspire new`
+4. Deploys using `aspire deploy`
+5. Verifies deployed endpoints work
+6. Reports results to GitHub step summary
+7. Cleans up Azure resources
+
+## Test Structure
+
+```csharp
+public sealed class MyDeploymentTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task DeployMyScenario()
+    {
+        // 1. Validate prerequisites
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure auth not available in CI.");
+            }
+            Assert.Skip("Azure auth not available. Run 'az login'.");
+        }
+
+        // 2. Setup
+        var resourceGroupName = AzureAuthenticationHelpers.GenerateResourceGroupName("my-scenario");
+        var workspace = TemporaryWorkspace.Create(output);
+        var recordingPath = DeploymentE2ETestHelpers.GetTestResultsRecordingPath(nameof(DeployMyScenario));
+        var startTime = DateTime.UtcNow;
+
+        try
+        {
+            // 3. Build terminal and run deployment
+            var builder = Hex1bTerminal.CreateBuilder()
+                .WithHeadless()
+                .WithAsciinemaRecording(recordingPath)
+                .WithPtyProcess("/bin/bash", ["--norc"]);
+
+            using var terminal = builder.Build();
+            var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+            var counter = new SequenceCounter();
+            var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+            // Build sequence: prepare, create project, deploy, verify
+            sequenceBuilder.PrepareEnvironment(workspace, counter);
+            // ... add deployment steps ...
+
+            var sequence = sequenceBuilder.Build();
+            await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+            await pendingRun;
+
+            // 4. Report success
+            var duration = DateTime.UtcNow - startTime;
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployMyScenario),
+                resourceGroupName,
+                deploymentUrls,
+                duration);
+        }
+        catch (Exception ex)
+        {
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployMyScenario),
+                resourceGroupName,
+                ex.Message);
+            throw;
+        }
+        finally
+        {
+            // 5. Cleanup Azure resources
+            await CleanupResourceGroupAsync(resourceGroupName);
+        }
+    }
+}
+```
+
+## Azure Authentication
+
+### In CI (GitHub Actions)
+
+Tests use OIDC (Workload Identity Federation) for authentication:
+
+```yaml
+- name: Azure Login (OIDC)
+  uses: azure/login@v2
+  with:
+    client-id: ${{ secrets.AZURE_CLIENT_ID }}
+    tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+    subscription-id: ${{ vars.ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION }}
+```
+
+The test code automatically detects CI and uses `DefaultAzureCredential` which picks up the OIDC session.
+
+### Local Development
+
+Authenticate with Azure CLI before running tests:
+
+```bash
+# Login to Azure
+az login
+
+# Set your subscription
+az account set --subscription "your-subscription-id"
+
+# Set environment variable
+export ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION="your-subscription-id"
+
+# Run tests
+dotnet test tests/Aspire.Deployment.EndToEnd.Tests/
+```
+
+### Authentication Helpers
+
+```csharp
+// Check if auth is available
+if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+{
+    Assert.Skip("Azure auth not available");
+}
+
+// Get subscription ID
+var subscriptionId = AzureAuthenticationHelpers.GetSubscriptionId();
+
+// Generate unique resource group name
+var rgName = AzureAuthenticationHelpers.GenerateResourceGroupName("my-test");
+// Result: "aspire-e2e-my-test-20240115-abc12345"
+
+// Check auth type
+if (AzureAuthenticationHelpers.IsOidcConfigured())
+{
+    // Using OIDC (CI)
+}
+else
+{
+    // Using Azure CLI (local)
+}
+```
+
+## Resource Group Naming
+
+Resource groups are named with a consistent pattern for easy identification and cleanup:
+
+```
+{prefix}-{testname}-{date}-{runid}
+```
+
+Example: `aspire-e2e-aca-starter-20240115-12345678`
+
+Components:
+- **prefix**: From `ASPIRE_DEPLOYMENT_TEST_RG_PREFIX` (default: `aspire-e2e`)
+- **testname**: Sanitized test name (lowercase, alphanumeric, hyphens)
+- **date**: UTC date in YYYYMMDD format
+- **runid**: GitHub run ID or random GUID suffix
+
+## Reporting Results
+
+### GitHub Step Summary
+
+Tests automatically write to the GitHub step summary:
+
+```csharp
+// Report success with URLs
+DeploymentReporter.ReportDeploymentSuccess(
+    testName: "DeployStarterToACA",
+    resourceGroupName: "aspire-e2e-...",
+    deploymentUrls: new Dictionary<string, string>
+    {
+        ["Dashboard"] = "https://dashboard.azurecontainerapps.io",
+        ["Web Frontend"] = "https://webfrontend.azurecontainerapps.io"
+    },
+    duration: TimeSpan.FromMinutes(15));
+
+// Report failure
+DeploymentReporter.ReportDeploymentFailure(
+    testName: "DeployStarterToACA",
+    resourceGroupName: "aspire-e2e-...",
+    errorMessage: "Deployment timed out",
+    logs: "Full deployment logs...");
+```
+
+### Asciinema Recordings
+
+Tests generate recordings for debugging:
+
+```csharp
+var recordingPath = DeploymentE2ETestHelpers.GetTestResultsRecordingPath(nameof(MyTest));
+// CI: $GITHUB_WORKSPACE/testresults/recordings/MyTest.cast
+// Local: /tmp/aspire-deployment-e2e/recordings/MyTest.cast
+```
+
+## Cleanup
+
+Always cleanup Azure resources in a `finally` block:
+
+```csharp
+private static async Task CleanupResourceGroupAsync(string resourceGroupName)
+{
+    var process = new Process
+    {
+        StartInfo = new ProcessStartInfo
+        {
+            FileName = "az",
+            Arguments = $"group delete --name {resourceGroupName} --yes --no-wait",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        }
+    };
+
+    process.Start();
+    await process.WaitForExitAsync();
+
+    if (process.ExitCode != 0)
+    {
+        var error = await process.StandardError.ReadToEndAsync();
+        throw new InvalidOperationException($"Cleanup failed: {error}");
+    }
+}
+```
+
+## Workflow Triggers
+
+Deployment tests are triggered by:
+
+1. **Nightly schedule** (03:00 UTC) - Runs on `main`
+2. **Manual dispatch** - Via GitHub Actions UI
+3. **Push to `deploy-test/*`** - For rapid iteration
+
+### Iterating on Tests
+
+To iterate quickly during development:
+
+```bash
+# Create a protected branch
+git checkout -b deploy-test/my-feature
+
+# Make changes
+# ...
+
+# Push to trigger workflow
+git push origin deploy-test/my-feature
+```
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION` | Yes | Azure subscription ID |
+| `ASPIRE_DEPLOYMENT_TEST_RG_PREFIX` | No | Resource group prefix (default: `aspire-e2e`) |
+| `AZURE_DEPLOYMENT_TEST_TENANT_ID` | CI | Azure AD tenant ID |
+| `AZURE_DEPLOYMENT_TEST_CLIENT_ID` | CI | OIDC app client ID |
+| `AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID` | CI | Azure subscription ID (GitHub variable)
+
+## DO: Always Validate Prerequisites
+
+```csharp
+var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+if (string.IsNullOrEmpty(subscriptionId))
+{
+    Assert.Skip("Subscription not configured");
+}
+
+if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+{
+    Assert.Skip("Azure auth not available");
+}
+```
+
+## DO: Generate Unique Resource Groups
+
+```csharp
+var rgName = AzureAuthenticationHelpers.GenerateResourceGroupName("my-test");
+```
+
+## DO: Report to GitHub Summary
+
+```csharp
+DeploymentReporter.ReportDeploymentSuccess(...);
+// or
+DeploymentReporter.ReportDeploymentFailure(...);
+```
+
+## DO: Always Cleanup Resources
+
+```csharp
+try
+{
+    // ... deployment test ...
+}
+finally
+{
+    await CleanupResourceGroupAsync(resourceGroupName);
+}
+```
+
+## DON'T: Hardcode Subscription IDs
+
+```csharp
+// DON'T
+var subscriptionId = "12345-abcde-...";
+
+// DO
+var subscriptionId = AzureAuthenticationHelpers.GetSubscriptionId();
+```
+
+## DON'T: Skip Cleanup on Failure
+
+```csharp
+// DON'T - cleanup might not run
+await DeployAsync();
+await CleanupAsync();  // Skipped if deploy throws!
+
+// DO - always cleanup
+try
+{
+    await DeployAsync();
+}
+finally
+{
+    await CleanupAsync();  // Always runs
+}
+```
+
+## Troubleshooting
+
+### Authentication Failures
+
+**Local**: Ensure Azure CLI is authenticated:
+```bash
+az login
+az account show
+```
+
+**CI**: Check OIDC configuration:
+- `AZURE_CLIENT_ID` secret is set
+- `AZURE_TENANT_ID` secret is set
+- Workload Identity Federation is configured in Azure AD
+
+### Deployment Timeouts
+
+Deployments can take 15-30+ minutes. If tests timeout:
+- Check the asciinema recording for where it stopped
+- Increase timeout in `WaitUntil` calls
+- Check Azure portal for deployment status
+
+### Orphaned Resources
+
+Find and cleanup orphaned test resources:
+
+```bash
+# List all test resource groups
+az group list --query "[?starts_with(name, 'aspire-e2e')]" -o table
+
+# Delete specific resource group
+az group delete --name aspire-e2e-xxx --yes
+```
+
+### Tenant Rotation
+
+The test tenant rotates every ~90 days. When rotation occurs:
+
+1. Create new App Registration in new tenant
+2. Configure Workload Identity Federation for the `deployment-tests` environment
+3. Grant Owner role on subscription (constrained - cannot create other Owner identities)
+4. Update GitHub secrets: `AZURE_DEPLOYMENT_TEST_CLIENT_ID`, `AZURE_DEPLOYMENT_TEST_TENANT_ID`
+5. Update GitHub variable: `AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID`

--- a/.github/skills/deployment-e2e-testing/SKILL.md
+++ b/.github/skills/deployment-e2e-testing/SKILL.md
@@ -306,9 +306,9 @@ git push origin deploy-test/my-feature
 |----------|----------|-------------|
 | `ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION` | Yes | Azure subscription ID |
 | `ASPIRE_DEPLOYMENT_TEST_RG_PREFIX` | No | Resource group prefix (default: `aspire-e2e`) |
-| `AZURE_DEPLOYMENT_TEST_TENANT_ID` | CI | Azure AD tenant ID |
-| `AZURE_DEPLOYMENT_TEST_CLIENT_ID` | CI | OIDC app client ID |
-| `AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID` | CI | Azure subscription ID (GitHub variable)
+| `AZURE_DEPLOYMENT_TEST_TENANT_ID` | CI | Azure AD tenant ID (GitHub secret) |
+| `AZURE_DEPLOYMENT_TEST_CLIENT_ID` | CI | OIDC app client ID (GitHub secret) |
+| `AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID` | CI | Azure subscription ID (GitHub secret) |
 
 ## DO: Always Validate Prerequisites
 
@@ -419,7 +419,6 @@ az group delete --name aspire-e2e-xxx --yes
 The test tenant rotates every ~90 days. When rotation occurs:
 
 1. Create new App Registration in new tenant
-2. Configure Workload Identity Federation for the `deployment-tests` environment
+2. Configure Workload Identity Federation for the `deployment-testing` environment
 3. Grant Owner role on subscription (constrained - cannot create other Owner identities)
-4. Update GitHub secrets: `AZURE_DEPLOYMENT_TEST_CLIENT_ID`, `AZURE_DEPLOYMENT_TEST_TENANT_ID`
-5. Update GitHub variable: `AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID`
+4. Update GitHub secrets: `AZURE_DEPLOYMENT_TEST_CLIENT_ID`, `AZURE_DEPLOYMENT_TEST_TENANT_ID`, `AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID`

--- a/.github/workflows/deployment-cleanup.yml
+++ b/.github/workflows/deployment-cleanup.yml
@@ -81,12 +81,12 @@ jobs:
           NOW=$(date +%s)
           MAX_AGE_SECONDS=$((MAX_AGE_HOURS * 3600))
 
-          # List all resource groups matching our prefix
-          RG_LIST=$(az group list --query "[?starts_with(name, 'aspire-e2e-')].name" -o tsv || echo "")
+          # List all resource groups matching our prefixes (rg-aspire-* from aspire deploy, aspire-e2e-* legacy)
+          RG_LIST=$(az group list --query "[?starts_with(name, 'rg-aspire-') || starts_with(name, 'aspire-e2e-')].name" -o tsv || echo "")
 
           if [ -z "$RG_LIST" ]; then
-            echo "No resource groups found matching 'aspire-e2e-*' prefix."
-            echo "✅ No resource groups found matching prefix." >> $GITHUB_STEP_SUMMARY
+            echo "No resource groups found matching deployment test prefixes."
+            echo "✅ No resource groups found matching prefixes." >> $GITHUB_STEP_SUMMARY
             echo "deleted_count=0" >> $GITHUB_OUTPUT
             echo "skipped_count=0" >> $GITHUB_OUTPUT
             exit 0
@@ -105,56 +105,64 @@ jobs:
           for RG in $RG_LIST; do
             echo "Processing: $RG"
 
-            # Extract timestamp from RG name (format: aspire-e2e-{hash}-{YYYYMMDDHHMMSS}-{suffix})
-            # Look for 14-digit number in the name
-            TIMESTAMP=$(echo "$RG" | grep -oE '[0-9]{14}' | head -1)
-
-            if [ -z "$TIMESTAMP" ]; then
-              echo "  ⚠️ Could not parse timestamp from: $RG (skipping)"
-              echo "| $RG | Unknown | ⚠️ Skipped (no timestamp) |" >> $GITHUB_STEP_SUMMARY
-              SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
-              SKIPPED_LIST="${SKIPPED_LIST}${RG}\n"
-              continue
-            fi
-
-            # Parse timestamp (YYYYMMDDHHMMSS)
-            YEAR=${TIMESTAMP:0:4}
-            MONTH=${TIMESTAMP:4:2}
-            DAY=${TIMESTAMP:6:2}
-            HOUR=${TIMESTAMP:8:2}
-            MIN=${TIMESTAMP:10:2}
-            SEC=${TIMESTAMP:12:2}
-
-            # Convert to epoch seconds (assuming UTC)
-            RG_EPOCH=$(date -u -d "${YEAR}-${MONTH}-${DAY} ${HOUR}:${MIN}:${SEC}" +%s 2>/dev/null || echo "0")
-
-            if [ "$RG_EPOCH" = "0" ]; then
-              echo "  ⚠️ Invalid timestamp format: $TIMESTAMP (skipping)"
-              echo "| $RG | Invalid | ⚠️ Skipped (invalid timestamp) |" >> $GITHUB_STEP_SUMMARY
-              SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
-              SKIPPED_LIST="${SKIPPED_LIST}${RG}\n"
-              continue
+            # Get resource group creation time from Azure (tags.createdAt or fall back to managed-by tag timestamp)
+            # We use the resource group's properties since name patterns vary
+            RG_INFO=$(az group show -n "$RG" --query "{createdAt:tags.createdAt}" -o tsv 2>/dev/null || echo "")
+            
+            if [ -z "$RG_INFO" ] || [ "$RG_INFO" = "None" ]; then
+              # No createdAt tag - check if there's a timestamp in the name (legacy aspire-e2e-* format)
+              TIMESTAMP=$(echo "$RG" | grep -oE '[0-9]{14}' | head -1)
+              if [ -n "$TIMESTAMP" ]; then
+                # Parse timestamp from name (YYYYMMDDHHMMSS)
+                YEAR=${TIMESTAMP:0:4}
+                MONTH=${TIMESTAMP:4:2}
+                DAY=${TIMESTAMP:6:2}
+                HOUR=${TIMESTAMP:8:2}
+                MIN=${TIMESTAMP:10:2}
+                SEC=${TIMESTAMP:12:2}
+                RG_EPOCH=$(date -u -d "${YEAR}-${MONTH}-${DAY} ${HOUR}:${MIN}:${SEC}" +%s 2>/dev/null || echo "0")
+              else
+                # No timestamp available - delete if it matches our prefix (orphaned resource)
+                echo "  ⚠️ No timestamp found, treating as old: $RG"
+                RG_EPOCH=0
+              fi
+            else
+              # Parse ISO8601 timestamp from tag
+              RG_EPOCH=$(date -u -d "$RG_INFO" +%s 2>/dev/null || echo "0")
             fi
 
             # Calculate age
-            AGE_SECONDS=$((NOW - RG_EPOCH))
-            AGE_HOURS=$((AGE_SECONDS / 3600))
-            AGE_MINS=$(((AGE_SECONDS % 3600) / 60))
-
-            if [ $AGE_SECONDS -gt $MAX_AGE_SECONDS ]; then
-              if [ "$DRY_RUN" = "true" ]; then
-                echo "  🔍 Would delete: $RG (age: ${AGE_HOURS}h ${AGE_MINS}m)"
-                echo "| $RG | ${AGE_HOURS}h ${AGE_MINS}m | 🔍 Would delete (dry run) |" >> $GITHUB_STEP_SUMMARY
+            if [ "$RG_EPOCH" = "0" ]; then
+              AGE_HOURS="unknown"
+              AGE_DISPLAY="unknown"
+              # Treat unknown age as old (delete it)
+              SHOULD_DELETE=true
+            else
+              AGE_SECONDS=$((NOW - RG_EPOCH))
+              AGE_HOURS=$((AGE_SECONDS / 3600))
+              AGE_MINS=$(((AGE_SECONDS % 3600) / 60))
+              AGE_DISPLAY="${AGE_HOURS}h ${AGE_MINS}m"
+              if [ $AGE_SECONDS -gt $MAX_AGE_SECONDS ]; then
+                SHOULD_DELETE=true
               else
-                echo "  🗑️ Deleting: $RG (age: ${AGE_HOURS}h ${AGE_MINS}m)"
+                SHOULD_DELETE=false
+              fi
+            fi
+
+            if [ "$SHOULD_DELETE" = "true" ]; then
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "  🔍 Would delete: $RG (age: $AGE_DISPLAY)"
+                echo "| $RG | $AGE_DISPLAY | 🔍 Would delete (dry run) |" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "  🗑️ Deleting: $RG (age: $AGE_DISPLAY)"
                 az group delete --name "$RG" --yes --no-wait || echo "  ⚠️ Failed to delete $RG"
-                echo "| $RG | ${AGE_HOURS}h ${AGE_MINS}m | 🗑️ Deleted |" >> $GITHUB_STEP_SUMMARY
+                echo "| $RG | $AGE_DISPLAY | 🗑️ Deleted |" >> $GITHUB_STEP_SUMMARY
               fi
               DELETED_COUNT=$((DELETED_COUNT + 1))
               DELETED_LIST="${DELETED_LIST}${RG}\n"
             else
-              echo "  ✅ Keeping: $RG (age: ${AGE_HOURS}h ${AGE_MINS}m, under threshold)"
-              echo "| $RG | ${AGE_HOURS}h ${AGE_MINS}m | ✅ Kept (recent) |" >> $GITHUB_STEP_SUMMARY
+              echo "  ✅ Keeping: $RG (age: $AGE_DISPLAY, under threshold)"
+              echo "| $RG | $AGE_DISPLAY | ✅ Kept (recent) |" >> $GITHUB_STEP_SUMMARY
               SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
             fi
           done

--- a/.github/workflows/deployment-cleanup.yml
+++ b/.github/workflows/deployment-cleanup.yml
@@ -40,26 +40,30 @@ jobs:
     environment: deployment-testing
 
     steps:
-      - name: Get OIDC token
-        id: oidc
+      - name: Azure Login (OIDC)
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          script: |
-            const token = await core.getIDToken('api://AzureADTokenExchange');
-            core.setOutput('token', token);
-
-      - name: Azure Login (OIDC via CLI)
         env:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
-        run: |
-          az login --service-principal \
-            --username "$AZURE_CLIENT_ID" \
-            --tenant "$AZURE_TENANT_ID" \
-            --federated-token "${{ steps.oidc.outputs.token }}" \
-            --allow-no-subscriptions
-          az account set --subscription "$AZURE_SUBSCRIPTION_ID"
+        with:
+          script: |
+            const token = await core.getIDToken('api://AzureADTokenExchange');
+            core.setSecret(token);
+            
+            // Login directly - token never leaves this step
+            await exec.exec('az', [
+              'login', '--service-principal',
+              '--username', process.env.AZURE_CLIENT_ID,
+              '--tenant', process.env.AZURE_TENANT_ID,
+              '--federated-token', token,
+              '--allow-no-subscriptions'
+            ]);
+            
+            await exec.exec('az', [
+              'account', 'set',
+              '--subscription', process.env.AZURE_SUBSCRIPTION_ID
+            ]);
 
       - name: Cleanup old resource groups
         id: cleanup

--- a/.github/workflows/deployment-cleanup.yml
+++ b/.github/workflows/deployment-cleanup.yml
@@ -1,10 +1,10 @@
 # Cleanup workflow for deployment test resources
 #
-# Runs hourly to remove orphaned Azure resource groups from deployment tests.
-# Resource groups older than 3 hours are deleted.
+# Uses a mark-and-sweep approach:
+# 1. Mark: Tag untagged rg-aspire-* RGs with 'deployment-test-first-seen' timestamp
+# 2. Sweep: Delete RGs where 'deployment-test-first-seen' is older than threshold
 #
-# Resource group naming format: aspire-e2e-{hash}-{YYYYMMDDHHMMSS}-{runId}
-# The timestamp is parsed to determine age.
+# This ensures RGs are only deleted after they've been seen for the full retention period.
 #
 name: Deployment Environment Cleanup
 
@@ -30,7 +30,6 @@ on:
 permissions:
   id-token: write
   contents: read
-  pull-requests: write  # For posting PR comments
 
 jobs:
   cleanup:
@@ -70,100 +69,91 @@ jobs:
         env:
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
           MAX_AGE_HOURS: ${{ inputs.max_age_hours || '3' }}
+          TAG_NAME: deployment-test-first-seen
         run: |
-          echo "## Deployment Environment Cleanup" >> $GITHUB_STEP_SUMMARY
+          echo "## Deployment Environment Cleanup (Mark & Sweep)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Max Age:** ${MAX_AGE_HOURS} hours" >> $GITHUB_STEP_SUMMARY
           echo "**Dry Run:** ${DRY_RUN}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Get current time in seconds since epoch
+          # Get current time
           NOW=$(date +%s)
+          NOW_ISO=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           MAX_AGE_SECONDS=$((MAX_AGE_HOURS * 3600))
 
-          # List all resource groups matching our prefixes (rg-aspire-* from aspire deploy, aspire-e2e-* legacy)
-          RG_LIST=$(az group list --query "[?starts_with(name, 'rg-aspire-') || starts_with(name, 'aspire-e2e-')].name" -o tsv || echo "")
+          # List all resource groups matching rg-aspire-* prefix
+          RG_LIST=$(az group list --query "[?starts_with(name, 'rg-aspire-')].name" -o tsv || echo "")
 
           if [ -z "$RG_LIST" ]; then
-            echo "No resource groups found matching deployment test prefixes."
-            echo "✅ No resource groups found matching prefixes." >> $GITHUB_STEP_SUMMARY
+            echo "No resource groups found matching 'rg-aspire-*' prefix."
+            echo "✅ No resource groups found." >> $GITHUB_STEP_SUMMARY
+            echo "marked_count=0" >> $GITHUB_OUTPUT
             echo "deleted_count=0" >> $GITHUB_OUTPUT
-            echo "skipped_count=0" >> $GITHUB_OUTPUT
+            echo "kept_count=0" >> $GITHUB_OUTPUT
             exit 0
           fi
 
+          MARKED_COUNT=0
           DELETED_COUNT=0
-          SKIPPED_COUNT=0
+          KEPT_COUNT=0
           DELETED_LIST=""
-          SKIPPED_LIST=""
 
           echo "### Resource Groups Processed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Resource Group | Age | Action |" >> $GITHUB_STEP_SUMMARY
-          echo "|----------------|-----|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Resource Group | First Seen | Age | Action |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------------|------------|-----|--------|" >> $GITHUB_STEP_SUMMARY
 
           for RG in $RG_LIST; do
             echo "Processing: $RG"
 
-            # Get resource group creation time from Azure (tags.createdAt or fall back to managed-by tag timestamp)
-            # We use the resource group's properties since name patterns vary
-            RG_INFO=$(az group show -n "$RG" --query "{createdAt:tags.createdAt}" -o tsv 2>/dev/null || echo "")
-            
-            if [ -z "$RG_INFO" ] || [ "$RG_INFO" = "None" ]; then
-              # No createdAt tag - check if there's a timestamp in the name (legacy aspire-e2e-* format)
-              TIMESTAMP=$(echo "$RG" | grep -oE '[0-9]{14}' | head -1)
-              if [ -n "$TIMESTAMP" ]; then
-                # Parse timestamp from name (YYYYMMDDHHMMSS)
-                YEAR=${TIMESTAMP:0:4}
-                MONTH=${TIMESTAMP:4:2}
-                DAY=${TIMESTAMP:6:2}
-                HOUR=${TIMESTAMP:8:2}
-                MIN=${TIMESTAMP:10:2}
-                SEC=${TIMESTAMP:12:2}
-                RG_EPOCH=$(date -u -d "${YEAR}-${MONTH}-${DAY} ${HOUR}:${MIN}:${SEC}" +%s 2>/dev/null || echo "0")
-              else
-                # No timestamp available - delete if it matches our prefix (orphaned resource)
-                echo "  ⚠️ No timestamp found, treating as old: $RG"
-                RG_EPOCH=0
-              fi
-            else
-              # Parse ISO8601 timestamp from tag
-              RG_EPOCH=$(date -u -d "$RG_INFO" +%s 2>/dev/null || echo "0")
-            fi
+            # Check if RG has the first-seen tag
+            FIRST_SEEN=$(az group show -n "$RG" --query "tags.\"${TAG_NAME}\"" -o tsv 2>/dev/null || echo "")
 
-            # Calculate age
-            if [ "$RG_EPOCH" = "0" ]; then
-              AGE_HOURS="unknown"
-              AGE_DISPLAY="unknown"
-              # Treat unknown age as old (delete it)
-              SHOULD_DELETE=true
+            if [ -z "$FIRST_SEEN" ] || [ "$FIRST_SEEN" = "None" ]; then
+              # MARK: Tag this RG with current timestamp
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "  🏷️ Would mark: $RG with $TAG_NAME=$NOW_ISO"
+                echo "| $RG | (untagged) | new | 🏷️ Would mark (dry run) |" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "  🏷️ Marking: $RG with $TAG_NAME=$NOW_ISO"
+                az group update -n "$RG" --set "tags.${TAG_NAME}=$NOW_ISO" -o none 2>/dev/null || echo "  ⚠️ Failed to tag $RG"
+                echo "| $RG | $NOW_ISO | new | 🏷️ Marked |" >> $GITHUB_STEP_SUMMARY
+              fi
+              MARKED_COUNT=$((MARKED_COUNT + 1))
             else
-              AGE_SECONDS=$((NOW - RG_EPOCH))
+              # SWEEP: Check if tag is older than threshold
+              FIRST_SEEN_EPOCH=$(date -u -d "$FIRST_SEEN" +%s 2>/dev/null || echo "0")
+              
+              if [ "$FIRST_SEEN_EPOCH" = "0" ]; then
+                echo "  ⚠️ Invalid timestamp in tag: $FIRST_SEEN (skipping)"
+                echo "| $RG | $FIRST_SEEN | invalid | ⚠️ Skipped |" >> $GITHUB_STEP_SUMMARY
+                KEPT_COUNT=$((KEPT_COUNT + 1))
+                continue
+              fi
+
+              AGE_SECONDS=$((NOW - FIRST_SEEN_EPOCH))
               AGE_HOURS=$((AGE_SECONDS / 3600))
               AGE_MINS=$(((AGE_SECONDS % 3600) / 60))
               AGE_DISPLAY="${AGE_HOURS}h ${AGE_MINS}m"
-              if [ $AGE_SECONDS -gt $MAX_AGE_SECONDS ]; then
-                SHOULD_DELETE=true
-              else
-                SHOULD_DELETE=false
-              fi
-            fi
 
-            if [ "$SHOULD_DELETE" = "true" ]; then
-              if [ "$DRY_RUN" = "true" ]; then
-                echo "  🔍 Would delete: $RG (age: $AGE_DISPLAY)"
-                echo "| $RG | $AGE_DISPLAY | 🔍 Would delete (dry run) |" >> $GITHUB_STEP_SUMMARY
+              if [ $AGE_SECONDS -gt $MAX_AGE_SECONDS ]; then
+                # Old enough to delete
+                if [ "$DRY_RUN" = "true" ]; then
+                  echo "  🔍 Would delete: $RG (age: $AGE_DISPLAY)"
+                  echo "| $RG | $FIRST_SEEN | $AGE_DISPLAY | 🔍 Would delete (dry run) |" >> $GITHUB_STEP_SUMMARY
+                else
+                  echo "  🗑️ Deleting: $RG (age: $AGE_DISPLAY)"
+                  az group delete --name "$RG" --yes --no-wait || echo "  ⚠️ Failed to delete $RG"
+                  echo "| $RG | $FIRST_SEEN | $AGE_DISPLAY | 🗑️ Deleted |" >> $GITHUB_STEP_SUMMARY
+                fi
+                DELETED_COUNT=$((DELETED_COUNT + 1))
+                DELETED_LIST="${DELETED_LIST}${RG}\n"
               else
-                echo "  🗑️ Deleting: $RG (age: $AGE_DISPLAY)"
-                az group delete --name "$RG" --yes --no-wait || echo "  ⚠️ Failed to delete $RG"
-                echo "| $RG | $AGE_DISPLAY | 🗑️ Deleted |" >> $GITHUB_STEP_SUMMARY
+                echo "  ✅ Keeping: $RG (age: $AGE_DISPLAY, under threshold)"
+                echo "| $RG | $FIRST_SEEN | $AGE_DISPLAY | ✅ Kept |" >> $GITHUB_STEP_SUMMARY
+                KEPT_COUNT=$((KEPT_COUNT + 1))
               fi
-              DELETED_COUNT=$((DELETED_COUNT + 1))
-              DELETED_LIST="${DELETED_LIST}${RG}\n"
-            else
-              echo "  ✅ Keeping: $RG (age: $AGE_DISPLAY, under threshold)"
-              echo "| $RG | $AGE_DISPLAY | ✅ Kept (recent) |" >> $GITHUB_STEP_SUMMARY
-              SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
             fi
           done
 
@@ -171,66 +161,20 @@ jobs:
           echo "### Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           if [ "$DRY_RUN" = "true" ]; then
+            echo "- **Would mark:** $MARKED_COUNT resource groups" >> $GITHUB_STEP_SUMMARY
             echo "- **Would delete:** $DELETED_COUNT resource groups" >> $GITHUB_STEP_SUMMARY
           else
+            echo "- **Marked:** $MARKED_COUNT resource groups" >> $GITHUB_STEP_SUMMARY
             echo "- **Deleted:** $DELETED_COUNT resource groups" >> $GITHUB_STEP_SUMMARY
           fi
-          echo "- **Kept/Skipped:** $SKIPPED_COUNT resource groups" >> $GITHUB_STEP_SUMMARY
+          echo "- **Kept:** $KEPT_COUNT resource groups" >> $GITHUB_STEP_SUMMARY
 
+          echo "marked_count=$MARKED_COUNT" >> $GITHUB_OUTPUT
           echo "deleted_count=$DELETED_COUNT" >> $GITHUB_OUTPUT
-          echo "skipped_count=$SKIPPED_COUNT" >> $GITHUB_OUTPUT
+          echo "kept_count=$KEPT_COUNT" >> $GITHUB_OUTPUT
           echo "deleted_list<<EOF" >> $GITHUB_OUTPUT
           echo -e "$DELETED_LIST" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Find associated PR (if any)
-        id: find_pr
-        if: ${{ steps.cleanup.outputs.deleted_count != '0' }}
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          script: |
-            // Check if this workflow was triggered by a PR or has associated PRs
-            // For scheduled runs, we won't have a PR context
-            const { data: prs } = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              head: `${context.repo.owner}:deploy-test/initial-infrastructure`,
-              per_page: 1
-            });
-
-            if (prs.length > 0) {
-              core.setOutput('pr_number', prs[0].number);
-              core.setOutput('has_pr', 'true');
-            } else {
-              core.setOutput('has_pr', 'false');
-            }
-
-      - name: Post cleanup results to PR
-        if: ${{ steps.find_pr.outputs.has_pr == 'true' && steps.cleanup.outputs.deleted_count != '0' }}
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          script: |
-            const prNumber = ${{ steps.find_pr.outputs.pr_number }};
-            const deletedCount = ${{ steps.cleanup.outputs.deleted_count }};
-            const skippedCount = ${{ steps.cleanup.outputs.skipped_count }};
-            const deletedList = `${{ steps.cleanup.outputs.deleted_list }}`.trim();
-
-            let body = `## 🧹 Deployment Environment Cleanup\n\n`;
-            body += `**Deleted:** ${deletedCount} resource groups\n`;
-            body += `**Kept/Skipped:** ${skippedCount} resource groups\n\n`;
-
-            if (deletedList) {
-              body += `### Deleted Resource Groups\n\`\`\`\n${deletedList}\n\`\`\`\n`;
-            }
-
-            body += `\n[View workflow run](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body: body
-            });
-
-            console.log(`Posted cleanup results to PR #${prNumber}`);
+      # Cleanup results are available in the GitHub Actions step summary.
+      # No PR posting - this runs on schedule without PR context.

--- a/.github/workflows/deployment-cleanup.yml
+++ b/.github/workflows/deployment-cleanup.yml
@@ -1,0 +1,224 @@
+# Cleanup workflow for deployment test resources
+#
+# Runs hourly to remove orphaned Azure resource groups from deployment tests.
+# Resource groups older than 3 hours are deleted.
+#
+# Resource group naming format: aspire-e2e-{hash}-{YYYYMMDDHHMMSS}-{runId}
+# The timestamp is parsed to determine age.
+#
+name: Deployment Environment Cleanup
+
+on:
+  schedule:
+    # Run every hour
+    - cron: '0 * * * *'
+
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (list but do not delete)'
+        required: false
+        type: boolean
+        default: false
+      max_age_hours:
+        description: 'Delete RGs older than this many hours'
+        required: false
+        type: number
+        default: 3
+
+# OIDC permissions for Azure login
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write  # For posting PR comments
+
+jobs:
+  cleanup:
+    name: Cleanup Azure Resources
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'dotnet' }}
+    environment: deployment-testing
+
+    steps:
+      - name: Get OIDC token
+        id: oidc
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const token = await core.getIDToken('api://AzureADTokenExchange');
+            core.setOutput('token', token);
+
+      - name: Azure Login (OIDC via CLI)
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
+        run: |
+          az login --service-principal \
+            --username "$AZURE_CLIENT_ID" \
+            --tenant "$AZURE_TENANT_ID" \
+            --federated-token "${{ steps.oidc.outputs.token }}" \
+            --allow-no-subscriptions
+          az account set --subscription "$AZURE_SUBSCRIPTION_ID"
+
+      - name: Cleanup old resource groups
+        id: cleanup
+        env:
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          MAX_AGE_HOURS: ${{ inputs.max_age_hours || '3' }}
+        run: |
+          echo "## Deployment Environment Cleanup" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Max Age:** ${MAX_AGE_HOURS} hours" >> $GITHUB_STEP_SUMMARY
+          echo "**Dry Run:** ${DRY_RUN}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Get current time in seconds since epoch
+          NOW=$(date +%s)
+          MAX_AGE_SECONDS=$((MAX_AGE_HOURS * 3600))
+
+          # List all resource groups matching our prefix
+          RG_LIST=$(az group list --query "[?starts_with(name, 'aspire-e2e-')].name" -o tsv || echo "")
+
+          if [ -z "$RG_LIST" ]; then
+            echo "No resource groups found matching 'aspire-e2e-*' prefix."
+            echo "✅ No resource groups found matching prefix." >> $GITHUB_STEP_SUMMARY
+            echo "deleted_count=0" >> $GITHUB_OUTPUT
+            echo "skipped_count=0" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          DELETED_COUNT=0
+          SKIPPED_COUNT=0
+          DELETED_LIST=""
+          SKIPPED_LIST=""
+
+          echo "### Resource Groups Processed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Resource Group | Age | Action |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------------|-----|--------|" >> $GITHUB_STEP_SUMMARY
+
+          for RG in $RG_LIST; do
+            echo "Processing: $RG"
+
+            # Extract timestamp from RG name (format: aspire-e2e-{hash}-{YYYYMMDDHHMMSS}-{suffix})
+            # Look for 14-digit number in the name
+            TIMESTAMP=$(echo "$RG" | grep -oE '[0-9]{14}' | head -1)
+
+            if [ -z "$TIMESTAMP" ]; then
+              echo "  ⚠️ Could not parse timestamp from: $RG (skipping)"
+              echo "| $RG | Unknown | ⚠️ Skipped (no timestamp) |" >> $GITHUB_STEP_SUMMARY
+              SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+              SKIPPED_LIST="${SKIPPED_LIST}${RG}\n"
+              continue
+            fi
+
+            # Parse timestamp (YYYYMMDDHHMMSS)
+            YEAR=${TIMESTAMP:0:4}
+            MONTH=${TIMESTAMP:4:2}
+            DAY=${TIMESTAMP:6:2}
+            HOUR=${TIMESTAMP:8:2}
+            MIN=${TIMESTAMP:10:2}
+            SEC=${TIMESTAMP:12:2}
+
+            # Convert to epoch seconds (assuming UTC)
+            RG_EPOCH=$(date -u -d "${YEAR}-${MONTH}-${DAY} ${HOUR}:${MIN}:${SEC}" +%s 2>/dev/null || echo "0")
+
+            if [ "$RG_EPOCH" = "0" ]; then
+              echo "  ⚠️ Invalid timestamp format: $TIMESTAMP (skipping)"
+              echo "| $RG | Invalid | ⚠️ Skipped (invalid timestamp) |" >> $GITHUB_STEP_SUMMARY
+              SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+              SKIPPED_LIST="${SKIPPED_LIST}${RG}\n"
+              continue
+            fi
+
+            # Calculate age
+            AGE_SECONDS=$((NOW - RG_EPOCH))
+            AGE_HOURS=$((AGE_SECONDS / 3600))
+            AGE_MINS=$(((AGE_SECONDS % 3600) / 60))
+
+            if [ $AGE_SECONDS -gt $MAX_AGE_SECONDS ]; then
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "  🔍 Would delete: $RG (age: ${AGE_HOURS}h ${AGE_MINS}m)"
+                echo "| $RG | ${AGE_HOURS}h ${AGE_MINS}m | 🔍 Would delete (dry run) |" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "  🗑️ Deleting: $RG (age: ${AGE_HOURS}h ${AGE_MINS}m)"
+                az group delete --name "$RG" --yes --no-wait || echo "  ⚠️ Failed to delete $RG"
+                echo "| $RG | ${AGE_HOURS}h ${AGE_MINS}m | 🗑️ Deleted |" >> $GITHUB_STEP_SUMMARY
+              fi
+              DELETED_COUNT=$((DELETED_COUNT + 1))
+              DELETED_LIST="${DELETED_LIST}${RG}\n"
+            else
+              echo "  ✅ Keeping: $RG (age: ${AGE_HOURS}h ${AGE_MINS}m, under threshold)"
+              echo "| $RG | ${AGE_HOURS}h ${AGE_MINS}m | ✅ Kept (recent) |" >> $GITHUB_STEP_SUMMARY
+              SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+            fi
+          done
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "- **Would delete:** $DELETED_COUNT resource groups" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- **Deleted:** $DELETED_COUNT resource groups" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "- **Kept/Skipped:** $SKIPPED_COUNT resource groups" >> $GITHUB_STEP_SUMMARY
+
+          echo "deleted_count=$DELETED_COUNT" >> $GITHUB_OUTPUT
+          echo "skipped_count=$SKIPPED_COUNT" >> $GITHUB_OUTPUT
+          echo "deleted_list<<EOF" >> $GITHUB_OUTPUT
+          echo -e "$DELETED_LIST" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Find associated PR (if any)
+        id: find_pr
+        if: ${{ steps.cleanup.outputs.deleted_count != '0' }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            // Check if this workflow was triggered by a PR or has associated PRs
+            // For scheduled runs, we won't have a PR context
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${context.repo.owner}:deploy-test/initial-infrastructure`,
+              per_page: 1
+            });
+
+            if (prs.length > 0) {
+              core.setOutput('pr_number', prs[0].number);
+              core.setOutput('has_pr', 'true');
+            } else {
+              core.setOutput('has_pr', 'false');
+            }
+
+      - name: Post cleanup results to PR
+        if: ${{ steps.find_pr.outputs.has_pr == 'true' && steps.cleanup.outputs.deleted_count != '0' }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const prNumber = ${{ steps.find_pr.outputs.pr_number }};
+            const deletedCount = ${{ steps.cleanup.outputs.deleted_count }};
+            const skippedCount = ${{ steps.cleanup.outputs.skipped_count }};
+            const deletedList = `${{ steps.cleanup.outputs.deleted_list }}`.trim();
+
+            let body = `## 🧹 Deployment Environment Cleanup\n\n`;
+            body += `**Deleted:** ${deletedCount} resource groups\n`;
+            body += `**Kept/Skipped:** ${skippedCount} resource groups\n\n`;
+
+            if (deletedList) {
+              body += `### Deleted Resource Groups\n\`\`\`\n${deletedList}\n\`\`\`\n`;
+            }
+
+            body += `\n[View workflow run](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: body
+            });
+
+            console.log(`Posted cleanup results to PR #${prNumber}`);

--- a/.github/workflows/deployment-test-command.yml
+++ b/.github/workflows/deployment-test-command.yml
@@ -1,0 +1,112 @@
+# Trigger deployment tests from PR comments
+#
+# Usage: Comment `/deployment-test` on a PR
+#
+# This workflow validates the commenter is an org member and triggers
+# the deployment-tests.yml workflow with the PR context.
+#
+name: Deployment Test Command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: write  # To trigger workflows
+
+jobs:
+  deployment-test:
+    # Only run when the comment is exactly /deployment-test on a PR
+    if: >-
+      ${{
+        github.event.comment.body == '/deployment-test' &&
+        github.event.issue.pull_request &&
+        github.repository_owner == 'dotnet'
+      }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check org membership
+        id: check_membership
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const commenter = context.payload.comment.user.login;
+            
+            try {
+              // Check if user is a member of the dotnet org
+              const { status } = await github.rest.orgs.checkMembershipForUser({
+                org: 'dotnet',
+                username: commenter
+              });
+              
+              if (status === 204 || status === 302) {
+                core.info(`✅ ${commenter} is a member of dotnet org`);
+                core.setOutput('is_member', 'true');
+                return;
+              }
+            } catch (error) {
+              if (error.status === 404) {
+                core.warning(`❌ ${commenter} is not a member of dotnet org`);
+                core.setOutput('is_member', 'false');
+                
+                // Post a comment explaining the restriction
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: `@${commenter} The \`/deployment-test\` command is restricted to dotnet org members for security reasons (it deploys to real Azure infrastructure).`
+                });
+                return;
+              }
+              throw error;
+            }
+
+      - name: Get PR details
+        if: steps.check_membership.outputs.is_member == 'true'
+        id: pr
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            
+            core.setOutput('number', pr.number);
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('head_ref', pr.head.ref);
+
+      - name: Acknowledge command
+        if: steps.check_membership.outputs.is_member == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const prNumber = ${{ steps.pr.outputs.number }};
+            
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `🚀 Starting deployment tests on PR #${prNumber}...\n\nThis will deploy to real Azure infrastructure. Results will be posted here when complete.\n\n[View workflow run](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/deployment-tests.yml)`
+            });
+
+      - name: Trigger deployment tests
+        if: steps.check_membership.outputs.is_member == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'deployment-tests.yml',
+              ref: '${{ steps.pr.outputs.head_ref }}',
+              inputs: {
+                pr_number: '${{ steps.pr.outputs.number }}'
+              }
+            });
+            
+            core.info('✅ Triggered deployment-tests.yml workflow');

--- a/.github/workflows/deployment-test-command.yml
+++ b/.github/workflows/deployment-test-command.yml
@@ -99,17 +99,17 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            // Always dispatch from main branch to prevent workflow injection attacks.
-            // The PR number is passed as input so tests know which PR triggered them,
-            // but the workflow code itself comes from the trusted main branch.
+            // Dispatch from the PR's head ref to test the PR's code changes.
+            // Security: Org membership check is the security boundary - only trusted
+            // dotnet org members can trigger this workflow.
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'deployment-tests.yml',
-              ref: 'main',
+              ref: '${{ steps.pr.outputs.head_ref }}',
               inputs: {
                 pr_number: '${{ steps.pr.outputs.number }}'
               }
             });
             
-            core.info('✅ Triggered deployment-tests.yml workflow from main branch');
+            core.info('✅ Triggered deployment-tests.yml workflow');

--- a/.github/workflows/deployment-test-command.yml
+++ b/.github/workflows/deployment-test-command.yml
@@ -99,14 +99,17 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
+            // Always dispatch from main branch to prevent workflow injection attacks.
+            // The PR number is passed as input so tests know which PR triggered them,
+            // but the workflow code itself comes from the trusted main branch.
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'deployment-tests.yml',
-              ref: '${{ steps.pr.outputs.head_ref }}',
+              ref: 'main',
               inputs: {
                 pr_number: '${{ steps.pr.outputs.number }}'
               }
             });
             
-            core.info('✅ Triggered deployment-tests.yml workflow');
+            core.info('✅ Triggered deployment-tests.yml workflow from main branch');

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -50,47 +50,15 @@ env:
   ASPIRE_DEPLOYMENT_TEST_RG_PREFIX: ${{ vars.ASPIRE_DEPLOYMENT_TEST_RG_PREFIX || 'aspire-e2e' }}
 
 jobs:
-  # Build packages first (needed for CLI installation)
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'dotnet' }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Build the solution
-        run: |
-          ./build.sh --restore --build -c Release
-
-      - name: Build CLI archives
-        run: |
-          ./build.sh --pack -c Release /p:BuildCliArchives=true
-
-      - name: Upload CLI artifacts
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
-        with:
-          name: cli-archives
-          path: |
-            artifacts/packages/Release/Shipping/aspire-cli-*.tar.gz
-            artifacts/packages/Release/Shipping/aspire-cli-*.zip
-          retention-days: 1
-
   # Run deployment tests
   deployment_tests:
     name: Deployment Tests
-    needs: [build]
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'dotnet' }}
     environment: deployment-testing  # GitHub environment with OIDC configuration
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Download CLI artifacts
-        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
-        with:
-          name: cli-archives
-          path: artifacts/cli
 
       - name: Get OIDC token
         id: oidc
@@ -123,10 +91,11 @@ jobs:
         with:
           global-json-file: global.json
 
-      - name: Build test project
+      - name: Restore and build test project only
         run: |
-          ./build.sh --restore --build -c Release \
-            /p:Projects=tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj
+          # Only restore and build the test project (not full solution)
+          ./dotnet.sh restore tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj
+          ./dotnet.sh build tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj -c Release --no-restore
 
       - name: Run deployment tests
         id: run_tests
@@ -136,13 +105,14 @@ jobs:
           AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_CLIENT_ID }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           TEST_FILTER=""
           if [ -n "${{ inputs.scenario }}" ]; then
             TEST_FILTER="--filter-class *.${{ inputs.scenario }}*"
           fi
 
-          dotnet test tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj \
+          ./dotnet.sh test tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj \
             -c Release \
             --no-build \
             --logger "trx;LogFileName=deployment-tests.trx" \

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -92,12 +92,25 @@ jobs:
           name: cli-archives
           path: artifacts/cli
 
-      - name: Azure Login (OIDC)
-        uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+      - name: Get OIDC token
+        id: oidc
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          client-id: ${{ secrets.AZURE_DEPLOYMENT_TEST_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_DEPLOYMENT_TEST_TENANT_ID }}
-          subscription-id: ${{ vars.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
+          script: |
+            const token = await core.getIDToken('api://AzureADTokenExchange');
+            core.setOutput('token', token);
+
+      - name: Azure Login (OIDC via CLI)
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_TENANT_ID }}
+        run: |
+          az login --service-principal \
+            --username "$AZURE_CLIENT_ID" \
+            --tenant "$AZURE_TENANT_ID" \
+            --federated-token "${{ steps.oidc.outputs.token }}" \
+            --allow-no-subscriptions
+          az account set --subscription "${{ vars.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}"
 
       - name: Verify Azure authentication
         run: |

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -81,7 +81,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'dotnet' }}
-    environment: deployment-tests  # GitHub environment with OIDC configuration
+    environment: deployment-testing  # GitHub environment with OIDC configuration
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -171,26 +171,30 @@ jobs:
           echo "✅ Aspire CLI installed:"
           "$ASPIRE_HOME/bin/aspire" --version
 
-      - name: Get OIDC token
-        id: oidc
+      - name: Azure Login (OIDC)
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          script: |
-            const token = await core.getIDToken('api://AzureADTokenExchange');
-            core.setOutput('token', token);
-
-      - name: Azure Login (OIDC via CLI)
         env:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
-        run: |
-          az login --service-principal \
-            --username "$AZURE_CLIENT_ID" \
-            --tenant "$AZURE_TENANT_ID" \
-            --federated-token "${{ steps.oidc.outputs.token }}" \
-            --allow-no-subscriptions
-          az account set --subscription "$AZURE_SUBSCRIPTION_ID"
+        with:
+          script: |
+            const token = await core.getIDToken('api://AzureADTokenExchange');
+            core.setSecret(token);
+            
+            // Login directly - token never leaves this step
+            await exec.exec('az', [
+              'login', '--service-principal',
+              '--username', process.env.AZURE_CLIENT_ID,
+              '--tenant', process.env.AZURE_TENANT_ID,
+              '--federated-token', token,
+              '--allow-no-subscriptions'
+            ]);
+            
+            await exec.exec('az', [
+              'account', 'set',
+              '--subscription', process.env.AZURE_SUBSCRIPTION_ID
+            ]);
 
       - name: Verify Azure authentication
         run: |

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -109,24 +109,20 @@ jobs:
           ASPIRE_HOME="$HOME/.aspire"
           mkdir -p "$ASPIRE_HOME/bin"
           
-          # The CLI is built to artifacts/bin/Aspire.Cli/Release/net10.0/
-          CLI_BIN="${{ github.workspace }}/artifacts/bin/Aspire.Cli/Release/net10.0/Aspire.Cli"
+          # The CLI is built to artifacts/bin/Aspire.Cli/Release/net10.0/aspire (lowercase on Linux)
+          CLI_BIN="${{ github.workspace }}/artifacts/bin/Aspire.Cli/Release/net10.0/aspire"
           if [ -f "$CLI_BIN" ]; then
             cp "$CLI_BIN" "$ASPIRE_HOME/bin/aspire"
             chmod +x "$ASPIRE_HOME/bin/aspire"
           else
-            # Try the publish output
-            CLI_PUBLISH="${{ github.workspace }}/artifacts/bin/Aspire.Cli/Release/net10.0/publish/Aspire.Cli"
-            if [ -f "$CLI_PUBLISH" ]; then
-              cp "$CLI_PUBLISH" "$ASPIRE_HOME/bin/aspire"
-              chmod +x "$ASPIRE_HOME/bin/aspire"
-            else
-              echo "❌ Could not find CLI binary"
-              echo "Available files in CLI output:"
-              find "${{ github.workspace }}/artifacts/bin/Aspire.Cli" -type f 2>/dev/null || echo "Directory not found"
-              exit 1
-            fi
+            echo "❌ Could not find CLI binary at $CLI_BIN"
+            echo "Available files in CLI output:"
+            find "${{ github.workspace }}/artifacts/bin/Aspire.Cli" -type f -name "aspire*" 2>/dev/null || echo "Directory not found"
+            exit 1
           fi
+          
+          # Copy all dependencies to the bin directory (required for non-self-contained app)
+          cp -r "${{ github.workspace }}/artifacts/bin/Aspire.Cli/Release/net10.0/"* "$ASPIRE_HOME/bin/"
           
           # Add to PATH for this job
           echo "$ASPIRE_HOME/bin" >> $GITHUB_PATH

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -45,17 +45,17 @@ permissions:
   contents: read
   issues: write  # For creating issues on failure
 
-env:
-  ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION: ${{ vars.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
-  ASPIRE_DEPLOYMENT_TEST_RG_PREFIX: ${{ vars.ASPIRE_DEPLOYMENT_TEST_RG_PREFIX || 'aspire-e2e' }}
-
 jobs:
   # Run deployment tests
   deployment_tests:
     name: Deployment Tests
-    runs-on: ubuntu-latest
+    runs-on: 8-core-ubuntu-latest  # Larger runner for disk space
     if: ${{ github.repository_owner == 'dotnet' }}
     environment: deployment-testing  # GitHub environment with OIDC configuration
+    env:
+      # Environment-level variables are accessed here within the job that uses the environment
+      ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION: ${{ vars.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
+      ASPIRE_DEPLOYMENT_TEST_RG_PREFIX: ${{ vars.ASPIRE_DEPLOYMENT_TEST_RG_PREFIX || 'aspire-e2e' }}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -72,13 +72,14 @@ jobs:
         env:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
         run: |
           az login --service-principal \
             --username "$AZURE_CLIENT_ID" \
             --tenant "$AZURE_TENANT_ID" \
             --federated-token "${{ steps.oidc.outputs.token }}" \
             --allow-no-subscriptions
-          az account set --subscription "${{ vars.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}"
+          az account set --subscription "$AZURE_SUBSCRIPTION_ID"
 
       - name: Verify Azure authentication
         run: |

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -35,18 +35,14 @@ concurrency:
   group: deployment-e2e-${{ github.ref }}
   cancel-in-progress: true
 
-# OIDC permissions for Azure login
-permissions:
-  id-token: write
-  contents: read
-  issues: write  # For creating issues on failure
-
 jobs:
   # Enumerate test classes to build the matrix
   enumerate:
     name: Enumerate Tests
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'dotnet' }}
+    permissions:
+      contents: read
     outputs:
       matrix: ${{ steps.enumerate.outputs.deployment_tests_matrix }}
     steps:
@@ -67,6 +63,8 @@ jobs:
     name: Build
     runs-on: 8-core-ubuntu-latest
     if: ${{ github.repository_owner == 'dotnet' }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -120,6 +118,9 @@ jobs:
     if: ${{ needs.enumerate.outputs.matrix != '{"shortname":[]}' && needs.enumerate.outputs.matrix != '' }}
     runs-on: 8-core-ubuntu-latest
     environment: deployment-testing
+    permissions:
+      id-token: write  # For OIDC Azure login
+      contents: read
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.enumerate.outputs.matrix) }}

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -54,7 +54,7 @@ jobs:
     environment: deployment-testing  # GitHub environment with OIDC configuration
     env:
       # Environment-level variables are accessed here within the job that uses the environment
-      ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION: ${{ vars.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
+      ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION: ${{ secrets.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
       ASPIRE_DEPLOYMENT_TEST_RG_PREFIX: ${{ vars.ASPIRE_DEPLOYMENT_TEST_RG_PREFIX || 'aspire-e2e' }}
 
     steps:
@@ -72,7 +72,7 @@ jobs:
         env:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_TENANT_ID }}
-          AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
         run: |
           az login --service-principal \
             --username "$AZURE_CLIENT_ID" \
@@ -103,7 +103,7 @@ jobs:
         env:
           GITHUB_PR_NUMBER: ${{ inputs.pr_number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ github.sha }}
-          AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_CLIENT_ID }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -46,19 +46,134 @@ permissions:
   issues: write  # For creating issues on failure
 
 jobs:
-  # Run deployment tests
-  deployment_tests:
-    name: Deployment Tests
-    runs-on: 8-core-ubuntu-latest  # Larger runner for disk space
+  # Enumerate test classes to build the matrix
+  enumerate:
+    name: Enumerate Tests
+    runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'dotnet' }}
-    environment: deployment-testing  # GitHub environment with OIDC configuration
+    outputs:
+      matrix: ${{ steps.enumerate.outputs.deployment_tests_matrix }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: ./.github/actions/enumerate-tests
+        id: enumerate
+        with:
+          includeDeployment: true
+
+      - name: Display test matrix
+        run: |
+          echo "Deployment test matrix:"
+          echo '${{ steps.enumerate.outputs.deployment_tests_matrix }}' | jq .
+
+  # Build solution and CLI once, share via artifacts
+  build:
+    name: Build
+    runs-on: 8-core-ubuntu-latest
+    if: ${{ github.repository_owner == 'dotnet' }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          global-json-file: global.json
+
+      - name: Restore solution
+        run: ./restore.sh
+
+      - name: Build solution and pack CLI
+        run: |
+          # Build the full solution and pack CLI for local testing
+          ./build.sh --build --pack -c Release
+        env:
+          # Skip native build to save time - we'll use the non-native CLI
+          SkipNativeBuild: true
+
+      - name: Prepare CLI artifacts
+        run: |
+          # Create a clean artifact directory with CLI and packages
+          ARTIFACT_DIR="${{ github.workspace }}/cli-artifacts"
+          mkdir -p "$ARTIFACT_DIR/bin"
+          mkdir -p "$ARTIFACT_DIR/packages"
+          
+          # Copy CLI binary and dependencies
+          cp -r "${{ github.workspace }}/artifacts/bin/Aspire.Cli/Release/net10.0/"* "$ARTIFACT_DIR/bin/"
+          
+          # Copy NuGet packages
+          PACKAGES_DIR="${{ github.workspace }}/artifacts/packages/Release/Shipping"
+          if [ -d "$PACKAGES_DIR" ]; then
+            find "$PACKAGES_DIR" -name "*.nupkg" -exec cp {} "$ARTIFACT_DIR/packages/" \;
+          fi
+          
+          echo "CLI artifacts prepared:"
+          ls -la "$ARTIFACT_DIR/bin/"
+          echo "Package count: $(find "$ARTIFACT_DIR/packages" -name "*.nupkg" | wc -l)"
+
+      - name: Upload CLI artifacts
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: aspire-cli-artifacts
+          path: ${{ github.workspace }}/cli-artifacts/
+          retention-days: 1
+
+  # Run each test class in parallel
+  deploy-test:
+    name: Deploy (${{ matrix.shortname }})
+    needs: [enumerate, build]
+    if: ${{ needs.enumerate.outputs.matrix != '{"shortname":[]}' && needs.enumerate.outputs.matrix != '' }}
+    runs-on: 8-core-ubuntu-latest
+    environment: deployment-testing
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.enumerate.outputs.matrix) }}
     env:
-      # Environment-level variables are accessed here within the job that uses the environment
       ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION: ${{ secrets.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
       ASPIRE_DEPLOYMENT_TEST_RG_PREFIX: ${{ vars.ASPIRE_DEPLOYMENT_TEST_RG_PREFIX || 'aspire-e2e' }}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          global-json-file: global.json
+
+      - name: Restore and build test project
+        run: |
+          ./restore.sh
+          ./build.sh -restore -ci -build -projects ${{ github.workspace }}/tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj -c Release
+        env:
+          SkipNativeBuild: true
+
+      - name: Download CLI artifacts
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: aspire-cli-artifacts
+          path: ${{ github.workspace }}/cli-artifacts
+
+      - name: Install Aspire CLI from artifacts
+        run: |
+          ASPIRE_HOME="$HOME/.aspire"
+          mkdir -p "$ASPIRE_HOME/bin"
+          
+          # Copy CLI binary and dependencies
+          cp -r "${{ github.workspace }}/cli-artifacts/bin/"* "$ASPIRE_HOME/bin/"
+          chmod +x "$ASPIRE_HOME/bin/aspire"
+          
+          # Add to PATH for this job
+          echo "$ASPIRE_HOME/bin" >> $GITHUB_PATH
+          
+          # Set up NuGet hive for local packages
+          HIVE_DIR="$ASPIRE_HOME/hives/local/packages"
+          mkdir -p "$HIVE_DIR"
+          cp "${{ github.workspace }}/cli-artifacts/packages/"*.nupkg "$HIVE_DIR/" 2>/dev/null || true
+          
+          # Configure CLI to use local channel
+          "$ASPIRE_HOME/bin/aspire" config set channel local --global || true
+          
+          echo "✅ Aspire CLI installed:"
+          "$ASPIRE_HOME/bin/aspire" --version
 
       - name: Get OIDC token
         id: oidc
@@ -94,65 +209,7 @@ jobs:
           docker info | head -20
           echo "✅ Docker is available"
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
-        with:
-          global-json-file: global.json
-
-      - name: Restore solution
-        run: ./restore.sh
-
-      - name: Build solution and pack CLI
-        run: |
-          # Build the full solution and pack CLI for local testing
-          ./build.sh --build --pack -c Release
-        env:
-          # Skip native build to save time - we'll use the non-native CLI
-          SkipNativeBuild: true
-
-      - name: Install Aspire CLI from local build
-        run: |
-          # Set up CLI from local build artifacts
-          ASPIRE_HOME="$HOME/.aspire"
-          mkdir -p "$ASPIRE_HOME/bin"
-          
-          # The CLI is built to artifacts/bin/Aspire.Cli/Release/net10.0/aspire (lowercase on Linux)
-          CLI_BIN="${{ github.workspace }}/artifacts/bin/Aspire.Cli/Release/net10.0/aspire"
-          if [ -f "$CLI_BIN" ]; then
-            cp "$CLI_BIN" "$ASPIRE_HOME/bin/aspire"
-            chmod +x "$ASPIRE_HOME/bin/aspire"
-          else
-            echo "❌ Could not find CLI binary at $CLI_BIN"
-            echo "Available files in CLI output:"
-            find "${{ github.workspace }}/artifacts/bin/Aspire.Cli" -type f -name "aspire*" 2>/dev/null || echo "Directory not found"
-            exit 1
-          fi
-          
-          # Copy all dependencies to the bin directory (required for non-self-contained app)
-          cp -r "${{ github.workspace }}/artifacts/bin/Aspire.Cli/Release/net10.0/"* "$ASPIRE_HOME/bin/"
-          
-          # Add to PATH for this job
-          echo "$ASPIRE_HOME/bin" >> $GITHUB_PATH
-          
-          # Set up NuGet hive for local packages
-          HIVE_DIR="$ASPIRE_HOME/hives/local/packages"
-          mkdir -p "$HIVE_DIR"
-          
-          # Copy built packages to hive
-          PACKAGES_DIR="${{ github.workspace }}/artifacts/packages/Release/Shipping"
-          if [ -d "$PACKAGES_DIR" ]; then
-            find "$PACKAGES_DIR" -name "*.nupkg" -exec cp {} "$HIVE_DIR/" \;
-            PKG_COUNT=$(find "$HIVE_DIR" -name "*.nupkg" | wc -l)
-            echo "✅ Copied $PKG_COUNT packages to hive"
-          fi
-          
-          # Configure CLI to use local channel
-          "$ASPIRE_HOME/bin/aspire" config set channel local --global || true
-          
-          echo "✅ Aspire CLI installed:"
-          "$ASPIRE_HOME/bin/aspire" --version
-
-      - name: Run deployment tests
+      - name: Run deployment test (${{ matrix.shortname }})
         id: run_tests
         env:
           GITHUB_PR_NUMBER: ${{ inputs.pr_number || '' }}
@@ -160,31 +217,24 @@ jobs:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_CLIENT_ID }}
-          # Aspire configuration uses Azure:SubscriptionId - set via env var with __ separator
           Azure__SubscriptionId: ${{ secrets.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
           Azure__Location: eastus
           GH_TOKEN: ${{ github.token }}
         run: |
-          TEST_FILTER=""
-          if [ -n "${{ inputs.scenario }}" ]; then
-            TEST_FILTER="--filter-class *.${{ inputs.scenario }}*"
-          fi
-
           ./dotnet.sh test tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj \
             -c Release \
-            --no-build \
-            --logger "trx;LogFileName=deployment-tests.trx" \
+            --logger "trx;LogFileName=${{ matrix.shortname }}.trx" \
             --results-directory ${{ github.workspace }}/testresults \
             -- \
             --filter-not-trait "quarantined=true" \
-            $TEST_FILTER \
+            --filter-class "Aspire.Deployment.EndToEnd.Tests.${{ matrix.shortname }}" \
             || echo "test_failed=true" >> $GITHUB_OUTPUT
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
-          name: deployment-test-results
+          name: deployment-test-results-${{ matrix.shortname }}
           path: |
             ${{ github.workspace }}/testresults/
           retention-days: 30
@@ -193,7 +243,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
-          name: deployment-test-recordings
+          name: deployment-test-recordings-${{ matrix.shortname }}
           path: |
             ${{ github.workspace }}/testresults/recordings/
           retention-days: 30
@@ -202,13 +252,13 @@ jobs:
       - name: Check for test failures
         if: steps.run_tests.outputs.test_failed == 'true'
         run: |
-          echo "::error::Deployment tests failed. Check the test results artifact for details."
+          echo "::error::Deployment test ${{ matrix.shortname }} failed. Check the test results artifact for details."
           exit 1
 
   # Create GitHub issue on nightly failure
   create_issue_on_failure:
     name: Create Issue on Failure
-    needs: [deployment_tests]
+    needs: [deploy-test]
     runs-on: ubuntu-latest
     if: ${{ failure() && github.event_name == 'schedule' }}
     permissions:

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -3,12 +3,12 @@
 # Triggers:
 # - workflow_dispatch: Manual trigger with scenario selection
 # - schedule: Nightly at 03:00 UTC
-# - push to deploy-test/* branches: Rapid iteration during development
+# - /deployment-test command on PRs (via deployment-test-command.yml)
 #
 # Security:
 # - Uses OIDC (Workload Identity Federation) for Azure authentication
 # - No stored Azure secrets
-# - deploy-test/* branches protected via branch protection rules
+# - Only dotnet org members can trigger via PR command
 #
 name: Deployment E2E Tests
 
@@ -29,10 +29,6 @@ on:
   schedule:
     # Run nightly at 03:00 UTC
     - cron: '0 3 * * *'
-
-  push:
-    branches:
-      - 'deploy-test/**'
 
 # Limit concurrent runs to avoid Azure quota issues
 concurrency:

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -87,6 +87,13 @@ jobs:
           az account show --query "{subscriptionId:id, tenantId:tenantId, user:user.name}" -o table
           echo "✅ Azure authentication successful"
 
+      - name: Verify Docker is running
+        run: |
+          echo "Verifying Docker daemon..."
+          docker version
+          docker info | head -20
+          echo "✅ Docker is available"
+
       - name: Setup .NET
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
@@ -153,6 +160,9 @@ jobs:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_CLIENT_ID }}
+          # Aspire configuration uses Azure:SubscriptionId - set via env var with __ separator
+          Azure__SubscriptionId: ${{ secrets.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
+          Azure__Location: eastus
           GH_TOKEN: ${{ github.token }}
         run: |
           TEST_FILTER=""

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -92,11 +92,62 @@ jobs:
         with:
           global-json-file: global.json
 
-      - name: Restore and build test project only
+      - name: Restore solution
+        run: ./restore.sh
+
+      - name: Build solution and pack CLI
         run: |
-          # Only restore and build the test project (not full solution)
-          ./dotnet.sh restore tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj
-          ./dotnet.sh build tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj -c Release --no-restore
+          # Build the full solution and pack CLI for local testing
+          ./build.sh --build --pack -c Release
+        env:
+          # Skip native build to save time - we'll use the non-native CLI
+          SkipNativeBuild: true
+
+      - name: Install Aspire CLI from local build
+        run: |
+          # Set up CLI from local build artifacts
+          ASPIRE_HOME="$HOME/.aspire"
+          mkdir -p "$ASPIRE_HOME/bin"
+          
+          # The CLI is built to artifacts/bin/Aspire.Cli/Release/net10.0/
+          CLI_BIN="${{ github.workspace }}/artifacts/bin/Aspire.Cli/Release/net10.0/Aspire.Cli"
+          if [ -f "$CLI_BIN" ]; then
+            cp "$CLI_BIN" "$ASPIRE_HOME/bin/aspire"
+            chmod +x "$ASPIRE_HOME/bin/aspire"
+          else
+            # Try the publish output
+            CLI_PUBLISH="${{ github.workspace }}/artifacts/bin/Aspire.Cli/Release/net10.0/publish/Aspire.Cli"
+            if [ -f "$CLI_PUBLISH" ]; then
+              cp "$CLI_PUBLISH" "$ASPIRE_HOME/bin/aspire"
+              chmod +x "$ASPIRE_HOME/bin/aspire"
+            else
+              echo "❌ Could not find CLI binary"
+              echo "Available files in CLI output:"
+              find "${{ github.workspace }}/artifacts/bin/Aspire.Cli" -type f 2>/dev/null || echo "Directory not found"
+              exit 1
+            fi
+          fi
+          
+          # Add to PATH for this job
+          echo "$ASPIRE_HOME/bin" >> $GITHUB_PATH
+          
+          # Set up NuGet hive for local packages
+          HIVE_DIR="$ASPIRE_HOME/hives/local/packages"
+          mkdir -p "$HIVE_DIR"
+          
+          # Copy built packages to hive
+          PACKAGES_DIR="${{ github.workspace }}/artifacts/packages/Release/Shipping"
+          if [ -d "$PACKAGES_DIR" ]; then
+            find "$PACKAGES_DIR" -name "*.nupkg" -exec cp {} "$HIVE_DIR/" \;
+            PKG_COUNT=$(find "$HIVE_DIR" -name "*.nupkg" | wc -l)
+            echo "✅ Copied $PKG_COUNT packages to hive"
+          fi
+          
+          # Configure CLI to use local channel
+          "$ASPIRE_HOME/bin/aspire" config set channel local --global || true
+          
+          echo "✅ Aspire CLI installed:"
+          "$ASPIRE_HOME/bin/aspire" --version
 
       - name: Run deployment tests
         id: run_tests

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -1,0 +1,236 @@
+# End-to-end deployment tests that deploy Aspire applications to real Azure infrastructure
+#
+# Triggers:
+# - workflow_dispatch: Manual trigger with scenario selection
+# - schedule: Nightly at 03:00 UTC
+# - push to deploy-test/* branches: Rapid iteration during development
+#
+# Security:
+# - Uses OIDC (Workload Identity Federation) for Azure authentication
+# - No stored Azure secrets
+# - deploy-test/* branches protected via branch protection rules
+#
+name: Deployment E2E Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      scenario:
+        description: 'Test scenario to run (leave empty for all)'
+        required: false
+        type: string
+        default: ''
+      pr_number:
+        description: 'PR number to test (for testing PR builds)'
+        required: false
+        type: string
+        default: ''
+
+  schedule:
+    # Run nightly at 03:00 UTC
+    - cron: '0 3 * * *'
+
+  push:
+    branches:
+      - 'deploy-test/**'
+
+# Limit concurrent runs to avoid Azure quota issues
+concurrency:
+  group: deployment-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+# OIDC permissions for Azure login
+permissions:
+  id-token: write
+  contents: read
+  issues: write  # For creating issues on failure
+
+env:
+  ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION: ${{ vars.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
+  ASPIRE_DEPLOYMENT_TEST_RG_PREFIX: ${{ vars.ASPIRE_DEPLOYMENT_TEST_RG_PREFIX || 'aspire-e2e' }}
+
+jobs:
+  # Build packages first (needed for CLI installation)
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'dotnet' }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build the solution
+        run: |
+          ./build.sh --restore --build -c Release
+
+      - name: Build CLI archives
+        run: |
+          ./build.sh --pack -c Release /p:BuildCliArchives=true
+
+      - name: Upload CLI artifacts
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: cli-archives
+          path: |
+            artifacts/packages/Release/Shipping/aspire-cli-*.tar.gz
+            artifacts/packages/Release/Shipping/aspire-cli-*.zip
+          retention-days: 1
+
+  # Run deployment tests
+  deployment_tests:
+    name: Deployment Tests
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'dotnet' }}
+    environment: deployment-tests  # GitHub environment with OIDC configuration
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Download CLI artifacts
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: cli-archives
+          path: artifacts/cli
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+        with:
+          client-id: ${{ secrets.AZURE_DEPLOYMENT_TEST_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_DEPLOYMENT_TEST_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
+
+      - name: Verify Azure authentication
+        run: |
+          echo "Verifying Azure authentication..."
+          az account show --query "{subscriptionId:id, tenantId:tenantId, user:user.name}" -o table
+          echo "✅ Azure authentication successful"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          global-json-file: global.json
+
+      - name: Build test project
+        run: |
+          ./build.sh --restore --build -c Release \
+            /p:Projects=tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj
+
+      - name: Run deployment tests
+        id: run_tests
+        env:
+          GITHUB_PR_NUMBER: ${{ inputs.pr_number || '' }}
+          GITHUB_PR_HEAD_SHA: ${{ github.sha }}
+          AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_DEPLOYMENT_TEST_CLIENT_ID }}
+        run: |
+          TEST_FILTER=""
+          if [ -n "${{ inputs.scenario }}" ]; then
+            TEST_FILTER="--filter-class *.${{ inputs.scenario }}*"
+          fi
+
+          dotnet test tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj \
+            -c Release \
+            --no-build \
+            --logger "trx;LogFileName=deployment-tests.trx" \
+            --results-directory ${{ github.workspace }}/testresults \
+            -- \
+            --filter-not-trait "quarantined=true" \
+            $TEST_FILTER \
+            || echo "test_failed=true" >> $GITHUB_OUTPUT
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: deployment-test-results
+          path: |
+            ${{ github.workspace }}/testresults/
+          retention-days: 30
+
+      - name: Upload recordings
+        if: always()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: deployment-test-recordings
+          path: |
+            ${{ github.workspace }}/testresults/recordings/
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Check for test failures
+        if: steps.run_tests.outputs.test_failed == 'true'
+        run: |
+          echo "::error::Deployment tests failed. Check the test results artifact for details."
+          exit 1
+
+  # Create GitHub issue on nightly failure
+  create_issue_on_failure:
+    name: Create Issue on Failure
+    needs: [deployment_tests]
+    runs-on: ubuntu-latest
+    if: ${{ failure() && github.event_name == 'schedule' }}
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Create GitHub Issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const date = new Date().toISOString().split('T')[0];
+
+            const issueTitle = `[Deployment E2E] Nightly test failure - ${date}`;
+            const issueBody = `## Deployment E2E Test Failure
+
+            The nightly deployment E2E tests failed on ${date}.
+
+            **Workflow Run:** ${runUrl}
+
+            ### Next Steps
+            1. Check the workflow run for detailed error logs
+            2. Download test artifacts for asciinema recordings
+            3. Investigate and fix the failing tests
+
+            ### Labels
+            This issue was automatically created by the deployment E2E test workflow.
+
+            /cc @dotnet/aspire-team
+            `;
+
+            // Check if a similar issue already exists (created today)
+            const existingIssues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'area-testing,deployment-e2e',
+              per_page: 10
+            });
+
+            const todayIssue = existingIssues.data.find(issue =>
+              issue.title.includes(date) && issue.title.includes('[Deployment E2E]')
+            );
+
+            if (todayIssue) {
+              console.log(`Issue already exists for today: ${todayIssue.html_url}`);
+              // Add a comment instead
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: todayIssue.number,
+                body: `Another failure occurred. See: ${runUrl}`
+              });
+            } else {
+              // Create new issue
+              const issue = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: issueTitle,
+                body: issueBody,
+                labels: ['area-testing', 'deployment-e2e']
+              });
+              console.log(`Created issue: ${issue.data.html_url}`);
+            }

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -15,11 +15,6 @@ name: Deployment E2E Tests
 on:
   workflow_dispatch:
     inputs:
-      scenario:
-        description: 'Test scenario to run (leave empty for all)'
-        required: false
-        type: string
-        default: ''
       pr_number:
         description: 'PR number to test (for testing PR builds)'
         required: false

--- a/Aspire.slnx
+++ b/Aspire.slnx
@@ -374,6 +374,7 @@
     <Project Path="src/Aspire.Hosting.Testing/Aspire.Hosting.Testing.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj" />
     <Project Path="tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj" />
     <Project Path="tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj" />
     <Project Path="tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj" />

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
@@ -1,0 +1,195 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Tests.Utils;
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Hex1b;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests for deploying Aspire applications to Azure Container Apps.
+/// </summary>
+public sealed class AcaStarterDeploymentTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task DeployStarterTemplateToAzureContainerApps()
+    {
+        // Validate prerequisites
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var resourceGroupName = AzureAuthenticationHelpers.GenerateResourceGroupName("aca-starter");
+        var workspace = TemporaryWorkspace.Create(output);
+        var recordingPath = DeploymentE2ETestHelpers.GetTestResultsRecordingPath(nameof(DeployStarterTemplateToAzureContainerApps));
+        var startTime = DateTime.UtcNow;
+        var deploymentUrls = new Dictionary<string, string>();
+
+        output.WriteLine($"Test: {nameof(DeployStarterTemplateToAzureContainerApps)}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            var builder = Hex1bTerminal.CreateBuilder()
+                .WithHeadless()
+                .WithAsciinemaRecording(recordingPath)
+                .WithPtyProcess("/bin/bash", ["--norc"]);
+
+            using var terminal = builder.Build();
+            var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+            // Pattern searchers
+            var waitingForTemplatePrompt = new CellPatternSearcher().FindPattern("> Starter App");
+            var waitingForProjectNamePrompt = new CellPatternSearcher().Find("Enter the project name");
+            var waitingForCtrlCMessage = new CellPatternSearcher().Find("Press Ctrl+C");
+            var waitingForDeploymentComplete = new CellPatternSearcher().Find("Deployment complete");
+
+            var counter = new SequenceCounter();
+            var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+            // Step 1: Prepare environment
+            output.WriteLine("Step 1: Preparing environment...");
+            sequenceBuilder.PrepareEnvironment(workspace, counter);
+
+            // Step 2: Install Aspire CLI (in CI) or use local
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                var prNumber = DeploymentE2ETestHelpers.GetPrNumber();
+                if (prNumber > 0)
+                {
+                    output.WriteLine($"Step 2: Installing Aspire CLI from PR #{prNumber}...");
+                    sequenceBuilder.InstallAspireCliFromPullRequest(prNumber, counter);
+                }
+                sequenceBuilder.SourceAspireCliEnvironment(counter);
+            }
+
+            // Step 3: Create starter project
+            output.WriteLine("Step 3: Creating starter project...");
+            sequenceBuilder
+                .Type("aspire new")
+                .Enter()
+                .WaitUntil(s => waitingForTemplatePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
+                .Enter() // Select Starter App
+                .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+                .Type("AcaStarterTest")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+
+            // Step 4: Navigate to project directory
+            output.WriteLine("Step 4: Navigating to project directory...");
+            sequenceBuilder
+                .Type("cd AcaStarterTest/AcaStarterTest.AppHost")
+                .Enter()
+                .WaitForSuccessPrompt(counter);
+
+            // Step 5: Deploy to Azure Container Apps
+            output.WriteLine("Step 5: Deploying to Azure Container Apps...");
+            // aspire deploy with non-interactive mode for CI
+            // We'll need to provide subscription, resource group, and location via environment or prompts
+            sequenceBuilder
+                .Type($"aspire deploy --subscription {subscriptionId} --resource-group {resourceGroupName} --location eastus --non-interactive")
+                .Enter()
+                .WaitUntil(s => waitingForDeploymentComplete.Search(s).Count > 0, TimeSpan.FromMinutes(30));
+
+            // Step 6: Capture deployment URLs from output
+            output.WriteLine("Step 6: Capturing deployment URLs...");
+            sequenceBuilder
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
+
+            // Step 7: Exit terminal
+            sequenceBuilder
+                .Type("exit")
+                .Enter();
+
+            var sequence = sequenceBuilder.Build();
+            await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"Deployment completed in {duration}");
+
+            // Report success
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployStarterTemplateToAzureContainerApps),
+                resourceGroupName,
+                deploymentUrls,
+                duration);
+
+            output.WriteLine("✅ Test passed!");
+        }
+        catch (Exception ex)
+        {
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"❌ Test failed after {duration}: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployStarterTemplateToAzureContainerApps),
+                resourceGroupName,
+                ex.Message,
+                ex.StackTrace);
+
+            throw;
+        }
+        finally
+        {
+            // Cleanup: Delete resource group
+            output.WriteLine($"Cleaning up resource group: {resourceGroupName}");
+            try
+            {
+                await CleanupResourceGroupAsync(resourceGroupName);
+                DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true);
+            }
+            catch (Exception cleanupEx)
+            {
+                output.WriteLine($"⚠️ Cleanup failed: {cleanupEx.Message}");
+                DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, cleanupEx.Message);
+            }
+        }
+    }
+
+    private static async Task CleanupResourceGroupAsync(string resourceGroupName)
+    {
+        // Use Azure CLI to delete the resource group
+        // This runs in the background and doesn't wait for completion
+        var process = new System.Diagnostics.Process
+        {
+            StartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "az",
+                Arguments = $"group delete --name {resourceGroupName} --yes --no-wait",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        process.Start();
+        await process.WaitForExitAsync();
+
+        if (process.ExitCode != 0)
+        {
+            var error = await process.StandardError.ReadToEndAsync();
+            throw new InvalidOperationException($"Failed to delete resource group: {error}");
+        }
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
@@ -98,6 +98,10 @@ public sealed class AcaStarterDeploymentTests(ITestOutputHelper output)
             var waitingForBuildingApphost = new CellPatternSearcher()
                 .Find("Building apphost");
 
+            // Pattern searcher for deployment success
+            var waitingForPipelineSucceeded = new CellPatternSearcher()
+                .Find("PIPELINE SUCCEEDED");
+
             var counter = new SequenceCounter();
             var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
 
@@ -207,18 +211,29 @@ builder.Build().Run();
                 .Enter()
                 .WaitForSuccessPrompt(counter);
 
-            // Step 9: Deploy to Azure Container Apps using aspire deploy with interactive prompts
-            // For now, just verify the deploy command starts and shows the expected output
-            // The full deployment would take 15-30+ minutes, so we'll stop after initial verification
+            // Step 9: Deploy to Azure Container Apps using aspire deploy
             output.WriteLine("Step 7: Starting Azure Container Apps deployment...");
             sequenceBuilder
                 .Type("aspire deploy")
                 .Enter()
-                // Wait for deployment to start building the apphost
-                .WaitUntil(s => waitingForBuildingApphost.Search(s).Count > 0, TimeSpan.FromMinutes(2))
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(30));
+                // Wait for pipeline to complete successfully
+                .WaitUntil(s => waitingForPipelineSucceeded.Search(s).Count > 0, TimeSpan.FromMinutes(10))
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
 
-            // Step 10: Exit terminal
+            // Step 10: Extract deployment URLs and verify endpoints
+            output.WriteLine("Step 8: Verifying deployed endpoints...");
+            sequenceBuilder
+                .Type("RG_NAME=$(az group list --query \"[?starts_with(name, 'rg-aspire-')].name\" -o tsv | head -1) && " +
+                      "echo \"Resource group: $RG_NAME\" && " +
+                      "for url in $(az containerapp list -g \"$RG_NAME\" --query \"[].properties.configuration.ingress.fqdn\" -o tsv 2>/dev/null); do " +
+                      "echo -n \"Checking https://$url... \"; " +
+                      "STATUS=$(curl -s -o /dev/null -w \"%{http_code}\" \"https://$url\" --max-time 10 2>/dev/null); " +
+                      "if [ \"$STATUS\" = \"200\" ] || [ \"$STATUS\" = \"302\" ]; then echo \"✅ $STATUS\"; else echo \"❌ $STATUS\"; fi; " +
+                      "done")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
+
+            // Step 11: Exit terminal
             sequenceBuilder
                 .Type("exit")
                 .Enter();
@@ -254,22 +269,78 @@ builder.Build().Run();
         }
         finally
         {
-            // Cleanup: Delete resource group
-            output.WriteLine($"Cleaning up resource group: {resourceGroupName}");
+            // Note: aspire deploy creates its own resource group (rg-aspire-{appname})
+            // The cleanup workflow runs hourly and removes resource groups older than 3 hours.
+            // We attempt cleanup here as a best-effort, but rely on the cleanup workflow for reliability.
+            output.WriteLine($"Attempting cleanup of test resource group: {resourceGroupName}");
+
+            // Try to clean up any RGs that match our test prefix pattern
             try
             {
-                await CleanupResourceGroupAsync(resourceGroupName);
-                DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true);
+                await CleanupTestResourceGroupsAsync(output);
+                DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Cleanup initiated (async)");
             }
             catch (Exception cleanupEx)
             {
-                output.WriteLine($"⚠️ Cleanup failed: {cleanupEx.Message}");
+                // Cleanup failures are non-fatal - the hourly cleanup workflow will handle orphaned resources
+                output.WriteLine($"⚠️ Cleanup attempt failed (will be handled by hourly cleanup workflow): {cleanupEx.Message}");
                 DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, cleanupEx.Message);
             }
         }
     }
 
-    private static async Task CleanupResourceGroupAsync(string resourceGroupName)
+    /// <summary>
+    /// Attempts to clean up resource groups created by this test run.
+    /// This is best-effort - the hourly cleanup workflow handles any missed resources.
+    /// </summary>
+    private static async Task CleanupTestResourceGroupsAsync(ITestOutputHelper output)
+    {
+        // List resource groups matching our prefix
+        var listProcess = new System.Diagnostics.Process
+        {
+            StartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "az",
+                Arguments = "group list --query \"[?starts_with(name, 'aspire-e2e-') || starts_with(name, 'rg-aspire-')].name\" -o tsv",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        listProcess.Start();
+        var rgList = await listProcess.StandardOutput.ReadToEndAsync();
+        await listProcess.WaitForExitAsync();
+
+        if (listProcess.ExitCode != 0 || string.IsNullOrWhiteSpace(rgList))
+        {
+            output.WriteLine("No test resource groups found or failed to list.");
+            return;
+        }
+
+        var resourceGroups = rgList.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        foreach (var rg in resourceGroups)
+        {
+            var rgName = rg.Trim();
+            if (string.IsNullOrEmpty(rgName))
+            {
+                continue;
+            }
+
+            output.WriteLine($"Deleting resource group: {rgName}");
+            try
+            {
+                await DeleteResourceGroupAsync(rgName);
+            }
+            catch (Exception ex)
+            {
+                output.WriteLine($"  ⚠️ Failed to delete {rgName}: {ex.Message}");
+            }
+        }
+    }
+
+    private static async Task DeleteResourceGroupAsync(string resourceGroupName)
     {
         // Use Azure CLI to delete the resource group
         // This runs in the background and doesn't wait for completion

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
@@ -195,15 +195,16 @@ builder.Build().Run();
                 .Enter()
                 .WaitForSuccessPrompt(counter);
 
-            // Step 8: Unset ASPIRE_PLAYGROUND before deploy
-            sequenceBuilder.Type("unset ASPIRE_PLAYGROUND")
+            // Step 8: Unset ASPIRE_PLAYGROUND before deploy and set Azure location
+            sequenceBuilder.Type("unset ASPIRE_PLAYGROUND && export Azure__Location=westus3")
                 .Enter()
                 .WaitForSuccessPrompt(counter);
 
             // Step 9: Deploy to Azure Container Apps using aspire deploy
+            // Use --clear-cache to ensure fresh deployment without cached location from previous runs
             output.WriteLine("Step 7: Starting Azure Container Apps deployment...");
             sequenceBuilder
-                .Type("aspire deploy --location westus3")
+                .Type("aspire deploy --clear-cache")
                 .Enter()
                 // Wait for pipeline to complete successfully
                 .WaitUntil(s => waitingForPipelineSucceeded.Search(s).Count > 0, TimeSpan.FromMinutes(10))

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
@@ -203,7 +203,7 @@ builder.Build().Run();
             // Step 9: Deploy to Azure Container Apps using aspire deploy
             output.WriteLine("Step 7: Starting Azure Container Apps deployment...");
             sequenceBuilder
-                .Type("aspire deploy")
+                .Type("aspire deploy --location westus3")
                 .Enter()
                 // Wait for pipeline to complete successfully
                 .WaitUntil(s => waitingForPipelineSucceeded.Search(s).Count > 0, TimeSpan.FromMinutes(10))

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
@@ -14,9 +14,9 @@ namespace Aspire.Deployment.EndToEnd.Tests;
 /// </summary>
 public sealed class AcaStarterDeploymentTests(ITestOutputHelper output)
 {
-    // Timeout set to 3 minutes during development for faster iteration.
-    // Increase to 30+ minutes once the test automation is stable.
-    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(3);
+    // Timeout set to 15 minutes to allow for Azure provisioning.
+    // Full deployments can take 10-20+ minutes. Increase if needed.
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(15);
 
     [Fact]
     public async Task DeployStarterTemplateToAzureContainerApps()

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
@@ -70,15 +70,22 @@ public sealed class AcaStarterDeploymentTests(ITestOutputHelper output)
             output.WriteLine("Step 1: Preparing environment...");
             sequenceBuilder.PrepareEnvironment(workspace, counter);
 
-            // Step 2: Install Aspire CLI (in CI) or use local
+            // Step 2: Set up CLI environment (in CI)
+            // The workflow pre-installs the CLI to ~/.aspire/bin, but we need to source it in the bash session
             if (DeploymentE2ETestHelpers.IsRunningInCI)
             {
                 var prNumber = DeploymentE2ETestHelpers.GetPrNumber();
                 if (prNumber > 0)
                 {
+                    // Install from PR artifacts if PR number is provided
                     output.WriteLine($"Step 2: Installing Aspire CLI from PR #{prNumber}...");
                     sequenceBuilder.InstallAspireCliFromPullRequest(prNumber, counter);
                 }
+                else
+                {
+                    output.WriteLine("Step 2: Using pre-installed Aspire CLI...");
+                }
+                // Always source the CLI environment (sets PATH and other env vars)
                 sequenceBuilder.SourceAspireCliEnvironment(counter);
             }
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
@@ -57,10 +57,7 @@ public sealed class AcaStarterDeploymentTests(ITestOutputHelper output)
             using var terminal = builder.Build();
             var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-            // Pattern searchers
-            var waitingForTemplatePrompt = new CellPatternSearcher().FindPattern("> Starter App");
-            var waitingForProjectNamePrompt = new CellPatternSearcher().Find("Enter the project name");
-            var waitingForCtrlCMessage = new CellPatternSearcher().Find("Press Ctrl+C");
+            // Pattern searchers for aspire deploy output
             var waitingForDeploymentComplete = new CellPatternSearcher().Find("Deployment complete");
 
             var counter = new SequenceCounter();
@@ -90,14 +87,11 @@ public sealed class AcaStarterDeploymentTests(ITestOutputHelper output)
             }
 
             // Step 3: Create starter project
+            // Use --name to provide project name non-interactively
+            // The starter template is the default when only one template version is available
             output.WriteLine("Step 3: Creating starter project...");
             sequenceBuilder
-                .Type("aspire new")
-                .Enter()
-                .WaitUntil(s => waitingForTemplatePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
-                .Enter() // Select Starter App
-                .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-                .Type("AcaStarterTest")
+                .Type("aspire new --name AcaStarterTest")
                 .Enter()
                 .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
@@ -216,8 +216,9 @@ builder.Build().Run();
                 .Type($"RG_NAME=\"{expectedResourceGroup}\" && " +
                       "echo \"Resource group: $RG_NAME\" && " +
                       "if ! az group show -n \"$RG_NAME\" &>/dev/null; then echo \"❌ Resource group not found\"; exit 1; fi && " +
-                      "urls=$(az containerapp list -g \"$RG_NAME\" --query \"[].properties.configuration.ingress.fqdn\" -o tsv 2>/dev/null) && " +
-                      "if [ -z \"$urls\" ]; then echo \"❌ No container app endpoints found\"; exit 1; fi && " +
+                      // Get external endpoints only (exclude .internal. which are not publicly accessible)
+                      "urls=$(az containerapp list -g \"$RG_NAME\" --query \"[].properties.configuration.ingress.fqdn\" -o tsv 2>/dev/null | grep -v '\\.internal\\.') && " +
+                      "if [ -z \"$urls\" ]; then echo \"❌ No external container app endpoints found\"; exit 1; fi && " +
                       "failed=0 && " +
                       "for url in $urls; do " +
                       "echo -n \"Checking https://$url... \"; " +

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
@@ -86,13 +86,18 @@ public sealed class AcaStarterDeploymentTests(ITestOutputHelper output)
                 sequenceBuilder.SourceAspireCliEnvironment(counter);
             }
 
-            // Step 3: Create starter project
-            // Use --name to provide project name non-interactively
-            // The starter template is the default when only one template version is available
+            // Step 3: Create starter project using aspire new
+            // Provide --name for project name, then press Enter to select default template
             output.WriteLine("Step 3: Creating starter project...");
+
+            // Pattern to detect template selection prompt
+            var waitingForTemplatePrompt = new CellPatternSearcher().FindPattern("Select a template");
+
             sequenceBuilder
                 .Type("aspire new --name AcaStarterTest")
                 .Enter()
+                .WaitUntil(s => waitingForTemplatePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
+                .Enter() // Select default template (Starter App ASP.NET Core/Blazor)
                 .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
 
             // Step 4: Navigate to project directory

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
@@ -16,12 +16,12 @@ public sealed class AcaStarterDeploymentTests(ITestOutputHelper output)
 {
     // Timeout set to 3 minutes during development for faster iteration.
     // Increase to 30+ minutes once the test automation is stable.
-    private static readonly TimeSpan TestTimeout = TimeSpan.FromMinutes(3);
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(3);
 
     [Fact]
     public async Task DeployStarterTemplateToAzureContainerApps()
     {
-        using var cts = new CancellationTokenSource(TestTimeout);
+        using var cts = new CancellationTokenSource(s_testTimeout);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
             cts.Token, TestContext.Current.CancellationToken);
         var cancellationToken = linkedCts.Token;

--- a/tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj
@@ -12,10 +12,10 @@
     <!-- Disable strong name signing because Hex1b package is not signed -->
     <SignAssembly>false</SignAssembly>
 
-    <!-- Only run on Linux since Hex1b requires a Linux terminal environment -->
+    <!-- Do not run in the standard CI workflow - use deployment-tests.yml workflow instead -->
     <RunOnGithubActionsWindows>false</RunOnGithubActionsWindows>
     <RunOnGithubActionsMacOS>false</RunOnGithubActionsMacOS>
-    <RunOnGithubActionsLinux>true</RunOnGithubActionsLinux>
+    <RunOnGithubActionsLinux>false</RunOnGithubActionsLinux>
 
     <!-- Do not run tests in Helix - use GitHub Actions matrix strategy instead -->
     <RunOnAzdoHelixWindows>false</RunOnAzdoHelixWindows>

--- a/tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj
@@ -1,0 +1,55 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <IsUnitTestProject>true</IsUnitTestProject>
+    <OutputType>Exe</OutputType>
+
+    <!-- Disable strong name signing because Hex1b package is not signed -->
+    <SignAssembly>false</SignAssembly>
+
+    <!-- Only run on Linux since Hex1b requires a Linux terminal environment -->
+    <RunOnGithubActionsWindows>false</RunOnGithubActionsWindows>
+    <RunOnGithubActionsMacOS>false</RunOnGithubActionsMacOS>
+    <RunOnGithubActionsLinux>true</RunOnGithubActionsLinux>
+
+    <!-- Do not run tests in Helix - use GitHub Actions matrix strategy instead -->
+    <RunOnAzdoHelixWindows>false</RunOnAzdoHelixWindows>
+    <RunOnAzdoHelixLinux>false</RunOnAzdoHelixLinux>
+
+    <!-- Do not run tests on AzDO -->
+    <RunOnAzdoCIWindows>false</RunOnAzdoCIWindows>
+    <RunOnAzdoCILinux>false</RunOnAzdoCILinux>
+
+    <!-- Each test class runs as a separate CI job via DeploymentEndToEndTestRunsheetBuilder -->
+    <ExtractTestClassNamesForHelix Condition="'$(ContinuousIntegrationBuild)' == 'true' or '$(PrepareForHelix)' == 'true'">true</ExtractTestClassNamesForHelix>
+    <ExtractTestClassNamesPrefix>Aspire.Deployment.EndToEnd.Tests</ExtractTestClassNamesPrefix>
+
+    <!-- These tests require built NuGet packages -->
+    <TestUsingWorkloads>true</TestUsingWorkloads>
+    <InstallWorkloadForTesting>true</InstallWorkloadForTesting>
+    <IncludeTestPackages>false</IncludeTestPackages>
+
+    <XunitRunnerJson>xunit.runner.json</XunitRunnerJson>
+    <TestArchiveTestsDir>$(TestArchiveTestsDirForDeploymentEndToEndTests)</TestArchiveTestsDir>
+
+    <!-- Extended test session settings for deployment tests -->
+    <TestSessionTimeout>60m</TestSessionTimeout>
+    <TestHangTimeout>45m</TestHangTimeout>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Hex1b" />
+    <PackageReference Include="Microsoft.DotNet.XUnitV3Extensions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(TestsSharedDir)TemporaryRepo.cs" Link="shared\TemporaryRepo.cs" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AuthenticationTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AuthenticationTests.cs
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// Tests that validate Azure authentication is working correctly.
+/// These tests run first to fail fast if authentication is not configured.
+/// </summary>
+public sealed class AuthenticationTests(ITestOutputHelper output)
+{
+    [Fact]
+    public void SubscriptionIdIsConfigured()
+    {
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            output.WriteLine("⚠️ Azure subscription ID is not configured.");
+            output.WriteLine("Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION or AZURE_SUBSCRIPTION_ID environment variable.");
+            output.WriteLine("");
+            output.WriteLine("For local development:");
+            output.WriteLine("  export ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION=\"your-subscription-id\"");
+            output.WriteLine("");
+            Assert.Skip("Azure subscription ID not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION environment variable.");
+        }
+
+        output.WriteLine($"✅ Subscription ID configured: {subscriptionId[..8]}...");
+        Assert.False(string.IsNullOrEmpty(subscriptionId));
+    }
+
+    [Fact]
+    public void AzureCredentialsAreAvailable()
+    {
+        // Skip if subscription isn't configured (no point testing auth without a target)
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Subscription not configured - skipping auth test.");
+        }
+
+        var isAuthAvailable = AzureAuthenticationHelpers.IsAzureAuthAvailable();
+
+        if (!isAuthAvailable)
+        {
+            output.WriteLine("⚠️ Azure authentication is not available.");
+            output.WriteLine("");
+            output.WriteLine("For local development, authenticate with Azure CLI:");
+            output.WriteLine("  az login");
+            output.WriteLine("  az account set --subscription \"your-subscription-id\"");
+            output.WriteLine("");
+            output.WriteLine("For CI, ensure OIDC is configured:");
+            output.WriteLine("  - AZURE_CLIENT_ID is set");
+            output.WriteLine("  - AZURE_TENANT_ID is set");
+            output.WriteLine("  - Workload Identity Federation is configured");
+            output.WriteLine("");
+
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                // In CI, this should fail - auth must be configured
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                // Locally, skip with helpful message
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        output.WriteLine("✅ Azure credentials are available.");
+
+        if (AzureAuthenticationHelpers.IsOidcConfigured())
+        {
+            var clientId = AzureAuthenticationHelpers.GetClientId();
+            output.WriteLine($"   Using OIDC authentication (Client ID: {clientId?[..Math.Min(8, clientId?.Length ?? 0)]}...)");
+        }
+        else
+        {
+            output.WriteLine("   Using Azure CLI authentication");
+        }
+    }
+
+    [Fact]
+    public void ResourceGroupNameGenerationWorks()
+    {
+        var rgName = AzureAuthenticationHelpers.GenerateResourceGroupName("TestScenario");
+
+        output.WriteLine($"Generated resource group name: {rgName}");
+
+        Assert.NotNull(rgName);
+        Assert.StartsWith(AzureAuthenticationHelpers.GetResourceGroupPrefix(), rgName);
+        Assert.Contains("testscenario", rgName.ToLowerInvariant());
+
+        // Verify it's a valid Azure resource group name
+        Assert.True(rgName.Length <= 90, "Resource group name must be <= 90 characters");
+        Assert.Matches(@"^[a-zA-Z0-9\-_\.]+$", rgName);
+
+        output.WriteLine("✅ Resource group name generation works correctly.");
+    }
+
+    [Fact]
+    public void EnvironmentDetectionWorks()
+    {
+        var isCI = DeploymentE2ETestHelpers.IsRunningInCI;
+        var prNumber = DeploymentE2ETestHelpers.GetPrNumber();
+        var commitSha = DeploymentE2ETestHelpers.GetCommitSha();
+
+        output.WriteLine($"Running in CI: {isCI}");
+        output.WriteLine($"PR Number: {prNumber}");
+        output.WriteLine($"Commit SHA: {commitSha}");
+
+        if (isCI)
+        {
+            output.WriteLine("✅ CI environment detected.");
+        }
+        else
+        {
+            output.WriteLine("✅ Local development environment detected.");
+            Assert.Equal(0, prNumber);
+            Assert.Equal("local0000", commitSha);
+        }
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AuthenticationTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AuthenticationTests.cs
@@ -92,11 +92,16 @@ public sealed class AuthenticationTests(ITestOutputHelper output)
 
         Assert.NotNull(rgName);
         Assert.StartsWith(AzureAuthenticationHelpers.GetResourceGroupPrefix(), rgName);
-        Assert.Contains("testscenario", rgName.ToLowerInvariant());
+        // The test name is hashed to create a short identifier in the resource group name
+        // So we verify the format rather than looking for the literal test name
 
         // Verify it's a valid Azure resource group name
         Assert.True(rgName.Length <= 90, "Resource group name must be <= 90 characters");
         Assert.Matches(@"^[a-zA-Z0-9\-_\.]+$", rgName);
+
+        // Verify the format: {prefix}-{hash}-{timestamp}-{suffix}
+        var parts = rgName.Split('-');
+        Assert.True(parts.Length >= 4, $"Expected at least 4 parts in name, got {parts.Length}: {rgName}");
 
         output.WriteLine("✅ Resource group name generation works correctly.");
     }

--- a/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/AzureAuthenticationHelpers.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/AzureAuthenticationHelpers.cs
@@ -1,0 +1,161 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Azure.Core;
+using Azure.Identity;
+
+namespace Aspire.Deployment.EndToEnd.Tests.Helpers;
+
+/// <summary>
+/// Helper methods for Azure authentication in deployment tests.
+/// Supports both OIDC (Workload Identity Federation) in CI and Azure CLI locally.
+/// </summary>
+internal static class AzureAuthenticationHelpers
+{
+    private const string SubscriptionEnvVar = "ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION";
+    private const string ResourceGroupPrefixEnvVar = "ASPIRE_DEPLOYMENT_TEST_RG_PREFIX";
+    private const string DefaultResourceGroupPrefix = "aspire-e2e";
+
+    /// <summary>
+    /// Gets whether Azure authentication is available.
+    /// Returns true if we have either OIDC credentials (CI) or Azure CLI credentials (local).
+    /// </summary>
+    internal static bool IsAzureAuthAvailable()
+    {
+        try
+        {
+            var credential = GetAzureCredential();
+            // Try to get a token to validate credentials work
+            var context = new TokenRequestContext(["https://management.azure.com/.default"]);
+            credential.GetToken(context, CancellationToken.None);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Gets the Azure credential to use for authentication.
+    /// In CI (GitHub Actions), uses DefaultAzureCredential which will pick up OIDC.
+    /// Locally, falls back to Azure CLI credentials.
+    /// </summary>
+    internal static TokenCredential GetAzureCredential()
+    {
+        // DefaultAzureCredential tries multiple authentication methods in order:
+        // 1. Environment variables (AZURE_CLIENT_ID, AZURE_TENANT_ID for OIDC in CI)
+        // 2. Managed Identity
+        // 3. Azure CLI
+        // 4. Azure PowerShell
+        // 5. etc.
+        return new DefaultAzureCredential();
+    }
+
+    /// <summary>
+    /// Gets the subscription ID from environment variable.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when subscription ID is not configured.</exception>
+    internal static string GetSubscriptionId()
+    {
+        var subscriptionId = Environment.GetEnvironmentVariable(SubscriptionEnvVar);
+
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            // Also check AZURE_SUBSCRIPTION_ID as fallback
+            subscriptionId = Environment.GetEnvironmentVariable("AZURE_SUBSCRIPTION_ID");
+        }
+
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            throw new InvalidOperationException(
+                $"Azure subscription ID not configured. Set the {SubscriptionEnvVar} or AZURE_SUBSCRIPTION_ID environment variable.");
+        }
+
+        return subscriptionId;
+    }
+
+    /// <summary>
+    /// Gets the subscription ID if available, or null if not configured.
+    /// </summary>
+    internal static string? TryGetSubscriptionId()
+    {
+        try
+        {
+            return GetSubscriptionId();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Gets the resource group prefix for naming test resources.
+    /// </summary>
+    internal static string GetResourceGroupPrefix()
+    {
+        var prefix = Environment.GetEnvironmentVariable(ResourceGroupPrefixEnvVar);
+        return string.IsNullOrEmpty(prefix) ? DefaultResourceGroupPrefix : prefix;
+    }
+
+    /// <summary>
+    /// Generates a unique resource group name for a test run.
+    /// Format: {prefix}-{date}-{runId or random}
+    /// </summary>
+    internal static string GenerateResourceGroupName(string? testName = null)
+    {
+        var prefix = GetResourceGroupPrefix();
+        var date = DateTime.UtcNow.ToString("yyyyMMdd");
+
+        // Use GitHub run ID if available, otherwise generate random suffix
+        var runId = Environment.GetEnvironmentVariable("GITHUB_RUN_ID");
+        var suffix = !string.IsNullOrEmpty(runId)
+            ? runId[..Math.Min(8, runId.Length)]
+            : Guid.NewGuid().ToString("N")[..8];
+
+        if (!string.IsNullOrEmpty(testName))
+        {
+            // Sanitize test name for Azure resource naming (lowercase, alphanumeric, hyphens)
+            var sanitizedName = new string(testName
+                .ToLowerInvariant()
+                .Select(c => char.IsLetterOrDigit(c) ? c : '-')
+                .ToArray())
+                .Trim('-');
+
+            // Truncate if too long (Azure RG names max 90 chars)
+            if (sanitizedName.Length > 20)
+            {
+                sanitizedName = sanitizedName[..20];
+            }
+
+            return $"{prefix}-{sanitizedName}-{date}-{suffix}";
+        }
+
+        return $"{prefix}-{date}-{suffix}";
+    }
+
+    /// <summary>
+    /// Gets the Azure tenant ID if configured.
+    /// </summary>
+    internal static string? GetTenantId()
+    {
+        return Environment.GetEnvironmentVariable("AZURE_TENANT_ID");
+    }
+
+    /// <summary>
+    /// Gets the Azure client ID for OIDC authentication if configured.
+    /// </summary>
+    internal static string? GetClientId()
+    {
+        return Environment.GetEnvironmentVariable("AZURE_CLIENT_ID");
+    }
+
+    /// <summary>
+    /// Checks if OIDC credentials are configured (for CI environment).
+    /// </summary>
+    internal static bool IsOidcConfigured()
+    {
+        return !string.IsNullOrEmpty(GetClientId()) && !string.IsNullOrEmpty(GetTenantId());
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentE2ETestHelpers.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentE2ETestHelpers.cs
@@ -1,0 +1,176 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+
+namespace Aspire.Deployment.EndToEnd.Tests.Helpers;
+
+/// <summary>
+/// Helper methods for creating and managing Hex1b terminal sessions for deployment testing.
+/// Extends the patterns from CLI E2E tests with deployment-specific functionality.
+/// </summary>
+internal static class DeploymentE2ETestHelpers
+{
+    /// <summary>
+    /// Gets whether the tests are running in CI (GitHub Actions) vs locally.
+    /// </summary>
+    internal static bool IsRunningInCI =>
+        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"));
+
+    /// <summary>
+    /// Gets the PR number from the GITHUB_PR_NUMBER environment variable.
+    /// When running locally (not in CI), returns 0.
+    /// </summary>
+    internal static int GetPrNumber()
+    {
+        var prNumberStr = Environment.GetEnvironmentVariable("GITHUB_PR_NUMBER");
+        if (string.IsNullOrEmpty(prNumberStr) || !int.TryParse(prNumberStr, out var prNumber))
+        {
+            return 0;
+        }
+        return prNumber;
+    }
+
+    /// <summary>
+    /// Gets the commit SHA from the GITHUB_PR_HEAD_SHA environment variable.
+    /// When running locally (not in CI), returns "local0000".
+    /// </summary>
+    internal static string GetCommitSha()
+    {
+        var commitSha = Environment.GetEnvironmentVariable("GITHUB_PR_HEAD_SHA");
+        return string.IsNullOrEmpty(commitSha) ? "local0000" : commitSha;
+    }
+
+    /// <summary>
+    /// Gets the path for storing asciinema recordings that will be uploaded as CI artifacts.
+    /// </summary>
+    internal static string GetTestResultsRecordingPath(string testName)
+    {
+        var githubWorkspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE");
+        string recordingsDir;
+
+        if (!string.IsNullOrEmpty(githubWorkspace))
+        {
+            recordingsDir = Path.Combine(githubWorkspace, "testresults", "recordings");
+        }
+        else
+        {
+            recordingsDir = Path.Combine(Path.GetTempPath(), "aspire-deployment-e2e", "recordings");
+        }
+
+        Directory.CreateDirectory(recordingsDir);
+        return Path.Combine(recordingsDir, $"{testName}.cast");
+    }
+
+    /// <summary>
+    /// Gets the path for the GitHub step summary file.
+    /// Returns null when not running in CI.
+    /// </summary>
+    internal static string? GetGitHubStepSummaryPath()
+    {
+        return Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY");
+    }
+
+    /// <summary>
+    /// Prepares the terminal environment with a custom prompt for command tracking.
+    /// </summary>
+    internal static Hex1bTerminalInputSequenceBuilder PrepareEnvironment(
+        this Hex1bTerminalInputSequenceBuilder builder,
+        TemporaryWorkspace workspace,
+        SequenceCounter counter)
+    {
+        var waitingForInputPattern = new CellPatternSearcher()
+            .Find("b").RightUntil("$").Right(' ').Right(' ');
+
+        builder.WaitUntil(s => waitingForInputPattern.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Wait(500);
+
+        // Bash prompt setup with command tracking
+        const string promptSetup = "CMDCOUNT=0; PROMPT_COMMAND='s=$?;((CMDCOUNT++));PS1=\"[$CMDCOUNT $([ $s -eq 0 ] && echo OK || echo ERR:$s)] \\$ \"'";
+        builder.Type(promptSetup).Enter();
+
+        return builder.WaitForSuccessPrompt(counter)
+            .Type($"cd {workspace.WorkspaceRoot.FullName}").Enter()
+            .WaitForSuccessPrompt(counter);
+    }
+
+    /// <summary>
+    /// Installs the Aspire CLI from PR build artifacts.
+    /// </summary>
+    internal static Hex1bTerminalInputSequenceBuilder InstallAspireCliFromPullRequest(
+        this Hex1bTerminalInputSequenceBuilder builder,
+        int prNumber,
+        SequenceCounter counter)
+    {
+        var command = $"curl -fsSL https://raw.githubusercontent.com/dotnet/aspire/main/eng/scripts/get-aspire-cli-pr.sh | bash -s -- {prNumber}";
+
+        return builder
+            .Type(command)
+            .Enter()
+            .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(300));
+    }
+
+    /// <summary>
+    /// Configures the PATH and environment variables for the Aspire CLI.
+    /// </summary>
+    internal static Hex1bTerminalInputSequenceBuilder SourceAspireCliEnvironment(
+        this Hex1bTerminalInputSequenceBuilder builder,
+        SequenceCounter counter)
+    {
+        return builder
+            .Type("export PATH=~/.aspire/bin:$PATH ASPIRE_PLAYGROUND=true DOTNET_CLI_TELEMETRY_OPTOUT=true DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true DOTNET_GENERATE_ASPNET_CERTIFICATE=false")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+    }
+
+    /// <summary>
+    /// Waits for a successful command prompt with the expected sequence number.
+    /// </summary>
+    internal static Hex1bTerminalInputSequenceBuilder WaitForSuccessPrompt(
+        this Hex1bTerminalInputSequenceBuilder builder,
+        SequenceCounter counter,
+        TimeSpan? timeout = null)
+    {
+        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(500);
+
+        return builder.WaitUntil(snapshot =>
+            {
+                var successPromptSearcher = new CellPatternSearcher()
+                    .FindPattern(counter.Value.ToString())
+                    .RightText(" OK] $ ");
+
+                var result = successPromptSearcher.Search(snapshot);
+                return result.Count > 0;
+            }, effectiveTimeout)
+            .IncrementSequence(counter);
+    }
+
+    /// <summary>
+    /// Increments the sequence counter.
+    /// </summary>
+    internal static Hex1bTerminalInputSequenceBuilder IncrementSequence(
+        this Hex1bTerminalInputSequenceBuilder builder,
+        SequenceCounter counter)
+    {
+        return builder.WaitUntil(s =>
+        {
+            counter.Increment();
+            return true;
+        }, TimeSpan.FromSeconds(1));
+    }
+
+    /// <summary>
+    /// Executes an arbitrary callback action during the sequence execution.
+    /// </summary>
+    internal static Hex1bTerminalInputSequenceBuilder ExecuteCallback(
+        this Hex1bTerminalInputSequenceBuilder builder,
+        Action callback)
+    {
+        return builder.WaitUntil(s =>
+        {
+            callback();
+            return true;
+        }, TimeSpan.FromSeconds(1));
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentReporter.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentReporter.cs
@@ -1,0 +1,166 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+
+namespace Aspire.Deployment.EndToEnd.Tests.Helpers;
+
+/// <summary>
+/// Reports deployment test results to GitHub Actions step summary and other outputs.
+/// </summary>
+internal static class DeploymentReporter
+{
+    /// <summary>
+    /// Reports a successful deployment with URLs to the GitHub step summary.
+    /// </summary>
+    internal static void ReportDeploymentSuccess(
+        string testName,
+        string resourceGroupName,
+        IReadOnlyDictionary<string, string> deploymentUrls,
+        TimeSpan duration)
+    {
+        var summaryPath = DeploymentE2ETestHelpers.GetGitHubStepSummaryPath();
+        if (string.IsNullOrEmpty(summaryPath))
+        {
+            // Not running in CI, just log to console
+            Console.WriteLine($"✅ Deployment succeeded: {testName}");
+            Console.WriteLine($"   Duration: {duration}");
+            Console.WriteLine($"   Resource Group: {resourceGroupName}");
+            foreach (var (name, url) in deploymentUrls)
+            {
+                Console.WriteLine($"   {name}: {url}");
+            }
+            return;
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine("## ✅ Deployment Succeeded");
+        sb.AppendLine();
+        sb.AppendLine($"**Test:** {testName}");
+        sb.AppendLine($"**Duration:** {duration:hh\\:mm\\:ss}");
+        sb.AppendLine($"**Resource Group:** `{resourceGroupName}`");
+        sb.AppendLine();
+
+        if (deploymentUrls.Count > 0)
+        {
+            sb.AppendLine("### Deployed Resources");
+            sb.AppendLine();
+            sb.AppendLine("| Resource | URL |");
+            sb.AppendLine("|----------|-----|");
+            foreach (var (name, url) in deploymentUrls)
+            {
+                sb.AppendLine($"| {name} | [{url}]({url}) |");
+            }
+            sb.AppendLine();
+        }
+
+        var azurePortalUrl = $"https://portal.azure.com/#@/resource/subscriptions/{AzureAuthenticationHelpers.TryGetSubscriptionId()}/resourceGroups/{resourceGroupName}/overview";
+        sb.AppendLine($"[View in Azure Portal]({azurePortalUrl})");
+        sb.AppendLine();
+
+        File.AppendAllText(summaryPath, sb.ToString());
+    }
+
+    /// <summary>
+    /// Reports a failed deployment to the GitHub step summary.
+    /// </summary>
+    internal static void ReportDeploymentFailure(
+        string testName,
+        string resourceGroupName,
+        string errorMessage,
+        string? logs = null)
+    {
+        var summaryPath = DeploymentE2ETestHelpers.GetGitHubStepSummaryPath();
+        if (string.IsNullOrEmpty(summaryPath))
+        {
+            // Not running in CI, just log to console
+            Console.WriteLine($"❌ Deployment failed: {testName}");
+            Console.WriteLine($"   Resource Group: {resourceGroupName}");
+            Console.WriteLine($"   Error: {errorMessage}");
+            if (!string.IsNullOrEmpty(logs))
+            {
+                Console.WriteLine($"   Logs: {logs}");
+            }
+            return;
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine("## ❌ Deployment Failed");
+        sb.AppendLine();
+        sb.AppendLine($"**Test:** {testName}");
+        sb.AppendLine($"**Resource Group:** `{resourceGroupName}`");
+        sb.AppendLine();
+        sb.AppendLine("### Error");
+        sb.AppendLine();
+        sb.AppendLine("```");
+        sb.AppendLine(errorMessage);
+        sb.AppendLine("```");
+        sb.AppendLine();
+
+        if (!string.IsNullOrEmpty(logs))
+        {
+            sb.AppendLine("<details>");
+            sb.AppendLine("<summary>Full Logs</summary>");
+            sb.AppendLine();
+            sb.AppendLine("```");
+            sb.AppendLine(logs);
+            sb.AppendLine("```");
+            sb.AppendLine();
+            sb.AppendLine("</details>");
+            sb.AppendLine();
+        }
+
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (!string.IsNullOrEmpty(subscriptionId))
+        {
+            var azurePortalUrl = $"https://portal.azure.com/#@/resource/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/overview";
+            sb.AppendLine($"[View Resource Group in Azure Portal]({azurePortalUrl})");
+            sb.AppendLine();
+        }
+
+        File.AppendAllText(summaryPath, sb.ToString());
+    }
+
+    /// <summary>
+    /// Reports resource cleanup status to the GitHub step summary.
+    /// </summary>
+    internal static void ReportCleanupStatus(string resourceGroupName, bool success, string? errorMessage = null)
+    {
+        var summaryPath = DeploymentE2ETestHelpers.GetGitHubStepSummaryPath();
+        if (string.IsNullOrEmpty(summaryPath))
+        {
+            if (success)
+            {
+                Console.WriteLine($"🧹 Cleanup completed: {resourceGroupName}");
+            }
+            else
+            {
+                Console.WriteLine($"⚠️ Cleanup failed: {resourceGroupName} - {errorMessage}");
+            }
+            return;
+        }
+
+        var sb = new StringBuilder();
+        if (success)
+        {
+            sb.AppendLine($"### 🧹 Cleanup");
+            sb.AppendLine();
+            sb.AppendLine($"Resource group `{resourceGroupName}` deleted successfully.");
+        }
+        else
+        {
+            sb.AppendLine($"### ⚠️ Cleanup Warning");
+            sb.AppendLine();
+            sb.AppendLine($"Failed to delete resource group `{resourceGroupName}`.");
+            if (!string.IsNullOrEmpty(errorMessage))
+            {
+                sb.AppendLine($"Error: {errorMessage}");
+            }
+            sb.AppendLine();
+            sb.AppendLine("Manual cleanup may be required.");
+        }
+        sb.AppendLine();
+
+        File.AppendAllText(summaryPath, sb.ToString());
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/SequenceCounter.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/SequenceCounter.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Deployment.EndToEnd.Tests.Helpers;
+
+/// <summary>
+/// Tracks the sequence number for shell prompt detection in Hex1b terminal sessions.
+/// </summary>
+public class SequenceCounter
+{
+    public int Value { get; private set; } = 1;
+
+    public int Increment()
+    {
+        return ++Value;
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/README.md
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/README.md
@@ -88,8 +88,8 @@ In CI, tests use Azure Workload Identity Federation (OIDC) for authentication. T
 Required GitHub repository configuration:
 - Secret: `AZURE_DEPLOYMENT_TEST_CLIENT_ID` - App registration client ID
 - Secret: `AZURE_DEPLOYMENT_TEST_TENANT_ID` - Azure AD tenant ID
-- Variable: `AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID` - Subscription ID
-- Environment: `deployment-tests` with branch protection rules
+- Secret: `AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID` - Subscription ID
+- Environment: `deployment-testing` with branch protection rules
 
 ## Test Structure
 
@@ -152,7 +152,7 @@ public sealed class MyDeploymentTests : IAsyncDisposable
 
 ### Deployment Timeouts
 
-Deployments can take 15-30+ minutes. The test timeout is set to 60 minutes to accommodate this.
+Deployments can take 15-30+ minutes. The per-test timeout is set to 15 minutes, and the test session timeout is 60 minutes.
 
 ### Resource Cleanup
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/README.md
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/README.md
@@ -1,0 +1,185 @@
+# Aspire Deployment End-to-End Tests
+
+This project contains end-to-end tests that deploy Aspire applications to real Azure infrastructure. These tests verify that the complete deployment workflow works correctly, from project creation to live deployment and endpoint verification.
+
+## Overview
+
+These tests use the [Hex1b](https://github.com/hex1b/hex1b) terminal automation library to drive the Aspire CLI, similar to the CLI E2E tests. The key difference is that these tests actually deploy to Azure and verify the deployed applications work correctly.
+
+## Prerequisites
+
+### For Local Development
+
+1. **Linux environment** - Hex1b requires a Linux terminal (WSL2 works on Windows)
+2. **Azure CLI** - Install and authenticate with `az login`
+3. **Azure subscription** - You need access to an Azure subscription for deployments
+
+### Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION` | Yes | Azure subscription ID for test deployments |
+| `ASPIRE_DEPLOYMENT_TEST_RG_PREFIX` | No | Prefix for resource group names (default: `aspire-e2e`) |
+| `AZURE_DEPLOYMENT_TEST_TENANT_ID` | CI only | Azure AD tenant ID for OIDC authentication |
+| `AZURE_DEPLOYMENT_TEST_CLIENT_ID` | CI only | Azure AD app client ID for OIDC authentication |
+| `AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID` | CI only | Azure subscription ID (GitHub variable) |
+
+### Local Setup
+
+```bash
+# Authenticate with Azure CLI
+az login
+
+# Set your subscription
+export ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION="your-subscription-id"
+
+# Optional: customize resource group prefix
+export ASPIRE_DEPLOYMENT_TEST_RG_PREFIX="my-aspire-tests"
+```
+
+## Running Tests
+
+### Run All Tests Locally
+
+```bash
+# From repository root
+./build.sh
+
+# Run the deployment tests
+dotnet test tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj
+```
+
+### Run a Specific Test
+
+```bash
+dotnet test tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj \
+  -- --filter-method "*.DeployStarterTemplateToAzureContainerApps"
+```
+
+## CI/CD
+
+### Triggers
+
+The deployment tests are triggered by:
+
+1. **Nightly schedule** - Runs at 03:00 UTC daily on `main`
+2. **Manual dispatch** - Via GitHub Actions workflow_dispatch
+3. **Push to `deploy-test/*` branches** - For rapid iteration during development
+
+### Branch Protection
+
+The `deploy-test/*` branch pattern is protected to ensure only team members can trigger deployment tests. This provides security at the Git level.
+
+To iterate on deployment tests:
+
+```bash
+# Create a branch with the protected prefix
+git checkout -b deploy-test/my-feature
+
+# Make changes and push
+git push origin deploy-test/my-feature
+# This automatically triggers deployment tests
+```
+
+### OIDC Authentication
+
+In CI, tests use Azure Workload Identity Federation (OIDC) for authentication. This eliminates the need for stored secrets.
+
+Required GitHub repository configuration:
+- Secret: `AZURE_DEPLOYMENT_TEST_CLIENT_ID` - App registration client ID
+- Secret: `AZURE_DEPLOYMENT_TEST_TENANT_ID` - Azure AD tenant ID
+- Variable: `AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID` - Subscription ID
+- Environment: `deployment-tests` with branch protection rules
+
+## Test Structure
+
+```
+Aspire.Deployment.EndToEnd.Tests/
+├── Helpers/
+│   ├── AzureAuthenticationHelpers.cs  # Azure auth (OIDC/CLI)
+│   ├── DeploymentE2ETestHelpers.cs    # Terminal automation helpers
+│   ├── DeploymentReporter.cs          # GitHub step summary reporting
+│   └── SequenceCounter.cs             # Prompt tracking
+├── AcaStarterDeploymentTests.cs       # Azure Container Apps tests
+├── xunit.runner.json                  # Test runner config
+└── README.md                          # This file
+```
+
+## Writing New Tests
+
+See the [Deployment E2E Testing Skill](../../.github/skills/deployment-e2e-testing/SKILL.md) for detailed patterns and guidance.
+
+Basic test structure:
+
+```csharp
+public sealed class MyDeploymentTests : IAsyncDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly string _resourceGroupName;
+
+    public MyDeploymentTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _resourceGroupName = AzureAuthenticationHelpers.GenerateResourceGroupName(nameof(MyDeploymentTests));
+    }
+
+    [Fact]
+    public async Task DeployMyScenario()
+    {
+        // 1. Create workspace and terminal
+        var workspace = TemporaryWorkspace.Create(_output);
+        var recordingPath = DeploymentE2ETestHelpers.GetTestResultsRecordingPath(nameof(DeployMyScenario));
+
+        // 2. Build terminal and sequence
+        // 3. Create project, deploy, verify endpoints
+        // 4. Report results and cleanup
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        // Cleanup resources
+    }
+}
+```
+
+## Troubleshooting
+
+### Authentication Failures
+
+**Local**: Ensure you're logged in with `az login` and have access to the subscription.
+
+**CI**: Check that OIDC federation is correctly configured between GitHub and Azure AD.
+
+### Deployment Timeouts
+
+Deployments can take 15-30+ minutes. The test timeout is set to 60 minutes to accommodate this.
+
+### Resource Cleanup
+
+Tests attempt to clean up Azure resources after completion. If cleanup fails, resources are tagged with creation metadata for manual cleanup.
+
+To find orphaned resources:
+
+```bash
+az group list --query "[?starts_with(name, 'aspire-e2e')]" -o table
+```
+
+### Viewing Recordings
+
+Tests generate asciinema recordings in CI. Download from the workflow artifacts to replay:
+
+```bash
+asciinema play path/to/recording.cast
+```
+
+## Tenant Rotation
+
+The test Azure tenant/subscription rotates approximately every 90 days per policy. When rotation occurs:
+
+1. Create new App Registration in the new tenant
+2. Configure Workload Identity Federation for the `deployment-tests` GitHub environment
+3. Grant Owner role on subscription (constrained - cannot create other Owner identities)
+4. Update GitHub secrets: `AZURE_DEPLOYMENT_TEST_CLIENT_ID`, `AZURE_DEPLOYMENT_TEST_TENANT_ID`
+5. Update GitHub variable: `AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID`
+
+See [Deployment Testing Documentation](../../docs/deployment-testing.md) for detailed rotation procedures.

--- a/tests/Aspire.Deployment.EndToEnd.Tests/README.md
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/README.md
@@ -156,12 +156,13 @@ Deployments can take 15-30+ minutes. The per-test timeout is set to 15 minutes, 
 
 ### Resource Cleanup
 
-Tests attempt to clean up Azure resources after completion. If cleanup fails, resources are tagged with creation metadata for manual cleanup.
+Tests attempt to clean up Azure resources after completion. The cleanup workflow runs hourly to remove orphaned resources.
 
 To find orphaned resources:
 
 ```bash
-az group list --query "[?starts_with(name, 'aspire-e2e')]" -o table
+# Resource groups created by aspire deploy
+az group list --query "[?starts_with(name, 'rg-aspire-')]" -o table
 ```
 
 ### Viewing Recordings

--- a/tests/Aspire.Deployment.EndToEnd.Tests/README.md
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/README.md
@@ -93,7 +93,7 @@ Required GitHub repository configuration:
 
 ## Test Structure
 
-```
+```text
 Aspire.Deployment.EndToEnd.Tests/
 ├── Helpers/
 │   ├── AzureAuthenticationHelpers.cs  # Azure auth (OIDC/CLI)

--- a/tests/Aspire.Deployment.EndToEnd.Tests/xunit.runner.json
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": false
+}

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -10,6 +10,7 @@
     <TestArchiveTestsDirForEndToEndTests Condition="'$(TestArchiveTestsDirForEndToEndTests)' == ''">$([MSBuild]::NormalizeDirectory($(ArtifactsDir), 'helix', 'e2e-tests'))</TestArchiveTestsDirForEndToEndTests>
     <TestArchiveTestsDirForBuildOnHelixTests Condition="'$(TestArchiveTestsDirForBuildOnHelixTests)' == ''">$([MSBuild]::NormalizeDirectory($(ArtifactsDir), 'helix', 'build-on-helix-tests'))</TestArchiveTestsDirForBuildOnHelixTests>
     <TestArchiveTestsDirForCliEndToEndTests Condition="'$(TestArchiveTestsDirForCliEndToEndTests)' == ''">$([MSBuild]::NormalizeDirectory($(ArtifactsDir), 'helix', 'cli-e2e-tests'))</TestArchiveTestsDirForCliEndToEndTests>
+    <TestArchiveTestsDirForDeploymentEndToEndTests Condition="'$(TestArchiveTestsDirForDeploymentEndToEndTests)' == ''">$([MSBuild]::NormalizeDirectory($(ArtifactsDir), 'helix', 'deployment-e2e-tests'))</TestArchiveTestsDirForDeploymentEndToEndTests>
     <PlaywrightDependenciesDirectory>$(ArtifactsBinDir)playwright-deps</PlaywrightDependenciesDirectory>
     <GeneratedPackagesVersionsPropsPath>$(IntermediateOutputPath)Directory.Packages.Versions.props</GeneratedPackagesVersionsPropsPath>
 


### PR DESCRIPTION
## Summary

This PR introduces end-to-end deployment tests that deploy Aspire applications to real Azure infrastructure.

## What's Included

### Test Infrastructure
- **Test Project**: `tests/Aspire.Deployment.EndToEnd.Tests/`
  - `AcaStarterDeploymentTests.cs` - Deploys starter app to Azure Container Apps
  - `AuthenticationTests.cs` - Validates Azure OIDC authentication
  - Helper classes for Azure auth, deployment reporting, and test utilities

### Workflows
- **`deployment-tests.yml`**: Main deployment test workflow
  - Triggered by `workflow_dispatch`, nightly schedule, or `/deployment-test` command
  - Uses matrix strategy for parallel test execution
  - OIDC authentication (no stored secrets)
  
- **`deployment-test-command.yml`**: Handles `/deployment-test` PR comments
  - Validates org membership before triggering
  - Security: Only dotnet org members can trigger

- **`deployment-cleanup.yml`**: Hourly cleanup of orphaned Azure resources
  - Deletes resource groups older than 3 hours
  - Prevents resource accumulation from failed tests

### enumerate-tests Action Extension
- Added `includeDeployment` input for deployment test discovery
- Added `deployment_tests_matrix` output for matrix job creation

## Security
- Uses OIDC (Workload Identity Federation) for Azure authentication
- No stored Azure secrets
- Only dotnet org members can trigger via PR command
- Tests excluded from standard CI (`RunOnGithubActionsLinux=false`)

## Usage

### Manual Trigger
Go to Actions → Deployment E2E Tests → Run workflow

### From PR
Comment `/deployment-test` on any PR (org members only)

### Nightly
Runs automatically at 03:00 UTC

## Testing
This infrastructure has been validated through multiple successful runs on the `deploy-test/*` branches.