### PR TITLE
Add v2 backchannel RPC API with capability negotiation

### DIFF
--- a/docs/specs/cli-backchannel.md
+++ b/docs/specs/cli-backchannel.md
@@ -1,0 +1,221 @@
+# CLI Auxiliary Backchannel
+
+This document describes the design philosophy and patterns for the CLI-to-AppHost RPC communication channel.
+
+## Philosophy
+
+The auxiliary backchannel exists because the CLI and AppHost are **separately versioned components** that need to communicate reliably across version boundaries. Users may run:
+
+- A new CLI against an old AppHost (updated CLI, existing project)
+- An old CLI against a new AppHost (CI environment with pinned CLI)
+
+This creates a **compatibility matrix** that we must handle gracefully. The backchannel is designed with these principles:
+
+### 1. Never Break Existing Clients
+
+Once a method signature ships, it ships forever. We don't remove methods or change their signatures. Instead, we deprecate and add new methods alongside them.
+
+### 2. Design for Extensibility from Day One
+
+Every method takes a **single request object** and returns a **single response object**. This allows us to add optional properties later without breaking the wire format.
+
+**Bad** (can't add parameters without breaking):
+```csharp
+Task<Logs> GetLogsAsync(string resourceName, bool follow)
+```
+
+**Good** (can add `TailLines`, `Filter`, etc. later):
+```csharp
+Task<GetLogsResponse> GetLogsAsync(GetLogsRequest request)
+```
+
+### 3. Capability Negotiation Over Version Numbers
+
+Rather than exposing a version number and maintaining a compatibility table, we use **capability strings**. The client asks "what can you do?" and adapts accordingly.
+
+```
+CLI: "What capabilities do you have?"
+AppHost: ["aux.v1", "aux.v2"]
+CLI: "Great, I'll use v2 methods"
+```
+
+If the method doesn't exist (old AppHost), the CLI catches the exception and falls back.
+
+### 4. The Contract is the Interface
+
+The C# interface **is** the spec. We don't maintain a separate IDL or proto file. The interface with its XML docs is the source of truth:
+
+```csharp
+public interface IAuxiliaryBackchannel
+{
+    Task<GetCapabilitiesResponse> GetCapabilitiesAsync(GetCapabilitiesRequest? request = null);
+    Task<GetResourcesResponse> GetResourcesAsync(GetResourcesRequest? request = null);
+    IAsyncEnumerable<ResourceSnapshot> WatchResourcesAsync(WatchResourcesRequest? request = null);
+    // ...
+}
+```
+
+## Contract Rules
+
+When adding or modifying backchannel methods, follow these rules:
+
+```csharp
+// =============================================================================
+// Auxiliary Backchannel Contract Rules:
+//
+// 1. All methods take a single request object (nullable where sensible)
+// 2. All methods return a response object (or IAsyncEnumerable<T> for streaming)
+// 3. Request/response types are sealed classes with { get; init; } properties
+// 4. Required properties use 'required' keyword
+// 5. Optional properties are nullable (T?) - can be added without breaking
+// 6. Empty request classes are allowed (for future expansion)
+// 7. Method names: Get*Async, Watch*Async (streaming), Call*Async (actions)
+// =============================================================================
+```
+
+### Why These Rules?
+
+**Rule 1 & 2 (Request/Response objects)**: Allows adding parameters and return fields without changing the method signature.
+
+**Rule 3 (Sealed classes with init)**: Immutable after construction, thread-safe, clear intent.
+
+**Rule 4 & 5 (Required vs nullable)**: Makes the contract explicit. Required = must be set. Nullable = optional, can be added later.
+
+**Rule 6 (Empty request classes)**: Even if a method needs no parameters today, wrap it in a request object. Tomorrow you might need to add filtering, pagination, or options.
+
+**Rule 7 (Naming convention)**: Consistent naming makes the API predictable.
+
+## Versioning Strategy
+
+### Capability Strings
+
+```csharp
+internal static class AuxiliaryBackchannelCapabilities
+{
+    public const string V1 = "aux.v1";  // 13.1 baseline
+    public const string V2 = "aux.v2";  // 13.2+ with request objects
+}
+```
+
+### What Shipped When
+
+| Version | Capability | Methods |
+|---------|------------|---------|
+| 13.1 | `aux.v1` | `GetAppHostInformationAsync()`, `GetDashboardMcpConnectionInfoAsync()`, `StopAppHostAsync()` |
+| 13.2 | `aux.v2` | All v1 methods + new request-object-based methods |
+
+### Compatibility Matrix
+
+| CLI | AppHost | Behavior |
+|-----|---------|----------|
+| Old | Old | Works (v1) |
+| Old | New | Works (v1 methods still exist) |
+| New | Old | Works (CLI detects missing capability, falls back) |
+| New | New | Works (uses v2) |
+
+## Adding New Methods
+
+### Step 1: Define the Request/Response Types
+
+```csharp
+internal sealed class GetSomethingRequest
+{
+    public string? Filter { get; init; }  // Optional from day one
+}
+
+internal sealed class GetSomethingResponse
+{
+    public required SomethingData[] Items { get; init; }
+}
+```
+
+### Step 2: Add to the Server
+
+```csharp
+public Task<GetSomethingResponse> GetSomethingAsync(
+    GetSomethingRequest? request = null,
+    CancellationToken cancellationToken = default)
+{
+    // Implementation
+}
+```
+
+### Step 3: Add to JSON Serializer Context (for AOT)
+
+```csharp
+[JsonSerializable(typeof(GetSomethingRequest))]
+[JsonSerializable(typeof(GetSomethingResponse))]
+internal partial class BackchannelJsonSerializerContext : JsonSerializerContext
+```
+
+### Step 4: Add to CLI Client with Fallback
+
+```csharp
+public async Task<GetSomethingResponse> GetSomethingAsync(...)
+{
+    if (!SupportsV2)
+    {
+        // Fall back to v1 behavior or return empty/default
+        return new GetSomethingResponse { Items = [] };
+    }
+    
+    return await _rpc.InvokeAsync<GetSomethingResponse>("GetSomethingAsync", [request], ct);
+}
+```
+
+## Adding New Properties
+
+This is the beauty of request objects - just add the property:
+
+```csharp
+internal sealed class GetResourcesRequest
+{
+    public string? Filter { get; init; }
+    public int? Limit { get; init; }     // NEW - old clients send null, old servers ignore it
+}
+```
+
+No version bump needed. No new capability needed. It just works.
+
+## Transport Details
+
+- **Protocol**: JSON-RPC 2.0 over StreamJsonRpc
+- **Transport**: Unix domain sockets
+- **Socket path**: `{temp}/auxi.sock.{hash}` (hash from AppHost project path)
+- **Serialization**: System.Text.Json with source generation for AOT
+
+## Thread Safety
+
+- Request/response types are immutable (`init` properties)
+- CLI caches capabilities in `ImmutableHashSet<string>`
+- Server methods are stateless - they resolve services per-call
+
+## What NOT to Do
+
+❌ **Don't add positional parameters to methods**
+```csharp
+// BAD - can't extend
+Task<Logs> GetLogsAsync(string name, bool follow, int? tail)
+```
+
+❌ **Don't remove or rename methods**
+```csharp
+// BAD - breaks old clients
+// Removed: GetResourceSnapshotsAsync
+```
+
+❌ **Don't change property types**
+```csharp
+// BAD - breaks serialization
+public int Count { get; init; }  // was string
+```
+
+❌ **Don't make optional properties required**
+```csharp
+// BAD - breaks old clients that don't send it
+public required string Filter { get; init; }  // was optional
+```
+
+## Summary
+
+The backchannel is designed for **long-term compatibility**. The patterns may seem overly cautious for internal APIs, but they pay off when users mix CLI and AppHost versions in the real world. When in doubt, add a new method rather than modifying an existing one.

--- a/docs/specs/cli-backchannel.md
+++ b/docs/specs/cli-backchannel.md
@@ -33,7 +33,7 @@ Task<GetLogsResponse> GetLogsAsync(GetLogsRequest request)
 
 Rather than exposing a version number and maintaining a compatibility table, we use **capability strings**. The client asks "what can you do?" and adapts accordingly.
 
-```
+```text
 CLI: "What capabilities do you have?"
 AppHost: ["aux.v1", "aux.v2"]
 CLI: "Great, I'll use v2 methods"

--- a/src/Aspire.Cli/Backchannel/AppHostAuxiliaryBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostAuxiliaryBackchannel.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -19,6 +20,7 @@ internal sealed class AppHostAuxiliaryBackchannel : IDisposable
     private readonly ILogger? _logger;
     private JsonRpc? _rpc;
     private bool _disposed;
+    private ImmutableHashSet<string> _capabilities = ImmutableHashSet<string>.Empty;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AppHostAuxiliaryBackchannel"/> class
@@ -95,6 +97,11 @@ internal sealed class AppHostAuxiliaryBackchannel : IDisposable
     public DateTimeOffset ConnectedAt { get; }
 
     /// <summary>
+    /// Gets a value indicating whether the AppHost supports v2 API.
+    /// </summary>
+    public bool SupportsV2 => _capabilities.Contains(AuxiliaryBackchannelCapabilities.V2);
+
+    /// <summary>
     /// Gets the JSON-RPC proxy for communicating with the AppHost.
     /// </summary>
     internal JsonRpc? Rpc => _rpc;
@@ -148,8 +155,36 @@ internal sealed class AppHostAuxiliaryBackchannel : IDisposable
 
         _logger?.LogDebug("Connected to auxiliary backchannel at {SocketPath}", SocketPath);
 
+        // Fetch capabilities to determine API version support
+        await FetchCapabilitiesAsync(cancellationToken).ConfigureAwait(false);
+
         // Get the AppHost information
         AppHostInfo = await GetAppHostInformationAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Fetches the capabilities from the AppHost to determine supported API versions.
+    /// </summary>
+    private async Task FetchCapabilitiesAsync(CancellationToken cancellationToken)
+    {
+        var rpc = EnsureConnected();
+
+        try
+        {
+            var response = await rpc.InvokeWithCancellationAsync<GetCapabilitiesResponse>(
+                "GetCapabilitiesAsync",
+                [null], // Pass null request
+                cancellationToken).ConfigureAwait(false);
+
+            _capabilities = response?.Capabilities?.ToImmutableHashSet() ?? ImmutableHashSet.Create(AuxiliaryBackchannelCapabilities.V1);
+            _logger?.LogDebug("AppHost capabilities: {Capabilities}", string.Join(", ", _capabilities));
+        }
+        catch (RemoteMethodNotFoundException)
+        {
+            // Older AppHost without GetCapabilitiesAsync - assume v1 only
+            _capabilities = ImmutableHashSet.Create(AuxiliaryBackchannelCapabilities.V1);
+            _logger?.LogDebug("AppHost does not support GetCapabilitiesAsync, assuming v1 only");
+        }
     }
 
     /// <summary>
@@ -379,6 +414,318 @@ internal sealed class AppHostAuxiliaryBackchannel : IDisposable
             [resourceName, toolName, arguments],
             cancellationToken).ConfigureAwait(false);
     }
+
+    #region V2 API Methods
+
+    /// <summary>
+    /// Gets AppHost information using the v2 API.
+    /// Falls back to v1 if not supported.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The AppHost information response.</returns>
+    public async Task<GetAppHostInfoResponse?> GetAppHostInfoV2Async(CancellationToken cancellationToken = default)
+    {
+        if (!SupportsV2)
+        {
+            // Fall back to v1 and convert
+            var legacyInfo = await GetAppHostInformationAsync(cancellationToken).ConfigureAwait(false);
+            if (legacyInfo is null)
+            {
+                return null;
+            }
+
+            return new GetAppHostInfoResponse
+            {
+                Pid = legacyInfo.ProcessId.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                AspireHostVersion = "unknown",
+                AppHostPath = legacyInfo.AppHostPath,
+                CliProcessId = legacyInfo.CliProcessId,
+                StartedAt = legacyInfo.StartedAt
+            };
+        }
+
+        var rpc = EnsureConnected();
+
+        _logger?.LogDebug("Getting AppHost info (v2)");
+
+        return await rpc.InvokeWithCancellationAsync<GetAppHostInfoResponse>(
+            "GetAppHostInfoAsync",
+            [null],
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Gets Dashboard information using the v2 API.
+    /// Falls back to v1 if not supported.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The Dashboard information response.</returns>
+    public async Task<GetDashboardInfoResponse?> GetDashboardInfoV2Async(CancellationToken cancellationToken = default)
+    {
+        if (!SupportsV2)
+        {
+            // Fall back to v1 and combine results
+            var mcpInfo = await GetDashboardMcpConnectionInfoAsync(cancellationToken).ConfigureAwait(false);
+            var urlsState = await GetDashboardUrlsAsync(cancellationToken).ConfigureAwait(false);
+
+            var urls = new List<string>();
+            if (!string.IsNullOrEmpty(urlsState?.BaseUrlWithLoginToken))
+            {
+                urls.Add(urlsState.BaseUrlWithLoginToken);
+            }
+            if (!string.IsNullOrEmpty(urlsState?.CodespacesUrlWithLoginToken))
+            {
+                urls.Add(urlsState.CodespacesUrlWithLoginToken);
+            }
+
+            return new GetDashboardInfoResponse
+            {
+                McpBaseUrl = mcpInfo?.EndpointUrl,
+                McpApiToken = mcpInfo?.ApiToken,
+                DashboardUrls = urls.ToArray(),
+                IsHealthy = urlsState?.DashboardHealthy ?? false
+            };
+        }
+
+        var rpc = EnsureConnected();
+
+        _logger?.LogDebug("Getting Dashboard info (v2)");
+
+        return await rpc.InvokeWithCancellationAsync<GetDashboardInfoResponse>(
+            "GetDashboardInfoAsync",
+            [null],
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Gets resource snapshots using the v2 API.
+    /// Falls back to v1 if not supported.
+    /// </summary>
+    /// <param name="request">The request with optional filtering.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The resources response.</returns>
+    public async Task<GetResourcesResponse> GetResourcesV2Async(GetResourcesRequest? request = null, CancellationToken cancellationToken = default)
+    {
+        if (!SupportsV2)
+        {
+            // Fall back to v1
+            var snapshots = await GetResourceSnapshotsAsync(cancellationToken).ConfigureAwait(false);
+
+            // Apply filter if specified
+            if (!string.IsNullOrEmpty(request?.Filter))
+            {
+                var filter = request.Filter;
+                snapshots = snapshots.Where(s => s.Name.Contains(filter, StringComparison.OrdinalIgnoreCase)).ToList();
+            }
+
+            return new GetResourcesResponse
+            {
+                Resources = snapshots.ToArray()
+            };
+        }
+
+        var rpc = EnsureConnected();
+
+        _logger?.LogDebug("Getting resources (v2)");
+
+        return await rpc.InvokeWithCancellationAsync<GetResourcesResponse>(
+            "GetResourcesAsync",
+            [request],
+            cancellationToken).ConfigureAwait(false) ?? new GetResourcesResponse { Resources = [] };
+    }
+
+    /// <summary>
+    /// Watches for resource changes using the v2 API.
+    /// Falls back to v1 if not supported.
+    /// </summary>
+    /// <param name="request">The request with optional filtering.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An async enumerable of resource snapshots.</returns>
+    public async IAsyncEnumerable<ResourceSnapshot> WatchResourcesV2Async(
+        WatchResourcesRequest? request = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (!SupportsV2)
+        {
+            // Fall back to v1
+            var filter = request?.Filter;
+            await foreach (var snapshot in WatchResourceSnapshotsAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (!string.IsNullOrEmpty(filter) && !snapshot.Name.Contains(filter, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+                yield return snapshot;
+            }
+            yield break;
+        }
+
+        var rpc = EnsureConnected();
+
+        _logger?.LogDebug("Watching resources (v2)");
+
+        IAsyncEnumerable<ResourceSnapshot>? snapshots;
+        try
+        {
+            snapshots = await rpc.InvokeWithCancellationAsync<IAsyncEnumerable<ResourceSnapshot>>(
+                "WatchResourcesAsync",
+                [request],
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (RemoteMethodNotFoundException)
+        {
+            yield break;
+        }
+
+        if (snapshots is null)
+        {
+            yield break;
+        }
+
+        await foreach (var snapshot in snapshots.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            yield return snapshot;
+        }
+    }
+
+    /// <summary>
+    /// Gets console logs using the v2 API.
+    /// Falls back to v1 if not supported.
+    /// </summary>
+    /// <param name="request">The request specifying resource and options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An async enumerable of log lines.</returns>
+    public IAsyncEnumerable<ResourceLogLine> GetConsoleLogsV2Async(
+        GetConsoleLogsRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!SupportsV2)
+        {
+            // Fall back to v1
+            return GetResourceLogsAsync(request.ResourceName, request.Follow, cancellationToken);
+        }
+
+        return GetConsoleLogsV2InternalAsync(request, cancellationToken);
+    }
+
+    private async IAsyncEnumerable<ResourceLogLine> GetConsoleLogsV2InternalAsync(
+        GetConsoleLogsRequest request,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var rpc = EnsureConnected();
+
+        _logger?.LogDebug("Getting console logs (v2) for {ResourceName}", request.ResourceName);
+
+        IAsyncEnumerable<ResourceLogLine>? logLines;
+        try
+        {
+            logLines = await rpc.InvokeWithCancellationAsync<IAsyncEnumerable<ResourceLogLine>>(
+                "GetConsoleLogsAsync",
+                [request],
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (RemoteMethodNotFoundException)
+        {
+            yield break;
+        }
+
+        if (logLines is null)
+        {
+            yield break;
+        }
+
+        await foreach (var logLine in logLines.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            yield return logLine;
+        }
+    }
+
+    /// <summary>
+    /// Calls an MCP tool using the v2 API.
+    /// Falls back to v1 if not supported.
+    /// </summary>
+    /// <param name="request">The request specifying resource, tool, and arguments.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The tool call response.</returns>
+    public async Task<CallMcpToolResponse> CallMcpToolV2Async(
+        CallMcpToolRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!SupportsV2)
+        {
+            // Fall back to v1 - convert request arguments
+            Dictionary<string, JsonElement>? arguments = null;
+            if (request.Arguments is JsonElement argsElement && argsElement.ValueKind == JsonValueKind.Object)
+            {
+                arguments = new Dictionary<string, JsonElement>();
+                foreach (var prop in argsElement.EnumerateObject())
+                {
+                    arguments[prop.Name] = prop.Value;
+                }
+            }
+
+            var result = await CallResourceMcpToolAsync(request.ResourceName, request.ToolName, arguments, cancellationToken).ConfigureAwait(false);
+
+            return new CallMcpToolResponse
+            {
+                IsError = result.IsError ?? false,
+                Content = result.Content.Select(c => new McpToolContentItem
+                {
+                    Type = c.Type,
+                    Text = (c as ModelContextProtocol.Protocol.TextContentBlock)?.Text
+                }).ToArray()
+            };
+        }
+
+        var rpc = EnsureConnected();
+
+        _logger?.LogDebug("Calling MCP tool (v2) {ToolName} on {ResourceName}", request.ToolName, request.ResourceName);
+
+        return await rpc.InvokeWithCancellationAsync<CallMcpToolResponse>(
+            "CallMcpToolAsync",
+            [request],
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Stops the AppHost using the v2 API.
+    /// Falls back to v1 if not supported.
+    /// </summary>
+    /// <param name="request">The request with optional exit code.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the stop was initiated, false if the method wasn't available.</returns>
+    public async Task<bool> StopAppHostV2Async(StopAppHostRequest? request = null, CancellationToken cancellationToken = default)
+    {
+        if (!SupportsV2)
+        {
+            // Fall back to v1
+            return await StopAppHostAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        var rpc = EnsureConnected();
+
+        _logger?.LogDebug("Stopping AppHost (v2)");
+
+        try
+        {
+            await rpc.InvokeWithCancellationAsync<StopAppHostResponse>(
+                "StopAsync",
+                [request],
+                cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (RemoteMethodNotFoundException)
+        {
+            // Fall back to v1
+            return await StopAppHostAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    #endregion
 
     /// <summary>
     /// Disposes the auxiliary backchannel connection.

--- a/src/Aspire.Cli/Backchannel/BackchannelJsonSerializerContext.cs
+++ b/src/Aspire.Cli/Backchannel/BackchannelJsonSerializerContext.cs
@@ -55,6 +55,23 @@ namespace Aspire.Cli.Backchannel;
 [JsonSerializable(typeof(Dictionary<string, string>))]
 [JsonSerializable(typeof(CapabilitiesInfo))]
 [JsonSerializable(typeof(CommonErrorData))]
+// V2 API request/response types
+[JsonSerializable(typeof(GetCapabilitiesRequest))]
+[JsonSerializable(typeof(GetCapabilitiesResponse))]
+[JsonSerializable(typeof(GetAppHostInfoRequest))]
+[JsonSerializable(typeof(GetAppHostInfoResponse))]
+[JsonSerializable(typeof(GetDashboardInfoRequest))]
+[JsonSerializable(typeof(GetDashboardInfoResponse))]
+[JsonSerializable(typeof(GetResourcesRequest))]
+[JsonSerializable(typeof(GetResourcesResponse))]
+[JsonSerializable(typeof(WatchResourcesRequest))]
+[JsonSerializable(typeof(GetConsoleLogsRequest))]
+[JsonSerializable(typeof(CallMcpToolRequest))]
+[JsonSerializable(typeof(CallMcpToolResponse))]
+[JsonSerializable(typeof(McpToolContentItem))]
+[JsonSerializable(typeof(McpToolContentItem[]))]
+[JsonSerializable(typeof(StopAppHostRequest))]
+[JsonSerializable(typeof(StopAppHostResponse))]
 internal partial class BackchannelJsonSerializerContext : JsonSerializerContext
 {
     [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Using the Json source generator.")]

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -9,8 +9,246 @@ namespace Aspire.Cli.Backchannel;
 namespace Aspire.Hosting.Backchannel;
 #endif
 
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
+
+// =============================================================================
+// Auxiliary Backchannel Contract Rules:
+//
+// 1. All methods take a single request object (nullable where sensible)
+// 2. All methods return a response object (or IAsyncEnumerable<T> for streaming)
+// 3. Request/response types are sealed classes with { get; init; } properties
+// 4. Required properties use 'required' keyword
+// 5. Optional properties are nullable (T?) - can be added without breaking
+// 6. Empty request classes are allowed (for future expansion)
+// 7. Method names: Get*Async, Watch*Async (streaming), Call*Async (actions)
+// =============================================================================
+
+#region Capability Constants
+
+/// <summary>
+/// Constants for auxiliary backchannel capability versions.
+/// </summary>
+internal static class AuxiliaryBackchannelCapabilities
+{
+    /// <summary>
+    /// Version 1 capabilities (13.1 baseline): GetAppHostInformationAsync, GetDashboardMcpConnectionInfoAsync, StopAppHostAsync.
+    /// </summary>
+    public const string V1 = "aux.v1";
+
+    /// <summary>
+    /// Version 2 capabilities (13.2+): Request objects, new methods.
+    /// </summary>
+    public const string V2 = "aux.v2";
+}
+
+#endregion
+
+#region V2 Request/Response Types
+
+/// <summary>
+/// Request for getting auxiliary backchannel capabilities.
+/// </summary>
+internal sealed class GetCapabilitiesRequest { }
+
+/// <summary>
+/// Response containing auxiliary backchannel capabilities.
+/// </summary>
+internal sealed class GetCapabilitiesResponse
+{
+    /// <summary>
+    /// Gets the list of supported capability versions (e.g., "aux.v1", "aux.v2").
+    /// </summary>
+    public required string[] Capabilities { get; init; }
+}
+
+/// <summary>
+/// Request for getting AppHost information.
+/// </summary>
+internal sealed class GetAppHostInfoRequest { }
+
+/// <summary>
+/// Response containing AppHost information.
+/// </summary>
+internal sealed class GetAppHostInfoResponse
+{
+    /// <summary>
+    /// Gets the AppHost process ID.
+    /// </summary>
+    public required string Pid { get; init; }
+
+    /// <summary>
+    /// Gets the Aspire hosting version.
+    /// </summary>
+    public required string AspireHostVersion { get; init; }
+
+    /// <summary>
+    /// Gets the fully qualified path to the AppHost project.
+    /// </summary>
+    public required string AppHostPath { get; init; }
+
+    /// <summary>
+    /// Gets the CLI process ID if the AppHost was launched via the CLI.
+    /// </summary>
+    public int? CliProcessId { get; init; }
+
+    /// <summary>
+    /// Gets when the AppHost process started.
+    /// </summary>
+    public DateTimeOffset? StartedAt { get; init; }
+}
+
+/// <summary>
+/// Request for getting Dashboard information.
+/// </summary>
+internal sealed class GetDashboardInfoRequest { }
+
+/// <summary>
+/// Response containing Dashboard information.
+/// </summary>
+internal sealed class GetDashboardInfoResponse
+{
+    /// <summary>
+    /// Gets the base URL of the Dashboard MCP endpoint.
+    /// </summary>
+    public string? McpBaseUrl { get; init; }
+
+    /// <summary>
+    /// Gets the Dashboard MCP API token.
+    /// </summary>
+    public string? McpApiToken { get; init; }
+
+    /// <summary>
+    /// Gets the Dashboard URLs with login tokens.
+    /// </summary>
+    public required string[] DashboardUrls { get; init; }
+
+    /// <summary>
+    /// Gets whether the Dashboard is healthy.
+    /// </summary>
+    public bool IsHealthy { get; init; }
+}
+
+/// <summary>
+/// Request for getting resource snapshots.
+/// </summary>
+internal sealed class GetResourcesRequest
+{
+    /// <summary>
+    /// Gets an optional filter pattern for resource names.
+    /// </summary>
+    public string? Filter { get; init; }
+}
+
+/// <summary>
+/// Response containing resource snapshots.
+/// </summary>
+internal sealed class GetResourcesResponse
+{
+    /// <summary>
+    /// Gets the resource snapshots.
+    /// </summary>
+    public required ResourceSnapshot[] Resources { get; init; }
+}
+
+/// <summary>
+/// Request for watching resource changes.
+/// </summary>
+internal sealed class WatchResourcesRequest
+{
+    /// <summary>
+    /// Gets an optional filter pattern for resource names.
+    /// </summary>
+    public string? Filter { get; init; }
+}
+
+/// <summary>
+/// Request for getting console logs.
+/// </summary>
+internal sealed class GetConsoleLogsRequest
+{
+    /// <summary>
+    /// Gets the resource name to get logs for.
+    /// </summary>
+    public required string ResourceName { get; init; }
+
+    /// <summary>
+    /// Gets whether to follow (stream) new log entries.
+    /// </summary>
+    public bool Follow { get; init; }
+}
+
+/// <summary>
+/// Request for calling an MCP tool on a resource.
+/// </summary>
+internal sealed class CallMcpToolRequest
+{
+    /// <summary>
+    /// Gets the resource name.
+    /// </summary>
+    public required string ResourceName { get; init; }
+
+    /// <summary>
+    /// Gets the tool name.
+    /// </summary>
+    public required string ToolName { get; init; }
+
+    /// <summary>
+    /// Gets the tool arguments.
+    /// </summary>
+    public JsonElement? Arguments { get; init; }
+}
+
+/// <summary>
+/// Response from calling an MCP tool.
+/// </summary>
+internal sealed class CallMcpToolResponse
+{
+    /// <summary>
+    /// Gets whether the tool call resulted in an error.
+    /// </summary>
+    public required bool IsError { get; init; }
+
+    /// <summary>
+    /// Gets the content items returned by the tool.
+    /// </summary>
+    public required McpToolContentItem[] Content { get; init; }
+}
+
+/// <summary>
+/// Represents a content item returned by an MCP tool.
+/// </summary>
+internal sealed class McpToolContentItem
+{
+    /// <summary>
+    /// Gets the content type (e.g., "text").
+    /// </summary>
+    public required string Type { get; init; }
+
+    /// <summary>
+    /// Gets the text content.
+    /// </summary>
+    public string? Text { get; init; }
+}
+
+/// <summary>
+/// Request for stopping the AppHost.
+/// </summary>
+internal sealed class StopAppHostRequest
+{
+    /// <summary>
+    /// Gets the exit code to use when stopping.
+    /// </summary>
+    public int? ExitCode { get; init; }
+}
+
+/// <summary>
+/// Response from stopping the AppHost.
+/// </summary>
+internal sealed class StopAppHostResponse { }
+
+#endregion
 
 /// <summary>
 /// Represents the state of a resource reported via RPC.

--- a/tests/Aspire.Hosting.Tests/Backchannel/BackchannelContractTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/BackchannelContractTests.cs
@@ -1,0 +1,149 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using System.Text;
+
+namespace Aspire.Hosting.Backchannel;
+
+/// <summary>
+/// Validates that backchannel request/response types follow the contract rules.
+/// </summary>
+public class BackchannelContractTests
+{
+    // V2 request/response types that must follow the contract
+    private static readonly Type[] s_contractTypes =
+    [
+        typeof(GetCapabilitiesRequest),
+        typeof(GetCapabilitiesResponse),
+        typeof(GetAppHostInfoRequest),
+        typeof(GetAppHostInfoResponse),
+        typeof(GetDashboardInfoRequest),
+        typeof(GetDashboardInfoResponse),
+        typeof(GetResourcesRequest),
+        typeof(GetResourcesResponse),
+        typeof(WatchResourcesRequest),
+        typeof(GetConsoleLogsRequest),
+        typeof(CallMcpToolRequest),
+        typeof(CallMcpToolResponse),
+        typeof(McpToolContentItem),
+        typeof(StopAppHostRequest),
+        typeof(StopAppHostResponse),
+        typeof(ResourceSnapshot),
+        typeof(ResourceSnapshotEndpoint),
+        typeof(ResourceSnapshotRelationship),
+        typeof(ResourceSnapshotHealthReport),
+        typeof(ResourceSnapshotVolume),
+        typeof(ResourceSnapshotMcpServer),
+        typeof(ResourceLogLine),
+    ];
+
+    /// <summary>
+    /// Validates all backchannel contract rules:
+    /// 1. All types are sealed classes
+    /// 2. Properties use { get; init; } pattern (not { get; set; })
+    /// 3. Required properties have 'required' modifier and are not nullable
+    /// 4. Optional properties are nullable (T?) or have default values
+    /// 5. No public fields allowed
+    /// 6. Request/Response types follow naming convention
+    /// </summary>
+    [Fact]
+    public void BackchannelTypes_FollowContractRules()
+    {
+        var errors = new StringBuilder();
+
+        foreach (var type in s_contractTypes)
+        {
+            // Rule 1: Must be sealed class
+            if (!type.IsClass)
+            {
+                errors.AppendLine($"❌ {type.Name}: Must be a class (not struct or interface)");
+            }
+            else if (!type.IsSealed)
+            {
+                errors.AppendLine($"❌ {type.Name}: Must be sealed");
+            }
+
+            // Rule 5: No public fields
+            foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Instance))
+            {
+                errors.AppendLine($"❌ {type.Name}.{field.Name}: Public fields not allowed, use properties");
+            }
+
+            // Rule 6: Naming convention (skip helper types)
+            if (!type.Name.StartsWith("ResourceSnapshot") &&
+                type.Name != "McpToolContentItem" &&
+                type.Name != "ResourceLogLine")
+            {
+                if (!type.Name.EndsWith("Request") && !type.Name.EndsWith("Response"))
+                {
+                    errors.AppendLine($"❌ {type.Name}: Name should end with 'Request' or 'Response'");
+                }
+            }
+
+            foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                var setMethod = prop.GetSetMethod();
+
+                // Skip computed properties (no setter)
+                if (setMethod is null)
+                {
+                    continue;
+                }
+
+                // Rule 2: Must use { get; init; } not { get; set; }
+                var isInitOnly = setMethod.ReturnParameter
+                    .GetRequiredCustomModifiers()
+                    .Any(m => m.FullName == "System.Runtime.CompilerServices.IsExternalInit");
+
+                if (!isInitOnly)
+                {
+                    errors.AppendLine($"❌ {type.Name}.{prop.Name}: Must use {{ get; init; }} not {{ get; set; }}");
+                }
+
+                var isRequired = prop.GetCustomAttribute<System.Runtime.CompilerServices.RequiredMemberAttribute>() is not null;
+                var nullabilityContext = new NullabilityInfoContext();
+                var nullabilityInfo = nullabilityContext.Create(prop);
+
+                if (isRequired)
+                {
+                    // Rule 3: Required properties should not be nullable
+                    bool isNullable = prop.PropertyType.IsValueType
+                        ? Nullable.GetUnderlyingType(prop.PropertyType) is not null
+                        : nullabilityInfo.WriteState == NullabilityState.Nullable;
+
+                    if (isNullable)
+                    {
+                        errors.AppendLine($"❌ {type.Name}.{prop.Name}: Required properties should not be nullable");
+                    }
+                }
+                else
+                {
+                    // Rule 4: Optional reference types should be nullable or have defaults
+                    if (!prop.PropertyType.IsValueType)
+                    {
+                        var isNullable = nullabilityInfo.WriteState == NullabilityState.Nullable;
+                        var isCollectionWithDefault = prop.PropertyType.IsArray ||
+                            (prop.PropertyType.IsGenericType && IsAllowedCollectionType(prop.PropertyType));
+
+                        if (!isNullable && !isCollectionWithDefault)
+                        {
+                            errors.AppendLine($"❌ {type.Name}.{prop.Name}: Optional properties should be nullable (T?) or have a default");
+                        }
+                    }
+                }
+            }
+        }
+
+        Assert.True(errors.Length == 0, $"Contract violations found:\n{errors}");
+    }
+
+    private static bool IsAllowedCollectionType(Type type)
+    {
+        var genericDef = type.GetGenericTypeDefinition();
+        return genericDef == typeof(Dictionary<,>) ||
+               genericDef == typeof(List<>) ||
+               genericDef == typeof(IReadOnlyList<>) ||
+               genericDef == typeof(IReadOnlyDictionary<,>);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Backchannel/JsonElementConversionTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/JsonElementConversionTests.cs
@@ -1,0 +1,160 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using System.Text.Json;
+
+namespace Aspire.Hosting.Backchannel;
+
+/// <summary>
+/// Tests for JsonElement to object conversion used in MCP tool calls.
+/// </summary>
+public class JsonElementConversionTests
+{
+    // Access the private ConvertJsonElementToObject method via reflection for testing
+    private static readonly MethodInfo s_convertMethod = typeof(AuxiliaryBackchannelRpcTarget)
+        .GetMethod("ConvertJsonElementToObject", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static object? ConvertJsonElementToObject(JsonElement element)
+    {
+        return s_convertMethod.Invoke(null, [element]);
+    }
+
+    [Fact]
+    public void ConvertJsonElement_String_ReturnsString()
+    {
+        var json = JsonDocument.Parse("\"hello\"");
+        var result = ConvertJsonElementToObject(json.RootElement);
+
+        Assert.Equal("hello", result);
+    }
+
+    [Fact]
+    public void ConvertJsonElement_Integer_ReturnsInt()
+    {
+        var json = JsonDocument.Parse("42");
+        var result = ConvertJsonElementToObject(json.RootElement);
+
+        Assert.IsType<int>(result);
+        Assert.Equal(42, (int)result!);
+    }
+
+    [Fact]
+    public void ConvertJsonElement_Float_ReturnsDouble()
+    {
+        var json = JsonDocument.Parse("3.14");
+        var result = ConvertJsonElementToObject(json.RootElement);
+
+        Assert.Equal(3.14, result);
+    }
+
+    [Fact]
+    public void ConvertJsonElement_True_ReturnsBoolTrue()
+    {
+        var json = JsonDocument.Parse("true");
+        var result = ConvertJsonElementToObject(json.RootElement);
+
+        Assert.Equal(true, result);
+    }
+
+    [Fact]
+    public void ConvertJsonElement_False_ReturnsBoolFalse()
+    {
+        var json = JsonDocument.Parse("false");
+        var result = ConvertJsonElementToObject(json.RootElement);
+
+        Assert.Equal(false, result);
+    }
+
+    [Fact]
+    public void ConvertJsonElement_Null_ReturnsNull()
+    {
+        var json = JsonDocument.Parse("null");
+        var result = ConvertJsonElementToObject(json.RootElement);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ConvertJsonElement_Array_ReturnsObjectArray()
+    {
+        var json = JsonDocument.Parse("[1, 2, 3]");
+        var result = ConvertJsonElementToObject(json.RootElement);
+
+        var array = Assert.IsType<object?[]>(result);
+        Assert.Equal(3, array.Length);
+        Assert.Equal(1, array[0]);
+        Assert.Equal(2, array[1]);
+        Assert.Equal(3, array[2]);
+    }
+
+    [Fact]
+    public void ConvertJsonElement_Object_ReturnsDictionary()
+    {
+        var json = JsonDocument.Parse("""{"name": "test", "value": 123}""");
+        var result = ConvertJsonElementToObject(json.RootElement);
+
+        var dict = Assert.IsType<Dictionary<string, object?>>(result);
+        Assert.Equal("test", dict["name"]);
+        Assert.Equal(123, dict["value"]);
+    }
+
+    [Fact]
+    public void ConvertJsonElement_NestedObject_ReturnsNestedDictionary()
+    {
+        var json = JsonDocument.Parse("""{"outer": {"inner": "value"}}""");
+        var result = ConvertJsonElementToObject(json.RootElement);
+
+        var dict = Assert.IsType<Dictionary<string, object?>>(result);
+        var nested = Assert.IsType<Dictionary<string, object?>>(dict["outer"]);
+        Assert.Equal("value", nested["inner"]);
+    }
+
+    [Fact]
+    public void ConvertJsonElement_MixedArray_ReturnsCorrectTypes()
+    {
+        var json = JsonDocument.Parse("""["text", 42, true, null]""");
+        var result = ConvertJsonElementToObject(json.RootElement);
+
+        var array = Assert.IsType<object?[]>(result);
+        Assert.Equal(4, array.Length);
+        Assert.Equal("text", array[0]);
+        Assert.Equal(42, array[1]);
+        Assert.Equal(true, array[2]);
+        Assert.Null(array[3]);
+    }
+
+    [Fact]
+    public void ConvertJsonElement_ComplexMcpArguments_ConvertsCorrectly()
+    {
+        // Simulate typical MCP tool arguments
+        var json = JsonDocument.Parse("""
+        {
+            "query": "SELECT * FROM users",
+            "limit": 100,
+            "includeDeleted": false,
+            "filters": ["active", "verified"],
+            "options": {
+                "timeout": 30,
+                "retries": 3
+            }
+        }
+        """);
+
+        var result = ConvertJsonElementToObject(json.RootElement);
+
+        var dict = Assert.IsType<Dictionary<string, object?>>(result);
+        Assert.Equal("SELECT * FROM users", dict["query"]);
+        Assert.Equal(100, dict["limit"]);
+        Assert.Equal(false, dict["includeDeleted"]);
+
+        var filters = Assert.IsType<object?[]>(dict["filters"]);
+        Assert.Equal(2, filters.Length);
+        Assert.Equal("active", filters[0]);
+        Assert.Equal("verified", filters[1]);
+
+        var options = Assert.IsType<Dictionary<string, object?>>(dict["options"]);
+        Assert.Equal(30, options["timeout"]);
+        Assert.Equal(3, options["retries"]);
+    }
+}


### PR DESCRIPTION
## Description

This PR cleans up the auxiliary backchannel RPC protocol between the Aspire CLI and AppHost with a versioned, extensible API design.

### Design Philosophy

This API follows **proto/gRPC versioning guidance** for evolving RPC contracts:

- **Additive-only changes**: New fields can be added to request/response types without breaking existing clients
- **Optional fields are nullable**: New properties are `T?` so old clients/servers that don't send them still work
- **Required fields are immutable**: Once a field is `required`, it stays required forever
- **Capability negotiation**: Clients discover server capabilities before calling methods, enabling graceful fallback
- **Never remove or rename**: V1 methods stay forever for backward compatibility

This ensures the CLI ↔ AppHost compatibility matrix always works across version mismatches.

### What's Changed

**V2 API with request/response objects**: All new methods take a single request object and return a response object, following consistent patterns that are easy to extend without breaking compatibility.

**Capability negotiation**: CLI calls `GetCapabilitiesAsync` on connect to discover what the AppHost supports (`["aux.v1", "aux.v2"]`). Falls back to v1 methods for older AppHosts.

**Contract rules enforced by tests**: Request/response types must be:
- Sealed classes with `{ get; init; }` properties
- Required properties use `required` keyword
- Optional properties are nullable (`T?`)

**JsonElement conversion fix**: MCP tool arguments are now properly converted from `JsonElement` to CLR types before passing to the MCP SDK.

### Compatibility

V1 methods (shipped in 13.1) are kept for backward compatibility:
- `GetAppHostInformationAsync`
- `GetDashboardMcpConnectionInfoAsync`
- `StopAppHostAsync`

| CLI | AppHost | Result |
|-----|---------|--------|
| 13.1 | 13.1 | ✅ v1 methods |
| 13.1 | 13.2+ | ✅ v1 methods still exist |
| 13.2+ | 13.1 | ✅ CLI falls back to v1 |
| 13.2+ | 13.2+ | ✅ v2 methods |

### New V2 Methods

| V2 Method | Replaces |
|-----------|----------|
| `GetCapabilitiesAsync` | (new) |
| `GetAppHostInfoAsync` | `GetAppHostInformationAsync` |
| `GetDashboardInfoAsync` | `GetDashboardMcpConnectionInfoAsync` |
| `GetResourcesAsync` | `GetResourceSnapshotsAsync` |
| `WatchResourcesAsync` | `WatchResourceSnapshotsAsync` |
| `GetConsoleLogsAsync` | `GetResourceLogsAsync` |
| `CallMcpToolAsync` | `CallResourceMcpToolAsync` |
| `StopAsync` | `StopAppHostAsync` |

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No