### PR TITLE
Retry dotnet-install during polyglot sdk tests

### DIFF
--- a/.github/workflows/polyglot-validation/Dockerfile.go
+++ b/.github/workflows/polyglot-validation/Dockerfile.go
@@ -19,8 +19,9 @@ RUN apt-get update && apt-get install -y \
     jq \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET SDK 10.0
-RUN curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 10.0
+# Install .NET SDK 10.0 with retry logic
+COPY install-dotnet.sh /scripts/install-dotnet.sh
+RUN chmod +x /scripts/install-dotnet.sh && /scripts/install-dotnet.sh
 ENV PATH="/root/.dotnet:${PATH}"
 ENV DOTNET_ROOT="/root/.dotnet"
 

--- a/.github/workflows/polyglot-validation/Dockerfile.java
+++ b/.github/workflows/polyglot-validation/Dockerfile.java
@@ -19,8 +19,9 @@ RUN apt-get update && apt-get install -y \
     jq \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET SDK 10.0
-RUN curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 10.0
+# Install .NET SDK 10.0 with retry logic
+COPY install-dotnet.sh /scripts/install-dotnet.sh
+RUN chmod +x /scripts/install-dotnet.sh && /scripts/install-dotnet.sh
 ENV PATH="/root/.dotnet:${PATH}"
 ENV DOTNET_ROOT="/root/.dotnet"
 

--- a/.github/workflows/polyglot-validation/Dockerfile.python
+++ b/.github/workflows/polyglot-validation/Dockerfile.python
@@ -19,8 +19,9 @@ RUN apt-get update && apt-get install -y \
     jq \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET SDK 10.0
-RUN curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 10.0
+# Install .NET SDK 10.0 with retry logic
+COPY install-dotnet.sh /scripts/install-dotnet.sh
+RUN chmod +x /scripts/install-dotnet.sh && /scripts/install-dotnet.sh
 ENV PATH="/root/.dotnet:${PATH}"
 ENV DOTNET_ROOT="/root/.dotnet"
 

--- a/.github/workflows/polyglot-validation/Dockerfile.rust
+++ b/.github/workflows/polyglot-validation/Dockerfile.rust
@@ -19,8 +19,9 @@ RUN apt-get update && apt-get install -y \
     jq \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET SDK 10.0
-RUN curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 10.0
+# Install .NET SDK 10.0 with retry logic
+COPY install-dotnet.sh /scripts/install-dotnet.sh
+RUN chmod +x /scripts/install-dotnet.sh && /scripts/install-dotnet.sh
 ENV PATH="/root/.dotnet:${PATH}"
 ENV DOTNET_ROOT="/root/.dotnet"
 

--- a/.github/workflows/polyglot-validation/Dockerfile.typescript
+++ b/.github/workflows/polyglot-validation/Dockerfile.typescript
@@ -19,8 +19,9 @@ RUN apt-get update && apt-get install -y \
     jq \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET SDK 10.0
-RUN curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 10.0
+# Install .NET SDK 10.0 with retry logic
+COPY install-dotnet.sh /scripts/install-dotnet.sh
+RUN chmod +x /scripts/install-dotnet.sh && /scripts/install-dotnet.sh
 ENV PATH="/root/.dotnet:${PATH}"
 ENV DOTNET_ROOT="/root/.dotnet"
 

--- a/.github/workflows/polyglot-validation/install-dotnet.sh
+++ b/.github/workflows/polyglot-validation/install-dotnet.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 # Installs .NET SDK with retry logic for polyglot validation Dockerfiles
 
 MAX_ATTEMPTS=3

--- a/.github/workflows/polyglot-validation/install-dotnet.sh
+++ b/.github/workflows/polyglot-validation/install-dotnet.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Installs .NET SDK with retry logic for polyglot validation Dockerfiles
+
+MAX_ATTEMPTS=3
+RETRY_DELAY=5
+DOTNET_CHANNEL="10.0"
+
+for attempt in $(seq 1 $MAX_ATTEMPTS); do
+    echo "=== .NET SDK installation attempt $attempt of $MAX_ATTEMPTS ==="
+
+    if curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel $DOTNET_CHANNEL; then
+        # Verify installation
+        export PATH="/root/.dotnet:${PATH}"
+        export DOTNET_ROOT="/root/.dotnet"
+
+        if dotnet --version > /dev/null 2>&1; then
+            echo "=== .NET SDK installation successful ==="
+            exit 0
+        else
+            echo "WARNING: .NET install script succeeded but 'dotnet --version' failed"
+        fi
+    else
+        echo "WARNING: .NET install script failed on attempt $attempt"
+    fi
+
+    if [ $attempt -lt $MAX_ATTEMPTS ]; then
+        echo "Retrying in $RETRY_DELAY seconds..."
+        sleep $RETRY_DELAY
+    fi
+done
+
+echo "ERROR: .NET SDK installation failed after $MAX_ATTEMPTS attempts"
+echo "Please check network connectivity and try again"
+exit 1


### PR DESCRIPTION
## Description

Replaces https://github.com/dotnet/aspire/pull/14144 as the root cause is the dotnet-install script failures.

Fixes #14156
