### PR TITLE
DotNetCliRunner refactor. Add executor, centralize test implementations

### DIFF
--- a/src/Aspire.Cli/Backchannel/FailedToConnectBackchannelConnection.cs
+++ b/src/Aspire.Cli/Backchannel/FailedToConnectBackchannelConnection.cs
@@ -1,11 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
-
 namespace Aspire.Cli.Backchannel;
 
-internal sealed class FailedToConnectBackchannelConnection(string message, Process process, Exception innerException) : Exception(message, innerException)
+internal sealed class FailedToConnectBackchannelConnection(string message, Exception innerException) : Exception(message, innerException)
 {
-    public Process Process => process;
 }

--- a/src/Aspire.Cli/DotNet/DotNetCliExecution.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliExecution.cs
@@ -1,0 +1,183 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.DotNet;
+
+/// <summary>
+/// Represents a configured dotnet CLI execution backed by a real process.
+/// </summary>
+internal sealed class DotNetCliExecution : IDotNetCliExecution
+{
+    private readonly Process _process;
+    private readonly ILogger _logger;
+    private readonly DotNetCliRunnerInvocationOptions _options;
+    private Task? _stdoutForwarder;
+    private Task? _stderrForwarder;
+
+    internal DotNetCliExecution(Process process, ILogger logger, DotNetCliRunnerInvocationOptions options)
+    {
+        _process = process;
+        _logger = logger;
+        _options = options;
+    }
+
+    /// <inheritdoc />
+    public string FileName => _process.StartInfo.FileName;
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> Arguments => _process.StartInfo.ArgumentList.ToArray();
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<string, string?> EnvironmentVariables =>
+        _process.StartInfo.Environment.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+    /// <inheritdoc />
+    public bool HasExited => _process.HasExited;
+
+    /// <inheritdoc />
+    public int ExitCode => _process.ExitCode;
+
+    /// <inheritdoc />
+    public bool Start()
+    {
+        var suppressLogging = _options.SuppressLogging;
+
+        if (!suppressLogging)
+        {
+            _logger.LogDebug("Running dotnet with args: {Args}", string.Join(" ", Arguments));
+        }
+
+        var started = _process.Start();
+
+        if (!started)
+        {
+            if (!suppressLogging)
+            {
+                _logger.LogDebug("Failed to start dotnet process with args: {Args}", string.Join(" ", Arguments));
+            }
+            return false;
+        }
+
+        if (!suppressLogging)
+        {
+            _logger.LogDebug("Started dotnet with PID: {ProcessId}", _process.Id);
+        }
+
+        // Start stream forwarders
+        _stdoutForwarder = Task.Run(async () =>
+        {
+            await ForwardStreamToLoggerAsync(
+                _process.StandardOutput,
+                "stdout",
+                _options.StandardOutputCallback,
+                suppressLogging);
+        });
+
+        _stderrForwarder = Task.Run(async () =>
+        {
+            await ForwardStreamToLoggerAsync(
+                _process.StandardError,
+                "stderr",
+                _options.StandardErrorCallback,
+                suppressLogging);
+        });
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public async Task<int> WaitForExitAsync(CancellationToken cancellationToken)
+    {
+        var suppressLogging = _options.SuppressLogging;
+
+        if (!suppressLogging)
+        {
+            _logger.LogDebug("Waiting for dotnet process to exit with PID: {ProcessId}", _process.Id);
+        }
+
+        await _process.WaitForExitAsync(cancellationToken);
+
+        if (!_process.HasExited)
+        {
+            if (!suppressLogging)
+            {
+                _logger.LogDebug("dotnet process with PID: {ProcessId} has not exited, killing it.", _process.Id);
+            }
+            _process.Kill(false);
+        }
+        else
+        {
+            if (!suppressLogging)
+            {
+                _logger.LogDebug("dotnet process with PID: {ProcessId} has exited with code: {ExitCode}", _process.Id, _process.ExitCode);
+            }
+        }
+
+        // Explicitly close the streams to unblock any pending ReadLineAsync calls.
+        // In some environments (particularly CI containers), the stream handles may not
+        // be automatically closed when the process exits, causing ReadLineAsync to block
+        // indefinitely. Disposing the streams forces them to close.
+        _logger.LogDebug("Closing stdout/stderr streams for PID: {ProcessId}", _process.Id);
+        _process.StandardOutput.Close();
+        _process.StandardError.Close();
+
+        // Wait for all the stream forwarders to finish so we know we've got everything
+        // fired off through the callbacks. Use a timeout as a safety net in case
+        // something else is unexpectedly holding the streams open.
+        if (_stdoutForwarder is not null && _stderrForwarder is not null)
+        {
+            var forwarderTimeout = Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+            var forwardersCompleted = Task.WhenAll([_stdoutForwarder, _stderrForwarder]);
+
+            var completedTask = await Task.WhenAny(forwardersCompleted, forwarderTimeout);
+            if (completedTask == forwarderTimeout)
+            {
+                _logger.LogWarning("Stream forwarders for PID {ProcessId} did not complete within timeout after stream close. Continuing anyway.", _process.Id);
+            }
+            else
+            {
+                _logger.LogDebug("Pending forwarders for PID completed: {ProcessId}", _process.Id);
+            }
+        }
+
+        return _process.ExitCode;
+    }
+
+    private async Task ForwardStreamToLoggerAsync(StreamReader reader, string identifier, Action<string>? lineCallback, bool suppressLogging)
+    {
+        if (!suppressLogging)
+        {
+            _logger.LogDebug(
+                "Starting to forward stream with identifier '{Identifier}' on process '{ProcessId}' to logger",
+                identifier,
+                _process.Id
+                );
+        }
+
+        try
+        {
+            string? line;
+            while ((line = await reader.ReadLineAsync()) is not null)
+            {
+                if (!suppressLogging)
+                {
+                    _logger.LogDebug(
+                        "dotnet({ProcessId}) {Identifier}: {Line}",
+                        _process.Id,
+                        identifier,
+                        line
+                        );
+                }
+                lineCallback?.Invoke(line);
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // Stream was closed externally (e.g., after process exit). This is expected.
+            _logger.LogDebug("Stream forwarder completed for {Identifier} - stream was closed", identifier);
+        }
+    }
+}

--- a/src/Aspire.Cli/DotNet/DotNetCliExecution.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliExecution.cs
@@ -45,11 +45,6 @@ internal sealed class DotNetCliExecution : IDotNetCliExecution
     {
         var suppressLogging = _options.SuppressLogging;
 
-        if (!suppressLogging)
-        {
-            _logger.LogDebug("Running dotnet with args: {Args}", string.Join(" ", Arguments));
-        }
-
         var started = _process.Start();
 
         if (!started)

--- a/src/Aspire.Cli/DotNet/DotNetCliExecutionFactory.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliExecutionFactory.cs
@@ -27,6 +27,21 @@ internal sealed class DotNetCliExecutionFactory(
 
     public IDotNetCliExecution CreateExecution(string[] args, IDictionary<string, string>? env, DirectoryInfo workingDirectory, DotNetCliRunnerInvocationOptions options)
     {
+        var suppressLogging = options.SuppressLogging;
+
+        if (!suppressLogging)
+        {
+            logger.LogDebug("Running {FullName} with args: {Args}", workingDirectory.FullName, string.Join(" ", args));
+
+            if (env is not null)
+            {
+                foreach (var envKvp in env)
+                {
+                    logger.LogDebug("Running {FullName} with env: {EnvKey}={EnvValue}", workingDirectory.FullName, , envKvp.Key, envKvp.Value);
+                }
+            }
+        }
+
         var startInfo = new ProcessStartInfo("dotnet")
         {
             WorkingDirectory = workingDirectory.FullName,

--- a/src/Aspire.Cli/DotNet/DotNetCliExecutionFactory.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliExecutionFactory.cs
@@ -37,7 +37,7 @@ internal sealed class DotNetCliExecutionFactory(
             {
                 foreach (var envKvp in env)
                 {
-                    logger.LogDebug("Running {FullName} with env: {EnvKey}={EnvValue}", workingDirectory.FullName, , envKvp.Key, envKvp.Value);
+                    logger.LogDebug("Running {FullName} with env: {EnvKey}={EnvValue}", workingDirectory.FullName, envKvp.Key, envKvp.Value);
                 }
             }
         }

--- a/src/Aspire.Cli/DotNet/DotNetCliExecutionFactory.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliExecutionFactory.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using Aspire.Cli.Configuration;
+using Aspire.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.DotNet;
+
+internal sealed class DotNetCliExecutionFactory(
+    ILogger<DotNetCliExecutionFactory> logger,
+    IConfiguration configuration,
+    IFeatures features,
+    CliExecutionContext executionContext) : IDotNetCliExecutionFactory
+{
+    internal static int GetCurrentProcessId() => Environment.ProcessId;
+
+    internal static long GetCurrentProcessStartTimeUnixSeconds()
+    {
+        var startTime = Process.GetCurrentProcess().StartTime;
+        return ((DateTimeOffset)startTime).ToUnixTimeSeconds();
+    }
+
+    public IDotNetCliExecution CreateExecution(string[] args, IDictionary<string, string>? env, DirectoryInfo workingDirectory, DotNetCliRunnerInvocationOptions options)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            WorkingDirectory = workingDirectory.FullName,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        if (env is not null)
+        {
+            foreach (var envKvp in env)
+            {
+                startInfo.EnvironmentVariables[envKvp.Key] = envKvp.Value;
+            }
+        }
+
+        foreach (var a in args)
+        {
+            startInfo.ArgumentList.Add(a);
+        }
+
+        // The AppHost uses this environment variable to signal to the CliOrphanDetector which process
+        // it should monitor in order to know when to stop the CLI. As long as the process still exists
+        // the orphan detector will allow the CLI to keep running. If the environment variable does
+        // not exist the orphan detector will exit.
+        startInfo.EnvironmentVariables[KnownConfigNames.CliProcessId] = GetCurrentProcessId().ToString(CultureInfo.InvariantCulture);
+
+        // Set the CLI process start time for robust orphan detection to prevent PID reuse issues.
+        // The AppHost will verify both PID and start time to ensure it's monitoring the correct process.
+        if (features.IsFeatureEnabled(KnownFeatures.OrphanDetectionWithTimestampEnabled, true))
+        {
+            startInfo.EnvironmentVariables[KnownConfigNames.CliProcessStarted] = GetCurrentProcessStartTimeUnixSeconds().ToString(CultureInfo.InvariantCulture);
+        }
+
+        // Always set MSBUILDTERMINALLOGGER=false for all dotnet command executions to ensure consistent terminal logger behavior
+        startInfo.EnvironmentVariables[KnownConfigNames.MsBuildTerminalLogger] = "false";
+
+        // Suppress the .NET welcome message that appears on first run
+        startInfo.EnvironmentVariables["DOTNET_NOLOGO"] = "1";
+
+        // Configure DOTNET_ROOT to point to the private SDK installation if it exists
+        ConfigurePrivateSdkEnvironment(startInfo);
+
+        // Set debug session info if available
+        var debugSessionInfo = configuration[KnownConfigNames.DebugSessionInfo];
+        if (!string.IsNullOrEmpty(debugSessionInfo))
+        {
+            startInfo.EnvironmentVariables[KnownConfigNames.DebugSessionInfo] = debugSessionInfo;
+        }
+
+        var process = new Process { StartInfo = startInfo };
+        return new DotNetCliExecution(process, logger, options);
+    }
+
+    /// <summary>
+    /// Configures environment variables to use the private SDK installation if it exists.
+    /// </summary>
+    /// <param name="startInfo">The process start info to configure.</param>
+    private void ConfigurePrivateSdkEnvironment(ProcessStartInfo startInfo)
+    {
+        // Get the effective minimum SDK version to determine which private SDK to use
+        var sdkVersion = DotNetSdkInstaller.GetEffectiveMinimumSdkVersion(configuration);
+        var sdksDirectory = executionContext.SdksDirectory.FullName;
+        var sdkInstallPath = Path.Combine(sdksDirectory, "dotnet", sdkVersion);
+        var dotnetExecutablePath = Path.Combine(
+            sdkInstallPath,
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet"
+        );
+
+        // Check if the private SDK exists
+        if (Directory.Exists(sdkInstallPath))
+        {
+            // Set the executable path to be the private SDK.
+            startInfo.FileName = dotnetExecutablePath;
+
+            // Set DOTNET_ROOT to point to the private SDK installation
+            startInfo.EnvironmentVariables["DOTNET_ROOT"] = sdkInstallPath;
+
+            // Also set DOTNET_MULTILEVEL_LOOKUP to 0 to prevent fallback to system SDKs
+            startInfo.EnvironmentVariables["DOTNET_MULTILEVEL_LOOKUP"] = "0";
+
+            // Prepend the private SDK path to PATH so the dotnet executable from the private installation is found first
+            var currentPath = startInfo.EnvironmentVariables["PATH"] ?? Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+            startInfo.EnvironmentVariables["PATH"] = $"{sdkInstallPath}{Path.PathSeparator}{currentPath}";
+
+            logger.LogDebug("Using private SDK installation at {SdkPath}", sdkInstallPath);
+        }
+    }
+}

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -5,12 +5,12 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net.Sockets;
-using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
-using Aspire.Cli.Configuration;
 using Aspire.Cli.Caching;
+using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
@@ -21,7 +21,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
-using System.Security.Cryptography;
 
 namespace Aspire.Cli.DotNet;
 
@@ -60,7 +59,16 @@ internal sealed class DotNetCliRunnerInvocationOptions
     public bool SuppressLogging { get; set; }
 }
 
-internal class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider serviceProvider, AspireCliTelemetry telemetry, IConfiguration configuration, IFeatures features, IInteractionService interactionService, CliExecutionContext executionContext, IDiskCache diskCache) : IDotNetCliRunner
+internal sealed class DotNetCliRunner(
+    ILogger<DotNetCliRunner> logger,
+    IServiceProvider serviceProvider,
+    AspireCliTelemetry telemetry,
+    IConfiguration configuration,
+    IDiskCache diskCache,
+    IFeatures features,
+    IInteractionService interactionService,
+    CliExecutionContext executionContext,
+    IDotNetCliExecutionFactory executionFactory) : IDotNetCliRunner
 {
     private readonly IDiskCache _diskCache = diskCache;
 
@@ -68,17 +76,153 @@ internal class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider
     private const int MaxSearchRetries = 3;
     private static readonly TimeSpan[] s_searchRetryDelays = [TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2)];
 
-    internal Func<int> GetCurrentProcessId { get; set; } = () => Environment.ProcessId;
-
-    internal Func<long> GetCurrentProcessStartTime { get; set; } = () =>
-    {
-        var startTime = Process.GetCurrentProcess().StartTime;
-        return ((DateTimeOffset)startTime).ToUnixTimeSeconds();
-    };
-
     private string GetMsBuildServerValue()
     {
         return configuration["DOTNET_CLI_USE_MSBUILD_SERVER"] ?? "true";
+    }
+
+    internal static string GetBackchannelSocketPath()
+    {
+        var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var aspireCliPath = Path.Combine(homeDirectory, ".aspire", "cli", "backchannels");
+
+        if (!Directory.Exists(aspireCliPath))
+        {
+            Directory.CreateDirectory(aspireCliPath);
+        }
+
+        var uniqueSocketPathSegment = Guid.NewGuid().ToString("N");
+        var socketPath = Path.Combine(aspireCliPath, $"cli.sock.{uniqueSocketPathSegment}");
+        return socketPath;
+    }
+
+    private async Task<int> ExecuteAsync(
+        string[] args,
+        IDictionary<string, string>? env,
+        FileInfo? projectFile,
+        DirectoryInfo workingDirectory,
+        TaskCompletionSource<IAppHostCliBackchannel>? backchannelCompletionSource,
+        DotNetCliRunnerInvocationOptions options,
+        CancellationToken cancellationToken)
+    {
+        var execution = executionFactory.CreateExecution(args, env, workingDirectory, options);
+
+        // Get socket path from env if present
+        string? socketPath = null;
+        env?.TryGetValue(KnownConfigNames.UnixSocketPath, out socketPath);
+
+        // Handle extension-based launch for app hosts with backchannel
+        if (backchannelCompletionSource is not null)
+        {
+            if (ExtensionHelper.IsExtensionHost(interactionService, out var extensionInteractionService, out var extensionBackchannel)
+                && projectFile is not null
+                && !options.NoExtensionLaunch
+                && await extensionBackchannel.HasCapabilityAsync(KnownCapabilities.Project, cancellationToken))
+            {
+                await extensionInteractionService.LaunchAppHostAsync(
+                    projectFile.FullName,
+                    execution.Arguments.ToList(),
+                    execution.EnvironmentVariables.Select(kvp => new EnvVar { Name = kvp.Key, Value = kvp.Value }).ToList(),
+                    options.StartDebugSession);
+
+                _ = StartBackchannelAsync(null, socketPath!, backchannelCompletionSource, cancellationToken);
+
+                return ExitCodeConstants.Success;
+            }
+        }
+
+        var started = execution.Start();
+
+        if (!started)
+        {
+            return ExitCodeConstants.FailedToDotnetRunAppHost;
+        }
+
+        if (backchannelCompletionSource is not null && socketPath is not null)
+        {
+            _ = StartBackchannelAsync(execution, socketPath, backchannelCompletionSource, cancellationToken);
+        }
+
+        return await execution.WaitForExitAsync(cancellationToken);
+    }
+
+    private async Task StartBackchannelAsync(IDotNetCliExecution? execution, string socketPath, TaskCompletionSource<IAppHostCliBackchannel> backchannelCompletionSource, CancellationToken cancellationToken)
+    {
+        using var activity = telemetry.StartDiagnosticActivity();
+
+        using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(50));
+
+        var backchannel = serviceProvider.GetRequiredService<IAppHostCliBackchannel>();
+        var connectionAttempts = 0;
+
+        logger.LogDebug("Starting backchannel connection to AppHost at {SocketPath}", socketPath);
+
+        var startTime = DateTimeOffset.UtcNow;
+
+        do
+        {
+            try
+            {
+                logger.LogTrace("Attempting to connect to AppHost backchannel at {SocketPath} (attempt {Attempt})", socketPath, connectionAttempts++);
+                await backchannel.ConnectAsync(socketPath, cancellationToken).ConfigureAwait(false);
+                backchannelCompletionSource.SetResult(backchannel);
+                // Note: We intentionally do not call Environment.Exit when the backchannel disconnects.
+                // The CLI should complete normally and return the appropriate exit code based on the
+                // deployment result. Calling Environment.Exit here would bypass the normal exit code
+                // logic and always return success (0), even when the deployment failed.
+
+                logger.LogDebug("Connected to AppHost backchannel at {SocketPath}", socketPath);
+                return;
+            }
+            catch (SocketException ex) when (execution is not null && execution.HasExited && execution.ExitCode != 0)
+            {
+                logger.LogError(ex, "AppHost process has exited. Unable to connect to backchannel at {SocketPath}", socketPath);
+                var backchannelException = new FailedToConnectBackchannelConnection($"AppHost process has exited unexpectedly. Use --debug to see more details.", ex);
+                backchannelCompletionSource.SetException(backchannelException);
+                return;
+            }
+            catch (SocketException ex)
+            {
+                // If the process is taking a long time to open a back channel but
+                // it has not exited then it probably means that its a larger build
+                // (remember it has to build the apphost and its dependencies).
+                // In that case, after 30 seconds we just slow down the polling to
+                // once per second.
+                var waitingFor = DateTimeOffset.UtcNow - startTime;
+                if (waitingFor > TimeSpan.FromSeconds(10))
+                {
+                    logger.LogTrace(ex, "Slow polling for backchannel connection (attempt {Attempt})", connectionAttempts);
+                    await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    // We don't want to spam the logs with our early connection attempts.
+                }
+            }
+            catch (AppHostIncompatibleException ex)
+            {
+                logger.LogError(
+                    ex,
+                    "The app host is incompatible with the CLI and must be updated to a version that supports the {RequiredCapability} capability.",
+                    ex.RequiredCapability
+                    );
+
+                // If the app host is incompatible then there is no point
+                // trying to reconnect, we should propogate the exception
+                // up to the code that needs to back channel so it can display
+                // and error message to the user.
+                backchannelCompletionSource.SetException(ex);
+
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "An unexpected error occurred while trying to connect to the backchannel.");
+                backchannelCompletionSource.SetException(ex);
+                throw;
+            }
+
+        } while (await timer.WaitForNextTickAsync(cancellationToken));
     }
 
     // Cache expiry/max age handled inside DiskCache implementation.
@@ -267,28 +411,20 @@ internal class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider
 
         cliArgs = [.. cliArgs.Where(arg => !string.IsNullOrWhiteSpace(arg))];
 
-        // Inject DOTNET_CLI_USE_MSBUILD_SERVER when noBuild == false - we copy the
-        // dictionary here because we don't want to mutate the input.
-        IDictionary<string, string>? finalEnv = env;
+        // We copy the dictionary here because we don't want to mutate the input.
+        var finalEnv = env?.ToDictionary() ?? new Dictionary<string, string>();
+
+        // Inject DOTNET_CLI_USE_MSBUILD_SERVER when noBuild == false
         if (!noBuild)
         {
-            finalEnv = new Dictionary<string, string>(env ?? new Dictionary<string, string>())
-            {
-                ["DOTNET_CLI_USE_MSBUILD_SERVER"] = GetMsBuildServerValue()
-            };
+            finalEnv["DOTNET_CLI_USE_MSBUILD_SERVER"] = GetMsBuildServerValue();
         }
 
         // Check if update notifications are disabled and set version check environment variable
         if (!features.IsFeatureEnabled(KnownFeatures.UpdateNotificationsEnabled, defaultValue: true))
         {
-            // Copy the environment if we haven't already
-            if (finalEnv == env)
-            {
-                finalEnv = new Dictionary<string, string>(env ?? new Dictionary<string, string>());
-            }
-
             // Only set the environment variable if it's not already set by the user
-            if (finalEnv is not null && !finalEnv.ContainsKey(KnownConfigNames.VersionCheckDisabled))
+            if (!finalEnv.ContainsKey(KnownConfigNames.VersionCheckDisabled))
             {
                 finalEnv[KnownConfigNames.VersionCheckDisabled] = "true";
             }
@@ -297,14 +433,8 @@ internal class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider
         // Set DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER when watch is enabled to prevent launching browser
         if (watch)
         {
-            // Copy the environment if we haven't already
-            if (finalEnv == env)
-            {
-                finalEnv = new Dictionary<string, string>(env ?? new Dictionary<string, string>());
-            }
-
             // Only set the environment variable if it's not already set by the user
-            if (finalEnv is not null && !finalEnv.ContainsKey("DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER"))
+            if (!finalEnv.ContainsKey("DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER"))
             {
                 finalEnv["DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER"] = "true";
             }
@@ -312,16 +442,18 @@ internal class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider
 
         if (features.IsFeatureEnabled(KnownFeatures.DotNetSdkInstallationEnabled, true))
         {
-            if (finalEnv == env)
-            {
-                finalEnv = new Dictionary<string, string>(env ?? new Dictionary<string, string>());
-            }
-
             // Only set the environment variable if it's not already set by the user
-            if (finalEnv is not null && !finalEnv.ContainsKey("DOTNET_ROLL_FORWARD"))
+            if (!finalEnv.ContainsKey("DOTNET_ROLL_FORWARD"))
             {
                 finalEnv["DOTNET_ROLL_FORWARD"] = "LatestMajor";
-            }            
+            }
+        }
+
+        // Set the backchannel socket path when backchannel is configured
+        if (backchannelCompletionSource is not null)
+        {
+            var socketPath = GetBackchannelSocketPath();
+            finalEnv[KnownConfigNames.UnixSocketPath] = socketPath;
         }
 
         return await ExecuteAsync(
@@ -561,325 +693,6 @@ internal class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider
             backchannelCompletionSource: null,
             options: options,
             cancellationToken: cancellationToken);
-    }
-
-    internal static string GetBackchannelSocketPath()
-    {
-        var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        var aspireCliPath = Path.Combine(homeDirectory, ".aspire", "cli", "backchannels");
-
-        if (!Directory.Exists(aspireCliPath))
-        {
-            Directory.CreateDirectory(aspireCliPath);
-        }
-
-        var uniqueSocketPathSegment = Guid.NewGuid().ToString("N");
-        var socketPath = Path.Combine(aspireCliPath, $"cli.sock.{uniqueSocketPathSegment}");
-        return socketPath;
-    }
-
-    public virtual async Task<int> ExecuteAsync(string[] args, IDictionary<string, string>? env, FileInfo? projectFile, DirectoryInfo workingDirectory, TaskCompletionSource<IAppHostCliBackchannel>? backchannelCompletionSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
-    {
-        using var activity = telemetry.StartDiagnosticActivity();
-
-        var suppressLogging = options.SuppressLogging;
-
-        var startInfo = new ProcessStartInfo("dotnet")
-        {
-            WorkingDirectory = workingDirectory.FullName,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-            RedirectStandardInput = true,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-        };
-
-        if (env is not null)
-        {
-            foreach (var envKvp in env)
-            {
-                startInfo.EnvironmentVariables[envKvp.Key] = envKvp.Value;
-            }
-        }
-
-        foreach (var a in args)
-        {
-            startInfo.ArgumentList.Add(a);
-        }
-
-        var socketPath = GetBackchannelSocketPath();
-        if (backchannelCompletionSource is not null)
-        {
-            startInfo.EnvironmentVariables[KnownConfigNames.UnixSocketPath] = socketPath;
-        }
-
-        // The AppHost uses this environment variable to signal to the CliOrphanDetector which process
-        // it should monitor in order to know when to stop the CLI. As long as the process still exists
-        // the orphan detector will allow the CLI to keep running. If the environment variable does
-        // not exist the orphan detector will exit.
-        startInfo.EnvironmentVariables[KnownConfigNames.CliProcessId] = GetCurrentProcessId().ToString(CultureInfo.InvariantCulture);
-
-        // Set the CLI process start time for robust orphan detection to prevent PID reuse issues.
-        // The AppHost will verify both PID and start time to ensure it's monitoring the correct process.
-        if (features.IsFeatureEnabled(KnownFeatures.OrphanDetectionWithTimestampEnabled, true))
-        {
-            startInfo.EnvironmentVariables[KnownConfigNames.CliProcessStarted] = GetCurrentProcessStartTime().ToString(CultureInfo.InvariantCulture);
-        }
-
-        // Always set MSBUILDTERMINALLOGGER=false for all dotnet command executions to ensure consistent terminal logger behavior
-        startInfo.EnvironmentVariables[KnownConfigNames.MsBuildTerminalLogger] = "false";
-
-        // Suppress the .NET welcome message that appears on first run
-        startInfo.EnvironmentVariables["DOTNET_NOLOGO"] = "1";
-
-        // Configure DOTNET_ROOT to point to the private SDK installation if it exists
-        ConfigurePrivateSdkEnvironment(startInfo);
-
-        if (ExtensionHelper.IsExtensionHost(interactionService, out var extensionInteractionService, out var backchannel))
-        {
-            // Even if AppHost is launched through the CLI, we still need to set the extension capabilities so that supported resource types may be started through VS Code.
-            startInfo.EnvironmentVariables[KnownConfigNames.DebugSessionInfo] = configuration[KnownConfigNames.DebugSessionInfo];
-
-            if (backchannelCompletionSource is not null
-                && projectFile is not null
-                && !options.NoExtensionLaunch
-                && await backchannel.HasCapabilityAsync(KnownCapabilities.Project, cancellationToken))
-            {
-                await extensionInteractionService.LaunchAppHostAsync(
-                    projectFile.FullName,
-                    startInfo.ArgumentList.ToList(),
-                    startInfo.Environment.Select(kvp => new EnvVar { Name = kvp.Key, Value = kvp.Value }).ToList(),
-                    options.StartDebugSession);
-
-                _ = StartBackchannelAsync(null, socketPath, backchannelCompletionSource, cancellationToken);
-
-                return ExitCodeConstants.Success;
-            }
-        }
-
-        var process = new Process { StartInfo = startInfo };
-
-        if (!suppressLogging)
-        {
-            logger.LogDebug("Running dotnet with args: {Args}", string.Join(" ", args));
-
-            if (env != null)
-            {
-                foreach (var envKvp in env)
-                {
-                    startInfo.EnvironmentVariables[envKvp.Key] = envKvp.Value;
-
-                    logger.LogDebug("Running dotnet with env: {EnvKey}={EnvValue}", envKvp.Key, envKvp.Value);
-                }
-            }
-        }
-
-        var started = process.Start();
-
-        if (backchannelCompletionSource is not null)
-        {
-#pragma warning disable CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
-            _ = StartBackchannelAsync(process, socketPath, backchannelCompletionSource, cancellationToken);
-#pragma warning restore CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
-        }
-
-        var pendingStdoutStreamForwarder = Task.Run(async () => {
-            await ForwardStreamToLoggerAsync(
-                process.StandardOutput,
-                "stdout",
-                process,
-                options.StandardOutputCallback,
-                cancellationToken);
-            }, cancellationToken);
-
-        var pendingStderrStreamForwarder = Task.Run(async () => {
-            await ForwardStreamToLoggerAsync(
-                process.StandardError,
-                "stderr",
-                process,
-                options.StandardErrorCallback,
-                cancellationToken);
-            }, cancellationToken);
-
-        if (!started)
-        {
-            if (!suppressLogging)
-            {
-                logger.LogDebug("Failed to start dotnet process with args: {Args}", string.Join(" ", args));
-            }
-            return ExitCodeConstants.FailedToDotnetRunAppHost;
-        }
-        else
-        {
-            if (!suppressLogging)
-            {
-                logger.LogDebug("Started dotnet with PID: {ProcessId}", process.Id);
-            }
-        }
-
-        if (!suppressLogging)
-        {
-            logger.LogDebug("Waiting for dotnet process to exit with PID: {ProcessId}", process.Id);
-        }
-
-        await process.WaitForExitAsync(cancellationToken);
-
-        if (!process.HasExited)
-        {
-            if (!suppressLogging)
-            {
-                logger.LogDebug("dotnet process with PID: {ProcessId} has not exited, killing it.", process.Id);
-            }
-            process.Kill(false);
-        }
-        else
-        {
-            if (!suppressLogging)
-            {
-                logger.LogDebug("dotnet process with PID: {ProcessId} has exited with code: {ExitCode}", process.Id, process.ExitCode);
-            }
-        }
-
-        // Explicitly close the streams to unblock any pending ReadLineAsync calls.
-        // In some environments (particularly CI containers), the stream handles may not
-        // be automatically closed when the process exits, causing ReadLineAsync to block
-        // indefinitely. Disposing the streams forces them to close.
-        logger.LogDebug("Closing stdout/stderr streams for PID: {ProcessId}", process.Id);
-        process.StandardOutput.Close();
-        process.StandardError.Close();
-
-        // Wait for all the stream forwarders to finish so we know we've got everything
-        // fired off through the callbacks. Use a timeout as a safety net in case
-        // something else is unexpectedly holding the streams open.
-        var forwarderTimeout = Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
-        var forwardersCompleted = Task.WhenAll([pendingStdoutStreamForwarder, pendingStderrStreamForwarder]);
-
-        var completedTask = await Task.WhenAny(forwardersCompleted, forwarderTimeout);
-        if (completedTask == forwarderTimeout)
-        {
-            logger.LogWarning("Stream forwarders for PID {ProcessId} did not complete within timeout after stream close. Continuing anyway.", process.Id);
-        }
-        else
-        {
-            logger.LogDebug("Pending forwarders for PID completed: {ProcessId}", process.Id);
-        }
-
-        return process.ExitCode;
-
-        async Task ForwardStreamToLoggerAsync(StreamReader reader, string identifier, Process process, Action<string>? lineCallback, CancellationToken cancellationToken)
-        {
-            if (!suppressLogging)
-            {
-                logger.LogDebug(
-                    "Starting to forward stream with identifier '{Identifier}' on process '{ProcessId}' to logger",
-                    identifier,
-                    process.Id
-                    );
-            }
-
-            try
-            {
-                string? line;
-                while (!cancellationToken.IsCancellationRequested &&
-                    (line = await reader.ReadLineAsync(cancellationToken)) is not null)
-                {
-                    if (!suppressLogging)
-                    {
-                        logger.LogDebug(
-                            "dotnet({ProcessId}) {Identifier}: {Line}",
-                            process.Id,
-                            identifier,
-                            line
-                            );
-                    }
-                    lineCallback?.Invoke(line!);
-                }                
-            }
-            catch (ObjectDisposedException)
-            {
-                // Stream was closed externally (e.g., after process exit). This is expected.
-                logger.LogDebug("Stream forwarder completed for {Identifier} - stream was closed", identifier);
-            }
-        }
-    }
-
-    private async Task StartBackchannelAsync(Process? process, string socketPath, TaskCompletionSource<IAppHostCliBackchannel> backchannelCompletionSource, CancellationToken cancellationToken)
-    {
-        using var activity = telemetry.StartDiagnosticActivity();
-
-        using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(50));
-
-        var backchannel = serviceProvider.GetRequiredService<IAppHostCliBackchannel>();
-        var connectionAttempts = 0;
-
-        logger.LogDebug("Starting backchannel connection to AppHost at {SocketPath}", socketPath);
-
-        var startTime = DateTimeOffset.UtcNow;
-
-        do
-        {
-            try
-            {
-                logger.LogTrace("Attempting to connect to AppHost backchannel at {SocketPath} (attempt {Attempt})", socketPath, connectionAttempts++);
-                await backchannel.ConnectAsync(socketPath, cancellationToken).ConfigureAwait(false);
-                backchannelCompletionSource.SetResult(backchannel);
-                // Note: We intentionally do not call Environment.Exit when the backchannel disconnects.
-                // The CLI should complete normally and return the appropriate exit code based on the
-                // deployment result. Calling Environment.Exit here would bypass the normal exit code
-                // logic and always return success (0), even when the deployment failed.
-
-                logger.LogDebug("Connected to AppHost backchannel at {SocketPath}", socketPath);
-                return;
-            }
-            catch (SocketException ex) when (process is not null && process.HasExited && process.ExitCode != 0)
-            {
-                logger.LogError(ex, "AppHost process has exited. Unable to connect to backchannel at {SocketPath}", socketPath);
-                var backchannelException = new FailedToConnectBackchannelConnection($"AppHost process has exited unexpectedly. Use --debug to see more details.", process, ex);
-                backchannelCompletionSource.SetException(backchannelException);
-                return;
-            }
-            catch (SocketException ex)
-            {
-                // If the process is taking a long time to open a back channel but
-                // it has not exited then it probably means that its a larger build
-                // (remember it has to build the apphost and its dependencies).
-                // In that case, after 30 seconds we just slow down the polling to
-                // once per second.
-                var waitingFor = DateTimeOffset.UtcNow - startTime;
-                if (waitingFor > TimeSpan.FromSeconds(10))
-                {
-                    logger.LogTrace(ex, "Slow polling for backchannel connection (attempt {Attempt})", connectionAttempts);
-                    await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
-                }
-                else
-                {
-                    // We don't want to spam the logs with our early connection attempts.
-                }
-            }
-            catch (AppHostIncompatibleException ex)
-            {
-                logger.LogError(
-                    ex,
-                    "The app host is incompatible with the CLI and must be updated to a version that supports the {RequiredCapability} capability.",
-                    ex.RequiredCapability
-                    );
-
-                // If the app host is incompatible then there is no point
-                // trying to reconnect, we should propogate the exception
-                // up to the code that needs to back channel so it can display
-                // and error message to the user.
-                backchannelCompletionSource.SetException(ex);
-
-                throw;
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "An unexpected error occurred while trying to connect to the backchannel.");
-                backchannelCompletionSource.SetException(ex);
-                throw;
-            }
-
-        } while (await timer.WaitForNextTickAsync(cancellationToken));
     }
 
     public async Task<int> BuildAsync(FileInfo projectFilePath, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
@@ -1358,41 +1171,5 @@ internal class DotNetCliRunner(ILogger<DotNetCliRunner> logger, IServiceProvider
         }
 
         return result;
-    }
-
-    /// <summary>
-    /// Configures environment variables to use the private SDK installation if it exists.
-    /// </summary>
-    /// <param name="startInfo">The process start info to configure.</param>
-    private void ConfigurePrivateSdkEnvironment(ProcessStartInfo startInfo)
-    {
-        // Get the effective minimum SDK version to determine which private SDK to use
-        var sdkInstaller = serviceProvider.GetRequiredService<IDotNetSdkInstaller>();
-        var sdkVersion = sdkInstaller.GetEffectiveMinimumSdkVersion();
-        var sdksDirectory = executionContext.SdksDirectory.FullName;
-        var sdkInstallPath = Path.Combine(sdksDirectory, "dotnet", sdkVersion);
-        var dotnetExecutablePath = Path.Combine(
-            sdkInstallPath,
-            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet"
-        );
-
-        // Check if the private SDK exists
-        if (Directory.Exists(sdkInstallPath))
-        {
-            // Set the executable path to be the private SDK.
-            startInfo.FileName = dotnetExecutablePath;
-
-            // Set DOTNET_ROOT to point to the private SDK installation
-            startInfo.EnvironmentVariables["DOTNET_ROOT"] = sdkInstallPath;
-            
-            // Also set DOTNET_MULTILEVEL_LOOKUP to 0 to prevent fallback to system SDKs
-            startInfo.EnvironmentVariables["DOTNET_MULTILEVEL_LOOKUP"] = "0";
-            
-            // Prepend the private SDK path to PATH so the dotnet executable from the private installation is found first
-            var currentPath = startInfo.EnvironmentVariables["PATH"] ?? Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
-            startInfo.EnvironmentVariables["PATH"] = $"{sdkInstallPath}{Path.PathSeparator}{currentPath}";
-            
-            logger.LogDebug("Using private SDK installation at {SdkPath}", sdkInstallPath);
-        }
     }
 }

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -208,7 +208,7 @@ internal sealed class DotNetCliRunner(
                     );
 
                 // If the app host is incompatible then there is no point
-                // trying to reconnect, we should propogate the exception
+                // trying to reconnect, we should propagate the exception
                 // up to the code that needs to back channel so it can display
                 // and error message to the user.
                 backchannelCompletionSource.SetException(ex);

--- a/src/Aspire.Cli/DotNet/DotNetSdkInstaller.cs
+++ b/src/Aspire.Cli/DotNet/DotNetSdkInstaller.cs
@@ -24,7 +24,7 @@ internal sealed class DotNetSdkInstaller(IFeatures features, IConfiguration conf
     /// <inheritdoc />
     public async Task<(bool Success, string? HighestDetectedVersion, string MinimumRequiredVersion, bool ForceInstall)> CheckAsync(CancellationToken cancellationToken = default)
     {
-        var minimumVersion = GetEffectiveMinimumSdkVersion();
+        var minimumVersion = GetEffectiveMinimumSdkVersion(configuration);
 
         // Check if alwaysInstallSdk is enabled - this forces installation even when SDK check passes
         var alwaysInstallSdk = configuration["alwaysInstallSdk"];
@@ -129,7 +129,7 @@ internal sealed class DotNetSdkInstaller(IFeatures features, IConfiguration conf
     /// <inheritdoc />
     public async Task InstallAsync(CancellationToken cancellationToken = default)
     {
-        var sdkVersion = GetEffectiveMinimumSdkVersion();
+        var sdkVersion = GetEffectiveMinimumSdkVersion(configuration);
         var sdksDirectory = GetSdksDirectory();
         var sdkInstallPath = Path.Combine(sdksDirectory, "dotnet", sdkVersion);
 
@@ -380,8 +380,9 @@ internal sealed class DotNetSdkInstaller(IFeatures features, IConfiguration conf
     /// <summary>
     /// Gets the effective minimum SDK version based on configuration.
     /// </summary>
+    /// <param name="configuration">The configuration to check for overrides.</param>
     /// <returns>The minimum SDK version string.</returns>
-    public string GetEffectiveMinimumSdkVersion()
+    public static string GetEffectiveMinimumSdkVersion(IConfiguration configuration)
     {
         // Check for configuration override first
         var overrideVersion = configuration["overrideMinimumSdkVersion"];

--- a/src/Aspire.Cli/DotNet/IDotNetCliExecution.cs
+++ b/src/Aspire.Cli/DotNet/IDotNetCliExecution.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.DotNet;
+
+/// <summary>
+/// Represents a configured dotnet CLI execution that can be started and awaited.
+/// </summary>
+internal interface IDotNetCliExecution
+{
+    /// <summary>
+    /// Gets the file name of the executable to run.
+    /// </summary>
+    string FileName { get; }
+
+    /// <summary>
+    /// Gets the command-line arguments.
+    /// </summary>
+    IReadOnlyList<string> Arguments { get; }
+
+    /// <summary>
+    /// Gets the environment variables configured for the process.
+    /// </summary>
+    IReadOnlyDictionary<string, string?> EnvironmentVariables { get; }
+
+    /// <summary>
+    /// Starts the execution.
+    /// </summary>
+    /// <returns><c>true</c> if the process was started successfully; otherwise, <c>false</c>.</returns>
+    bool Start();
+
+    /// <summary>
+    /// Waits for the process to exit asynchronously.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The exit code of the process.</returns>
+    Task<int> WaitForExitAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets a value indicating whether the process has exited. Only valid after <see cref="Start"/> returns <c>true</c>.
+    /// </summary>
+    bool HasExited { get; }
+
+    /// <summary>
+    /// Gets the exit code of the process. Only valid after <see cref="HasExited"/> returns <c>true</c>.
+    /// </summary>
+    int ExitCode { get; }
+}

--- a/src/Aspire.Cli/DotNet/IDotNetCliExecutionFactory.cs
+++ b/src/Aspire.Cli/DotNet/IDotNetCliExecutionFactory.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.DotNet;
+
+/// <summary>
+/// Creates configured dotnet CLI executions.
+/// </summary>
+internal interface IDotNetCliExecutionFactory
+{
+    /// <summary>
+    /// Creates a configured dotnet CLI execution ready to be started.
+    /// </summary>
+    /// <param name="args">The command-line arguments to pass to dotnet.</param>
+    /// <param name="env">Optional environment variables to set for the process. If backchannel communication
+    /// is needed, the socket path should be set via <c>ASPIRE__BACKCHANNEL__UNIXSOCKETPATH</c>.</param>
+    /// <param name="workingDirectory">The working directory for the process.</param>
+    /// <param name="options">Invocation options for the command.</param>
+    /// <returns>A configured <see cref="IDotNetCliExecution"/> ready to be started.</returns>
+    IDotNetCliExecution CreateExecution(
+        string[] args,
+        IDictionary<string, string>? env,
+        DirectoryInfo workingDirectory,
+        DotNetCliRunnerInvocationOptions options);
+}

--- a/src/Aspire.Cli/DotNet/IDotNetSdkInstaller.cs
+++ b/src/Aspire.Cli/DotNet/IDotNetSdkInstaller.cs
@@ -22,9 +22,4 @@ internal interface IDotNetSdkInstaller
     /// <returns>A task representing the asynchronous operation.</returns>
     Task InstallAsync(CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Gets the effective minimum SDK version based on configuration and feature flags.
-    /// </summary>
-    /// <returns>The minimum SDK version string.</returns>
-    string GetEffectiveMinimumSdkVersion();
 }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -159,6 +159,7 @@ public class Program
         builder.Services.AddSingleton(BuildConfigurationService);
         builder.Services.AddSingleton<IFeatures, Features>();
         builder.Services.AddTelemetryServices();
+        builder.Services.AddTransient<IDotNetCliExecutionFactory, DotNetCliExecutionFactory>();
         builder.Services.AddTransient<IDotNetCliRunner, DotNetCliRunner>();
         builder.Services.AddSingleton<IDiskCache, DiskCache>();
         builder.Services.AddSingleton<IDotNetSdkInstaller, DotNetSdkInstaller>();

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -770,7 +770,7 @@ internal sealed class GuestAppHostProject : IAppHostProject
             catch (SocketException ex) when (process.HasExited && process.ExitCode != 0)
             {
                 _logger.LogError("AppHost server process has exited. Unable to connect to backchannel at {SocketPath}", socketPath);
-                var backchannelException = new FailedToConnectBackchannelConnection($"AppHost server process has exited unexpectedly.", process, ex);
+                var backchannelException = new FailedToConnectBackchannelConnection($"AppHost server process has exited unexpectedly.", ex);
                 backchannelCompletionSource.TrySetException(backchannelException);
                 return;
             }

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -4,21 +4,16 @@
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
-using Aspire.Cli.Caching;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
-using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
-using Aspire.Cli.Telemetry;
-using Aspire.Cli.Tests.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Aspire.Shared.UserSecrets;
 using Microsoft.AspNetCore.InternalTesting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -788,16 +783,10 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks"))
         );
 
-        var runner = new AssertingDotNetCliRunner(
-            logger,
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
-            TestTelemetryHelper.CreateInitializedTelemetry(),
-            provider.GetRequiredService<IConfiguration>(),
-            provider.GetRequiredService<IFeatures>(),
-            provider.GetRequiredService<IInteractionService>(),
             executionContext,
-            new NullDiskCache(),
-            (args, env, workingDirectory, projectFile, backchannelCompletionSource, options) =>
+            (args, env, workingDirectory, options) =>
             {
                 // Verify that --non-interactive is included when watch mode is enabled
                 Assert.Contains("watch", args);
@@ -808,7 +797,8 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
                 var nonInteractiveIndex = Array.IndexOf(args, "--non-interactive");
                 Assert.True(watchIndex < nonInteractiveIndex);
             },
-            0
+            0,
+            logger: logger
         );
 
         var exitCode = await runner.RunAsync(
@@ -842,23 +832,18 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks"))
         );
 
-        var runner = new AssertingDotNetCliRunner(
-            logger,
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
-            TestTelemetryHelper.CreateInitializedTelemetry(),
-            provider.GetRequiredService<IConfiguration>(),
-            provider.GetRequiredService<IFeatures>(),
-            provider.GetRequiredService<IInteractionService>(),
             executionContext,
-            new NullDiskCache(),
-            (args, env, workingDirectory, projectFile, backchannelCompletionSource, options) =>
+            (args, env, workingDirectory, options) =>
             {
                 // Verify that --non-interactive is NOT included when watch mode is disabled
                 Assert.Contains("run", args);
                 Assert.DoesNotContain("watch", args);
                 Assert.DoesNotContain("--non-interactive", args);
             },
-            0
+            0,
+            logger: logger
         );
 
         var exitCode = await runner.RunAsync(
@@ -892,16 +877,10 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks"))
         );
 
-        var runner = new AssertingDotNetCliRunner(
-            logger,
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
-            TestTelemetryHelper.CreateInitializedTelemetry(),
-            provider.GetRequiredService<IConfiguration>(),
-            provider.GetRequiredService<IFeatures>(),
-            provider.GetRequiredService<IInteractionService>(),
             executionContext,
-            new NullDiskCache(),
-            (args, env, workingDirectory, projectFile, backchannelCompletionSource, options) =>
+            (args, env, workingDirectory, options) =>
             {
                 // Verify that --verbose is included when watch mode and debug are both enabled
                 Assert.Contains("watch", args);
@@ -912,7 +891,8 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
                 var verboseIndex = Array.IndexOf(args, "--verbose");
                 Assert.True(watchIndex < verboseIndex);
             },
-            0
+            0,
+            logger: logger
         );
 
         var exitCode = await runner.RunAsync(
@@ -946,22 +926,17 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks"))
         );
 
-        var runner = new AssertingDotNetCliRunner(
-            logger,
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
-            TestTelemetryHelper.CreateInitializedTelemetry(),
-            provider.GetRequiredService<IConfiguration>(),
-            provider.GetRequiredService<IFeatures>(),
-            provider.GetRequiredService<IInteractionService>(),
             executionContext,
-            new NullDiskCache(),
-            (args, env, workingDirectory, projectFile, backchannelCompletionSource, options) =>
+            (args, env, workingDirectory, options) =>
             {
                 // Verify that --verbose is NOT included when debug is false
                 Assert.Contains("watch", args);
                 Assert.DoesNotContain("--verbose", args);
             },
-            0
+            0,
+            logger: logger
         );
 
         var exitCode = await runner.RunAsync(
@@ -995,23 +970,18 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks"))
         );
 
-        var runner = new AssertingDotNetCliRunner(
-            logger,
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
-            TestTelemetryHelper.CreateInitializedTelemetry(),
-            provider.GetRequiredService<IConfiguration>(),
-            provider.GetRequiredService<IFeatures>(),
-            provider.GetRequiredService<IInteractionService>(),
             executionContext,
-            new NullDiskCache(),
-            (args, env, workingDirectory, projectFile, backchannelCompletionSource, options) =>
+            (args, env, workingDirectory, options) =>
             {
                 // Verify that --verbose is NOT included when watch is false even if debug is true
                 Assert.Contains("run", args);
                 Assert.DoesNotContain("watch", args);
                 Assert.DoesNotContain("--verbose", args);
             },
-            0
+            0,
+            logger: logger
         );
 
         var exitCode = await runner.RunAsync(
@@ -1045,23 +1015,18 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks"))
         );
 
-        var runner = new AssertingDotNetCliRunner(
-            logger,
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
-            TestTelemetryHelper.CreateInitializedTelemetry(),
-            provider.GetRequiredService<IConfiguration>(),
-            provider.GetRequiredService<IFeatures>(),
-            provider.GetRequiredService<IInteractionService>(),
             executionContext,
-            new NullDiskCache(),
-            (args, env, workingDirectory, projectFile, backchannelCompletionSource, options) =>
+            (args, env, workingDirectory, options) =>
             {
                 // Verify that DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER is set when watch mode is enabled
                 Assert.NotNull(env);
                 Assert.True(env.ContainsKey("DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER"));
                 Assert.Equal("true", env["DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER"]);
             },
-            0
+            0,
+            logger: logger
         );
 
         var exitCode = await runner.RunAsync(
@@ -1095,16 +1060,10 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks"))
         );
 
-        var runner = new AssertingDotNetCliRunner(
-            logger,
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
-            TestTelemetryHelper.CreateInitializedTelemetry(),
-            provider.GetRequiredService<IConfiguration>(),
-            provider.GetRequiredService<IFeatures>(),
-            provider.GetRequiredService<IInteractionService>(),
             executionContext,
-            new NullDiskCache(),
-            (args, env, workingDirectory, projectFile, backchannelCompletionSource, options) =>
+            (args, env, workingDirectory, options) =>
             {
                 // Verify that DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER is NOT set when watch mode is disabled
                 if (env != null)
@@ -1112,7 +1071,8 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
                     Assert.False(env.ContainsKey("DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER"));
                 }
             },
-            0
+            0,
+            logger: logger
         );
 
         var exitCode = await runner.RunAsync(
@@ -1255,25 +1215,5 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
                 Directory.Delete(originalSecretsDir);
             }
         }
-    }
-}
-
-internal sealed class AssertingDotNetCliRunner(
-    ILogger<DotNetCliRunner> logger,
-    IServiceProvider serviceProvider,
-    AspireCliTelemetry telemetry,
-    IConfiguration configuration,
-    IFeatures features,
-    IInteractionService interactionService,
-    CliExecutionContext executionContext,
-    IDiskCache diskCache,
-    Action<string[], IDictionary<string, string>?, DirectoryInfo, FileInfo?, TaskCompletionSource<IAppHostCliBackchannel>?, DotNetCliRunnerInvocationOptions> assertionCallback,
-    int exitCode
-    ) : DotNetCliRunner(logger, serviceProvider, telemetry, configuration, features, interactionService, executionContext, diskCache)
-{
-    public override Task<int> ExecuteAsync(string[] args, IDictionary<string, string>? env, FileInfo? projectFile, DirectoryInfo workingDirectory, TaskCompletionSource<IAppHostCliBackchannel>? backchannelCompletionSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
-    {
-        assertionCallback(args, env, workingDirectory, projectFile, backchannelCompletionSource, options);
-        return Task.FromResult(exitCode);
     }
 }

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
@@ -2,14 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Backchannel;
-using Aspire.Cli.Caching;
-using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
-using Aspire.Cli.Telemetry;
-using Aspire.Cli.Tests.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -44,10 +41,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         };
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             executionContext,
-            (args, _, _, _, _, _) => Assert.Contains(args, arg => arg == "--no-launch-profile"),
+            (args, _, _, _) => Assert.Contains(args, arg => arg == "--no-launch-profile"),
             42);
 
         // This is what we are really testing here - that RunAsync reads
@@ -62,8 +59,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             env: new Dictionary<string, string>(),
             null,
             options,
-            CancellationToken.None
-            );
+            CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(42, exitCode);
     }
@@ -81,10 +77,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var options = new DotNetCliRunnerInvocationOptions();
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             executionContext,
-            (args, env, _, _, _, _) =>
+            (args, env, _, _) =>
             {
                 Assert.NotNull(env);
                 Assert.True(env.ContainsKey("DOTNET_CLI_USE_MSBUILD_SERVER"));
@@ -92,7 +88,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             },
             0);
 
-        var exitCode = await runner.BuildAsync(projectFile, options, CancellationToken.None);
+        var exitCode = await runner.BuildAsync(projectFile, options, CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(0, exitCode);
     }
@@ -120,10 +116,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var options = new DotNetCliRunnerInvocationOptions();
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             executionContext,
-            (args, env, _, _, _, _) =>
+            (args, env, _, _) =>
             {
                 Assert.NotNull(env);
                 Assert.True(env.ContainsKey("DOTNET_CLI_USE_MSBUILD_SERVER"));
@@ -131,7 +127,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             },
             0);
 
-        var exitCode = await runner.BuildAsync(projectFile, options, CancellationToken.None);
+        var exitCode = await runner.BuildAsync(projectFile, options, CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(0, exitCode);
     }
@@ -149,10 +145,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var options = new DotNetCliRunnerInvocationOptions();
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             executionContext,
-            (args, env, _, _, _, _) =>
+            (args, env, _, _) =>
             {
                 Assert.NotNull(env);
                 Assert.True(env.ContainsKey("DOTNET_CLI_USE_MSBUILD_SERVER"));
@@ -168,8 +164,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             env: new Dictionary<string, string>(),
             null,
             options,
-            CancellationToken.None
-            );
+            CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(0, exitCode);
     }
@@ -187,10 +182,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var options = new DotNetCliRunnerInvocationOptions();
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             executionContext,
-            (args, env, _, _, _, _) =>
+            (args, env, _, _) =>
             {
                 // When noBuild is true, the original env should be passed through unchanged
                 // or should be null if no env was provided
@@ -209,8 +204,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             env: new Dictionary<string, string>(),
             null,
             options,
-            CancellationToken.None
-            );
+            CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(0, exitCode);
     }
@@ -228,10 +222,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var options = new DotNetCliRunnerInvocationOptions();
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             executionContext,
-            (args, env, _, _, _, _) =>
+            (args, env, _, _) =>
             {
                 Assert.NotNull(env);
                 Assert.True(env.ContainsKey("DOTNET_CLI_USE_MSBUILD_SERVER"));
@@ -255,8 +249,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             env: existingEnv,
             null,
             options,
-            CancellationToken.None
-            );
+            CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(0, exitCode);
     }
@@ -271,10 +264,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var options = new DotNetCliRunnerInvocationOptions();
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             executionContext,
-            (args, env, _, _, _, _) =>
+            (args, env, _, _) =>
             {
                 // Verify the arguments are correct for dotnet new
                 Assert.Contains("new", args);
@@ -287,7 +280,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             73); // Return exit code 73 to simulate project already exists
 
         // Act
-        var exitCode = await runner.NewProjectAsync("aspire", "TestProject", "/tmp/test", [], options, CancellationToken.None);
+        var exitCode = await runner.NewProjectAsync("aspire", "TestProject", "/tmp/test", [], options, CancellationToken.None).DefaultTimeout();
 
         // Assert
         Assert.Equal(73, exitCode);
@@ -308,10 +301,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
 
         var options = new DotNetCliRunnerInvocationOptions();
 
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             provider.GetRequiredService<CliExecutionContext>(),
-            (args, env, _, _, _, _) =>
+            (args, env, _, _) =>
             {
                 Assert.NotNull(env);
                 Assert.True(env.ContainsKey("ASPIRE_VERSION_CHECK_DISABLED"));
@@ -327,8 +320,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             env: new Dictionary<string, string>(),
             null,
             options,
-            CancellationToken.None
-            );
+            CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(0, exitCode);
     }
@@ -348,10 +340,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
 
         var options = new DotNetCliRunnerInvocationOptions();
 
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             provider.GetRequiredService<CliExecutionContext>(),
-            (args, env, _, _, _, _) =>
+            (args, env, _, _) =>
             {
                 // When the feature is enabled (default), the version check env var should NOT be set
                 if (env != null)
@@ -369,8 +361,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             env: new Dictionary<string, string>(),
             null,
             options,
-            CancellationToken.None
-            );
+            CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(0, exitCode);
     }
@@ -390,10 +381,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
 
         var options = new DotNetCliRunnerInvocationOptions();
 
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             provider.GetRequiredService<CliExecutionContext>(),
-            (args, env, _, _, _, _) =>
+            (args, env, _, _) =>
             {
                 Assert.NotNull(env);
                 Assert.True(env.ContainsKey("ASPIRE_VERSION_CHECK_DISABLED"));
@@ -416,25 +407,29 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             env: userEnv,
             null,
             options,
-            CancellationToken.None
-            );
+            CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(0, exitCode);
     }
 
     [Fact]
-    public async Task ExecuteAsyncLaunchesAppHostInExtensionHostIfConnected()
+    public async Task RunAsyncLaunchesAppHostInExtensionHostIfConnected()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
         await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
 
         var launchAppHostCalledTcs = new TaskCompletionSource();
+        TestExtensionInteractionService? testExtensionInteractionService = null;
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            options.InteractionServiceFactory = sp => new TestExtensionInteractionService(sp)
+            options.InteractionServiceFactory = sp =>
             {
-                LaunchAppHostCallback = () => launchAppHostCalledTcs.SetResult(),
+                testExtensionInteractionService = new TestExtensionInteractionService(sp)
+                {
+                    LaunchAppHostCallback = () => launchAppHostCalledTcs.SetResult(),
+                };
+                return testExtensionInteractionService;
             };
             options.ConfigurationCallback = configBuilder =>
             {
@@ -448,32 +443,19 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         });
 
         var provider = services.BuildServiceProvider();
-        var logger = provider.GetRequiredService<ILogger<DotNetCliRunner>>();
-        var interactionService = provider.GetRequiredService<IInteractionService>();
+        var runner = provider.GetRequiredService<IDotNetCliRunner>();
 
-        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = new DotNetCliRunner(
-            logger,
-            provider,
-            TestTelemetryHelper.CreateInitializedTelemetry(),
-            provider.GetRequiredService<IConfiguration>(),
-            provider.GetRequiredService<IFeatures>(),
-            interactionService,
-            executionContext,
-            new NullDiskCache()
-        );
-
-        var exitCode = await runner.ExecuteAsync(
-            args: ["run", "--project", projectFile.FullName],
-            env: null,
+        var exitCode = await runner.RunAsync(
             projectFile: projectFile,
-            workingDirectory: workspace.WorkspaceRoot,
+            watch: false,
+            noBuild: false,
+            args: [],
+            env: null,
             backchannelCompletionSource: new TaskCompletionSource<IAppHostCliBackchannel>(),
             options: new DotNetCliRunnerInvocationOptions(),
-            cancellationToken: CancellationToken.None
-        );
+            cancellationToken: CancellationToken.None).DefaultTimeout();
 
-        await launchAppHostCalledTcs.Task;
+        await launchAppHostCalledTcs.Task.DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
     }
 
@@ -490,10 +472,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var options = new DotNetCliRunnerInvocationOptions();
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             executionContext,
-            (args, _, _, _, _, _) =>
+            (args, _, _, _) =>
             {
                 // Verify arguments are correct for single-file AppHost
                 Assert.Contains("add", args);
@@ -542,10 +524,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var options = new DotNetCliRunnerInvocationOptions();
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             executionContext,
-            (args, _, _, _, _, _) =>
+            (args, _, _, _) =>
             {
                 // Verify arguments are correct for .csproj file (new behavior with --version)
                 Assert.Contains("add", args);
@@ -602,10 +584,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var options = new DotNetCliRunnerInvocationOptions();
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             executionContext,
-            (args, _, _, _, _, _) =>
+            (args, _, _, _) =>
             {
                 // Verify arguments are correct for .csproj file with --no-restore (no source provided)
                 Assert.Contains("add", args);
@@ -678,10 +660,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         };
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             executionContext,
-            (args, _, _, _, _, invocationOptions) =>
+            (args, _, _, invocationOptions) =>
             {
                 // Simulate dotnet sln list output
                 invocationOptions.StandardOutputCallback?.Invoke("Project(s)");
@@ -691,7 +673,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             },
             0);
 
-        var (exitCode, projects) = await runner.GetSolutionProjectsAsync(solutionFile, options, CancellationToken.None);
+        var (exitCode, projects) = await runner.GetSolutionProjectsAsync(solutionFile, options, CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(0, exitCode);
         Assert.Equal(2, projects.Count);
@@ -716,10 +698,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var options = new DotNetCliRunnerInvocationOptions();
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             executionContext,
-            (args, _, _, _, _, _) =>
+            (args, _, _, _) =>
             {
                 Assert.Contains("add", args);
                 Assert.Contains(projectFile.FullName, args);
@@ -728,7 +710,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             },
             0);
 
-        var exitCode = await runner.AddProjectReferenceAsync(projectFile, referencedProject, options, CancellationToken.None);
+        var exitCode = await runner.AddProjectReferenceAsync(projectFile, referencedProject, options, CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(0, exitCode);
     }
@@ -749,10 +731,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         };
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             executionContext,
-            (args, _, _, _, _, _) =>
+            (args, _, _, _) =>
             {
                 // For single-file .cs files, should include --no-launch-profile
                 Assert.Collection(args,
@@ -773,8 +755,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             env: new Dictionary<string, string>(),
             null,
             options,
-            CancellationToken.None
-        );
+            CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(0, exitCode);
     }
@@ -795,10 +776,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         };
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             executionContext,
-            (args, _, _, _, _, _) =>
+            (args, _, _, _) =>
             {
                 // For single-file .cs files, should NOT include --no-launch-profile when false
                 Assert.Collection(args,
@@ -818,8 +799,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             env: new Dictionary<string, string>(),
             null,
             options,
-            CancellationToken.None
-        );
+            CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(0, exitCode);
     }
@@ -842,10 +822,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         };
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             executionContext,
-            (args, _, _, _, _, _) =>
+            (args, _, _, _) =>
             {
                 // Verify no empty or whitespace-only arguments exist
                 foreach (var arg in args)
@@ -863,8 +843,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             env: new Dictionary<string, string>(),
             null,
             options,
-            CancellationToken.None
-        );
+            CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(0, exitCode);
     }
@@ -885,10 +864,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         };
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             executionContext,
-            (args, _, _, _, _, _) =>
+            (args, _, _, _) =>
             {
                 // Verify no empty or whitespace-only arguments exist in single-file AppHost scenario
                 foreach (var arg in args)
@@ -914,8 +893,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             env: new Dictionary<string, string>(),
             null,
             options,
-            CancellationToken.None
-        );
+            CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(0, exitCode);
     }
@@ -937,10 +915,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         };
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             executionContext,
-            (args, _, _, _, _, _) =>
+            (args, _, _, _) =>
             {
                 // With watch=true and Debug=true, should include --verbose
                 Assert.Collection(args,
@@ -963,8 +941,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             env: new Dictionary<string, string>(),
             null,
             options,
-            CancellationToken.None
-        );
+            CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(0, exitCode);
     }
@@ -986,10 +963,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         };
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             executionContext,
-            (args, _, _, _, _, _) =>
+            (args, _, _, _) =>
             {
                 // With watch=true but Debug=false, should NOT include --verbose
                 Assert.Collection(args,
@@ -1011,8 +988,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             env: new Dictionary<string, string>(),
             null,
             options,
-            CancellationToken.None
-        );
+            CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(0, exitCode);
     }
@@ -1030,10 +1006,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var options = new DotNetCliRunnerInvocationOptions();
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             executionContext,
-            (args, _, _, _, _, invocationOptions) =>
+            (args, _, _, invocationOptions) =>
             {
                 // Verify that "build" command is used for single-file app host
                 Assert.Contains("build", args);
@@ -1066,10 +1042,10 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var options = new DotNetCliRunnerInvocationOptions();
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = AssertingDotNetCliRunner.Create(
+        var runner = DotNetCliRunnerTestHelper.Create(
             provider,
             executionContext,
-            (args, _, _, _, _, invocationOptions) =>
+            (args, _, _, invocationOptions) =>
             {
                 // Verify that "msbuild" command is used for .csproj files
                 Assert.Contains("msbuild", args);
@@ -1100,15 +1076,9 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var interactionService = provider.GetRequiredService<IInteractionService>();
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = new RetryingDotNetCliRunner(
-            logger,
+        var (runner, executor) = DotNetCliRunnerTestHelper.CreateWithRetry(
             provider,
-            TestTelemetryHelper.CreateInitializedTelemetry(),
-            provider.GetRequiredService<IConfiguration>(),
-            provider.GetRequiredService<IFeatures>(),
-            interactionService,
             executionContext,
-            new NullDiskCache(),
             (attempt, options) =>
             {
                 // First attempt fails, second succeeds
@@ -1118,7 +1088,8 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
                 }
 
                 return (0, "{\"version\":1,\"searchResult\":[{\"sourceName\":\"nuget.org\",\"packages\":[{\"id\":\"Aspire.Hosting.Redis\",\"latestVersion\":\"9.0.0\"}]}]}");
-            }
+            },
+            logger: logger
         );
 
         var options = new DotNetCliRunnerInvocationOptions { SuppressLogging = true };
@@ -1137,7 +1108,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(0, result.ExitCode);
         Assert.NotNull(result.Packages);
-        Assert.Equal(2, runner.AttemptCount);
+        Assert.Equal(2, executor.AttemptCount);
     }
 
     [Fact]
@@ -1151,20 +1122,15 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var interactionService = provider.GetRequiredService<IInteractionService>();
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = new RetryingDotNetCliRunner(
-            logger,
+        var (runner, executor) = DotNetCliRunnerTestHelper.CreateWithRetry(
             provider,
-            TestTelemetryHelper.CreateInitializedTelemetry(),
-            provider.GetRequiredService<IConfiguration>(),
-            provider.GetRequiredService<IFeatures>(),
-            interactionService,
             executionContext,
-            new NullDiskCache(),
             (attempt, options) =>
             {
                 // Always fail
                 return (1, null);
-            }
+            },
+            logger: logger
         );
 
         var options = new DotNetCliRunnerInvocationOptions { SuppressLogging = true };
@@ -1183,7 +1149,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(1, result.ExitCode);
         Assert.Null(result.Packages);
-        Assert.Equal(3, runner.AttemptCount); // Should have attempted 3 times
+        Assert.Equal(3, executor.AttemptCount); // Should have attempted 3 times
     }
 
     [Fact]
@@ -1197,20 +1163,15 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var interactionService = provider.GetRequiredService<IInteractionService>();
 
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var runner = new RetryingDotNetCliRunner(
-            logger,
+        var (runner, executor) = DotNetCliRunnerTestHelper.CreateWithRetry(
             provider,
-            TestTelemetryHelper.CreateInitializedTelemetry(),
-            provider.GetRequiredService<IConfiguration>(),
-            provider.GetRequiredService<IFeatures>(),
-            interactionService,
             executionContext,
-            new NullDiskCache(),
             (attempt, options) =>
             {
                 // Always succeed
                 return (0, "{\"version\":1,\"searchResult\":[{\"sourceName\":\"nuget.org\",\"packages\":[{\"id\":\"Aspire.Hosting.Redis\",\"latestVersion\":\"9.0.0\"}]}]}");
-            }
+            },
+            logger: logger
         );
 
         var options = new DotNetCliRunnerInvocationOptions { SuppressLogging = true };
@@ -1229,80 +1190,6 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(0, result.ExitCode);
         Assert.NotNull(result.Packages);
-        Assert.Equal(1, runner.AttemptCount); // Should have attempted only once
-    }
-}
-
-internal sealed class AssertingDotNetCliRunner(
-    ILogger<DotNetCliRunner> logger,
-    IServiceProvider serviceProvider,
-    AspireCliTelemetry telemetry,
-    IConfiguration configuration,
-    IFeatures features,
-    IInteractionService interactionService,
-    CliExecutionContext executionContext,
-    IDiskCache diskCache,
-    Action<string[], IDictionary<string, string>?, DirectoryInfo, FileInfo?, TaskCompletionSource<IAppHostCliBackchannel>?, DotNetCliRunnerInvocationOptions> assertionCallback,
-    int exitCode
-    ) : DotNetCliRunner(logger, serviceProvider, telemetry, configuration, features, interactionService, executionContext, diskCache)
-{
-    public static AssertingDotNetCliRunner Create(
-        IServiceProvider serviceProvider,
-        CliExecutionContext executionContext,
-        Action<string[], IDictionary<string, string>?, DirectoryInfo, FileInfo?, TaskCompletionSource<IAppHostCliBackchannel>?, DotNetCliRunnerInvocationOptions> assertionCallback,
-        int exitCode,
-        ILogger<DotNetCliRunner>? logger = null,
-        AspireCliTelemetry? telemetry = null,
-        IConfiguration? configuration = null,
-        IFeatures? features = null,
-        IInteractionService? interactionService = null,
-        IDiskCache? diskCache = null)
-    {
-        return new AssertingDotNetCliRunner(
-            logger ?? serviceProvider.GetRequiredService<ILogger<DotNetCliRunner>>(),
-            serviceProvider,
-            telemetry ?? TestTelemetryHelper.CreateInitializedTelemetry(),
-            configuration ?? serviceProvider.GetRequiredService<IConfiguration>(),
-            features ?? serviceProvider.GetRequiredService<IFeatures>(),
-            interactionService ?? serviceProvider.GetRequiredService<IInteractionService>(),
-            executionContext,
-            diskCache ?? new NullDiskCache(),
-            assertionCallback,
-            exitCode);
-    }
-
-    public override Task<int> ExecuteAsync(string[] args, IDictionary<string, string>? env, FileInfo? projectFile, DirectoryInfo workingDirectory, TaskCompletionSource<IAppHostCliBackchannel>? backchannelCompletionSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
-    {
-        assertionCallback(args, env, workingDirectory, projectFile, backchannelCompletionSource, options);
-        return Task.FromResult(exitCode);
-    }
-}
-
-internal sealed class RetryingDotNetCliRunner(
-    ILogger<DotNetCliRunner> logger,
-    IServiceProvider serviceProvider,
-    AspireCliTelemetry telemetry,
-    IConfiguration configuration,
-    IFeatures features,
-    IInteractionService interactionService,
-    CliExecutionContext executionContext,
-    IDiskCache diskCache,
-    Func<int, DotNetCliRunnerInvocationOptions, (int ExitCode, string? Stdout)> attemptCallback
-    ) : DotNetCliRunner(logger, serviceProvider, telemetry, configuration, features, interactionService, executionContext, diskCache)
-{
-    private int _attemptCount;
-
-    public int AttemptCount => _attemptCount;
-
-    public override Task<int> ExecuteAsync(string[] args, IDictionary<string, string>? env, FileInfo? projectFile, DirectoryInfo workingDirectory, TaskCompletionSource<IAppHostCliBackchannel>? backchannelCompletionSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
-    {
-        _attemptCount++;
-        var (exitCode, stdout) = attemptCallback(_attemptCount, options);
-        if (stdout is not null)
-        {
-            options.StandardOutputCallback?.Invoke(stdout);
-        }
-
-        return Task.FromResult(exitCode);
+        Assert.Equal(1, executor.AttemptCount); // Should have attempted only once
     }
 }

--- a/tests/Aspire.Cli.Tests/DotNetSdkInstallerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNetSdkInstallerTests.cs
@@ -112,11 +112,12 @@ public class DotNetSdkInstallerTests
         var features = new TestFeatures()
             .SetFeature(KnownFeatures.MinimumSdkCheckEnabled, true);
         var context = CreateTestExecutionContext();
-        var installer = new DotNetSdkInstaller(features, CreateEmptyConfiguration(), context, CreateTestDotNetCliRunner(), CreateTestLogger());
+        var configuration = CreateEmptyConfiguration();
+        var installer = new DotNetSdkInstaller(features, configuration, context, CreateTestDotNetCliRunner(), CreateTestLogger());
 
         // Get the sdks directory path
         var sdksDirectory = context.SdksDirectory.FullName;
-        var sdkVersion = installer.GetEffectiveMinimumSdkVersion();
+        var sdkVersion = DotNetSdkInstaller.GetEffectiveMinimumSdkVersion(configuration);
         var sdkInstallPath = Path.Combine(sdksDirectory, "dotnet", sdkVersion);
 
         // Clean up if it exists from a previous test
@@ -242,11 +243,9 @@ public class DotNetSdkInstallerTests
     [Fact]
     public void GetEffectiveMinimumSdkVersion_ReturnsBaseline_WhenNoOverrides()
     {
-        var features = new TestFeatures();
-        var context = CreateTestExecutionContext();
-        var installer = new DotNetSdkInstaller(features, CreateEmptyConfiguration(), context, CreateTestDotNetCliRunner(), CreateTestLogger());
+        var configuration = CreateEmptyConfiguration();
 
-        var effectiveVersion = installer.GetEffectiveMinimumSdkVersion();
+        var effectiveVersion = DotNetSdkInstaller.GetEffectiveMinimumSdkVersion(configuration);
 
         Assert.Equal(DotNetSdkInstaller.MinimumSdkVersion, effectiveVersion);
     }
@@ -254,11 +253,9 @@ public class DotNetSdkInstallerTests
     [Fact]
     public void GetEffectiveMinimumSdkVersion_ReturnsOverride_WhenOverrideConfigured()
     {
-        var features = new TestFeatures();
         var configuration = CreateConfigurationWithOverride("7.0.0");
-        var installer = new DotNetSdkInstaller(features, configuration, CreateTestExecutionContext(), CreateTestDotNetCliRunner(), CreateTestLogger());
 
-        var effectiveVersion = installer.GetEffectiveMinimumSdkVersion();
+        var effectiveVersion = DotNetSdkInstaller.GetEffectiveMinimumSdkVersion(configuration);
 
         Assert.Equal("7.0.0", effectiveVersion);
     }

--- a/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliExecutionFactory.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliExecutionFactory.cs
@@ -1,0 +1,196 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Caching;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.DotNet;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Telemetry;
+using Aspire.Cli.Tests.Telemetry;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+internal sealed class TestDotNetCliExecutionFactory : IDotNetCliExecutionFactory
+{
+    private int _attemptCount;
+
+    /// <summary>
+    /// Gets or sets a callback that is invoked when <see cref="CreateExecution"/> is called.
+    /// If this returns an <see cref="IDotNetCliExecution"/>, that execution is returned directly.
+    /// </summary>
+    public Func<string[], IDictionary<string, string>?, DirectoryInfo, DotNetCliRunnerInvocationOptions, IDotNetCliExecution>? CreateExecutionCallback { get; set; }
+
+    /// <summary>
+    /// Gets or sets an action that is invoked when <see cref="CreateExecution"/> is called,
+    /// typically used for assertions on the arguments.
+    /// </summary>
+    public Action<string[], IDictionary<string, string>?, DirectoryInfo, DotNetCliRunnerInvocationOptions>? AssertionCallback { get; set; }
+
+    /// <summary>
+    /// Gets or sets a callback that is invoked for each execution attempt, receiving the attempt number (1-based)
+    /// and options, and returning the exit code and optional stdout content.
+    /// This is used for testing retry scenarios.
+    /// </summary>
+    public Func<int, DotNetCliRunnerInvocationOptions, (int ExitCode, string? Stdout)>? AttemptCallback { get; set; }
+
+    /// <summary>
+    /// When set, the execution will use this exit code when <see cref="IDotNetCliExecution.WaitForExitAsync"/> is called.
+    /// </summary>
+    public int DefaultExitCode { get; set; }
+
+    /// <summary>
+    /// When set, the interaction service that may be used to simulate DevKit extension behavior.
+    /// </summary>
+    public IInteractionService? InteractionService { get; set; }
+
+    /// <summary>
+    /// Gets the number of times <see cref="CreateExecution"/> has been called.
+    /// </summary>
+    public int AttemptCount => _attemptCount;
+
+    public IDotNetCliExecution CreateExecution(string[] args, IDictionary<string, string>? env, DirectoryInfo workingDirectory, DotNetCliRunnerInvocationOptions options)
+    {
+        _attemptCount++;
+
+        // Invoke assertion callback if set
+        AssertionCallback?.Invoke(args, env, workingDirectory, options);
+
+        // If a custom callback is provided, use it
+        if (CreateExecutionCallback is not null)
+        {
+            return CreateExecutionCallback(args, env, workingDirectory, options);
+        }
+
+        // Use AttemptCallback if provided, otherwise create a simple callback that returns the default exit code
+        var callback = AttemptCallback ?? ((_, _) => (DefaultExitCode, null));
+        return new TestDotNetCliExecution(args, env, options, callback, () => _attemptCount);
+    }
+}
+
+internal sealed class TestDotNetCliExecution : IDotNetCliExecution
+{
+    private readonly DotNetCliRunnerInvocationOptions _options;
+    private readonly Func<int, DotNetCliRunnerInvocationOptions, (int ExitCode, string? Stdout)> _attemptCallback;
+    private readonly Func<int> _attemptCounter;
+    private bool _started;
+
+    public TestDotNetCliExecution(
+        string[] args,
+        IDictionary<string, string>? env,
+        DotNetCliRunnerInvocationOptions options,
+        Func<int, DotNetCliRunnerInvocationOptions, (int ExitCode, string? Stdout)> attemptCallback,
+        Func<int> attemptCounter)
+    {
+        Arguments = args;
+        EnvironmentVariables = env?.ToDictionary(kvp => kvp.Key, kvp => (string?)kvp.Value)
+            ?? new Dictionary<string, string?>();
+        _options = options;
+        _attemptCallback = attemptCallback;
+        _attemptCounter = attemptCounter;
+    }
+
+    public string FileName => "dotnet";
+
+    public IReadOnlyList<string> Arguments { get; }
+
+    public IReadOnlyDictionary<string, string?> EnvironmentVariables { get; }
+
+    public bool HasExited => false;
+
+    public int ExitCode => 0;
+
+    public bool Start()
+    {
+        _started = true;
+        return true;
+    }
+
+    public Task<int> WaitForExitAsync(CancellationToken cancellationToken)
+    {
+        if (!_started)
+        {
+            throw new InvalidOperationException("Process has not been started.");
+        }
+
+        var attempt = _attemptCounter();
+        var (exitCode, stdout) = _attemptCallback(attempt, _options);
+        if (stdout is not null)
+        {
+            _options.StandardOutputCallback?.Invoke(stdout);
+        }
+        return Task.FromResult(exitCode);
+    }
+}
+
+/// <summary>
+/// Helper class for creating a <see cref="DotNetCliRunner"/> with a <see cref="TestDotNetCliExecutionFactory"/>
+/// configured for assertion-based testing.
+/// </summary>
+internal static class DotNetCliRunnerTestHelper
+{
+    /// <summary>
+    /// Creates a <see cref="DotNetCliRunner"/> with an assertion callback that is invoked on each execution.
+    /// </summary>
+    public static DotNetCliRunner Create(
+        IServiceProvider serviceProvider,
+        CliExecutionContext executionContext,
+        Action<string[], IDictionary<string, string>?, DirectoryInfo, DotNetCliRunnerInvocationOptions> assertionCallback,
+        int exitCode = 0,
+        ILogger<DotNetCliRunner>? logger = null,
+        AspireCliTelemetry? telemetry = null,
+        IConfiguration? configuration = null,
+        IDiskCache? diskCache = null)
+    {
+        var executionFactory = new TestDotNetCliExecutionFactory
+        {
+            AssertionCallback = assertionCallback,
+            DefaultExitCode = exitCode
+        };
+
+        return new DotNetCliRunner(
+            logger ?? serviceProvider.GetRequiredService<ILogger<DotNetCliRunner>>(),
+            serviceProvider,
+            telemetry ?? TestTelemetryHelper.CreateInitializedTelemetry(),
+            configuration ?? serviceProvider.GetRequiredService<IConfiguration>(),
+            diskCache ?? new NullDiskCache(),
+            serviceProvider.GetRequiredService<IFeatures>(),
+            serviceProvider.GetRequiredService<IInteractionService>(),
+            executionContext,
+            executionFactory);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="DotNetCliRunner"/> with an attempt callback for testing retry scenarios.
+    /// Returns both the runner and the factory so the test can check <see cref="TestDotNetCliExecutionFactory.AttemptCount"/>.
+    /// </summary>
+    public static (DotNetCliRunner Runner, TestDotNetCliExecutionFactory ExecutionFactory) CreateWithRetry(
+        IServiceProvider serviceProvider,
+        CliExecutionContext executionContext,
+        Func<int, DotNetCliRunnerInvocationOptions, (int ExitCode, string? Stdout)> attemptCallback,
+        ILogger<DotNetCliRunner>? logger = null,
+        AspireCliTelemetry? telemetry = null,
+        IConfiguration? configuration = null,
+        IDiskCache? diskCache = null)
+    {
+        var executionFactory = new TestDotNetCliExecutionFactory
+        {
+            AttemptCallback = attemptCallback
+        };
+
+        var runner = new DotNetCliRunner(
+            logger ?? serviceProvider.GetRequiredService<ILogger<DotNetCliRunner>>(),
+            serviceProvider,
+            telemetry ?? TestTelemetryHelper.CreateInitializedTelemetry(),
+            configuration ?? serviceProvider.GetRequiredService<IConfiguration>(),
+            diskCache ?? new NullDiskCache(),
+            serviceProvider.GetRequiredService<IFeatures>(),
+            serviceProvider.GetRequiredService<IInteractionService>(),
+            executionContext,
+            executionFactory);
+
+        return (runner, executionFactory);
+    }
+}

--- a/tests/Aspire.Cli.Tests/TestServices/TestDotNetSdkInstaller.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestDotNetSdkInstaller.cs
@@ -23,9 +23,4 @@ internal sealed class TestDotNetSdkInstaller : IDotNetSdkInstaller
             ? InstallAsyncCallback(cancellationToken)
             : throw new NotImplementedException();
     }
-
-    public string GetEffectiveMinimumSdkVersion()
-    {
-        return "9.0.302"; // Default test value
-    }
 }

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -86,6 +86,7 @@ internal static class CliTestHelper
         services.AddSingleton(options.NewCommandPrompterFactory);
         services.AddSingleton(options.AddCommandPrompterFactory);
         services.AddSingleton(options.PublishCommandPrompterFactory);
+        services.AddTransient(options.DotNetCliExecutionFactoryFactory);
         services.AddTransient(options.DotNetCliRunnerFactory);
         services.AddTransient(options.NuGetPackageCacheFactory);
         services.AddSingleton(options.TemplateProviderFactory);
@@ -302,17 +303,23 @@ internal sealed class CliServiceCollectionTestOptions
         return new CertificateService(interactiveService, telemetry);
     };
 
+    public Func<IServiceProvider, IDotNetCliExecutionFactory> DotNetCliExecutionFactoryFactory { get; set; } = (IServiceProvider serviceProvider) =>
+    {
+        return new TestDotNetCliExecutionFactory();
+    };
+
     public Func<IServiceProvider, IDotNetCliRunner> DotNetCliRunnerFactory { get; set; } = (IServiceProvider serviceProvider) =>
     {
         var logger = serviceProvider.GetRequiredService<ILogger<DotNetCliRunner>>();
         var telemetry = serviceProvider.GetRequiredService<AspireCliTelemetry>();
         var configuration = serviceProvider.GetRequiredService<IConfiguration>();
         var features = serviceProvider.GetRequiredService<IFeatures>();
+        var diskCache = serviceProvider.GetRequiredService<IDiskCache>();
+        var executionContext = serviceProvider.GetRequiredService<CliExecutionContext>();
+        var executionFactory = serviceProvider.GetRequiredService<IDotNetCliExecutionFactory>();
         var interactionService = serviceProvider.GetRequiredService<IInteractionService>();
-    var executionContext = serviceProvider.GetRequiredService<CliExecutionContext>();
-    var diskCache = serviceProvider.GetRequiredService<IDiskCache>();
 
-    return new DotNetCliRunner(logger, serviceProvider, telemetry, configuration, features, interactionService, executionContext, diskCache);
+        return new DotNetCliRunner(logger, serviceProvider, telemetry, configuration, diskCache, features, interactionService, executionContext, executionFactory);
     };
 
     public Func<IServiceProvider, IDotNetSdkInstaller> DotNetSdkInstallerFactory { get; set; } = (IServiceProvider serviceProvider) =>


### PR DESCRIPTION
## Description

PR improvements:
- DotNetCliRunner does too much. It configures arguments, parses results and executes process. This PR splits executing process out into a new PR.
- DotNetCliRunner is now sealed. Tests can inject a test executor into it.
- Remove multiple implementations of DotNetCliRunner. Reuse a single test implementation.
- Remove circular dependency between DotNetCliRunner and DotNetSdkInstaller.
- Separate code that starts backchannel/interaction service from code that executes dotnet CLI
- Clean up how RunAsync builds envs

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
