### PR TITLE
Add telemetry to logs, resources, and ps commands

### DIFF
--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -98,8 +98,8 @@ internal sealed class LogsCommand : BaseCommand
         IFeatures features,
         ICliUpdateNotifier updateNotifier,
         CliExecutionContext executionContext,
-        AspireCliTelemetry telemetry,
         ICliHostEnvironment hostEnvironment,
+        AspireCliTelemetry telemetry,
         ILogger<LogsCommand> logger)
         : base("logs", LogsCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
@@ -141,6 +141,8 @@ internal sealed class LogsCommand : BaseCommand
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
+        using var activity = Telemetry.StartDiagnosticActivity(Name);
+
         var resourceName = parseResult.GetValue<string?>("resource");
         var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
         var follow = parseResult.GetValue<bool>("--follow");

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -75,6 +75,8 @@ internal sealed class PsCommand : BaseCommand
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
+        using var activity = Telemetry.StartDiagnosticActivity(Name);
+
         var format = parseResult.GetValue(s_formatOption);
 
         // Scan for running AppHosts (same as ListAppHostsTool)

--- a/src/Aspire.Cli/Commands/ResourcesCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourcesCommand.cs
@@ -108,6 +108,8 @@ internal sealed class ResourcesCommand : BaseCommand
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
+        using var activity = Telemetry.StartDiagnosticActivity(Name);
+
         var resourceName = parseResult.GetValue<string?>("resource");
         var passedAppHostProjectFile = parseResult.GetValue<FileInfo?>("--project");
         var watch = parseResult.GetValue<bool>("--watch");


### PR DESCRIPTION
## Description

Adds telemetry support to the new CLI commands (`logs`, `resources`, `ps`) that were added in #14122. These commands were merged after the telemetry PR #13963, resulting in a build break due to missing `AspireCliTelemetry` parameter in the `BaseCommand` constructor.

Changes:
- Added `AspireCliTelemetry` parameter to `LogsCommand` and `ResourcesCommand` constructors
- Added diagnostic activity tracking to all three commands following the existing pattern

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No