### PR TITLE
Aspire CLI telemetry follow up changes

### DIFF
--- a/src/Aspire.Cli/CliConfigNames.cs
+++ b/src/Aspire.Cli/CliConfigNames.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli;
+
+// These config names don't include command arguments that are defined in commands themselves.
+internal static class CliConfigNames
+{
+    public const string NoLogo = "ASPIRE_CLI_NOLOGO";
+}

--- a/src/Aspire.Cli/ConsoleEnvironment.cs
+++ b/src/Aspire.Cli/ConsoleEnvironment.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Spectre.Console;
+
+namespace Aspire.Cli;
+
+/// <summary>
+/// Provides access to console output streams for the CLI.
+/// </summary>
+internal sealed class ConsoleEnvironment
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConsoleEnvironment"/> class.
+    /// </summary>
+    /// <param name="output">The console for standard output.</param>
+    /// <param name="error">The console for standard error.</param>
+    public ConsoleEnvironment(IAnsiConsole output, IAnsiConsole error)
+    {
+        ArgumentNullException.ThrowIfNull(output);
+        ArgumentNullException.ThrowIfNull(error);
+
+        Out = output;
+        Error = error;
+    }
+
+    /// <summary>
+    /// Gets the console for standard output.
+    /// </summary>
+    public IAnsiConsole Out { get; }
+
+    /// <summary>
+    /// Gets the console for standard error.
+    /// </summary>
+    public IAnsiConsole Error { get; }
+}

--- a/src/Aspire.Cli/Resources/RootCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/RootCommandStrings.Designer.cs
@@ -91,7 +91,7 @@ namespace Aspire.Cli.Resources {
         ///   Looks up a localized string similar to Telemetry
         ///---------
         ///
-        ///The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to &apos;1&apos; or &apos;true&apos; using your favorite shell.
+        ///The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to &apos;1&apos; or &apos;true&apos; using your preferred shell.
         ///
         ///Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry.
         /// </summary>

--- a/src/Aspire.Cli/Resources/RootCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/RootCommandStrings.resx
@@ -142,7 +142,7 @@
     <value>Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.cs.xlf
@@ -21,13 +21,13 @@
         <source>Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
         <target state="new">Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.de.xlf
@@ -21,13 +21,13 @@
         <source>Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
         <target state="new">Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.es.xlf
@@ -21,13 +21,13 @@
         <source>Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
         <target state="new">Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.fr.xlf
@@ -21,13 +21,13 @@
         <source>Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
         <target state="new">Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.it.xlf
@@ -21,13 +21,13 @@
         <source>Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
         <target state="new">Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ja.xlf
@@ -21,13 +21,13 @@
         <source>Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
         <target state="new">Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ko.xlf
@@ -21,13 +21,13 @@
         <source>Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
         <target state="new">Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pl.xlf
@@ -21,13 +21,13 @@
         <source>Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
         <target state="new">Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pt-BR.xlf
@@ -21,13 +21,13 @@
         <source>Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
         <target state="new">Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ru.xlf
@@ -21,13 +21,13 @@
         <source>Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
         <target state="new">Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.tr.xlf
@@ -21,13 +21,13 @@
         <source>Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
         <target state="new">Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hans.xlf
@@ -21,13 +21,13 @@
         <source>Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
         <target state="new">Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hant.xlf
@@ -21,13 +21,13 @@
         <source>Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
         <target state="new">Telemetry
 ---------
 
-The Aspire CLI collects usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
 Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</target>
         <note />

--- a/tests/Aspire.Cli.Tests/CliSmokeTests.cs
+++ b/tests/Aspire.Cli.Tests/CliSmokeTests.cs
@@ -5,13 +5,22 @@ using Microsoft.DotNet.RemoteExecutor;
 
 namespace Aspire.Cli.Tests;
 
-public class CliSmokeTests
+public class CliSmokeTests(ITestOutputHelper outputHelper)
 {
-    [Fact]
-    public async Task NoArgsReturnsExitCode1()
+    private static readonly RemoteInvokeOptions s_remoteInvokeOptions = new()
     {
-        var exitCode = await Aspire.Cli.Program.Main([]);
-        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        StartInfo = { RedirectStandardOutput = true }
+    };
+
+    [Theory]
+    [InlineData(new string[] { }, ExitCodeConstants.InvalidCommand)]
+    [InlineData(new[] { "-d", "--help" }, ExitCodeConstants.Success)]
+    [InlineData(new[] { "--help" }, ExitCodeConstants.Success)]
+    [InlineData(new[] { "--version" }, ExitCodeConstants.Success)]
+    public async Task MainReturnsExpectedExitCode(string[] args, int expectedExitCode)
+    {
+        var exitCode = await Program.Main(args);
+        Assert.Equal(expectedExitCode, exitCode);
     }
 
     [Theory]
@@ -23,19 +32,62 @@ public class CliSmokeTests
     [InlineData("el", false)]
     public void LocaleOverrideReturnsExitCode(string locale, bool isValid, string environmentVariableName = "ASPIRE_LOCALE_OVERRIDE")
     {
-        RemoteExecutor.Invoke(async (loc, validStr, envVar) =>
+        using var result = RemoteExecutor.Invoke(async (loc, validStr, envVar) =>
         {
             var valid = bool.Parse(validStr);
-            var expectedErrorMessagesLocal = valid ? 1 : 2;
             await using var errorWriter = new StringWriter();
             var oldErrorOutput = Console.Error;
             Console.SetError(errorWriter);
             Environment.SetEnvironmentVariable(envVar, loc);
+            // Suppress first-time use notice to avoid extra lines in stderr
+            Environment.SetEnvironmentVariable(CliConfigNames.NoLogo, "true");
             await Program.Main([]);
             Environment.SetEnvironmentVariable(envVar, null);
-            var errorOutput = errorWriter.ToString().Trim();
-            Assert.Equal(expectedErrorMessagesLocal, errorOutput.Count(c => c == '\n') + 1);
+            Environment.SetEnvironmentVariable(CliConfigNames.NoLogo, null);
             Console.SetError(oldErrorOutput);
-        }, locale, isValid.ToString(), environmentVariableName).Dispose();
+
+            var errorOutput = errorWriter.ToString();
+            var lines = errorOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+            // Write to stdout so it can be captured by the test harness
+            Console.WriteLine($"Error output: {errorOutput}");
+
+            // Valid locales should not produce locale error messages
+            if (valid)
+            {
+                Assert.DoesNotContain(lines, line => line.Contains("locale", StringComparison.OrdinalIgnoreCase));
+            }
+            else
+            {
+                Assert.Contains(lines, line => line.Contains("locale", StringComparison.OrdinalIgnoreCase));
+            }
+        }, locale, isValid.ToString(), environmentVariableName, options: s_remoteInvokeOptions);
+
+        outputHelper.WriteLine(result.Process.StandardOutput.ReadToEnd());
+    }
+
+    [Fact]
+    public void DebugOutputWritesToStderr()
+    {
+        using var result = RemoteExecutor.Invoke(async () =>
+        {
+            await using var errorWriter = new StringWriter();
+            var oldErrorOutput = Console.Error;
+            Console.SetError(errorWriter);
+
+            await Program.Main(["-d", "--help"]);
+
+            Console.SetError(oldErrorOutput);
+            var errorOutput = errorWriter.ToString();
+
+            // Write to stdout so it can be captured by the test harness
+            Console.WriteLine($"Error output: {errorOutput}");
+
+            // Debug mode should write log output to stderr (SpectreConsoleLogger uses [HH:mm:ss] [level] Category: message format)
+            var lines = errorOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            Assert.Contains(lines, line => line.EndsWith("[dbug] Program: Parsing arguments: -d --help"));
+        }, options: s_remoteInvokeOptions);
+
+        outputHelper.WriteLine(result.Process.StandardOutput.ReadToEnd());
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/RootCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RootCommandTests.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Commands;
+using Aspire.Cli.Resources;
+using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Cli.Tests.Commands;
@@ -21,5 +24,147 @@ public class RootCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
         Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task RootCommandWithNoLogoArgumentReturnsZero()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("--nologo --help");
+
+        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+        Assert.Equal(0, exitCode);
+    }
+
+    [Theory]
+    [InlineData("1", true)]
+    [InlineData("true", true)]
+    [InlineData("TRUE", true)]
+    [InlineData("True", true)]
+    [InlineData("0", false)]
+    [InlineData("false", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public async Task NoLogoEnvironmentVariable_ParsedCorrectly(string? value, bool expectedNoLogo)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ConfigurationCallback = config =>
+            {
+                config[CliConfigNames.NoLogo] = value;
+            };
+        });
+        var provider = services.BuildServiceProvider();
+
+        var configuration = provider.GetRequiredService<IConfiguration>();
+        var isNoLogo = configuration.GetBool(CliConfigNames.NoLogo, defaultValue: false);
+
+        Assert.Equal(expectedNoLogo, isNoLogo);
+
+        // Also verify command still works with the configuration
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("--help");
+        var exitCode = await result.InvokeAsync().WaitAsync(CliTestConstants.DefaultTimeout);
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public void FirstTimeUseNotice_DisplayedWhenSentinelDoesNotExist()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var errorWriter = new StringWriter();
+        var sentinel = new TestFirstTimeUseNoticeSentinel { SentinelExists = false };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ErrorTextWriter = errorWriter;
+            options.FirstTimeUseNoticeSentinelFactory = _ => sentinel;
+        });
+        var provider = services.BuildServiceProvider();
+
+        Program.DisplayFirstTimeUseNoticeIfNeeded(provider, noLogo: false);
+
+        var errorOutput = errorWriter.ToString();
+        var lines = errorOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Contains(lines, line => line.EndsWith(RootCommandStrings.FirstTimeUseWelcome, StringComparison.Ordinal));
+        Assert.True(sentinel.WasCreated);
+    }
+
+    [Fact]
+    public void FirstTimeUseNotice_NotDisplayedWhenSentinelExists()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var errorWriter = new StringWriter();
+        var sentinel = new TestFirstTimeUseNoticeSentinel { SentinelExists = true };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ErrorTextWriter = errorWriter;
+            options.FirstTimeUseNoticeSentinelFactory = _ => sentinel;
+        });
+        var provider = services.BuildServiceProvider();
+
+        Program.DisplayFirstTimeUseNoticeIfNeeded(provider, noLogo: false);
+
+        var errorOutput = errorWriter.ToString();
+        var lines = errorOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.DoesNotContain(lines, line => line.EndsWith(RootCommandStrings.FirstTimeUseWelcome, StringComparison.Ordinal));
+        Assert.False(sentinel.WasCreated);
+    }
+
+    [Fact]
+    public void FirstTimeUseNotice_NotDisplayedWithNoLogoArgument()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var errorWriter = new StringWriter();
+        var sentinel = new TestFirstTimeUseNoticeSentinel { SentinelExists = false };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ErrorTextWriter = errorWriter;
+            options.FirstTimeUseNoticeSentinelFactory = _ => sentinel;
+        });
+        var provider = services.BuildServiceProvider();
+
+        Program.DisplayFirstTimeUseNoticeIfNeeded(provider, noLogo: true);
+
+        var errorOutput = errorWriter.ToString();
+        var lines = errorOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.DoesNotContain(lines, line => line.EndsWith(RootCommandStrings.FirstTimeUseWelcome, StringComparison.Ordinal));
+        Assert.True(sentinel.WasCreated);
+    }
+
+    [Fact]
+    public void FirstTimeUseNotice_NotDisplayedWithNoLogoEnvironmentVariable()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var errorWriter = new StringWriter();
+        var sentinel = new TestFirstTimeUseNoticeSentinel { SentinelExists = false };
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ErrorTextWriter = errorWriter;
+            options.FirstTimeUseNoticeSentinelFactory = _ => sentinel;
+            options.ConfigurationCallback = config =>
+            {
+                config[CliConfigNames.NoLogo] = "1";
+            };
+        });
+        var provider = services.BuildServiceProvider();
+
+        var configuration = provider.GetRequiredService<IConfiguration>();
+        var noLogo = configuration.GetBool(CliConfigNames.NoLogo, defaultValue: false);
+
+        Program.DisplayFirstTimeUseNoticeIfNeeded(provider, noLogo);
+
+        var errorOutput = errorWriter.ToString();
+        var lines = errorOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.DoesNotContain(lines, line => line.EndsWith(RootCommandStrings.FirstTimeUseWelcome, StringComparison.Ordinal));
+        Assert.True(sentinel.WasCreated);
     }
 }

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
+using Aspire.Cli.Utils;
 using Spectre.Console;
 using System.Text;
 
@@ -10,12 +11,18 @@ namespace Aspire.Cli.Tests.Interaction;
 
 public class ConsoleInteractionServiceTests
 {
+    private static ConsoleInteractionService CreateInteractionService(IAnsiConsole console, CliExecutionContext executionContext, ICliHostEnvironment? hostEnvironment = null)
+    {
+        var consoleEnvironment = new ConsoleEnvironment(console, console);
+        return new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment ?? TestHelpers.CreateInteractiveHostEnvironment());
+    }
+
     [Fact]
     public async Task PromptForSelectionAsync_EmptyChoices_ThrowsEmptyChoicesException()
     {
         // Arrange
         var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
-        var interactionService = new ConsoleInteractionService(AnsiConsole.Console, executionContext, TestHelpers.CreateInteractiveHostEnvironment());
+        var interactionService = CreateInteractionService(AnsiConsole.Console, executionContext);
         var choices = Array.Empty<string>();
 
         // Act & Assert
@@ -28,7 +35,7 @@ public class ConsoleInteractionServiceTests
     {
         // Arrange
         var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
-        var interactionService = new ConsoleInteractionService(AnsiConsole.Console, executionContext, TestHelpers.CreateInteractiveHostEnvironment());
+        var interactionService = CreateInteractionService(AnsiConsole.Console, executionContext);
         var choices = Array.Empty<string>();
 
         // Act & Assert
@@ -49,7 +56,7 @@ public class ConsoleInteractionServiceTests
         });
         
         var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
-        var interactionService = new ConsoleInteractionService(console, executionContext, TestHelpers.CreateInteractiveHostEnvironment());
+        var interactionService = CreateInteractionService(console, executionContext);
         var errorMessage = "The JSON value could not be converted to <Type>. Path: $.values[0].Type | LineNumber: 0 | BytePositionInLine: 121.";
 
         // Act - this should not throw an exception due to markup parsing
@@ -74,7 +81,7 @@ public class ConsoleInteractionServiceTests
         });
         
         var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
-        var interactionService = new ConsoleInteractionService(console, executionContext, TestHelpers.CreateInteractiveHostEnvironment());
+        var interactionService = CreateInteractionService(console, executionContext);
         var message = "Path with <brackets> and [markup] characters";
 
         // Act - this should not throw an exception due to markup parsing
@@ -99,7 +106,7 @@ public class ConsoleInteractionServiceTests
         });
         
         var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
-        var interactionService = new ConsoleInteractionService(console, executionContext, TestHelpers.CreateInteractiveHostEnvironment());
+        var interactionService = CreateInteractionService(console, executionContext);
         var lines = new[]
         {
             ("stdout", "Command output with <angle> brackets"),
@@ -130,7 +137,7 @@ public class ConsoleInteractionServiceTests
         });
         
         var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
-        var interactionService = new ConsoleInteractionService(console, executionContext, TestHelpers.CreateInteractiveHostEnvironment());
+        var interactionService = CreateInteractionService(console, executionContext);
         var markdown = "# Header\nThis is **bold** and *italic* text with `code`.";
 
         // Act
@@ -157,7 +164,7 @@ public class ConsoleInteractionServiceTests
         });
         
         var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
-        var interactionService = new ConsoleInteractionService(console, executionContext, TestHelpers.CreateInteractiveHostEnvironment());
+        var interactionService = CreateInteractionService(console, executionContext);
         var plainText = "This is just plain text without any markdown.";
 
         // Act
@@ -182,7 +189,7 @@ public class ConsoleInteractionServiceTests
         });
 
         var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), debugMode: true);
-        var interactionService = new ConsoleInteractionService(console, executionContext, TestHelpers.CreateInteractiveHostEnvironment());
+        var interactionService = CreateInteractionService(console, executionContext);
         var statusText = "Processing request...";
         var result = "test result";
 
@@ -209,7 +216,7 @@ public class ConsoleInteractionServiceTests
         });
 
         var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), debugMode: true);
-        var interactionService = new ConsoleInteractionService(console, executionContext, TestHelpers.CreateInteractiveHostEnvironment());
+        var interactionService = CreateInteractionService(console, executionContext);
         var statusText = "Processing synchronous request...";
         var actionCalled = false;
 
@@ -229,7 +236,7 @@ public class ConsoleInteractionServiceTests
         // Arrange
         var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
         var hostEnvironment = TestHelpers.CreateNonInteractiveHostEnvironment();
-        var interactionService = new ConsoleInteractionService(AnsiConsole.Console, executionContext, hostEnvironment);
+        var interactionService = CreateInteractionService(AnsiConsole.Console, executionContext, hostEnvironment);
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -243,7 +250,7 @@ public class ConsoleInteractionServiceTests
         // Arrange
         var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
         var hostEnvironment = TestHelpers.CreateNonInteractiveHostEnvironment();
-        var interactionService = new ConsoleInteractionService(AnsiConsole.Console, executionContext, hostEnvironment);
+        var interactionService = CreateInteractionService(AnsiConsole.Console, executionContext, hostEnvironment);
         var choices = new[] { "option1", "option2" };
 
         // Act & Assert
@@ -258,7 +265,7 @@ public class ConsoleInteractionServiceTests
         // Arrange
         var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
         var hostEnvironment = TestHelpers.CreateNonInteractiveHostEnvironment();
-        var interactionService = new ConsoleInteractionService(AnsiConsole.Console, executionContext, hostEnvironment);
+        var interactionService = CreateInteractionService(AnsiConsole.Console, executionContext, hostEnvironment);
         var choices = new[] { "option1", "option2" };
 
         // Act & Assert
@@ -273,7 +280,7 @@ public class ConsoleInteractionServiceTests
         // Arrange
         var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
         var hostEnvironment = TestHelpers.CreateNonInteractiveHostEnvironment();
-        var interactionService = new ConsoleInteractionService(AnsiConsole.Console, executionContext, hostEnvironment);
+        var interactionService = CreateInteractionService(AnsiConsole.Console, executionContext, hostEnvironment);
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -294,7 +301,7 @@ public class ConsoleInteractionServiceTests
         });
 
         var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
-        var interactionService = new ConsoleInteractionService(console, executionContext, TestHelpers.CreateInteractiveHostEnvironment());
+        var interactionService = CreateInteractionService(console, executionContext);
         
         var outerStatusText = "Outer operation...";
         var innerStatusText = "Inner operation...";
@@ -327,7 +334,7 @@ public class ConsoleInteractionServiceTests
         });
 
         var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
-        var interactionService = new ConsoleInteractionService(console, executionContext, TestHelpers.CreateInteractiveHostEnvironment());
+        var interactionService = CreateInteractionService(console, executionContext);
         
         var outerStatusText = "Outer synchronous operation...";
         var innerStatusText = "Inner synchronous operation...";

--- a/tests/Aspire.Cli.Tests/TestServices/TestFirstTimeUseNoticeSentinel.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestFirstTimeUseNoticeSentinel.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Utils;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+internal sealed class TestFirstTimeUseNoticeSentinel : IFirstTimeUseNoticeSentinel
+{
+    public bool SentinelExists { get; set; }
+    public bool WasCreated { get; private set; }
+
+    public bool Exists() => SentinelExists;
+
+    public void CreateIfNotExists()
+    {
+        if (!SentinelExists)
+        {
+            SentinelExists = true;
+            WasCreated = true;
+        }
+    }
+}


### PR DESCRIPTION
## Description

PR:
- Adds option to hide first run experience using env var
- Tweaks telemetry notice text
- Adds unit tests
- Improves writing to Console.Error

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
