### PR TITLE
Update DCP to 0.22.1

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.22.0">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.22.1">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>1c89661b2ccc0708efd847ae2ebe2a7311a39105</Sha>
+      <Sha>1d5d617292c05ff9870cd20d1f455f8f41dac523</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.22.0">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.22.1">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>1c89661b2ccc0708efd847ae2ebe2a7311a39105</Sha>
+      <Sha>1d5d617292c05ff9870cd20d1f455f8f41dac523</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.22.0">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.22.1">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>1c89661b2ccc0708efd847ae2ebe2a7311a39105</Sha>
+      <Sha>1d5d617292c05ff9870cd20d1f455f8f41dac523</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.22.0">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.22.1">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>1c89661b2ccc0708efd847ae2ebe2a7311a39105</Sha>
+      <Sha>1d5d617292c05ff9870cd20d1f455f8f41dac523</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.22.0">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.22.1">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>1c89661b2ccc0708efd847ae2ebe2a7311a39105</Sha>
+      <Sha>1d5d617292c05ff9870cd20d1f455f8f41dac523</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.22.0">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.22.1">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>1c89661b2ccc0708efd847ae2ebe2a7311a39105</Sha>
+      <Sha>1d5d617292c05ff9870cd20d1f455f8f41dac523</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.22.0">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.22.1">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>1c89661b2ccc0708efd847ae2ebe2a7311a39105</Sha>
+      <Sha>1d5d617292c05ff9870cd20d1f455f8f41dac523</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.DependencyInjection.AutoActivation" Version="10.2.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,13 +28,13 @@
     <!-- Package versions defined directly in <reporoot>/Directory.Packages.props -->
     <MicrosoftDotnetSdkInternalVersion>8.0.100-rtm.23512.16</MicrosoftDotnetSdkInternalVersion>
     <!-- DCP -->
-    <MicrosoftDeveloperControlPlanedarwinamd64Version>0.22.0</MicrosoftDeveloperControlPlanedarwinamd64Version>
-    <MicrosoftDeveloperControlPlanedarwinarm64Version>0.22.0</MicrosoftDeveloperControlPlanedarwinarm64Version>
-    <MicrosoftDeveloperControlPlanelinuxamd64Version>0.22.0</MicrosoftDeveloperControlPlanelinuxamd64Version>
-    <MicrosoftDeveloperControlPlanelinuxarm64Version>0.22.0</MicrosoftDeveloperControlPlanelinuxarm64Version>
-    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.22.0</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
-    <MicrosoftDeveloperControlPlanewindowsamd64Version>0.22.0</MicrosoftDeveloperControlPlanewindowsamd64Version>
-    <MicrosoftDeveloperControlPlanewindowsarm64Version>0.22.0</MicrosoftDeveloperControlPlanewindowsarm64Version>
+    <MicrosoftDeveloperControlPlanedarwinamd64Version>0.22.1</MicrosoftDeveloperControlPlanedarwinamd64Version>
+    <MicrosoftDeveloperControlPlanedarwinarm64Version>0.22.1</MicrosoftDeveloperControlPlanedarwinarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxamd64Version>0.22.1</MicrosoftDeveloperControlPlanelinuxamd64Version>
+    <MicrosoftDeveloperControlPlanelinuxarm64Version>0.22.1</MicrosoftDeveloperControlPlanelinuxarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.22.1</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
+    <MicrosoftDeveloperControlPlanewindowsamd64Version>0.22.1</MicrosoftDeveloperControlPlanewindowsamd64Version>
+    <MicrosoftDeveloperControlPlanewindowsarm64Version>0.22.1</MicrosoftDeveloperControlPlanewindowsarm64Version>
     <!-- Other -->
     <MicrosoftDotNetRemoteExecutorVersion>11.0.0-beta.25610.3</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetXUnitV3ExtensionsVersion>11.0.0-beta.25610.3</MicrosoftDotNetXUnitV3ExtensionsVersion>

--- a/eng/dcppack/UnixFilePermissions.xml
+++ b/eng/dcppack/UnixFilePermissions.xml
@@ -1,6 +1,3 @@
 <FileList>
   <File Path="tools/dcp" Permission="755"/>
-  <File Path="tools/ext/dcpctrl" Permission="755"/>
-  <File Path="tools/ext/bin/dcpproc" Permission="755"/>
-  <File Path="tools/ext/bin/dcptun" Permission="755"/>
 </FileList>

--- a/spelling.dic
+++ b/spelling.dic
@@ -18,7 +18,6 @@ consolelogs
 cors
 csproj
 dbug
-dcpctrl
 dockerfile
 dylib
 entrypoint

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -190,8 +190,6 @@ namespace Projects%3B
       <DcpDir>$([MSBuild]::EnsureTrailingSlash('$(DcpDir)'))</DcpDir>
       <DcpExtensionsDir Condition=" '$(DcpExtensionsDir)' == '' ">$([MSBuild]::NormalizePath($(DcpDir), 'ext'))</DcpExtensionsDir>
       <DcpExtensionsDir>$([MSBuild]::EnsureTrailingSlash('$(DcpExtensionsDir)'))</DcpExtensionsDir>
-      <DcpBinDir Condition=" '$(DcpBinDir)' == '' ">$([MSBuild]::NormalizePath($(DcpExtensionsDir), 'bin'))</DcpBinDir>
-      <DcpBinDir>$([MSBuild]::EnsureTrailingSlash('$(DcpBinDir)'))</DcpBinDir>
       <DcpCliPath Condition=" '$(DcpCliPath)'  == '' ">$([MSBuild]::NormalizePath($(DcpDir), 'dcp'))</DcpCliPath>
       <DcpCliPath Condition=" '$(OS)' == 'Windows_NT' and !$(DcpCliPath.EndsWith('.exe')) ">$(DcpCliPath).exe</DcpCliPath>
     </PropertyGroup>
@@ -204,10 +202,6 @@ namespace Projects%3B
       <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
         <_Parameter1>dcpextensionpaths</_Parameter1>
         <_Parameter2>$(DcpExtensionsDir)</_Parameter2>
-      </AssemblyAttribute>
-      <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
-        <_Parameter1>dcpbinpath</_Parameter1>
-        <_Parameter2>$(DcpBinDir)</_Parameter2>
       </AssemblyAttribute>
       <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
         <_Parameter1>apphostprojectpath</_Parameter1>

--- a/src/Aspire.Hosting/Dcp/DcpHost.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHost.cs
@@ -111,7 +111,7 @@ internal sealed class DcpHost
             if (dcpInfo is not null)
             {
                 DcpDependencyCheck.CheckDcpInfoAndLogErrors(_logger, _dcpOptions, dcpInfo, throwIfUnhealthy: requireContainerRuntimeInitialization);
-                
+
                 // Show UI notification if container runtime is unhealthy
                 TryShowContainerRuntimeNotification(dcpInfo, cancellationToken);
             }
@@ -198,11 +198,6 @@ internal sealed class DcpHost
         if (!string.IsNullOrEmpty(_dcpOptions.ExtensionsPath))
         {
             dcpProcessSpec.EnvironmentVariables.Add("DCP_EXTENSIONS_PATH", _dcpOptions.ExtensionsPath);
-        }
-
-        if (!string.IsNullOrEmpty(_dcpOptions.BinPath))
-        {
-            dcpProcessSpec.EnvironmentVariables.Add("DCP_BIN_PATH", _dcpOptions.BinPath);
         }
 
         // Set an environment variable to contain session info that should be deleted when DCP is done
@@ -408,7 +403,7 @@ internal sealed class DcpHost
 
             // Create a cancellation token source that can be cancelled when runtime becomes healthy
             var notificationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
-            
+
             // Single background task to show notification and poll for health updates
             _ = Task.Run(async () =>
             {
@@ -424,7 +419,7 @@ internal sealed class DcpHost
                         try
                         {
                             var dcpInfo = await _dependencyCheckService.GetDcpInfoAsync(force: true, cancellationToken: notificationCts.Token).ConfigureAwait(false);
-                            
+
                             if (dcpInfo is not null && IsContainerRuntimeHealthy(dcpInfo))
                             {
                                 // Container runtime is now healthy, exit the polling loop
@@ -442,10 +437,10 @@ internal sealed class DcpHost
                             _logger.LogDebug(ex, "Error while polling container runtime health for notification");
                         }
                     }
-                    
+
                     // Cancel the notification at the end of the loop
                     notificationCts.Cancel();
-                    
+
                     // Wait for notification task to complete
                     try
                     {

--- a/src/Aspire.Hosting/Dcp/DcpLogParser.cs
+++ b/src/Aspire.Hosting/Dcp/DcpLogParser.cs
@@ -31,7 +31,7 @@ internal static class DcpLogParser
         {
             // The log format is
             // <date>\t<level>\t<category>\t<log message>
-            // e.g. 2023-09-19T20:40:50.509-0700      info    dcpctrl.ServiceReconciler       service /apigateway is now in state Ready       {"ServiceName": {"name":"apigateway"}}
+            // e.g. 2023-09-19T20:40:50.509-0700      info    dcp.ServiceReconciler       service /apigateway is now in state Ready       {"ServiceName": {"name":"apigateway"}}
 
             var tab = line.IndexOf((byte)'\t');
             if (tab < 0)
@@ -41,22 +41,22 @@ internal static class DcpLogParser
 
             // Skip date
             line = line[(tab + 1)..];
-            
+
             tab = line.IndexOf((byte)'\t');
             if (tab < 0)
             {
                 return false;
             }
-            
+
             var level = line[..tab];
             line = line[(tab + 1)..];
-            
+
             tab = line.IndexOf((byte)'\t');
             if (tab < 0)
             {
                 return false;
             }
-            
+
             var categorySpan = line[..tab];
             line = line[(tab + 1)..];
 
@@ -124,7 +124,7 @@ internal static class DcpLogParser
     public static string FormatSystemLog(string message)
     {
         const string SystemLogPrefix = "[sys] ";
-        
+
         // Try to find JSON portion in the message (starts with a tab followed by '{')
         var jsonStart = message.IndexOf('\t');
         if (jsonStart < 0)
@@ -145,7 +145,7 @@ internal static class DcpLogParser
             // Build the formatted message
             var sb = new StringBuilder();
             sb.Append(SystemLogPrefix);
-            
+
             // Add the text part if it exists
             if (!string.IsNullOrWhiteSpace(textPart))
             {
@@ -195,7 +195,7 @@ internal static class DcpLogParser
                         {
                             sb.Append(hasAddedField ? ", " : ": ");
                         }
-                        
+
                         // Add field in format "Name = Value"
                         sb.Append(name);
                         sb.Append(" = ");

--- a/src/Aspire.Hosting/Dcp/DcpOptions.cs
+++ b/src/Aspire.Hosting/Dcp/DcpOptions.cs
@@ -18,7 +18,7 @@ internal sealed class DcpOptions
     public string? CliPath { get; set; }
 
     /// <summary>
-    /// Optional path to a folder containing the DCP extension assemblies (dcpctrl, etc.).
+    /// Optional path to a folder containing the DCP extension assemblies.
     /// </summary>
     /// <example>
     /// C:\Program Files\dotnet\packs\Aspire.Hosting.Orchestration.win-x64\8.0.0-preview.1.23518.6\tools\ext\

--- a/src/Aspire.Hosting/Dcp/DcpOptions.cs
+++ b/src/Aspire.Hosting/Dcp/DcpOptions.cs
@@ -34,14 +34,6 @@ internal sealed class DcpOptions
     public string? DashboardPath { get; set; }
 
     /// <summary>
-    /// Optional path to a folder containing additional DCP binaries.
-    /// </summary>
-    /// <example>
-    /// C:\Program Files\dotnet\packs\Aspire.Hosting.Orchestration.win-x64\8.0.0-preview.1.23518.6\tools\ext\bin\
-    /// </example>
-    public string? BinPath { get; set; }
-
-    /// <summary>
     /// Optional container runtime to override default runtime for DCP containers.
     /// </summary>
     /// <example>
@@ -145,7 +137,6 @@ internal class ConfigureDefaultDcpOptions(
 {
     private const string DcpCliPathMetadataKey = "DcpCliPath";
     private const string DcpExtensionsPathMetadataKey = "DcpExtensionsPath";
-    private const string DcpBinPathMetadataKey = "DcpBinPath";
     private const string DashboardPathMetadataKey = "aspiredashboardpath";
 
     public static string DcpPublisher = nameof(DcpPublisher);
@@ -162,14 +153,12 @@ internal class ConfigureDefaultDcpOptions(
             if (Path.GetDirectoryName(options.CliPath) is string dcpDir && !string.IsNullOrEmpty(dcpDir))
             {
                 options.ExtensionsPath = Path.Combine(dcpDir, "ext");
-                options.BinPath = Path.Combine(options.ExtensionsPath, "bin");
             }
         }
         else
         {
             options.CliPath = GetMetadataValue(assemblyMetadata, DcpCliPathMetadataKey);
             options.ExtensionsPath = GetMetadataValue(assemblyMetadata, DcpExtensionsPathMetadataKey);
-            options.BinPath = GetMetadataValue(assemblyMetadata, DcpBinPathMetadataKey);
         }
 
         if (!string.IsNullOrEmpty(dcpPublisherConfiguration[nameof(options.DashboardPath)]))

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -790,15 +790,15 @@ public class DcpExecutorTests
                     return new MemoryStream();
                 case Logs.StreamTypeSystem:
                     // Simulate real DCP system log format with JSON metadata
-                    var systemLogs = 
-                        "2024-08-19T06:10:01.000Z\tinfo\tdcpctrl.ExecutableReconciler\tStarting process...\t{\"Executable\": \"/foo-pwrqgpew\", \"Reconciliation\": 4, \"Cmd\": \"bla\", \"Args\": []}" + Environment.NewLine +
-                        "2024-08-19T06:10:02.000Z\terror\tdcpctrl.ExecutableReconciler\tFailed to start process\t{\"Executable\": \"/foo-pwrqgpew\", \"Reconciliation\": 4, \"Cmd\": \"bla\", \"Args\": [], \"error\": \"exec: \\\"bla\\\": executable file not found in $PATH\"}" + Environment.NewLine;
+                    var systemLogs =
+                        "2024-08-19T06:10:01.000Z\tinfo\tdcp.ExecutableReconciler\tStarting process...\t{\"Executable\": \"/foo-pwrqgpew\", \"Reconciliation\": 4, \"Cmd\": \"bla\", \"Args\": []}" + Environment.NewLine +
+                        "2024-08-19T06:10:02.000Z\terror\tdcp.ExecutableReconciler\tFailed to start process\t{\"Executable\": \"/foo-pwrqgpew\", \"Reconciliation\": 4, \"Cmd\": \"bla\", \"Args\": [], \"error\": \"exec: \\\"bla\\\": executable file not found in $PATH\"}" + Environment.NewLine;
                     return new MemoryStream(Encoding.UTF8.GetBytes(systemLogs));
                 default:
                     throw new InvalidOperationException("Unexpected type: " + logStreamType);
             }
         });
-        
+
         using var app = builder.Build();
         var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
         var dcpOptions = new DcpOptions { DashboardPath = "./dashboard" };
@@ -824,7 +824,7 @@ public class DcpExecutorTests
 
         var watchLogsResults = await watchLogsTask;
         Assert.True(watchLogsResults.Count >= 2, $"Expected at least 2 log entries, got {watchLogsResults.Count}");
-        
+
         // Verify the system logs are formatted with [sys] prefix and proper formatting
         Assert.Contains(watchLogsResults, l => l.Content.Contains("[sys] Starting process...: Cmd = bla, Args = []"));
         Assert.Contains(watchLogsResults, l => l.Content.Contains("[sys] Failed to start process: Cmd = bla, Args = [], Error = exec: \"bla\": executable file not found in $PATH"));

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpLogParserTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpLogParserTests.cs
@@ -13,7 +13,7 @@ public sealed class DcpLogParserTests
     public void TryParseDcpLog_ValidInfoLog_ParsesSuccessfully()
     {
         // Arrange
-        var logLine = "2023-09-19T20:40:50.509-0700\tinfo\tdcpctrl.ServiceReconciler\tservice /apigateway is now in state Ready";
+        var logLine = "2023-09-19T20:40:50.509-0700\tinfo\tdcp.ServiceReconciler\tservice /apigateway is now in state Ready";
         var bytes = Encoding.UTF8.GetBytes(logLine);
 
         // Act
@@ -23,14 +23,14 @@ public sealed class DcpLogParserTests
         Assert.True(result);
         Assert.Equal("service /apigateway is now in state Ready", message);
         Assert.Equal(LogLevel.Information, logLevel);
-        Assert.Equal("dcpctrl.ServiceReconciler", category);
+        Assert.Equal("dcp.ServiceReconciler", category);
     }
 
     [Fact]
     public void TryParseDcpLog_ValidErrorLog_ParsesSuccessfully()
     {
         // Arrange
-        var logLine = "2023-09-19T20:40:50.509-0700\terror\tdcpctrl.ExecutableReconciler\tFailed to start a process";
+        var logLine = "2023-09-19T20:40:50.509-0700\terror\tdcp.ExecutableReconciler\tFailed to start a process";
         var bytes = Encoding.UTF8.GetBytes(logLine);
 
         // Act
@@ -40,14 +40,14 @@ public sealed class DcpLogParserTests
         Assert.True(result);
         Assert.Equal("Failed to start a process", message);
         Assert.Equal(LogLevel.Error, logLevel);
-        Assert.Equal("dcpctrl.ExecutableReconciler", category);
+        Assert.Equal("dcp.ExecutableReconciler", category);
     }
 
     [Fact]
     public void TryParseDcpLog_ValidWarningLog_ParsesSuccessfully()
     {
         // Arrange
-        var logLine = "2023-09-19T20:40:50.509-0700\twarning\tdcpctrl.TestReconciler\tWarning message";
+        var logLine = "2023-09-19T20:40:50.509-0700\twarning\tdcp.TestReconciler\tWarning message";
         var bytes = Encoding.UTF8.GetBytes(logLine);
 
         // Act
@@ -57,14 +57,14 @@ public sealed class DcpLogParserTests
         Assert.True(result);
         Assert.Equal("Warning message", message);
         Assert.Equal(LogLevel.Warning, logLevel);
-        Assert.Equal("dcpctrl.TestReconciler", category);
+        Assert.Equal("dcp.TestReconciler", category);
     }
 
     [Fact]
     public void TryParseDcpLog_ValidDebugLog_ParsesSuccessfully()
     {
         // Arrange
-        var logLine = "2023-09-19T20:40:50.509-0700\tdebug\tdcpctrl.TestReconciler\tDebug message";
+        var logLine = "2023-09-19T20:40:50.509-0700\tdebug\tdcp.TestReconciler\tDebug message";
         var bytes = Encoding.UTF8.GetBytes(logLine);
 
         // Act
@@ -74,14 +74,14 @@ public sealed class DcpLogParserTests
         Assert.True(result);
         Assert.Equal("Debug message", message);
         Assert.Equal(LogLevel.Debug, logLevel);
-        Assert.Equal("dcpctrl.TestReconciler", category);
+        Assert.Equal("dcp.TestReconciler", category);
     }
 
     [Fact]
     public void TryParseDcpLog_ValidTraceLog_ParsesSuccessfully()
     {
         // Arrange
-        var logLine = "2023-09-19T20:40:50.509-0700\ttrace\tdcpctrl.TestReconciler\tTrace message";
+        var logLine = "2023-09-19T20:40:50.509-0700\ttrace\tdcp.TestReconciler\tTrace message";
         var bytes = Encoding.UTF8.GetBytes(logLine);
 
         // Act
@@ -91,14 +91,14 @@ public sealed class DcpLogParserTests
         Assert.True(result);
         Assert.Equal("Trace message", message);
         Assert.Equal(LogLevel.Trace, logLevel);
-        Assert.Equal("dcpctrl.TestReconciler", category);
+        Assert.Equal("dcp.TestReconciler", category);
     }
 
     [Fact]
     public void TryParseDcpLog_WithCarriageReturn_TrimsSuccessfully()
     {
         // Arrange
-        var logLine = "2023-09-19T20:40:50.509-0700\tinfo\tdcpctrl.ServiceReconciler\ttest message\r";
+        var logLine = "2023-09-19T20:40:50.509-0700\tinfo\tdcp.ServiceReconciler\ttest message\r";
         var bytes = Encoding.UTF8.GetBytes(logLine);
 
         // Act
@@ -114,7 +114,7 @@ public sealed class DcpLogParserTests
     public void TryParseDcpLog_WithJsonPayload_ParsesSuccessfully()
     {
         // Arrange
-        var logLine = "2023-09-19T20:40:50.509-0700\tinfo\tdcpctrl.ServiceReconciler\tservice /apigateway is now in state Ready\t{\"ServiceName\": {\"name\":\"apigateway\"}}";
+        var logLine = "2023-09-19T20:40:50.509-0700\tinfo\tdcp.ServiceReconciler\tservice /apigateway is now in state Ready\t{\"ServiceName\": {\"name\":\"apigateway\"}}";
         var bytes = Encoding.UTF8.GetBytes(logLine);
 
         // Act
@@ -158,7 +158,7 @@ public sealed class DcpLogParserTests
     public void TryParseDcpLog_StringOverload_ValidErrorLog_ParsesSuccessfully()
     {
         // Arrange
-        var logLine = "2023-09-19T20:40:50.509-0700\terror\tdcpctrl.ExecutableReconciler\tFailed to start a process";
+        var logLine = "2023-09-19T20:40:50.509-0700\terror\tdcp.ExecutableReconciler\tFailed to start a process";
 
         // Act
         var result = DcpLogParser.TryParseDcpLog(logLine, out var message, out var logLevel, out var isErrorLevel);
@@ -174,7 +174,7 @@ public sealed class DcpLogParserTests
     public void TryParseDcpLog_StringOverload_ValidInfoLog_ParsesSuccessfully()
     {
         // Arrange
-        var logLine = "2023-09-19T20:40:50.509-0700\tinfo\tdcpctrl.ServiceReconciler\tservice /apigateway is now in state Ready";
+        var logLine = "2023-09-19T20:40:50.509-0700\tinfo\tdcp.ServiceReconciler\tservice /apigateway is now in state Ready";
 
         // Act
         var result = DcpLogParser.TryParseDcpLog(logLine, out var message, out var logLevel, out var isErrorLevel);
@@ -203,7 +203,7 @@ public sealed class DcpLogParserTests
     public void TryParseDcpLog_RealWorldExampleFromIssue_ParsesSuccessfully()
     {
         // Arrange - Example from the issue
-        var logLine = "2023-09-19T20:40:50.509-0700\tinfo\tdcpctrl.ExecutableReconciler\tStarting process...\t{\"Executable\": \"/python-api-duafrsvy\", \"Reconciliation\": 3, \"Cmd\": \"d:\\\\dev\\\\git\\\\dogfood\\\\hellopython\\\\pyapp\\\\.venv\\\\Scripts\\\\python.exe\", \"Args\": [\"main.py\"]}";
+        var logLine = "2023-09-19T20:40:50.509-0700\tinfo\tdcp.ExecutableReconciler\tStarting process...\t{\"Executable\": \"/python-api-duafrsvy\", \"Reconciliation\": 3, \"Cmd\": \"d:\\\\dev\\\\git\\\\dogfood\\\\hellopython\\\\pyapp\\\\.venv\\\\Scripts\\\\python.exe\", \"Args\": [\"main.py\"]}";
         var bytes = Encoding.UTF8.GetBytes(logLine);
 
         // Act
@@ -213,7 +213,7 @@ public sealed class DcpLogParserTests
         Assert.True(result);
         Assert.Contains("Starting process...", message);
         Assert.Equal(LogLevel.Information, logLevel);
-        Assert.Equal("dcpctrl.ExecutableReconciler", category);
+        Assert.Equal("dcp.ExecutableReconciler", category);
     }
 
     [Theory]
@@ -225,7 +225,7 @@ public sealed class DcpLogParserTests
     public void TryParseDcpLog_ParsesAllLogLevels(string dcpLogLevel, LogLevel expectedLogLevel)
     {
         // Arrange
-        var logLine = $"2023-09-19T20:40:50.509-0700\t{dcpLogLevel}\tdcpctrl.TestReconciler\tTest message";
+        var logLine = $"2023-09-19T20:40:50.509-0700\t{dcpLogLevel}\tdcp.TestReconciler\tTest message";
         var bytes = Encoding.UTF8.GetBytes(logLine);
 
         // Act
@@ -235,7 +235,7 @@ public sealed class DcpLogParserTests
         Assert.True(result);
         Assert.Equal("Test message", message);
         Assert.Equal(expectedLogLevel, logLevel);
-        Assert.Equal("dcpctrl.TestReconciler", category);
+        Assert.Equal("dcp.TestReconciler", category);
     }
 
     [Fact]

--- a/tests/helix/send-to-helix-inner.proj
+++ b/tests/helix/send-to-helix-inner.proj
@@ -47,8 +47,8 @@
     <_ShutdownDockerContainersCommand Condition="'$(OS)' != 'Windows_NT'">for f in `docker ps -aq`%3B do docker stop $f%3B docker rm $f%3B done</_ShutdownDockerContainersCommand>
     <_DeleteDockerVolumesCommand Condition="'$(OS)' != 'Windows_NT'">for f in `docker volume ls -q`%3B do docker volume rm $f%3B done</_DeleteDockerVolumesCommand>
 
-    <_CleanupProcessesCommand Condition="'$(OS)' == 'Windows_NT'">powershell -ExecutionPolicy ByPass -NoProfile -command "&amp; get-ciminstance win32_process | where-object ExecutablePath -Match 'dotnet-tests|dcp.exe|dcpctrl.exe' | foreach-object { echo $_.ProcessId $_.ExecutablePath %3B stop-process -id $_.ProcessId -force -ErrorAction SilentlyContinue }"</_CleanupProcessesCommand>
-    <_CleanupProcessesCommand Condition="'$(OS)' != 'Windows_NT'">pgrep -lf "dotnet-tests|dcp.exe|dcpctrl.exe" | awk '{print %3B system("kill -9 "$1)}'</_CleanupProcessesCommand>
+    <_CleanupProcessesCommand Condition="'$(OS)' == 'Windows_NT'">powershell -ExecutionPolicy ByPass -NoProfile -command "&amp; get-ciminstance win32_process | where-object ExecutablePath -Match 'dotnet-tests|dcp.exe' | foreach-object { echo $_.ProcessId $_.ExecutablePath %3B stop-process -id $_.ProcessId -force -ErrorAction SilentlyContinue }"</_CleanupProcessesCommand>
+    <_CleanupProcessesCommand Condition="'$(OS)' != 'Windows_NT'">pgrep -lf "dotnet-tests|dcp.exe" | awk '{print %3B system("kill -9 "$1)}'</_CleanupProcessesCommand>
 
     <_WaitForDcpCommand Condition="'$(OS)' != 'Windows_NT'">echo "Waiting for dcp process to exit..."; start_time=$(date +%s); echo "Start time: $start_time"; timeout=120; while pgrep -lf "dcp.exe" &gt; /dev/null &amp;&amp; [ $timeout -gt 0 ]; do sleep 1; timeout=$((timeout - 1)); done; end_time=$(date +%s); echo "End time: $end_time"; if pgrep -lf "dcp.exe" &gt; /dev/null; then echo "dcp process did not exit within the timeout period."; exit 1; fi</_WaitForDcpCommand>
     <!-- Figure out the powershell... -->


### PR DESCRIPTION
## Description

Update DCP to version 0.22.1 which consolidates several sub-binaries into the main dcp binary (we no longer ship separate dcpctrl and dcpproc binaries). This shrinks the total disk size required by a DCP install by more than half.

I removed existing references to dcpctrl from the code as part of this update.

You can see the full DCP release notes for 0.22.1 here: https://github.com/microsoft/dcp/releases/tag/v0.22.1