### PR TITLE
Add Copilot CLI to devcontainer and fix Yarn GPG key issue

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/devcontainers/dotnet:10.0-noble
+
+# Workaround for expired Yarn GPG key (https://github.com/yarnpkg/yarn/issues/9218)
+# This updates the yarn keyring before apt-get update is called by devcontainer features
+RUN rm -f /etc/apt/sources.list.d/yarn.list 2>/dev/null || true \
+    && rm -f /usr/share/keyrings/yarn-archive-keyring.gpg 2>/dev/null || true \
+    && rm -f /usr/share/keyrings/yarn.gpg 2>/dev/null || true

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,11 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
 {
 	"name": "Aspire - Contribute",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/dotnet:10.0-noble",
+	// Use Dockerfile to work around Yarn GPG key expiration issue
+	// See: https://github.com/yarnpkg/yarn/issues/9218
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
 	"features": {
 		"ghcr.io/devcontainers/features/azure-cli:1": {},
 		"ghcr.io/azure/azure-dev/azd:0": {},
@@ -20,7 +23,8 @@
 			"helm": "latest",
 			"minikube": "latest"
 		},
-		"ghcr.io/devcontainers/features/sshd:1": {}
+		"ghcr.io/devcontainers/features/sshd:1": {},
+		"ghcr.io/devcontainers/features/copilot-cli:1": {}
 	},
 
 	"hostRequirements": {
@@ -59,7 +63,7 @@
 			}
 		}
 	},
-	"onCreateCommand": "dotnet restore && gh extension install github/gh-copilot",
+	"onCreateCommand": "dotnet restore",
 	"postStartCommand": "dotnet dev-certs https --trust",
 
 	"remoteEnv": {


### PR DESCRIPTION
## Summary

This PR configures the devcontainer for better remote development experience with the GitHub Copilot CLI.

### Changes

1. **Added Copilot CLI feature** - Installs the new standalone GitHub Copilot CLI (`copilot` command) using the official devcontainer feature `ghcr.io/devcontainers/features/copilot-cli:1`

2. **Removed old gh-copilot extension** - Replaced `gh extension install github/gh-copilot` in `onCreateCommand` with the proper devcontainer feature

3. **Dockerfile workaround for Yarn GPG key issue** - The Yarn apt repository GPG key expired on Jan 28, 2026 (see https://github.com/yarnpkg/yarn/issues/9218). This was causing the docker-in-docker feature to fail during `apt-get update`. The Dockerfile removes the stale Yarn apt sources before features are installed.

### Testing

- Created and tested codespace on this branch
- Verified `copilot --version` returns `GitHub Copilot CLI 0.0.398`
- Verified SSH access works via `gh cs ssh`