### PR TITLE
Fix dashboard URL logged in app host to be the actual port (for randomization)

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -458,7 +458,7 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
         dashboardResource.Annotations.Add(new ResourceUrlsCallbackAnnotation(c =>
         {
             var browserToken = options.DashboardToken;
-            
+
             foreach (var url in c.Urls)
             {
                 if (url.Endpoint is { } endpoint)
@@ -469,7 +469,7 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
                         // Order these before non-browser usable endpoints.
                         url.DisplayText = $"Dashboard ({endpoint.EndpointName})";
                         url.DisplayOrder = 1;
-                        
+
                         // Append the browser token to the URL as a query string parameter if token is configured
                         if (!string.IsNullOrEmpty(browserToken))
                         {

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -171,51 +171,51 @@ public class FrontendBrowserTokenAuthTests
         Assert.Collection(l,
             w =>
             {
-                Assert.Equal("Aspire version: {Version}", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("Aspire version: {Version}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
             },
             w =>
             {
-                Assert.Equal("Now listening on: {DashboardUri}", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("Now listening on: {DashboardUri}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
 
-                var uri = new Uri((string)GetValue(w.State, "DashboardUri")!);
+                var uri = new Uri((string)LogTestHelpers.GetValue(w, "DashboardUri")!);
                 Assert.NotEqual(0, uri.Port);
             },
             w =>
             {
-                Assert.Equal("OTLP/gRPC listening on: {OtlpEndpointUri}", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("OTLP/gRPC listening on: {OtlpEndpointUri}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
 
-                var uri = new Uri((string)GetValue(w.State, "OtlpEndpointUri")!);
+                var uri = new Uri((string)LogTestHelpers.GetValue(w, "OtlpEndpointUri")!);
                 Assert.NotEqual(0, uri.Port);
             },
             w =>
             {
-                Assert.Equal("OTLP/HTTP listening on: {OtlpEndpointUri}", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("OTLP/HTTP listening on: {OtlpEndpointUri}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
 
-                var uri = new Uri((string)GetValue(w.State, "OtlpEndpointUri")!);
+                var uri = new Uri((string)LogTestHelpers.GetValue(w, "OtlpEndpointUri")!);
                 Assert.NotEqual(0, uri.Port);
             },
             w =>
             {
-                Assert.Equal("MCP listening on: {McpEndpointUri}", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("MCP listening on: {McpEndpointUri}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
 
-                var uri = new Uri((string)GetValue(w.State, "McpEndpointUri")!);
+                var uri = new Uri((string)LogTestHelpers.GetValue(w, "McpEndpointUri")!);
                 Assert.NotEqual(0, uri.Port);
             },
             w =>
             {
-                Assert.Equal("OTLP server is unsecured. Untrusted apps can send telemetry to the dashboard. For more information, visit https://go.microsoft.com/fwlink/?linkid=2267030", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("OTLP server is unsecured. Untrusted apps can send telemetry to the dashboard. For more information, visit https://go.microsoft.com/fwlink/?linkid=2267030", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
                 Assert.Equal(LogLevel.Warning, w.LogLevel);
             },
             w =>
             {
-                Assert.Equal("MCP server is unsecured. Untrusted apps can access sensitive information.", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("MCP server is unsecured. Untrusted apps can access sensitive information.", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
                 Assert.Equal(LogLevel.Warning, w.LogLevel);
             },
             w =>
             {
-                Assert.Equal("Login to the dashboard at {DashboardLoginUrl}", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("Login to the dashboard at {DashboardLoginUrl}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
 
-                var uri = new Uri((string)GetValue(w.State, "DashboardLoginUrl")!, UriKind.Absolute);
+                var uri = new Uri((string)LogTestHelpers.GetValue(w, "DashboardLoginUrl")!, UriKind.Absolute);
                 var queryString = HttpUtility.ParseQueryString(uri.Query);
                 Assert.NotNull(queryString["t"]);
             });
@@ -243,9 +243,9 @@ public class FrontendBrowserTokenAuthTests
         var l = testSink.Writes.Where(w => w.LoggerName == typeof(DashboardWebApplication).FullName).ToList();
 
         // Testing via the log template is kind of hacky. If this becomes a problem then consider adding proper log definitions and match via ID.
-        var loginLinkLog = l.Single(w => "Login to the dashboard at {DashboardLoginUrl}" == (string?)GetValue(w.State, "{OriginalFormat}"));
+        var loginLinkLog = l.Single(w => "Login to the dashboard at {DashboardLoginUrl}" == (string?)LogTestHelpers.GetValue(w, "{OriginalFormat}"));
 
-        var uri = new Uri((string)GetValue(loginLinkLog.State, "DashboardLoginUrl")!, UriKind.Absolute);
+        var uri = new Uri((string)LogTestHelpers.GetValue(loginLinkLog, "DashboardLoginUrl")!, UriKind.Absolute);
         var queryString = HttpUtility.ParseQueryString(uri.Query);
         Assert.NotNull(queryString["t"]);
 
@@ -270,12 +270,6 @@ public class FrontendBrowserTokenAuthTests
         var l = testSink.Writes.Where(w => w.LoggerName == typeof(DashboardWebApplication).FullName).ToList();
 
         // Testing via the log template is kind of hacky. If this becomes a problem then consider adding proper log definitions and match via ID.
-        Assert.Single(l, w => (string?)GetValue(w.State, "{OriginalFormat}") == "Login to the dashboard at {DashboardLoginUrl} . The URL may need changes depending on how network access to the container is configured.");
-    }
-
-    private static object? GetValue(object? values, string key)
-    {
-        var list = values as IReadOnlyList<KeyValuePair<string, object>>;
-        return list?.SingleOrDefault(kvp => kvp.Key == key).Value;
+        Assert.Single(l, w => (string?)LogTestHelpers.GetValue(w, "{OriginalFormat}") == "Login to the dashboard at {DashboardLoginUrl} . The URL may need changes depending on how network access to the container is configured.");
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -685,44 +685,44 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         Assert.Collection(l,
             w =>
             {
-                Assert.Equal("Aspire version: {Version}", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("Aspire version: {Version}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
             },
             w =>
             {
-                Assert.Equal("Now listening on: {DashboardUri}", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("Now listening on: {DashboardUri}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
 
-                var uri = new Uri((string)GetValue(w.State, "DashboardUri")!);
+                var uri = new Uri((string)LogTestHelpers.GetValue(w, "DashboardUri")!);
                 Assert.NotEqual(0, uri.Port);
             },
             w =>
             {
-                Assert.Equal("OTLP/gRPC listening on: {OtlpEndpointUri}", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("OTLP/gRPC listening on: {OtlpEndpointUri}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
 
-                var uri = new Uri((string)GetValue(w.State, "OtlpEndpointUri")!);
+                var uri = new Uri((string)LogTestHelpers.GetValue(w, "OtlpEndpointUri")!);
                 Assert.NotEqual(0, uri.Port);
             },
             w =>
             {
-                Assert.Equal("OTLP/HTTP listening on: {OtlpEndpointUri}", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("OTLP/HTTP listening on: {OtlpEndpointUri}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
 
-                var uri = new Uri((string)GetValue(w.State, "OtlpEndpointUri")!);
+                var uri = new Uri((string)LogTestHelpers.GetValue(w, "OtlpEndpointUri")!);
                 Assert.NotEqual(0, uri.Port);
             },
             w =>
             {
-                Assert.Equal("MCP listening on: {McpEndpointUri}", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("MCP listening on: {McpEndpointUri}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
 
-                var uri = new Uri((string)GetValue(w.State, "McpEndpointUri")!);
+                var uri = new Uri((string)LogTestHelpers.GetValue(w, "McpEndpointUri")!);
                 Assert.NotEqual(0, uri.Port);
             },
             w =>
             {
-                Assert.Equal("OTLP server is unsecured. Untrusted apps can send telemetry to the dashboard. For more information, visit https://go.microsoft.com/fwlink/?linkid=2267030", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("OTLP server is unsecured. Untrusted apps can send telemetry to the dashboard. For more information, visit https://go.microsoft.com/fwlink/?linkid=2267030", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
                 Assert.Equal(LogLevel.Warning, w.LogLevel);
             },
             w =>
             {
-                Assert.Equal("MCP server is unsecured. Untrusted apps can access sensitive information.", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("MCP server is unsecured. Untrusted apps can access sensitive information.", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
                 Assert.Equal(LogLevel.Warning, w.LogLevel);
             });
     }
@@ -750,19 +750,19 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         Assert.Collection(l,
             w =>
             {
-                Assert.Equal("Aspire version: {Version}", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("Aspire version: {Version}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
             },
             w =>
             {
-                Assert.Equal("Now listening on: {DashboardUri}", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("Now listening on: {DashboardUri}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
             },
             w =>
             {
-                Assert.Equal("MCP listening on: {McpEndpointUri}", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("MCP listening on: {McpEndpointUri}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
             },
             w =>
             {
-                Assert.Equal("MCP server is unsecured. Untrusted apps can access sensitive information.", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("MCP server is unsecured. Untrusted apps can access sensitive information.", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
                 Assert.Equal(LogLevel.Warning, w.LogLevel);
             });
     }
@@ -821,46 +821,46 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         Assert.Collection(l,
             w =>
             {
-                Assert.Equal("Aspire version: {Version}", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("Aspire version: {Version}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
             },
             w =>
             {
-                Assert.Equal("Now listening on: {DashboardUri}", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("Now listening on: {DashboardUri}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
 
-                var uri = new Uri((string)GetValue(w.State, "DashboardUri")!);
+                var uri = new Uri((string)LogTestHelpers.GetValue(w, "DashboardUri")!);
                 Assert.Equal("https", uri.Scheme);
                 Assert.Equal("localhost", uri.Host);
                 Assert.Equal(frontendPort1, uri.Port);
             },
             w =>
             {
-                Assert.Equal("OTLP/gRPC listening on: {OtlpEndpointUri}", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("OTLP/gRPC listening on: {OtlpEndpointUri}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
 
-                var uri = new Uri((string)GetValue(w.State, "OtlpEndpointUri")!);
+                var uri = new Uri((string)LogTestHelpers.GetValue(w, "OtlpEndpointUri")!);
                 Assert.Equal(otlpGrpcPort, uri.Port);
             },
             w =>
             {
-                Assert.Equal("OTLP/HTTP listening on: {OtlpEndpointUri}", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("OTLP/HTTP listening on: {OtlpEndpointUri}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
 
-                var uri = new Uri((string)GetValue(w.State, "OtlpEndpointUri")!);
+                var uri = new Uri((string)LogTestHelpers.GetValue(w, "OtlpEndpointUri")!);
                 Assert.Equal(otlpHttpPort, uri.Port);
             },
             w =>
             {
-                Assert.Equal("MCP listening on: {McpEndpointUri}", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("MCP listening on: {McpEndpointUri}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
 
-                var uri = new Uri((string)GetValue(w.State, "McpEndpointUri")!);
+                var uri = new Uri((string)LogTestHelpers.GetValue(w, "McpEndpointUri")!);
                 Assert.NotEqual(0, uri.Port); // Check that allocated port is in log message
             },
             w =>
             {
-                Assert.Equal("OTLP server is unsecured. Untrusted apps can send telemetry to the dashboard. For more information, visit https://go.microsoft.com/fwlink/?linkid=2267030", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("OTLP server is unsecured. Untrusted apps can send telemetry to the dashboard. For more information, visit https://go.microsoft.com/fwlink/?linkid=2267030", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
                 Assert.Equal(LogLevel.Warning, w.LogLevel);
             },
             w =>
             {
-                Assert.Equal("MCP server is unsecured. Untrusted apps can access sensitive information.", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("MCP server is unsecured. Untrusted apps can access sensitive information.", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
                 Assert.Equal(LogLevel.Warning, w.LogLevel);
             });
     }
@@ -1084,11 +1084,5 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
                 next(app);
             };
         }
-    }
-
-    private static object? GetValue(object? values, string key)
-    {
-        var list = values as IReadOnlyList<KeyValuePair<string, object>>;
-        return list?.SingleOrDefault(kvp => kvp.Key == key).Value;
     }
 }

--- a/tests/Shared/Logging/LogTestHelpers.cs
+++ b/tests/Shared/Logging/LogTestHelpers.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.Logging.Testing;
+
+/// <summary>
+/// Helper methods for testing log output.
+/// </summary>
+public static class LogTestHelpers
+{
+    /// <summary>
+    /// Gets a value from structured log state by key.
+    /// </summary>
+    /// <param name="context">The write context from the test sink.</param>
+    /// <param name="key">The key to look up (e.g., "DashboardUrl" or "{OriginalFormat}").</param>
+    /// <returns>The value associated with the key, or null if not found.</returns>
+    public static object? GetValue(WriteContext context, string key)
+    {
+        return GetValue(context.State, key);
+    }
+
+    /// <summary>
+    /// Gets a value from structured log state by key.
+    /// </summary>
+    /// <param name="state">The log state object, typically from <see cref="WriteContext.State"/>.</param>
+    /// <param name="key">The key to look up (e.g., "DashboardUrl" or "{OriginalFormat}").</param>
+    /// <returns>The value associated with the key, or null if not found.</returns>
+    public static object? GetValue(object? state, string key)
+    {
+        var list = state as IReadOnlyList<KeyValuePair<string, object?>>;
+        return list?.SingleOrDefault(kvp => kvp.Key == key).Value;
+    }
+}


### PR DESCRIPTION
## Description

The app host displays dashboard URL in console when it starts. It uses the config value. Ports can now be randomized so displaying the config value is wrong.

PR gets the allocated endpoint from the resource and displays its value.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
