### PR TITLE
Make Aspire CLI telemetry version number consistent with dashboard

### DIFF
--- a/src/Aspire.Cli/Telemetry/AspireCliTelemetry.cs
+++ b/src/Aspire.Cli/Telemetry/AspireCliTelemetry.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Reflection;
 using System.Runtime.CompilerServices;
-using Aspire.Cli.Utils;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -195,7 +195,11 @@ internal sealed class AspireCliTelemetry : IHostedService
 
             _tagsList.Add(new(TelemetryConstants.Tags.MacAddressHash, macAddressHashTask.Result));
             _tagsList.Add(new(TelemetryConstants.Tags.DeviceId, deviceIdTask.Result));
-            _tagsList.Add(new(TelemetryConstants.Tags.CliVersion, VersionHelper.GetDefaultTemplateVersion()));
+
+            // This is consistent with dashboard version data.
+            _tagsList.Add(new(TelemetryConstants.Tags.CliVersion, typeof(Program).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty));
+            _tagsList.Add(new(TelemetryConstants.Tags.CliBuildId, typeof(Program).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version ?? string.Empty));
+
             _tagsList.Add(new(TelemetryConstants.Tags.DeploymentEnvironmentName, _ciEnvironmentDetector.IsCIEnvironment() ? "ci" : "local"));
         }
         catch (Exception ex)

--- a/src/Aspire.Cli/Telemetry/TelemetryConstants.cs
+++ b/src/Aspire.Cli/Telemetry/TelemetryConstants.cs
@@ -64,7 +64,7 @@ internal static class TelemetryConstants
         public const string CliVersion = "aspire.cli.version";
 
         /// <summary>
-        /// Tag for the CLI version.
+        /// Tag for the CLI build identifier, such as the file version or build ID.
         /// </summary>
         public const string CliBuildId = "aspire.cli.build_id";
 

--- a/src/Aspire.Cli/Telemetry/TelemetryConstants.cs
+++ b/src/Aspire.Cli/Telemetry/TelemetryConstants.cs
@@ -64,6 +64,11 @@ internal static class TelemetryConstants
         public const string CliVersion = "aspire.cli.version";
 
         /// <summary>
+        /// Tag for the CLI version.
+        /// </summary>
+        public const string CliBuildId = "aspire.cli.build_id";
+
+        /// <summary>
         /// Tag for the deployment environment name ("ci" or "local").
         /// </summary>
         public const string DeploymentEnvironmentName = "deployment.environment.name";

--- a/src/Aspire.Cli/Telemetry/TelemetryManager.cs
+++ b/src/Aspire.Cli/Telemetry/TelemetryManager.cs
@@ -24,7 +24,7 @@ internal sealed class TelemetryManager
     private const int ShutDownTimeoutMilliseconds = -1;
 #else
     // Chosen to provide time to send remaining telemetry without noticeably delaying exit.
-    private const int ShutDownTimeoutMilliseconds = 100;
+    private const int ShutDownTimeoutMilliseconds = 200;
 #endif
 
     private readonly TracerProvider? _azureMonitorProvider;

--- a/src/Aspire.Dashboard/Telemetry/DashboardTelemetryService.cs
+++ b/src/Aspire.Dashboard/Telemetry/DashboardTelemetryService.cs
@@ -24,6 +24,7 @@ public sealed class DashboardTelemetryService
 
         _defaultProperties = new Dictionary<string, AspireTelemetryProperty>
         {
+            // This is consistent with CLI version data.
             { TelemetryPropertyKeys.DashboardVersion, new AspireTelemetryProperty(typeof(DashboardWebApplication).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty) },
             { TelemetryPropertyKeys.DashboardBuildId, new AspireTelemetryProperty(typeof(DashboardWebApplication).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version ?? string.Empty) },
         };


### PR DESCRIPTION
Makes the CLI version numbers consistent with what the dashboard does. Also, slightly increase exit timeout.