### PR TITLE
[release/13.1] Update Azure.Identity package version to 1.17.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -164,7 +164,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <!-- Pinned versions for Component Governance - Remove when root dependencies are updated -->
     <PackageVersion Include="Azure.Core" Version="1.50.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.17.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.17.1" />
     <!-- https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3313 -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <!-- tools/scripts dependencies -->


### PR DESCRIPTION
Azure.Identity 1.17.0 is marked as deprecated. Updating to the latest released version.