### PR TITLE
Refactor CLI MCP to get resources from app host

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -67,6 +67,10 @@
     <Compile Include="$(SharedDir)Mcp\McpIconHelper.cs" Link="Mcp\McpIconHelper.cs" />
     <Compile Include="$(SharedDir)X509Certificate2Extensions.cs" Link="Utils\X509Certificate2Extensions.cs" />
     <Compile Include="$(SharedDir)Model\Serialization\ResourceJson.cs" Link="Model\Serialization\ResourceJson.cs" />
+    <Compile Include="$(SharedDir)Model\KnownProperties.cs" Link="Model\KnownProperties.cs" />
+    <Compile Include="$(SharedDir)Model\KnownResourceTypes.cs" Link="Model\KnownResourceTypes.cs" />
+    <Compile Include="$(SharedDir)Model\ResourceSourceViewModel.cs" Link="Model\ResourceSourceViewModel.cs" />
+    <Compile Include="$(SharedDir)DashboardUrls.cs" Link="Utils\DashboardUrls.cs" />
     <Compile Include="$(SharedDir)UserSecrets\UserSecretsPathHelper.cs" Link="Utils\UserSecretsPathHelper.cs" />
     <Compile Include="$(SharedDir)UserSecrets\IsolatedUserSecretsHelper.cs" Link="Utils\IsolatedUserSecretsHelper.cs" />
   </ItemGroup>

--- a/src/Aspire.Cli/Backchannel/AppHostConnectionHelper.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionHelper.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+
+namespace Aspire.Cli.Backchannel;
+
+/// <summary>
+/// Provides helper methods for working with AppHost connections.
+/// </summary>
+internal static class AppHostConnectionHelper
+{
+    /// <summary>
+    /// Gets the appropriate AppHost connection based on the selection logic:
+    /// 1. If a specific AppHost is selected via select_apphost, use that
+    /// 2. Otherwise, look for in-scope connections (AppHosts within the working directory)
+    /// 3. If exactly one in-scope connection exists, use it
+    /// 4. If multiple in-scope connections exist, throw an error listing them
+    /// 5. If no in-scope connections exist, fall back to the first available connection
+    /// </summary>
+    /// <param name="auxiliaryBackchannelMonitor">The backchannel monitor to get connections from.</param>
+    /// <param name="logger">Logger for debug output.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The selected connection, or null if none available.</returns>
+    public static async Task<AppHostAuxiliaryBackchannel?> GetSelectedConnectionAsync(
+        IAuxiliaryBackchannelMonitor auxiliaryBackchannelMonitor,
+        ILogger logger,
+        CancellationToken cancellationToken = default)
+    {
+        var connections = auxiliaryBackchannelMonitor.Connections.ToList();
+
+        if (connections.Count == 0)
+        {
+            await auxiliaryBackchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
+            connections = auxiliaryBackchannelMonitor.Connections.ToList();
+            if (connections.Count == 0)
+            {
+                return null;
+            }
+        }
+
+        // Check if a specific AppHost was selected
+        var selectedPath = auxiliaryBackchannelMonitor.SelectedAppHostPath;
+        if (!string.IsNullOrEmpty(selectedPath))
+        {
+            var selectedConnection = connections.FirstOrDefault(c =>
+                c.AppHostInfo?.AppHostPath != null &&
+                string.Equals(c.AppHostInfo.AppHostPath, selectedPath, StringComparison.OrdinalIgnoreCase));
+
+            if (selectedConnection != null)
+            {
+                logger.LogDebug("Using explicitly selected AppHost: {AppHostPath}", selectedPath);
+                return selectedConnection;
+            }
+
+            logger.LogWarning("Selected AppHost at '{SelectedPath}' is no longer running, falling back to selection logic", selectedPath);
+            // Clear the selection since the AppHost is no longer available
+            auxiliaryBackchannelMonitor.SelectedAppHostPath = null;
+        }
+
+        // Get in-scope connections
+        var inScopeConnections = connections.Where(c => c.IsInScope).ToList();
+
+        if (inScopeConnections.Count == 1)
+        {
+            logger.LogDebug("Using single in-scope AppHost: {AppHostPath}", inScopeConnections[0].AppHostInfo?.AppHostPath ?? "N/A");
+            return inScopeConnections[0];
+        }
+
+        if (inScopeConnections.Count > 1)
+        {
+            var paths = inScopeConnections
+                .Where(c => c.AppHostInfo?.AppHostPath != null)
+                .Select(c => c.AppHostInfo!.AppHostPath)
+                .ToList();
+
+            var pathsList = string.Join("\n", paths.Select(p => $"  - {p}"));
+
+            throw new McpProtocolException(
+                $"Multiple Aspire AppHosts are running in the scope of the MCP server's working directory. " +
+                $"Use the 'select_apphost' tool to specify which AppHost to use.\n\nRunning AppHosts:\n{pathsList}",
+                McpErrorCode.InternalError);
+        }
+
+        var fallback = connections
+            .OrderBy(c => c.AppHostInfo?.AppHostPath ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(c => c.AppHostInfo?.ProcessId ?? int.MaxValue)
+            .FirstOrDefault();
+
+        logger.LogDebug(
+            "No in-scope AppHosts found. Falling back to first available AppHost: {AppHostPath}",
+            fallback?.AppHostInfo?.AppHostPath ?? "N/A");
+
+        return fallback;
+    }
+}

--- a/src/Aspire.Cli/Backchannel/ResourceSnapshotMapper.cs
+++ b/src/Aspire.Cli/Backchannel/ResourceSnapshotMapper.cs
@@ -68,13 +68,12 @@ internal static class ResourceSnapshotMapper
             })
             .ToArray();
 
-        // Build relationships by matching DisplayName and filtering out hidden resources
+        // Build relationships by matching DisplayName
         var relationships = new List<ResourceRelationshipJson>();
         foreach (var relationship in snapshot.Relationships)
         {
             var matches = allSnapshots
                 .Where(r => string.Equals(r.DisplayName, relationship.ResourceName, StringComparisons.ResourceName))
-                .Where(r => !string.Equals(r.State, "Hidden", StringComparison.OrdinalIgnoreCase))
                 .ToList();
 
             foreach (var match in matches)

--- a/src/Aspire.Cli/Backchannel/ResourceSnapshotMapper.cs
+++ b/src/Aspire.Cli/Backchannel/ResourceSnapshotMapper.cs
@@ -31,12 +31,13 @@ internal static class ResourceSnapshotMapper
     /// <param name="dashboardBaseUrl">Optional base URL of the Aspire Dashboard for generating resource URLs.</param>
     public static ResourceJson MapToResourceJson(ResourceSnapshot snapshot, IReadOnlyList<ResourceSnapshot> allSnapshots, string? dashboardBaseUrl = null)
     {
-        var urls = snapshot.Endpoints
-            .Select(e => new ResourceUrlJson
+        var urls = snapshot.Urls
+            .Select(u => new ResourceUrlJson
             {
-                Name = e.Name,
-                Url = e.Url,
-                IsInternal = e.IsInternal
+                Name = u.Name,
+                DisplayName = u.DisplayProperties?.DisplayName,
+                Url = u.Url,
+                IsInternal = u.IsInternal
             })
             .ToArray();
 
@@ -57,6 +58,15 @@ internal static class ResourceSnapshotMapper
                 Status = h.Status,
                 Description = h.Description,
                 ExceptionMessage = h.ExceptionText
+            })
+            .ToArray();
+
+        var environment = snapshot.EnvironmentVariables
+            .Where(e => e.IsFromSpec)
+            .Select(e => new ResourceEnvironmentVariableJson
+            {
+                Name = e.Name,
+                Value = e.Value
             })
             .ToArray();
 
@@ -110,6 +120,7 @@ internal static class ResourceSnapshotMapper
         return new ResourceJson
         {
             Name = snapshot.Name,
+            DisplayName = snapshot.DisplayName,
             ResourceType = snapshot.ResourceType,
             State = snapshot.State,
             StateStyle = snapshot.StateStyle,
@@ -122,6 +133,7 @@ internal static class ResourceSnapshotMapper
             DashboardUrl = dashboardUrl,
             Urls = urls,
             Volumes = volumes,
+            Environment = environment,
             HealthReports = healthReports,
             Properties = properties,
             Relationships = relationships.ToArray(),

--- a/src/Aspire.Cli/Backchannel/ResourceSnapshotMapper.cs
+++ b/src/Aspire.Cli/Backchannel/ResourceSnapshotMapper.cs
@@ -1,0 +1,177 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Utils;
+using Aspire.Shared.Model;
+using Aspire.Shared.Model.Serialization;
+
+namespace Aspire.Cli.Backchannel;
+
+/// <summary>
+/// Maps <see cref="ResourceSnapshot"/> to <see cref="ResourceJson"/> for serialization.
+/// </summary>
+internal static class ResourceSnapshotMapper
+{
+    /// <summary>
+    /// Maps a list of <see cref="ResourceSnapshot"/> to a list of <see cref="ResourceJson"/>.
+    /// </summary>
+    /// <param name="snapshots">The resource snapshots to map.</param>
+    /// <param name="dashboardBaseUrl">Optional base URL of the Aspire Dashboard for generating resource URLs.</param>
+    public static List<ResourceJson> MapToResourceJsonList(IEnumerable<ResourceSnapshot> snapshots, string? dashboardBaseUrl = null)
+    {
+        var snapshotList = snapshots.ToList();
+        return snapshotList.Select(s => MapToResourceJson(s, snapshotList, dashboardBaseUrl)).ToList();
+    }
+
+    /// <summary>
+    /// Maps a <see cref="ResourceSnapshot"/> to <see cref="ResourceJson"/>.
+    /// </summary>
+    /// <param name="snapshot">The resource snapshot to map.</param>
+    /// <param name="allSnapshots">All resource snapshots for resolving relationships.</param>
+    /// <param name="dashboardBaseUrl">Optional base URL of the Aspire Dashboard for generating resource URLs.</param>
+    public static ResourceJson MapToResourceJson(ResourceSnapshot snapshot, IReadOnlyList<ResourceSnapshot> allSnapshots, string? dashboardBaseUrl = null)
+    {
+        var urls = snapshot.Endpoints
+            .Select(e => new ResourceUrlJson
+            {
+                Name = e.Name,
+                Url = e.Url,
+                IsInternal = e.IsInternal
+            })
+            .ToArray();
+
+        var volumes = snapshot.Volumes
+            .Select(v => new ResourceVolumeJson
+            {
+                Source = v.Source,
+                Target = v.Target,
+                MountType = v.MountType,
+                IsReadOnly = v.IsReadOnly
+            })
+            .ToArray();
+
+        var healthReports = snapshot.HealthReports
+            .Select(h => new ResourceHealthReportJson
+            {
+                Name = h.Name,
+                Status = h.Status,
+                Description = h.Description,
+                ExceptionMessage = h.ExceptionText
+            })
+            .ToArray();
+
+        var properties = snapshot.Properties
+            .Select(p => new ResourcePropertyJson
+            {
+                Name = p.Key,
+                Value = p.Value
+            })
+            .ToArray();
+
+        // Build relationships by matching DisplayName and filtering out hidden resources
+        var relationships = new List<ResourceRelationshipJson>();
+        foreach (var relationship in snapshot.Relationships)
+        {
+            var matches = allSnapshots
+                .Where(r => string.Equals(r.DisplayName, relationship.ResourceName, StringComparisons.ResourceName))
+                .Where(r => !string.Equals(r.State, "Hidden", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            foreach (var match in matches)
+            {
+                relationships.Add(new ResourceRelationshipJson
+                {
+                    Type = relationship.Type,
+                    ResourceName = match.Name
+                });
+            }
+        }
+
+        // Only include enabled commands
+        var commands = snapshot.Commands
+            .Where(c => string.Equals(c.State, "Enabled", StringComparison.OrdinalIgnoreCase))
+            .Select(c => new ResourceCommandJson
+            {
+                Name = c.Name,
+                Description = c.Description
+            })
+            .ToArray();
+
+        // Get source information using the shared ResourceSourceViewModel
+        var sourceViewModel = ResourceSource.GetSourceModel(snapshot.ResourceType, snapshot.Properties);
+
+        // Generate dashboard URL for this resource if a base URL is provided
+        string? dashboardUrl = null;
+        if (!string.IsNullOrEmpty(dashboardBaseUrl))
+        {
+            var resourcePath = DashboardUrls.ResourcesUrl(snapshot.Name);
+            dashboardUrl = DashboardUrls.CombineUrl(dashboardBaseUrl, resourcePath);
+        }
+
+        return new ResourceJson
+        {
+            Name = snapshot.Name,
+            ResourceType = snapshot.ResourceType,
+            State = snapshot.State,
+            StateStyle = snapshot.StateStyle,
+            HealthStatus = snapshot.HealthStatus,
+            ExitCode = snapshot.ExitCode,
+            CreationTimestamp = snapshot.CreatedAt,
+            StartTimestamp = snapshot.StartedAt,
+            StopTimestamp = snapshot.StoppedAt,
+            Urls = urls,
+            Volumes = volumes,
+            HealthReports = healthReports,
+            Properties = properties,
+            Relationships = relationships.ToArray(),
+            Commands = commands,
+            Source = sourceViewModel?.Value,
+            DashboardUrl = dashboardUrl
+        };
+    }
+
+    /// <summary>
+    /// Gets the display name for a resource, returning the unique name if there are multiple resources
+    /// with the same display name (replicas).
+    /// </summary>
+    /// <param name="resource">The resource to get the name for.</param>
+    /// <param name="allResources">All resources to check for duplicates.</param>
+    /// <returns>The display name if unique, otherwise the unique resource name.</returns>
+    public static string GetResourceName(ResourceSnapshot resource, IDictionary<string, ResourceSnapshot> allResources)
+    {
+        return GetResourceName(resource, allResources.Values);
+    }
+
+    /// <summary>
+    /// Gets the display name for a resource, returning the unique name if there are multiple resources
+    /// with the same display name (replicas).
+    /// </summary>
+    /// <param name="resource">The resource to get the name for.</param>
+    /// <param name="allResources">All resources to check for duplicates.</param>
+    /// <returns>The display name if unique, otherwise the unique resource name.</returns>
+    public static string GetResourceName(ResourceSnapshot resource, IEnumerable<ResourceSnapshot> allResources)
+    {
+        var count = 0;
+        foreach (var item in allResources)
+        {
+            // Skip hidden resources
+            if (string.Equals(item.State, "Hidden", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (string.Equals(item.DisplayName, resource.DisplayName, StringComparisons.ResourceName))
+            {
+                count++;
+                if (count >= 2)
+                {
+                    // There are multiple resources with the same display name so they're part of a replica set.
+                    // Need to use the name which has a unique ID to tell them apart.
+                    return resource.Name;
+                }
+            }
+        }
+
+        return resource.DisplayName ?? resource.Name;
+    }
+}

--- a/src/Aspire.Cli/Backchannel/ResourceSnapshotMapper.cs
+++ b/src/Aspire.Cli/Backchannel/ResourceSnapshotMapper.cs
@@ -115,18 +115,18 @@ internal static class ResourceSnapshotMapper
             State = snapshot.State,
             StateStyle = snapshot.StateStyle,
             HealthStatus = snapshot.HealthStatus,
+            Source = sourceViewModel?.Value,
             ExitCode = snapshot.ExitCode,
             CreationTimestamp = snapshot.CreatedAt,
             StartTimestamp = snapshot.StartedAt,
             StopTimestamp = snapshot.StoppedAt,
+            DashboardUrl = dashboardUrl,
             Urls = urls,
             Volumes = volumes,
             HealthReports = healthReports,
             Properties = properties,
             Relationships = relationships.ToArray(),
-            Commands = commands,
-            Source = sourceViewModel?.Value,
-            DashboardUrl = dashboardUrl
+            Commands = commands
         };
     }
 

--- a/src/Aspire.Cli/Commands/McpStartCommand.cs
+++ b/src/Aspire.Cli/Commands/McpStartCommand.cs
@@ -60,7 +60,7 @@ internal sealed class McpStartCommand : BaseCommand
     {
         // Display deprecation warning to stderr (all MCP logging goes to stderr)
         InteractionService.DisplayMarkupLine($"[yellow]⚠ {McpCommandStrings.DeprecatedCommandWarning}[/]");
-        
+
         // Delegate to the new AgentMcpCommand
         return _agentMcpCommand.ExecuteCommandAsync(parseResult, cancellationToken);
     }

--- a/src/Aspire.Cli/Commands/ResourcesCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourcesCommand.cs
@@ -256,8 +256,8 @@ internal sealed class ResourcesCommand : BaseCommand
 
         foreach (var (snapshot, displayName) in orderedItems)
         {
-            var endpoints = snapshot.Endpoints.Length > 0
-                ? string.Join(", ", snapshot.Endpoints.Where(e => !e.IsInternal).Select(e => e.Url))
+            var endpoints = snapshot.Urls.Length > 0
+                ? string.Join(", ", snapshot.Urls.Where(e => !e.IsInternal).Select(e => e.Url))
                 : "-";
 
             var type = snapshot.ResourceType ?? "-";
@@ -274,8 +274,8 @@ internal sealed class ResourcesCommand : BaseCommand
     {
         var displayName = ResourceSnapshotMapper.GetResourceName(snapshot, allResources);
 
-        var endpoints = snapshot.Endpoints.Length > 0
-            ? string.Join(", ", snapshot.Endpoints.Where(e => !e.IsInternal).Select(e => e.Url))
+        var endpoints = snapshot.Urls.Length > 0
+            ? string.Join(", ", snapshot.Urls.Where(e => !e.IsInternal).Select(e => e.Url))
             : "";
 
         var health = !string.IsNullOrEmpty(snapshot.HealthStatus) ? $" ({snapshot.HealthStatus})" : "";

--- a/src/Aspire.Cli/Commands/ResourcesCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourcesCommand.cs
@@ -32,6 +32,7 @@ internal sealed class ResourcesOutput
 [JsonSerializable(typeof(ResourceHealthReportJson))]
 [JsonSerializable(typeof(ResourcePropertyJson))]
 [JsonSerializable(typeof(ResourceRelationshipJson))]
+[JsonSerializable(typeof(ResourceCommandJson))]
 [JsonSourceGenerationOptions(
     WriteIndented = true,
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
@@ -148,8 +149,14 @@ internal sealed class ResourcesCommand : BaseCommand
 
     private async Task<int> ExecuteSnapshotAsync(AppHostAuxiliaryBackchannel connection, string? resourceName, OutputFormat format, CancellationToken cancellationToken)
     {
-        // Get current resource snapshots using the dedicated RPC method
-        var snapshots = await connection.GetResourceSnapshotsAsync(cancellationToken).ConfigureAwait(false);
+        // Get dashboard URL and resource snapshots in parallel
+        var dashboardUrlsTask = connection.GetDashboardUrlsAsync(cancellationToken);
+        var snapshotsTask = connection.GetResourceSnapshotsAsync(cancellationToken);
+
+        await Task.WhenAll(dashboardUrlsTask, snapshotsTask).ConfigureAwait(false);
+
+        var dashboardUrls = await dashboardUrlsTask.ConfigureAwait(false);
+        var snapshots = await snapshotsTask.ConfigureAwait(false);
 
         // Filter by resource name if specified
         if (resourceName is not null)
@@ -164,7 +171,9 @@ internal sealed class ResourcesCommand : BaseCommand
             return ExitCodeConstants.FailedToFindProject;
         }
 
-        var resourceList = snapshots.Select(MapToResourceJson).ToList();
+        // Use the dashboard base URL if available
+        var dashboardBaseUrl = dashboardUrls?.BaseUrlWithLoginToken;
+        var resourceList = ResourceSnapshotMapper.MapToResourceJsonList(snapshots, dashboardBaseUrl);
 
         if (format == OutputFormat.Json)
         {
@@ -174,7 +183,7 @@ internal sealed class ResourcesCommand : BaseCommand
         }
         else
         {
-            DisplayResourcesTable(resourceList);
+            DisplayResourcesTable(snapshots);
         }
 
         return ExitCodeConstants.Success;
@@ -182,16 +191,26 @@ internal sealed class ResourcesCommand : BaseCommand
 
     private async Task<int> ExecuteWatchAsync(AppHostAuxiliaryBackchannel connection, string? resourceName, OutputFormat format, CancellationToken cancellationToken)
     {
+        // Get dashboard URL first for generating resource links
+        var dashboardUrls = await connection.GetDashboardUrlsAsync(cancellationToken).ConfigureAwait(false);
+        var dashboardBaseUrl = dashboardUrls?.BaseUrlWithLoginToken;
+
+        // Maintain a dictionary of all resources seen so far for relationship resolution
+        var allResources = new Dictionary<string, ResourceSnapshot>(StringComparer.OrdinalIgnoreCase);
+
         // Stream resource snapshots
         await foreach (var snapshot in connection.WatchResourceSnapshotsAsync(cancellationToken).ConfigureAwait(false))
         {
+            // Update the dictionary with the latest snapshot for this resource
+            allResources[snapshot.Name] = snapshot;
+
             // Filter by resource name if specified
             if (resourceName is not null && !string.Equals(snapshot.Name, resourceName, StringComparison.OrdinalIgnoreCase))
             {
                 continue;
             }
 
-            var resourceJson = MapToResourceJson(snapshot);
+            var resourceJson = ResourceSnapshotMapper.MapToResourceJson(snapshot, allResources.Values.ToList(), dashboardBaseUrl);
 
             if (format == OutputFormat.Json)
             {
@@ -202,26 +221,31 @@ internal sealed class ResourcesCommand : BaseCommand
             else
             {
                 // Human-readable update
-                DisplayResourceUpdate(resourceJson);
+                DisplayResourceUpdate(snapshot, allResources);
             }
         }
 
         return ExitCodeConstants.Success;
     }
 
-    private void DisplayResourcesTable(List<ResourceJson> resources)
+    private void DisplayResourcesTable(IReadOnlyList<ResourceSnapshot> snapshots)
     {
-        if (resources.Count == 0)
+        if (snapshots.Count == 0)
         {
             _interactionService.DisplayPlainText("No resources found.");
             return;
         }
 
+        // Get display names for all resources
+        var orderedItems = snapshots.Select(s => (Snapshot: s, DisplayName: ResourceSnapshotMapper.GetResourceName(s, snapshots)))
+            .OrderBy(x => x.DisplayName)
+            .ToList();;
+
         // Calculate column widths based on data
-        var nameWidth = Math.Max("NAME".Length, resources.Max(r => r.Name?.Length ?? 0));
-        var typeWidth = Math.Max("TYPE".Length, resources.Max(r => r.ResourceType?.Length ?? 0));
-        var stateWidth = Math.Max("STATE".Length, resources.Max(r => r.State?.Length ?? "Unknown".Length));
-        var healthWidth = Math.Max("HEALTH".Length, resources.Max(r => r.HealthStatus?.Length ?? 1));
+        var nameWidth = Math.Max("NAME".Length, orderedItems.Max(i => i.DisplayName.Length));
+        var typeWidth = Math.Max("TYPE".Length, orderedItems.Max(i => i.Snapshot.ResourceType?.Length ?? 0));
+        var stateWidth = Math.Max("STATE".Length, orderedItems.Max(i => i.Snapshot.State?.Length ?? "Unknown".Length));
+        var healthWidth = Math.Max("HEALTH".Length, orderedItems.Max(i => i.Snapshot.HealthStatus?.Length ?? 1));
 
         var totalWidth = nameWidth + typeWidth + stateWidth + healthWidth + 12 + 20; // 12 for spacing, 20 for endpoints min
 
@@ -230,89 +254,33 @@ internal sealed class ResourcesCommand : BaseCommand
         _interactionService.DisplayPlainText($"{"NAME".PadRight(nameWidth)}  {"TYPE".PadRight(typeWidth)}  {"STATE".PadRight(stateWidth)}  {"HEALTH".PadRight(healthWidth)}  {"ENDPOINTS"}");
         _interactionService.DisplayPlainText(new string('-', totalWidth));
 
-        foreach (var resource in resources.OrderBy(r => r.Name))
+        foreach (var (snapshot, displayName) in orderedItems)
         {
-            var endpoints = resource.Urls?.Length > 0
-                ? string.Join(", ", resource.Urls.Where(u => !u.IsInternal).Select(u => u.Url))
+            var endpoints = snapshot.Endpoints.Length > 0
+                ? string.Join(", ", snapshot.Endpoints.Where(e => !e.IsInternal).Select(e => e.Url))
                 : "-";
 
-            var name = resource.Name ?? "-";
-            var type = resource.ResourceType ?? "-";
-            var state = resource.State ?? "Unknown";
-            var health = resource.HealthStatus ?? "-";
+            var type = snapshot.ResourceType ?? "-";
+            var state = snapshot.State ?? "Unknown";
+            var health = snapshot.HealthStatus ?? "-";
 
-            _interactionService.DisplayPlainText($"{name.PadRight(nameWidth)}  {type.PadRight(typeWidth)}  {state.PadRight(stateWidth)}  {health.PadRight(healthWidth)}  {endpoints}");
+            _interactionService.DisplayPlainText($"{displayName.PadRight(nameWidth)}  {type.PadRight(typeWidth)}  {state.PadRight(stateWidth)}  {health.PadRight(healthWidth)}  {endpoints}");
         }
 
         _interactionService.DisplayPlainText("");
     }
 
-    private void DisplayResourceUpdate(ResourceJson resource)
+    private void DisplayResourceUpdate(ResourceSnapshot snapshot, IDictionary<string, ResourceSnapshot> allResources)
     {
-        var endpoints = resource.Urls?.Length > 0
-            ? string.Join(", ", resource.Urls.Where(u => !u.IsInternal).Select(u => u.Url))
+        var displayName = ResourceSnapshotMapper.GetResourceName(snapshot, allResources);
+
+        var endpoints = snapshot.Endpoints.Length > 0
+            ? string.Join(", ", snapshot.Endpoints.Where(e => !e.IsInternal).Select(e => e.Url))
             : "";
 
-        var health = !string.IsNullOrEmpty(resource.HealthStatus) ? $" ({resource.HealthStatus})" : "";
+        var health = !string.IsNullOrEmpty(snapshot.HealthStatus) ? $" ({snapshot.HealthStatus})" : "";
         var endpointsStr = !string.IsNullOrEmpty(endpoints) ? $" - {endpoints}" : "";
 
-        _interactionService.DisplayPlainText($"[{resource.Name}] {resource.State ?? "Unknown"}{health}{endpointsStr}");
-    }
-
-    private static ResourceJson MapToResourceJson(ResourceSnapshot snapshot)
-    {
-        return new ResourceJson
-        {
-            Name = snapshot.Name,
-            DisplayName = snapshot.Name, // Use name as display name for now
-            ResourceType = snapshot.Type,
-            State = snapshot.State,
-            StateStyle = snapshot.StateStyle,
-            CreationTimestamp = snapshot.CreatedAt,
-            StartTimestamp = snapshot.StartedAt,
-            StopTimestamp = snapshot.StoppedAt,
-            ExitCode = snapshot.ExitCode,
-            HealthStatus = snapshot.HealthStatus,
-            Urls = snapshot.Endpoints is { Length: > 0 }
-                ? snapshot.Endpoints.Select(e => new ResourceUrlJson
-                {
-                    Name = e.Name,
-                    Url = e.Url,
-                    IsInternal = e.IsInternal
-                }).ToArray()
-                : null,
-            Volumes = snapshot.Volumes is { Length: > 0 }
-                ? snapshot.Volumes.Select(v => new ResourceVolumeJson
-                {
-                    Source = v.Source,
-                    Target = v.Target,
-                    MountType = v.MountType,
-                    IsReadOnly = v.IsReadOnly
-                }).ToArray()
-                : null,
-            HealthReports = snapshot.HealthReports is { Length: > 0 }
-                ? snapshot.HealthReports.Select(h => new ResourceHealthReportJson
-                {
-                    Name = h.Name,
-                    Status = h.Status,
-                    Description = h.Description,
-                    ExceptionMessage = h.ExceptionText
-                }).ToArray()
-                : null,
-            Properties = snapshot.Properties is { Count: > 0 }
-                ? snapshot.Properties.Select(p => new ResourcePropertyJson
-                {
-                    Name = p.Key,
-                    Value = p.Value
-                }).ToArray()
-                : null,
-            Relationships = snapshot.Relationships is { Length: > 0 }
-                ? snapshot.Relationships.Select(r => new ResourceRelationshipJson
-                {
-                    Type = r.Type,
-                    ResourceName = r.ResourceName
-                }).ToArray()
-                : null
-        };
+        _interactionService.DisplayPlainText($"[{displayName}] {snapshot.State ?? "Unknown"}{health}{endpointsStr}");
     }
 }

--- a/src/Aspire.Cli/Mcp/KnownMcpTools.cs
+++ b/src/Aspire.Cli/Mcp/KnownMcpTools.cs
@@ -32,10 +32,10 @@ internal static class KnownMcpTools
         KnownMcpTools.RefreshTools or
         KnownMcpTools.ListDocs or
         KnownMcpTools.SearchDocs or
-        KnownMcpTools.GetDoc;
+        KnownMcpTools.GetDoc or
+        KnownMcpTools.ListResources;
 
     public static bool IsDashboardTool(string toolName) => toolName is
-        KnownMcpTools.ListResources or
         KnownMcpTools.ListConsoleLogs or
         KnownMcpTools.ExecuteResourceCommand or
         KnownMcpTools.ListStructuredLogs or

--- a/src/Aspire.Cli/Mcp/McpErrorMessages.cs
+++ b/src/Aspire.Cli/Mcp/McpErrorMessages.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Mcp;
+
+/// <summary>
+/// Provides common error messages used by MCP tools.
+/// </summary>
+internal static class McpErrorMessages
+{
+    /// <summary>
+    /// Error message when no Aspire AppHost is currently running.
+    /// </summary>
+    public const string NoAppHostRunning =
+        "No Aspire AppHost is currently running. " +
+        "To use Aspire MCP tools, you must first start an Aspire application by running 'aspire run' in your AppHost project directory. " +
+        "Once the application is running, the MCP tools will be able to connect to the dashboard and execute commands.";
+
+    /// <summary>
+    /// Error message when the dashboard is not available in the running AppHost.
+    /// </summary>
+    public const string DashboardNotAvailable =
+        "The Aspire Dashboard is not available in the running AppHost. " +
+        "The dashboard must be enabled to use MCP tools. " +
+        "Ensure your AppHost is configured with the dashboard enabled (this is the default configuration).";
+}

--- a/src/Aspire.Cli/Mcp/Tools/ListResourcesTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListResourcesTool.cs
@@ -1,13 +1,50 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using Aspire.Cli.Backchannel;
+using Aspire.Shared.Model.Serialization;
+using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
 
 namespace Aspire.Cli.Mcp.Tools;
 
-internal sealed class ListResourcesTool : CliMcpTool
+[JsonSerializable(typeof(ResourceJson[]))]
+[JsonSerializable(typeof(ResourceUrlJson))]
+[JsonSerializable(typeof(ResourceVolumeJson))]
+[JsonSerializable(typeof(ResourceEnvironmentVariableJson))]
+[JsonSerializable(typeof(ResourceHealthReportJson))]
+[JsonSerializable(typeof(ResourcePropertyJson))]
+[JsonSerializable(typeof(ResourceRelationshipJson))]
+[JsonSerializable(typeof(ResourceCommandJson))]
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+internal sealed partial class ListResourcesToolJsonContext : JsonSerializerContext
+{
+    private static ListResourcesToolJsonContext? s_relaxedEscaping;
+
+    /// <summary>
+    /// Gets a context with relaxed JSON escaping for non-ASCII character support (pretty-printed).
+    /// </summary>
+    public static ListResourcesToolJsonContext RelaxedEscaping => s_relaxedEscaping ??= new(new JsonSerializerOptions
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    });
+}
+
+/// <summary>
+/// MCP tool for listing application resources.
+/// Gets resource data directly from the AppHost backchannel instead of forwarding to the dashboard.
+/// </summary>
+internal sealed class ListResourcesTool(IAuxiliaryBackchannelMonitor auxiliaryBackchannelMonitor, ILogger<ListResourcesTool> logger) : CliMcpTool
 {
     public override string Name => KnownMcpTools.ListResources;
 
@@ -20,22 +57,62 @@ internal sealed class ListResourcesTool : CliMcpTool
 
     public override async ValueTask<CallToolResult> CallToolAsync(ModelContextProtocol.Client.McpClient mcpClient, IReadOnlyDictionary<string, JsonElement>? arguments, CancellationToken cancellationToken)
     {
-        // Convert JsonElement arguments to Dictionary<string, object?>
-        Dictionary<string, object?>? convertedArgs = null;
-        if (arguments != null)
+        // This tool does not use the MCP client as it operates via backchannel
+        _ = mcpClient;
+        _ = arguments;
+
+        var connection = await AppHostConnectionHelper.GetSelectedConnectionAsync(auxiliaryBackchannelMonitor, logger, cancellationToken).ConfigureAwait(false);
+        if (connection is null)
         {
-            convertedArgs = new Dictionary<string, object?>();
-            foreach (var kvp in arguments)
-            {
-                convertedArgs[kvp.Key] = kvp.Value.ValueKind == JsonValueKind.Null ? null : kvp.Value;
-            }
+            logger.LogWarning("No Aspire AppHost is currently running");
+            throw new McpProtocolException(McpErrorMessages.NoAppHostRunning, McpErrorCode.InternalError);
         }
 
-        // Forward the call to the dashboard's MCP server
-        return await mcpClient.CallToolAsync(
-            Name,
-            convertedArgs,
-            serializerOptions: McpJsonUtilities.DefaultOptions,
-            cancellationToken: cancellationToken);
+        try
+        {
+            // Get dashboard URL and resource snapshots in parallel
+            var dashboardUrlsTask = connection.GetDashboardUrlsAsync(cancellationToken);
+            var snapshotsTask = connection.GetResourceSnapshotsAsync(cancellationToken);
+
+            await Task.WhenAll(dashboardUrlsTask, snapshotsTask).ConfigureAwait(false);
+
+            var dashboardUrls = await dashboardUrlsTask.ConfigureAwait(false);
+            var snapshots = await snapshotsTask.ConfigureAwait(false);
+
+            if (snapshots.Count == 0)
+            {
+                return new CallToolResult
+                {
+                    Content = [new TextContentBlock { Text = "No resources found." }]
+                };
+            }
+
+            // Use the dashboard base URL if available
+            var dashboardBaseUrl = dashboardUrls?.BaseUrlWithLoginToken;
+            var resources = ResourceSnapshotMapper.MapToResourceJsonList(snapshots, dashboardBaseUrl);
+            var resourceGraphData = JsonSerializer.Serialize(resources.ToArray(), ListResourcesToolJsonContext.RelaxedEscaping.ResourceJsonArray);
+
+            var response = $"""
+            resource_name is the identifier of resources.
+            environment_variables is a list of environment variables configured for the resource. Environment variable values aren't provided because they could contain sensitive information.
+            Console logs for a resource can provide more information about why a resource is not in a running state.
+
+            # RESOURCE DATA
+
+            {resourceGraphData}
+            """;
+
+            return new CallToolResult
+            {
+                Content = [new TextContentBlock { Text = response }]
+            };
+        }
+        catch
+        {
+            return new CallToolResult
+            {
+                Content = [new TextContentBlock { Text = "No resources found." }]
+            };
+        }
     }
 }

--- a/src/Aspire.Cli/Properties/launchSettings.json
+++ b/src/Aspire.Cli/Properties/launchSettings.json
@@ -62,6 +62,14 @@
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
+    "get-resources": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "commandLineArgs": "resources --project ../../../../../playground/TestShop/TestShop.AppHost/TestShop.AppHost.csproj",
+      "environmentVariables": {
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+      }
+    },
     "run-singlefileapphost": {
       "commandName": "Project",
       "dotnetRunMessages": true,

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -288,6 +288,7 @@
     <Compile Include="$(SharedDir)Model\KnownProperties.cs" Link="Utils\KnownProperties.cs" />
     <Compile Include="$(SharedDir)Model\KnownResourceTypes.cs" Link="Utils\KnownResourceTypes.cs" />
     <Compile Include="$(SharedDir)Model\KnownRelationshipTypes.cs" Link="Utils\KnownRelationshipTypes.cs" />
+    <Compile Include="$(SharedDir)Model\ResourceSourceViewModel.cs" Link="Model\ResourceSourceViewModel.shared.cs" />
     <Compile Include="$(SharedDir)CircularBuffer.cs" Link="Otlp\Storage\CircularBuffer.cs" />
     <Compile Include="$(SharedDir)DashboardConfigNames.cs" Link="Utils\DashboardConfigNames.cs" />
     <Compile Include="$(SharedDir)DurationFormatter.cs" Link="Utils\DurationFormatter.cs" />
@@ -302,6 +303,8 @@
     <Compile Include="$(SharedDir)InteractionHelpers.cs" Link="Utils\InteractionHelpers.cs" />
     <Compile Include="$(SharedDir)Mcp\McpIconHelper.cs" Link="Mcp\McpIconHelper.cs" />
     <Compile Include="$(SharedDir)Model\Serialization\ResourceJson.cs" Link="Model\Serialization\ResourceJson.cs" />
+    <Compile Include="$(SharedDir)DashboardUrls.cs" Link="Utils\DashboardUrls.cs" />
+
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -304,7 +304,6 @@
     <Compile Include="$(SharedDir)Mcp\McpIconHelper.cs" Link="Mcp\McpIconHelper.cs" />
     <Compile Include="$(SharedDir)Model\Serialization\ResourceJson.cs" Link="Model\Serialization\ResourceJson.cs" />
     <Compile Include="$(SharedDir)DashboardUrls.cs" Link="Utils\DashboardUrls.cs" />
-
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
@@ -45,9 +45,6 @@ public partial class ResourceActions : ComponentBase
     public required ResourceViewModel Resource { get; set; }
 
     [Parameter]
-    public required Func<ResourceViewModel, string> GetResourceName { get; set; }
-
-    [Parameter]
     public required int MaxHighlightedCount { get; set; }
 
     [Parameter]
@@ -67,8 +64,7 @@ public partial class ResourceActions : ComponentBase
         ResourceMenuBuilder.AddMenuItems(
             _menuItems,
             Resource,
-            (IReadOnlyList<ResourceViewModel>)ResourceByName.Values.ToList(),
-            GetResourceName,
+            ResourceByName,
             EventCallback.Factory.Create(this, () => OnViewDetails.InvokeAsync(_menuButton?.MenuButtonId)),
             CommandSelected,
             IsCommandExecuting,

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
@@ -67,6 +67,7 @@ public partial class ResourceActions : ComponentBase
         ResourceMenuBuilder.AddMenuItems(
             _menuItems,
             Resource,
+            (IReadOnlyList<ResourceViewModel>)ResourceByName.Values.ToList(),
             GetResourceName,
             EventCallback.Factory.Create(this, () => OnViewDetails.InvokeAsync(_menuButton?.MenuButtonId)),
             CommandSelected,

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -268,6 +268,7 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
         ResourceMenuBuilder.AddMenuItems(
             _resourceActionsMenuItems,
             Resource,
+            (IReadOnlyList<ResourceViewModel>)ResourceByName.Values.ToList(),
             FormatName,
             EventCallback.Empty, // View details not shown since we're already in the details view
             CommandSelected,

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -268,8 +268,7 @@ public partial class ResourceDetails : IComponentWithTelemetry, IDisposable
         ResourceMenuBuilder.AddMenuItems(
             _resourceActionsMenuItems,
             Resource,
-            (IReadOnlyList<ResourceViewModel>)ResourceByName.Values.ToList(),
-            FormatName,
+            ResourceByName,
             EventCallback.Empty, // View details not shown since we're already in the details view
             CommandSelected,
             IsCommandExecuting,

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -505,8 +505,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
             ResourceMenuBuilder.AddMenuItems(
                 _resourceMenuItems,
                 selectedResource,
-                (IReadOnlyList<ResourceViewModel>)_resourceByName.Values.ToList(),
-                GetResourceName,
+                _resourceByName,
                 EventCallback.Factory.Create(this, () =>
                 {
                     NavigationManager.NavigateTo(DashboardUrls.ResourcesUrl(resource: selectedResource.Name));
@@ -779,7 +778,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
                     }
                 }
 
-                var resourcePrefix = ResourceViewModel.GetResourceName(subscription.Resource, _resourceByName, _showHiddenResources);
+                var resourcePrefix = ResourceViewModel.GetResourceName(subscription.Resource, _resourceByName);
 
                 var logParser = new LogParser(ConsoleColor.Black);
                 await foreach (var batch in logSubscription.ConfigureAwait(false))

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -505,6 +505,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
             ResourceMenuBuilder.AddMenuItems(
                 _resourceMenuItems,
                 selectedResource,
+                (IReadOnlyList<ResourceViewModel>)_resourceByName.Values.ToList(),
                 GetResourceName,
                 EventCallback.Factory.Create(this, () =>
                 {

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -205,7 +205,6 @@
                                                                      IsCommandExecuting="@((resource, command) => DashboardCommandExecutor.IsExecuting(resource.Name, command.Name))"
                                                                      OnViewDetails="@((buttonId) => ShowResourceDetailsAsync(context.Resource, buttonId))"
                                                                      Resource="context.Resource"
-                                                                     GetResourceName="GetResourceName"
                                                                      MaxHighlightedCount="_maxHighlightedCount"
                                                                      ResourceByName="@_resourceByName" />
                                                 </div>

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -643,6 +643,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             ResourceMenuBuilder.AddMenuItems(
                 _contextMenuItems,
                 resource,
+                (IReadOnlyList<ResourceViewModel>)_resourceByName.Values.ToList(),
                 GetResourceName,
                 EventCallback.Factory.Create(this, () => ShowResourceDetailsAsync(resource, buttonId: null)),
                 EventCallback.Factory.Create<CommandViewModel>(this, (command) => ExecuteResourceCommandAsync(resource, command)),

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -643,8 +643,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
             ResourceMenuBuilder.AddMenuItems(
                 _contextMenuItems,
                 resource,
-                (IReadOnlyList<ResourceViewModel>)_resourceByName.Values.ToList(),
-                GetResourceName,
+                _resourceByName,
                 EventCallback.Factory.Create(this, () => ShowResourceDetailsAsync(resource, buttonId: null)),
                 EventCallback.Factory.Create<CommandViewModel>(this, (command) => ExecuteResourceCommandAsync(resource, command)),
                 (resource, command) => DashboardCommandExecutor.IsExecuting(resource.Name, command.Name),
@@ -735,7 +734,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
         _elementIdBeforeDetailsViewOpened = null;
     }
 
-    private string GetResourceName(ResourceViewModel resource) => ResourceViewModel.GetResourceName(resource, _resourceByName, _showHiddenResources);
+    private string GetResourceName(ResourceViewModel resource) => ResourceViewModel.GetResourceName(resource, _resourceByName);
 
     private bool HasMultipleReplicas(ResourceViewModel resource)
     {

--- a/src/Aspire.Dashboard/Model/Assistant/Prompts/KnownChatMessages.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/Prompts/KnownChatMessages.cs
@@ -84,7 +84,7 @@ internal static class KnownChatMessages
                 Summarize recent traces and structured logs for all resources.
                 Investigate the root cause of any errors in traces or structured logs.
                 """;
-                
+
             return new(ChatRole.User, prompt);
         }
 

--- a/src/Aspire.Dashboard/Model/ExportHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ExportHelpers.cs
@@ -62,11 +62,12 @@ internal static class ExportHelpers
     /// Gets a resource as a JSON export result.
     /// </summary>
     /// <param name="resource">The resource to convert.</param>
+    /// <param name="allResources">All resources for resolving relationships.</param>
     /// <param name="getResourceName">A function to resolve the resource name for the file name.</param>
     /// <returns>A result containing the JSON representation and suggested file name.</returns>
-    public static ExportResult GetResourceAsJson(ResourceViewModel resource, Func<ResourceViewModel, string> getResourceName)
+    public static ExportResult GetResourceAsJson(ResourceViewModel resource, IReadOnlyList<ResourceViewModel> allResources, Func<ResourceViewModel, string> getResourceName)
     {
-        var json = TelemetryExportService.ConvertResourceToJson(resource);
+        var json = TelemetryExportService.ConvertResourceToJson(resource, allResources);
         var fileName = $"{getResourceName(resource)}.json";
         return new ExportResult(json, fileName);
     }

--- a/src/Aspire.Dashboard/Model/ExportHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ExportHelpers.cs
@@ -62,13 +62,12 @@ internal static class ExportHelpers
     /// Gets a resource as a JSON export result.
     /// </summary>
     /// <param name="resource">The resource to convert.</param>
-    /// <param name="allResources">All resources for resolving relationships.</param>
-    /// <param name="getResourceName">A function to resolve the resource name for the file name.</param>
+    /// <param name="resourceByName">All resources for resolving relationships and resource names.</param>
     /// <returns>A result containing the JSON representation and suggested file name.</returns>
-    public static ExportResult GetResourceAsJson(ResourceViewModel resource, IReadOnlyList<ResourceViewModel> allResources, Func<ResourceViewModel, string> getResourceName)
+    public static ExportResult GetResourceAsJson(ResourceViewModel resource, IDictionary<string, ResourceViewModel> resourceByName)
     {
-        var json = TelemetryExportService.ConvertResourceToJson(resource, allResources);
-        var fileName = $"{getResourceName(resource)}.json";
+        var json = TelemetryExportService.ConvertResourceToJson(resource, resourceByName.Values.ToList());
+        var fileName = $"{ResourceViewModel.GetResourceName(resource, resourceByName)}.json";
         return new ExportResult(json, fileName);
     }
 
@@ -76,12 +75,12 @@ internal static class ExportHelpers
     /// Gets environment variables as a .env file export result.
     /// </summary>
     /// <param name="resource">The resource containing environment variables.</param>
-    /// <param name="getResourceName">A function to resolve the resource name for the file name.</param>
+    /// <param name="resourceByName">All resources for resolving resource names.</param>
     /// <returns>A result containing the .env file content and suggested file name.</returns>
-    public static ExportResult GetEnvironmentVariablesAsEnvFile(ResourceViewModel resource, Func<ResourceViewModel, string> getResourceName)
+    public static ExportResult GetEnvironmentVariablesAsEnvFile(ResourceViewModel resource, IDictionary<string, ResourceViewModel> resourceByName)
     {
         var envContent = EnvHelpers.ConvertToEnvFormat(resource.Environment.Select(e => new KeyValuePair<string, string?>(e.Name, e.Value)));
-        var fileName = $"{getResourceName(resource)}.env";
+        var fileName = $"{ResourceViewModel.GetResourceName(resource, resourceByName)}.env";
         return new ExportResult(envContent, fileName);
     }
 }

--- a/src/Aspire.Dashboard/Model/ResourceMenuBuilder.cs
+++ b/src/Aspire.Dashboard/Model/ResourceMenuBuilder.cs
@@ -73,8 +73,7 @@ public sealed class ResourceMenuBuilder
     public void AddMenuItems(
         List<MenuButtonItem> menuItems,
         ResourceViewModel resource,
-        IReadOnlyList<ResourceViewModel> allResources,
-        Func<ResourceViewModel, string> getResourceName,
+        IDictionary<string, ResourceViewModel> resourceByName,
         EventCallback onViewDetails,
         EventCallback<CommandViewModel> commandSelected,
         Func<ResourceViewModel, CommandViewModel, bool> isCommandExecuting,
@@ -100,7 +99,7 @@ public sealed class ResourceMenuBuilder
                 Icon = s_consoleLogsIcon,
                 OnClick = () =>
                 {
-                    _navigationManager.NavigateTo(DashboardUrls.ConsoleLogsUrl(resource: getResourceName(resource)));
+                    _navigationManager.NavigateTo(DashboardUrls.ConsoleLogsUrl(resource: ResourceViewModel.GetResourceName(resource, resourceByName)));
                     return Task.CompletedTask;
                 }
             });
@@ -112,7 +111,7 @@ public sealed class ResourceMenuBuilder
             Icon = s_bracesIcon,
             OnClick = async () =>
             {
-                var result = ExportHelpers.GetResourceAsJson(resource, allResources, getResourceName);
+                var result = ExportHelpers.GetResourceAsJson(resource, resourceByName);
                 await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
                 {
                     DialogService = _dialogService,
@@ -133,7 +132,7 @@ public sealed class ResourceMenuBuilder
                 Icon = s_exportEnvIcon,
                 OnClick = async () =>
                 {
-                    var result = ExportHelpers.GetEnvironmentVariablesAsEnvFile(resource, getResourceName);
+                    var result = ExportHelpers.GetEnvironmentVariablesAsEnvFile(resource, resourceByName);
                     await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
                     {
                         DialogService = _dialogService,
@@ -164,7 +163,7 @@ public sealed class ResourceMenuBuilder
             });
         }
 
-        AddTelemetryMenuItems(menuItems, resource, getResourceName);
+        AddTelemetryMenuItems(menuItems, resource, resourceByName);
 
         AddCommandMenuItems(menuItems, resource, commandSelected, isCommandExecuting);
 
@@ -231,7 +230,7 @@ public sealed class ResourceMenuBuilder
         };
     }
 
-    private void AddTelemetryMenuItems(List<MenuButtonItem> menuItems, ResourceViewModel resource, Func<ResourceViewModel, string> getResourceName)
+    private void AddTelemetryMenuItems(List<MenuButtonItem> menuItems, ResourceViewModel resource, IDictionary<string, ResourceViewModel> resourceByName)
     {
         // Show telemetry menu items if there is telemetry for the resource.
         var telemetryResource = _telemetryRepository.GetResourceByCompositeName(resource.Name);
@@ -248,7 +247,7 @@ public sealed class ResourceMenuBuilder
                     Icon = s_structuredLogsIcon,
                     OnClick = () =>
                     {
-                        _navigationManager.NavigateTo(DashboardUrls.StructuredLogsUrl(resource: getResourceName(resource)));
+                        _navigationManager.NavigateTo(DashboardUrls.StructuredLogsUrl(resource: ResourceViewModel.GetResourceName(resource, resourceByName)));
                         return Task.CompletedTask;
                     }
                 });
@@ -261,7 +260,7 @@ public sealed class ResourceMenuBuilder
                 Icon = s_tracesIcon,
                 OnClick = () =>
                 {
-                    _navigationManager.NavigateTo(DashboardUrls.TracesUrl(resource: getResourceName(resource)));
+                    _navigationManager.NavigateTo(DashboardUrls.TracesUrl(resource: ResourceViewModel.GetResourceName(resource, resourceByName)));
                     return Task.CompletedTask;
                 }
             });
@@ -275,7 +274,7 @@ public sealed class ResourceMenuBuilder
                     Icon = s_metricsIcon,
                     OnClick = () =>
                     {
-                        _navigationManager.NavigateTo(DashboardUrls.MetricsUrl(resource: getResourceName(resource)));
+                        _navigationManager.NavigateTo(DashboardUrls.MetricsUrl(resource: ResourceViewModel.GetResourceName(resource, resourceByName)));
                         return Task.CompletedTask;
                     }
                 });

--- a/src/Aspire.Dashboard/Model/ResourceMenuBuilder.cs
+++ b/src/Aspire.Dashboard/Model/ResourceMenuBuilder.cs
@@ -73,6 +73,7 @@ public sealed class ResourceMenuBuilder
     public void AddMenuItems(
         List<MenuButtonItem> menuItems,
         ResourceViewModel resource,
+        IReadOnlyList<ResourceViewModel> allResources,
         Func<ResourceViewModel, string> getResourceName,
         EventCallback onViewDetails,
         EventCallback<CommandViewModel> commandSelected,
@@ -111,7 +112,7 @@ public sealed class ResourceMenuBuilder
             Icon = s_bracesIcon,
             OnClick = async () =>
             {
-                var result = ExportHelpers.GetResourceAsJson(resource, getResourceName);
+                var result = ExportHelpers.GetResourceAsJson(resource, allResources, getResourceName);
                 await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
                 {
                     DialogService = _dialogService,

--- a/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
@@ -2,10 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Utils;
+using Aspire.Shared.Model;
 
 namespace Aspire.Dashboard.Model;
 
-public class ResourceSourceViewModel(string value, List<LaunchArgument>? contentAfterValue, string valueToVisualize, string tooltip)
+public record LaunchArgument(string Value, bool IsShown);
+
+internal sealed record ResourceSourceViewModel(string value, List<LaunchArgument>? contentAfterValue, string valueToVisualize, string tooltip)
 {
     public string Value { get; } = value;
     public List<LaunchArgument>? ContentAfterValue { get; } = contentAfterValue;
@@ -14,84 +17,70 @@ public class ResourceSourceViewModel(string value, List<LaunchArgument>? content
 
     internal static ResourceSourceViewModel? GetSourceViewModel(ResourceViewModel resource)
     {
-        var commandLineInfo = GetCommandLineInfo(resource);
+        var properties = resource.GetPropertiesAsDictionary();
 
-        // NOTE project and tools are also executables, so check for those first
-        if (resource.IsProject() && resource.TryGetProjectPath(out var projectPath))
+        var source = ResourceSource.GetSourceModel(resource.ResourceType, properties);
+        if (source is null)
         {
-            return CreateResourceSourceViewModel(Path.GetFileName(projectPath), projectPath, commandLineInfo);
-        }
-        if (resource.IsTool() && resource.TryGetToolPackage(out var toolPackage))
-        {
-            return CreateResourceSourceViewModel(toolPackage, toolPackage, commandLineInfo);
-        }
-
-        if (resource.TryGetExecutablePath(out var executablePath))
-        {
-            return CreateResourceSourceViewModel(Path.GetFileName(executablePath), executablePath, commandLineInfo);
-        }
-
-        if (resource.TryGetContainerImage(out var containerImage))
-        {
-            return CreateResourceSourceViewModel(containerImage, containerImage, commandLineInfo);
-        }
-
-        if (resource.Properties.TryGetValue(KnownProperties.Resource.Source, out var property) && property.Value is { HasStringValue: true, StringValue: var value })
-        {
-            return new ResourceSourceViewModel(value, contentAfterValue: null, valueToVisualize: value, tooltip: value);
-        }
-
-        return null;
-
-        static CommandLineInfo? GetCommandLineInfo(ResourceViewModel resourceViewModel)
-        {
-            // If the resource contains launch arguments, these project arguments should be shown in place of all executable arguments,
-            // which include args added by the app host
-            if (resourceViewModel.TryGetAppArgs(out var launchArguments))
-            {
-                if (launchArguments.IsDefaultOrEmpty)
-                {
-                    return null;
-                }
-
-                var argumentsString = string.Join(" ", launchArguments);
-                if (resourceViewModel.TryGetAppArgsSensitivity(out var areArgumentsSensitive))
-                {
-                    var arguments = launchArguments
-                        .Select((arg, i) => new LaunchArgument(arg, IsShown: !areArgumentsSensitive[i]))
-                        .ToList();
-
-                    return new CommandLineInfo(
-                        Arguments: arguments,
-                        ArgumentsString: argumentsString,
-                        TooltipString: string.Join(" ", arguments.Select(arg => arg.IsShown
-                            ? arg.Value
-                            : DashboardUIHelpers.GetMaskingText(6).Text)));
-                }
-
-                return new CommandLineInfo(Arguments: launchArguments.Select(arg => new LaunchArgument(arg, true)).ToList(), ArgumentsString: argumentsString, TooltipString: argumentsString);
-            }
-
-            if (resourceViewModel.TryGetExecutableArguments(out var executableArguments) && !resourceViewModel.IsProject())
-            {
-                var arguments = executableArguments.IsDefaultOrEmpty ? [] : executableArguments.Select(arg => new LaunchArgument(arg, true)).ToList();
-                var argumentsString = string.Join(" ", executableArguments);
-
-                return new CommandLineInfo(Arguments: arguments, ArgumentsString: argumentsString, TooltipString: argumentsString);
-            }
-
             return null;
         }
 
-        static ResourceSourceViewModel CreateResourceSourceViewModel(string value, string path, CommandLineInfo? commandLineInfo)
+        var commandLineInfo = GetCommandLineInfo(resource);
+        if (commandLineInfo is null)
         {
-            return commandLineInfo is not null
-                ? new ResourceSourceViewModel(value: value, contentAfterValue: commandLineInfo.Arguments, valueToVisualize: $"{path} {commandLineInfo.ArgumentsString}", tooltip: $"{path} {commandLineInfo.TooltipString}")
-                : new ResourceSourceViewModel(value: value, contentAfterValue: null, valueToVisualize: path, tooltip: path);
+            return new ResourceSourceViewModel(
+                value: source.Value,
+                contentAfterValue: null,
+                valueToVisualize: source.OriginalValue,
+                tooltip: source.OriginalValue);
         }
+
+        return new ResourceSourceViewModel(
+            value: source.Value,
+            contentAfterValue: commandLineInfo.Arguments,
+            valueToVisualize: $"{source.OriginalValue} {commandLineInfo.ArgumentsString}",
+            tooltip: $"{source.OriginalValue} {commandLineInfo.TooltipString}");
+    }
+
+    private static CommandLineInfo? GetCommandLineInfo(ResourceViewModel resourceViewModel)
+    {
+        // If the resource contains launch arguments, these project arguments should be shown in place of all executable arguments,
+        // which include args added by the app host
+        if (resourceViewModel.TryGetAppArgs(out var launchArguments))
+        {
+            if (launchArguments.IsDefaultOrEmpty)
+            {
+                return null;
+            }
+
+            var argumentsString = string.Join(" ", launchArguments);
+            if (resourceViewModel.TryGetAppArgsSensitivity(out var areArgumentsSensitive))
+            {
+                var arguments = launchArguments
+                    .Select((arg, i) => new LaunchArgument(arg, IsShown: !areArgumentsSensitive[i]))
+                    .ToList();
+
+                return new CommandLineInfo(
+                    Arguments: arguments,
+                    ArgumentsString: argumentsString,
+                    TooltipString: string.Join(" ", arguments.Select(arg => arg.IsShown
+                        ? arg.Value
+                        : DashboardUIHelpers.GetMaskingText(6).Text)));
+            }
+
+            return new CommandLineInfo(Arguments: launchArguments.Select(arg => new LaunchArgument(arg, true)).ToList(), ArgumentsString: argumentsString, TooltipString: argumentsString);
+        }
+
+        if (resourceViewModel.TryGetExecutableArguments(out var executableArguments) && !resourceViewModel.IsProject())
+        {
+            var arguments = executableArguments.IsDefaultOrEmpty ? [] : executableArguments.Select(arg => new LaunchArgument(arg, true)).ToList();
+            var argumentsString = string.Join(" ", executableArguments);
+
+            return new CommandLineInfo(Arguments: arguments, ArgumentsString: argumentsString, TooltipString: argumentsString);
+        }
+
+        return null;
     }
 
     private record CommandLineInfo(List<LaunchArgument> Arguments, string ArgumentsString, string TooltipString);
 }
-
-public record LaunchArgument(string Value, bool IsShown);

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -154,21 +154,16 @@ public sealed class ResourceViewModel
               ?? Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy;
     }
 
-    public static string GetResourceName(ResourceViewModel resource, IDictionary<string, ResourceViewModel> allResources, bool showHiddenResources = false)
+    public static string GetResourceName(ResourceViewModel resource, IDictionary<string, ResourceViewModel> allResources)
     {
         return GetResourceName(resource, allResources.Values);
     }
 
-    public static string GetResourceName(ResourceViewModel resource, IEnumerable<ResourceViewModel> allResources, bool showHiddenResources = false)
+    public static string GetResourceName(ResourceViewModel resource, IEnumerable<ResourceViewModel> allResources)
     {
         var count = 0;
         foreach (var item in allResources)
         {
-            if (item.IsResourceHidden(showHiddenResources))
-            {
-                continue;
-            }
-
             if (string.Equals(item.DisplayName, resource.DisplayName, StringComparisons.ResourceName))
             {
                 count++;

--- a/src/Aspire.Dashboard/Model/ResourceViewModelExtensions.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModelExtensions.cs
@@ -9,6 +9,26 @@ namespace Aspire.Dashboard.Model;
 
 internal static class ResourceViewModelExtensions
 {
+    /// <summary>
+    /// Converts the resource properties to a dictionary of string values.
+    /// This is used to provide a consistent interface for code that works with both
+    /// ResourceViewModel (Dashboard) and ResourceSnapshot (CLI).
+    /// </summary>
+    public static IReadOnlyDictionary<string, string?> GetPropertiesAsDictionary(this ResourceViewModel resource)
+    {
+        var result = new Dictionary<string, string?>(StringComparer.Ordinal);
+
+        foreach (var (key, property) in resource.Properties)
+        {
+            if (property.Value.TryConvertToString(out var stringValue))
+            {
+                result[key] = stringValue;
+            }
+        }
+
+        return result;
+    }
+
     public static bool IsContainer(this ResourceViewModel resource)
     {
         return StringComparers.ResourceType.Equals(resource.ResourceType, KnownResourceTypes.Container);

--- a/src/Aspire.Dashboard/Model/Serialization/ResourceJsonSerializerContext.cs
+++ b/src/Aspire.Dashboard/Model/Serialization/ResourceJsonSerializerContext.cs
@@ -23,6 +23,7 @@ namespace Aspire.Dashboard.Model.Serialization;
 [JsonSerializable(typeof(ResourceHealthReportJson))]
 [JsonSerializable(typeof(ResourcePropertyJson))]
 [JsonSerializable(typeof(ResourceRelationshipJson))]
+[JsonSerializable(typeof(ResourceCommandJson))]
 internal sealed partial class ResourceJsonSerializerContext : JsonSerializerContext
 {
     /// <summary>

--- a/src/Aspire.Dashboard/Model/TelemetryExportService.cs
+++ b/src/Aspire.Dashboard/Model/TelemetryExportService.cs
@@ -143,7 +143,7 @@ public sealed class TelemetryExportService
         foreach (var resource in resources)
         {
             var resourceName = ResourceViewModel.GetResourceName(resource, resources);
-            var resourceJson = ConvertResourceToJson(resource);
+            var resourceJson = ConvertResourceToJson(resource, resources);
             var entry = archive.CreateEntry($"resources/{SanitizeFileName(resourceName)}.json");
             using var entryStream = entry.Open();
             using var writer = new StreamWriter(entryStream, Encoding.UTF8);
@@ -676,8 +676,32 @@ public sealed class TelemetryExportService
         return sanitized.ToString();
     }
 
-    internal static string ConvertResourceToJson(ResourceViewModel resource)
+    internal static string ConvertResourceToJson(ResourceViewModel resource, IReadOnlyList<ResourceViewModel> allResources)
     {
+        // Build relationships by matching DisplayName and filtering out hidden resources
+        ResourceRelationshipJson[]? relationshipsJson = null;
+        if (resource.Relationships.Length > 0)
+        {
+            var relationships = new List<ResourceRelationshipJson>();
+            foreach (var relationship in resource.Relationships)
+            {
+                var matches = allResources
+                    .Where(r => string.Equals(r.DisplayName, relationship.ResourceName, StringComparisons.ResourceName))
+                    .Where(r => r.KnownState != KnownResourceState.Hidden)
+                    .ToList();
+
+                foreach (var match in matches)
+                {
+                    relationships.Add(new ResourceRelationshipJson
+                    {
+                        Type = relationship.Type,
+                        ResourceName = ResourceViewModel.GetResourceName(match, allResources)
+                    });
+                }
+            }
+            relationshipsJson = relationships.ToArray();
+        }
+
         var resourceJson = new ResourceJson
         {
             Name = resource.Name,
@@ -729,13 +753,17 @@ public sealed class TelemetryExportService
                     Value = p.Value.Value.TryConvertToString(out var value) ? value : null
                 }).ToArray()
                 : null,
-            Relationships = resource.Relationships.Length > 0
-                ? resource.Relationships.Select(r => new ResourceRelationshipJson
-                {
-                    Type = r.Type,
-                    ResourceName = r.ResourceName
-                }).ToArray()
-                : null
+            Relationships = relationshipsJson,
+            Commands = resource.Commands.Length > 0
+                ? resource.Commands
+                    .Where(c => c.State == CommandViewModelState.Enabled)
+                    .Select(c => new ResourceCommandJson
+                    {
+                        Name = c.Name,
+                        Description = c.GetDisplayDescription()
+                    }).ToArray()
+                : null,
+            Source = ResourceSourceViewModel.GetSourceViewModel(resource)?.Value
         };
 
         return JsonSerializer.Serialize(resourceJson, ResourceJsonSerializerContext.IndentedOptions);

--- a/src/Aspire.Dashboard/Model/TelemetryExportService.cs
+++ b/src/Aspire.Dashboard/Model/TelemetryExportService.cs
@@ -731,7 +731,7 @@ public sealed class TelemetryExportService
                 }).ToArray()
                 : null,
             Environment = resource.Environment.Length > 0
-                ? resource.Environment.Select(e => new ResourceEnvironmentVariableJson
+                ? resource.Environment.Where(e => e.FromSpec).Select(e => new ResourceEnvironmentVariableJson
                 {
                     Name = e.Name,
                     Value = e.Value

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -1081,20 +1081,6 @@ public static class ResourceExtensions
     }
 
     /// <summary>
-    /// Gets instance names for the specified resource.
-    /// If the resource has DCP instances, returns the instance names; otherwise, returns the resource name.
-    /// </summary>
-    internal static IEnumerable<string> GetResolvedInstances(this IResource resource)
-    {
-        if (resource.TryGetInstances(out var instances))
-        {
-            return instances.Select(i => i.Name);
-        }
-
-        return [resource.Name];
-    }
-
-    /// <summary>
     /// Gets resolved names for the specified resource.
     /// DCP resources are given a unique suffix as part of the complete name. We want to use that value.
     /// Also, a DCP resource could have multiple instances. All instance names are returned for a resource.

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -1081,6 +1081,20 @@ public static class ResourceExtensions
     }
 
     /// <summary>
+    /// Gets instance names for the specified resource.
+    /// If the resource has DCP instances, returns the instance names; otherwise, returns the resource name.
+    /// </summary>
+    internal static IEnumerable<string> GetResolvedInstances(this IResource resource)
+    {
+        if (resource.TryGetInstances(out var instances))
+        {
+            return instances.Select(i => i.Name);
+        }
+
+        return [resource.Name];
+    }
+
+    /// <summary>
     /// Gets resolved names for the specified resource.
     /// DCP resources are given a unique suffix as part of the complete name. We want to use that value.
     /// Also, a DCP resource could have multiple instances. All instance names are returned for a resource.

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -339,7 +339,7 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
                 continue;
             }
 
-            foreach (var instanceName in resource.GetResolvedInstances())
+            foreach (var instanceName in resource.GetResolvedResourceNames())
             {
                 await AddResult(instanceName).ConfigureAwait(false);
             }

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -339,10 +339,9 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
                 continue;
             }
 
-            resource.TryGetLastAnnotation<DcpInstancesAnnotation>(out var dcpInstancesAnnotation);
-            if (dcpInstancesAnnotation is not null)
+            if (resource.TryGetInstances(out var instances))
             {
-                foreach (var instance in dcpInstancesAnnotation.Instances)
+                foreach (var instance in instances)
                 {
                     await AddResult(instance.Name).ConfigureAwait(false);
                 }

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -339,16 +339,9 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
                 continue;
             }
 
-            if (resource.TryGetInstances(out var instances))
+            foreach (var instanceName in resource.GetResolvedInstances())
             {
-                foreach (var instance in instances)
-                {
-                    await AddResult(instance.Name).ConfigureAwait(false);
-                }
-            }
-            else
-            {
-                await AddResult(resource.Name).ConfigureAwait(false);
+                await AddResult(instanceName).ConfigureAwait(false);
             }
         }
 

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -578,9 +578,9 @@ internal sealed class ResourceSnapshot
     public DateTimeOffset? StoppedAt { get; init; }
 
     /// <summary>
-    /// Gets the endpoints exposed by this resource.
+    /// Gets the URLs exposed by this resource.
     /// </summary>
-    public ResourceSnapshotEndpoint[] Endpoints { get; init; } = [];
+    public ResourceSnapshotUrl[] Urls { get; init; } = [];
 
     /// <summary>
     /// Gets the relationships to other resources.
@@ -596,6 +596,11 @@ internal sealed class ResourceSnapshot
     /// Gets the volumes mounted to this resource.
     /// </summary>
     public ResourceSnapshotVolume[] Volumes { get; init; } = [];
+
+    /// <summary>
+    /// Gets the environment variables for this resource.
+    /// </summary>
+    public ResourceSnapshotEnvironmentVariable[] EnvironmentVariables { get; init; } = [];
 
     /// <summary>
     /// Gets additional properties as key-value pairs.
@@ -642,13 +647,13 @@ internal sealed class ResourceSnapshotCommand
 }
 
 /// <summary>
-/// Represents an endpoint exposed by a resource.
+/// Represents a URL exposed by a resource.
 /// </summary>
 [DebuggerDisplay("Name = {Name}, Url = {Url}")]
-internal sealed class ResourceSnapshotEndpoint
+internal sealed class ResourceSnapshotUrl
 {
     /// <summary>
-    /// Gets the endpoint name (e.g., "http", "https", "tcp").
+    /// Gets the URL name (e.g., "http", "https", "tcp").
     /// </summary>
     public required string Name { get; init; }
 
@@ -658,9 +663,31 @@ internal sealed class ResourceSnapshotEndpoint
     public required string Url { get; init; }
 
     /// <summary>
-    /// Gets whether this is an internal endpoint.
+    /// Gets whether this is an internal URL.
     /// </summary>
     public bool IsInternal { get; init; }
+
+    /// <summary>
+    /// Gets the display properties for the URL.
+    /// </summary>
+    public ResourceSnapshotUrlDisplayProperties? DisplayProperties { get; init; }
+}
+
+/// <summary>
+/// Represents display properties for a URL.
+/// </summary>
+[DebuggerDisplay("DisplayName = {DisplayName}, SortOrder = {SortOrder}")]
+internal sealed class ResourceSnapshotUrlDisplayProperties
+{
+    /// <summary>
+    /// Gets the display name of the URL.
+    /// </summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>
+    /// Gets the sort order for display. Higher numbers are displayed first.
+    /// </summary>
+    public int SortOrder { get; init; }
 }
 
 /// <summary>
@@ -732,6 +759,28 @@ internal sealed class ResourceSnapshotVolume
     /// Gets whether the volume is read-only.
     /// </summary>
     public bool IsReadOnly { get; init; }
+}
+
+/// <summary>
+/// Represents an environment variable for a resource.
+/// </summary>
+[DebuggerDisplay("Name = {Name}, Value = {Value}")]
+internal sealed class ResourceSnapshotEnvironmentVariable
+{
+    /// <summary>
+    /// Gets the name of the environment variable.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets the value of the environment variable.
+    /// </summary>
+    public string? Value { get; init; }
+
+    /// <summary>
+    /// Gets whether this environment variable is from the resource specification.
+    /// </summary>
+    public bool IsFromSpec { get; init; }
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -617,6 +617,7 @@ internal sealed class ResourceSnapshot
 /// <summary>
 /// Represents a command available for a resource.
 /// </summary>
+[DebuggerDisplay("Name = {Name}, State = {State}")]
 internal sealed class ResourceSnapshotCommand
 {
     /// <summary>
@@ -643,6 +644,7 @@ internal sealed class ResourceSnapshotCommand
 /// <summary>
 /// Represents an endpoint exposed by a resource.
 /// </summary>
+[DebuggerDisplay("Name = {Name}, Url = {Url}")]
 internal sealed class ResourceSnapshotEndpoint
 {
     /// <summary>
@@ -664,6 +666,7 @@ internal sealed class ResourceSnapshotEndpoint
 /// <summary>
 /// Represents a relationship to another resource.
 /// </summary>
+[DebuggerDisplay("ResourceName = {ResourceName}, Type = {Type}")]
 internal sealed class ResourceSnapshotRelationship
 {
     /// <summary>
@@ -680,6 +683,7 @@ internal sealed class ResourceSnapshotRelationship
 /// <summary>
 /// Represents a health report for a resource.
 /// </summary>
+[DebuggerDisplay("Name = {Name}, Status = {Status}")]
 internal sealed class ResourceSnapshotHealthReport
 {
     /// <summary>
@@ -706,6 +710,7 @@ internal sealed class ResourceSnapshotHealthReport
 /// <summary>
 /// Represents a volume mounted to a resource.
 /// </summary>
+[DebuggerDisplay("Source = {Source}, Target = {Target}")]
 internal sealed class ResourceSnapshotVolume
 {
     /// <summary>
@@ -732,6 +737,7 @@ internal sealed class ResourceSnapshotVolume
 /// <summary>
 /// Represents MCP server information for a resource.
 /// </summary>
+[DebuggerDisplay("EndpointUrl = {EndpointUrl}")]
 internal sealed class ResourceSnapshotMcpServer
 {
     /// <summary>

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -530,13 +530,17 @@ internal sealed class ResourceSnapshot
     /// </summary>
     public string? DisplayName { get; init; }
 
+    // ResourceType can't be required because older versions of the backchannel may not set it.
     /// <summary>
     /// Gets the type of the resource (e.g., "Project", "Container", "Executable").
     /// </summary>
-    public string ResourceType { get; init; } = default!;
+    public string? ResourceType { get; init; }
 
+    /// <summary>
+    /// Gets the type of the resource (e.g., "Project", "Container", "Executable").
+    /// </summary>
     [Obsolete("Use ResourceType property instead.")]
-    public string Type
+    public string? Type
     {
         get => ResourceType;
         init => ResourceType = value;

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -533,7 +533,14 @@ internal sealed class ResourceSnapshot
     /// <summary>
     /// Gets the type of the resource (e.g., "Project", "Container", "Executable").
     /// </summary>
-    public required string ResourceType { get; init; }
+    public string ResourceType { get; init; } = default!;
+
+    [Obsolete("Use ResourceType property instead.")]
+    public string Type
+    {
+        get => ResourceType;
+        init => ResourceType = value;
+    }
 
     /// <summary>
     /// Gets the current state of the resource (e.g., "Running", "Stopped", "Starting").

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -9,6 +9,7 @@ namespace Aspire.Cli.Backchannel;
 namespace Aspire.Hosting.Backchannel;
 #endif
 
+using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
@@ -516,6 +517,7 @@ internal sealed class DashboardMcpConnectionInfo
 /// Represents a snapshot of a resource in the application model, suitable for RPC communication.
 /// Designed to be extensible - new fields can be added without breaking existing consumers.
 /// </summary>
+[DebuggerDisplay("Name = {Name}, ResourceType = {ResourceType}, State = {State}, Properties = {Properties.Count}")]
 internal sealed class ResourceSnapshot
 {
     /// <summary>
@@ -524,9 +526,14 @@ internal sealed class ResourceSnapshot
     public required string Name { get; init; }
 
     /// <summary>
+    /// Gets the display name of the resource.
+    /// </summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>
     /// Gets the type of the resource (e.g., "Project", "Container", "Executable").
     /// </summary>
-    public required string Type { get; init; }
+    public required string ResourceType { get; init; }
 
     /// <summary>
     /// Gets the current state of the resource (e.g., "Running", "Stopped", "Starting").
@@ -593,6 +600,37 @@ internal sealed class ResourceSnapshot
     /// Gets the MCP server information if the resource exposes an MCP endpoint.
     /// </summary>
     public ResourceSnapshotMcpServer? McpServer { get; init; }
+
+    /// <summary>
+    /// Gets the commands available for this resource.
+    /// </summary>
+    public ResourceSnapshotCommand[] Commands { get; init; } = [];
+}
+
+/// <summary>
+/// Represents a command available for a resource.
+/// </summary>
+internal sealed class ResourceSnapshotCommand
+{
+    /// <summary>
+    /// Gets the command name (e.g., "resource-start", "resource-stop", "resource-restart").
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets the display name of the command.
+    /// </summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>
+    /// Gets the description of the command.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Gets the state of the command (e.g., "Enabled", "Disabled", "Hidden").
+    /// </summary>
+    public required string State { get; init; }
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1867,12 +1867,12 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
     /// </summary>
     private static DcpInstance GetDcpInstance(IResource resource, int instanceIndex)
     {
-        if (!resource.TryGetLastAnnotation<DcpInstancesAnnotation>(out var replicaAnnotation))
+        if (!resource.TryGetInstances(out var instances))
         {
             throw new DistributedApplicationException($"Couldn't find required {nameof(DcpInstancesAnnotation)} annotation on resource {resource.Name}.");
         }
 
-        foreach (var instance in replicaAnnotation.Instances)
+        foreach (var instance in instances)
         {
             if (instance.Index == instanceIndex)
             {

--- a/src/Aspire.Hosting/Dcp/DcpNameGenerator.cs
+++ b/src/Aspire.Hosting/Dcp/DcpNameGenerator.cs
@@ -27,7 +27,7 @@ internal sealed class DcpNameGenerator
 
     public void EnsureDcpInstancesPopulated(IResource resource)
     {
-        if (resource.TryGetLastAnnotation<DcpInstancesAnnotation>(out _))
+        if (resource.TryGetInstances(out _))
         {
             return;
         }

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -609,23 +609,26 @@ public class DistributedApplication : IHost, IAsyncDisposable
                 var results = new List<ResourceStateDebugView>(app._model.Resources.Count);
                 foreach (var resource in app._model.Resources)
                 {
-                    resource.TryGetLastAnnotation<DcpInstancesAnnotation>(out var dcpInstancesAnnotation);
-                    if (dcpInstancesAnnotation is not null)
+                    if (resource.TryGetInstances(out var instances))
                     {
-                        foreach (var instance in dcpInstancesAnnotation.Instances)
+                        foreach (var instance in instances)
                         {
-                            app.ResourceNotifications.TryGetCurrentState(instance.Name, out var resourceEvent);
-                            results.Add(new() { Resource = resource, Snapshot = resourceEvent?.Snapshot });
+                            AddResult(app, results, instance.Name, resource);
                         }
                     }
                     else
                     {
-                        app.ResourceNotifications.TryGetCurrentState(resource.Name, out var resourceEvent);
-                        results.Add(new() { Resource = resource, Snapshot = resourceEvent?.Snapshot });
+                        AddResult(app, results, resource.Name, resource);
                     }
                 }
 
                 return results;
+
+                static void AddResult(DistributedApplication app, List<ResourceStateDebugView> debugViews, string resourceName, IResource resource)
+                {
+                    app.ResourceNotifications.TryGetCurrentState(resourceName, out var resourceEvent);
+                    debugViews.Add(new() { Resource = resource, Snapshot = resourceEvent?.Snapshot });
+                }
             }
         }
 

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -609,7 +609,7 @@ public class DistributedApplication : IHost, IAsyncDisposable
                 var results = new List<ResourceStateDebugView>(app._model.Resources.Count);
                 foreach (var resource in app._model.Resources)
                 {
-                    foreach (var instanceName in resource.GetResolvedInstances())
+                    foreach (var instanceName in resource.GetResolvedResourceNames())
                     {
                         app.ResourceNotifications.TryGetCurrentState(instanceName, out var resourceEvent);
                         results.Add(new() { Resource = resource, Snapshot = resourceEvent?.Snapshot });

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -609,26 +609,14 @@ public class DistributedApplication : IHost, IAsyncDisposable
                 var results = new List<ResourceStateDebugView>(app._model.Resources.Count);
                 foreach (var resource in app._model.Resources)
                 {
-                    if (resource.TryGetInstances(out var instances))
+                    foreach (var instanceName in resource.GetResolvedInstances())
                     {
-                        foreach (var instance in instances)
-                        {
-                            AddResult(app, results, instance.Name, resource);
-                        }
-                    }
-                    else
-                    {
-                        AddResult(app, results, resource.Name, resource);
+                        app.ResourceNotifications.TryGetCurrentState(instanceName, out var resourceEvent);
+                        results.Add(new() { Resource = resource, Snapshot = resourceEvent?.Snapshot });
                     }
                 }
 
                 return results;
-
-                static void AddResult(DistributedApplication app, List<ResourceStateDebugView> debugViews, string resourceName, IResource resource)
-                {
-                    app.ResourceNotifications.TryGetCurrentState(resourceName, out var resourceEvent);
-                    debugViews.Add(new() { Resource = resource, Snapshot = resourceEvent?.Snapshot });
-                }
             }
         }
 

--- a/src/Shared/DashboardUrls.cs
+++ b/src/Shared/DashboardUrls.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Text.Encodings.Web;
 
 namespace Aspire.Dashboard.Utils;
 
@@ -188,12 +189,13 @@ internal static class DashboardUrls
     }
 
     /// <summary>
-    /// Adds a query string parameter to a URL. This is a simple implementation
-    /// that doesn't handle all edge cases but works for our use cases.
+    /// Adds a query string parameter to a URL.
+    /// This implementation matches the behavior of QueryHelpers.AddQueryString from ASP.NET Core,
+    /// which uses UrlEncoder.Default that doesn't encode certain characters like ! and @.
     /// </summary>
     private static string AddQueryString(string url, string name, string value)
     {
         var separator = url.Contains('?') ? '&' : '?';
-        return $"{url}{separator}{Uri.EscapeDataString(name)}={Uri.EscapeDataString(value)}";
+        return $"{url}{separator}{UrlEncoder.Default.Encode(name)}={UrlEncoder.Default.Encode(value)}";
     }
 }

--- a/src/Shared/DashboardUrls.cs
+++ b/src/Shared/DashboardUrls.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-using Microsoft.AspNetCore.WebUtilities;
 
 namespace Aspire.Dashboard.Utils;
 
@@ -21,23 +20,23 @@ internal static class DashboardUrls
         var url = $"/{ResourcesBasePath}";
         if (resource != null)
         {
-            url = QueryHelpers.AddQueryString(url, "resource", resource);
+            url = AddQueryString(url, "resource", resource);
         }
         if (view != null)
         {
-            url = QueryHelpers.AddQueryString(url, "view", view);
+            url = AddQueryString(url, "view", view);
         }
         if (hiddenTypes != null)
         {
-            url = QueryHelpers.AddQueryString(url, "hiddenTypes", hiddenTypes);
+            url = AddQueryString(url, "hiddenTypes", hiddenTypes);
         }
         if (hiddenStates != null)
         {
-            url = QueryHelpers.AddQueryString(url, "hiddenStates", hiddenStates);
+            url = AddQueryString(url, "hiddenStates", hiddenStates);
         }
         if (hiddenHealthStates != null)
         {
-            url = QueryHelpers.AddQueryString(url, "hiddenHealthStates", hiddenHealthStates);
+            url = AddQueryString(url, "hiddenHealthStates", hiddenHealthStates);
         }
 
         return url;
@@ -64,19 +63,19 @@ internal static class DashboardUrls
         if (meter is not null)
         {
             // Meter and instrument must be querystring parameters because it's valid for the name to contain forward slashes.
-            url = QueryHelpers.AddQueryString(url, "meter", meter);
+            url = AddQueryString(url, "meter", meter);
             if (instrument is not null)
             {
-                url = QueryHelpers.AddQueryString(url, "instrument", instrument);
+                url = AddQueryString(url, "instrument", instrument);
             }
         }
         if (duration != null)
         {
-            url = QueryHelpers.AddQueryString(url, "duration", duration.Value.ToString(CultureInfo.InvariantCulture));
+            url = AddQueryString(url, "duration", duration.Value.ToString(CultureInfo.InvariantCulture));
         }
         if (view != null)
         {
-            url = QueryHelpers.AddQueryString(url, "view", view);
+            url = AddQueryString(url, "view", view);
         }
 
         return url;
@@ -91,26 +90,26 @@ internal static class DashboardUrls
         }
         if (logLevel != null)
         {
-            url = QueryHelpers.AddQueryString(url, "logLevel", logLevel);
+            url = AddQueryString(url, "logLevel", logLevel);
         }
         if (filters != null)
         {
             // Filters contains : and + characters. These are escaped when they're not needed to,
             // which makes the URL harder to read. Consider having a custom method for appending
             // query string here that uses an encoder that doesn't encode those characters.
-            url = QueryHelpers.AddQueryString(url, "filters", filters);
+            url = AddQueryString(url, "filters", filters);
         }
         if (traceId != null)
         {
-            url = QueryHelpers.AddQueryString(url, "traceId", traceId);
+            url = AddQueryString(url, "traceId", traceId);
         }
         if (spanId != null)
         {
-            url = QueryHelpers.AddQueryString(url, "spanId", spanId);
+            url = AddQueryString(url, "spanId", spanId);
         }
         if (logEntryId != null)
         {
-            url = QueryHelpers.AddQueryString(url, "logEntryId", logEntryId.Value.ToString(CultureInfo.InvariantCulture));
+            url = AddQueryString(url, "logEntryId", logEntryId.Value.ToString(CultureInfo.InvariantCulture));
         }
 
         return url;
@@ -125,14 +124,14 @@ internal static class DashboardUrls
         }
         if (type != null)
         {
-            url = QueryHelpers.AddQueryString(url, "type", type);
+            url = AddQueryString(url, "type", type);
         }
         if (filters != null)
         {
             // Filters contains : and + characters. These are escaped when they're not needed to,
             // which makes the URL harder to read. Consider having a custom method for appending
             // query string here that uses an encoder that doesn't encode those characters.
-            url = QueryHelpers.AddQueryString(url, "filters", filters);
+            url = AddQueryString(url, "filters", filters);
         }
 
         return url;
@@ -143,7 +142,7 @@ internal static class DashboardUrls
         var url = $"/{TracesBasePath}/detail/{Uri.EscapeDataString(traceId)}";
         if (spanId != null)
         {
-            url = QueryHelpers.AddQueryString(url, "spanId", spanId);
+            url = AddQueryString(url, "spanId", spanId);
         }
 
         return url;
@@ -154,11 +153,11 @@ internal static class DashboardUrls
         var url = $"/{LoginBasePath}";
         if (returnUrl != null)
         {
-            url = QueryHelpers.AddQueryString(url, "returnUrl", returnUrl);
+            url = AddQueryString(url, "returnUrl", returnUrl);
         }
         if (token != null)
         {
-            url = QueryHelpers.AddQueryString(url, "t", token);
+            url = AddQueryString(url, "t", token);
         }
 
         return url;
@@ -167,9 +166,34 @@ internal static class DashboardUrls
     public static string SetLanguageUrl(string language, string redirectUrl)
     {
         var url = "/api/set-language";
-        url = QueryHelpers.AddQueryString(url, "language", language);
-        url = QueryHelpers.AddQueryString(url, "redirectUrl", redirectUrl);
+        url = AddQueryString(url, "language", language);
+        url = AddQueryString(url, "redirectUrl", redirectUrl);
 
         return url;
+    }
+
+    /// <summary>
+    /// Combines a base URL with a path.
+    /// </summary>
+    /// <param name="baseUrl">The base URL (e.g., "https://localhost:5000").</param>
+    /// <param name="path">The path (e.g., "/?resource=myapp").</param>
+    /// <returns>The combined URL.</returns>
+    public static string CombineUrl(string baseUrl, string path)
+    {
+        // Remove trailing slash from base URL and leading slash from path to avoid double slashes
+        var trimmedBase = baseUrl.TrimEnd('/');
+        var trimmedPath = path.TrimStart('/');
+
+        return $"{trimmedBase}/{trimmedPath}";
+    }
+
+    /// <summary>
+    /// Adds a query string parameter to a URL. This is a simple implementation
+    /// that doesn't handle all edge cases but works for our use cases.
+    /// </summary>
+    private static string AddQueryString(string url, string name, string value)
+    {
+        var separator = url.Contains('?') ? '&' : '?';
+        return $"{url}{separator}{Uri.EscapeDataString(name)}={Uri.EscapeDataString(value)}";
     }
 }

--- a/src/Shared/Model/ResourceSourceViewModel.cs
+++ b/src/Shared/Model/ResourceSourceViewModel.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+
+namespace Aspire.Shared.Model;
+
+internal record ResourceSource(string Value, string OriginalValue)
+{
+    public static ResourceSource? GetSourceModel(string? resourceType, IReadOnlyDictionary<string, string?> properties)
+    {
+        // NOTE project and tools are also executables, so check for those first
+        if (StringComparers.ResourceType.Equals(resourceType, KnownResourceTypes.Project) &&
+            properties.TryGetValue(KnownProperties.Project.Path, out var projectPath) &&
+            !string.IsNullOrEmpty(projectPath))
+        {
+            return new ResourceSource(Path.GetFileName(projectPath), projectPath);
+        }
+
+        if (StringComparers.ResourceType.Equals(resourceType, KnownResourceTypes.Tool) &&
+            properties.TryGetValue(KnownProperties.Tool.Package, out var toolPackage) &&
+            !string.IsNullOrEmpty(toolPackage))
+        {
+            return new ResourceSource(toolPackage, toolPackage);
+        }
+
+        if (properties.TryGetValue(KnownProperties.Executable.Path, out var executablePath) &&
+            !string.IsNullOrEmpty(executablePath))
+        {
+            return new ResourceSource(Path.GetFileName(executablePath), executablePath);
+        }
+
+        if (properties.TryGetValue(KnownProperties.Container.Image, out var containerImage) &&
+            !string.IsNullOrEmpty(containerImage))
+        {
+            return new ResourceSource(containerImage, containerImage);
+        }
+
+        if (properties.TryGetValue(KnownProperties.Resource.Source, out var source) &&
+            !string.IsNullOrEmpty(source))
+        {
+            return new ResourceSource(source, source);
+        }
+
+        return null;
+    }
+}

--- a/src/Shared/Model/Serialization/ResourceJson.cs
+++ b/src/Shared/Model/Serialization/ResourceJson.cs
@@ -72,6 +72,11 @@ internal sealed class ResourceJson
     public string? HealthStatus { get; set; }
 
     /// <summary>
+    /// The URL to the resource in the Aspire Dashboard.
+    /// </summary>
+    public string? DashboardUrl { get; set; }
+
+    /// <summary>
     /// The URLs/endpoints associated with the resource.
     /// </summary>
     public ResourceUrlJson[]? Urls { get; set; }
@@ -100,11 +105,6 @@ internal sealed class ResourceJson
     /// The relationships of the resource.
     /// </summary>
     public ResourceRelationshipJson[]? Relationships { get; set; }
-
-    /// <summary>
-    /// The URL to the resource in the Aspire Dashboard.
-    /// </summary>
-    public string? DashboardUrl { get; set; }
 
     /// <summary>
     /// The commands available for the resource.

--- a/src/Shared/Model/Serialization/ResourceJson.cs
+++ b/src/Shared/Model/Serialization/ResourceJson.cs
@@ -57,6 +57,11 @@ internal sealed class ResourceJson
     public DateTimeOffset? StopTimestamp { get; set; }
 
     /// <summary>
+    /// The source of the resource (e.g., project path, container image, executable path).
+    /// </summary>
+    public string? Source { get; set; }
+
+    /// <summary>
     /// The exit code if the resource has exited.
     /// </summary>
     public int? ExitCode { get; set; }
@@ -95,6 +100,16 @@ internal sealed class ResourceJson
     /// The relationships of the resource.
     /// </summary>
     public ResourceRelationshipJson[]? Relationships { get; set; }
+
+    /// <summary>
+    /// The URL to the resource in the Aspire Dashboard.
+    /// </summary>
+    public string? DashboardUrl { get; set; }
+
+    /// <summary>
+    /// The commands available for the resource.
+    /// </summary>
+    public ResourceCommandJson[]? Commands { get; set; }
 }
 
 /// <summary>
@@ -231,4 +246,20 @@ internal sealed class ResourceRelationshipJson
     /// The name of the related resource.
     /// </summary>
     public string? ResourceName { get; set; }
+}
+
+/// <summary>
+/// Represents a command in JSON format.
+/// </summary>
+internal sealed class ResourceCommandJson
+{
+    /// <summary>
+    /// The name of the command.
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// The description of the command.
+    /// </summary>
+    public string? Description { get; set; }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/ExportHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ExportHelpersTests.cs
@@ -22,11 +22,13 @@ public sealed class ExportHelpersTests
             environment: [new EnvironmentVariableViewModel("MY_VAR", "my-value", fromSpec: false)],
             relationships: [new RelationshipViewModel("dependency", "Reference")]);
 
+        var resourceByName = new Dictionary<string, ResourceViewModel>(StringComparer.OrdinalIgnoreCase) { [resource.Name] = resource };
+
         // Act
-        var result = ExportHelpers.GetResourceAsJson(resource, [resource], r => r.Name);
+        var result = ExportHelpers.GetResourceAsJson(resource, resourceByName);
 
         // Assert
-        Assert.Equal("test-resource.json", result.FileName);
+        Assert.Equal("Test Resource.json", result.FileName);
         Assert.NotNull(result.Content);
     }
 
@@ -43,11 +45,13 @@ public sealed class ExportHelpersTests
                 new EnvironmentVariableViewModel("MY_VAR", "my-value", fromSpec: false)
             ]);
 
+        var resourceByName = new Dictionary<string, ResourceViewModel>(StringComparer.OrdinalIgnoreCase) { [resource.Name] = resource };
+
         // Act
-        var result = ExportHelpers.GetEnvironmentVariablesAsEnvFile(resource, r => r.Name);
+        var result = ExportHelpers.GetEnvironmentVariablesAsEnvFile(resource, resourceByName);
 
         // Assert
-        Assert.Equal("test-resource.env", result.FileName);
+        Assert.Equal("Test Resource.env", result.FileName);
         Assert.Contains("MY_VAR=my-value", result.Content);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/ExportHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ExportHelpersTests.cs
@@ -23,7 +23,7 @@ public sealed class ExportHelpersTests
             relationships: [new RelationshipViewModel("dependency", "Reference")]);
 
         // Act
-        var result = ExportHelpers.GetResourceAsJson(resource, r => r.Name);
+        var result = ExportHelpers.GetResourceAsJson(resource, [resource], r => r.Name);
 
         // Assert
         Assert.Equal("test-resource.json", result.FileName);

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceMenuBuilderTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceMenuBuilderTests.cs
@@ -62,6 +62,7 @@ public sealed class ResourceMenuBuilderTests
         resourceMenuBuilder.AddMenuItems(
             menuItems,
             resource,
+            [resource],
             r => r.Name,
             EventCallback.Empty,
             EventCallback<CommandViewModel>.Empty,
@@ -113,6 +114,7 @@ public sealed class ResourceMenuBuilderTests
         resourceMenuBuilder.AddMenuItems(
             menuItems,
             resource,
+            [resource],
             r => r.Name,
             EventCallback.Empty,
             EventCallback<CommandViewModel>.Empty,
@@ -164,6 +166,7 @@ public sealed class ResourceMenuBuilderTests
         resourceMenuBuilder.AddMenuItems(
             menuItems,
             resource,
+            [resource],
             r => r.Name,
             EventCallback.Empty,
             EventCallback<CommandViewModel>.Empty,

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceMenuBuilderTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceMenuBuilderTests.cs
@@ -62,8 +62,7 @@ public sealed class ResourceMenuBuilderTests
         resourceMenuBuilder.AddMenuItems(
             menuItems,
             resource,
-            [resource],
-            r => r.Name,
+            new Dictionary<string, ResourceViewModel>(StringComparer.OrdinalIgnoreCase) { [resource.Name] = resource },
             EventCallback.Empty,
             EventCallback<CommandViewModel>.Empty,
             (_, _) => false,
@@ -114,8 +113,7 @@ public sealed class ResourceMenuBuilderTests
         resourceMenuBuilder.AddMenuItems(
             menuItems,
             resource,
-            [resource],
-            r => r.Name,
+            new Dictionary<string, ResourceViewModel>(StringComparer.OrdinalIgnoreCase) { [resource.Name] = resource },
             EventCallback.Empty,
             EventCallback<CommandViewModel>.Empty,
             (_, _) => false,
@@ -166,8 +164,7 @@ public sealed class ResourceMenuBuilderTests
         resourceMenuBuilder.AddMenuItems(
             menuItems,
             resource,
-            [resource],
-            r => r.Name,
+            new Dictionary<string, ResourceViewModel>(StringComparer.OrdinalIgnoreCase) { [resource.Name] = resource },
             EventCallback.Empty,
             EventCallback<CommandViewModel>.Empty,
             (_, _) => false,

--- a/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
@@ -1049,7 +1049,7 @@ public sealed class TelemetryExportServiceTests
             relationships: [new RelationshipViewModel("dependency", "Reference")]);
 
         // Act
-        var json = TelemetryExportService.ConvertResourceToJson(resource);
+        var json = TelemetryExportService.ConvertResourceToJson(resource, [resource]);
 
         // Assert
         var deserialized = JsonSerializer.Deserialize(json, ResourceJsonSerializerContext.Default.ResourceJson);
@@ -1089,7 +1089,7 @@ public sealed class TelemetryExportServiceTests
             environment: [new EnvironmentVariableViewModel("JAPANESE_VAR", japaneseEnvValue, fromSpec: false)]);
 
         // Act
-        var json = TelemetryExportService.ConvertResourceToJson(resource);
+        var json = TelemetryExportService.ConvertResourceToJson(resource, [resource]);
 
         // Assert - Verify Japanese characters appear directly in JSON (not Unicode-escaped)
         Assert.Contains(japaneseName, json);

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
@@ -1,0 +1,169 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Hosting.Backchannel;
+
+public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task GetResourceSnapshotsAsync_ReturnsEmptyList_WhenAppModelIsNull()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(ResourceNotificationServiceTestHelpers.Create());
+        var serviceProvider = services.BuildServiceProvider();
+
+        var target = new AuxiliaryBackchannelRpcTarget(
+            NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
+            serviceProvider);
+
+        var result = await target.GetResourceSnapshotsAsync();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetResourceSnapshotsAsync_EnumeratesResources()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+
+        builder.AddParameter("myparam");
+        builder.AddResource(new CustomResource(KnownResourceNames.AspireDashboard));
+
+        var resourceWithReplicas = builder.AddResource(new CustomResource("myresource"));
+        resourceWithReplicas.WithAnnotation(new DcpInstancesAnnotation([
+            new DcpInstance("myresource-abc123", "abc123", 0),
+            new DcpInstance("myresource-def456", "def456", 1)
+        ]));
+
+        using var app = builder.Build();
+        await app.StartAsync();
+
+        var notificationService = app.Services.GetRequiredService<ResourceNotificationService>();
+        await notificationService.PublishUpdateAsync(resourceWithReplicas.Resource, "myresource-abc123", s => s with
+        {
+            State = new ResourceStateSnapshot("Running", KnownResourceStateStyles.Success)
+        });
+        await notificationService.PublishUpdateAsync(resourceWithReplicas.Resource, "myresource-def456", s => s with
+        {
+            State = new ResourceStateSnapshot("Running", KnownResourceStateStyles.Success)
+        });
+
+        var target = new AuxiliaryBackchannelRpcTarget(
+            NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
+            app.Services);
+
+        var result = await target.GetResourceSnapshotsAsync();
+
+        // Dashboard resource should be skipped
+        Assert.DoesNotContain(result, r => r.Name == KnownResourceNames.AspireDashboard);
+
+        // Parameter resource (no replicas) should be returned with matching Name/DisplayName
+        var paramSnapshot = Assert.Single(result, r => r.Name == "myparam");
+        Assert.Equal("myparam", paramSnapshot.DisplayName);
+        Assert.Equal("Parameter", paramSnapshot.ResourceType);
+
+        // Resource with DcpInstancesAnnotation should return multiple instances
+        Assert.Contains(result, r => r.Name == "myresource-abc123");
+        Assert.Contains(result, r => r.Name == "myresource-def456");
+        Assert.All(result.Where(r => r.Name.StartsWith("myresource-")), r => Assert.Equal("myresource", r.DisplayName));
+
+        await app.StopAsync();
+    }
+
+    [Fact]
+    public async Task GetResourceSnapshotsAsync_MapsSnapshotData()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+
+        var custom = builder.AddResource(new CustomResource("myresource"));
+
+        using var app = builder.Build();
+        await app.StartAsync();
+
+        var createdAt = DateTime.UtcNow.AddMinutes(-5);
+        var startedAt = DateTime.UtcNow.AddMinutes(-4);
+
+        var notificationService = app.Services.GetRequiredService<ResourceNotificationService>();
+        await notificationService.PublishUpdateAsync(custom.Resource, s => s with
+        {
+            State = new ResourceStateSnapshot("Running", KnownResourceStateStyles.Success),
+            CreationTimeStamp = createdAt,
+            StartTimeStamp = startedAt,
+            Urls = [
+                new UrlSnapshot("http", "http://localhost:5000", false),
+                new UrlSnapshot("https", "https://localhost:5001", true),
+                new UrlSnapshot("inactive", "http://localhost:5002", false) { IsInactive = true }
+            ],
+            Relationships = [
+                new RelationshipSnapshot("dependency1", "Reference"),
+                new RelationshipSnapshot("dependency2", "WaitFor")
+            ],
+            HealthReports = [
+                new HealthReportSnapshot("check1", Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Healthy, "All good", null),
+                new HealthReportSnapshot("check2", Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy, "Failed", "Exception occurred")
+            ],
+            Volumes = [
+                new VolumeSnapshot("/host/path", "/container/path", "bind", false),
+                new VolumeSnapshot("myvolume", "/data", "volume", true)
+            ],
+            Properties = [
+                new ResourcePropertySnapshot(CustomResourceKnownProperties.Source, "normal-value"),
+                new ResourcePropertySnapshot("ConnectionString", "secret-value") { IsSensitive = true }
+            ]
+        });
+
+        var target = new AuxiliaryBackchannelRpcTarget(
+            NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
+            app.Services);
+
+        var result = await target.GetResourceSnapshotsAsync();
+
+        var snapshot = Assert.Single(result);
+
+        // State
+        Assert.Equal("Running", snapshot.State);
+        Assert.Equal(KnownResourceStateStyles.Success, snapshot.StateStyle);
+
+        // Timestamps
+        Assert.Equal(createdAt, snapshot.CreatedAt);
+        Assert.Equal(startedAt, snapshot.StartedAt);
+
+        // Endpoints (inactive endpoints should be excluded)
+        Assert.Equal(2, snapshot.Endpoints.Length);
+        Assert.Contains(snapshot.Endpoints, e => e.Name == "http" && e.Url == "http://localhost:5000" && !e.IsInternal);
+        Assert.Contains(snapshot.Endpoints, e => e.Name == "https" && e.Url == "https://localhost:5001" && e.IsInternal);
+        Assert.DoesNotContain(snapshot.Endpoints, e => e.Name == "inactive");
+
+        // Relationships
+        Assert.Equal(2, snapshot.Relationships.Length);
+        Assert.Contains(snapshot.Relationships, r => r.ResourceName == "dependency1" && r.Type == "Reference");
+        Assert.Contains(snapshot.Relationships, r => r.ResourceName == "dependency2" && r.Type == "WaitFor");
+
+        // Health reports
+        Assert.Equal(2, snapshot.HealthReports.Length);
+        Assert.Contains(snapshot.HealthReports, h => h.Name == "check1" && h.Status == "Healthy");
+        Assert.Contains(snapshot.HealthReports, h => h.Name == "check2" && h.Status == "Unhealthy" && h.ExceptionText == "Exception occurred");
+
+        // Volumes
+        Assert.Equal(2, snapshot.Volumes.Length);
+        Assert.Contains(snapshot.Volumes, v => v.Source == "/host/path" && v.Target == "/container/path" && !v.IsReadOnly);
+        Assert.Contains(snapshot.Volumes, v => v.Source == "myvolume" && v.Target == "/data" && v.IsReadOnly);
+
+        // Properties (sensitive values should be redacted)
+        Assert.True(snapshot.Properties.TryGetValue(CustomResourceKnownProperties.Source, out var normalValue));
+        Assert.Equal("normal-value", normalValue);
+        Assert.True(snapshot.Properties.TryGetValue("ConnectionString", out var sensitiveValue));
+        Assert.Null(sensitiveValue);
+
+        await app.StopAsync();
+    }
+
+    private sealed class CustomResource(string name) : Resource(name)
+    {
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Backchannel/BackchannelContractTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/BackchannelContractTests.cs
@@ -30,10 +30,12 @@ public class BackchannelContractTests
         typeof(StopAppHostRequest),
         typeof(StopAppHostResponse),
         typeof(ResourceSnapshot),
-        typeof(ResourceSnapshotEndpoint),
+        typeof(ResourceSnapshotUrl),
+        typeof(ResourceSnapshotUrlDisplayProperties),
         typeof(ResourceSnapshotRelationship),
         typeof(ResourceSnapshotHealthReport),
         typeof(ResourceSnapshotVolume),
+        typeof(ResourceSnapshotEnvironmentVariable),
         typeof(ResourceSnapshotMcpServer),
         typeof(ResourceLogLine),
     ];

--- a/tests/Aspire.Hosting.Tests/ResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceExtensionsTests.cs
@@ -509,4 +509,74 @@ public class ResourceExtensionsTests
     private sealed class TestContainerFilesResource(string name) : ContainerResource(name), IResourceWithContainerFiles
     {
     }
+
+    [Theory]
+    [InlineData(false)] // No annotation
+    [InlineData(true)]  // Empty annotation
+    public void TryGetInstances_ReturnsFalse_WhenNoInstances(bool addEmptyAnnotation)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var resource = builder.AddResource(new ParentResource("test"));
+
+        if (addEmptyAnnotation)
+        {
+            resource.WithAnnotation(new DcpInstancesAnnotation([]));
+        }
+
+        var result = resource.Resource.TryGetInstances(out var instances);
+
+        Assert.False(result);
+        Assert.Empty(instances);
+    }
+
+    [Fact]
+    public void TryGetInstances_ReturnsTrue_WhenAnnotationHasInstances()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var resource = builder.AddResource(new ParentResource("test"))
+            .WithAnnotation(new DcpInstancesAnnotation([
+                new DcpInstance("test-abc123", "abc123", 0),
+                new DcpInstance("test-def456", "def456", 1)
+            ]));
+
+        var result = resource.Resource.TryGetInstances(out var instances);
+
+        Assert.True(result);
+        Assert.Equal(2, instances.Length);
+        Assert.Equal("test-abc123", instances[0].Name);
+        Assert.Equal("test-def456", instances[1].Name);
+    }
+
+    [Theory]
+    [InlineData(false)] // No annotation
+    [InlineData(true)]  // Empty annotation
+    public void GetResolvedInstances_ReturnsResourceName_WhenNoInstances(bool addEmptyAnnotation)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var resource = builder.AddResource(new ParentResource("test"));
+
+        if (addEmptyAnnotation)
+        {
+            resource.WithAnnotation(new DcpInstancesAnnotation([]));
+        }
+
+        var result = resource.Resource.GetResolvedInstances();
+
+        Assert.Equal(["test"], result);
+    }
+
+    [Fact]
+    public void GetResolvedInstances_ReturnsInstanceNames_WhenAnnotationHasInstances()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var resource = builder.AddResource(new ParentResource("test"))
+            .WithAnnotation(new DcpInstancesAnnotation([
+                new DcpInstance("test-abc123", "abc123", 0),
+                new DcpInstance("test-def456", "def456", 1)
+            ]));
+
+        var result = resource.Resource.GetResolvedInstances();
+
+        Assert.Equal(["test-abc123", "test-def456"], result);
+    }
 }

--- a/tests/Aspire.Hosting.Tests/ResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceExtensionsTests.cs
@@ -550,7 +550,7 @@ public class ResourceExtensionsTests
     [Theory]
     [InlineData(false)] // No annotation
     [InlineData(true)]  // Empty annotation
-    public void GetResolvedInstances_ReturnsResourceName_WhenNoInstances(bool addEmptyAnnotation)
+    public void GetResolvedResourceNames_ReturnsResourceName_WhenNoInstances(bool addEmptyAnnotation)
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var resource = builder.AddResource(new ParentResource("test"));
@@ -560,13 +560,13 @@ public class ResourceExtensionsTests
             resource.WithAnnotation(new DcpInstancesAnnotation([]));
         }
 
-        var result = resource.Resource.GetResolvedInstances();
+        var result = resource.Resource.GetResolvedResourceNames();
 
         Assert.Equal(["test"], result);
     }
 
     [Fact]
-    public void GetResolvedInstances_ReturnsInstanceNames_WhenAnnotationHasInstances()
+    public void GetResolvedResourceNames_ReturnsInstanceNames_WhenAnnotationHasInstances()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var resource = builder.AddResource(new ParentResource("test"))
@@ -575,7 +575,7 @@ public class ResourceExtensionsTests
                 new DcpInstance("test-def456", "def456", 1)
             ]));
 
-        var result = resource.Resource.GetResolvedInstances();
+        var result = resource.Resource.GetResolvedResourceNames();
 
         Assert.Equal(["test-abc123", "test-def456"], result);
     }


### PR DESCRIPTION
## Description

Aspire CLI MCP gets resource data via the dashboard. This is more steps than nessessary.

PR changes:
- Get MCP tool gets resource data from the app host
- Improve resource data from the app host. Rename properties/types to match what we use elsewhere. Add missing env vars
- Avoiding duplicate logic. A number of types have been moved to shared source.
- Tests.

This is the first PR to remove dependency on dashboard MCP.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
