### PR TITLE
Improve dotnet tool resource

### DIFF
--- a/playground/DotnetTool/DotnetTool.AppHost/AppHost.cs
+++ b/playground/DotnetTool/DotnetTool.AppHost/AppHost.cs
@@ -68,7 +68,7 @@ builder.AddDotnetTool("offlineWildcard", "dotnet-ef")
 
 builder.AddDotnetTool("offlinePrerelease", "dotnet-ef")
     .WithToolPrerelease()
-     .WithParentRelationship(offline)
+    .WithParentRelationship(offline)
     .WithToolSource(fakeSourcesPath)
     .WithToolIgnoreExistingFeeds()
     .WithToolIgnoreFailedSources();
@@ -79,6 +79,9 @@ var secret = builder.AddParameter("secret", "Shhhhhhh", secret: true);
 builder.AddDotnetTool("secretArg", "dotnet-ef")
     .WithArgs("--version")
     .WithArgs(secret);
+
+builder.AddDotnetTool("incompatibleSdk", "dotnet-ef")
+    .WithWorkingDirectory(Path.Combine(Projects.DotnetTool_AppHost.ProjectPath, "IncompatibleSdk"));
 
 // Some issues only show up when installing for first time, rather than using existing downloaded versions
 // Use a specific NUGET_PACKAGES path for these playground tools, so we can easily reset them

--- a/playground/DotnetTool/DotnetTool.AppHost/IncompatibleSdk/global.json
+++ b/playground/DotnetTool/DotnetTool.AppHost/IncompatibleSdk/global.json
@@ -1,0 +1,8 @@
+{
+  // DO NOT UPDATE THE SDK VERSION IN THIS FILE
+  // It is very explicitly set to simulate an SDK version without `dotnet tool exec`
+  "sdk": {
+    "version": "9.0.0",
+    "rollForward": "latestFeature"
+  }
+}

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -114,6 +114,7 @@
     <InternalsVisibleTo Include="Aspire.Hosting.Python.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Testing.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Containers.Tests" />
+    <InternalsVisibleTo Include="Aspire.Hosting.DotnetTool.Tests" />
     <InternalsVisibleTo Include="Aspire.TestUtilities" />
     <InternalsVisibleTo Include="Aspire.Cli.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.RemoteHost" />

--- a/tests/Aspire.Hosting.DotnetTool.Tests/AddDotnetToolTests.cs
+++ b/tests/Aspire.Hosting.DotnetTool.Tests/AddDotnetToolTests.cs
@@ -377,4 +377,30 @@ public class AddDotnetToolTests
 
         Assert.Equal(expectedManifest, manifest.ToString());
     }
+
+    [Theory]
+    [InlineData("11.1.0", true)]
+    [InlineData("10.0.0", true)]
+    [InlineData("9.0.999", false)]
+    public void ValidateDotnetSdkVersion_ValidatesVersionCorrectly(string versionString, bool isAllowed)
+    {
+        var version = Version.Parse(versionString);
+
+        if (isAllowed)
+        {
+            DotnetToolResourceExtensions.ValidateDotnetSdkVersion(version, "");
+        }
+        else
+        {
+            Assert.Throws<DistributedApplicationException>(() =>
+                DotnetToolResourceExtensions.ValidateDotnetSdkVersion(version, ""));
+        }
+    }
+
+    [Fact]
+    public void ValidateDotnetSdkVersion_WithNullVersion_DoesNotThrow()
+    {
+        // Should not throw - null is treated as "unable to determine version"
+        DotnetToolResourceExtensions.ValidateDotnetSdkVersion(null, "");
+    }
 }


### PR DESCRIPTION
## Description

A few colleagues of mine have gotten confused with the error messages output by old .net sdks when the `dotnet tool exec` command is not found.  To mitigate against this, added a check for the .Net sdk version, and `FailToStart` the resource if a pre 10.0 sdk is detected in the resource's working directory.  Only blocks the execution if we concretely know the SDK is incompatible.  If we fail to determine the SDK, let the resource try to start and present whatever error it ends up presenting.

Ensure resource properties are correctly replaced if a tool resource is restarted, rather than being duplicated.

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
- Did you add public API?
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [X] No
- Does the change require an update in our Aspire docs?
  - [X] No
