### PR TITLE
Upgrade HTTP endpoints to HTTPS in Azure Container Apps

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
@@ -141,6 +141,12 @@ public class AzureContainerAppEnvironmentResource :
     internal bool EnableDashboard { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether HTTP endpoints should be preserved as HTTP instead of being upgraded to HTTPS.
+    /// Default is false (HTTP endpoints are upgraded to HTTPS).
+    /// </summary>
+    internal bool PreserveHttpEndpoints { get; set; }
+
+    /// <summary>
     /// Gets the unique identifier of the Container App Environment.
     /// </summary>
     internal BicepOutputReference ContainerAppEnvironmentId => new("AZURE_CONTAINER_APPS_ENVIRONMENT_ID", this);

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -372,6 +372,24 @@ public static class AzureContainerAppExtensions
     }
 
     /// <summary>
+    /// Configures whether HTTP endpoints should be upgraded to HTTPS in Azure Container Apps.
+    /// By default, HTTP endpoints are upgraded to HTTPS for security and WebSocket compatibility.
+    /// </summary>
+    /// <param name="builder">The AzureContainerAppEnvironmentResource to configure.</param>
+    /// <param name="upgrade">Whether to upgrade HTTP endpoints to HTTPS. Default is true.</param>
+    /// <returns><see cref="IResourceBuilder{T}"/></returns>
+    /// <remarks>
+    /// When disabled (<c>false</c>), HTTP endpoints will use HTTP scheme and port 80 in Azure Container Apps.
+    /// Note that explicit ports specified for development (e.g., port 8080) are still normalized
+    /// to standard ports (80/443) as required by Azure Container Apps.
+    /// </remarks>
+    public static IResourceBuilder<AzureContainerAppEnvironmentResource> WithHttpsUpgrade(this IResourceBuilder<AzureContainerAppEnvironmentResource> builder, bool upgrade = true)
+    {
+        builder.Resource.PreserveHttpEndpoints = !upgrade;
+        return builder;
+    }
+
+    /// <summary>
     /// Configures the container app environment resource to use the specified Log Analytics Workspace.
     /// </summary>
     /// <param name="builder">The AzureContainerAppEnvironmentResource to configure.</param>

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -63,6 +63,9 @@ internal sealed class AzureContainerAppsInfrastructure(
                     ComputeEnvironment = environment
                 });
             }
+
+            // Log once about all HTTP endpoints upgraded to HTTPS
+            containerAppEnvironmentContext.LogHttpsUpgradeIfNeeded();
         }
     }
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -1182,41 +1182,96 @@ public class AzureContainerAppsTests
     }
 
     [Fact]
-    public async Task DefaultHttpIngressMustUsePort80()
+    public async Task DefaultHttpIngressUsesPort80EvenWithDifferentDevPort()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
         builder.AddAzureContainerAppEnvironment("env");
 
+        // Dev port 8081 should be ignored in ACA, mapped to port 80
         builder.AddContainer("api", "myimage")
-            .WithHttpEndpoint(port: 8081);
+            .WithHttpEndpoint(port: 8081, targetPort: 8080);
 
         using var app = builder.Build();
 
+        await ExecuteBeforeStartHooksAsync(app, default);
+
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
 
-        var ex = await Assert.ThrowsAsync<NotSupportedException>(() => ExecuteBeforeStartHooksAsync(app, default));
+        var container = Assert.Single(model.GetContainerResources());
 
-        Assert.Equal($"The endpoint 'http' is an http endpoint and must use port 80", ex.Message);
+        container.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var target);
+
+        var resource = target?.DeploymentTarget as AzureProvisioningResource;
+
+        Assert.NotNull(resource);
+
+        var (manifest, bicep) = await GetManifestWithBicep(resource);
+
+        await Verify(manifest.ToString(), "json")
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]
-    public async Task DefaultHttpsIngressMustUsePort443()
+    public async Task DefaultHttpsIngressUsesPort443EvenWithDifferentDevPort()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
         builder.AddAzureContainerAppEnvironment("env");
 
+        // Dev port 8081 should be ignored in ACA, mapped to port 443
         builder.AddContainer("api", "myimage")
-            .WithHttpsEndpoint(port: 8081);
+            .WithHttpsEndpoint(port: 8081, targetPort: 8443);
 
         using var app = builder.Build();
 
+        await ExecuteBeforeStartHooksAsync(app, default);
+
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
 
-        var ex = await Assert.ThrowsAsync<NotSupportedException>(() => ExecuteBeforeStartHooksAsync(app, default));
+        var container = Assert.Single(model.GetContainerResources());
 
-        Assert.Equal($"The endpoint 'https' is an https endpoint and must use port 443", ex.Message);
+        container.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var target);
+
+        var resource = target?.DeploymentTarget as AzureProvisioningResource;
+
+        Assert.NotNull(resource);
+
+        var (manifest, bicep) = await GetManifestWithBicep(resource);
+
+        await Verify(manifest.ToString(), "json")
+              .AppendContentAsFile(bicep, "bicep");
+    }
+
+    [Fact]
+    public async Task CanPreserveHttpSchemeUsingWithHttpsUpgrade()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        builder.AddAzureContainerAppEnvironment("env")
+            .WithHttpsUpgrade(false);  // Preserve HTTP scheme, don't upgrade to HTTPS
+
+        builder.AddContainer("api", "myimage")
+            .WithHttpEndpoint(port: 8080, targetPort: 80);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var container = Assert.Single(model.GetContainerResources());
+
+        container.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var target);
+
+        var resource = target?.DeploymentTarget as AzureProvisioningResource;
+
+        Assert.NotNull(resource);
+
+        var (manifest, bicep) = await GetManifestWithBicep(resource);
+
+        await Verify(manifest.ToString(), "json")
+              .AppendContentAsFile(bicep, "bicep");
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.CanPreserveHttpSchemeUsingWithHttpsUpgrade.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.CanPreserveHttpSchemeUsingWithHttpsUpgrade.verified.bicep
@@ -1,0 +1,33 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param env_outputs_azure_container_apps_environment_default_domain string
+
+param env_outputs_azure_container_apps_environment_id string
+
+resource api 'Microsoft.App/containerApps@2025-01-01' = {
+  name: 'api'
+  location: location
+  properties: {
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        external: false
+        targetPort: 80
+        transport: 'http'
+      }
+    }
+    environmentId: env_outputs_azure_container_apps_environment_id
+    template: {
+      containers: [
+        {
+          image: 'myimage:latest'
+          name: 'api'
+        }
+      ]
+      scale: {
+        minReplicas: 1
+      }
+    }
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.CanPreserveHttpSchemeUsingWithHttpsUpgrade.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.CanPreserveHttpSchemeUsingWithHttpsUpgrade.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "api-containerapp.module.bicep",
+  "params": {
+    "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+    "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.DefaultHttpIngressUsesPort80EvenWithDifferentDevPort.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.DefaultHttpIngressUsesPort80EvenWithDifferentDevPort.verified.bicep
@@ -1,0 +1,33 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param env_outputs_azure_container_apps_environment_default_domain string
+
+param env_outputs_azure_container_apps_environment_id string
+
+resource api 'Microsoft.App/containerApps@2025-01-01' = {
+  name: 'api'
+  location: location
+  properties: {
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        external: false
+        targetPort: 8080
+        transport: 'http'
+      }
+    }
+    environmentId: env_outputs_azure_container_apps_environment_id
+    template: {
+      containers: [
+        {
+          image: 'myimage:latest'
+          name: 'api'
+        }
+      ]
+      scale: {
+        minReplicas: 1
+      }
+    }
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.DefaultHttpIngressUsesPort80EvenWithDifferentDevPort.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.DefaultHttpIngressUsesPort80EvenWithDifferentDevPort.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "api-containerapp.module.bicep",
+  "params": {
+    "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+    "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.DefaultHttpsIngressUsesPort443EvenWithDifferentDevPort.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.DefaultHttpsIngressUsesPort443EvenWithDifferentDevPort.verified.bicep
@@ -1,0 +1,33 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param env_outputs_azure_container_apps_environment_default_domain string
+
+param env_outputs_azure_container_apps_environment_id string
+
+resource api 'Microsoft.App/containerApps@2025-01-01' = {
+  name: 'api'
+  location: location
+  properties: {
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        external: false
+        targetPort: 8443
+        transport: 'http'
+      }
+    }
+    environmentId: env_outputs_azure_container_apps_environment_id
+    template: {
+      containers: [
+        {
+          image: 'myimage:latest'
+          name: 'api'
+        }
+      ]
+      scale: {
+        minReplicas: 1
+      }
+    }
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.DefaultHttpsIngressUsesPort443EvenWithDifferentDevPort.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.DefaultHttpsIngressUsesPort443EvenWithDifferentDevPort.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "api-containerapp.module.bicep",
+  "params": {
+    "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+    "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypes#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypes#00.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_apps_environment_default_domain string
@@ -203,7 +203,7 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
             }
             {
               name: 'HTTP_EP'
-              value: 'http://api.internal.${env_outputs_azure_container_apps_environment_default_domain}'
+              value: 'https://api.internal.${env_outputs_azure_container_apps_environment_default_domain}'
             }
             {
               name: 'HTTPS_EP'
@@ -219,7 +219,7 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
             }
             {
               name: 'PORT'
-              value: '80'
+              value: '443'
             }
             {
               name: 'HOST'
@@ -227,11 +227,11 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
             }
             {
               name: 'HOSTANDPORT'
-              value: 'api.internal.${env_outputs_azure_container_apps_environment_default_domain}:80'
+              value: 'api.internal.${env_outputs_azure_container_apps_environment_default_domain}:443'
             }
             {
               name: 'SCHEME'
-              value: 'http'
+              value: 'https'
             }
             {
               name: 'INTERNAL_HOSTANDPORT'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypesAndContainerAppEnvironment#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypesAndContainerAppEnvironment#00.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param cae_outputs_azure_container_apps_environment_default_domain string
@@ -192,7 +192,7 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
             }
             {
               name: 'HTTP_EP'
-              value: 'http://api.internal.${cae_outputs_azure_container_apps_environment_default_domain}'
+              value: 'https://api.internal.${cae_outputs_azure_container_apps_environment_default_domain}'
             }
             {
               name: 'HTTPS_EP'
@@ -208,7 +208,7 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
             }
             {
               name: 'PORT'
-              value: '80'
+              value: '443'
             }
             {
               name: 'HOST'
@@ -216,11 +216,11 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
             }
             {
               name: 'HOSTANDPORT'
-              value: 'api.internal.${cae_outputs_azure_container_apps_environment_default_domain}:80'
+              value: 'api.internal.${cae_outputs_azure_container_apps_environment_default_domain}:443'
             }
             {
               name: 'SCHEME'
-              value: 'http'
+              value: 'https'
             }
             {
               name: 'INTERNAL_HOSTANDPORT'


### PR DESCRIPTION
## Description

This PR changes how HTTP endpoints are handled when deploying to Azure Container Apps:

**Problem:**
- HTTP→HTTPS redirect in ACA breaks WebSocket upgrade requests (they just fail)
- Explicit ports like 8080 caused `NotSupportedException` at deploy time, even though they work fine for local dev
- Developers had to manually adjust endpoint configs between dev and production

**Solution:**
- HTTP endpoints are now automatically upgraded to HTTPS (port 443) by default
- Explicit ports specified for development are treated as dev-only hints and normalized to 80/443
- Removed `NotSupportedException` throws - instead logs informational messages
- Added `WithHttpsUpgrade(false)` on the environment to opt out and preserve HTTP scheme

**Usage:**
```csharp
// Default: HTTP endpoints upgraded to HTTPS
builder.AddAzureContainerAppEnvironment("env");

// Opt out: preserve HTTP scheme
builder.AddAzureContainerAppEnvironment("env")
    .WithHttpsUpgrade(false);
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No