### PR TITLE
Expose doc slug in search_docs tool result so that if the LLM decides…

### DIFF
--- a/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
+++ b/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
@@ -203,6 +203,23 @@ internal static class CommonAgentApplicators
 
         IMPORTANT! The aspire workload is obsolete. You should never attempt to install or use the Aspire workload.
 
+        ## Aspire Documentation Tools
+
+        IMPORTANT! The Aspire MCP server provides tools to search and retrieve official Aspire documentation directly. Use these tools to find accurate, up-to-date information about Aspire features, APIs, and integrations:
+
+        1. **list_docs**: Lists all available documentation pages from aspire.dev. Returns titles, slugs, and summaries. Use this to discover available topics.
+
+        2. **search_docs**: Searches the documentation using keywords. Returns ranked results with titles, slugs, and matched content. Use this when looking for specific features, APIs, or concepts.
+
+        3. **get_doc**: Retrieves the full content of a documentation page by its slug. After using `list_docs` or `search_docs` to find a relevant page, pass the slug to `get_doc` to retrieve the complete documentation.
+
+        ### Recommended workflow for documentation
+
+        1. Use `search_docs` with relevant keywords to find documentation about a topic
+        2. Review the search results - each result includes a **Slug** that identifies the page
+        3. Use `get_doc` with the slug to retrieve the full documentation content
+        4. Optionally use the `section` parameter with `get_doc` to retrieve only a specific section
+
         ## Official documentation
 
         IMPORTANT! Always prefer official documentation when available. The following sites contain the official documentation for Aspire and related components

--- a/src/Aspire.Cli/Mcp/Docs/DocsSearchService.cs
+++ b/src/Aspire.Cli/Mcp/Docs/DocsSearchService.cs
@@ -80,10 +80,10 @@ internal sealed class DocsSearchResponse
             sb.AppendLine(result.Content);
             sb.AppendLine();
             sb.AppendLine("---");
-            sb.AppendLine("Use `get_doc` with the slug to retrieve the full content of this page.");
-            sb.AppendLine();
         }
 
+        sb.AppendLine("Use `get_doc` with the slug to retrieve the full content of this page.");
+        sb.AppendLine();
         return sb.ToString();
     }
 }

--- a/src/Aspire.Cli/Mcp/Docs/DocsSearchService.cs
+++ b/src/Aspire.Cli/Mcp/Docs/DocsSearchService.cs
@@ -62,12 +62,14 @@ internal sealed class DocsSearchResponse
 
             if (showScores)
             {
-                sb.AppendLine(CultureInfo.InvariantCulture, $"## Result {i + 1} (Score: {result.Score:F3})");
+                sb.AppendLine(CultureInfo.InvariantCulture, $"## {result.Title} (Score: {result.Score:F3})");
             }
             else
             {
-                sb.AppendLine(CultureInfo.InvariantCulture, $"## Result {i + 1}");
+                sb.AppendLine(CultureInfo.InvariantCulture, $"## {result.Title}");
             }
+
+            sb.AppendLine(CultureInfo.InvariantCulture, $"**Slug:** `{result.Slug}`");
 
             if (!string.IsNullOrEmpty(result.Section))
             {
@@ -78,6 +80,7 @@ internal sealed class DocsSearchResponse
             sb.AppendLine(result.Content);
             sb.AppendLine();
             sb.AppendLine("---");
+            sb.AppendLine("Use `get_doc` with the slug to retrieve the full content of this page.");
             sb.AppendLine();
         }
 
@@ -90,6 +93,16 @@ internal sealed class DocsSearchResponse
 /// </summary>
 internal sealed class SearchResult
 {
+    /// <summary>
+    /// Gets the title of the matched document.
+    /// </summary>
+    public required string Title { get; init; }
+
+    /// <summary>
+    /// Gets the slug of the matched document, used with get_doc to retrieve full content.
+    /// </summary>
+    public required string Slug { get; init; }
+
     /// <summary>
     /// Gets the matched content.
     /// </summary>
@@ -126,6 +139,8 @@ internal sealed class DocsSearchService(
         // Convert DocsSearchResult to SearchResult
         var results = searchResults.Select(r => new SearchResult
         {
+            Title = r.Title,
+            Slug = r.Slug,
             Content = r.Summary ?? r.Title,
             Section = r.MatchedSection,
             Score = r.Score

--- a/tests/Aspire.Cli.Tests/Mcp/Docs/DocsSearchServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/Docs/DocsSearchServiceTests.cs
@@ -69,7 +69,8 @@ public class DocsSearchServiceTests
         var markdown = response.FormatAsMarkdown("Test Results");
 
         Assert.Contains("# Test Results", markdown);
-        Assert.Contains("## Result 1", markdown);
+        Assert.Contains("## Redis Integration", markdown);
+        Assert.Contains("**Slug:**", markdown);
     }
 
     [Fact]
@@ -264,8 +265,9 @@ public class DocsSearchServiceTests
 
         var markdown = response.FormatAsMarkdown("");
 
-        // Verify the content contains the search result header and result info
-        Assert.Contains("## Result", markdown);
+        // Verify the content contains the document title and slug
+        Assert.Contains("## Redis Integration", markdown);
+        Assert.Contains("**Slug:**", markdown);
         Assert.Contains("Redis", markdown);
     }
 


### PR DESCRIPTION
… to call get_doc it works.

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [ ] No
