### PR TITLE
Apply filters when set even if metrics collection is paused

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartBase.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartBase.cs
@@ -80,9 +80,14 @@ public abstract class ChartBase : ComponentBase, IAsyncDisposable
 
         var inProgressDataTime = PauseManager.AreMetricsPaused(out var pausedAt) ? pausedAt.Value : GetCurrentDataTime();
 
-        while (_currentDataStartTime.Add(_tickDuration) < inProgressDataTime)
+        // Only advance the time window when not paused. When paused, keep the chart's
+        // time axis stable so filter changes don't cause the x-axis to jump.
+        if (pausedAt is null)
         {
-            _currentDataStartTime = _currentDataStartTime.Add(_tickDuration);
+            while (_currentDataStartTime.Add(_tickDuration) < inProgressDataTime)
+            {
+                _currentDataStartTime = _currentDataStartTime.Add(_tickDuration);
+            }
         }
 
         var dimensionAttributes = InstrumentViewModel.MatchedDimensions.Select(d => d.Attributes).ToList();

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor
@@ -38,7 +38,7 @@ else
                        Icon="@(new Icons.Regular.Size24.DataArea())">
                 <div class="metrics-chart-container metric-tab">
                     <PlotlyChart InstrumentViewModel="_instrumentViewModel" Duration="Duration" Resources="Resources"/>
-                    <ChartFilters InstrumentViewModel="_instrumentViewModel" Instrument="_instrument" DimensionFilters="@DimensionFilters" />
+                    <ChartFilters InstrumentViewModel="_instrumentViewModel" Instrument="_instrument" DimensionFilters="@DimensionFilters" OnDimensionValuesChanged="DimensionValuesChangedAsync" />
                 </div>
             </FluentTab>
             <FluentTab LabelClass="tab-label"
@@ -47,7 +47,7 @@ else
                        Icon="@(new Icons.Regular.Size24.Table())">
                 <div class="metrics-chart-container metric-tab">
                     <MetricTable InstrumentViewModel="_instrumentViewModel" Duration="Duration" Resources="Resources" />
-                    <ChartFilters InstrumentViewModel="_instrumentViewModel" Instrument="_instrument" DimensionFilters="@DimensionFilters"/>
+                    <ChartFilters InstrumentViewModel="_instrumentViewModel" Instrument="_instrument" DimensionFilters="@DimensionFilters" OnDimensionValuesChanged="DimensionValuesChangedAsync" />
                 </div>
             </FluentTab>
         </FluentTabs>

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
@@ -183,7 +183,9 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
 
     private OtlpInstrumentData? GetInstrument()
     {
-        var endDate = DateTime.UtcNow;
+        // When paused, use the paused time to keep the data window stable.
+        // This ensures filter changes while paused still show the same data.
+        var endDate = PauseManager.AreMetricsPaused(out var pausedAt) ? pausedAt.Value : DateTime.UtcNow;
         // Get more data than is being displayed. Histogram graph uses some historical data to calculate bucket counts.
         // It's ok to get more data than is needed here. An additional date filter is applied when building chart values.
         var startDate = endDate.Subtract(Duration + TimeSpan.FromSeconds(30));

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
@@ -63,7 +63,8 @@
                                                 ThreeState="true"
                                                 ShowIndeterminate="false"
                                                 ThreeStateOrderUncheckToIntermediate="true"
-                                                @bind-CheckState="context.AreAllValuesSelected"/>
+                                                @bind-CheckState:get="context.AreAllValuesSelected"
+                                                @bind-CheckState:set="@(v => OnAllValuesSelectionChangedAsync(context, v))"/>
                                 @foreach (var tag in context.Values.OrderBy(v => v.Text))
                                 {
                                     var isChecked = context.SelectedValues.Contains(tag);
@@ -71,7 +72,7 @@
                                                     title="@tag.Text"
                                                     @key=tag
                                                     @bind-Value:get="isChecked"
-                                                    @bind-Value:set="c => context.OnTagSelectionChanged(tag, c)"/>
+                                                    @bind-Value:set="c => OnTagSelectionChangedAsync(context, tag, c)"/>
                                 }
                             </FluentStack>
                             </Body>

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor.cs
@@ -19,6 +19,9 @@ public partial class ChartFilters
     [Parameter, EditorRequired]
     public required ImmutableList<DimensionFilterViewModel> DimensionFilters { get; set; }
 
+    [Parameter]
+    public EventCallback<DimensionFilterViewModel> OnDimensionValuesChanged { get; set; }
+
     public bool ShowCounts { get; set; }
 
     protected override void OnInitialized()
@@ -33,5 +36,17 @@ public partial class ChartFilters
     private void ShowCountChanged()
     {
         InstrumentViewModel.ShowCount = ShowCounts;
+    }
+
+    private async Task OnTagSelectionChangedAsync(DimensionFilterViewModel context, DimensionValueViewModel tag, bool isChecked)
+    {
+        context.OnTagSelectionChanged(tag, isChecked);
+        await OnDimensionValuesChanged.InvokeAsync(context);
+    }
+
+    private async Task OnAllValuesSelectionChangedAsync(DimensionFilterViewModel context, bool? isChecked)
+    {
+        context.AreAllValuesSelected = isChecked;
+        await OnDimensionValuesChanged.InvokeAsync(context);
     }
 }

--- a/src/Aspire.Dashboard/Model/DimensionFilterViewModel.cs
+++ b/src/Aspire.Dashboard/Model/DimensionFilterViewModel.cs
@@ -34,8 +34,17 @@ public class DimensionFilterViewModel
             }
             else if (value is false)
             {
-                SelectedValues.Clear();
+                // Only clear if all values are currently selected.
+                // FluentCheckbox's three-state handling can spuriously fire the setter with false
+                // when the state transitions from true to null (intermediate) due to individual
+                // checkbox changes. In that case, AreAllValuesSelected is already null/false,
+                // and we should not clear the remaining selections.
+                if (AreAllValuesSelected is true)
+                {
+                    SelectedValues.Clear();
+                }
             }
+            // When value is null (intermediate state), do nothing.
         }
     }
 

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ChartFiltersTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ChartFiltersTests.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Xunit;
+
+namespace Aspire.Dashboard.Components.Tests.Controls;
+
+public class ChartFiltersTests
+{
+    [Fact]
+    public void AreAllValuesSelected_SetFalse_ClearsOnlyWhenAllSelected()
+    {
+        // Arrange - all values selected
+        var dimensionFilter = new DimensionFilterViewModel { Name = "http.method" };
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "GET", Value = "GET" });
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "POST", Value = "POST" });
+        dimensionFilter.SelectedValues.Add(dimensionFilter.Values[0]);
+        dimensionFilter.SelectedValues.Add(dimensionFilter.Values[1]);
+
+        Assert.True(dimensionFilter.AreAllValuesSelected);
+
+        // Act - set false when all are selected
+        dimensionFilter.AreAllValuesSelected = false;
+
+        // Assert - should clear
+        Assert.Empty(dimensionFilter.SelectedValues);
+    }
+
+    [Fact]
+    public void AreAllValuesSelected_SetFalse_DoesNotClearWhenPartiallySelected()
+    {
+        // This test verifies the fix for the FluentCheckbox ThreeState race condition.
+        // FluentCheckbox with ThreeState=true can spuriously fire the setter with false
+        // when the bound CheckState changes from true to null (intermediate state).
+        // Our fix prevents clearing when AreAllValuesSelected is not true.
+
+        // Arrange - only GET selected (partial selection, AreAllValuesSelected = null)
+        var dimensionFilter = new DimensionFilterViewModel { Name = "http.method" };
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "GET", Value = "GET" });
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "POST", Value = "POST" });
+        dimensionFilter.SelectedValues.Add(dimensionFilter.Values[0]); // Only GET
+
+        Assert.Null(dimensionFilter.AreAllValuesSelected); // Partial selection = null
+
+        // Act - simulate FluentCheckbox spuriously firing setter with false
+        dimensionFilter.AreAllValuesSelected = false;
+
+        // Assert - GET should still be selected (not cleared)
+        Assert.Single(dimensionFilter.SelectedValues);
+        Assert.Equal("GET", dimensionFilter.SelectedValues.First().Value);
+    }
+
+    [Fact]
+    public void AreAllValuesSelected_SetTrue_SelectsAllValues()
+    {
+        // Arrange - no values selected
+        var dimensionFilter = new DimensionFilterViewModel { Name = "http.method" };
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "GET", Value = "GET" });
+        dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "POST", Value = "POST" });
+
+        // Act
+        dimensionFilter.AreAllValuesSelected = true;
+
+        // Assert
+        Assert.Equal(2, dimensionFilter.SelectedValues.Count);
+        Assert.True(dimensionFilter.AreAllValuesSelected);
+    }
+
+    [Fact]
+    public void OnTagSelectionChanged_RemovesValue_LeavesOthersSelected()
+    {
+        // This tests the normal flow when user unchecks a single filter value.
+
+        // Arrange - both selected
+        var dimensionFilter = new DimensionFilterViewModel { Name = "http.method" };
+        var getValue = new DimensionValueViewModel { Text = "GET", Value = "GET" };
+        var postValue = new DimensionValueViewModel { Text = "POST", Value = "POST" };
+        dimensionFilter.Values.Add(getValue);
+        dimensionFilter.Values.Add(postValue);
+        dimensionFilter.SelectedValues.Add(getValue);
+        dimensionFilter.SelectedValues.Add(postValue);
+
+        // Act - uncheck GET
+        dimensionFilter.OnTagSelectionChanged(getValue, isChecked: false);
+
+        // Assert - only POST remains
+        Assert.Single(dimensionFilter.SelectedValues);
+        Assert.Contains(postValue, dimensionFilter.SelectedValues);
+        Assert.DoesNotContain(getValue, dimensionFilter.SelectedValues);
+    }
+}


### PR DESCRIPTION
## Description

Two small fixes.

First, adds a new event when dimension values change that the chart subscribes to so it can update its data when paused, as `UpdateDataAsync` only updates instrument data when collection is not paused. The end date is set to the pause time if paused so that the same data window is shown while paused.

Second, fixes a condition where all filter values could be set to false when any are unselected by only unselecting all filters if previously all were selected (meaning the user clicked the All checkbox).

Fixes #11692
Fixes #11693

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [X] No
