### PR TITLE
Remove argument null checks in command constructors

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -13,12 +13,13 @@
         "--project",
         "${workspaceFolder}/src/Aspire.Cli/Aspire.Cli.csproj",
         "--",
-        "mcp",
-        "start"
+        "agent",
+        "mcp"
       ],
     },
     // After starting this MCP server: Debug ->
     // Attach to Aspire MCP server -> Select the "aspire" process...
+    /*
     "aspire-debug": {
       "type": "stdio",
       "command": "dotnet",
@@ -27,11 +28,12 @@
         "--project",
         "${workspaceFolder}/src/Aspire.Cli/Aspire.Cli.csproj",
         "--",
+        "agent",
         "mcp",
-        "start",
         "--cli-wait-for-debugger"
       ],
     },
+    */
     "hex1b": {
       "type": "stdio",
       "command": "dnx",

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -3,8 +3,9 @@
     "aspire": {
       "type": "stdio",
       "command": "aspire",
-      "args": ["mcp", "start"]
+      "args": ["agent", "mcp"]
     },
+    /*
     "aspire-local": {
       "type": "stdio",
       "command": "dotnet",
@@ -17,6 +18,7 @@
         "mcp"
       ],
     },
+    */
     // After starting this MCP server: Debug ->
     // Attach to Aspire MCP server -> Select the "aspire" process...
     /*

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -47,15 +47,6 @@ internal sealed class AddCommand : BaseCommand
     public AddCommand(IPackagingService packagingService, IInteractionService interactionService, IProjectLocator projectLocator, IAddCommandPrompter prompter, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory)
         : base("add", AddCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        ArgumentNullException.ThrowIfNull(packagingService);
-        ArgumentNullException.ThrowIfNull(interactionService);
-        ArgumentNullException.ThrowIfNull(projectLocator);
-        ArgumentNullException.ThrowIfNull(prompter);
-        ArgumentNullException.ThrowIfNull(sdkInstaller);
-        ArgumentNullException.ThrowIfNull(hostEnvironment);
-        ArgumentNullException.ThrowIfNull(features);
-        ArgumentNullException.ThrowIfNull(projectFactory);
-
         _packagingService = packagingService;
         _projectLocator = projectLocator;
         _prompter = prompter;

--- a/src/Aspire.Cli/Commands/AgentCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentCommand.cs
@@ -26,9 +26,6 @@ internal sealed class AgentCommand : BaseCommand
         AspireCliTelemetry telemetry)
         : base("agent", AgentCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        ArgumentNullException.ThrowIfNull(mcpCommand);
-        ArgumentNullException.ThrowIfNull(initCommand);
-
         Subcommands.Add(mcpCommand);
         Subcommands.Add(initCommand);
     }

--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -45,10 +45,6 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         AspireCliTelemetry telemetry)
         : base("init", AgentCommandStrings.InitCommand_Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        ArgumentNullException.ThrowIfNull(interactionService);
-        ArgumentNullException.ThrowIfNull(agentEnvironmentDetector);
-        ArgumentNullException.ThrowIfNull(gitRepository);
-
         _interactionService = interactionService;
         _agentEnvironmentDetector = agentEnvironmentDetector;
         _gitRepository = gitRepository;

--- a/src/Aspire.Cli/Commands/CacheCommand.cs
+++ b/src/Aspire.Cli/Commands/CacheCommand.cs
@@ -17,8 +17,6 @@ internal sealed class CacheCommand : BaseCommand
     public CacheCommand(IInteractionService interactionService, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, AspireCliTelemetry telemetry)
         : base("cache", CacheCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        ArgumentNullException.ThrowIfNull(interactionService);
-
         var clearCommand = new ClearCommand(InteractionService, features, updateNotifier, executionContext, telemetry);
 
         Subcommands.Add(clearCommand);

--- a/src/Aspire.Cli/Commands/ConfigCommand.cs
+++ b/src/Aspire.Cli/Commands/ConfigCommand.cs
@@ -6,7 +6,6 @@ using System.CommandLine.Help;
 using System.Diagnostics;
 using System.Globalization;
 using Aspire.Cli.Configuration;
-using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
@@ -22,14 +21,9 @@ internal sealed class ConfigCommand : BaseCommand
     private readonly IConfiguration _configuration;
     private readonly IInteractionService _interactionService;
 
-    public ConfigCommand(IConfiguration configuration, IConfigurationService configurationService, IInteractionService interactionService, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, AspireCliTelemetry telemetry)
+    public ConfigCommand(IConfiguration configuration, IConfigurationService configurationService, IInteractionService interactionService, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, AspireCliTelemetry telemetry)
         : base("config", ConfigCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        ArgumentNullException.ThrowIfNull(configuration);
-        ArgumentNullException.ThrowIfNull(configurationService);
-        ArgumentNullException.ThrowIfNull(interactionService);
-        ArgumentNullException.ThrowIfNull(sdkInstaller);
-
         _configuration = configuration;
         _interactionService = interactionService;
 

--- a/src/Aspire.Cli/Commands/DoctorCommand.cs
+++ b/src/Aspire.Cli/Commands/DoctorCommand.cs
@@ -32,9 +32,6 @@ internal sealed class DoctorCommand : BaseCommand
         AspireCliTelemetry telemetry)
         : base("doctor", DoctorCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        ArgumentNullException.ThrowIfNull(environmentChecker);
-        ArgumentNullException.ThrowIfNull(ansiConsole);
-
         _environmentChecker = environmentChecker;
         _ansiConsole = ansiConsole;
 

--- a/src/Aspire.Cli/Commands/ExecCommand.cs
+++ b/src/Aspire.Cli/Commands/ExecCommand.cs
@@ -61,15 +61,6 @@ internal class ExecCommand : BaseCommand
         CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment)
         : base("exec", ExecCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        ArgumentNullException.ThrowIfNull(runner);
-        ArgumentNullException.ThrowIfNull(interactionService);
-        ArgumentNullException.ThrowIfNull(certificateService);
-        ArgumentNullException.ThrowIfNull(projectLocator);
-        ArgumentNullException.ThrowIfNull(ansiConsole);
-        ArgumentNullException.ThrowIfNull(sdkInstaller);
-        ArgumentNullException.ThrowIfNull(hostEnvironment);
-        ArgumentNullException.ThrowIfNull(features);
-
         _runner = runner;
         _certificateService = certificateService;
         _projectLocator = projectLocator;

--- a/src/Aspire.Cli/Commands/ExtensionInternalCommand.cs
+++ b/src/Aspire.Cli/Commands/ExtensionInternalCommand.cs
@@ -17,9 +17,6 @@ internal sealed class ExtensionInternalCommand : BaseCommand
 {
     public ExtensionInternalCommand(IFeatures features, ICliUpdateNotifier updateNotifier, IProjectLocator projectLocator, CliExecutionContext executionContext, IInteractionService interactionService, AspireCliTelemetry telemetry) : base("extension", "Hidden command for extension integration", features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        ArgumentNullException.ThrowIfNull(features);
-        ArgumentNullException.ThrowIfNull(updateNotifier);
-
         this.Hidden = true;
         this.Subcommands.Add(new GetAppHostCandidatesCommand(features, updateNotifier, projectLocator, executionContext, interactionService, telemetry));
     }

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -85,19 +85,6 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
         IScaffoldingService scaffoldingService)
         : base("init", InitCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        ArgumentNullException.ThrowIfNull(runner);
-        ArgumentNullException.ThrowIfNull(certificateService);
-        ArgumentNullException.ThrowIfNull(prompter);
-        ArgumentNullException.ThrowIfNull(templateFactory);
-        ArgumentNullException.ThrowIfNull(packagingService);
-        ArgumentNullException.ThrowIfNull(solutionLocator);
-        ArgumentNullException.ThrowIfNull(sdkInstaller);
-        ArgumentNullException.ThrowIfNull(hostEnvironment);
-        ArgumentNullException.ThrowIfNull(configurationService);
-        ArgumentNullException.ThrowIfNull(languageService);
-        ArgumentNullException.ThrowIfNull(languageDiscovery);
-        ArgumentNullException.ThrowIfNull(scaffoldingService);
-
         _runner = runner;
         _certificateService = certificateService;
         _prompter = prompter;

--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -125,11 +125,6 @@ internal sealed class LogsCommand : BaseCommand
         ILogger<LogsCommand> logger)
         : base("logs", LogsCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        ArgumentNullException.ThrowIfNull(interactionService);
-        ArgumentNullException.ThrowIfNull(backchannelMonitor);
-        ArgumentNullException.ThrowIfNull(hostEnvironment);
-        ArgumentNullException.ThrowIfNull(logger);
-
         _interactionService = interactionService;
         _hostEnvironment = hostEnvironment;
         _logger = logger;

--- a/src/Aspire.Cli/Commands/McpCommand.cs
+++ b/src/Aspire.Cli/Commands/McpCommand.cs
@@ -40,8 +40,6 @@ internal sealed class McpCommand : BaseCommand
         AspireCliTelemetry telemetry)
         : base("mcp", McpCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        ArgumentNullException.ThrowIfNull(interactionService);
-
         // Mark as hidden - use 'aspire agent' instead
         Hidden = true;
 

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -87,16 +87,6 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         IScaffoldingService scaffoldingService)
         : base("new", NewCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        ArgumentNullException.ThrowIfNull(runner);
-        ArgumentNullException.ThrowIfNull(nuGetPackageCache);
-        ArgumentNullException.ThrowIfNull(certificateService);
-        ArgumentNullException.ThrowIfNull(prompter);
-        ArgumentNullException.ThrowIfNull(templateProvider);
-        ArgumentNullException.ThrowIfNull(sdkInstaller);
-        ArgumentNullException.ThrowIfNull(hostEnvironment);
-        ArgumentNullException.ThrowIfNull(languageDiscovery);
-        ArgumentNullException.ThrowIfNull(scaffoldingService);
-
         _runner = runner;
         _nuGetPackageCache = nuGetPackageCache;
         _certificateService = certificateService;

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -70,15 +70,6 @@ internal abstract class PipelineCommandBase : BaseCommand
     protected PipelineCommandBase(string name, string description, IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory, ILogger logger, IAnsiConsole ansiConsole)
         : base(name, description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        ArgumentNullException.ThrowIfNull(runner);
-        ArgumentNullException.ThrowIfNull(projectLocator);
-        ArgumentNullException.ThrowIfNull(sdkInstaller);
-        ArgumentNullException.ThrowIfNull(hostEnvironment);
-        ArgumentNullException.ThrowIfNull(features);
-        ArgumentNullException.ThrowIfNull(projectFactory);
-        ArgumentNullException.ThrowIfNull(logger);
-        ArgumentNullException.ThrowIfNull(ansiConsole);
-
         _runner = runner;
         _projectLocator = projectLocator;
         _sdkInstaller = sdkInstaller;

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -62,10 +62,6 @@ internal sealed class PsCommand : BaseCommand
         ILogger<PsCommand> logger)
         : base("ps", PsCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        ArgumentNullException.ThrowIfNull(interactionService);
-        ArgumentNullException.ThrowIfNull(backchannelMonitor);
-        ArgumentNullException.ThrowIfNull(logger);
-
         _interactionService = interactionService;
         _backchannelMonitor = backchannelMonitor;
         _logger = logger;

--- a/src/Aspire.Cli/Commands/PublishCommand.cs
+++ b/src/Aspire.Cli/Commands/PublishCommand.cs
@@ -39,7 +39,6 @@ internal sealed class PublishCommand : PipelineCommandBase
     public PublishCommand(IDotNetCliRunner runner, IInteractionService interactionService, IProjectLocator projectLocator, IPublishCommandPrompter prompter, AspireCliTelemetry telemetry, IDotNetSdkInstaller sdkInstaller, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IAppHostProjectFactory projectFactory, ILogger<PublishCommand> logger, IAnsiConsole ansiConsole)
         : base("publish", PublishCommandStrings.Description, runner, interactionService, projectLocator, telemetry, sdkInstaller, features, updateNotifier, executionContext, hostEnvironment, projectFactory, logger, ansiConsole)
     {
-        ArgumentNullException.ThrowIfNull(prompter);
         _prompter = prompter;
     }
 

--- a/src/Aspire.Cli/Commands/ResourcesCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourcesCommand.cs
@@ -98,10 +98,6 @@ internal sealed class ResourcesCommand : BaseCommand
         ILogger<ResourcesCommand> logger)
         : base("resources", ResourcesCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        ArgumentNullException.ThrowIfNull(interactionService);
-        ArgumentNullException.ThrowIfNull(backchannelMonitor);
-        ArgumentNullException.ThrowIfNull(logger);
-
         _interactionService = interactionService;
         _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, executionContext, logger);
 

--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -78,29 +78,6 @@ internal sealed class RootCommand : BaseRootCommand
         IInteractionService interactionService)
         : base(RootCommandStrings.Description)
     {
-        ArgumentNullException.ThrowIfNull(newCommand);
-        ArgumentNullException.ThrowIfNull(initCommand);
-        ArgumentNullException.ThrowIfNull(runCommand);
-        ArgumentNullException.ThrowIfNull(stopCommand);
-        ArgumentNullException.ThrowIfNull(psCommand);
-        ArgumentNullException.ThrowIfNull(resourcesCommand);
-        ArgumentNullException.ThrowIfNull(logsCommand);
-        ArgumentNullException.ThrowIfNull(addCommand);
-        ArgumentNullException.ThrowIfNull(publishCommand);
-        ArgumentNullException.ThrowIfNull(configCommand);
-        ArgumentNullException.ThrowIfNull(cacheCommand);
-        ArgumentNullException.ThrowIfNull(doctorCommand);
-        ArgumentNullException.ThrowIfNull(deployCommand);
-        ArgumentNullException.ThrowIfNull(doCommand);
-        ArgumentNullException.ThrowIfNull(updateCommand);
-        ArgumentNullException.ThrowIfNull(execCommand);
-        ArgumentNullException.ThrowIfNull(mcpCommand);
-        ArgumentNullException.ThrowIfNull(agentCommand);
-        ArgumentNullException.ThrowIfNull(sdkCommand);
-        ArgumentNullException.ThrowIfNull(extensionInternalCommand);
-        ArgumentNullException.ThrowIfNull(featureFlags);
-        ArgumentNullException.ThrowIfNull(interactionService);
-
         _interactionService = interactionService;
 
 #if DEBUG

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -105,18 +105,6 @@ internal sealed class RunCommand : BaseCommand
         TimeProvider? timeProvider)
         : base("run", RunCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        ArgumentNullException.ThrowIfNull(runner);
-        ArgumentNullException.ThrowIfNull(interactionService);
-        ArgumentNullException.ThrowIfNull(certificateService);
-        ArgumentNullException.ThrowIfNull(projectLocator);
-        ArgumentNullException.ThrowIfNull(ansiConsole);
-        ArgumentNullException.ThrowIfNull(configuration);
-        ArgumentNullException.ThrowIfNull(sdkInstaller);
-        ArgumentNullException.ThrowIfNull(hostEnvironment);
-        ArgumentNullException.ThrowIfNull(logger);
-        ArgumentNullException.ThrowIfNull(projectFactory);
-        ArgumentNullException.ThrowIfNull(backchannelMonitor);
-
         _runner = runner;
         _interactionService = interactionService;
         _certificateService = certificateService;

--- a/src/Aspire.Cli/Commands/Sdk/SdkCommand.cs
+++ b/src/Aspire.Cli/Commands/Sdk/SdkCommand.cs
@@ -26,9 +26,6 @@ internal sealed class SdkCommand : BaseCommand
         AspireCliTelemetry telemetry)
         : base("sdk", "Commands for generating SDKs for building Aspire integrations in other languages.", features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        ArgumentNullException.ThrowIfNull(generateCommand);
-        ArgumentNullException.ThrowIfNull(dumpCommand);
-
         Subcommands.Add(generateCommand);
         Subcommands.Add(dumpCommand);
     }

--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -36,10 +36,6 @@ internal sealed class StopCommand : BaseCommand
         TimeProvider? timeProvider = null)
         : base("stop", StopCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        ArgumentNullException.ThrowIfNull(interactionService);
-        ArgumentNullException.ThrowIfNull(backchannelMonitor);
-        ArgumentNullException.ThrowIfNull(logger);
-
         _interactionService = interactionService;
         _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, executionContext, logger);
         _logger = logger;

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -56,14 +56,6 @@ internal sealed class UpdateCommand : BaseCommand
         AspireCliTelemetry telemetry)
         : base("update", UpdateCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        ArgumentNullException.ThrowIfNull(projectLocator);
-        ArgumentNullException.ThrowIfNull(packagingService);
-        ArgumentNullException.ThrowIfNull(projectFactory);
-        ArgumentNullException.ThrowIfNull(logger);
-        ArgumentNullException.ThrowIfNull(updateNotifier);
-        ArgumentNullException.ThrowIfNull(features);
-        ArgumentNullException.ThrowIfNull(configurationService);
-
         _projectLocator = projectLocator;
         _packagingService = packagingService;
         _projectFactory = projectFactory;


### PR DESCRIPTION
Command constructors are mostly created from DI and don't need null checks. Removed. Should stop AI from adding more checks in new commands.

Also, fix mcp.json based on recent changes.