### PR TITLE
Fix dashboard URL logging

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/EndpointHostHelpers.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointHostHelpers.cs
@@ -133,9 +133,8 @@ public static class EndpointHostHelpers
         // we need to use that instead of the allocated address (localhost) since the TLD hostname
         // is what the user expects to see and use in the browser.
         var targetHost = endpoint.EndpointAnnotation.TargetHost;
-        if (IsLocalhostTld(targetHost))
+        if (IsLocalhostTld(targetHost) && Uri.TryCreate(allocatedUrl, UriKind.Absolute, out var uri))
         {
-            var uri = new Uri(allocatedUrl);
             return $"{uri.Scheme}://{targetHost}:{uri.Port}";
         }
 

--- a/src/Aspire.Hosting/Backchannel/DashboardUrlsHelper.cs
+++ b/src/Aspire.Hosting/Backchannel/DashboardUrlsHelper.cs
@@ -70,7 +70,7 @@ internal static class DashboardUrlsHelper
             var apiEndpoint = httpsEndpoint.Exists ? httpsEndpoint : httpEndpoint;
             if (apiEndpoint.Exists)
             {
-                apiBaseUrl = await apiEndpoint.GetValueAsync(cancellationToken).ConfigureAwait(false);
+                apiBaseUrl = await EndpointHostHelpers.GetUrlWithTargetHostAsync(apiEndpoint, cancellationToken).ConfigureAwait(false);
             }
 
             // MCP endpoint

--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -393,22 +393,7 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
                 var endpoint = httpsEndpoint.Exists ? httpsEndpoint : httpEndpoint;
                 if (endpoint.Exists)
                 {
-                    // Get the URL from the allocated endpoint
-                    var allocatedUrl = await endpoint.GetValueAsync(cancellationToken).ConfigureAwait(false);
-
-                    // If the configured TargetHost is a localhost TLD (e.g., aspire-dashboard.dev.localhost),
-                    // we need to use that instead of the allocated address (localhost) since the TLD hostname
-                    // is what the user expects to see and use in the browser.
-                    var targetHost = endpoint.EndpointAnnotation.TargetHost;
-                    if (!string.IsNullOrEmpty(allocatedUrl) && EndpointHostHelpers.IsLocalhostTld(targetHost))
-                    {
-                        var uri = new Uri(allocatedUrl);
-                        dashboardUrl = $"{uri.Scheme}://{targetHost}:{uri.Port}";
-                    }
-                    else
-                    {
-                        dashboardUrl = allocatedUrl;
-                    }
+                    dashboardUrl = await EndpointHostHelpers.GetUrlWithTargetHostAsync(endpoint, cancellationToken).ConfigureAwait(false);
                 }
             }
 

--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -393,7 +393,22 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
                 var endpoint = httpsEndpoint.Exists ? httpsEndpoint : httpEndpoint;
                 if (endpoint.Exists)
                 {
-                    dashboardUrl = await endpoint.GetValueAsync(cancellationToken).ConfigureAwait(false);
+                    // Get the URL from the allocated endpoint
+                    var allocatedUrl = await endpoint.GetValueAsync(cancellationToken).ConfigureAwait(false);
+
+                    // If the configured TargetHost is a localhost TLD (e.g., aspire-dashboard.dev.localhost),
+                    // we need to use that instead of the allocated address (localhost) since the TLD hostname
+                    // is what the user expects to see and use in the browser.
+                    var targetHost = endpoint.EndpointAnnotation.TargetHost;
+                    if (!string.IsNullOrEmpty(allocatedUrl) && EndpointHostHelpers.IsLocalhostTld(targetHost))
+                    {
+                        var uri = new Uri(allocatedUrl);
+                        dashboardUrl = $"{uri.Scheme}://{targetHost}:{uri.Port}";
+                    }
+                    else
+                    {
+                        dashboardUrl = allocatedUrl;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dotnet/aspire/issues/14248

The value returned from `EndpointReference` is the correct port, but has a `localhost` host. It doesn't reflect the target host value.

Update places where GetValueAsync is used to resolve dashboard URLs with a helper method that corrects the host.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue (consider using one of the following templates):
      - [New (or update) `doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)
      - [New `breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)
      - [New `diagnostic` template](https://github.com/dotnet/docs-aspire/issues/new?template=06-diagnostic-addition.yml)
  - [x] No
