### PR TITLE
Update dashboard telemetry notice URL not to have dotnet in the name

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -48,7 +48,7 @@
         {
             <div>
                 <p class="setting-subtext">
-                    @Loc[nameof(Dialogs.SettingsDialogTelemetryEnabledInfo)] <a target="_blank" href="https://aka.ms/dotnet/aspire/microsoft-collected-telemetry" title="@Loc[nameof(Dialogs.SettingsDialogTelemetryInfoLinkTooltip)]">@Loc[nameof(Dialogs.SettingsDialogTelemetryInfoLinkText)]</a>
+                    @Loc[nameof(Dialogs.SettingsDialogTelemetryEnabledInfo)] <a target="_blank" href="https://aka.ms/aspire/dashboard-microsoft-collected-telemetry" title="@Loc[nameof(Dialogs.SettingsDialogTelemetryInfoLinkTooltip)]">@Loc[nameof(Dialogs.SettingsDialogTelemetryInfoLinkText)]</a>
                 </p>
             </div>
         }


### PR DESCRIPTION
Noticed while looking at telemetry notice links.