### PR TITLE
Fix SKILL.md header and add update detection for aspire agent init

### DIFF
--- a/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
+++ b/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
@@ -148,7 +148,7 @@ internal static class CommonAgentApplicators
         """
         ---
         name: aspire
-        description: Skills for working with Aspire within a repository. Review this for running and testing the application.
+        description: Skills for working with the Aspire CLI. Review this for running and testing Aspire applications.
         ---
 
         # Aspire Skill

--- a/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
+++ b/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
@@ -42,8 +42,12 @@ internal static class CommonAgentApplicators
         if (File.Exists(skillFilePath))
         {
             // Read existing content and check if it differs from current content
+            // Normalize line endings for comparison to handle cross-platform differences
             var existingContent = File.ReadAllText(skillFilePath);
-            if (!string.Equals(existingContent, SkillFileContent, StringComparison.Ordinal))
+            var normalizedExisting = NormalizeLineEndings(existingContent);
+            var normalizedExpected = NormalizeLineEndings(SkillFileContent);
+
+            if (!string.Equals(normalizedExisting, normalizedExpected, StringComparison.Ordinal))
             {
                 // Content differs, offer to update
                 context.AddApplicator(new AgentEnvironmentApplicator(
@@ -127,6 +131,14 @@ internal static class CommonAgentApplicators
     private static async Task UpdateSkillFileAsync(string skillFilePath, CancellationToken cancellationToken)
     {
         await File.WriteAllTextAsync(skillFilePath, SkillFileContent, cancellationToken);
+    }
+
+    /// <summary>
+    /// Normalizes line endings to LF for consistent comparison across platforms.
+    /// </summary>
+    private static string NormalizeLineEndings(string content)
+    {
+        return content.ReplaceLineEndings("\n");
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Agents/CommonAgentApplicatorsTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/CommonAgentApplicatorsTests.cs
@@ -134,6 +134,33 @@ public class CommonAgentApplicatorsTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void TryAddSkillFileApplicator_WhenSkillFileExistsWithDifferentLineEndings_DoesNotAddApplicator()
+    {
+        // Arrange
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var context = CreateScanContext(workspace.WorkspaceRoot);
+        
+        // Create the skill file with CRLF line endings (Windows style)
+        var skillFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, TestSkillRelativePath);
+        var skillDirectory = Path.GetDirectoryName(skillFilePath)!;
+        Directory.CreateDirectory(skillDirectory);
+        var contentWithCrlf = CommonAgentApplicators.SkillFileContent.ReplaceLineEndings("\r\n");
+        File.WriteAllText(skillFilePath, contentWithCrlf);
+
+        // Act
+        var result = CommonAgentApplicators.TryAddSkillFileApplicator(
+            context,
+            workspace.WorkspaceRoot,
+            TestSkillRelativePath,
+            TestDescription);
+
+        // Assert - should not add applicator since content is the same (just different line endings)
+        Assert.False(result);
+        Assert.True(context.HasSkillFileApplicator(TestSkillRelativePath));
+        Assert.Empty(context.Applicators);
+    }
+
+    [Fact]
     public async Task TryAddSkillFileApplicator_CreatesSkillFileWhenItDoesNotExist()
     {
         // Arrange

--- a/tests/Aspire.Cli.Tests/Agents/CommonAgentApplicatorsTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/CommonAgentApplicatorsTests.cs
@@ -53,17 +53,17 @@ public class CommonAgentApplicatorsTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void TryAddSkillFileApplicator_WhenSkillFileExists_DoesNotAddApplicator()
+    public void TryAddSkillFileApplicator_WhenSkillFileExistsWithSameContent_DoesNotAddApplicator()
     {
         // Arrange
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var context = CreateScanContext(workspace.WorkspaceRoot);
         
-        // Create the skill file with any content
+        // Create the skill file with the SAME content as SkillFileContent
         var skillFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, TestSkillRelativePath);
         var skillDirectory = Path.GetDirectoryName(skillFilePath)!;
         Directory.CreateDirectory(skillDirectory);
-        File.WriteAllText(skillFilePath, "# Existing Content\n\nThis already exists.");
+        File.WriteAllText(skillFilePath, CommonAgentApplicators.SkillFileContent);
 
         // Act
         var result = CommonAgentApplicators.TryAddSkillFileApplicator(
@@ -72,10 +72,65 @@ public class CommonAgentApplicatorsTests(ITestOutputHelper outputHelper)
             TestSkillRelativePath,
             TestDescription);
 
-        // Assert - should not add applicator since skill file already exists
+        // Assert - should not add applicator since skill file already exists with same content
         Assert.False(result);
         Assert.True(context.HasSkillFileApplicator(TestSkillRelativePath));
         Assert.Empty(context.Applicators);
+    }
+
+    [Fact]
+    public void TryAddSkillFileApplicator_WhenSkillFileExistsWithDifferentContent_AddsUpdateApplicator()
+    {
+        // Arrange
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var context = CreateScanContext(workspace.WorkspaceRoot);
+        
+        // Create the skill file with DIFFERENT content
+        var skillFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, TestSkillRelativePath);
+        var skillDirectory = Path.GetDirectoryName(skillFilePath)!;
+        Directory.CreateDirectory(skillDirectory);
+        File.WriteAllText(skillFilePath, "# Old Aspire Skill\n\nThis is outdated content.");
+
+        // Act
+        var result = CommonAgentApplicators.TryAddSkillFileApplicator(
+            context,
+            workspace.WorkspaceRoot,
+            TestSkillRelativePath,
+            TestDescription);
+
+        // Assert - should add an update applicator since content differs
+        Assert.True(result);
+        Assert.True(context.HasSkillFileApplicator(TestSkillRelativePath));
+        Assert.Single(context.Applicators);
+        Assert.Contains("update", context.Applicators[0].Description);
+    }
+
+    [Fact]
+    public async Task TryAddSkillFileApplicator_UpdateApplicator_ReplacesContent()
+    {
+        // Arrange
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var context = CreateScanContext(workspace.WorkspaceRoot);
+        
+        // Create the skill file with old content
+        var skillFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, TestSkillRelativePath);
+        var skillDirectory = Path.GetDirectoryName(skillFilePath)!;
+        Directory.CreateDirectory(skillDirectory);
+        var oldContent = "# Old Aspire Skill\n\nThis is outdated content.";
+        File.WriteAllText(skillFilePath, oldContent);
+
+        // Act
+        CommonAgentApplicators.TryAddSkillFileApplicator(
+            context,
+            workspace.WorkspaceRoot,
+            TestSkillRelativePath,
+            TestDescription);
+        await context.Applicators[0].ApplyAsync(CancellationToken.None).DefaultTimeout();
+
+        // Assert - content should be replaced with new content
+        var newContent = await File.ReadAllTextAsync(skillFilePath);
+        Assert.NotEqual(oldContent, newContent);
+        Assert.Equal(CommonAgentApplicators.SkillFileContent, newContent);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Agents/CopilotCliAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/CopilotCliAgentEnvironmentScannerTests.cs
@@ -151,10 +151,10 @@ public class CopilotCliAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
         var mcpConfigPath = Path.Combine(copilotFolder.FullName, "mcp-config.json");
         await File.WriteAllTextAsync(mcpConfigPath, existingConfig.ToJsonString());
         
-        // Also create the skill file to prevent that applicator
+        // Also create the skill file with the SAME content as SkillFileContent to prevent update applicator
         var skillFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, ".github", "skills", "aspire", "SKILL.md");
         Directory.CreateDirectory(Path.GetDirectoryName(skillFilePath)!);
-        await File.WriteAllTextAsync(skillFilePath, "# Aspire Skill");
+        await File.WriteAllTextAsync(skillFilePath, CommonAgentApplicators.SkillFileContent);
 
         var copilotCliRunner = new FakeCopilotCliRunner(new SemVersion(1, 0, 0));
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
@@ -163,7 +163,7 @@ public class CopilotCliAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
 
         await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
 
-        // No applicators should be returned since Aspire MCP, Playwright MCP are configured and skill file exists
+        // No applicators should be returned since Aspire MCP, Playwright MCP are configured and skill file exists with same content
         Assert.Empty(context.Applicators);
     }
 


### PR DESCRIPTION
## Summary

This PR fixes the SKILL.md file output by `aspire agent init` to include the proper YAML front matter header and adds the ability to detect and update existing skill files when content has changed.

## Changes

### 1. Added YAML front matter header to `SkillFileContent`
The skill file now includes proper YAML front matter so it can be picked up correctly by agent environments:
```yaml
---
name: aspire
description: Skills for working with Aspire within a repository. Review this for running and testing the application.
---
```

### 2. Modified `TryAddSkillFileApplicator` to detect and offer updates
- When the file exists, it now reads the content and compares with `SkillFileContent`
- If content differs, it adds an applicator with description indicating the update
- If content is identical, no applicator is added (nothing to do)

### 3. Added `UpdateSkillFileAsync` method
New helper method that overwrites the existing file with the new content.

## Behavior Change

Previously, running `aspire agent init` would NOT update an existing SKILL.md file - it would simply skip it. Now it will:
1. Detect if the existing file content differs from the current `SkillFileContent`
2. Offer to update the file by replacing it with the new contents

This is important because our skills capability is constantly evolving, and users need a way to get the latest skill content.

## Testing

- [x] Builds successfully
- Manual testing: Run `aspire agent init` in a repo with an existing (outdated) skill file to verify the update prompt appears