### PR TITLE
CLI fixes: MCP error message and help display

### DIFF
--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.CommandLine.Help;
 
 #if DEBUG
 using System.Globalization;
@@ -121,13 +122,19 @@ internal sealed class RootCommand : BaseRootCommand
         Options.Add(WaitForDebuggerOption);
         Options.Add(CliWaitForDebuggerOption);
 
-        // Handle standalone 'aspire --banner' (no subcommand)
+        // Handle standalone 'aspire' or 'aspire --banner' (no subcommand)
         this.SetAction((context, cancellationToken) =>
         {
             var bannerRequested = context.GetValue(BannerOption);
-            // If --banner was passed, we've already shown it in Main, just exit successfully
-            // Otherwise, show the standard "no command" error
-            return Task.FromResult(bannerRequested ? 0 : 1);
+            if (bannerRequested)
+            {
+                // If --banner was passed, we've already shown it in Main, just exit successfully
+                return Task.FromResult(0);
+            }
+
+            // No subcommand provided - show help
+            new HelpAction().Invoke(context);
+            return Task.FromResult(0);
         });
 
         Subcommands.Add(newCommand);

--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -129,12 +129,13 @@ internal sealed class RootCommand : BaseRootCommand
             if (bannerRequested)
             {
                 // If --banner was passed, we've already shown it in Main, just exit successfully
-                return Task.FromResult(0);
+                return Task.FromResult(ExitCodeConstants.Success);
             }
 
-            // No subcommand provided - show help
+            // No subcommand provided - show help but return InvalidCommand to signal usage error
+            // This is consistent with other parent commands (DocsCommand, SdkCommand, etc.)
             new HelpAction().Invoke(context);
-            return Task.FromResult(0);
+            return Task.FromResult(ExitCodeConstants.InvalidCommand);
         });
 
         Subcommands.Add(newCommand);

--- a/src/Aspire.Cli/Mcp/McpErrorMessages.cs
+++ b/src/Aspire.Cli/Mcp/McpErrorMessages.cs
@@ -13,7 +13,7 @@ internal static class McpErrorMessages
     /// </summary>
     public const string NoAppHostRunning =
         "No Aspire AppHost is currently running. " +
-        "To use Aspire MCP tools, you must first start an Aspire application by running 'aspire run' in your AppHost project directory. " +
+        "To use Aspire MCP tools, you must first start an Aspire application by running 'aspire run --detach' in your AppHost project directory. " +
         "Once the application is running, the MCP tools will be able to connect to the dashboard and execute commands.";
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Commands/CacheCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/CacheCommandTests.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Commands;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Cli.Tests.Commands;
+
+public class CacheCommandTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task CacheCommand_WithoutSubcommand_ReturnsInvalidCommand()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("cache");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+    }
+
+    [Fact]
+    public async Task CacheCommandWithHelpArgumentReturnsZero()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("cache --help");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(0, exitCode);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/McpCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/McpCommandTests.cs
@@ -11,6 +11,21 @@ namespace Aspire.Cli.Tests.Commands;
 public class McpCommandTests(ITestOutputHelper outputHelper)
 {
     [Fact]
+    public async Task McpCommand_WithoutSubcommand_ReturnsInvalidCommand()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("mcp");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+    }
+
+    [Fact]
     public async Task McpCommandWithHelpArgumentReturnsZero()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -80,6 +95,21 @@ public class McpCommandTests(ITestOutputHelper outputHelper)
 
         Assert.NotNull(mcpCommand);
         Assert.True(mcpCommand.Hidden, "The mcp command should be hidden for backward compatibility");
+    }
+
+    [Fact]
+    public async Task AgentCommand_WithoutSubcommand_ReturnsInvalidCommand()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("agent");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/SdkCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SdkCommandTests.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Commands;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Cli.Tests.Commands;
+
+public class SdkCommandTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task SdkCommand_WithoutSubcommand_ReturnsInvalidCommand()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("sdk");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+    }
+
+    [Fact]
+    public async Task SdkCommandWithHelpArgumentReturnsZero()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("sdk --help");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(0, exitCode);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Mcp/ExecuteResourceCommandToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ExecuteResourceCommandToolTests.cs
@@ -34,6 +34,7 @@ public class ExecuteResourceCommandToolTests
             () => tool.CallToolAsync(null!, CreateArguments("test-resource", "resource-start"), CancellationToken.None).AsTask()).DefaultTimeout();
 
         Assert.Contains("No Aspire AppHost", exception.Message);
+        Assert.Contains("--detach", exception.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Mcp/ListConsoleLogsToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListConsoleLogsToolTests.cs
@@ -28,6 +28,7 @@ public class ListConsoleLogsToolTests
             () => tool.CallToolAsync(null!, arguments, CancellationToken.None).AsTask()).DefaultTimeout();
 
         Assert.Contains("No Aspire AppHost", exception.Message);
+        Assert.Contains("--detach", exception.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Mcp/ListResourcesToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListResourcesToolTests.cs
@@ -22,6 +22,7 @@ public class ListResourcesToolTests
             () => tool.CallToolAsync(null!, null, CancellationToken.None).AsTask()).DefaultTimeout();
 
         Assert.Contains("No Aspire AppHost", exception.Message);
+        Assert.Contains("--detach", exception.Message);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Minor CLI fixes:
1. Update MCP error message to suggest `aspire run --detach` instead of just `aspire run` when no AppHost is running
2. Show help when `aspire` is invoked without any arguments (previously exited with code 1 and no output)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No