### PR TITLE
Add FileLoggerProvider for CLI log persistence to disk

### DIFF
--- a/src/Aspire.Cli/CliExecutionContext.cs
+++ b/src/Aspire.Cli/CliExecutionContext.cs
@@ -5,12 +5,24 @@ using System.CommandLine;
 
 namespace Aspire.Cli;
 
-internal sealed class CliExecutionContext(DirectoryInfo workingDirectory, DirectoryInfo hivesDirectory, DirectoryInfo cacheDirectory, DirectoryInfo sdksDirectory, bool debugMode = false, IReadOnlyDictionary<string, string?>? environmentVariables = null, DirectoryInfo? homeDirectory = null)
+internal sealed class CliExecutionContext(DirectoryInfo workingDirectory, DirectoryInfo hivesDirectory, DirectoryInfo cacheDirectory, DirectoryInfo sdksDirectory, DirectoryInfo logsDirectory, string logFilePath, bool debugMode = false, IReadOnlyDictionary<string, string?>? environmentVariables = null, DirectoryInfo? homeDirectory = null)
 {
     public DirectoryInfo WorkingDirectory { get; } = workingDirectory;
     public DirectoryInfo HivesDirectory { get; } = hivesDirectory;
     public DirectoryInfo CacheDirectory { get; } = cacheDirectory;
     public DirectoryInfo SdksDirectory { get; } = sdksDirectory;
+
+    /// <summary>
+    /// Gets the directory where CLI log files are stored.
+    /// Used by cache clear command to clean up old log files.
+    /// </summary>
+    public DirectoryInfo LogsDirectory { get; } = logsDirectory;
+
+    /// <summary>
+    /// Gets the path to the current session's log file.
+    /// </summary>
+    public string LogFilePath { get; } = logFilePath;
+
     public DirectoryInfo HomeDirectory { get; } = homeDirectory ?? new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
     public bool DebugMode { get; } = debugMode;
 

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -213,7 +213,7 @@ internal sealed class AddCommand : BaseCommand
                 {
                     InteractionService.DisplayLines(outputCollector.GetLines());
                 }
-                InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.PackageInstallationFailed, ExitCodeConstants.FailedToAddPackage));
+                InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, AddCommandStrings.PackageInstallationFailed, ExitCodeConstants.FailedToAddPackage, ExecutionContext.LogFilePath));
                 return ExitCodeConstants.FailedToAddPackage;
             }
 

--- a/src/Aspire.Cli/Commands/CacheCommand.cs
+++ b/src/Aspire.Cli/Commands/CacheCommand.cs
@@ -108,6 +108,45 @@ internal sealed class CacheCommand : BaseCommand
                     }
                 }
 
+                // Also clear the logs directory (skip current process's log file)
+                var logsDirectory = ExecutionContext.LogsDirectory;
+                // Log files are named cli-{timestamp}-{pid}.log, so we need to check the suffix
+                var currentLogFileSuffix = $"-{Environment.ProcessId}.log";
+                if (logsDirectory.Exists)
+                {
+                    foreach (var file in logsDirectory.GetFiles("*", SearchOption.AllDirectories))
+                    {
+                        // Skip the current process's log file to avoid deleting it while in use
+                        if (file.Name.EndsWith(currentLogFileSuffix, StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
+
+                        try
+                        {
+                            file.Delete();
+                            filesDeleted++;
+                        }
+                        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
+                        {
+                            // Continue deleting other files even if some fail
+                        }
+                    }
+
+                    // Delete subdirectories
+                    foreach (var directory in logsDirectory.GetDirectories())
+                    {
+                        try
+                        {
+                            directory.Delete(recursive: true);
+                        }
+                        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
+                        {
+                            // Continue deleting other directories even if some fail
+                        }
+                    }
+                }
+
                 if (filesDeleted == 0)
                 {
                     InteractionService.DisplayMessage("information", CacheCommandStrings.CacheAlreadyEmpty);

--- a/src/Aspire.Cli/Commands/ExecCommand.cs
+++ b/src/Aspire.Cli/Commands/ExecCommand.cs
@@ -152,7 +152,7 @@ internal class ExecCommand : BaseCommand
                 env[KnownConfigNames.WaitForDebugger] = "true";
             }
 
-            appHostCompatibilityCheck = await AppHostHelper.CheckAppHostCompatibilityAsync(_runner, InteractionService, effectiveAppHostProjectFile, Telemetry, ExecutionContext.WorkingDirectory, cancellationToken);
+            appHostCompatibilityCheck = await AppHostHelper.CheckAppHostCompatibilityAsync(_runner, InteractionService, effectiveAppHostProjectFile, Telemetry, ExecutionContext.WorkingDirectory, ExecutionContext.LogFilePath, cancellationToken);
             if (!appHostCompatibilityCheck?.IsCompatibleAppHost ?? throw new InvalidOperationException(RunCommandStrings.IsCompatibleAppHostIsNull))
             {
                 return ExitCodeConstants.FailedToDotnetRunAppHost;
@@ -253,7 +253,7 @@ internal class ExecCommand : BaseCommand
                 if (result != 0)
                 {
                     InteractionService.DisplayLines(runOutputCollector.GetLines());
-                    InteractionService.DisplayError(RunCommandStrings.ProjectCouldNotBeRun);
+                    InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, RunCommandStrings.ProjectCouldNotBeRun, ExecutionContext.LogFilePath));
                     return result;
                 }
                 else
@@ -264,7 +264,7 @@ internal class ExecCommand : BaseCommand
             else
             {
                 InteractionService.DisplayLines(runOutputCollector.GetLines());
-                InteractionService.DisplayError(RunCommandStrings.ProjectCouldNotBeRun);
+                InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, RunCommandStrings.ProjectCouldNotBeRun, ExecutionContext.LogFilePath));
                 return ExitCodeConstants.FailedToDotnetRunAppHost;
             }
         }

--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using System.CommandLine.Help;
+using Microsoft.Extensions.Logging;
 
 #if DEBUG
 using System.Globalization;
@@ -22,6 +23,13 @@ internal sealed class RootCommand : BaseRootCommand
     public static readonly Option<bool> DebugOption = new(CommonOptionNames.Debug, CommonOptionNames.DebugShort)
     {
         Description = RootCommandStrings.DebugArgumentDescription,
+        Recursive = true,
+        Hidden = true // Hidden for backward compatibility, use --debug-level instead
+    };
+
+    public static readonly Option<LogLevel?> DebugLevelOption = new("--debug-level", "-v")
+    {
+        Description = RootCommandStrings.DebugLevelArgumentDescription,
         Recursive = true
     };
 
@@ -57,6 +65,41 @@ internal sealed class RootCommand : BaseRootCommand
         Hidden = true,
         DefaultValueFactory = _ => false
     };
+
+    /// <summary>
+    /// Global options that should be passed through to child CLI processes when spawning.
+    /// Add new global options here to ensure they are forwarded during detached mode execution.
+    /// </summary>
+    private static readonly (Option Option, Func<ParseResult, string[]?> GetArgs)[] s_childProcessOptions =
+    [
+        (DebugOption, pr => pr.GetValue(DebugOption) ? ["--debug"] : null),
+        (DebugLevelOption, pr =>
+        {
+            var level = pr.GetValue(DebugLevelOption);
+            return level.HasValue ? ["--debug-level", level.Value.ToString()] : null;
+        }),
+        (WaitForDebuggerOption, pr => pr.GetValue(WaitForDebuggerOption) ? ["--wait-for-debugger"] : null),
+    ];
+
+    /// <summary>
+    /// Gets the command-line arguments for global options that should be passed to a child CLI process.
+    /// </summary>
+    /// <param name="parseResult">The parse result from the current command invocation.</param>
+    /// <returns>Arguments to pass to the child process.</returns>
+    public static IEnumerable<string> GetChildProcessArgs(ParseResult parseResult)
+    {
+        foreach (var (_, getArgs) in s_childProcessOptions)
+        {
+            var args = getArgs(parseResult);
+            if (args is not null)
+            {
+                foreach (var arg in args)
+                {
+                    yield return arg;
+                }
+            }
+        }
+    }
 
     private readonly IInteractionService _interactionService;
 
@@ -116,6 +159,7 @@ internal sealed class RootCommand : BaseRootCommand
 #endif
 
         Options.Add(DebugOption);
+        Options.Add(DebugLevelOption);
         Options.Add(NonInteractiveOption);
         Options.Add(NoLogoOption);
         Options.Add(BannerOption);

--- a/src/Aspire.Cli/Diagnostics/FileLoggerProvider.cs
+++ b/src/Aspire.Cli/Diagnostics/FileLoggerProvider.cs
@@ -1,0 +1,256 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Text;
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+
+namespace Aspire.Cli.Diagnostics;
+
+/// <summary>
+/// A logger provider that writes all log messages to a file on disk.
+/// This provider captures logs at all levels (Trace through Critical) for diagnostics,
+/// independent of console verbosity settings.
+/// </summary>
+internal sealed class FileLoggerProvider : ILoggerProvider
+{
+    private const int MaxQueuedMessages = 1024;
+
+    private readonly string _logFilePath;
+    private readonly StreamWriter? _writer;
+    private readonly Channel<string>? _channel;
+    private readonly Task? _writerTask;
+    private bool _disposed;
+
+    /// <summary>
+    /// Gets the path to the log file.
+    /// </summary>
+    public string LogFilePath => _logFilePath;
+
+    /// <summary>
+    /// Creates a new FileLoggerProvider that writes to the specified directory.
+    /// </summary>
+    /// <param name="logsDirectory">The directory where log files will be written.</param>
+    /// <param name="timeProvider">The time provider for timestamp generation.</param>
+    /// <param name="errorConsole">Optional console for error messages. Defaults to stderr.</param>
+    public FileLoggerProvider(string logsDirectory, TimeProvider timeProvider, IAnsiConsole? errorConsole = null)
+    {
+        var pid = Environment.ProcessId;
+        var timestamp = timeProvider.GetUtcNow().ToString("yyyy-MM-dd-HH-mm-ss", CultureInfo.InvariantCulture);
+        // Timestamp first so files sort chronologically by name
+        _logFilePath = Path.Combine(logsDirectory, $"cli-{timestamp}-{pid}.log");
+
+        try
+        {
+            Directory.CreateDirectory(logsDirectory);
+            _writer = new StreamWriter(_logFilePath, append: false, Encoding.UTF8)
+            {
+                AutoFlush = true
+            };
+
+            _channel = CreateChannel();
+            _writerTask = Task.Run(ProcessLogQueueAsync);
+        }
+        catch (IOException ex)
+        {
+            WriteWarning(errorConsole, _logFilePath, ex.Message);
+            _writer = null;
+            _channel = null;
+        }
+    }
+
+    /// <summary>
+    /// Creates a new FileLoggerProvider with a specific log file path (for testing).
+    /// </summary>
+    /// <param name="logFilePath">The full path to the log file.</param>
+    /// <param name="errorConsole">Optional console for error messages. Defaults to stderr.</param>
+    internal FileLoggerProvider(string logFilePath, IAnsiConsole? errorConsole = null)
+    {
+        _logFilePath = logFilePath;
+
+        try
+        {
+            var directory = Path.GetDirectoryName(logFilePath);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            _writer = new StreamWriter(logFilePath, append: false, Encoding.UTF8)
+            {
+                AutoFlush = true
+            };
+
+            _channel = CreateChannel();
+            _writerTask = Task.Run(ProcessLogQueueAsync);
+        }
+        catch (IOException ex)
+        {
+            WriteWarning(errorConsole, logFilePath, ex.Message);
+            _writer = null;
+            _channel = null;
+        }
+    }
+
+    private static Channel<string> CreateChannel() =>
+        Channel.CreateBounded<string>(new BoundedChannelOptions(MaxQueuedMessages)
+        {
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = true,
+            SingleWriter = false
+        });
+
+    private static void WriteWarning(IAnsiConsole? console, string path, string message)
+    {
+        // Use provided console or create a minimal one for stderr
+        var errorConsole = console ?? AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(Console.Error)
+        });
+        errorConsole.MarkupLine($"[yellow]⚠️ Warning:[/] Could not create log file at [blue]{path.EscapeMarkup()}[/]: {message.EscapeMarkup()}");
+    }
+
+    private async Task ProcessLogQueueAsync()
+    {
+        if (_channel is null || _writer is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await foreach (var message in _channel.Reader.ReadAllAsync())
+            {
+                await _writer.WriteLineAsync(message).ConfigureAwait(false);
+            }
+        }
+        catch (ChannelClosedException)
+        {
+            // Expected when channel is completed during disposal
+        }
+        catch (ObjectDisposedException)
+        {
+            // Writer was disposed while writing - expected during shutdown
+        }
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return new FileLogger(this, categoryName);
+    }
+
+    internal void WriteLog(string message)
+    {
+        if (_channel is null || _disposed)
+        {
+            return;
+        }
+
+        // Try to write to the channel - this will succeed as long as there's space
+        // and the channel hasn't been completed yet
+        if (_channel.Writer.TryWrite(message))
+        {
+            return;
+        }
+
+        // TryWrite failed - either channel is full (need backpressure) or completed (disposal)
+        if (_disposed)
+        {
+            return;
+        }
+
+        // Try async write which will wait for space or throw if completed
+        try
+        {
+            // WaitToWriteAsync returns false if the channel is completed
+            // This is cheaper than catching ChannelClosedException from WriteAsync
+            if (!_channel.Writer.WaitToWriteAsync().AsTask().GetAwaiter().GetResult())
+            {
+                return;
+            }
+
+            // Space is available, write the message
+            _channel.Writer.TryWrite(message);
+        }
+        catch (ChannelClosedException)
+        {
+            // Channel was completed between WaitToWriteAsync and TryWrite - rare race
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        // Complete the channel to signal the writer task to finish
+        // Any messages already in the channel will be drained by the writer task
+        _channel?.Writer.TryComplete();
+
+        // Wait for the writer task to finish processing ALL remaining messages
+        _writerTask?.GetAwaiter().GetResult();
+
+        _writer?.Dispose();
+    }
+}
+
+/// <summary>
+/// A logger that writes to a file via the FileLoggerProvider.
+/// </summary>
+internal sealed class FileLogger(FileLoggerProvider provider, string categoryName) : ILogger
+{
+    // Suppress Microsoft.Hosting.Lifetime logs - these are CLI host lifecycle noise
+    private static readonly string[] s_suppressedCategories = ["Microsoft.Hosting.Lifetime"];
+
+    // Always enabled for file logging, except suppressed categories
+    public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None && !s_suppressedCategories.Contains(categoryName);
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
+        var message = formatter(state, exception);
+        if (string.IsNullOrEmpty(message) && exception is null)
+        {
+            return;
+        }
+
+        var timestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture);
+        var level = GetLogLevelString(logLevel);
+        var shortCategory = GetShortCategoryName(categoryName);
+
+        var logMessage = exception is not null
+            ? $"[{timestamp}] [{level}] [{shortCategory}] {message}{Environment.NewLine}{exception}"
+            : $"[{timestamp}] [{level}] [{shortCategory}] {message}";
+
+        provider.WriteLog(logMessage);
+    }
+
+    private static string GetLogLevelString(LogLevel logLevel) => logLevel switch
+    {
+        LogLevel.Trace => "TRCE",
+        LogLevel.Debug => "DBUG",
+        LogLevel.Information => "INFO",
+        LogLevel.Warning => "WARN",
+        LogLevel.Error => "FAIL",
+        LogLevel.Critical => "CRIT",
+        _ => logLevel.ToString().ToUpperInvariant()
+    };
+
+    private static string GetShortCategoryName(string categoryName)
+    {
+        var lastDotIndex = categoryName.LastIndexOf('.');
+        return lastDotIndex >= 0 ? categoryName.Substring(lastDotIndex + 1) : categoryName;
+    }
+}

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -176,8 +176,9 @@ internal sealed class DotNetCliRunner(
             }
             catch (SocketException ex) when (execution is not null && execution.HasExited && execution.ExitCode != 0)
             {
-                logger.LogError(ex, "AppHost process has exited. Unable to connect to backchannel at {SocketPath}", socketPath);
-                var backchannelException = new FailedToConnectBackchannelConnection($"AppHost process has exited unexpectedly. Use --debug to see more details.", ex);
+                // Log at Debug level - this is expected when AppHost crashes, the real error is in AppHost output
+                logger.LogDebug(ex, "AppHost process has exited. Unable to connect to backchannel at {SocketPath}", socketPath);
+                var backchannelException = new FailedToConnectBackchannelConnection("AppHost process has exited unexpectedly.", ex);
                 backchannelCompletionSource.SetException(backchannelException);
                 return;
             }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -17,6 +17,7 @@ using Aspire.Cli.Certificates;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Commands.Sdk;
 using Aspire.Cli.Configuration;
+using Aspire.Cli.Diagnostics;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Git;
 using Aspire.Cli.Interaction;
@@ -50,6 +51,43 @@ public class Program
         var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         var aspirePath = Path.Combine(homeDirectory, ".aspire");
         return aspirePath;
+    }
+
+    /// <summary>
+    /// Parses logging options from command-line arguments.
+    /// Returns the console log level (if specified) and whether debug mode is enabled.
+    /// </summary>
+    private static (LogLevel? ConsoleLogLevel, bool DebugMode) ParseLoggingOptions(string[]? args)
+    {
+        if (args is null || args.Length == 0)
+        {
+            return (null, false);
+        }
+
+        // Check for --debug or -d (backward compatibility)
+        var debugMode = args.Any(a => a == "--debug" || a == "-d");
+
+        // Check for --debug-level or -v
+        LogLevel? logLevel = null;
+        for (var i = 0; i < args.Length; i++)
+        {
+            if ((args[i] == "--debug-level" || args[i] == "-v") && i + 1 < args.Length)
+            {
+                if (Enum.TryParse<LogLevel>(args[i + 1], ignoreCase: true, out var parsedLevel))
+                {
+                    logLevel = parsedLevel;
+                }
+                break;
+            }
+        }
+
+        // --debug implies Debug log level if --verbosity not specified
+        if (debugMode && logLevel is null)
+        {
+            logLevel = LogLevel.Debug;
+        }
+
+        return (logLevel, debugMode);
     }
 
     private static string GetGlobalSettingsPath()
@@ -112,12 +150,21 @@ public class Program
         // - Diagnostic provider for OTLP/console exporters (exports all activities, DEBUG only)
         builder.Services.AddSingleton(new TelemetryManager(builder.Configuration, args));
 
-        var debugMode = args?.Any(a => a == CommonOptionNames.Debug || a == CommonOptionNames.DebugShort) ?? false;
+        // Parse logging options from args
+        var (consoleLogLevel, debugMode) = ParseLoggingOptions(args);
         var extensionEndpoint = builder.Configuration[KnownConfigNames.ExtensionEndpoint];
 
-        if (debugMode && !isMcpStartCommand && extensionEndpoint is null)
+        // Always register FileLoggerProvider to capture logs to disk
+        // This captures complete CLI session details for diagnostics
+        var logsDirectory = Path.Combine(GetUsersAspirePath(), "logs");
+        var fileLoggerProvider = new FileLoggerProvider(logsDirectory, TimeProvider.System);
+        builder.Services.AddSingleton(fileLoggerProvider); // Register for direct access to LogFilePath
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider>(fileLoggerProvider));
+
+        // Configure console logging based on --verbosity or --debug
+        if (consoleLogLevel is not null && !isMcpStartCommand && extensionEndpoint is null)
         {
-            builder.Logging.AddFilter("Aspire.Cli", LogLevel.Debug);
+            builder.Logging.AddFilter("Aspire.Cli", consoleLogLevel.Value);
             builder.Logging.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.Warning); // Reduce noise from hosting lifecycle
             // Use custom Spectre Console logger for clean debug output to stderr
             builder.Services.AddSingleton<ILoggerProvider>(sp =>
@@ -128,9 +175,9 @@ public class Program
         // This keeps stdout clean for MCP protocol JSON-RPC messages
         if (isMcpStartCommand)
         {
-            if (debugMode)
+            if (consoleLogLevel is not null)
             {
-                builder.Logging.AddFilter("Aspire.Cli", LogLevel.Debug);
+                builder.Logging.AddFilter("Aspire.Cli", consoleLogLevel.Value);
                 builder.Logging.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.Warning); // Reduce noise from hosting lifecycle
             }
 
@@ -142,7 +189,11 @@ public class Program
         }
 
         // Shared services.
-        builder.Services.AddSingleton(_ => BuildCliExecutionContext(debugMode));
+        builder.Services.AddSingleton(sp =>
+        {
+            var logFilePath = sp.GetRequiredService<FileLoggerProvider>().LogFilePath;
+            return BuildCliExecutionContext(debugMode, logsDirectory, logFilePath);
+        });
         builder.Services.AddSingleton(s => new ConsoleEnvironment(
             BuildAnsiConsole(s, Console.Out),
             BuildAnsiConsole(s, Console.Error)));
@@ -302,13 +353,13 @@ public class Program
         return new DirectoryInfo(sdksPath);
     }
 
-    private static CliExecutionContext BuildCliExecutionContext(bool debugMode)
+    private static CliExecutionContext BuildCliExecutionContext(bool debugMode, string logsDirectory, string logFilePath)
     {
         var workingDirectory = new DirectoryInfo(Environment.CurrentDirectory);
         var hivesDirectory = GetHivesDirectory();
         var cacheDirectory = GetCacheDirectory();
         var sdksDirectory = GetSdksDirectory();
-        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, sdksDirectory, debugMode);
+        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, sdksDirectory, new DirectoryInfo(logsDirectory), logFilePath, debugMode);
     }
 
     private static DirectoryInfo GetCacheDirectory()
@@ -475,8 +526,17 @@ public class Program
             mainActivity.AddTag(TelemetryConstants.Tags.ProcessExecutableName, "aspire");
         }
 
+        // Create a dedicated logger for CLI session info
+        var cliLogger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger<Program>();
+
         try
         {
+            // Log command invocation details for debugging
+            var commandLine = args.Length > 0 ? $"aspire {string.Join(" ", args)}" : "aspire";
+            var workingDir = Environment.CurrentDirectory;
+            cliLogger.LogInformation("Command: {CommandLine}", commandLine);
+            cliLogger.LogInformation("Working directory: {WorkingDirectory}", workingDir);
+
             logger.LogDebug("Parsing arguments: {Args}", string.Join(" ", args));
             var parseResult = rootCommand.Parse(args);
 
@@ -486,6 +546,9 @@ public class Program
             mainActivity?.SetTag(TelemetryConstants.Tags.CommandName, commandName);
 
             var exitCode = await parseResult.InvokeAsync(invokeConfig, cts.Token);
+
+            // Log exit code for debugging
+            cliLogger.LogInformation("Exit code: {ExitCode}", exitCode);
 
             mainActivity?.SetTag(TelemetryConstants.Tags.ProcessExitCode, exitCode);
             mainActivity?.Stop();
@@ -508,6 +571,9 @@ public class Program
                 var interactionService = app.Services.GetRequiredService<IInteractionService>();
                 interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message));
             }
+
+            // Log exit code for debugging
+            cliLogger.LogError("Exit code: {ExitCode} (exception)", unknownErrorExitCode);
 
             mainActivity?.SetTag(TelemetryConstants.Tags.ProcessExitCode, unknownErrorExitCode);
             mainActivity?.Stop();

--- a/src/Aspire.Cli/Resources/AddCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.resx
@@ -148,7 +148,8 @@
     <value>Adding Aspire hosting integration...</value>
   </data>
   <data name="PackageInstallationFailed" xml:space="preserve">
-    <value>The package installation failed with exit code {0}. For more information run with --debug switch.</value>
+    <value>The package installation failed with exit code {0}. See logs at {1}</value>
+    <comment>{0} is a number, {1} is the log file path</comment>
   </data>
   <data name="PackageAddedSuccessfully" xml:space="preserve">
     <value>The package {0}::{1} was added successfully.</value>

--- a/src/Aspire.Cli/Resources/ErrorStrings.resx
+++ b/src/Aspire.Cli/Resources/ErrorStrings.resx
@@ -157,7 +157,7 @@
     <value>Project file does not exist.</value>
   </data>
   <data name="ProjectCouldNotBeAnalyzed" xml:space="preserve">
-    <value>The project could not be analyzed due to a build error. For more information run with --debug switch.</value>
+    <value>The project could not be analyzed due to a build error. See logs at {0}</value>
   </data>
   <data name="ProjectIsNotAppHost" xml:space="preserve">
     <value>The project does not contain an Aspire apphost.</value>

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
@@ -232,7 +232,7 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The project could not be built. For more information run with --debug switch..
+        ///   Looks up a localized string similar to The project could not be built. See logs at {0}.
         /// </summary>
         public static string ProjectCouldNotBeBuilt {
             get {
@@ -336,6 +336,15 @@ namespace Aspire.Cli.Resources {
         public static string UnexpectedErrorOccurred {
             get {
                 return ResourceManager.GetString("UnexpectedErrorOccurred", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to See logs at {0}.
+        /// </summary>
+        public static string SeeLogsAt {
+            get {
+                return ResourceManager.GetString("SeeLogsAt", resourceCulture);
             }
         }
         

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
@@ -182,7 +182,7 @@
     <value>The project argument was not specified and no app host project files were detected.</value>
   </data>
   <data name="ProjectCouldNotBeBuilt" xml:space="preserve">
-    <value>The project could not be built. For more information run with --debug switch.</value>
+    <value>The project could not be built. See logs at {0}</value>
   </data>
   <data name="OperationCancelled" xml:space="preserve">
     <value>The operation was canceled.</value>
@@ -199,6 +199,10 @@
   <data name="UnexpectedErrorOccurred" xml:space="preserve">
     <value>An unexpected error occurred: {0}</value>
     <comment>{0} is the exception message</comment>
+  </data>
+  <data name="SeeLogsAt" xml:space="preserve">
+    <value>See logs at {0}</value>
+    <comment>{0} is the log file path</comment>
   </data>
   <data name="WaitingForDebuggerToAttachToAppHost" xml:space="preserve">
     <value>Waiting for debugger to attach to app host process</value>

--- a/src/Aspire.Cli/Resources/RootCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/RootCommandStrings.Designer.cs
@@ -115,6 +115,15 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical)..
+        /// </summary>
+        public static string DebugLevelArgumentDescription {
+            get {
+                return ResourceManager.GetString("DebugLevelArgumentDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Telemetry
         ///---------
         ///

--- a/src/Aspire.Cli/Resources/RootCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/RootCommandStrings.resx
@@ -132,6 +132,9 @@
   <data name="DebugArgumentDescription" xml:space="preserve">
     <value>Enable debug logging to the console.</value>
   </data>
+  <data name="DebugLevelArgumentDescription" xml:space="preserve">
+    <value>Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</value>
+  </data>
   <data name="NoLogoArgumentDescription" xml:space="preserve">
     <value>Suppress the startup banner and telemetry notice.</value>
   </data>

--- a/src/Aspire.Cli/Resources/RunCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/RunCommandStrings.resx
@@ -170,7 +170,7 @@
     <comment>[bold] should not be localized</comment>
   </data>
   <data name="ProjectCouldNotBeRun" xml:space="preserve">
-    <value>The project could not be run. For more information run with --debug switch.</value>
+    <value>The project could not be run. See logs at {0}</value>
   </data>
   <data name="Dashboard" xml:space="preserve">
     <value>Dashboard</value>

--- a/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
@@ -277,7 +277,7 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Project creation failed with exit code {0}. For more information run with --debug switch..
+        ///   Looks up a localized string similar to Project creation failed with exit code {0}. See logs at {1}.
         /// </summary>
         public static string ProjectCreationFailed {
             get {
@@ -331,7 +331,7 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The template installation failed with exit code {0}. For more information run with --debug switch..
+        ///   Looks up a localized string similar to The template installation failed with exit code {0}. See logs at {1}.
         /// </summary>
         public static string TemplateInstallationFailed {
             get {

--- a/src/Aspire.Cli/Resources/TemplatingStrings.resx
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.resx
@@ -199,8 +199,8 @@
     <value>Getting templates...</value>
   </data>
   <data name="TemplateInstallationFailed" xml:space="preserve">
-    <value>The template installation failed with exit code {0}. For more information run with --debug switch.</value>
-    <comment>{0} is a number, --debug should not be localized</comment>
+    <value>The template installation failed with exit code {0}. See logs at {1}</value>
+    <comment>{0} is a number, {1} is the log file path</comment>
   </data>
   <data name="UsingProjectTemplatesVersion" xml:space="preserve">
     <value>Using project templates version: {0}</value>
@@ -209,8 +209,8 @@
     <value>Creating new Aspire project...</value>
   </data>
   <data name="ProjectCreationFailed" xml:space="preserve">
-    <value>Project creation failed with exit code {0}. For more information run with --debug switch.</value>
-    <comment>{0} is a number, --debug should not be localized</comment>
+    <value>Project creation failed with exit code {0}. See logs at {1}</value>
+    <comment>{0} is a number, {1} is the log file path</comment>
   </data>
   <data name="ProjectCreatedSuccessfully" xml:space="preserve">
     <value>Project created successfully in {0}.</value>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
@@ -43,9 +43,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">Instalace balíčku se nezdařila s ukončovacím kódem {0}. Další informace získáte spuštěním s přepínačem --debug.</target>
-        <note />
+        <source>The package installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The package installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the project file to add the integration to.</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
@@ -43,9 +43,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">Fehler bei der Paketinstallation. Exitcode: {0}. Weitere Informationen erhalten Sie, wenn Sie mit dem Schalter „--debug“ ausführen.</target>
-        <note />
+        <source>The package installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The package installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the project file to add the integration to.</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
@@ -43,9 +43,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">La instalación del paquete falló con el código de salida {0}. Para obtener más información, ejecute con el modificador --debug.</target>
-        <note />
+        <source>The package installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The package installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the project file to add the integration to.</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
@@ -43,9 +43,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">L’installation du package a échoué avec le code de sortie {0}. Pour plus d’informations, exécutez avec le commutateur --debug.</target>
-        <note />
+        <source>The package installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The package installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the project file to add the integration to.</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
@@ -43,9 +43,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">L'installazione del pacchetto non è riuscita con codice di uscita {0}. Per altre informazioni, eseguire con l'opzione --debug.</target>
-        <note />
+        <source>The package installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The package installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the project file to add the integration to.</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
@@ -43,9 +43,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">パッケージのインストールが終了コード {0} で失敗しました。詳細情報については、--debug スイッチを使用し実行してください。</target>
-        <note />
+        <source>The package installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The package installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the project file to add the integration to.</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
@@ -43,9 +43,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">패키지 설치에 실패했습니다(종료 코드: {0}). 자세한 내용을 보려면 --debug 스위치를 이용하여 실행하세요.</target>
-        <note />
+        <source>The package installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The package installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the project file to add the integration to.</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
@@ -43,9 +43,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">Instalacja pakietu nie powiodła się z kodem zakończenia {0}. Aby uzyskać więcej informacji, uruchom polecenie przełącznika --debug.</target>
-        <note />
+        <source>The package installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The package installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the project file to add the integration to.</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
@@ -43,9 +43,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">A instalação do pacote falhou com o código de saída {0}. Para mais informações, execute com a opção --debug.</target>
-        <note />
+        <source>The package installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The package installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the project file to add the integration to.</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
@@ -43,9 +43,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">Не удалось установить пакет. Код завершения: {0}. Для получения дополнительных сведений запустите команду с параметром --debug.</target>
-        <note />
+        <source>The package installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The package installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the project file to add the integration to.</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
@@ -43,9 +43,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">Paket yüklemesi {0} çıkış koduyla başarısız oldu. Daha fazla bilgi için --debug anahtarıyla çalıştırın.</target>
-        <note />
+        <source>The package installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The package installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the project file to add the integration to.</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
@@ -43,9 +43,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">包安装失败，退出代码为 {0}。有关详细信息，请使用 --debug 开关运行。</target>
-        <note />
+        <source>The package installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The package installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the project file to add the integration to.</source>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
@@ -43,9 +43,9 @@
         <note>{0} is the package name, {1} is the version.</note>
       </trans-unit>
       <trans-unit id="PackageInstallationFailed">
-        <source>The package installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">套件安裝失敗，結束代碼為 {0}。如需詳細資訊，請使用 --debug 切換執行。</target>
-        <note />
+        <source>The package installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The package installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="ProjectArgumentDescription">
         <source>The path to the project file to add the integration to.</source>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
-        <source>The project could not be analyzed due to a build error. For more information run with --debug switch.</source>
-        <target state="translated">Projekt se nepodařilo analyzovat kvůli chybě sestavení. Další informace získáte spuštěním s přepínačem --debug.</target>
+        <source>The project could not be analyzed due to a build error. See logs at {0}</source>
+        <target state="new">The project could not be analyzed due to a build error. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
-        <source>The project could not be analyzed due to a build error. For more information run with --debug switch.</source>
-        <target state="translated">Das Projekt konnte aufgrund eines Buildfehlers nicht analysiert werden. Weitere Informationen erhalten Sie, wenn Sie mit dem Schalter „--debug“ ausführen.</target>
+        <source>The project could not be analyzed due to a build error. See logs at {0}</source>
+        <target state="new">The project could not be analyzed due to a build error. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
-        <source>The project could not be analyzed due to a build error. For more information run with --debug switch.</source>
-        <target state="translated">No se pudo analizar el proyecto debido a un error de compilación. Para obtener más información, ejecute con el modificador --debug.</target>
+        <source>The project could not be analyzed due to a build error. See logs at {0}</source>
+        <target state="new">The project could not be analyzed due to a build error. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
-        <source>The project could not be analyzed due to a build error. For more information run with --debug switch.</source>
-        <target state="translated">Impossible d’analyser le projet en raison d’une erreur de build. Pour plus d’informations, exécutez avec le commutateur --debug.</target>
+        <source>The project could not be analyzed due to a build error. See logs at {0}</source>
+        <target state="new">The project could not be analyzed due to a build error. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
-        <source>The project could not be analyzed due to a build error. For more information run with --debug switch.</source>
-        <target state="translated">Non è possibile analizzare il progetto a causa di un errore di compilazione. Per altre informazioni, eseguire con l'opzione --debug.</target>
+        <source>The project could not be analyzed due to a build error. See logs at {0}</source>
+        <target state="new">The project could not be analyzed due to a build error. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
-        <source>The project could not be analyzed due to a build error. For more information run with --debug switch.</source>
-        <target state="translated">ビルド エラーのため、プロジェクトを分析できませんでした。詳細情報については、--debug スイッチを使用し実行してください。</target>
+        <source>The project could not be analyzed due to a build error. See logs at {0}</source>
+        <target state="new">The project could not be analyzed due to a build error. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
-        <source>The project could not be analyzed due to a build error. For more information run with --debug switch.</source>
-        <target state="translated">빌드 오류로 인해 프로젝트를 분석할 수 없습니다. 자세한 내용을 보려면 --debug 스위치를 이용하여 실행하세요.</target>
+        <source>The project could not be analyzed due to a build error. See logs at {0}</source>
+        <target state="new">The project could not be analyzed due to a build error. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
-        <source>The project could not be analyzed due to a build error. For more information run with --debug switch.</source>
-        <target state="translated">Nie można przeanalizować projektu z powodu błędu kompilacji. Aby uzyskać więcej informacji, uruchom polecenie przełącznika --debug.</target>
+        <source>The project could not be analyzed due to a build error. See logs at {0}</source>
+        <target state="new">The project could not be analyzed due to a build error. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
-        <source>The project could not be analyzed due to a build error. For more information run with --debug switch.</source>
-        <target state="translated">Não foi possível analisar o projeto devido a um erro de compilação. Para obter mais informações, execute com a opção --debug.</target>
+        <source>The project could not be analyzed due to a build error. See logs at {0}</source>
+        <target state="new">The project could not be analyzed due to a build error. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
-        <source>The project could not be analyzed due to a build error. For more information run with --debug switch.</source>
-        <target state="translated">Не удалось проанализировать проект из-за ошибки сборки. Для получения дополнительных сведений запустите команду с параметром --debug.</target>
+        <source>The project could not be analyzed due to a build error. See logs at {0}</source>
+        <target state="new">The project could not be analyzed due to a build error. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
-        <source>The project could not be analyzed due to a build error. For more information run with --debug switch.</source>
-        <target state="translated">Proje bir derleme hatası nedeniyle analiz edilemedi. Daha fazla bilgi için --debug anahtarıyla çalıştırın.</target>
+        <source>The project could not be analyzed due to a build error. See logs at {0}</source>
+        <target state="new">The project could not be analyzed due to a build error. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
-        <source>The project could not be analyzed due to a build error. For more information run with --debug switch.</source>
-        <target state="translated">由于生成错误，无法分析项目。有关详细信息，请使用 --debug 开关运行。</target>
+        <source>The project could not be analyzed due to a build error. See logs at {0}</source>
+        <target state="new">The project could not be analyzed due to a build error. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeAnalyzed">
-        <source>The project could not be analyzed due to a build error. For more information run with --debug switch.</source>
-        <target state="translated">因為組建錯誤，無法分析專案。如需詳細資訊，請使用 --debug 切換執行。</target>
+        <source>The project could not be analyzed due to a build error. See logs at {0}</source>
+        <target state="new">The project could not be analyzed due to a build error. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectFileDoesntExist">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. For more information run with --debug switch.</source>
-        <target state="translated">Projekt se nepovedlo sestavit. Další informace získáte spuštěním s přepínačem --debug.</target>
+        <source>The project could not be built. See logs at {0}</source>
+        <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
@@ -126,6 +126,11 @@
         <source>Searching...</source>
         <target state="translated">Vyhledávání…</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SeeLogsAt">
+        <source>See logs at {0}</source>
+        <target state="new">See logs at {0}</target>
+        <note>{0} is the log file path</note>
       </trans-unit>
       <trans-unit id="SelectAppHostToUse">
         <source>Select an apphost to use:</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. For more information run with --debug switch.</source>
-        <target state="translated">Das Projekt konnte nicht erstellt werden. Weitere Informationen erhalten Sie, wenn Sie mit dem Schalter „--debug“ ausführen.</target>
+        <source>The project could not be built. See logs at {0}</source>
+        <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
@@ -126,6 +126,11 @@
         <source>Searching...</source>
         <target state="translated">Suche wird ausgeführt...</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SeeLogsAt">
+        <source>See logs at {0}</source>
+        <target state="new">See logs at {0}</target>
+        <note>{0} is the log file path</note>
       </trans-unit>
       <trans-unit id="SelectAppHostToUse">
         <source>Select an apphost to use:</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. For more information run with --debug switch.</source>
-        <target state="translated">No se pudo compilar el proyecto. Para obtener más información, ejecute con el modificador --debug.</target>
+        <source>The project could not be built. See logs at {0}</source>
+        <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
@@ -126,6 +126,11 @@
         <source>Searching...</source>
         <target state="translated">Buscando...</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SeeLogsAt">
+        <source>See logs at {0}</source>
+        <target state="new">See logs at {0}</target>
+        <note>{0} is the log file path</note>
       </trans-unit>
       <trans-unit id="SelectAppHostToUse">
         <source>Select an apphost to use:</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. For more information run with --debug switch.</source>
-        <target state="translated">Le projet n’a pas pu être généré. Pour plus d’informations, exécutez avec le commutateur --debug.</target>
+        <source>The project could not be built. See logs at {0}</source>
+        <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
@@ -126,6 +126,11 @@
         <source>Searching...</source>
         <target state="translated">Recherche en cours...</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SeeLogsAt">
+        <source>See logs at {0}</source>
+        <target state="new">See logs at {0}</target>
+        <note>{0} is the log file path</note>
       </trans-unit>
       <trans-unit id="SelectAppHostToUse">
         <source>Select an apphost to use:</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. For more information run with --debug switch.</source>
-        <target state="translated">Non è possibile compilare il progetto. Per altre informazioni, eseguire con l'opzione --debug.</target>
+        <source>The project could not be built. See logs at {0}</source>
+        <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
@@ -126,6 +126,11 @@
         <source>Searching...</source>
         <target state="translated">Ricerca in corso...</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SeeLogsAt">
+        <source>See logs at {0}</source>
+        <target state="new">See logs at {0}</target>
+        <note>{0} is the log file path</note>
       </trans-unit>
       <trans-unit id="SelectAppHostToUse">
         <source>Select an apphost to use:</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. For more information run with --debug switch.</source>
-        <target state="translated">プロジェクトをビルドできませんでした。詳細については、--debug スイッチを使用し実行してください。</target>
+        <source>The project could not be built. See logs at {0}</source>
+        <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
@@ -126,6 +126,11 @@
         <source>Searching...</source>
         <target state="translated">検索しています...</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SeeLogsAt">
+        <source>See logs at {0}</source>
+        <target state="new">See logs at {0}</target>
+        <note>{0} is the log file path</note>
       </trans-unit>
       <trans-unit id="SelectAppHostToUse">
         <source>Select an apphost to use:</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. For more information run with --debug switch.</source>
-        <target state="translated">프로젝트를 빌드할 수 없습니다. 자세한 내용을 보려면 --debug 스위치를 이용하여 실행하세요.</target>
+        <source>The project could not be built. See logs at {0}</source>
+        <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
@@ -126,6 +126,11 @@
         <source>Searching...</source>
         <target state="translated">검색 중...</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SeeLogsAt">
+        <source>See logs at {0}</source>
+        <target state="new">See logs at {0}</target>
+        <note>{0} is the log file path</note>
       </trans-unit>
       <trans-unit id="SelectAppHostToUse">
         <source>Select an apphost to use:</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. For more information run with --debug switch.</source>
-        <target state="translated">Nie można skompilować projektu. Aby uzyskać więcej informacji, uruchom polecenie przełącznika --debug.</target>
+        <source>The project could not be built. See logs at {0}</source>
+        <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
@@ -126,6 +126,11 @@
         <source>Searching...</source>
         <target state="translated">Trwa wyszukiwanie...</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SeeLogsAt">
+        <source>See logs at {0}</source>
+        <target state="new">See logs at {0}</target>
+        <note>{0} is the log file path</note>
       </trans-unit>
       <trans-unit id="SelectAppHostToUse">
         <source>Select an apphost to use:</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. For more information run with --debug switch.</source>
-        <target state="translated">O projeto não pôde ser compilado. Para obter mais informações, execute com a opção --debug.</target>
+        <source>The project could not be built. See logs at {0}</source>
+        <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
@@ -126,6 +126,11 @@
         <source>Searching...</source>
         <target state="translated">Pesquisando...</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SeeLogsAt">
+        <source>See logs at {0}</source>
+        <target state="new">See logs at {0}</target>
+        <note>{0} is the log file path</note>
       </trans-unit>
       <trans-unit id="SelectAppHostToUse">
         <source>Select an apphost to use:</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. For more information run with --debug switch.</source>
-        <target state="translated">Не удалось выполнить сборку проекта. Для получения дополнительных сведений запустите команду с параметром --debug.</target>
+        <source>The project could not be built. See logs at {0}</source>
+        <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
@@ -126,6 +126,11 @@
         <source>Searching...</source>
         <target state="translated">Выполняется поиск...</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SeeLogsAt">
+        <source>See logs at {0}</source>
+        <target state="new">See logs at {0}</target>
+        <note>{0} is the log file path</note>
       </trans-unit>
       <trans-unit id="SelectAppHostToUse">
         <source>Select an apphost to use:</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. For more information run with --debug switch.</source>
-        <target state="translated">Proje oluşturulamadı. Daha fazla bilgi için --debug anahtarıyla çalıştırın.</target>
+        <source>The project could not be built. See logs at {0}</source>
+        <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
@@ -126,6 +126,11 @@
         <source>Searching...</source>
         <target state="translated">Aranıyor...</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SeeLogsAt">
+        <source>See logs at {0}</source>
+        <target state="new">See logs at {0}</target>
+        <note>{0} is the log file path</note>
       </trans-unit>
       <trans-unit id="SelectAppHostToUse">
         <source>Select an apphost to use:</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. For more information run with --debug switch.</source>
-        <target state="translated">无法生成项目。有关详细信息，请使用 --debug 开关运行。</target>
+        <source>The project could not be built. See logs at {0}</source>
+        <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
@@ -126,6 +126,11 @@
         <source>Searching...</source>
         <target state="translated">正在搜索...</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SeeLogsAt">
+        <source>See logs at {0}</source>
+        <target state="new">See logs at {0}</target>
+        <note>{0} is the log file path</note>
       </trans-unit>
       <trans-unit id="SelectAppHostToUse">
         <source>Select an apphost to use:</source>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeBuilt">
-        <source>The project could not be built. For more information run with --debug switch.</source>
-        <target state="translated">無法建置專案。如需詳細資訊，請使用 --debug 切換執行。</target>
+        <source>The project could not be built. See logs at {0}</source>
+        <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
@@ -126,6 +126,11 @@
         <source>Searching...</source>
         <target state="translated">正在搜尋...</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SeeLogsAt">
+        <source>See logs at {0}</source>
+        <target state="new">See logs at {0}</target>
+        <note>{0} is the log file path</note>
       </trans-unit>
       <trans-unit id="SelectAppHostToUse">
         <source>Select an apphost to use:</source>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.cs.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Povolte protokolování ladění do konzoly.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugLevelArgumentDescription">
+        <source>Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</source>
+        <target state="new">Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>The Aspire CLI can be used to create, run, and publish Aspire-based applications.</source>
         <target state="translated">Aspire CLI lze použít k vytváření, spouštění a publikování aplikací založených na Aspire.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.de.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Aktivieren Sie die Debugprotokollierung in der Konsole.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugLevelArgumentDescription">
+        <source>Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</source>
+        <target state="new">Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>The Aspire CLI can be used to create, run, and publish Aspire-based applications.</source>
         <target state="translated">Die Aspire CLI kann zum Erstellen, Ausführen und Veröffentlichen von Aspire-basierten Anwendungen verwendet werden.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.es.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Habilite el registro de depuración en la consola.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugLevelArgumentDescription">
+        <source>Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</source>
+        <target state="new">Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>The Aspire CLI can be used to create, run, and publish Aspire-based applications.</source>
         <target state="translated">La CLI de Aspire puede utilizarse para crear, ejecutar y publicar aplicaciones basadas en Aspire.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.fr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Activez la journalisation de débogage dans la console.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugLevelArgumentDescription">
+        <source>Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</source>
+        <target state="new">Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>The Aspire CLI can be used to create, run, and publish Aspire-based applications.</source>
         <target state="translated">L’interface CLI Aspire peut être utilisée pour créer, exécuter et publier des applications basées sur Aspire.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.it.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Abilita la registrazione di debug nella console.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugLevelArgumentDescription">
+        <source>Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</source>
+        <target state="new">Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>The Aspire CLI can be used to create, run, and publish Aspire-based applications.</source>
         <target state="translated">L'interfaccia della riga di comando Aspire può essere usata per creare, eseguire e pubblicare applicazioni basate su Aspire.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ja.xlf
@@ -27,6 +27,11 @@
         <target state="translated">コンソールへのデバッグ ログを有効にします。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugLevelArgumentDescription">
+        <source>Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</source>
+        <target state="new">Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>The Aspire CLI can be used to create, run, and publish Aspire-based applications.</source>
         <target state="translated">Aspire CLI を使用して、Aspire ベースのアプリケーションを作成、実行、発行できます。</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ko.xlf
@@ -27,6 +27,11 @@
         <target state="translated">콘솔에 디버그 로깅을 활성화하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugLevelArgumentDescription">
+        <source>Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</source>
+        <target state="new">Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>The Aspire CLI can be used to create, run, and publish Aspire-based applications.</source>
         <target state="translated">Aspire CLI를 사용하여 Aspire 기반 애플리케이션을 만들고, 실행하고, 게시할 수 있습니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pl.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Włącz rejestrowanie debugowania w konsoli.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugLevelArgumentDescription">
+        <source>Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</source>
+        <target state="new">Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>The Aspire CLI can be used to create, run, and publish Aspire-based applications.</source>
         <target state="translated">Interfejs wiersza polecenia platformy Aspire może służyć do tworzenia, uruchamiania i publikowania aplikacji opartych na platformie Aspire.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Habilitar o log de depuração no console.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugLevelArgumentDescription">
+        <source>Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</source>
+        <target state="new">Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>The Aspire CLI can be used to create, run, and publish Aspire-based applications.</source>
         <target state="translated">A CLI do Aspire pode ser usada para criar, executar e publicar aplicações baseadas em Aspire.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ru.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Включает журналирование отладки в консоли.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugLevelArgumentDescription">
+        <source>Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</source>
+        <target state="new">Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>The Aspire CLI can be used to create, run, and publish Aspire-based applications.</source>
         <target state="translated">CLI Aspire можно использовать для создания, запуска и публикации приложений на основе Aspire.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.tr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Konsolda hata ayıklama kaydını etkinleştirin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugLevelArgumentDescription">
+        <source>Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</source>
+        <target state="new">Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>The Aspire CLI can be used to create, run, and publish Aspire-based applications.</source>
         <target state="translated">Aspire CLI, Aspire tabanlı uygulamalar oluşturmak, çalıştırmak ve yayımlamak için kullanılabilir.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="translated">启用控制台的调试日志记录。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugLevelArgumentDescription">
+        <source>Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</source>
+        <target state="new">Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>The Aspire CLI can be used to create, run, and publish Aspire-based applications.</source>
         <target state="translated">Aspire CLI 可用于创建、运行和发布基于 Aspire 的应用程序。</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="translated">啟用控制台的偵錯記錄。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugLevelArgumentDescription">
+        <source>Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</source>
+        <target state="new">Set the minimum log level for console output (Trace, Debug, Information, Warning, Error, Critical).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>The Aspire CLI can be used to create, run, and publish Aspire-based applications.</source>
         <target state="translated">Aspire CLI 可用來建立、執行及發佈以 Aspire 為基礎的應用程式。</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.cs.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeRun">
-        <source>The project could not be run. For more information run with --debug switch.</source>
-        <target state="translated">Projekt nelze spustit. Další informace získáte spuštěním s přepínačem --debug.</target>
+        <source>The project could not be run. See logs at {0}</source>
+        <target state="new">The project could not be run. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Resource">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.de.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeRun">
-        <source>The project could not be run. For more information run with --debug switch.</source>
-        <target state="translated">Das Projekt konnte nicht ausgeführt werden. Weitere Informationen erhalten Sie, wenn Sie mit dem Schalter „--debug“ ausführen.</target>
+        <source>The project could not be run. See logs at {0}</source>
+        <target state="new">The project could not be run. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Resource">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.es.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeRun">
-        <source>The project could not be run. For more information run with --debug switch.</source>
-        <target state="translated">No se pudo ejecutar el proyecto. Para obtener más información, ejecute con el conmutador --debug.</target>
+        <source>The project could not be run. See logs at {0}</source>
+        <target state="new">The project could not be run. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Resource">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.fr.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeRun">
-        <source>The project could not be run. For more information run with --debug switch.</source>
-        <target state="translated">Le projet n’a pas pu être exécuté. Pour plus d’informations, exécutez avec le commutateur --debug.</target>
+        <source>The project could not be run. See logs at {0}</source>
+        <target state="new">The project could not be run. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Resource">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.it.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeRun">
-        <source>The project could not be run. For more information run with --debug switch.</source>
-        <target state="translated">Non è possibile eseguire il progetto. Per altre informazioni, eseguire con l'opzione --debug.</target>
+        <source>The project could not be run. See logs at {0}</source>
+        <target state="new">The project could not be run. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Resource">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ja.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeRun">
-        <source>The project could not be run. For more information run with --debug switch.</source>
-        <target state="translated">プロジェクトを実行できませんでした。詳細情報については、--debug スイッチを使用し実行してください。</target>
+        <source>The project could not be run. See logs at {0}</source>
+        <target state="new">The project could not be run. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Resource">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ko.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeRun">
-        <source>The project could not be run. For more information run with --debug switch.</source>
-        <target state="translated">프로젝트를 실행할 수 없습니다. 자세한 내용을 보려면 --debug 스위치를 이용하여 실행하세요.</target>
+        <source>The project could not be run. See logs at {0}</source>
+        <target state="new">The project could not be run. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Resource">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pl.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeRun">
-        <source>The project could not be run. For more information run with --debug switch.</source>
-        <target state="translated">Nie można uruchomić projektu. Aby uzyskać więcej informacji, uruchom polecenie przełącznika --debug.</target>
+        <source>The project could not be run. See logs at {0}</source>
+        <target state="new">The project could not be run. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Resource">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pt-BR.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeRun">
-        <source>The project could not be run. For more information run with --debug switch.</source>
-        <target state="translated">Não foi possível executar o projeto. Para obter mais informações, execute com a opção --debug.</target>
+        <source>The project could not be run. See logs at {0}</source>
+        <target state="new">The project could not be run. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Resource">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ru.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeRun">
-        <source>The project could not be run. For more information run with --debug switch.</source>
-        <target state="translated">Не удалось запустить проект. Для получения дополнительных сведений запустите команду с параметром --debug.</target>
+        <source>The project could not be run. See logs at {0}</source>
+        <target state="new">The project could not be run. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Resource">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.tr.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeRun">
-        <source>The project could not be run. For more information run with --debug switch.</source>
-        <target state="translated">Proje çalıştırılamadı. Daha fazla bilgi için --debug anahtarıyla çalıştırın.</target>
+        <source>The project could not be run. See logs at {0}</source>
+        <target state="new">The project could not be run. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Resource">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hans.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeRun">
-        <source>The project could not be run. For more information run with --debug switch.</source>
-        <target state="translated">无法运行该项目。有关详细信息，请使用 --debug 开关运行。</target>
+        <source>The project could not be run. See logs at {0}</source>
+        <target state="new">The project could not be run. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Resource">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hant.xlf
@@ -148,8 +148,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ProjectCouldNotBeRun">
-        <source>The project could not be run. For more information run with --debug switch.</source>
-        <target state="translated">無法執行專案。如需詳細資訊，請使用 --debug 切換執行。</target>
+        <source>The project could not be run. See logs at {0}</source>
+        <target state="new">The project could not be run. See logs at {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Resource">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
@@ -123,9 +123,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">Vytvoření projektu se nezdařilo s ukončovacím kódem {0}. Další informace získáte spuštěním s přepínačem --debug.</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>Project creation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">Project creation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">Instalace balíčku se nezdařila s ukončovacím kódem {0}. Další informace získáte spuštěním s přepínačem --debug.</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>The template installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The template installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
@@ -123,9 +123,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">Fehler bei der Projekterstellung. Exitcode {0}: Weitere Informationen erhalten Sie, wenn Sie mit dem Schalter „--debug“ ausführen.</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>Project creation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">Project creation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">Fehler bei der Vorlageninstallation. Exitcode {0}: Weitere Informationen erhalten Sie, wenn Sie mit dem Schalter „--debug“ ausführen.</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>The template installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The template installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
@@ -123,9 +123,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">Error al crear el proyecto con el código de salida {0}. Para obtener más información, ejecute con el modificador --debug.</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>Project creation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">Project creation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">La instalación de la plantilla falló con el código de salida {0}. Para obtener más información, ejecute con el modificador --debug.</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>The template installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The template installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
@@ -123,9 +123,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">Échec de la création du projet avec le code de sortie {0}. Pour plus d’informations, exécutez avec le commutateur --debug.</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>Project creation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">Project creation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">L’installation du modèle a échoué avec le code de sortie {0}. Pour plus d’informations, exécutez avec le commutateur --debug.</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>The template installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The template installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
@@ -123,9 +123,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">Creazione del progetto non riuscita con codice di uscita {0}. Per altre informazioni, eseguire con l'opzione --debug.</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>Project creation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">Project creation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">L'installazione del modello non è riuscita con codice di uscita {0}. Per altre informazioni, eseguire con l'opzione --debug.</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>The template installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The template installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
@@ -123,9 +123,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">プロジェクトの作成が、次の終了コードで失敗しました: {0}。詳細情報については、--debug スイッチを使用し実行してください。</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>Project creation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">Project creation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">テンプレートのインストールが、次の終了コードで失敗しました: {0}。詳細情報については、--debug スイッチを使用し実行してください。</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>The template installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The template installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
@@ -123,9 +123,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">{0} 종료 코드를 이용하여 프로젝트 만들기에 실패했습니다. 자세한 내용을 보려면 --debug 스위치를 이용하여 실행하세요.</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>Project creation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">Project creation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">{0} 종료 코드를 이용한 템플릿 설치에 실패했습니다. 자세한 내용을 보려면 --debug 스위치를 이용하여 실행하세요.</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>The template installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The template installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
@@ -123,9 +123,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">Tworzenie projektu nie powiodło się z kodem zakończenia {0}. Aby uzyskać więcej informacji, uruchom polecenie przełącznika --debug.</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>Project creation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">Project creation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">Instalacja szablonu nie powiodła się z kodem zakończenia {0}. Aby uzyskać więcej informacji, uruchom polecenie przełącznika --debug.</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>The template installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The template installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
@@ -123,9 +123,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">Falha na criação do projeto com código de saída {0}. Para mais informações, execute com a opção --debug.</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>Project creation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">Project creation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">A instalação do modelo falhou com o código de saída {0}. Para mais informações, execute com a opção --debug.</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>The template installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The template installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
@@ -123,9 +123,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">Не удалось создать проект. Код завершения: {0}. Для получения дополнительных сведений запустите команду с параметром --debug.</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>Project creation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">Project creation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">Не удалось установить шаблон. Код завершения: {0}. Для получения дополнительных сведений запустите команду с параметром --debug.</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>The template installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The template installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
@@ -123,9 +123,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">Proje oluşturma başarısız oldu, çıkış kodu {0}. Daha fazla bilgi için --debug anahtarıyla çalıştırın.</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>Project creation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">Project creation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">Şablon yüklemesi, {0} çıkış koduyla başarısız oldu. Daha fazla bilgi için --debug anahtarıyla çalıştırın.</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>The template installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The template installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
@@ -123,9 +123,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">项目创建失败，退出代码为 {0}。有关详细信息，请使用 --debug 开关运行。</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>Project creation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">Project creation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">模板安装失败，退出代码为 {0}。有关详细信息，请使用 --debug 开关运行。</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>The template installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The template installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
@@ -123,9 +123,9 @@
         <note>{0} is a path</note>
       </trans-unit>
       <trans-unit id="ProjectCreationFailed">
-        <source>Project creation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">專案建立失敗，結束代碼為 {0}。如需詳細資訊，請使用 --debug 切換執行。</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>Project creation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">Project creation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="PromptForTFMOptions_Description">
         <source>Configures whether to create a project for integration tests using MSTest, NUnit, or xUnit.net.</source>
@@ -153,9 +153,9 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateInstallationFailed">
-        <source>The template installation failed with exit code {0}. For more information run with --debug switch.</source>
-        <target state="translated">範本安裝失敗，結束代碼為 {0}。如需詳細資訊，請使用 --debug 切換執行。</target>
-        <note>{0} is a number, --debug should not be localized</note>
+        <source>The template installation failed with exit code {0}. See logs at {1}</source>
+        <target state="new">The template installation failed with exit code {0}. See logs at {1}</target>
+        <note>{0} is a number, {1} is the log file path</note>
       </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -440,7 +440,7 @@ internal class DotNetTemplateFactory(
             if (templateInstallResult.ExitCode != 0)
             {
                 interactionService.DisplayLines(templateInstallCollector.GetLines());
-                interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.TemplateInstallationFailed, templateInstallResult.ExitCode));
+                interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.TemplateInstallationFailed, templateInstallResult.ExitCode, executionContext.LogFilePath));
                 return new TemplateResult(ExitCodeConstants.FailedToInstallTemplates);
             }
 
@@ -479,7 +479,7 @@ internal class DotNetTemplateFactory(
                 }
 
                 interactionService.DisplayLines(newProjectCollector.GetLines());
-                interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.ProjectCreationFailed, newProjectExitCode));
+                interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.ProjectCreationFailed, newProjectExitCode, executionContext.LogFilePath));
                 return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
             }
 

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -14,13 +14,13 @@ namespace Aspire.Cli.Utils;
 
 internal static class AppHostHelper
 {
-    internal static async Task<(bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingVersion)> CheckAppHostCompatibilityAsync(IDotNetCliRunner runner, IInteractionService interactionService, FileInfo projectFile, AspireCliTelemetry telemetry, DirectoryInfo workingDirectory, CancellationToken cancellationToken)
+    internal static async Task<(bool IsCompatibleAppHost, bool SupportsBackchannel, string? AspireHostingVersion)> CheckAppHostCompatibilityAsync(IDotNetCliRunner runner, IInteractionService interactionService, FileInfo projectFile, AspireCliTelemetry telemetry, DirectoryInfo workingDirectory, string logFilePath, CancellationToken cancellationToken)
     {
         var appHostInformation = await GetAppHostInformationAsync(runner, interactionService, projectFile, telemetry, workingDirectory, cancellationToken);
 
         if (appHostInformation.ExitCode != 0)
         {
-            interactionService.DisplayError(ErrorStrings.ProjectCouldNotBeAnalyzed);
+            interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, ErrorStrings.ProjectCouldNotBeAnalyzed, logFilePath));
             return (false, false, null);
         }
 
@@ -135,18 +135,4 @@ internal static class AppHostHelper
     /// <returns>The number of orphaned sockets deleted.</returns>
     internal static int CleanupOrphanedSockets(string backchannelsDirectory, string hash, int currentPid)
         => BackchannelConstants.CleanupOrphanedSockets(backchannelsDirectory, hash, currentPid);
-
-    /// <summary>
-    /// Gets the log file path for an AppHost process.
-    /// </summary>
-    /// <param name="pid">The process ID of the AppHost.</param>
-    /// <param name="homeDirectory">The user's home directory.</param>
-    /// <param name="timeProvider">The time provider for timestamp generation.</param>
-    /// <returns>The log file path.</returns>
-    internal static FileInfo GetLogFilePath(int pid, string homeDirectory, TimeProvider timeProvider)
-    {
-        var logsPath = Path.Combine(homeDirectory, ".aspire", "cli", "logs");
-        var logFilePath = Path.Combine(logsPath, $"apphost-{pid}-{timeProvider.GetUtcNow():yyyy-MM-dd-HH-mm-ss}.log");
-        return new FileInfo(logFilePath);
-    }
 }

--- a/src/Aspire.Cli/Utils/OutputCollector.cs
+++ b/src/Aspire.Cli/Utils/OutputCollector.cs
@@ -1,18 +1,41 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Cli.Diagnostics;
+
 namespace Aspire.Cli.Utils;
 
 internal sealed class OutputCollector
 {
     private readonly CircularBuffer<(string Stream, string Line)> _lines = new(10000); // 10k lines.
     private readonly object _lock = new object();
+    private readonly FileLoggerProvider? _fileLogger;
+    private readonly string _category;
+
+    /// <summary>
+    /// Creates an OutputCollector that only buffers output in memory.
+    /// </summary>
+    public OutputCollector() : this(null, "AppHost")
+    {
+    }
+
+    /// <summary>
+    /// Creates an OutputCollector that buffers output and optionally logs to disk.
+    /// </summary>
+    /// <param name="fileLogger">Optional file logger for writing output to disk.</param>
+    /// <param name="category">Category for log entries (e.g., "Build", "AppHost").</param>
+    public OutputCollector(FileLoggerProvider? fileLogger, string category = "AppHost")
+    {
+        _fileLogger = fileLogger;
+        _category = category;
+    }
 
     public void AppendOutput(string line)
     {
         lock (_lock)
         {
             _lines.Add(("stdout", line));
+            _fileLogger?.WriteLog(FormatLogLine("stdout", line));
         }
     }
 
@@ -21,6 +44,7 @@ internal sealed class OutputCollector
         lock (_lock)
         {
             _lines.Add(("stderr", line));
+            _fileLogger?.WriteLog(FormatLogLine("stderr", line));
         }
     }
 
@@ -30,5 +54,12 @@ internal sealed class OutputCollector
         {
             return _lines.ToArray();
         }
+    }
+
+    private string FormatLogLine(string stream, string line)
+    {
+        var timestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff", System.Globalization.CultureInfo.InvariantCulture);
+        var level = stream == "stderr" ? "FAIL" : "INFO";
+        return $"[{timestamp}] [{level}] [{_category}] {line}";
     }
 }

--- a/tests/Aspire.Cli.Tests/Agents/CopilotCliAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/CopilotCliAgentEnvironmentScannerTests.cs
@@ -201,6 +201,8 @@ public class CopilotCliAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
             hivesDirectory: workingDirectory,
             cacheDirectory: workingDirectory,
             sdksDirectory: workingDirectory,
+            logsDirectory: workingDirectory,
+            logFilePath: "test.log",
             debugMode: false,
             environmentVariables: new Dictionary<string, string?>(),
             homeDirectory: workingDirectory);
@@ -218,6 +220,8 @@ public class CopilotCliAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
             hivesDirectory: workingDirectory,
             cacheDirectory: workingDirectory,
             sdksDirectory: workingDirectory,
+            logsDirectory: workingDirectory,
+            logFilePath: "test.log",
             debugMode: false,
             environmentVariables: environmentVariables,
             homeDirectory: workingDirectory);

--- a/tests/Aspire.Cli.Tests/Agents/VsCodeAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/VsCodeAgentEnvironmentScannerTests.cs
@@ -323,6 +323,8 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
             hivesDirectory: workingDirectory,
             cacheDirectory: workingDirectory,
             sdksDirectory: workingDirectory,
+            logsDirectory: workingDirectory,
+            logFilePath: "test.log",
             debugMode: false,
             environmentVariables: environmentVariables,
             homeDirectory: homeDirectory);

--- a/tests/Aspire.Cli.Tests/Caching/DiskCacheTests.cs
+++ b/tests/Aspire.Cli.Tests/Caching/DiskCacheTests.cs
@@ -19,7 +19,7 @@ public class DiskCacheTests(ITestOutputHelper outputHelper)
         var configuration = new ConfigurationBuilder().AddInMemoryCollection(values).Build();
         var hives = new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "hives"));
         var cacheDir = new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cache"));
-        var ctx = new CliExecutionContext(workspace.WorkspaceRoot, hives, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var ctx = new CliExecutionContext(workspace.WorkspaceRoot, hives, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var loggerFactory = NullLoggerFactory.Instance; // no-op logging is fine here
         var logger = loggerFactory.CreateLogger<DiskCache>();
         return new DiskCache(logger, ctx, configuration);

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -865,7 +865,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var options = new DotNetCliRunnerInvocationOptions();
 
         var executionContext = new CliExecutionContext(
-            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks"))
+            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")), logsDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), logFilePath: "test.log"
         );
 
         var runner = DotNetCliRunnerTestHelper.Create(
@@ -914,7 +914,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var options = new DotNetCliRunnerInvocationOptions();
 
         var executionContext = new CliExecutionContext(
-            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks"))
+            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")), logsDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), logFilePath: "test.log"
         );
 
         var runner = DotNetCliRunnerTestHelper.Create(
@@ -959,7 +959,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var options = new DotNetCliRunnerInvocationOptions { Debug = true };
 
         var executionContext = new CliExecutionContext(
-            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks"))
+            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")), logsDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), logFilePath: "test.log"
         );
 
         var runner = DotNetCliRunnerTestHelper.Create(
@@ -1008,7 +1008,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var options = new DotNetCliRunnerInvocationOptions { Debug = false };
 
         var executionContext = new CliExecutionContext(
-            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks"))
+            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")), logsDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), logFilePath: "test.log"
         );
 
         var runner = DotNetCliRunnerTestHelper.Create(
@@ -1052,7 +1052,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var options = new DotNetCliRunnerInvocationOptions { Debug = true };
 
         var executionContext = new CliExecutionContext(
-            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks"))
+            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")), logsDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), logFilePath: "test.log"
         );
 
         var runner = DotNetCliRunnerTestHelper.Create(
@@ -1097,7 +1097,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var options = new DotNetCliRunnerInvocationOptions();
 
         var executionContext = new CliExecutionContext(
-            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks"))
+            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")), logsDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), logFilePath: "test.log"
         );
 
         var runner = DotNetCliRunnerTestHelper.Create(
@@ -1142,7 +1142,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var options = new DotNetCliRunnerInvocationOptions();
 
         var executionContext = new CliExecutionContext(
-            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks"))
+            workingDirectory: workspace.WorkspaceRoot, hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("hives"), cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire").CreateSubdirectory("cache"), sdksDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")), logsDirectory: new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), logFilePath: "test.log"
         );
 
         var runner = DotNetCliRunnerTestHelper.Create(

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
@@ -22,7 +22,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         var settingsDirectory = workingDirectory.CreateSubdirectory(".aspire");
         var hivesDirectory = settingsDirectory.CreateSubdirectory("hives");
         var cacheDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "cache"));
-        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/DotNetSdkInstallerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNetSdkInstallerTests.cs
@@ -23,8 +23,9 @@ public class DotNetSdkInstallerTests
         var hivesDirectory = new DirectoryInfo(Path.Combine(tempPath, "hives"));
         var cacheDirectory = new DirectoryInfo(Path.Combine(tempPath, "cache"));
         var sdksDirectory = new DirectoryInfo(Path.Combine(tempPath, "sdks"));
+        var logsDirectory = new DirectoryInfo(Path.Combine(tempPath, "logs"));
         
-        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, sdksDirectory, debugMode: false);
+        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, sdksDirectory, logsDirectory, "test.log", debugMode: false);
     }
 
     private static ILogger<DotNetSdkInstaller> CreateTestLogger()

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -22,7 +22,7 @@ public class ConsoleInteractionServiceTests
     public async Task PromptForSelectionAsync_EmptyChoices_ThrowsEmptyChoicesException()
     {
         // Arrange
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var interactionService = CreateInteractionService(AnsiConsole.Console, executionContext);
         var choices = Array.Empty<string>();
 
@@ -35,7 +35,7 @@ public class ConsoleInteractionServiceTests
     public async Task PromptForSelectionsAsync_EmptyChoices_ThrowsEmptyChoicesException()
     {
         // Arrange
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var interactionService = CreateInteractionService(AnsiConsole.Console, executionContext);
         var choices = Array.Empty<string>();
 
@@ -56,7 +56,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
         
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var interactionService = CreateInteractionService(console, executionContext);
         var errorMessage = "The JSON value could not be converted to <Type>. Path: $.values[0].Type | LineNumber: 0 | BytePositionInLine: 121.";
 
@@ -81,7 +81,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
         
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var interactionService = CreateInteractionService(console, executionContext);
         var message = "Path with <brackets> and [markup] characters";
 
@@ -106,7 +106,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
         
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var interactionService = CreateInteractionService(console, executionContext);
         var lines = new[]
         {
@@ -137,7 +137,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
         
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var interactionService = CreateInteractionService(console, executionContext);
         var markdown = "# Header\nThis is **bold** and *italic* text with `code`.";
 
@@ -164,7 +164,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
         
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var interactionService = CreateInteractionService(console, executionContext);
         var plainText = "This is just plain text without any markdown.";
 
@@ -189,7 +189,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
 
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), debugMode: true);
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log", debugMode: true);
         var interactionService = CreateInteractionService(console, executionContext);
         var statusText = "Processing request...";
         var result = "test result";
@@ -216,7 +216,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
 
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), debugMode: true);
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log", debugMode: true);
         var interactionService = CreateInteractionService(console, executionContext);
         var statusText = "Processing synchronous request...";
         var actionCalled = false;
@@ -235,7 +235,7 @@ public class ConsoleInteractionServiceTests
     public async Task PromptForStringAsync_WhenInteractiveInputNotSupported_ThrowsInvalidOperationException()
     {
         // Arrange
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var hostEnvironment = TestHelpers.CreateNonInteractiveHostEnvironment();
         var interactionService = CreateInteractionService(AnsiConsole.Console, executionContext, hostEnvironment);
 
@@ -249,7 +249,7 @@ public class ConsoleInteractionServiceTests
     public async Task PromptForSelectionAsync_WhenInteractiveInputNotSupported_ThrowsInvalidOperationException()
     {
         // Arrange
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var hostEnvironment = TestHelpers.CreateNonInteractiveHostEnvironment();
         var interactionService = CreateInteractionService(AnsiConsole.Console, executionContext, hostEnvironment);
         var choices = new[] { "option1", "option2" };
@@ -264,7 +264,7 @@ public class ConsoleInteractionServiceTests
     public async Task PromptForSelectionsAsync_WhenInteractiveInputNotSupported_ThrowsInvalidOperationException()
     {
         // Arrange
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var hostEnvironment = TestHelpers.CreateNonInteractiveHostEnvironment();
         var interactionService = CreateInteractionService(AnsiConsole.Console, executionContext, hostEnvironment);
         var choices = new[] { "option1", "option2" };
@@ -279,7 +279,7 @@ public class ConsoleInteractionServiceTests
     public async Task ConfirmAsync_WhenInteractiveInputNotSupported_ThrowsInvalidOperationException()
     {
         // Arrange
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var hostEnvironment = TestHelpers.CreateNonInteractiveHostEnvironment();
         var interactionService = CreateInteractionService(AnsiConsole.Console, executionContext, hostEnvironment);
 
@@ -301,7 +301,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
 
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var interactionService = CreateInteractionService(console, executionContext);
         
         var outerStatusText = "Outer operation...";
@@ -334,7 +334,7 @@ public class ConsoleInteractionServiceTests
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
 
-        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var interactionService = CreateInteractionService(console, executionContext);
         
         var outerStatusText = "Outer synchronous operation...";

--- a/tests/Aspire.Cli.Tests/Mcp/ListAppHostsToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListAppHostsToolTests.cs
@@ -168,7 +168,7 @@ public class ListAppHostsToolTests(ITestOutputHelper outputHelper)
     {
         var hivesDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "hives"));
         var cacheDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "cache"));
-        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")));
+        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
     }
 
     private static AppHostAuxiliaryBackchannel CreateAppHostConnection(string hash, string socketPath, AppHostInformation appHostInfo, bool isInScope)

--- a/tests/Aspire.Cli.Tests/Mcp/MockPackagingService.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/MockPackagingService.cs
@@ -55,7 +55,9 @@ internal static class TestExecutionContextFactory
             new DirectoryInfo(Path.GetTempPath()),
             new DirectoryInfo(Path.Combine(Path.GetTempPath(), "hives")),
             new DirectoryInfo(Path.Combine(Path.GetTempPath(), "cache")),
-            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "sdks")));
+            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "sdks")),
+            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "logs")),
+            "test.log");
     }
 }
 

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
@@ -15,7 +15,7 @@ public class NuGetPackagePrefetcherTests
         var workingDir = new DirectoryInfo(Environment.CurrentDirectory);
         var hivesDir = new DirectoryInfo(Path.Combine(Environment.CurrentDirectory, "hives"));
     var cacheDir = new DirectoryInfo(Path.Combine(workingDir.FullName, ".aspire", "cache"));
-    var executionContext = new CliExecutionContext(workingDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+    var executionContext = new CliExecutionContext(workingDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         
         Assert.Null(executionContext.Command);
         

--- a/tests/Aspire.Cli.Tests/Packaging/NuGetConfigMergerSnapshotTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/NuGetConfigMergerSnapshotTests.cs
@@ -63,7 +63,7 @@ public class NuGetConfigMergerSnapshotTests
         // Add a deterministic PR hive for testing realistic PR channel mappings.
         hivesDir.CreateSubdirectory("pr-1234");
         var cacheDir = new DirectoryInfo(Path.Combine(root.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(root, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(root, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var packagingService = CreatePackagingService(executionContext);
 
         // Existing config purposely minimal (no packageSourceMapping yet)
@@ -112,7 +112,7 @@ public class NuGetConfigMergerSnapshotTests
         // Add a deterministic PR hive for testing realistic PR channel mappings.
         hivesDir.CreateSubdirectory("pr-1234");
         var cacheDir2 = new DirectoryInfo(Path.Combine(root.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(root, hivesDir, cacheDir2, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(root, hivesDir, cacheDir2, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var packagingService = CreatePackagingService(executionContext);
 
         // Existing config purposely minimal (no packageSourceMapping yet)
@@ -174,7 +174,7 @@ public class NuGetConfigMergerSnapshotTests
         // Add a deterministic PR hive for testing realistic PR channel mappings.
         hivesDir.CreateSubdirectory("pr-1234");
         var cacheDir3 = new DirectoryInfo(Path.Combine(root.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(root, hivesDir, cacheDir3, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(root, hivesDir, cacheDir3, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var packagingService = CreatePackagingService(executionContext);
 
         // Existing config purposely minimal (no packageSourceMapping yet)
@@ -235,7 +235,7 @@ public class NuGetConfigMergerSnapshotTests
         // Add a deterministic PR hive for testing realistic PR channel mappings.
         hivesDir.CreateSubdirectory("pr-1234");
         var cacheDir4 = new DirectoryInfo(Path.Combine(root.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(root, hivesDir, cacheDir4, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(root, hivesDir, cacheDir4, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var packagingService = CreatePackagingService(executionContext);
 
         // Existing config purposely minimal (no packageSourceMapping yet)
@@ -294,7 +294,7 @@ public class NuGetConfigMergerSnapshotTests
         // Add a deterministic PR hive for testing realistic PR channel mappings.
         hivesDir.CreateSubdirectory("pr-1234");
         var cacheDir5 = new DirectoryInfo(Path.Combine(root.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(root, hivesDir, cacheDir5, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(root, hivesDir, cacheDir5, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var packagingService = CreatePackagingService(executionContext);
 
         // Existing config purposely minimal (no packageSourceMapping yet)

--- a/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
@@ -45,7 +45,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
         var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         
         var features = new TestFeatures();
         var configuration = new ConfigurationBuilder().Build();
@@ -80,7 +80,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
         var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -124,7 +124,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
         var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -157,7 +157,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
         var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -190,7 +190,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
         var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -222,7 +222,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
         var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -253,7 +253,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
         var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -284,7 +284,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
         var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -315,7 +315,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var tempDir = workspace.WorkspaceRoot;
         var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
         var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -355,7 +355,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
             .Build();
 
         var packagingService = new PackagingService(
-            new CliExecutionContext(tempDir, tempDir, tempDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes"))), 
+            new CliExecutionContext(tempDir, tempDir, tempDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log"), 
             new FakeNuGetPackageCache(), 
             features, 
             configuration);
@@ -399,7 +399,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         Directory.CreateDirectory(Path.Combine(hivesDir.FullName, "pr-10167"));
         Directory.CreateDirectory(Path.Combine(hivesDir.FullName, "pr-11832"));
         
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
@@ -455,7 +455,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         hivesDir.Create();
         Directory.CreateDirectory(Path.Combine(hivesDir.FullName, "pr-12345"));
         
-        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         
         var features = new TestFeatures();
         // Staging disabled by default

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -26,7 +26,7 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
         var settingsDirectory = workingDirectory.CreateSubdirectory(".aspire");
         var hivesDirectory = settingsDirectory.CreateSubdirectory("hives");
     var cacheDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "cache"));
-    return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+    return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
@@ -893,7 +893,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
         var settingsDirectory = workingDirectory.CreateSubdirectory(".aspire");
         var hivesDirectory = settingsDirectory.CreateSubdirectory("hives");
         var cacheDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "cache"));
-        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -333,7 +333,7 @@ public class DotNetTemplateFactoryTests
         var workingDirectory = new DirectoryInfo("/tmp");
         var hivesDirectory = new DirectoryInfo("/tmp/hives");
         var cacheDirectory = new DirectoryInfo("/tmp/cache");
-        var executionContext = new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")));
+        var executionContext = new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
         var configurationService = new FakeConfigurationService();
 
         return new DotNetTemplateFactory(


### PR DESCRIPTION
## CLI Logging Improvements

Writes **all CLI logs to disk** at `~/.aspire/logs/cli-{timestamp}-{pid}.log` for diagnostics, regardless of console verbosity settings. This enables agents and users to diagnose issues without needing `--debug` mode.

### Key Features

| Feature | Description |
|---------|-------------|
| **File logging** | All logs (Trace→Critical) written to disk automatically |
| **Console verbosity** | `--debug-level` controls console output level |
| **Clean error messages** | Console shows "See logs at {path}" instead of raw stack traces |
| **Session info** | Logs command, working directory, and exit code |
| **Build output** | Captured with `[Build]` prefix in log file |
| **AppHost output** | Captured with `[AppHost]` prefix in log file |
| **Async writing** | Uses bounded Channel for non-blocking writes |
| **Log cleanup** | `aspire cache clear` deletes old log files |
| **Child process forwarding** | Global options centralized via `RootCommand.GetChildProcessArgs()` |

### Log Format
```
[2026-02-05 15:45:00.123] [INFO] [Program] Command: aspire run
[2026-02-05 15:45:00.124] [INFO] [Program] Working directory: /path/to/project
[2026-02-05 15:45:02.456] [INFO] [Build] Restored project.csproj
[2026-02-05 15:45:05.789] [FAIL] [AppHost] Unhandled exception...
[2026-02-05 15:45:05.800] [INFO] [Program] Exit code: 1
```

### Error Experience

Before: raw stack traces with Spectre markup errors from brackets (fixes #13787)
After:
```
❌ The project could not be built. See logs at /Users/me/.aspire/logs/cli-2026-02-06-03-11-36-32819.log
```

### Files Changed
- `FileLoggerProvider.cs` - New Channel-based async file logger
- `RootCommand.cs` - Added `--debug-level` option, centralized child process option forwarding
- `Program.cs` - Registers file logger, logs session info
- `CliExecutionContext.cs` - `LogFilePath` as required constructor parameter
- `CacheCommand.cs` - Clears log directory
- `OutputCollector.cs` - Routes build/apphost output to file logger
- `DotNetCliRunner.cs` - Backchannel errors at Debug level when AppHost exited
- Various command files - Clean error messages with log file path

### Usage

```bash
# Normal usage - logs written to disk automatically
aspire run

# Verbose console output
aspire run --debug-level debug

# View logs
cat ~/.aspire/logs/cli-*.log

# Clear old logs
aspire cache clear
```