### PR TITLE
Refactor CLI telemetry MCP tools to use dashboard APIs

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -75,6 +75,7 @@
     <Compile Include="$(SharedDir)UserSecrets\UserSecretsPathHelper.cs" Link="Utils\UserSecretsPathHelper.cs" />
     <Compile Include="$(SharedDir)UserSecrets\IsolatedUserSecretsHelper.cs" Link="Utils\IsolatedUserSecretsHelper.cs" />
     <Compile Include="$(SharedDir)Otlp\OtlpHelpers.cs" Link="Otlp\OtlpHelpers.cs" />
+    <Compile Include="$(SharedDir)Otlp\IOtlpResource.cs" Link="Otlp\IOtlpResource.cs" />
     <Compile Include="$(SharedDir)Otlp\Serialization\OtlpCommonJson.cs" Link="Otlp\OtlpCommonJson.cs" />
     <Compile Include="$(SharedDir)Otlp\Serialization\OtlpResourceJson.cs" Link="Otlp\OtlpResourceJson.cs" />
     <Compile Include="$(SharedDir)Otlp\Serialization\OtlpLogsJson.cs" Link="Otlp\OtlpLogsJson.cs" />
@@ -84,6 +85,7 @@
     <Compile Include="$(SharedDir)ConsoleLogs\LogEntry.cs" Link="ConsoleLogs\LogEntry.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\LogParser.cs" Link="ConsoleLogs\LogParser.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\LogPauseViewModel.cs" Link="ConsoleLogs\LogPauseViewModel.cs" />
+    <Compile Include="$(SharedDir)ConsoleLogs\PromptContext.cs" Link="ConsoleLogs\PromptContext.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\SharedAIHelpers.cs" Link="ConsoleLogs\SharedAIHelpers.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\TimestampParser.cs" Link="ConsoleLogs\TimestampParser.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\UrlParser.cs" Link="ConsoleLogs\UrlParser.cs" />

--- a/src/Aspire.Cli/Commands/AgentMcpCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentMcpCommand.cs
@@ -18,7 +18,6 @@ using Aspire.Cli.Utils.EnvironmentChecker;
 using Aspire.Shared.Mcp;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
-using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
@@ -56,6 +55,7 @@ internal sealed class AgentMcpCommand : BaseCommand
         IEnvironmentChecker environmentChecker,
         IDocsSearchService docsSearchService,
         IDocsIndexService docsIndexService,
+        IHttpClientFactory httpClientFactory,
         AspireCliTelemetry telemetry)
         : base("mcp", AgentCommandStrings.McpCommand_Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
@@ -69,9 +69,9 @@ internal sealed class AgentMcpCommand : BaseCommand
             [KnownMcpTools.ListResources] = new ListResourcesTool(auxiliaryBackchannelMonitor, loggerFactory.CreateLogger<ListResourcesTool>()),
             [KnownMcpTools.ListConsoleLogs] = new ListConsoleLogsTool(auxiliaryBackchannelMonitor, loggerFactory.CreateLogger<ListConsoleLogsTool>()),
             [KnownMcpTools.ExecuteResourceCommand] = new ExecuteResourceCommandTool(auxiliaryBackchannelMonitor, loggerFactory.CreateLogger<ExecuteResourceCommandTool>()),
-            [KnownMcpTools.ListStructuredLogs] = new ListStructuredLogsTool(),
-            [KnownMcpTools.ListTraces] = new ListTracesTool(),
-            [KnownMcpTools.ListTraceStructuredLogs] = new ListTraceStructuredLogsTool(),
+            [KnownMcpTools.ListStructuredLogs] = new ListStructuredLogsTool(auxiliaryBackchannelMonitor, httpClientFactory, loggerFactory.CreateLogger<ListStructuredLogsTool>()),
+            [KnownMcpTools.ListTraces] = new ListTracesTool(auxiliaryBackchannelMonitor, httpClientFactory, loggerFactory.CreateLogger<ListTracesTool>()),
+            [KnownMcpTools.ListTraceStructuredLogs] = new ListTraceStructuredLogsTool(auxiliaryBackchannelMonitor, httpClientFactory, loggerFactory.CreateLogger<ListTraceStructuredLogsTool>()),
             [KnownMcpTools.SelectAppHost] = new SelectAppHostTool(auxiliaryBackchannelMonitor, executionContext),
             [KnownMcpTools.ListAppHosts] = new ListAppHostsTool(auxiliaryBackchannelMonitor, executionContext),
             [KnownMcpTools.ListIntegrations] = new ListIntegrationsTool(packagingService, executionContext, auxiliaryBackchannelMonitor),
@@ -176,33 +176,17 @@ internal sealed class AgentMcpCommand : BaseCommand
 
         _logger.LogDebug("MCP CallTool request received for tool: {ToolName}", toolName);
 
-        // Known tools?
         if (KnownTools.TryGetValue(toolName, out var tool))
         {
-            // Handle tools that don't need an MCP connection to the AppHost
-            if (KnownMcpTools.IsLocalTool(toolName))
+            var args = request.Params?.Arguments;
+            var context = new CallToolContext
             {
-                var args = request.Params?.Arguments;
-                var context = new CallToolContext
-                {
-                    Notifier = new McpServerNotifier(_server!),
-                    McpClient = null,
-                    Arguments = args,
-                    ProgressToken = request.Params?.ProgressToken
-                };
-                return await tool.CallToolAsync(context, cancellationToken).ConfigureAwait(false);
-            }
-
-            if (KnownMcpTools.IsDashboardTool(toolName))
-            {
-                var args = request.Params?.Arguments;
-                return await CallDashboardToolAsync(toolName, tool, request.Params?.ProgressToken, args, cancellationToken).ConfigureAwait(false);
-            }
-
-            // If a tool is registered in _tools, it must be classified as either local or dashboard-backed.
-            throw new McpProtocolException(
-                $"Tool '{toolName}' is not classified as local or dashboard-backed.",
-                McpErrorCode.InternalError);
+                Notifier = new McpServerNotifier(_server!),
+                McpClient = null,
+                Arguments = args,
+                ProgressToken = request.Params?.ProgressToken
+            };
+            return await tool.CallToolAsync(context, cancellationToken).ConfigureAwait(false);
         }
 
         var toolsRefreshed = false;
@@ -253,75 +237,6 @@ internal sealed class AgentMcpCommand : BaseCommand
         }
 
         throw new McpProtocolException($"Unknown tool: '{toolName}'", McpErrorCode.MethodNotFound);
-    }
-
-    private async ValueTask<CallToolResult> CallDashboardToolAsync(
-        string toolName,
-        CliMcpTool tool,
-        ProgressToken? progressToken,
-        IReadOnlyDictionary<string, JsonElement>? arguments,
-        CancellationToken cancellationToken)
-    {
-        var connection = await GetSelectedConnectionAsync(cancellationToken).ConfigureAwait(false);
-        if (connection is null)
-        {
-            _logger.LogWarning("No Aspire AppHost is currently running");
-            throw new McpProtocolException(McpErrorMessages.NoAppHostRunning, McpErrorCode.InternalError);
-        }
-
-        if (connection.McpInfo is null)
-        {
-            _logger.LogWarning("Dashboard is not available in the running AppHost");
-            throw new McpProtocolException(McpErrorMessages.DashboardNotAvailable, McpErrorCode.InternalError);
-        }
-
-        _logger.LogInformation(
-            "Connecting to dashboard MCP server. " +
-            "Dashboard URL: {EndpointUrl}, " +
-            "AppHost Path: {AppHostPath}, " +
-            "AppHost PID: {AppHostPid}, " +
-            "CLI PID: {CliPid}",
-            connection.McpInfo.EndpointUrl,
-            connection.AppHostInfo?.AppHostPath ?? "N/A",
-            connection.AppHostInfo?.ProcessId.ToString(CultureInfo.InvariantCulture) ?? "N/A",
-            connection.AppHostInfo?.CliProcessId?.ToString(CultureInfo.InvariantCulture) ?? "N/A");
-
-        var transportOptions = new HttpClientTransportOptions
-        {
-            Endpoint = new Uri(connection.McpInfo.EndpointUrl),
-            AdditionalHeaders = new Dictionary<string, string>
-            {
-                ["x-mcp-api-key"] = connection.McpInfo.ApiToken
-            }
-        };
-
-        using var httpClient = new HttpClient();
-        await using var transport = new HttpClientTransport(transportOptions, httpClient, _loggerFactory, ownsHttpClient: true);
-
-        // Create MCP client to communicate with the dashboard
-        await using var mcpClient = await McpClient.CreateAsync(transport, cancellationToken: cancellationToken);
-
-        _logger.LogDebug("Calling tool {ToolName} on dashboard MCP server", toolName);
-
-        try
-        {
-            _logger.LogDebug("Invoking CallToolAsync for tool {ToolName} with arguments: {Arguments}", toolName, arguments);
-            var context = new CallToolContext
-            {
-                Notifier = new McpServerNotifier(_server!),
-                McpClient = mcpClient,
-                Arguments = arguments,
-                ProgressToken = progressToken
-            };
-            var result = await tool.CallToolAsync(context, cancellationToken).ConfigureAwait(false);
-            _logger.LogDebug("Tool {ToolName} completed successfully", toolName);
-            return result;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while calling tool {ToolName}", toolName);
-            throw;
-        }
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Commands/AgentMcpCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentMcpCommand.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.Globalization;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Configuration;

--- a/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
@@ -111,11 +111,10 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         using var client = TelemetryCommandHelpers.CreateApiClient(_httpClientFactory, apiToken);
 
         // Resolve resource name to specific instances (handles replicas)
-        var resolvedResources = await TelemetryCommandHelpers.ResolveResourceNamesAsync(
-            client, baseUrl, resource, cancellationToken);
+        var resources = await TelemetryCommandHelpers.GetAllResourcesAsync(client, baseUrl, cancellationToken).ConfigureAwait(false);
 
-        // If a resource was specified but not found, show error
-        if (!string.IsNullOrEmpty(resource) && resolvedResources?.Count == 0)
+        // If a resource was specified but not found, return error
+        if (!TelemetryCommandHelpers.TryResolveResourceNames(resource, resources, out var resolvedResources))
         {
             _interactionService.DisplayError($"Resource '{resource}' not found.");
             return ExitCodeConstants.InvalidCommand;

--- a/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
@@ -107,11 +107,10 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         using var client = TelemetryCommandHelpers.CreateApiClient(_httpClientFactory, apiToken);
 
         // Resolve resource name to specific instances (handles replicas)
-        var resolvedResources = await TelemetryCommandHelpers.ResolveResourceNamesAsync(
-            client, baseUrl, resource, cancellationToken);
+        var resources = await TelemetryCommandHelpers.GetAllResourcesAsync(client, baseUrl, cancellationToken).ConfigureAwait(false);
 
-        // If a resource was specified but not found, show error
-        if (!string.IsNullOrEmpty(resource) && resolvedResources?.Count == 0)
+        // If a resource was specified but not found, return error
+        if (!TelemetryCommandHelpers.TryResolveResourceNames(resource, resources, out var resolvedResources))
         {
             _interactionService.DisplayError($"Resource '{resource}' not found.");
             return ExitCodeConstants.InvalidCommand;

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -160,11 +160,10 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         using var client = TelemetryCommandHelpers.CreateApiClient(_httpClientFactory, apiToken);
 
         // Resolve resource name to specific instances (handles replicas)
-        var resolvedResources = await TelemetryCommandHelpers.ResolveResourceNamesAsync(
-            client, baseUrl, resource, cancellationToken);
+        var resources = await TelemetryCommandHelpers.GetAllResourcesAsync(client, baseUrl, cancellationToken).ConfigureAwait(false);
 
-        // If a resource was specified but not found, show error
-        if (!string.IsNullOrEmpty(resource) && resolvedResources?.Count == 0)
+        // If a resource was specified but not found, return error
+        if (!TelemetryCommandHelpers.TryResolveResourceNames(resource, resources, out var resolvedResources))
         {
             _interactionService.DisplayError($"Resource '{resource}' not found.");
             return ExitCodeConstants.InvalidCommand;

--- a/src/Aspire.Cli/Mcp/KnownMcpTools.cs
+++ b/src/Aspire.Cli/Mcp/KnownMcpTools.cs
@@ -14,7 +14,6 @@ internal static class KnownMcpTools
     internal const string ListStructuredLogs = "list_structured_logs";
     internal const string ListTraces = "list_traces";
     internal const string ListTraceStructuredLogs = "list_trace_structured_logs";
-
     internal const string SelectAppHost = "select_apphost";
     internal const string ListAppHosts = "list_apphosts";
     internal const string ListIntegrations = "list_integrations";
@@ -45,21 +44,4 @@ internal static class KnownMcpTools
         GetDoc
     ];
 
-    public static bool IsLocalTool(string toolName) => toolName is
-        SelectAppHost or
-        ListAppHosts or
-        ListIntegrations or
-        Doctor or
-        RefreshTools or
-        ListDocs or
-        SearchDocs or
-        GetDoc or
-        ListResources or
-        ListConsoleLogs or
-        ExecuteResourceCommand;
-
-    public static bool IsDashboardTool(string toolName) => toolName is
-        ListStructuredLogs or
-        ListTraces or
-        ListTraceStructuredLogs;
 }

--- a/src/Aspire.Cli/Mcp/Tools/DoctorTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/DoctorTool.cs
@@ -30,9 +30,6 @@ internal sealed class DoctorTool(IEnvironmentChecker environmentChecker) : CliMc
 
     public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
-        // This tool does not use the MCP client or arguments
-        _ = context;
-
         try
         {
             // Run all environment checks

--- a/src/Aspire.Cli/Mcp/Tools/ExecuteResourceCommandTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ExecuteResourceCommandTool.cs
@@ -44,7 +44,6 @@ internal sealed class ExecuteResourceCommandTool(
     public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
         var arguments = context.Arguments;
-
         if (arguments is null ||
             !arguments.TryGetValue("resourceName", out var resourceNameElement) ||
             !arguments.TryGetValue("commandName", out var commandNameElement))

--- a/src/Aspire.Cli/Mcp/Tools/GetDocTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/GetDocTool.cs
@@ -44,9 +44,7 @@ internal sealed class GetDocTool(IDocsIndexService docsIndexService) : CliMcpToo
             """).RootElement;
     }
 
-    public override async ValueTask<CallToolResult> CallToolAsync(
-        CallToolContext context,
-        CancellationToken cancellationToken)
+    public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
         var arguments = context.Arguments;
 

--- a/src/Aspire.Cli/Mcp/Tools/ListAppHostsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListAppHostsTool.cs
@@ -37,9 +37,6 @@ internal sealed class ListAppHostsTool(IAuxiliaryBackchannelMonitor auxiliaryBac
 
     public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
-        // This tool does not use the MCP client as it operates locally
-        _ = context;
-
         // Trigger an immediate scan to ensure we have the latest AppHost connections
         await auxiliaryBackchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Aspire.Cli/Mcp/Tools/ListConsoleLogsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListConsoleLogsTool.cs
@@ -72,15 +72,15 @@ internal sealed class ListConsoleLogsTool(IAuxiliaryBackchannelMonitor auxiliary
 
             var entries = logEntries.GetEntries().ToList();
             var totalLogsCount = entries.Count == 0 ? 0 : entries.Last().LineNumber;
-            var (trimmedItems, limitMessage) = SharedAIHelpers.GetLimitFromEndWithSummary<LogEntry>(
+            var (trimmedItems, limitMessage) = SharedAIHelpers.GetLimitFromEndWithSummary(
                 entries,
                 totalLogsCount,
                 SharedAIHelpers.ConsoleLogsLimit,
                 "console log",
                 "console logs",
                 SharedAIHelpers.SerializeLogEntry,
-                logEntry => SharedAIHelpers.EstimateTokenCount((string)logEntry));
-            var consoleLogsText = SharedAIHelpers.SerializeConsoleLogs(trimmedItems.Cast<string>().ToList());
+                SharedAIHelpers.EstimateTokenCount);
+            var consoleLogsText = SharedAIHelpers.SerializeConsoleLogs(trimmedItems);
 
             var consoleLogsData = $"""
                 {limitMessage}

--- a/src/Aspire.Cli/Mcp/Tools/ListDocsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListDocsTool.cs
@@ -38,9 +38,7 @@ internal sealed class ListDocsTool(IDocsIndexService docsIndexService) : CliMcpT
             """).RootElement;
     }
 
-    public override async ValueTask<CallToolResult> CallToolAsync(
-        CallToolContext context,
-        CancellationToken cancellationToken)
+    public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
         await DocsToolHelper.EnsureIndexedWithNotificationsAsync(_docsIndexService, context.ProgressToken, context.Notifier, cancellationToken).ConfigureAwait(false);
 

--- a/src/Aspire.Cli/Mcp/Tools/ListIntegrationsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListIntegrationsTool.cs
@@ -69,9 +69,6 @@ internal sealed class ListIntegrationsTool(IPackagingService packagingService, C
 
     public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
-        // This tool does not use the MCP client as it operates locally
-        _ = context;
-
         try
         {
             // Get all channels

--- a/src/Aspire.Cli/Mcp/Tools/ListResourcesTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListResourcesTool.cs
@@ -57,9 +57,6 @@ internal sealed class ListResourcesTool(IAuxiliaryBackchannelMonitor auxiliaryBa
 
     public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
-        // This tool does not use the MCP client as it operates via backchannel
-        _ = context;
-
         var connection = await AppHostConnectionHelper.GetSelectedConnectionAsync(auxiliaryBackchannelMonitor, logger, cancellationToken).ConfigureAwait(false);
         if (connection is null)
         {

--- a/src/Aspire.Cli/Mcp/Tools/ListStructuredLogsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListStructuredLogsTool.cs
@@ -1,13 +1,25 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net.Http.Json;
 using System.Text.Json;
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Commands;
+using Aspire.Cli.Otlp;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Utils;
+using Aspire.Shared.ConsoleLogs;
+using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
 
 namespace Aspire.Cli.Mcp.Tools;
 
-internal sealed class ListStructuredLogsTool : CliMcpTool
+/// <summary>
+/// MCP tool for listing structured logs.
+/// Gets log data directly from the Dashboard telemetry API.
+/// </summary>
+internal sealed class ListStructuredLogsTool(IAuxiliaryBackchannelMonitor auxiliaryBackchannelMonitor, IHttpClientFactory httpClientFactory, ILogger<ListStructuredLogsTool> logger) : CliMcpTool
 {
     public override string Name => KnownMcpTools.ListStructuredLogs;
 
@@ -30,22 +42,66 @@ internal sealed class ListStructuredLogsTool : CliMcpTool
 
     public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
-        // Convert JsonElement arguments to Dictionary<string, object?>
-        Dictionary<string, object?>? convertedArgs = null;
-        if (context.Arguments != null)
+        var arguments = context.Arguments;
+        var (apiToken, apiBaseUrl, dashboardBaseUrl) = await McpToolHelpers.GetDashboardInfoAsync(auxiliaryBackchannelMonitor, logger, cancellationToken).ConfigureAwait(false);
+
+        // Extract resourceName from arguments
+        string? resourceName = null;
+        if (arguments?.TryGetValue("resourceName", out var resourceNameElement) == true &&
+            resourceNameElement.ValueKind == JsonValueKind.String)
         {
-            convertedArgs = new Dictionary<string, object?>();
-            foreach (var kvp in context.Arguments)
-            {
-                convertedArgs[kvp.Key] = kvp.Value.ValueKind == JsonValueKind.Null ? null : kvp.Value;
-            }
+            resourceName = resourceNameElement.GetString();
         }
 
-        // Forward the call to the dashboard's MCP server
-        return await context.McpClient!.CallToolAsync(
-            Name,
-            convertedArgs,
-            serializerOptions: McpJsonUtilities.DefaultOptions,
-            cancellationToken: cancellationToken);
+        try
+        {
+            using var client = TelemetryCommandHelpers.CreateApiClient(httpClientFactory, apiToken);
+
+            // Resolve resource name to specific instances (handles replicas)
+            var resources = await TelemetryCommandHelpers.GetAllResourcesAsync(client, apiBaseUrl, cancellationToken).ConfigureAwait(false);
+
+            // If a resource was specified but not found, return error
+            if (!TelemetryCommandHelpers.TryResolveResourceNames(resourceName, resources, out var resolvedResources))
+            {
+                return new CallToolResult
+                {
+                    Content = [new TextContentBlock { Text = $"Resource '{resourceName}' not found." }],
+                    IsError = true
+                };
+            }
+
+            var url = DashboardUrls.TelemetryLogsApiUrl(apiBaseUrl, resolvedResources);
+
+            logger.LogDebug("Fetching structured logs from {Url}", url);
+
+            var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            var apiResponse = await response.Content.ReadFromJsonAsync(OtlpCliJsonSerializerContext.Default.TelemetryApiResponse, cancellationToken).ConfigureAwait(false);
+            var resourceLogs = apiResponse?.Data?.ResourceLogs;
+
+            var (logsData, limitMessage) = SharedAIHelpers.GetStructuredLogsJson(
+                resourceLogs,
+                getResourceName: s => OtlpHelpers.GetResourceName(s, resources.Select(r => new SimpleOtlpResource(r.Name, r.InstanceId)).ToList()),
+                dashboardBaseUrl: dashboardBaseUrl);
+
+            var text = $"""
+                {limitMessage}
+
+                # STRUCTURED LOGS DATA
+
+                {logsData}
+                """;
+
+            return new CallToolResult
+            {
+                Content = [new TextContentBlock { Text = text }]
+            };
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.LogError(ex, "Failed to fetch structured logs from Dashboard API");
+            throw new McpProtocolException($"Failed to fetch structured logs: {ex.Message}", McpErrorCode.InternalError);
+        }
     }
 }

--- a/src/Aspire.Cli/Mcp/Tools/ListTraceStructuredLogsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListTraceStructuredLogsTool.cs
@@ -1,13 +1,25 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net.Http.Json;
 using System.Text.Json;
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Commands;
+using Aspire.Cli.Otlp;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Utils;
+using Aspire.Shared.ConsoleLogs;
+using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
 
 namespace Aspire.Cli.Mcp.Tools;
 
-internal sealed class ListTraceStructuredLogsTool : CliMcpTool
+/// <summary>
+/// MCP tool for listing structured logs for a specific distributed trace.
+/// Gets log data directly from the Dashboard telemetry API.
+/// </summary>
+internal sealed class ListTraceStructuredLogsTool(IAuxiliaryBackchannelMonitor auxiliaryBackchannelMonitor, IHttpClientFactory httpClientFactory, ILogger<ListTraceStructuredLogsTool> logger) : CliMcpTool
 {
     public override string Name => KnownMcpTools.ListTraceStructuredLogs;
 
@@ -31,22 +43,65 @@ internal sealed class ListTraceStructuredLogsTool : CliMcpTool
 
     public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
-        // Convert JsonElement arguments to Dictionary<string, object?>
-        Dictionary<string, object?>? convertedArgs = null;
-        if (context.Arguments != null)
+        var arguments = context.Arguments;
+        var (apiToken, apiBaseUrl, dashboardBaseUrl) = await McpToolHelpers.GetDashboardInfoAsync(auxiliaryBackchannelMonitor, logger, cancellationToken).ConfigureAwait(false);
+
+        // Extract traceId from arguments (required)
+        string? traceId = null;
+        if (arguments?.TryGetValue("traceId", out var traceIdElement) == true &&
+            traceIdElement.ValueKind == JsonValueKind.String)
         {
-            convertedArgs = new Dictionary<string, object?>();
-            foreach (var kvp in context.Arguments)
-            {
-                convertedArgs[kvp.Key] = kvp.Value.ValueKind == JsonValueKind.Null ? null : kvp.Value;
-            }
+            traceId = traceIdElement.GetString();
         }
 
-        // Forward the call to the dashboard's MCP server
-        return await context.McpClient!.CallToolAsync(
-            Name,
-            convertedArgs,
-            serializerOptions: McpJsonUtilities.DefaultOptions,
-            cancellationToken: cancellationToken);
+        if (string.IsNullOrEmpty(traceId))
+        {
+            return new CallToolResult
+            {
+                Content = [new TextContentBlock { Text = "The 'traceId' parameter is required." }],
+                IsError = true
+            };
+        }
+
+        try
+        {
+            using var client = TelemetryCommandHelpers.CreateApiClient(httpClientFactory, apiToken);
+
+            var resources = await TelemetryCommandHelpers.GetAllResourcesAsync(client, apiBaseUrl, cancellationToken).ConfigureAwait(false);
+
+            // Build the logs API URL with traceId filter
+            var url = DashboardUrls.TelemetryLogsApiUrl(apiBaseUrl, resources: null, ("traceId", traceId));
+
+            logger.LogDebug("Fetching structured logs from {Url}", url);
+
+            var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            var apiResponse = await response.Content.ReadFromJsonAsync(OtlpCliJsonSerializerContext.Default.TelemetryApiResponse, cancellationToken).ConfigureAwait(false);
+            var resourceLogs = apiResponse?.Data?.ResourceLogs;
+
+            var (logsData, limitMessage) = SharedAIHelpers.GetStructuredLogsJson(
+                resourceLogs,
+                getResourceName: s => OtlpHelpers.GetResourceName(s, resources.Select(r => new SimpleOtlpResource(r.Name, r.InstanceId)).ToList()),
+                dashboardBaseUrl: dashboardBaseUrl);
+
+            var text = $"""
+                {limitMessage}
+
+                # STRUCTURED LOGS DATA
+
+                {logsData}
+                """;
+
+            return new CallToolResult
+            {
+                Content = [new TextContentBlock { Text = text }]
+            };
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.LogError(ex, "Failed to fetch structured logs for trace from Dashboard API");
+            throw new McpProtocolException($"Failed to fetch structured logs for trace: {ex.Message}", McpErrorCode.InternalError);
+        }
     }
 }

--- a/src/Aspire.Cli/Mcp/Tools/ListTracesTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListTracesTool.cs
@@ -1,13 +1,25 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net.Http.Json;
 using System.Text.Json;
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Commands;
+using Aspire.Cli.Otlp;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Utils;
+using Aspire.Shared.ConsoleLogs;
+using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
 
 namespace Aspire.Cli.Mcp.Tools;
 
-internal sealed class ListTracesTool : CliMcpTool
+/// <summary>
+/// MCP tool for listing distributed traces.
+/// Gets trace data directly from the Dashboard telemetry API.
+/// </summary>
+internal sealed class ListTracesTool(IAuxiliaryBackchannelMonitor auxiliaryBackchannelMonitor, IHttpClientFactory httpClientFactory, ILogger<ListTracesTool> logger) : CliMcpTool
 {
     public override string Name => KnownMcpTools.ListTraces;
 
@@ -30,22 +42,66 @@ internal sealed class ListTracesTool : CliMcpTool
 
     public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
-        // Convert JsonElement arguments to Dictionary<string, object?>
-        Dictionary<string, object?>? convertedArgs = null;
-        if (context.Arguments != null)
+        var arguments = context.Arguments;
+        var (apiToken, apiBaseUrl, dashboardBaseUrl) = await McpToolHelpers.GetDashboardInfoAsync(auxiliaryBackchannelMonitor, logger, cancellationToken).ConfigureAwait(false);
+
+        // Extract resourceName from arguments
+        string? resourceName = null;
+        if (arguments?.TryGetValue("resourceName", out var resourceNameElement) == true &&
+            resourceNameElement.ValueKind == JsonValueKind.String)
         {
-            convertedArgs = new Dictionary<string, object?>();
-            foreach (var kvp in context.Arguments)
-            {
-                convertedArgs[kvp.Key] = kvp.Value.ValueKind == JsonValueKind.Null ? null : kvp.Value;
-            }
+            resourceName = resourceNameElement.GetString();
         }
 
-        // Forward the call to the dashboard's MCP server
-        return await context.McpClient!.CallToolAsync(
-            Name,
-            convertedArgs,
-            serializerOptions: McpJsonUtilities.DefaultOptions,
-            cancellationToken: cancellationToken);
+        try
+        {
+            using var client = TelemetryCommandHelpers.CreateApiClient(httpClientFactory, apiToken);
+
+            // Resolve resource name to specific instances (handles replicas)
+            var resources = await TelemetryCommandHelpers.GetAllResourcesAsync(client, apiBaseUrl, cancellationToken).ConfigureAwait(false);
+
+            // If a resource was specified but not found, return error
+            if (!TelemetryCommandHelpers.TryResolveResourceNames(resourceName, resources, out var resolvedResources))
+            {
+                return new CallToolResult
+                {
+                    Content = [new TextContentBlock { Text = $"Resource '{resourceName}' not found." }],
+                    IsError = true
+                };
+            }
+
+            var url = DashboardUrls.TelemetryTracesApiUrl(apiBaseUrl, resolvedResources);
+
+            logger.LogDebug("Fetching traces from {Url}", url);
+
+            var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            var apiResponse = await response.Content.ReadFromJsonAsync(OtlpCliJsonSerializerContext.Default.TelemetryApiResponse, cancellationToken).ConfigureAwait(false);
+            var resourceSpans = apiResponse?.Data?.ResourceSpans;
+
+            var (tracesData, limitMessage) = SharedAIHelpers.GetTracesJson(
+                resourceSpans,
+                getResourceName: s => OtlpHelpers.GetResourceName(s, resources.Select(r => new SimpleOtlpResource(r.Name, r.InstanceId)).ToList()),
+                dashboardBaseUrl: dashboardBaseUrl);
+
+            var text = $"""
+                {limitMessage}
+
+                # TRACES DATA
+
+                {tracesData}
+                """;
+
+            return new CallToolResult
+            {
+                Content = [new TextContentBlock { Text = text }]
+            };
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.LogError(ex, "Failed to fetch traces from Dashboard API");
+            throw new McpProtocolException($"Failed to fetch traces: {ex.Message}", McpErrorCode.InternalError);
+        }
     }
 }

--- a/src/Aspire.Cli/Mcp/Tools/McpToolHelpers.cs
+++ b/src/Aspire.Cli/Mcp/Tools/McpToolHelpers.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Backchannel;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+
+namespace Aspire.Cli.Mcp.Tools;
+
+internal static class McpToolHelpers
+{
+    public static async Task<(string apiToken, string apiBaseUrl, string? dashboardBaseUrl)> GetDashboardInfoAsync(IAuxiliaryBackchannelMonitor auxiliaryBackchannelMonitor, ILogger logger, CancellationToken cancellationToken)
+    {
+        var connection = await AppHostConnectionHelper.GetSelectedConnectionAsync(auxiliaryBackchannelMonitor, logger, cancellationToken).ConfigureAwait(false);
+        if (connection is null)
+        {
+            logger.LogWarning("No Aspire AppHost is currently running");
+            throw new McpProtocolException(McpErrorMessages.NoAppHostRunning, McpErrorCode.InternalError);
+        }
+
+        var dashboardInfo = await connection.GetDashboardInfoV2Async(cancellationToken).ConfigureAwait(false);
+        if (dashboardInfo?.ApiBaseUrl is null || dashboardInfo.ApiToken is null)
+        {
+            logger.LogWarning("Dashboard API is not available");
+            throw new McpProtocolException(McpErrorMessages.DashboardNotAvailable, McpErrorCode.InternalError);
+        }
+
+        var dashboardBaseUrl = GetBaseUrl(dashboardInfo.DashboardUrls.FirstOrDefault());
+
+        return (dashboardInfo.ApiToken, dashboardInfo.ApiBaseUrl, dashboardBaseUrl);
+    }
+
+    /// <summary>
+    /// Extracts the base URL (scheme, host, and port) from a URL, removing any path and query string.
+    /// </summary>
+    /// <param name="url">The full URL that may contain path and query string.</param>
+    /// <returns>The base URL with only scheme, host, and port, or null if the input is null or invalid.</returns>
+    internal static string? GetBaseUrl(string? url)
+    {
+        if (url is null)
+        {
+            return null;
+        }
+
+        if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return $"{uri.Scheme}://{uri.Authority}";
+        }
+
+        return url;
+    }
+}

--- a/src/Aspire.Cli/Mcp/Tools/RefreshToolsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/RefreshToolsTool.cs
@@ -19,8 +19,6 @@ internal sealed class RefreshToolsTool(IMcpResourceToolRefreshService refreshSer
 
     public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
-        _ = context;
-
         var resourceToolMap = await refreshService.RefreshResourceToolMapAsync(cancellationToken).ConfigureAwait(false);
         await refreshService.SendToolsListChangedNotificationAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Aspire.Cli/Mcp/Tools/SearchDocsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/SearchDocsTool.cs
@@ -48,12 +48,9 @@ internal sealed class SearchDocsTool(IDocsSearchService docsSearchService, IDocs
             """).RootElement;
     }
 
-    public override async ValueTask<CallToolResult> CallToolAsync(
-        CallToolContext context,
-        CancellationToken cancellationToken)
+    public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
         var arguments = context.Arguments;
-
         if (arguments is null || !arguments.TryGetValue("query", out var queryElement))
         {
             return new CallToolResult

--- a/src/Aspire.Cli/Mcp/Tools/SelectAppHostTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/SelectAppHostTool.cs
@@ -34,9 +34,6 @@ internal sealed class SelectAppHostTool(IAuxiliaryBackchannelMonitor auxiliaryBa
 
     public override ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
-        // This tool does not use the MCP client as it operates locally
-        _ = cancellationToken;
-
         var arguments = context.Arguments;
 
         if (arguments == null || !arguments.TryGetValue("appHostPath", out var appHostPathElement))

--- a/src/Aspire.Cli/Otlp/OtlpCliJsonSerializerContext.cs
+++ b/src/Aspire.Cli/Otlp/OtlpCliJsonSerializerContext.cs
@@ -47,17 +47,10 @@ internal sealed class ResourceInfoJson
     public string Name { get; set; } = "";
 
     /// <summary>
-    /// The instance ID if this is a replica (e.g., "abc123"), or null if single instance.
+    /// The instance ID (e.g., "abc123").
     /// </summary>
     [JsonPropertyName("instanceId")]
     public string? InstanceId { get; set; }
-
-    /// <summary>
-    /// The full display name including instance ID (e.g., "catalogservice-abc123" or "catalogservice").
-    /// Use this when querying the telemetry API.
-    /// </summary>
-    [JsonPropertyName("displayName")]
-    public string DisplayName { get; set; } = "";
 
     /// <summary>
     /// Whether this resource has structured logs.
@@ -76,6 +69,20 @@ internal sealed class ResourceInfoJson
     /// </summary>
     [JsonPropertyName("hasMetrics")]
     public bool HasMetrics { get; set; }
+
+    /// <summary>
+    /// Gets the full display name by combining Name and InstanceId.
+    /// </summary>
+    /// <returns>The full display name (e.g., "catalogservice-abc123" or "catalogservice").</returns>
+    public string GetCompositeName()
+    {
+        if (InstanceId is null)
+        {
+            return Name;
+        }
+
+        return $"{Name}-{InstanceId}";
+    }
 }
 
 /// <summary>

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -300,6 +300,7 @@
     <Compile Include="$(SharedDir)ConsoleLogs\LogEntry.cs" Link="Utils\ConsoleLogs\LogEntry.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\LogParser.cs" Link="Utils\ConsoleLogs\LogParser.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\LogPauseViewModel.cs" Link="Utils\ConsoleLogs\LogPauseViewModel.cs" />
+    <Compile Include="$(SharedDir)ConsoleLogs\PromptContext.cs" Link="Utils\ConsoleLogs\PromptContext.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\SharedAIHelpers.cs" Link="Utils\ConsoleLogs\SharedAIHelpers.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\TimestampParser.cs" Link="Utils\ConsoleLogs\TimestampParser.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\UrlParser.cs" Link="Utils\ConsoleLogs\UrlParser.cs" />
@@ -309,6 +310,7 @@
     <Compile Include="$(SharedDir)Model\Serialization\ResourceJson.cs" Link="Model\Serialization\ResourceJson.cs" />
     <Compile Include="$(SharedDir)DashboardUrls.cs" Link="Utils\DashboardUrls.cs" />
     <Compile Include="$(SharedDir)Otlp\OtlpHelpers.cs" Link="Otlp\Model\OtlpHelpersShared.cs" />
+    <Compile Include="$(SharedDir)Otlp\IOtlpResource.cs" Link="Otlp\Model\IOtlpResource.cs" />
     <Compile Include="$(SharedDir)Otlp\Serialization\OtlpCommonJson.cs" Link="Otlp\Model\Serialization\OtlpCommonJson.cs" />
     <Compile Include="$(SharedDir)Otlp\Serialization\OtlpResourceJson.cs" Link="Otlp\Model\Serialization\OtlpResourceJson.cs" />
     <Compile Include="$(SharedDir)Otlp\Serialization\OtlpLogsJson.cs" Link="Otlp\Model\Serialization\OtlpLogsJson.cs" />

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
@@ -341,7 +341,7 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
 
     private string GetResourceName(ResourceViewModel resource) => ResourceViewModel.GetResourceName(resource, _resourceByName);
 
-    private string GetOtlpResourceName(OtlpResource resource) => OtlpResource.GetResourceName(resource, TelemetryRepository.GetResources());
+    private string GetOtlpResourceName(OtlpResource resource) => OtlpHelpers.GetResourceName(resource, TelemetryRepository.GetResources());
 
     private string GetDataTypeDisplayName(AspireDataType dataType) => dataType switch
     {

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -414,7 +414,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
         await ClearSelectedLogEntryAsync();
     }
 
-    private string GetResourceName(OtlpResourceView app) => OtlpResource.GetResourceName(app.Resource, _resources);
+    private string GetResourceName(OtlpResourceView app) => OtlpHelpers.GetResourceName(app.Resource, _resources);
 
     private string GetRowClass(OtlpLogEntry entry)
     {

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -248,8 +248,8 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
         await InvokeAsync(_dataGrid.SafeRefreshDataAsync);
     }
 
-    private string GetResourceName(OtlpResource app) => OtlpResource.GetResourceName(app, _resources);
-    private string GetResourceName(OtlpResourceView app) => OtlpResource.GetResourceName(app, _resources);
+    private string GetResourceName(OtlpResource app) => OtlpHelpers.GetResourceName(app, _resources);
+    private string GetResourceName(OtlpResourceView app) => OtlpHelpers.GetResourceName(app.Resource, _resources);
 
     private static string GetRowClass(OtlpTrace entry)
     {

--- a/src/Aspire.Dashboard/Mcp/AspireResourceMcpTools.cs
+++ b/src/Aspire.Dashboard/Mcp/AspireResourceMcpTools.cs
@@ -115,15 +115,15 @@ internal sealed class AspireResourceMcpTools
 
         var entries = logEntries.GetEntries().ToList();
         var totalLogsCount = entries.Count == 0 ? 0 : entries.Last().LineNumber;
-        var (trimmedItems, limitMessage) = SharedAIHelpers.GetLimitFromEndWithSummary<LogEntry>(
+        var (trimmedItems, limitMessage) = SharedAIHelpers.GetLimitFromEndWithSummary(
             entries,
             totalLogsCount,
             AIHelpers.ConsoleLogsLimit,
             "console log",
             "console logs",
             SharedAIHelpers.SerializeLogEntry,
-            logEntry => SharedAIHelpers.EstimateTokenCount((string)logEntry));
-        var consoleLogsText = SharedAIHelpers.SerializeConsoleLogs(trimmedItems.Cast<string>().ToList());
+            SharedAIHelpers.EstimateTokenCount);
+        var consoleLogsText = SharedAIHelpers.SerializeConsoleLogs(trimmedItems);
 
         var consoleLogsData = $"""
             {limitMessage}

--- a/src/Aspire.Dashboard/Model/Assistant/AIHelpers.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/AIHelpers.cs
@@ -3,12 +3,13 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Model.Serialization;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Utils;
@@ -22,16 +23,16 @@ internal static class AIHelpers
 {
     public const int TracesLimit = 200;
     public const int StructuredLogsLimit = 200;
-    public const int ConsoleLogsLimit = SharedAIHelpers.ConsoleLogsLimit;
+    public const int ConsoleLogsLimit = 500;
 
     // There is currently a 64K token limit in VS.
     // Limit the result from individual token calls to a smaller number so multiple results can live inside the context.
-    public const int MaximumListTokenLength = SharedAIHelpers.MaximumListTokenLength;
+    public const int MaximumListTokenLength = 8192;
 
     // This value is chosen to balance:
     // - Providing enough data to the model for it to provide accurate answers.
     // - Providing too much data and exceeding length limits.
-    public const int MaximumStringLength = SharedAIHelpers.MaximumStringLength;
+    public const int MaximumStringLength = 2048;
 
     // Always pass English translations to AI
     private static readonly IStringLocalizer<Columns> s_columnsLoc = new InvariantStringLocalizer<Columns>();
@@ -41,177 +42,101 @@ internal static class AIHelpers
 
     private static readonly JsonSerializerOptions s_jsonSerializerOptions = new JsonSerializerOptions
     {
-        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
     };
 
-    internal static object GetTraceDto(OtlpTrace trace, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers, PromptContext context, DashboardOptions options, bool includeDashboardUrl = false, Func<OtlpResource, string>? getResourceName = null)
-    {
-        var spanData = trace.Spans.Select(s => new
-        {
-            span_id = OtlpHelpers.ToShortenedId(s.SpanId),
-            parent_span_id = s.ParentSpanId is { } id ? OtlpHelpers.ToShortenedId(id) : null,
-            kind = s.Kind.ToString(),
-            name = context.AddValue(s.Name, id => $@"Duplicate of ""name"" for span {OtlpHelpers.ToShortenedId(id)}", s.SpanId),
-            status = s.Status != OtlpSpanStatusCode.Unset ? s.Status.ToString() : null,
-            status_message = context.AddValue(s.StatusMessage, id => $@"Duplicate of ""status_message"" for span {OtlpHelpers.ToShortenedId(id)}", s.SpanId),
-            source = getResourceName?.Invoke(s.Source.Resource) ?? s.Source.ResourceKey.GetCompositeName(),
-            destination = GetDestination(s, outgoingPeerResolvers),
-            duration_ms = ConvertToMilliseconds(s.Duration),
-            attributes = s.Attributes
-                .ToDictionary(a => a.Key, a => context.AddValue(MapOtelAttributeValue(a), id => $@"Duplicate of attribute ""{id.Key}"" for span {OtlpHelpers.ToShortenedId(id.SpanId)}", (s.SpanId, a.Key))),
-            links = s.Links.Select(l => new { trace_id = OtlpHelpers.ToShortenedId(l.TraceId), span_id = OtlpHelpers.ToShortenedId(l.SpanId) }).ToList(),
-            back_links = s.BackLinks.Select(l => new { source_trace_id = OtlpHelpers.ToShortenedId(l.SourceTraceId), source_span_id = OtlpHelpers.ToShortenedId(l.SourceSpanId) }).ToList()
-        }).ToList();
-
-        var traceId = OtlpHelpers.ToShortenedId(trace.TraceId);
-        var traceData = new Dictionary<string, object?>
-        {
-            ["trace_id"] = traceId,
-            ["duration_ms"] = ConvertToMilliseconds(trace.Duration),
-            ["title"] = trace.RootOrFirstSpan.Name,
-            ["spans"] = spanData,
-            ["has_error"] = trace.Spans.Any(s => s.Status == OtlpSpanStatusCode.Error),
-            ["timestamp"] = trace.TimeStamp,
-        };
-
-        if (includeDashboardUrl)
-        {
-            traceData["dashboard_link"] = GetDashboardLink(options, DashboardUrls.TraceDetailUrl(traceId), traceId);
-        }
-
-        return traceData;
-    }
-
-    private static string MapOtelAttributeValue(KeyValuePair<string, string> attribute)
-    {
-        switch (attribute.Key)
-        {
-            case "http.response.status_code":
-                {
-                    if (int.TryParse(attribute.Value, CultureInfo.InvariantCulture, out var value))
-                    {
-                        return OtelAttributeHelpers.GetHttpStatusName(value);
-                    }
-                    goto default;
-                }
-            case "rpc.grpc.status_code":
-                {
-                    if (int.TryParse(attribute.Value, CultureInfo.InvariantCulture, out var value))
-                    {
-                        return OtelAttributeHelpers.GetGrpcStatusName(value);
-                    }
-                    goto default;
-                }
-            default:
-                return attribute.Value;
-        }
-    }
-
-    private static int ConvertToMilliseconds(TimeSpan duration)
-    {
-        return (int)Math.Round(duration.TotalMilliseconds, 0, MidpointRounding.AwayFromZero);
-    }
-
-    public static (string json, string limitMessage) GetTracesJson(List<OtlpTrace> traces, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers, DashboardOptions options, bool includeDashboardUrl = false, Func<OtlpResource, string>? getResourceName = null)
-    {
-        var promptContext = new PromptContext();
-        var (trimmedItems, limitMessage) = SharedAIHelpers.GetLimitFromEndWithSummary(
-            traces,
-            TracesLimit,
-            "trace",
-            "traces",
-            trace => GetTraceDto(trace, outgoingPeerResolvers, promptContext, options, includeDashboardUrl, getResourceName),
-            EstimateSerializedJsonTokenSize);
-        var tracesData = SerializeJson(trimmedItems);
-
-        return (tracesData, limitMessage);
-    }
-
-    internal static string GetTraceJson(OtlpTrace trace, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers, PromptContext context, DashboardOptions options, bool includeDashboardUrl = false, Func<OtlpResource, string>? getResourceName = null)
-    {
-        var dto = GetTraceDto(trace, outgoingPeerResolvers, context, options, includeDashboardUrl, getResourceName);
-
-        var json = SerializeJson(dto);
-        return json;
-    }
-
-    private static string? GetDestination(OtlpSpan s, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
-    {
-        return ResolveUninstrumentedPeerName(s, outgoingPeerResolvers);
-    }
-
-    private static string? ResolveUninstrumentedPeerName(OtlpSpan span, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
-    {
-        // Attempt to resolve uninstrumented peer to a friendly name from the span.
-        foreach (var resolver in outgoingPeerResolvers)
-        {
-            if (resolver.TryResolvePeer(span.Attributes, out var name, out _))
-            {
-                return name;
-            }
-        }
-
-        // Fallback to the peer address.
-        return span.Attributes.GetPeerAddress();
-    }
-
     internal static string GetResponseGraphJson(List<ResourceViewModel> resources, DashboardOptions options, bool includeDashboardUrl = false, Func<ResourceViewModel, string>? getResourceName = null, bool includeEnvironmentVariables = false)
     {
-        var data = resources.Where(resource => !resource.IsResourceHidden(false)).Select(resource =>
+        var dashboardBaseUrl = includeDashboardUrl ? GetDashboardUrl(options) : null;
+        return GetResponseGraphJson(resources, dashboardBaseUrl, includeDashboardUrl, getResourceName, includeEnvironmentVariables);
+    }
+
+    internal static string GetResponseGraphJson(List<ResourceViewModel> resources, string? dashboardBaseUrl, bool includeDashboardUrl = false, Func<ResourceViewModel, string>? getResourceName = null, bool includeEnvironmentVariables = false)
+    {
+        var dataArray = new JsonArray();
+
+        foreach (var resource in resources.Where(resource => !resource.IsResourceHidden(false)))
         {
             var resourceName = getResourceName?.Invoke(resource) ?? resource.Name;
 
-            var resourceObj = new Dictionary<string, object?>
+            var endpointUrlsArray = new JsonArray();
+            foreach (var u in resource.Urls.Where(u => !u.IsInternal))
+            {
+                var urlObj = new JsonObject
+                {
+                    ["name"] = u.EndpointName,
+                    ["url"] = u.Url.ToString()
+                };
+                if (!string.IsNullOrEmpty(u.DisplayProperties.DisplayName))
+                {
+                    urlObj["display_name"] = u.DisplayProperties.DisplayName;
+                }
+                endpointUrlsArray.Add(urlObj);
+            }
+
+            var healthReportsArray = new JsonArray();
+            foreach (var report in resource.HealthReports)
+            {
+                healthReportsArray.Add(new JsonObject
+                {
+                    ["name"] = report.Name,
+                    ["health_status"] = GetReportHealthStatus(resource, report),
+                    ["exception"] = report.ExceptionText
+                });
+            }
+
+            var healthObj = new JsonObject
+            {
+                ["resource_health_status"] = GetResourceHealthStatus(resource),
+                ["health_reports"] = healthReportsArray
+            };
+
+            var commandsArray = new JsonArray();
+            foreach (var cmd in resource.Commands.Where(cmd => cmd.State == CommandViewModelState.Enabled))
+            {
+                commandsArray.Add(new JsonObject
+                {
+                    ["name"] = cmd.Name,
+                    ["description"] = cmd.GetDisplayDescription()
+                });
+            }
+
+            var resourceObj = new JsonObject
             {
                 ["resource_name"] = resourceName,
                 ["type"] = resource.ResourceType,
                 ["state"] = resource.State,
                 ["state_description"] = ResourceStateViewModel.GetResourceStateTooltip(resource, s_columnsLoc),
-                ["relationships"] = GetResourceRelationships(resources, resource, getResourceName),
-                ["endpoint_urls"] = resource.Urls.Where(u => !u.IsInternal).Select(u => new
-                {
-                    name = u.EndpointName,
-                    url = u.Url,
-                    display_name = !string.IsNullOrEmpty(u.DisplayProperties.DisplayName) ? u.DisplayProperties.DisplayName : null,
-                }).ToList(),
-                ["health"] = new
-                {
-                    resource_health_status = GetResourceHealthStatus(resource),
-                    health_reports = resource.HealthReports.Select(report => new
-                    {
-                        name = report.Name,
-                        health_status = GetReportHealthStatus(resource, report),
-                        exception = report.ExceptionText
-                    }).ToList()
-                },
+                ["relationships"] = GetResourceRelationshipsJson(resources, resource, getResourceName),
+                ["endpoint_urls"] = endpointUrlsArray,
+                ["health"] = healthObj,
                 ["source"] = ResourceSourceViewModel.GetSourceViewModel(resource)?.Value,
-                ["commands"] = resource.Commands.Where(cmd => cmd.State == CommandViewModelState.Enabled).Select(cmd => new
-                {
-                    name = cmd.Name,
-                    description = cmd.GetDisplayDescription()
-                }).ToList()
+                ["commands"] = commandsArray
             };
 
-            if (includeDashboardUrl)
+            if (includeDashboardUrl && dashboardBaseUrl != null)
             {
-                resourceObj["dashboard_link"] = GetDashboardLink(options, DashboardUrls.ResourcesUrl(resource: resource.Name), resourceName);
+                resourceObj["dashboard_link"] = SharedAIHelpers.GetDashboardLinkObject(dashboardBaseUrl, DashboardUrls.ResourcesUrl(resource: resource.Name), resourceName);
             }
 
             if (includeEnvironmentVariables)
             {
-                resourceObj["environment_variables"] = resource.Environment.Where(e => e.FromSpec).Select(e => e.Name).ToList();
+                var envVarsArray = new JsonArray();
+                foreach (var e in resource.Environment.Where(e => e.FromSpec))
+                {
+                    envVarsArray.Add(JsonValue.Create(e.Name));
+                }
+                resourceObj["environment_variables"] = envVarsArray;
             }
 
-            return resourceObj;
-        }).ToList();
+            dataArray.Add(resourceObj);
+        }
 
-        var resourceGraphData = SerializeJson(data);
-        return resourceGraphData;
+        return dataArray.ToJsonString(s_jsonSerializerOptions);
 
-        static List<object> GetResourceRelationships(List<ResourceViewModel> allResources, ResourceViewModel resourceViewModel, Func<ResourceViewModel, string>? getResourceName)
+        static JsonArray GetResourceRelationshipsJson(List<ResourceViewModel> allResources, ResourceViewModel resourceViewModel, Func<ResourceViewModel, string>? getResourceName)
         {
-            var relationships = new List<object>();
+            var relationships = new JsonArray();
 
             foreach (var relationship in resourceViewModel.Relationships)
             {
@@ -222,10 +147,10 @@ internal static class AIHelpers
 
                 foreach (var match in matches)
                 {
-                    relationships.Add(new
+                    relationships.Add(new JsonObject
                     {
-                        resource_name = getResourceName?.Invoke(match) ?? match.Name,
-                        Types = relationship.Type
+                        ["resource_name"] = getResourceName?.Invoke(match) ?? match.Name,
+                        ["Types"] = relationship.Type
                     });
                 }
             }
@@ -259,22 +184,7 @@ internal static class AIHelpers
         }
     }
 
-    public static object? GetDashboardLink(DashboardOptions options, string path, string text)
-    {
-        var url = GetDashboardUrl(options, path);
-        if (string.IsNullOrEmpty(url))
-        {
-            return null;
-        }
-
-        return new
-        {
-            url = url,
-            text = text
-        };
-    }
-
-    public static string? GetDashboardUrl(DashboardOptions options, string path)
+    public static string? GetDashboardUrl(DashboardOptions options)
     {
         var frontendEndpoints = options.Frontend.GetEndpointAddresses();
 
@@ -282,73 +192,17 @@ internal static class AIHelpers
             ?? frontendEndpoints.FirstOrDefault(e => string.Equals(e.Scheme, "https", StringComparison.Ordinal))?.ToString()
             ?? frontendEndpoints.FirstOrDefault(e => string.Equals(e.Scheme, "http", StringComparison.Ordinal))?.ToString();
 
-        if (frontendUrl == null)
-        {
-            return null;
-        }
-
-        return new Uri(new Uri(frontendUrl), path).ToString();
+        return frontendUrl;
     }
 
-    public static int EstimateSerializedJsonTokenSize<T>(T value)
+    public static (string json, string limitMessage) GetStructuredLogsJson(OtlpTelemetryDataJson otlpData, DashboardOptions options, Func<IOtlpResource, string> getResourceName, bool includeDashboardUrl = false)
     {
-        var json = SerializeJson(value);
-        return SharedAIHelpers.EstimateTokenCount(json);
+        return SharedAIHelpers.GetStructuredLogsJson(otlpData.ResourceLogs, getResourceName, includeDashboardUrl ? GetDashboardUrl(options) : null);
     }
 
-    private static string SerializeJson<T>(T value)
+    internal static string GetStructuredLogJson(OtlpTelemetryDataJson otlpData, DashboardOptions options, Func<IOtlpResource, string> getResourceName, bool includeDashboardUrl = false)
     {
-        return JsonSerializer.Serialize(value, s_jsonSerializerOptions);
-    }
-
-    public static (string json, string limitMessage) GetStructuredLogsJson(List<OtlpLogEntry> errorLogs, DashboardOptions options, bool includeDashboardUrl = false, Func<OtlpResource, string>? getResourceName = null)
-    {
-        var promptContext = new PromptContext();
-        var (trimmedItems, limitMessage) = SharedAIHelpers.GetLimitFromEndWithSummary(
-            errorLogs,
-            StructuredLogsLimit,
-            "log entry",
-            "log entries",
-            i => GetLogEntryDto(i, promptContext, options, includeDashboardUrl, getResourceName),
-            EstimateSerializedJsonTokenSize);
-        var logsData = SerializeJson(trimmedItems);
-
-        return (logsData, limitMessage);
-    }
-
-    internal static string GetStructuredLogJson(OtlpLogEntry l, DashboardOptions options, bool includeDashboardUrl = false, Func<OtlpResource, string>? getResourceName = null)
-    {
-        var dto = GetLogEntryDto(l, new PromptContext(), options, includeDashboardUrl, getResourceName);
-
-        var json = SerializeJson(dto);
-        return json;
-    }
-
-    public static object GetLogEntryDto(OtlpLogEntry l, PromptContext context, DashboardOptions options, bool includeDashboardUrl = false, Func<OtlpResource, string>? getResourceName = null)
-    {
-        var exceptionText = OtlpLogEntry.GetExceptionText(l);
-
-        var log = new Dictionary<string, object?>
-        {
-            ["log_id"] = l.InternalId,
-            ["span_id"] = OtlpHelpers.ToShortenedId(l.SpanId),
-            ["trace_id"] = OtlpHelpers.ToShortenedId(l.TraceId),
-            ["message"] = context.AddValue(l.Message, id => $@"Duplicate of ""message"" for log entry {id.InternalId}", l),
-            ["severity"] = l.Severity.ToString(),
-            ["resource_name"] = getResourceName?.Invoke(l.ResourceView.Resource) ?? l.ResourceView.Resource.ResourceKey.GetCompositeName(),
-            ["attributes"] = l.Attributes
-                .Where(l => l.Key is not (OtlpLogEntry.ExceptionStackTraceField or OtlpLogEntry.ExceptionMessageField or OtlpLogEntry.ExceptionTypeField))
-                .ToDictionary(a => a.Key, a => context.AddValue(MapOtelAttributeValue(a), id => $@"Duplicate of attribute ""{id.Key}"" for log entry {id.InternalId}", (l.InternalId, a.Key))),
-            ["exception"] = context.AddValue(exceptionText, id => $@"Duplicate of ""exception"" for log entry {id.InternalId}", l),
-            ["source"] = l.Scope.Name
-        };
-
-        if (includeDashboardUrl)
-        {
-            log["dashboard_link"] = GetDashboardLink(options, DashboardUrls.StructuredLogsUrl(logEntryId: l.InternalId), $"log_id: {l.InternalId}");
-        }
-
-        return log;
+        return SharedAIHelpers.GetStructuredLogJson(otlpData.ResourceLogs, getResourceName, includeDashboardUrl ? GetDashboardUrl(options) : null);
     }
 
     public static bool TryGetSingleResult<T>(IEnumerable<T> source, Func<T, bool> predicate, [NotNullWhen(true)] out T? result)

--- a/src/Aspire.Dashboard/Model/Assistant/AssistantChatDataContext.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/AssistantChatDataContext.cs
@@ -96,7 +96,10 @@ public sealed class AssistantChatDataContext
 
         _referencedTraces.TryAdd(trace.TraceId, trace);
 
-        return AIHelpers.GetTraceJson(trace, _outgoingPeerResolvers, new PromptContext(), _dashboardOptions.CurrentValue);
+        var spans = TelemetryExportService.ConvertTracesToOtlpJson([trace], _outgoingPeerResolvers.ToArray()).ResourceSpans;
+        var resources = TelemetryRepository.GetResources();
+
+        return SharedAIHelpers.GetTraceJson(spans, r => OtlpHelpers.GetResourceName(r, resources), AIHelpers.GetDashboardUrl(_dashboardOptions.CurrentValue));
     }
 
     [Description("Get structured logs for resources.")]
@@ -128,7 +131,9 @@ public sealed class AssistantChatDataContext
             Filters = []
         });
 
-        var (logsData, limitMessage) = AIHelpers.GetStructuredLogsJson(logs.Items, _dashboardOptions.CurrentValue);
+        var otlpData = TelemetryExportService.ConvertLogsToOtlpJson(logs.Items);
+        var resources = TelemetryRepository.GetResources();
+        var (logsData, limitMessage) = AIHelpers.GetStructuredLogsJson(otlpData, _dashboardOptions.CurrentValue, r => OtlpHelpers.GetResourceName(r, resources));
 
         var response = $"""
             Always format log_id in the response as code like this: `log_id: 123`.
@@ -170,7 +175,9 @@ public sealed class AssistantChatDataContext
             FilterText = string.Empty
         });
 
-        var (tracesData, limitMessage) = AIHelpers.GetTracesJson(traces.PagedResult.Items, _outgoingPeerResolvers, _dashboardOptions.CurrentValue);
+        var spans = TelemetryExportService.ConvertTracesToOtlpJson(traces.PagedResult.Items, _outgoingPeerResolvers.ToArray()).ResourceSpans;
+        var resources = TelemetryRepository.GetResources();
+        var (tracesData, limitMessage) = SharedAIHelpers.GetTracesJson(spans, r => OtlpHelpers.GetResourceName(r, resources), AIHelpers.GetDashboardUrl(_dashboardOptions.CurrentValue));
 
         var response = $"""
             {limitMessage}
@@ -207,7 +214,9 @@ public sealed class AssistantChatDataContext
 
         await InvokeToolCallbackAsync(nameof(GetTraceStructuredLogsAsync), _loc.GetString(nameof(AIAssistant.ToolNotificationTraceStructuredLogs), OtlpHelpers.ToShortenedId(traceId)), cancellationToken).ConfigureAwait(false);
 
-        var (logsData, limitMessage) = AIHelpers.GetStructuredLogsJson(logs.Items, _dashboardOptions.CurrentValue);
+        var otlpData = TelemetryExportService.ConvertLogsToOtlpJson(logs.Items);
+        var resources = TelemetryRepository.GetResources();
+        var (logsData, limitMessage) = AIHelpers.GetStructuredLogsJson(otlpData, _dashboardOptions.CurrentValue, r => OtlpHelpers.GetResourceName(r, resources));
 
         var response = $"""
             {limitMessage}
@@ -264,15 +273,15 @@ public sealed class AssistantChatDataContext
 
         var entries = logEntries.GetEntries().ToList();
         var totalLogsCount = entries.Count == 0 ? 0 : entries.Last().LineNumber;
-        var (trimmedItems, limitMessage) = SharedAIHelpers.GetLimitFromEndWithSummary<LogEntry>(
+        var (trimmedItems, limitMessage) = SharedAIHelpers.GetLimitFromEndWithSummary(
             entries,
             totalLogsCount,
             AIHelpers.ConsoleLogsLimit,
             "console log",
             "console logs",
             SharedAIHelpers.SerializeLogEntry,
-            logEntry => SharedAIHelpers.EstimateTokenCount((string) logEntry));
-        var consoleLogsText = SharedAIHelpers.SerializeConsoleLogs(trimmedItems.Cast<string>().ToList());
+            SharedAIHelpers.EstimateTokenCount);
+        var consoleLogsText = SharedAIHelpers.SerializeConsoleLogs(trimmedItems);
 
         var consoleLogsData = $"""
             {limitMessage}

--- a/src/Aspire.Dashboard/Model/Assistant/Prompts/PromptContextsBuilder.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/Prompts/PromptContextsBuilder.cs
@@ -11,6 +11,8 @@ internal static class PromptContextsBuilder
     public static Task ErrorTraces(InitializePromptContext promptContext, string displayText, Func<PagedResult<OtlpTrace>> getErrorTraces)
     {
         var outgoingPeerResolvers = promptContext.ServiceProvider.GetRequiredService<IEnumerable<IOutgoingPeerResolver>>();
+        var repository = promptContext.ServiceProvider.GetRequiredService<TelemetryRepository>();
+        var resources = repository.GetResources();
         var errorTraces = getErrorTraces();
         foreach (var trace in errorTraces.Items)
         {
@@ -19,13 +21,15 @@ internal static class PromptContextsBuilder
 
         promptContext.ChatBuilder.AddUserMessage(
             displayText,
-            KnownChatMessages.Traces.CreateErrorTracesMessage(errorTraces.Items, outgoingPeerResolvers, promptContext.DashboardOptions).Text);
+            KnownChatMessages.Traces.CreateErrorTracesMessage(errorTraces.Items, outgoingPeerResolvers, promptContext.DashboardOptions, r => OtlpHelpers.GetResourceName(r, resources)).Text);
 
         return Task.CompletedTask;
     }
 
     public static Task ErrorStructuredLogs(InitializePromptContext promptContext, string displayText, Func<PagedResult<OtlpLogEntry>> getErrorLogs)
     {
+        var repository = promptContext.ServiceProvider.GetRequiredService<TelemetryRepository>();
+        var resources = repository.GetResources();
         var errorLogs = getErrorLogs();
         foreach (var log in errorLogs.Items)
         {
@@ -34,7 +38,7 @@ internal static class PromptContextsBuilder
 
         promptContext.ChatBuilder.AddUserMessage(
             displayText,
-            KnownChatMessages.StructuredLogs.CreateErrorStructuredLogsMessage(errorLogs.Items, promptContext.DashboardOptions).Text);
+            KnownChatMessages.StructuredLogs.CreateErrorStructuredLogsMessage(errorLogs.Items, promptContext.DashboardOptions, r => OtlpHelpers.GetResourceName(r, resources)).Text);
 
         return Task.CompletedTask;
     }
@@ -50,10 +54,12 @@ internal static class PromptContextsBuilder
 
     public static Task AnalyzeLogEntry(InitializePromptContext promptContext, string displayText, OtlpLogEntry logEntry)
     {
+        var repository = promptContext.ServiceProvider.GetRequiredService<TelemetryRepository>();
+        var resources = repository.GetResources();
         promptContext.DataContext.AddReferencedLogEntry(logEntry);
         promptContext.ChatBuilder.AddUserMessage(
             displayText,
-            KnownChatMessages.StructuredLogs.CreateAnalyzeLogEntryMessage(logEntry, promptContext.DashboardOptions).Text);
+            KnownChatMessages.StructuredLogs.CreateAnalyzeLogEntryMessage(logEntry, promptContext.DashboardOptions, r => OtlpHelpers.GetResourceName(r, resources)).Text);
 
         return Task.CompletedTask;
     }
@@ -64,6 +70,7 @@ internal static class PromptContextsBuilder
 
         var outgoingPeerResolvers = context.ServiceProvider.GetRequiredService<IEnumerable<IOutgoingPeerResolver>>();
         var repository = context.ServiceProvider.GetRequiredService<TelemetryRepository>();
+        var resources = repository.GetResources();
         var traceLogs = repository.GetLogsForTrace(trace.TraceId);
         foreach (var log in traceLogs)
         {
@@ -72,7 +79,7 @@ internal static class PromptContextsBuilder
 
         context.ChatBuilder.AddUserMessage(
             displayText,
-            KnownChatMessages.Traces.CreateAnalyzeTraceMessage(trace, traceLogs, outgoingPeerResolvers, context.DashboardOptions).Text);
+            KnownChatMessages.Traces.CreateAnalyzeTraceMessage(trace, traceLogs, outgoingPeerResolvers, context.DashboardOptions, r => OtlpHelpers.GetResourceName(r, resources)).Text);
 
         return Task.CompletedTask;
     }
@@ -83,6 +90,7 @@ internal static class PromptContextsBuilder
 
         var outgoingPeerResolvers = context.ServiceProvider.GetRequiredService<IEnumerable<IOutgoingPeerResolver>>();
         var repository = context.ServiceProvider.GetRequiredService<TelemetryRepository>();
+        var resources = repository.GetResources();
         var traceLogs = repository.GetLogsForTrace(span.Trace.TraceId);
         foreach (var log in traceLogs)
         {
@@ -91,7 +99,7 @@ internal static class PromptContextsBuilder
 
         context.ChatBuilder.AddUserMessage(
             displayText,
-            KnownChatMessages.Traces.CreateAnalyzeSpanMessage(span, traceLogs, outgoingPeerResolvers, context.DashboardOptions).Text);
+            KnownChatMessages.Traces.CreateAnalyzeSpanMessage(span, traceLogs, outgoingPeerResolvers, context.DashboardOptions, r => OtlpHelpers.GetResourceName(r, resources)).Text);
 
         return Task.CompletedTask;
     }

--- a/src/Aspire.Dashboard/Model/ExportHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ExportHelpers.cs
@@ -21,13 +21,10 @@ internal static class ExportHelpers
     /// <summary>
     /// Gets a span as a JSON export result, including associated log entries.
     /// </summary>
-    /// <param name="span">The span to convert.</param>
-    /// <param name="telemetryRepository">The telemetry repository to fetch logs from.</param>
-    /// <returns>A result containing the JSON representation and suggested file name.</returns>
-    public static ExportResult GetSpanAsJson(OtlpSpan span, TelemetryRepository telemetryRepository)
+    public static ExportResult GetSpanAsJson(OtlpSpan span, TelemetryRepository telemetryRepository, IOutgoingPeerResolver[] outgoingPeerResolvers)
     {
         var logs = telemetryRepository.GetLogsForSpan(span.TraceId, span.SpanId);
-        var json = TelemetryExportService.ConvertSpanToJson(span, logs);
+        var json = TelemetryExportService.ConvertSpanToJson(span, outgoingPeerResolvers, logs);
         var fileName = $"span-{OtlpHelpers.ToShortenedId(span.SpanId)}.json";
         return new ExportResult(json, fileName);
     }
@@ -47,13 +44,10 @@ internal static class ExportHelpers
     /// <summary>
     /// Gets all spans in a trace as a JSON export result, including associated log entries.
     /// </summary>
-    /// <param name="trace">The trace to convert.</param>
-    /// <param name="telemetryRepository">The telemetry repository to fetch logs from.</param>
-    /// <returns>A result containing the JSON representation and suggested file name.</returns>
-    public static ExportResult GetTraceAsJson(OtlpTrace trace, TelemetryRepository telemetryRepository)
+    public static ExportResult GetTraceAsJson(OtlpTrace trace, TelemetryRepository telemetryRepository, IOutgoingPeerResolver[] outgoingPeerResolvers)
     {
         var logs = telemetryRepository.GetLogsForTrace(trace.TraceId);
-        var json = TelemetryExportService.ConvertTraceToJson(trace, logs);
+        var json = TelemetryExportService.ConvertTraceToJson(trace, outgoingPeerResolvers, logs);
         var fileName = $"trace-{OtlpHelpers.ToShortenedId(trace.TraceId)}.json";
         return new ExportResult(json, fileName);
     }

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -63,9 +63,9 @@ public sealed class GenAIVisualizerDialogViewModel
             SpanDetailsViewModel = spanDetailsViewModel,
             SelectedLogEntryId = selectedLogEntryId,
             GetContextGenAISpans = getContextGenAISpans,
-            SourceName = OtlpResource.GetResourceName(spanDetailsViewModel.Span.Source, resources),
+            SourceName = OtlpHelpers.GetResourceName(spanDetailsViewModel.Span.Source.Resource, resources),
             PeerName = telemetryRepository.GetPeerResource(spanDetailsViewModel.Span) is { } peerResource
-                ? OtlpResource.GetResourceName(peerResource, resources)
+                ? OtlpHelpers.GetResourceName(peerResource, resources)
                 : OtlpHelpers.GetPeerAddress(spanDetailsViewModel.Span.Attributes) ?? UnknownPeerName
         };
 

--- a/src/Aspire.Dashboard/Model/Otlp/ResourcesSelectHelpers.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/ResourcesSelectHelpers.cs
@@ -111,7 +111,7 @@ public static class ResourcesSelectHelpers
                 new SelectViewModel<ResourceTypeDetails>
                 {
                     Id = ResourceTypeDetails.CreateReplicaInstance(replica.ResourceKey.ToString(), resourceName),
-                    Name = OtlpResource.GetResourceName(replica, resources)
+                    Name = OtlpHelpers.GetResourceName(replica, resources)
                 }));
         }
 

--- a/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
@@ -220,7 +220,7 @@ public sealed class SpanWaterfallViewModel
             // If the span has a peer name, use it. Note that when the peer is a resource with replicas, it's possible the uninstrumented peer name returned here isn't the real replica.
             // We are matching an address to replicas which share the same address. There isn't a way to know exactly which replica was called. The first replica instance will be chosen.
             // This shouldn't be a big issue because typically project replicas will have OTEL setup, and so a child span is recorded.
-            return OtlpResource.GetResourceName(span.UninstrumentedPeer, allResources);
+            return OtlpHelpers.GetResourceName(span.UninstrumentedPeer, allResources);
         }
 
         // Attempt to resolve uninstrumented peer to a friendly name from the span.

--- a/src/Aspire.Dashboard/Model/SpanDetailsViewModel.cs
+++ b/src/Aspire.Dashboard/Model/SpanDetailsViewModel.cs
@@ -32,7 +32,7 @@ public sealed class SpanDetailsViewModel
             {
                 Name = "Destination",
                 Key = KnownTraceFields.DestinationField,
-                Value = OtlpResource.GetResourceName(destination, resources)
+                Value = OtlpHelpers.GetResourceName(destination, resources)
             });
         }
         entryProperties.AddRange(span.GetAttributeProperties().Select(CreateTelemetryProperty));

--- a/src/Aspire.Dashboard/Model/SpanMenuBuilder.cs
+++ b/src/Aspire.Dashboard/Model/SpanMenuBuilder.cs
@@ -35,6 +35,7 @@ public sealed class SpanMenuBuilder
     private readonly IAIContextProvider _aiContextProvider;
     private readonly DashboardDialogService _dialogService;
     private readonly TelemetryRepository _telemetryRepository;
+    private readonly IOutgoingPeerResolver[] _outgoingPeerResolvers;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SpanMenuBuilder"/> class.
@@ -46,7 +47,8 @@ public sealed class SpanMenuBuilder
         NavigationManager navigationManager,
         IAIContextProvider aiContextProvider,
         DashboardDialogService dialogService,
-        TelemetryRepository telemetryRepository)
+        TelemetryRepository telemetryRepository,
+        IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
     {
         _controlsLoc = controlsLoc;
         _aiAssistantLoc = aiAssistantLoc;
@@ -55,6 +57,7 @@ public sealed class SpanMenuBuilder
         _aiContextProvider = aiContextProvider;
         _dialogService = dialogService;
         _telemetryRepository = telemetryRepository;
+        _outgoingPeerResolvers = outgoingPeerResolvers.ToArray();
     }
 
     /// <summary>
@@ -109,7 +112,7 @@ public sealed class SpanMenuBuilder
             Icon = s_bracesIcon,
             OnClick = async () =>
             {
-                var result = ExportHelpers.GetSpanAsJson(span, _telemetryRepository);
+                var result = ExportHelpers.GetSpanAsJson(span, _telemetryRepository, _outgoingPeerResolvers);
                 await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
                 {
                     DialogService = _dialogService,

--- a/src/Aspire.Dashboard/Model/TraceMenuBuilder.cs
+++ b/src/Aspire.Dashboard/Model/TraceMenuBuilder.cs
@@ -33,6 +33,7 @@ public sealed class TraceMenuBuilder
     private readonly IAIContextProvider _aiContextProvider;
     private readonly DashboardDialogService _dialogService;
     private readonly TelemetryRepository _telemetryRepository;
+    private readonly IOutgoingPeerResolver[] _outgoingPeerResolvers;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TraceMenuBuilder"/> class.
@@ -44,7 +45,8 @@ public sealed class TraceMenuBuilder
         NavigationManager navigationManager,
         IAIContextProvider aiContextProvider,
         DashboardDialogService dialogService,
-        TelemetryRepository telemetryRepository)
+        TelemetryRepository telemetryRepository,
+        IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
     {
         _controlsLoc = controlsLoc;
         _aiAssistantLoc = aiAssistantLoc;
@@ -53,6 +55,7 @@ public sealed class TraceMenuBuilder
         _aiContextProvider = aiContextProvider;
         _dialogService = dialogService;
         _telemetryRepository = telemetryRepository;
+        _outgoingPeerResolvers = outgoingPeerResolvers.ToArray();
     }
 
     /// <summary>
@@ -97,7 +100,7 @@ public sealed class TraceMenuBuilder
             Icon = s_bracesIcon,
             OnClick = async () =>
             {
-                var result = ExportHelpers.GetTraceAsJson(trace, _telemetryRepository);
+                var result = ExportHelpers.GetTraceAsJson(trace, _telemetryRepository, _outgoingPeerResolvers);
                 await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
                 {
                     DialogService = _dialogService,

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
@@ -50,6 +50,7 @@ public class OtlpLogEntry
                     return false;
                 case "SpanId":
                 case "TraceId":
+                case OtlpHelpers.AspireLogIdAttribute:
                     // Explicitly ignore these
                     return false;
                 case "logrecord.event.name":

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -1449,7 +1449,7 @@ public sealed partial class TelemetryRepository : IDisposable
             EndTime = OtlpHelpers.UnixNanoSecondsToDateTime(span.EndTimeUnixNano),
             Status = ConvertStatus(span.Status),
             StatusMessage = span.Status?.Message,
-            Attributes = span.Attributes.ToKeyValuePairs(context),
+            Attributes = span.Attributes.ToKeyValuePairs(context, filter: attribute => attribute.Key != OtlpHelpers.AspireDestinationNameAttribute),
             State = !string.IsNullOrEmpty(span.TraceState) ? span.TraceState : null,
             Events = events,
             Links = links,

--- a/src/Shared/ConsoleLogs/PromptContext.cs
+++ b/src/Shared/ConsoleLogs/PromptContext.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Shared.ConsoleLogs;
-
-namespace Aspire.Dashboard.Model.Assistant;
+namespace Aspire.Shared.ConsoleLogs;
 
 internal sealed class PromptContext
 {

--- a/src/Shared/ConsoleLogs/SharedAIHelpers.cs
+++ b/src/Shared/ConsoleLogs/SharedAIHelpers.cs
@@ -4,6 +4,12 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Utils;
+using Aspire.Otlp.Serialization;
 
 namespace Aspire.Shared.ConsoleLogs;
 
@@ -13,9 +19,16 @@ namespace Aspire.Shared.ConsoleLogs;
 /// </summary>
 internal static class SharedAIHelpers
 {
+    public const int TracesLimit = 200;
+    public const int StructuredLogsLimit = 200;
     public const int ConsoleLogsLimit = 500;
     public const int MaximumListTokenLength = 8192;
     public const int MaximumStringLength = 2048;
+
+    private static readonly JsonSerializerOptions s_jsonSerializerOptions = new JsonSerializerOptions
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
 
     /// <summary>
     /// Estimates the token count for a string.
@@ -24,6 +37,586 @@ internal static class SharedAIHelpers
     public static int EstimateTokenCount(string text)
     {
         return text.Length / 4;
+    }
+
+    /// <summary>
+    /// Estimates the serialized JSON token size for a JsonNode.
+    /// </summary>
+    public static int EstimateSerializedJsonTokenSize(JsonNode node)
+    {
+        var json = node.ToJsonString(s_jsonSerializerOptions);
+        return EstimateTokenCount(json);
+    }
+
+    /// <summary>
+    /// Converts OTLP resource logs to structured logs JSON for AI processing.
+    /// </summary>
+    /// <param name="resourceLogs">The OTLP resource logs containing log records.</param>
+    /// <param name="getResourceName">Optional function to resolve resource names.</param>
+    /// <param name="dashboardBaseUrl">Optional dashboard URL.</param>
+    /// <returns>A tuple containing the JSON string and a limit message.</returns>
+    public static (string json, string limitMessage) GetStructuredLogsJson(
+        IList<OtlpResourceLogsJson>? resourceLogs,
+        Func<IOtlpResource, string> getResourceName,
+        string? dashboardBaseUrl = null)
+    {
+        var logRecords = GetLogRecordsFromOtlpData(resourceLogs);
+        var promptContext = new PromptContext();
+
+        var (trimmedItems, limitMessage) = GetLimitFromEndWithSummary(
+            logRecords,
+            StructuredLogsLimit,
+            "log entry",
+            "log entries",
+            i => GetLogEntryDto(i, promptContext, getResourceName, dashboardBaseUrl),
+            EstimateSerializedJsonTokenSize);
+
+        var jsonArray = new JsonArray(trimmedItems.ToArray());
+        var logsData = jsonArray.ToJsonString(s_jsonSerializerOptions);
+
+        return (logsData, limitMessage);
+    }
+
+    /// <summary>
+    /// Converts OTLP resource logs to a single structured log JSON for AI processing.
+    /// </summary>
+    /// <param name="resourceLogs">The OTLP resource logs containing log records.</param>
+    /// <param name="getResourceName">Optional function to resolve resource names.</param>
+    /// <param name="dashboardBaseUrl">Optional dashboard URL.</param>
+    /// <returns>The JSON string for the first log entry.</returns>
+    public static string GetStructuredLogJson(
+        IList<OtlpResourceLogsJson>? resourceLogs,
+        Func<IOtlpResource, string> getResourceName,
+        string? dashboardBaseUrl = null)
+    {
+        var logRecords = GetLogRecordsFromOtlpData(resourceLogs);
+        var logEntry = logRecords.FirstOrDefault() ?? throw new InvalidOperationException("No log entry found in OTLP data.");
+        var promptContext = new PromptContext();
+        var dto = GetLogEntryDto(logEntry, promptContext, getResourceName, dashboardBaseUrl);
+
+        return dto.ToJsonString(s_jsonSerializerOptions);
+    }
+
+    /// <summary>
+    /// Converts OTLP resource spans to traces JSON for AI processing.
+    /// </summary>
+    /// <param name="resourceSpans">The OTLP resource spans containing trace data.</param>
+    /// <param name="getResourceName">Optional function to resolve resource names.</param>
+    /// <param name="dashboardBaseUrl">Optional dashboard URL.</param>
+    /// <returns>A tuple containing the JSON string and a limit message.</returns>
+    public static (string json, string limitMessage) GetTracesJson(
+        IList<OtlpResourceSpansJson>? resourceSpans,
+        Func<IOtlpResource, string> getResourceName,
+        string? dashboardBaseUrl = null)
+    {
+        var traces = GetTracesFromOtlpData(resourceSpans);
+        var promptContext = new PromptContext();
+
+        var (trimmedItems, limitMessage) = GetLimitFromEndWithSummary(
+            traces,
+            TracesLimit,
+            "trace",
+            "traces",
+            t => GetTraceDto(t, promptContext, getResourceName, dashboardBaseUrl),
+            EstimateSerializedJsonTokenSize);
+
+        var jsonArray = new JsonArray(trimmedItems.ToArray());
+        var tracesData = jsonArray.ToJsonString(s_jsonSerializerOptions);
+
+        return (tracesData, limitMessage);
+    }
+
+    /// <summary>
+    /// Converts OTLP resource spans to a single trace JSON for AI processing.
+    /// </summary>
+    /// <param name="resourceSpans">The OTLP resource spans containing trace data.</param>
+    /// <param name="getResourceName">Optional function to resolve resource names.</param>
+    /// <param name="dashboardBaseUrl">Optional dashboard URL.</param>
+    /// <returns>The JSON string for the first trace.</returns>
+    public static string GetTraceJson(
+        IList<OtlpResourceSpansJson>? resourceSpans,
+        Func<IOtlpResource, string> getResourceName,
+        string? dashboardBaseUrl = null)
+    {
+        var traces = GetTracesFromOtlpData(resourceSpans);
+        var trace = traces.FirstOrDefault() ?? throw new InvalidOperationException("No trace found in OTLP data.");
+        var promptContext = new PromptContext();
+        var dto = GetTraceDto(trace, promptContext, getResourceName, dashboardBaseUrl);
+
+        return dto.ToJsonString(s_jsonSerializerOptions);
+    }
+
+    /// <summary>
+    /// Extracts traces from OTLP resource spans, grouping spans by trace ID.
+    /// </summary>
+    public static List<OtlpTraceDto> GetTracesFromOtlpData(IList<OtlpResourceSpansJson>? resourceSpans)
+    {
+        var spansByTraceId = new Dictionary<string, List<OtlpSpanDto>>(StringComparer.Ordinal);
+
+        if (resourceSpans is null)
+        {
+            return [];
+        }
+
+        foreach (var resourceSpan in resourceSpans)
+        {
+            var resource = CreateResourceFromOtlpJson(resourceSpan.Resource);
+
+            if (resourceSpan.ScopeSpans is null)
+            {
+                continue;
+            }
+
+            foreach (var scopeSpan in resourceSpan.ScopeSpans)
+            {
+                var scopeName = scopeSpan.Scope?.Name;
+
+                if (scopeSpan.Spans is null)
+                {
+                    continue;
+                }
+
+                foreach (var span in scopeSpan.Spans)
+                {
+                    var traceId = span.TraceId ?? string.Empty;
+                    if (!spansByTraceId.TryGetValue(traceId, out var spanList))
+                    {
+                        spanList = [];
+                        spansByTraceId[traceId] = spanList;
+                    }
+
+                    spanList.Add(new OtlpSpanDto(span, resource, scopeName));
+                }
+            }
+        }
+
+        return spansByTraceId
+            .Select(kvp => new OtlpTraceDto(kvp.Key, kvp.Value))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Creates a JsonObject representing a trace for AI processing.
+    /// </summary>
+    /// <param name="trace">The trace DTO to convert.</param>
+    /// <param name="context">The prompt context for tracking duplicate values.</param>
+    /// <param name="getResourceName">Optional function to resolve resource names.</param>
+    /// <param name="dashboardBaseUrl">Optional dashboard URL.</param>
+    /// <returns>A JsonObject containing the trace data.</returns>
+    public static JsonObject GetTraceDto(
+        OtlpTraceDto trace,
+        PromptContext context,
+        Func<IOtlpResource, string> getResourceName,
+        string? dashboardBaseUrl = null)
+    {
+        var spanObjects = new List<JsonNode>();
+        foreach (var s in trace.Spans)
+        {
+            var span = s.Span;
+            var spanId = span.SpanId ?? string.Empty;
+
+            var attributesObj = new JsonObject();
+            if (span.Attributes is not null)
+            {
+                foreach (var attr in span.Attributes.Where(a => a.Key != OtlpHelpers.AspireDestinationNameAttribute))
+                {
+                    var attrValue = MapOtelAttributeValue(attr);
+                    attributesObj[attr.Key!] = context.AddValue(attrValue, id => $@"Duplicate of attribute ""{id.Key}"" for span {OtlpHelpers.ToShortenedId(id.SpanId)}", (SpanId: spanId, attr.Key));
+                }
+            }
+
+            JsonArray? linksArray = null;
+            if (span.Links is { Length: > 0 })
+            {
+                var linkObjects = span.Links.Select(link => (JsonNode)new JsonObject
+                {
+                    ["trace_id"] = OtlpHelpers.ToShortenedId(link.TraceId ?? string.Empty),
+                    ["span_id"] = OtlpHelpers.ToShortenedId(link.SpanId ?? string.Empty)
+                }).ToArray();
+                linksArray = new JsonArray(linkObjects);
+            }
+
+            var resourceName = getResourceName?.Invoke(s.Resource) ?? s.Resource.ResourceName;
+            var destination = GetAttributeStringValue(span.Attributes, OtlpHelpers.AspireDestinationNameAttribute);
+            var statusCode = span.Status?.Code;
+            var statusText = statusCode switch
+            {
+                1 => "Ok",
+                2 => "Error",
+                _ => null
+            };
+
+            var spanObj = new JsonObject
+            {
+                ["span_id"] = OtlpHelpers.ToShortenedId(spanId),
+                ["parent_span_id"] = span.ParentSpanId is { } id ? OtlpHelpers.ToShortenedId(id) : null,
+                ["kind"] = GetSpanKindName(span.Kind),
+                ["name"] = context.AddValue(span.Name, sId => $@"Duplicate of ""name"" for span {OtlpHelpers.ToShortenedId(sId)}", spanId),
+                ["status"] = statusText,
+                ["status_message"] = context.AddValue(span.Status?.Message, sId => $@"Duplicate of ""status_message"" for span {OtlpHelpers.ToShortenedId(sId)}", spanId),
+                ["source"] = resourceName,
+                ["destination"] = destination,
+                ["duration_ms"] = CalculateDurationMs(span.StartTimeUnixNano, span.EndTimeUnixNano),
+                ["attributes"] = attributesObj,
+                ["links"] = linksArray
+            };
+            spanObjects.Add(spanObj);
+        }
+
+        var spanArray = new JsonArray(spanObjects.ToArray());
+        var traceId = OtlpHelpers.ToShortenedId(trace.TraceId);
+        var rootSpan = trace.Spans.FirstOrDefault(s => string.IsNullOrEmpty(s.Span.ParentSpanId)) ?? trace.Spans.FirstOrDefault();
+        var hasError = trace.Spans.Any(s => s.Span.Status?.Code == 2);
+        var timestamp = rootSpan?.Span.StartTimeUnixNano is { } startNano
+            ? OtlpHelpers.UnixNanoSecondsToDateTime(startNano)
+            : (DateTime?)null;
+
+        var traceData = new JsonObject
+        {
+            ["trace_id"] = traceId,
+            ["duration_ms"] = CalculateTraceDurationMs(trace.Spans),
+            ["title"] = rootSpan?.Span.Name,
+            ["spans"] = spanArray,
+            ["has_error"] = hasError,
+            ["timestamp"] = timestamp
+        };
+
+        if (dashboardBaseUrl is not null)
+        {
+            traceData["dashboard_link"] = GetDashboardLinkObject(dashboardBaseUrl, DashboardUrls.TraceDetailUrl(traceId), traceId);
+        }
+
+        return traceData;
+    }
+
+    private static string MapOtelAttributeValue(OtlpKeyValueJson attribute)
+    {
+        var key = attribute.Key;
+        var value = GetAttributeValue(attribute);
+
+        switch (key)
+        {
+            case "http.response.status_code":
+                {
+                    if (int.TryParse(value, CultureInfo.InvariantCulture, out var intValue))
+                    {
+                        return GetHttpStatusName(intValue);
+                    }
+                    goto default;
+                }
+            case "rpc.grpc.status_code":
+                {
+                    if (int.TryParse(value, CultureInfo.InvariantCulture, out var intValue))
+                    {
+                        return GetGrpcStatusName(intValue);
+                    }
+                    goto default;
+                }
+            default:
+                return value;
+        }
+    }
+
+    private static string GetHttpStatusName(int statusCode)
+    {
+        return statusCode switch
+        {
+            200 => "200 OK",
+            201 => "201 Created",
+            204 => "204 No Content",
+            301 => "301 Moved Permanently",
+            302 => "302 Found",
+            304 => "304 Not Modified",
+            400 => "400 Bad Request",
+            401 => "401 Unauthorized",
+            403 => "403 Forbidden",
+            404 => "404 Not Found",
+            405 => "405 Method Not Allowed",
+            408 => "408 Request Timeout",
+            409 => "409 Conflict",
+            422 => "422 Unprocessable Entity",
+            429 => "429 Too Many Requests",
+            500 => "500 Internal Server Error",
+            501 => "501 Not Implemented",
+            502 => "502 Bad Gateway",
+            503 => "503 Service Unavailable",
+            504 => "504 Gateway Timeout",
+            _ => statusCode.ToString(CultureInfo.InvariantCulture)
+        };
+    }
+
+    private static string GetGrpcStatusName(int statusCode)
+    {
+        return statusCode switch
+        {
+            0 => "OK",
+            1 => "CANCELLED",
+            2 => "UNKNOWN",
+            3 => "INVALID_ARGUMENT",
+            4 => "DEADLINE_EXCEEDED",
+            5 => "NOT_FOUND",
+            6 => "ALREADY_EXISTS",
+            7 => "PERMISSION_DENIED",
+            8 => "RESOURCE_EXHAUSTED",
+            9 => "FAILED_PRECONDITION",
+            10 => "ABORTED",
+            11 => "OUT_OF_RANGE",
+            12 => "UNIMPLEMENTED",
+            13 => "INTERNAL",
+            14 => "UNAVAILABLE",
+            15 => "DATA_LOSS",
+            16 => "UNAUTHENTICATED",
+            _ => statusCode.ToString(CultureInfo.InvariantCulture)
+        };
+    }
+
+    private static string? GetSpanKindName(int? kind)
+    {
+        return kind switch
+        {
+            1 => "Internal",
+            2 => "Server",
+            3 => "Client",
+            4 => "Producer",
+            5 => "Consumer",
+            _ => null
+        };
+    }
+
+    private static int? CalculateDurationMs(ulong? startTimeUnixNano, ulong? endTimeUnixNano)
+    {
+        if (startTimeUnixNano is null || endTimeUnixNano is null)
+        {
+            return null;
+        }
+
+        var durationNano = endTimeUnixNano.Value - startTimeUnixNano.Value;
+        return (int)Math.Round(durationNano / 1_000_000.0, 0, MidpointRounding.AwayFromZero);
+    }
+
+    private static int? CalculateTraceDurationMs(List<OtlpSpanDto> spans)
+    {
+        if (spans.Count == 0)
+        {
+            return null;
+        }
+
+        ulong? minStart = null;
+        ulong? maxEnd = null;
+
+        foreach (var s in spans)
+        {
+            if (s.Span.StartTimeUnixNano is { } start)
+            {
+                minStart = minStart is null ? start : Math.Min(minStart.Value, start);
+            }
+            if (s.Span.EndTimeUnixNano is { } end)
+            {
+                maxEnd = maxEnd is null ? end : Math.Max(maxEnd.Value, end);
+            }
+        }
+
+        return CalculateDurationMs(minStart, maxEnd);
+    }
+
+    /// <summary>
+    /// Extracts log records from OTLP resource logs.
+    /// </summary>
+    public static List<OtlpLogEntryDto> GetLogRecordsFromOtlpData(IList<OtlpResourceLogsJson>? resourceLogs)
+    {
+        var logRecords = new List<OtlpLogEntryDto>();
+
+        if (resourceLogs is null)
+        {
+            return logRecords;
+        }
+
+        foreach (var resourceLog in resourceLogs)
+        {
+            var resource = CreateResourceFromOtlpJson(resourceLog.Resource);
+
+            if (resourceLog.ScopeLogs is null)
+            {
+                continue;
+            }
+
+            foreach (var scopeLogs in resourceLog.ScopeLogs)
+            {
+                var scopeName = scopeLogs.Scope?.Name;
+
+                if (scopeLogs.LogRecords is null)
+                {
+                    continue;
+                }
+
+                foreach (var logRecord in scopeLogs.LogRecords)
+                {
+                    logRecords.Add(new OtlpLogEntryDto(logRecord, resource, scopeName));
+                }
+            }
+        }
+
+        return logRecords;
+    }
+
+    /// <summary>
+    /// Gets the message from a log record.
+    /// </summary>
+    public static string? GetLogMessage(OtlpLogRecordJson logRecord)
+    {
+        return logRecord.Body?.StringValue;
+    }
+
+    /// <summary>
+    /// Gets the attribute value as a string.
+    /// </summary>
+    public static string GetAttributeValue(OtlpKeyValueJson attribute)
+    {
+        if (attribute.Value is null)
+        {
+            return string.Empty;
+        }
+
+        return attribute.Value.StringValue
+            ?? attribute.Value.IntValue?.ToString(CultureInfo.InvariantCulture)
+            ?? attribute.Value.DoubleValue?.ToString(CultureInfo.InvariantCulture)
+            ?? attribute.Value.BoolValue?.ToString(CultureInfo.InvariantCulture)
+            ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Gets the value of an attribute by key as a string, or null if not found.
+    /// </summary>
+    public static string? GetAttributeStringValue(OtlpKeyValueJson[]? attributes, string key)
+    {
+        if (attributes is null)
+        {
+            return null;
+        }
+
+        foreach (var attr in attributes)
+        {
+            if (attr.Key == key)
+            {
+                var value = GetAttributeValue(attr);
+                return string.IsNullOrEmpty(value) ? null : value;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Creates a SimpleOtlpResource from OTLP resource JSON.
+    /// </summary>
+    /// <param name="resource">The OTLP resource JSON, or null.</param>
+    /// <returns>A SimpleOtlpResource with the service name and instance ID extracted from attributes.</returns>
+    private static SimpleOtlpResource CreateResourceFromOtlpJson(OtlpResourceJson? resource)
+    {
+        var serviceName = GetAttributeStringValue(resource?.Attributes, "service.name");
+        var serviceInstanceId = GetAttributeStringValue(resource?.Attributes, "service.instance.id");
+        var resourceName = serviceName ?? "Unknown";
+        return new SimpleOtlpResource(resourceName, serviceInstanceId);
+    }
+
+    private const string ExceptionStackTraceField = "exception.stacktrace";
+    private const string ExceptionMessageField = "exception.message";
+    private const string ExceptionTypeField = "exception.type";
+
+    /// <summary>
+    /// Filters out exception-related attributes and internal Aspire attributes from the attributes list.
+    /// </summary>
+    public static IEnumerable<OtlpKeyValueJson> GetFilteredAttributes(OtlpKeyValueJson[]? attributes)
+    {
+        if (attributes is null)
+        {
+            return [];
+        }
+
+        return attributes.Where(a => a.Key is not (ExceptionStackTraceField or ExceptionMessageField or ExceptionTypeField or OtlpHelpers.AspireLogIdAttribute));
+    }
+
+    /// <summary>
+    /// Gets the exception text from a log entry's attributes.
+    /// </summary>
+    public static string? GetExceptionText(OtlpLogEntryDto logEntry)
+    {
+        var stackTrace = GetAttributeStringValue(logEntry.LogRecord.Attributes, ExceptionStackTraceField);
+        if (!string.IsNullOrEmpty(stackTrace))
+        {
+            return stackTrace;
+        }
+
+        var message = GetAttributeStringValue(logEntry.LogRecord.Attributes, ExceptionMessageField);
+        if (!string.IsNullOrEmpty(message))
+        {
+            var type = GetAttributeStringValue(logEntry.LogRecord.Attributes, ExceptionTypeField);
+            if (!string.IsNullOrEmpty(type))
+            {
+                return $"{type}: {message}";
+            }
+
+            return message;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Creates a JsonObject representing a log entry for AI processing.
+    /// </summary>
+    /// <param name="logEntry">The log entry to convert.</param>
+    /// <param name="context">The prompt context for tracking duplicate values.</param>
+    /// <param name="getResourceName">Optional function to resolve resource names.</param>
+    /// <param name="dashboardBaseUrl">Optional dashboard URL.</param>
+    /// <returns>A JsonObject containing the log entry data.</returns>
+    public static JsonObject GetLogEntryDto(
+        OtlpLogEntryDto logEntry,
+        PromptContext context,
+        Func<IOtlpResource, string> getResourceName,
+        string? dashboardBaseUrl = null)
+    {
+        var exceptionText = GetExceptionText(logEntry);
+        var logIdString = GetAttributeStringValue(logEntry.LogRecord.Attributes, OtlpHelpers.AspireLogIdAttribute);
+        var logId = long.TryParse(logIdString, CultureInfo.InvariantCulture, out var parsedLogId) ? parsedLogId : (long?)null;
+        var resourceName = getResourceName?.Invoke(logEntry.Resource) ?? logEntry.Resource.ResourceName;
+
+        var attributesObject = new JsonObject();
+        foreach (var attr in GetFilteredAttributes(logEntry.LogRecord.Attributes))
+        {
+            var attrValue = GetAttributeValue(attr);
+            attributesObject[attr.Key!] = context.AddValue(attrValue, id => $@"Duplicate of attribute ""{id.Key}"" for log entry {id.LogId}", (LogId: logId, attr.Key));
+        }
+
+        var message = GetLogMessage(logEntry.LogRecord) ?? string.Empty;
+        var log = new JsonObject
+        {
+            ["log_id"] = logId,
+            ["span_id"] = OtlpHelpers.ToShortenedId(logEntry.LogRecord.SpanId ?? string.Empty),
+            ["trace_id"] = OtlpHelpers.ToShortenedId(logEntry.LogRecord.TraceId ?? string.Empty),
+            ["message"] = context.AddValue(message, id => $@"Duplicate of ""message"" for log entry {id}", logId),
+            ["severity"] = logEntry.LogRecord.SeverityText ?? "Unknown",
+            ["resource_name"] = resourceName,
+            ["attributes"] = attributesObject,
+            ["exception"] = context.AddValue(exceptionText, id => $@"Duplicate of ""exception"" for log entry {id}", logId),
+            ["source"] = logEntry.ScopeName
+        };
+
+        if (dashboardBaseUrl is not null && logId is not null)
+        {
+            log["dashboard_link"] = GetDashboardLinkObject(dashboardBaseUrl, DashboardUrls.StructuredLogsUrl(logEntryId: logId), $"log_id: {logId}");
+        }
+
+        return log;
+    }
+
+    public static JsonObject? GetDashboardLinkObject(string dashboardBaseUrl, string path, string text)
+    {
+        return new JsonObject
+        {
+            ["url"] = DashboardUrls.CombineUrl(dashboardBaseUrl, path),
+            ["text"] = text
+        };
     }
 
     /// <summary>
@@ -81,13 +674,13 @@ internal static class SharedAIHelpers
     /// <summary>
     /// Gets items from the end of a list with a summary message, applying count and token limits.
     /// </summary>
-    public static (List<object> items, string message) GetLimitFromEndWithSummary<T>(
+    public static (List<TResult> items, string message) GetLimitFromEndWithSummary<T, TResult>(
         List<T> values,
         int limit,
         string itemName,
         string pluralItemName,
-        Func<T, object> convertToDto,
-        Func<object, int> estimateTokenSize)
+        Func<T, TResult> convertToDto,
+        Func<TResult, int> estimateTokenSize)
     {
         return GetLimitFromEndWithSummary(values, values.Count, limit, itemName, pluralItemName, convertToDto, estimateTokenSize);
     }
@@ -95,14 +688,14 @@ internal static class SharedAIHelpers
     /// <summary>
     /// Gets items from the end of a list with a summary message, applying count and token limits.
     /// </summary>
-    public static (List<object> items, string message) GetLimitFromEndWithSummary<T>(
+    public static (List<TResult> items, string message) GetLimitFromEndWithSummary<T, TResult>(
         List<T> values,
         int totalValues,
         int limit,
         string itemName,
         string pluralItemName,
-        Func<T, object> convertToDto,
-        Func<object, int> estimateTokenSize)
+        Func<T, TResult> convertToDto,
+        Func<TResult, int> estimateTokenSize)
     {
         Debug.Assert(totalValues >= values.Count, "Total values should be large or equal to the values passed into the method.");
 
@@ -157,3 +750,26 @@ internal static class SharedAIHelpers
         return string.Create(CultureInfo.InvariantCulture, $"{count} {name}");
     }
 }
+
+/// <summary>
+/// Represents a log entry extracted from OTLP JSON format for AI processing.
+/// </summary>
+/// <param name="LogRecord">The OTLP log record JSON data.</param>
+/// <param name="Resource">The resource information from the resource attributes.</param>
+/// <param name="ScopeName">The instrumentation scope name.</param>
+internal sealed record OtlpLogEntryDto(OtlpLogRecordJson LogRecord, IOtlpResource Resource, string? ScopeName);
+
+/// <summary>
+/// Represents a trace (collection of spans with the same trace ID) extracted from OTLP JSON format.
+/// </summary>
+/// <param name="TraceId">The trace ID.</param>
+/// <param name="Spans">The spans belonging to this trace.</param>
+internal sealed record OtlpTraceDto(string TraceId, List<OtlpSpanDto> Spans);
+
+/// <summary>
+/// Represents a span extracted from OTLP JSON format for AI processing.
+/// </summary>
+/// <param name="Span">The OTLP span JSON data.</param>
+/// <param name="Resource">The resource information from the resource attributes.</param>
+/// <param name="ScopeName">The instrumentation scope name.</param>
+internal sealed record OtlpSpanDto(OtlpSpanJson Span, IOtlpResource Resource, string? ScopeName);

--- a/src/Shared/Otlp/IOtlpResource.cs
+++ b/src/Shared/Otlp/IOtlpResource.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Otlp.Model;
+
+/// <summary>
+/// Interface for OTLP resource data.
+/// Used by both Dashboard and CLI.
+/// </summary>
+public interface IOtlpResource
+{
+    /// <summary>
+    /// Gets the resource name (typically the service.name attribute).
+    /// </summary>
+    string ResourceName { get; }
+
+    /// <summary>
+    /// Gets the instance ID (typically the service.instance.id attribute).
+    /// </summary>
+    string? InstanceId { get; }
+}
+
+/// <summary>
+/// Simple implementation of <see cref="IOtlpResource"/> for cases where only the name and instance ID are needed.
+/// </summary>
+/// <param name="ResourceName">The resource name (typically the service.name attribute).</param>
+/// <param name="InstanceId">The instance ID (typically the service.instance.id attribute).</param>
+public sealed record SimpleOtlpResource(string ResourceName, string? InstanceId) : IOtlpResource;

--- a/tests/Aspire.Cli.Tests/Mcp/Docs/DocsFetcherTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/Docs/DocsFetcherTests.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using Aspire.Cli.Mcp.Docs;
+using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Mcp.Docs;
@@ -374,55 +375,6 @@ public class DocsFetcherTests
             {
                 Content = new StringContent("# Content")
             });
-        }
-    }
-
-    private sealed class MockHttpMessageHandler : HttpMessageHandler
-    {
-        private readonly Func<HttpRequestMessage, HttpResponseMessage>? _responseFactory;
-        private readonly HttpResponseMessage? _response;
-        private readonly Exception? _exception;
-        private readonly Action<HttpRequestMessage>? _requestValidator;
-
-        public bool RequestValidated { get; private set; }
-
-        public MockHttpMessageHandler(HttpResponseMessage response, Action<HttpRequestMessage>? requestValidator = null)
-        {
-            _response = response;
-            _requestValidator = requestValidator;
-        }
-
-        public MockHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
-        {
-            _responseFactory = responseFactory;
-        }
-
-        public MockHttpMessageHandler(Exception exception)
-        {
-            _exception = exception;
-        }
-
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request,
-            CancellationToken cancellationToken)
-        {
-            if (_exception is not null)
-            {
-                throw _exception;
-            }
-
-            if (_requestValidator is not null)
-            {
-                _requestValidator(request);
-                RequestValidated = true;
-            }
-
-            if (_responseFactory is not null)
-            {
-                return Task.FromResult(_responseFactory(request));
-            }
-
-            return Task.FromResult(_response!);
         }
     }
 

--- a/tests/Aspire.Cli.Tests/Mcp/ListStructuredLogsToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListStructuredLogsToolTests.cs
@@ -1,0 +1,429 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Mcp;
+using Aspire.Cli.Mcp.Tools;
+using Aspire.Cli.Otlp;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Otlp.Serialization;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Protocol;
+
+namespace Aspire.Cli.Tests.Mcp;
+
+public class ListStructuredLogsToolTests
+{
+    private static readonly TestHttpClientFactory s_httpClientFactory = new();
+
+    [Fact]
+    public async Task ListStructuredLogsTool_ThrowsException_WhenNoAppHostRunning()
+    {
+        var tool = CreateTool();
+
+        var exception = await Assert.ThrowsAsync<ModelContextProtocol.McpProtocolException>(
+            () => tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).AsTask()).DefaultTimeout();
+
+        Assert.Contains("No Aspire AppHost", exception.Message);
+    }
+
+    [Fact]
+    public async Task ListStructuredLogsTool_ThrowsException_WhenDashboardApiNotAvailable()
+    {
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            DashboardInfoResponse = null
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var tool = CreateTool(monitor);
+
+        var exception = await Assert.ThrowsAsync<ModelContextProtocol.McpProtocolException>(
+            () => tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).AsTask()).DefaultTimeout();
+
+        Assert.Contains("Dashboard is not available", exception.Message);
+    }
+
+    [Fact]
+    public async Task ListStructuredLogsTool_ReturnsFormattedLogs_WhenApiReturnsData()
+    {
+        // Local function to create OtlpResourceLogsJson with service name and instance ID
+        static OtlpResourceLogsJson CreateResourceLogs(string serviceName, string? serviceInstanceId, params OtlpLogRecordJson[] logRecords)
+        {
+            var attributes = new List<OtlpKeyValueJson>
+            {
+                new() { Key = "service.name", Value = new OtlpAnyValueJson { StringValue = serviceName } }
+            };
+            if (serviceInstanceId is not null)
+            {
+                attributes.Add(new OtlpKeyValueJson { Key = "service.instance.id", Value = new OtlpAnyValueJson { StringValue = serviceInstanceId } });
+            }
+
+            return new OtlpResourceLogsJson
+            {
+                Resource = new OtlpResourceJson
+                {
+                    Attributes = [.. attributes]
+                },
+                ScopeLogs =
+                [
+                    new OtlpScopeLogsJson
+                    {
+                        Scope = new OtlpInstrumentationScopeJson { Name = "Microsoft.Extensions.Logging" },
+                        LogRecords = logRecords
+                    }
+                ]
+            };
+        }
+
+        // Arrange - Create mock HTTP handler with sample structured logs response
+        // Include aspire.log_id attribute to verify it's extracted to log_id field and filtered from attributes
+        var apiResponseObj = new TelemetryApiResponse
+        {
+            Data = new TelemetryDataJson
+            {
+                ResourceLogs =
+                [
+                    CreateResourceLogs("api-service", "instance-1",
+                        new OtlpLogRecordJson
+                        {
+                            TimeUnixNano = 1706540400000000000,
+                            SeverityNumber = 9,
+                            SeverityText = "Information",
+                            Body = new OtlpAnyValueJson { StringValue = "Application started successfully" },
+                            TraceId = "abc123",
+                            SpanId = "def456",
+                            Attributes =
+                            [
+                                new OtlpKeyValueJson { Key = OtlpHelpers.AspireLogIdAttribute, Value = new OtlpAnyValueJson { StringValue = "42" } },
+                                new OtlpKeyValueJson { Key = "custom.attr", Value = new OtlpAnyValueJson { StringValue = "custom-value" } }
+                            ]
+                        }),
+                    CreateResourceLogs("api-service", "instance-2",
+                        new OtlpLogRecordJson
+                        {
+                            TimeUnixNano = 1706540401000000000,
+                            SeverityNumber = 13,
+                            SeverityText = "Warning",
+                            Body = new OtlpAnyValueJson { StringValue = "Connection timeout warning" },
+                            TraceId = "abc123",
+                            SpanId = "ghi789",
+                            Attributes =
+                            [
+                                new OtlpKeyValueJson { Key = OtlpHelpers.AspireLogIdAttribute, Value = new OtlpAnyValueJson { IntValue = 43 } }
+                            ]
+                        }),
+                    CreateResourceLogs("worker-service", "instance-1",
+                        new OtlpLogRecordJson
+                        {
+                            TimeUnixNano = 1706540402000000000,
+                            SeverityNumber = 17,
+                            SeverityText = "Error",
+                            Body = new OtlpAnyValueJson { StringValue = "Worker failed to process message" },
+                            TraceId = "xyz789",
+                            SpanId = "uvw123",
+                            Attributes =
+                            [
+                                new OtlpKeyValueJson { Key = OtlpHelpers.AspireLogIdAttribute, Value = new OtlpAnyValueJson { IntValue = 44 } }
+                            ]
+                        })
+                ]
+            },
+            TotalCount = 3,
+            ReturnedCount = 3
+        };
+
+        var apiResponse = JsonSerializer.Serialize(apiResponseObj, OtlpCliJsonSerializerContext.Default.TelemetryApiResponse);
+
+        // Create resources that match the OtlpResourceLogsJson entries
+        var resources = new ResourceInfoJson[]
+        {
+            new() { Name = "api-service", InstanceId = "instance-1", HasLogs = true, HasTraces = true, HasMetrics = true },
+            new() { Name = "api-service", InstanceId = "instance-2", HasLogs = true, HasTraces = true, HasMetrics = true },
+            new() { Name = "worker-service", InstanceId = "instance-1", HasLogs = true, HasTraces = true, HasMetrics = true }
+        };
+        var resourcesResponse = JsonSerializer.Serialize(resources, OtlpCliJsonSerializerContext.Default.ResourceInfoJsonArray);
+
+        using var mockHandler = new MockHttpMessageHandler(request =>
+        {
+            // Handle the resources endpoint
+            if (request.RequestUri?.AbsolutePath.Contains("/resources") == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(resourcesResponse, System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+
+            // For logs endpoint, return the structured logs response
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(apiResponse, System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+        var mockHttpClientFactory = new MockHttpClientFactory(mockHandler);
+
+        // Use a dashboard URL with path and query string to test that only the base URL is used
+        var monitor = CreateMonitorWithDashboard(dashboardUrls: ["http://localhost:18888/login?t=authtoken123"]);
+        var tool = CreateTool(monitor, mockHttpClientFactory);
+
+        // Act
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).DefaultTimeout();
+
+        // Assert
+        Assert.True(result.IsError is null or false);
+        Assert.NotNull(result.Content);
+        Assert.Single(result.Content);
+
+        var textContent = result.Content[0] as TextContentBlock;
+        Assert.NotNull(textContent);
+
+        // Parse the JSON array from the response to verify log_id extraction and attribute filtering
+        var jsonStartIndex = textContent.Text.IndexOf('[');
+        var jsonEndIndex = textContent.Text.LastIndexOf(']') + 1;
+        var jsonText = textContent.Text[jsonStartIndex..jsonEndIndex];
+        var logsArray = JsonNode.Parse(jsonText)?.AsArray();
+
+        Assert.NotNull(logsArray);
+        Assert.Equal(3, logsArray.Count);
+
+        // Verify first log entry has correct resource_name, log_id extracted, and aspire.log_id not in attributes
+        var firstLog = logsArray[0]?.AsObject();
+        Assert.NotNull(firstLog);
+        Assert.Equal("api-service-instance-1", firstLog["resource_name"]?.GetValue<string>());
+        Assert.Equal(42, firstLog["log_id"]?.GetValue<long>());
+        var firstLogAttributes = firstLog["attributes"]?.AsObject();
+        Assert.NotNull(firstLogAttributes);
+        Assert.False(firstLogAttributes.ContainsKey(OtlpHelpers.AspireLogIdAttribute), "aspire.log_id should be filtered from attributes");
+        Assert.True(firstLogAttributes.ContainsKey("custom.attr"), "custom.attr should be present in attributes");
+
+        // Verify dashboard_link is included for each log entry with correct URLs
+        var firstDashboardLink = firstLog["dashboard_link"]?.AsObject();
+        Assert.NotNull(firstDashboardLink);
+        Assert.Equal("http://localhost:18888/structuredlogs?logEntryId=42", firstDashboardLink["url"]?.GetValue<string>());
+        Assert.Equal("log_id: 42", firstDashboardLink["text"]?.GetValue<string>());
+
+        // Verify second log entry has correct resource_name (different instance), log_id extracted (from intValue)
+        var secondLog = logsArray[1]?.AsObject();
+        Assert.NotNull(secondLog);
+        Assert.Equal("api-service-instance-2", secondLog["resource_name"]?.GetValue<string>());
+        Assert.Equal(43, secondLog["log_id"]?.GetValue<long>());
+        var secondLogAttributes = secondLog["attributes"]?.AsObject();
+        Assert.NotNull(secondLogAttributes);
+        Assert.False(secondLogAttributes.ContainsKey(OtlpHelpers.AspireLogIdAttribute), "aspire.log_id should be filtered from attributes");
+
+        var secondDashboardLink = secondLog["dashboard_link"]?.AsObject();
+        Assert.NotNull(secondDashboardLink);
+        Assert.Equal("http://localhost:18888/structuredlogs?logEntryId=43", secondDashboardLink["url"]?.GetValue<string>());
+        Assert.Equal("log_id: 43", secondDashboardLink["text"]?.GetValue<string>());
+
+        // Verify third log entry has correct resource_name (no instance ID)
+        var thirdLog = logsArray[2]?.AsObject();
+        Assert.NotNull(thirdLog);
+        Assert.Equal("worker-service", thirdLog["resource_name"]?.GetValue<string>());
+        Assert.Equal(44, thirdLog["log_id"]?.GetValue<long>());
+
+        var thirdDashboardLink = thirdLog["dashboard_link"]?.AsObject();
+        Assert.NotNull(thirdDashboardLink);
+        Assert.Equal("http://localhost:18888/structuredlogs?logEntryId=44", thirdDashboardLink["url"]?.GetValue<string>());
+        Assert.Equal("log_id: 44", thirdDashboardLink["text"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task ListStructuredLogsTool_ReturnsEmptyLogs_WhenApiReturnsNoData()
+    {
+        // Arrange - Create mock HTTP handler with empty logs response
+        var apiResponseObj = new TelemetryApiResponse
+        {
+            Data = new TelemetryDataJson { ResourceLogs = [] },
+            TotalCount = 0,
+            ReturnedCount = 0
+        };
+        var apiResponse = JsonSerializer.Serialize(apiResponseObj, OtlpCliJsonSerializerContext.Default.TelemetryApiResponse);
+
+        var resources = new ResourceInfoJson[]
+        {
+            new() { Name = "api-service", InstanceId = null, HasLogs = true, HasTraces = true, HasMetrics = true }
+        };
+        var resourcesResponse = JsonSerializer.Serialize(resources, OtlpCliJsonSerializerContext.Default.ResourceInfoJsonArray);
+
+        using var mockHandler = new MockHttpMessageHandler(request =>
+        {
+            // Handle the resources endpoint
+            if (request.RequestUri?.AbsolutePath.Contains("/resources") == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(resourcesResponse, System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+
+            // For logs endpoint, return empty logs response
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(apiResponse, System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+        var mockHttpClientFactory = new MockHttpClientFactory(mockHandler);
+
+        var monitor = CreateMonitorWithDashboard();
+        var tool = CreateTool(monitor, mockHttpClientFactory);
+
+        // Act
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).DefaultTimeout();
+
+        // Assert
+        Assert.True(result.IsError is null or false);
+        Assert.NotNull(result.Content);
+        Assert.Single(result.Content);
+
+        var textContent = result.Content[0] as TextContentBlock;
+        Assert.NotNull(textContent);
+        Assert.Contains("STRUCTURED LOGS DATA", textContent.Text);
+        // Empty array should be returned
+        Assert.Contains("[]", textContent.Text);
+    }
+
+    [Fact]
+    public async Task ListStructuredLogsTool_ReturnsResourceNotFound_WhenResourceDoesNotExist()
+    {
+        // Arrange - Create mock HTTP handler that returns resources that don't match the requested name
+        var resources = new ResourceInfoJson[]
+        {
+            new() { Name = "other-resource", InstanceId = null, HasLogs = true, HasTraces = true, HasMetrics = true }
+        };
+        var resourcesResponse = JsonSerializer.Serialize(resources, OtlpCliJsonSerializerContext.Default.ResourceInfoJsonArray);
+
+        var emptyLogsResponse = new TelemetryApiResponse
+        {
+            Data = new TelemetryDataJson { ResourceLogs = [] },
+            TotalCount = 0,
+            ReturnedCount = 0
+        };
+        var emptyLogsJson = JsonSerializer.Serialize(emptyLogsResponse, OtlpCliJsonSerializerContext.Default.TelemetryApiResponse);
+
+        using var mockHandler = new MockHttpMessageHandler(request =>
+        {
+            // Check if this is the resources lookup request
+            if (request.RequestUri?.AbsolutePath.Contains("/resources") == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(resourcesResponse, System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+
+            // For any other request, return empty logs response
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(emptyLogsJson, System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+        var mockHttpClientFactory = new MockHttpClientFactory(mockHandler);
+
+        var monitor = CreateMonitorWithDashboard();
+        var tool = CreateTool(monitor, mockHttpClientFactory);
+
+        var arguments = new Dictionary<string, JsonElement>
+        {
+            ["resourceName"] = JsonDocument.Parse("\"non-existent-resource\"").RootElement
+        };
+
+        // Act
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(arguments), CancellationToken.None).DefaultTimeout();
+
+        // Assert
+        Assert.True(result.IsError);
+        var textContent = result.Content![0] as TextContentBlock;
+        Assert.NotNull(textContent);
+        Assert.Contains("Resource 'non-existent-resource' not found", textContent.Text);
+    }
+
+    [Fact]
+    public void ListStructuredLogsTool_HasCorrectName()
+    {
+        var tool = CreateTool();
+
+        Assert.Equal(KnownMcpTools.ListStructuredLogs, tool.Name);
+    }
+
+    [Fact]
+    public void ListStructuredLogsTool_HasCorrectDescription()
+    {
+        var tool = CreateTool();
+
+        Assert.Equal("List structured logs for resources.", tool.Description);
+    }
+
+    [Fact]
+    public void ListStructuredLogsTool_InputSchema_HasResourceNameProperty()
+    {
+        var tool = CreateTool();
+
+        var schema = tool.GetInputSchema();
+
+        Assert.Equal(JsonValueKind.Object, schema.ValueKind);
+        Assert.True(schema.TryGetProperty("properties", out var properties));
+        Assert.True(properties.TryGetProperty("resourceName", out var resourceName));
+        Assert.True(resourceName.TryGetProperty("type", out var type));
+        Assert.Equal("string", type.GetString());
+    }
+
+    [Fact]
+    public void ListStructuredLogsTool_InputSchema_ResourceNameIsOptional()
+    {
+        var tool = CreateTool();
+
+        var schema = tool.GetInputSchema();
+
+        // Check that there's no "required" array or it doesn't include resourceName
+        if (schema.TryGetProperty("required", out var required))
+        {
+            var requiredArray = required.EnumerateArray().Select(e => e.GetString()).ToList();
+            Assert.DoesNotContain("resourceName", requiredArray);
+        }
+        // If no required property, that's also fine - means nothing is required
+    }
+
+    /// <summary>
+    /// Creates a ListStructuredLogsTool instance for testing with optional custom dependencies.
+    /// </summary>
+    private static ListStructuredLogsTool CreateTool(
+        TestAuxiliaryBackchannelMonitor? monitor = null,
+        IHttpClientFactory? httpClientFactory = null)
+    {
+        return new ListStructuredLogsTool(
+            monitor ?? new TestAuxiliaryBackchannelMonitor(),
+            httpClientFactory ?? s_httpClientFactory,
+            NullLogger<ListStructuredLogsTool>.Instance);
+    }
+
+    /// <summary>
+    /// Creates a TestAuxiliaryBackchannelMonitor with a connection configured with dashboard info.
+    /// </summary>
+    private static TestAuxiliaryBackchannelMonitor CreateMonitorWithDashboard(
+        string apiBaseUrl = "http://localhost:5000",
+        string apiToken = "test-token",
+        string[]? dashboardUrls = null)
+    {
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            DashboardInfoResponse = new GetDashboardInfoResponse
+            {
+                ApiBaseUrl = apiBaseUrl,
+                ApiToken = apiToken,
+                DashboardUrls = dashboardUrls ?? ["http://localhost:18888"]
+            }
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+        return monitor;
+    }
+}

--- a/tests/Aspire.Cli.Tests/Mcp/ListTracesToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListTracesToolTests.cs
@@ -1,0 +1,468 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Mcp.Tools;
+using Aspire.Cli.Otlp;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Aspire.Otlp.Serialization;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Protocol;
+
+namespace Aspire.Cli.Tests.Mcp;
+
+public class ListTracesToolTests
+{
+    private static readonly TestHttpClientFactory s_httpClientFactory = new();
+
+    [Fact]
+    public async Task ListTracesTool_ReturnsFormattedTraces_WhenApiReturnsData()
+    {
+        // Local function to create OtlpResourceSpansJson with service name and instance ID
+        static OtlpResourceSpansJson CreateResourceSpans(string serviceName, string? serviceInstanceId, params OtlpSpanJson[] spans)
+        {
+            var attributes = new List<OtlpKeyValueJson>
+            {
+                new() { Key = "service.name", Value = new OtlpAnyValueJson { StringValue = serviceName } }
+            };
+            if (serviceInstanceId is not null)
+            {
+                attributes.Add(new OtlpKeyValueJson { Key = "service.instance.id", Value = new OtlpAnyValueJson { StringValue = serviceInstanceId } });
+            }
+
+            return new OtlpResourceSpansJson
+            {
+                Resource = new OtlpResourceJson
+                {
+                    Attributes = [.. attributes]
+                },
+                ScopeSpans =
+                [
+                    new OtlpScopeSpansJson
+                    {
+                        Scope = new OtlpInstrumentationScopeJson { Name = "OpenTelemetry" },
+                        Spans = spans
+                    }
+                ]
+            };
+        }
+
+        // Arrange - Create mock HTTP handler with sample traces response
+        var apiResponseObj = new TelemetryApiResponse
+        {
+            Data = new TelemetryDataJson
+            {
+                ResourceSpans =
+                [
+                    CreateResourceSpans("api-service", "instance-1",
+                        new OtlpSpanJson
+                        {
+                            TraceId = "abc123def456789012345678901234567890",
+                            SpanId = "span123456789012",
+                            Name = "GET /api/products",
+                            Kind = 2, // Server
+                            StartTimeUnixNano = 1706540400000000000,
+                            EndTimeUnixNano = 1706540400100000000,
+                            Status = new OtlpSpanStatusJson { Code = 1 }, // Ok
+                            Attributes =
+                            [
+                                new OtlpKeyValueJson { Key = "http.method", Value = new OtlpAnyValueJson { StringValue = "GET" } },
+                                new OtlpKeyValueJson { Key = "http.url", Value = new OtlpAnyValueJson { StringValue = "/api/products" } }
+                            ]
+                        }),
+                    CreateResourceSpans("api-service", "instance-2",
+                        new OtlpSpanJson
+                        {
+                            TraceId = "abc123def456789012345678901234567890",
+                            SpanId = "span234567890123",
+                            ParentSpanId = "span123456789012",
+                            Name = "GET /api/catalog",
+                            Kind = 3, // Client
+                            StartTimeUnixNano = 1706540400010000000,
+                            EndTimeUnixNano = 1706540400090000000,
+                            Status = new OtlpSpanStatusJson { Code = 1 },
+                            Attributes =
+                            [
+                                new OtlpKeyValueJson { Key = "aspire.destination", Value = new OtlpAnyValueJson { StringValue = "catalog-service" } }
+                            ]
+                        }),
+                    CreateResourceSpans("worker-service", "instance-1",
+                        new OtlpSpanJson
+                        {
+                            TraceId = "xyz789abc123456789012345678901234567890",
+                            SpanId = "span345678901234",
+                            Name = "ProcessMessage",
+                            Kind = 1, // Internal
+                            StartTimeUnixNano = 1706540401000000000,
+                            EndTimeUnixNano = 1706540401500000000,
+                            Status = new OtlpSpanStatusJson { Code = 2 }, // Error
+                            Attributes =
+                            [
+                                new OtlpKeyValueJson { Key = "error", Value = new OtlpAnyValueJson { StringValue = "Processing failed" } }
+                            ]
+                        })
+                ]
+            },
+            TotalCount = 3,
+            ReturnedCount = 3
+        };
+
+        var apiResponse = JsonSerializer.Serialize(apiResponseObj, OtlpCliJsonSerializerContext.Default.TelemetryApiResponse);
+
+        // Create resources that match the OtlpResourceSpansJson entries
+        var resources = new ResourceInfoJson[]
+        {
+            new() { Name = "api-service", InstanceId = "instance-1", HasLogs = true, HasTraces = true, HasMetrics = true },
+            new() { Name = "api-service", InstanceId = "instance-2", HasLogs = true, HasTraces = true, HasMetrics = true },
+            new() { Name = "worker-service", InstanceId = "instance-1", HasLogs = true, HasTraces = true, HasMetrics = true }
+        };
+        var resourcesResponse = JsonSerializer.Serialize(resources, OtlpCliJsonSerializerContext.Default.ResourceInfoJsonArray);
+
+        using var mockHandler = new MockHttpMessageHandler(request =>
+        {
+            // Handle the resources endpoint
+            if (request.RequestUri?.AbsolutePath.Contains("/resources") == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(resourcesResponse, System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+
+            // For traces endpoint, return the traces response
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(apiResponse, System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+        var mockHttpClientFactory = new MockHttpClientFactory(mockHandler);
+
+        // Use a dashboard URL with path and query string to test that only the base URL is used
+        var monitor = CreateMonitorWithDashboard(dashboardUrls: ["http://localhost:18888/login?t=authtoken123"]);
+        var tool = CreateTool(monitor, mockHttpClientFactory);
+
+        // Act
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).DefaultTimeout();
+
+        // Assert
+        Assert.True(result.IsError is null or false);
+        Assert.NotNull(result.Content);
+        Assert.Single(result.Content);
+
+        var textContent = result.Content[0] as TextContentBlock;
+        Assert.NotNull(textContent);
+
+        // Parse the JSON array from the response
+        var jsonStartIndex = textContent.Text.IndexOf('[');
+        var jsonEndIndex = textContent.Text.LastIndexOf(']') + 1;
+        var jsonText = textContent.Text[jsonStartIndex..jsonEndIndex];
+        var tracesArray = JsonNode.Parse(jsonText)?.AsArray();
+
+        Assert.NotNull(tracesArray);
+        // Should have 2 traces (grouped by trace_id)
+        Assert.Equal(2, tracesArray.Count);
+
+        // Verify first trace (trace_id is shortened to 7 characters)
+        var firstTrace = tracesArray[0]?.AsObject();
+        Assert.NotNull(firstTrace);
+        Assert.Equal("abc123d", firstTrace["trace_id"]?.GetValue<string>());
+
+        // Verify spans in first trace have correct source and destination
+        var spans = firstTrace["spans"]?.AsArray();
+        Assert.NotNull(spans);
+        Assert.Equal(2, spans.Count);
+
+        // Verify dashboard_link is included for each trace with correct URLs (trace_id is shortened to 7 chars in the URL)
+        var firstDashboardLink = firstTrace["dashboard_link"]?.AsObject();
+        Assert.NotNull(firstDashboardLink);
+        Assert.Equal("http://localhost:18888/traces/detail/abc123d", firstDashboardLink["url"]?.GetValue<string>());
+        Assert.Equal("abc123d", firstDashboardLink["text"]?.GetValue<string>());
+
+        // First span (server) should have source from resource name, no destination
+        var serverSpan = spans.FirstOrDefault(s => s?["kind"]?.GetValue<string>() == "Server")?.AsObject();
+        Assert.NotNull(serverSpan);
+        Assert.Equal("api-service-instance-1", serverSpan["source"]?.GetValue<string>());
+        Assert.Null(serverSpan["destination"]);
+
+        // Second span (client) should have source from resource name and destination from aspire.destination
+        var clientSpan = spans.FirstOrDefault(s => s?["kind"]?.GetValue<string>() == "Client")?.AsObject();
+        Assert.NotNull(clientSpan);
+        Assert.Equal("api-service-instance-2", clientSpan["source"]?.GetValue<string>());
+        Assert.Equal("catalog-service", clientSpan["destination"]?.GetValue<string>());
+
+        // Verify second trace
+        var secondTrace = tracesArray[1]?.AsObject();
+        Assert.NotNull(secondTrace);
+        Assert.Equal("xyz789a", secondTrace["trace_id"]?.GetValue<string>());
+
+        var secondDashboardLink = secondTrace["dashboard_link"]?.AsObject();
+        Assert.NotNull(secondDashboardLink);
+        Assert.Equal("http://localhost:18888/traces/detail/xyz789a", secondDashboardLink["url"]?.GetValue<string>());
+        Assert.Equal("xyz789a", secondDashboardLink["text"]?.GetValue<string>());
+
+        // Verify spans in second trace have correct source and destination
+        var secondTraceSpans = secondTrace["spans"]?.AsArray();
+        Assert.NotNull(secondTraceSpans);
+        Assert.Single(secondTraceSpans);
+
+        // Internal span should have source from resource name (worker-service has no instance ID), no destination
+        var internalSpan = secondTraceSpans[0]?.AsObject();
+        Assert.NotNull(internalSpan);
+        Assert.Equal("Internal", internalSpan["kind"]?.GetValue<string>());
+        Assert.Equal("worker-service", internalSpan["source"]?.GetValue<string>());
+        Assert.Null(internalSpan["destination"]);
+    }
+
+    [Fact]
+    public async Task ListTracesTool_ReturnsEmptyTraces_WhenApiReturnsNoData()
+    {
+        // Arrange - Create mock HTTP handler with empty traces response
+        var apiResponseObj = new TelemetryApiResponse
+        {
+            Data = new TelemetryDataJson { ResourceSpans = [] },
+            TotalCount = 0,
+            ReturnedCount = 0
+        };
+        var apiResponse = JsonSerializer.Serialize(apiResponseObj, OtlpCliJsonSerializerContext.Default.TelemetryApiResponse);
+
+        var resources = new ResourceInfoJson[]
+        {
+            new() { Name = "api-service", InstanceId = null, HasLogs = true, HasTraces = true, HasMetrics = true }
+        };
+        var resourcesResponse = JsonSerializer.Serialize(resources, OtlpCliJsonSerializerContext.Default.ResourceInfoJsonArray);
+
+        using var mockHandler = new MockHttpMessageHandler(request =>
+        {
+            // Handle the resources endpoint
+            if (request.RequestUri?.AbsolutePath.Contains("/resources") == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(resourcesResponse, System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+
+            // For traces endpoint, return empty traces response
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(apiResponse, System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+        var mockHttpClientFactory = new MockHttpClientFactory(mockHandler);
+
+        var monitor = CreateMonitorWithDashboard();
+        var tool = CreateTool(monitor, mockHttpClientFactory);
+
+        // Act
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).DefaultTimeout();
+
+        // Assert
+        Assert.True(result.IsError is null or false);
+        Assert.NotNull(result.Content);
+        Assert.Single(result.Content);
+
+        var textContent = result.Content[0] as TextContentBlock;
+        Assert.NotNull(textContent);
+        Assert.Contains("TRACES DATA", textContent.Text);
+        // Empty array should be returned
+        Assert.Contains("[]", textContent.Text);
+    }
+
+    [Fact]
+    public async Task ListTracesTool_ReturnsResourceNotFound_WhenResourceDoesNotExist()
+    {
+        // Arrange - Create mock HTTP handler that returns resources that don't match the requested name
+        var resources = new ResourceInfoJson[]
+        {
+            new() { Name = "other-resource", InstanceId = null, HasLogs = true, HasTraces = true, HasMetrics = true }
+        };
+        var resourcesResponse = JsonSerializer.Serialize(resources, OtlpCliJsonSerializerContext.Default.ResourceInfoJsonArray);
+
+        var emptyTracesResponse = new TelemetryApiResponse
+        {
+            Data = new TelemetryDataJson { ResourceSpans = [] },
+            TotalCount = 0,
+            ReturnedCount = 0
+        };
+        var emptyTracesJson = JsonSerializer.Serialize(emptyTracesResponse, OtlpCliJsonSerializerContext.Default.TelemetryApiResponse);
+
+        using var mockHandler = new MockHttpMessageHandler(request =>
+        {
+            // Check if this is the resources lookup request
+            if (request.RequestUri?.AbsolutePath.Contains("/resources") == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(resourcesResponse, System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+
+            // For any other request, return empty traces response
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(emptyTracesJson, System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+        var mockHttpClientFactory = new MockHttpClientFactory(mockHandler);
+
+        var monitor = CreateMonitorWithDashboard();
+        var tool = CreateTool(monitor, mockHttpClientFactory);
+
+        var arguments = new Dictionary<string, JsonElement>
+        {
+            ["resourceName"] = JsonDocument.Parse("\"non-existent-resource\"").RootElement
+        };
+
+        // Act
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(arguments), CancellationToken.None).DefaultTimeout();
+
+        // Assert
+        Assert.True(result.IsError);
+        var textContent = result.Content![0] as TextContentBlock;
+        Assert.NotNull(textContent);
+        Assert.Contains("Resource 'non-existent-resource' not found", textContent.Text);
+    }
+
+    [Fact]
+    public async Task ListTracesTool_FiltersTracesByResource_WhenResourceNameProvided()
+    {
+        // Arrange - Create mock HTTP handler with traces from multiple resources
+        static OtlpResourceSpansJson CreateResourceSpans(string serviceName, string? serviceInstanceId, params OtlpSpanJson[] spans)
+        {
+            var attributes = new List<OtlpKeyValueJson>
+            {
+                new() { Key = "service.name", Value = new OtlpAnyValueJson { StringValue = serviceName } }
+            };
+            if (serviceInstanceId is not null)
+            {
+                attributes.Add(new OtlpKeyValueJson { Key = "service.instance.id", Value = new OtlpAnyValueJson { StringValue = serviceInstanceId } });
+            }
+
+            return new OtlpResourceSpansJson
+            {
+                Resource = new OtlpResourceJson
+                {
+                    Attributes = [.. attributes]
+                },
+                ScopeSpans =
+                [
+                    new OtlpScopeSpansJson
+                    {
+                        Scope = new OtlpInstrumentationScopeJson { Name = "OpenTelemetry" },
+                        Spans = spans
+                    }
+                ]
+            };
+        }
+
+        var apiResponseObj = new TelemetryApiResponse
+        {
+            Data = new TelemetryDataJson
+            {
+                ResourceSpans =
+                [
+                    CreateResourceSpans("api-service", null,
+                        new OtlpSpanJson
+                        {
+                            TraceId = "trace123",
+                            SpanId = "span123",
+                            Name = "GET /api/products",
+                            Kind = 2,
+                            StartTimeUnixNano = 1706540400000000000,
+                            EndTimeUnixNano = 1706540400100000000,
+                            Status = new OtlpSpanStatusJson { Code = 1 }
+                        })
+                ]
+            },
+            TotalCount = 1,
+            ReturnedCount = 1
+        };
+
+        var apiResponse = JsonSerializer.Serialize(apiResponseObj, OtlpCliJsonSerializerContext.Default.TelemetryApiResponse);
+
+        var resources = new ResourceInfoJson[]
+        {
+            new() { Name = "api-service", InstanceId = null, HasLogs = true, HasTraces = true, HasMetrics = true },
+            new() { Name = "worker-service", InstanceId = null, HasLogs = true, HasTraces = true, HasMetrics = true }
+        };
+        var resourcesResponse = JsonSerializer.Serialize(resources, OtlpCliJsonSerializerContext.Default.ResourceInfoJsonArray);
+
+        string? capturedUrl = null;
+        using var mockHandler = new MockHttpMessageHandler(request =>
+        {
+            // Capture the URL for assertions
+            capturedUrl = request.RequestUri?.ToString();
+
+            if (request.RequestUri?.AbsolutePath.Contains("/resources") == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(resourcesResponse, System.Text.Encoding.UTF8, "application/json")
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(apiResponse, System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+        var mockHttpClientFactory = new MockHttpClientFactory(mockHandler);
+
+        var monitor = CreateMonitorWithDashboard();
+        var tool = CreateTool(monitor, mockHttpClientFactory);
+
+        var arguments = new Dictionary<string, JsonElement>
+        {
+            ["resourceName"] = JsonDocument.Parse("\"api-service\"").RootElement
+        };
+
+        // Act
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(arguments), CancellationToken.None).DefaultTimeout();
+
+        // Assert
+        Assert.True(result.IsError is null or false);
+        Assert.NotNull(capturedUrl);
+        // Verify the URL contains the resource name filter
+        Assert.Contains("api-service", capturedUrl);
+    }
+
+    /// <summary>
+    /// Creates a ListTracesTool instance for testing with optional custom dependencies.
+    /// </summary>
+    private static ListTracesTool CreateTool(
+        TestAuxiliaryBackchannelMonitor? monitor = null,
+        IHttpClientFactory? httpClientFactory = null)
+    {
+        return new ListTracesTool(
+            monitor ?? new TestAuxiliaryBackchannelMonitor(),
+            httpClientFactory ?? s_httpClientFactory,
+            NullLogger<ListTracesTool>.Instance);
+    }
+
+    /// <summary>
+    /// Creates a TestAuxiliaryBackchannelMonitor with a connection configured with dashboard info.
+    /// </summary>
+    private static TestAuxiliaryBackchannelMonitor CreateMonitorWithDashboard(
+        string apiBaseUrl = "http://localhost:5000",
+        string apiToken = "test-token",
+        string[]? dashboardUrls = null)
+    {
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            DashboardInfoResponse = new GetDashboardInfoResponse
+            {
+                ApiBaseUrl = apiBaseUrl,
+                ApiToken = apiToken,
+                DashboardUrls = dashboardUrls ?? ["http://localhost:18888"]
+            }
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+        return monitor;
+    }
+}

--- a/tests/Aspire.Cli.Tests/Mcp/McpToolHelpersTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/McpToolHelpersTests.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Mcp.Tools;
+
+namespace Aspire.Cli.Tests.Mcp;
+
+public class McpToolHelpersTests
+{
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("http://localhost:18888", "http://localhost:18888")]
+    [InlineData("http://localhost:18888/", "http://localhost:18888")]
+    [InlineData("http://localhost:18888/login", "http://localhost:18888")]
+    [InlineData("http://localhost:18888/login?t=authtoken123", "http://localhost:18888")]
+    [InlineData("https://localhost:16319/login?t=d8d8255df4c79aebcb5b7325828ccb20", "https://localhost:16319")]
+    [InlineData("https://example.com:8080/path/to/resource?param=value", "https://example.com:8080")]
+    [InlineData("invalid-url", "invalid-url")] // Falls back to returning the original string
+    public void GetBaseUrl_ExtractsBaseUrl_RemovingPathAndQueryString(string? input, string? expected)
+    {
+        var result = McpToolHelpers.GetBaseUrl(input);
+        Assert.Equal(expected, result);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Utils/MockHttpClientFactory.cs
+++ b/tests/Aspire.Cli.Tests/Utils/MockHttpClientFactory.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Tests.Utils;
+
+/// <summary>
+/// Mock HTTP client factory that creates clients using the specified handler.
+/// Useful for testing code that depends on IHttpClientFactory.
+/// </summary>
+internal sealed class MockHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+{
+    /// <summary>
+    /// Creates an HTTP client using the configured handler.
+    /// </summary>
+    /// <param name="name">The name of the client (ignored).</param>
+    /// <returns>An HTTP client configured with the mock handler.</returns>
+    public HttpClient CreateClient(string name)
+    {
+        return new HttpClient(handler, disposeHandler: false);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Utils/MockHttpMessageHandler.cs
+++ b/tests/Aspire.Cli.Tests/Utils/MockHttpMessageHandler.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Tests.Utils;
+
+/// <summary>
+/// Mock HTTP message handler for testing HTTP client interactions.
+/// Supports returning fixed responses, dynamic responses via factory, throwing exceptions, and request validation.
+/// </summary>
+internal sealed class MockHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, HttpResponseMessage>? _responseFactory;
+    private readonly HttpResponseMessage? _response;
+    private readonly Exception? _exception;
+    private readonly Action<HttpRequestMessage>? _requestValidator;
+
+    /// <summary>
+    /// Gets a value indicating whether the request validator was invoked.
+    /// </summary>
+    public bool RequestValidated { get; private set; }
+
+    /// <summary>
+    /// Creates a handler that returns the specified response.
+    /// </summary>
+    /// <param name="response">The HTTP response to return.</param>
+    /// <param name="requestValidator">Optional action to validate the request.</param>
+    public MockHttpMessageHandler(HttpResponseMessage response, Action<HttpRequestMessage>? requestValidator = null)
+    {
+        _response = response;
+        _requestValidator = requestValidator;
+    }
+
+    /// <summary>
+    /// Creates a handler that generates responses dynamically using the provided factory.
+    /// </summary>
+    /// <param name="responseFactory">A function that creates responses based on the request.</param>
+    public MockHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+    {
+        _responseFactory = responseFactory;
+    }
+
+    /// <summary>
+    /// Creates a handler that throws the specified exception.
+    /// </summary>
+    /// <param name="exception">The exception to throw.</param>
+    public MockHttpMessageHandler(Exception exception)
+    {
+        _exception = exception;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        if (_exception is not null)
+        {
+            throw _exception;
+        }
+
+        if (_requestValidator is not null)
+        {
+            _requestValidator(request);
+            RequestValidated = true;
+        }
+
+        if (_responseFactory is not null)
+        {
+            return Task.FromResult(_responseFactory(request));
+        }
+
+        return Task.FromResult(_response!);
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Model/AIAssistant/AIHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/AIAssistant/AIHelpersTests.cs
@@ -187,10 +187,10 @@ public class AIHelpersTests
         Assert.True(options.Frontend.TryParseOptions(out _));
 
         // Act
-        var url = AIHelpers.GetDashboardUrl(options, "/path");
+        var url = AIHelpers.GetDashboardUrl(options);
 
         // Assert
-        Assert.Equal("https://localhost:1234/path", url);
+        Assert.Equal("https://localhost:1234", url);
     }
 
     [Fact]
@@ -202,10 +202,10 @@ public class AIHelpersTests
         Assert.True(options.Frontend.TryParseOptions(out _));
 
         // Act
-        var url = AIHelpers.GetDashboardUrl(options, "/path");
+        var url = AIHelpers.GetDashboardUrl(options);
 
         // Assert
-        Assert.Equal("https://localhost:1234/path", url);
+        Assert.Equal("https://localhost:1234", url);
     }
 
     [Fact]
@@ -217,9 +217,9 @@ public class AIHelpersTests
         Assert.True(options.Frontend.TryParseOptions(out _));
 
         // Act
-        var url = AIHelpers.GetDashboardUrl(options, "/path");
+        var url = AIHelpers.GetDashboardUrl(options);
 
         // Assert
-        Assert.Equal("http://localhost:5000/path", url);
+        Assert.Equal("http://localhost:5000", url);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/AIAssistant/AssistantChatDataContextTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/AIAssistant/AssistantChatDataContextTests.cs
@@ -128,12 +128,21 @@ public class AssistantChatDataContextTests
 
     internal static AssistantChatDataContext CreateAssistantChatDataContext(TelemetryRepository? telemetryRepository = null, IDashboardClient? dashboardClient = null)
     {
+        var dashboardOptions = new DashboardOptions
+        {
+            Frontend = new FrontendOptions
+            {
+                EndpointUrls = "http://localhost:5000"
+            }
+        };
+        Assert.True(dashboardOptions.Frontend.TryParseOptions(out _));
+
         var context = new AssistantChatDataContext(
             telemetryRepository ?? CreateRepository(),
             dashboardClient ?? new MockDashboardClient(),
             [],
             new TestStringLocalizer<Dashboard.Resources.AIAssistant>(),
-            new TestOptionsMonitor<DashboardOptions>(new DashboardOptions()));
+            new TestOptionsMonitor<DashboardOptions>(dashboardOptions));
 
         return context;
     }

--- a/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.IO.Compression;
 using System.Text.Json;
 using Aspire.Dashboard.Model;
@@ -9,6 +10,7 @@ using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Model.Serialization;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Tests.Shared;
+using Aspire.Dashboard.Tests.TelemetryRepositoryTests;
 using Aspire.Tests.Shared.DashboardModel;
 using Google.Protobuf.Collections;
 using Microsoft.AspNetCore.InternalTesting;
@@ -88,6 +90,44 @@ public sealed class TelemetryExportServiceTests
         Assert.Equal("6566676835363738", logRecord.SpanId); // hex of UTF-8 bytes of "efgh5678"
         Assert.NotNull(logRecord.Attributes);
         Assert.Contains(logRecord.Attributes, a => a.Key == "custom.attr" && a.Value?.StringValue == "custom-value");
+    }
+
+    [Fact]
+    public void ConvertLogsToOtlpJson_AddsAspireLogIdAttribute()
+    {
+        // Arrange
+        var repository = CreateRepository();
+        var addContext = new AddContext();
+        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "TestService", instanceId: "instance-1"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords = { CreateLogRecord(time: s_testTime, message: "Test log message") }
+                    }
+                }
+            }
+        });
+
+        var resources = repository.GetResources();
+        var resource = resources[0];
+        var logs = repository.GetLogs(GetLogsContext.ForResourceKey(resource.ResourceKey));
+
+        // Act
+        var result = TelemetryExportService.ConvertLogsToOtlpJson(logs.Items);
+
+        // Assert
+        var logRecord = result.ResourceLogs![0].ScopeLogs![0].LogRecords![0];
+        Assert.NotNull(logRecord.Attributes);
+
+        // Verify aspire.log_id attribute is added with the InternalId value
+        var logIdAttribute = Assert.Single(logRecord.Attributes, a => a.Key == OtlpHelpers.AspireLogIdAttribute);
+        Assert.Equal(logs.Items[0].InternalId.ToString(CultureInfo.InvariantCulture), logIdAttribute.Value?.StringValue);
     }
 
     [Fact]
@@ -252,7 +292,7 @@ public sealed class TelemetryExportServiceTests
         });
 
         // Act
-        var result = TelemetryExportService.ConvertTracesToOtlpJson(traces.PagedResult.Items);
+        var result = TelemetryExportService.ConvertTracesToOtlpJson(traces.PagedResult.Items, []);
 
         // Assert
         Assert.NotNull(result.ResourceSpans);
@@ -318,7 +358,7 @@ public sealed class TelemetryExportServiceTests
         var traces = repository.GetTraces(GetTracesRequest.ForResourceKey(resource.ResourceKey));
 
         // Act
-        var result = TelemetryExportService.ConvertTracesToOtlpJson(traces.PagedResult.Items);
+        var result = TelemetryExportService.ConvertTracesToOtlpJson(traces.PagedResult.Items, []);
 
         // Assert
         var spans = result.ResourceSpans![0].ScopeSpans![0].Spans!;
@@ -328,6 +368,98 @@ public sealed class TelemetryExportServiceTests
         var childSpan = spans.First(s => s.ParentSpanId is not null);
 
         Assert.NotNull(childSpan.ParentSpanId);
+    }
+
+    [Fact]
+    public void ConvertTracesToOtlpJson_WithPeerResolvers_AddsDestinationNameAttribute()
+    {
+        // Arrange
+        var repository = CreateRepository();
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "trace123456789012",
+                                spanId: "span1234",
+                                startTime: s_testTime,
+                                endTime: s_testTime.AddSeconds(5),
+                                attributes: [new KeyValuePair<string, string>("peer.service", "target-service")])
+                        }
+                    }
+                }
+            }
+        });
+
+        var resources = repository.GetResources();
+        var resource = resources[0];
+        var traces = repository.GetTraces(GetTracesRequest.ForResourceKey(resource.ResourceKey));
+
+        var outgoingPeerResolver = new TestOutgoingPeerResolver(onResolve: attributes =>
+        {
+            var peerService = attributes.FirstOrDefault(a => a.Key == "peer.service");
+            return (peerService.Value, null);
+        });
+
+        // Act
+        var result = TelemetryExportService.ConvertTracesToOtlpJson(traces.PagedResult.Items, [outgoingPeerResolver]);
+
+        // Assert
+        var span = result.ResourceSpans![0].ScopeSpans![0].Spans![0];
+        Assert.NotNull(span.Attributes);
+        Assert.Contains(span.Attributes, a => a.Key == OtlpHelpers.AspireDestinationNameAttribute && a.Value?.StringValue == "target-service");
+    }
+
+    [Fact]
+    public void ConvertTracesToOtlpJson_WithoutPeerResolvers_DoesNotAddDestinationNameAttribute()
+    {
+        // Arrange
+        var repository = CreateRepository();
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "trace123456789012",
+                                spanId: "span1234",
+                                startTime: s_testTime,
+                                endTime: s_testTime.AddSeconds(5),
+                                attributes: [new KeyValuePair<string, string>("peer.service", "target-service")])
+                        }
+                    }
+                }
+            }
+        });
+
+        var resources = repository.GetResources();
+        var resource = resources[0];
+        var traces = repository.GetTraces(GetTracesRequest.ForResourceKey(resource.ResourceKey));
+
+        // Act
+        var result = TelemetryExportService.ConvertTracesToOtlpJson(traces.PagedResult.Items, []);
+
+        // Assert
+        var span = result.ResourceSpans![0].ScopeSpans![0].Spans![0];
+        Assert.NotNull(span.Attributes);
+        Assert.DoesNotContain(span.Attributes, a => a.Key == OtlpHelpers.AspireDestinationNameAttribute);
     }
 
     [Fact]
@@ -758,7 +890,7 @@ public sealed class TelemetryExportServiceTests
         var span = repository.GetTraces(GetTracesRequest.ForResourceKey(repository.GetResources()[0].ResourceKey)).PagedResult.Items[0].Spans[0];
 
         // Act
-        var json = TelemetryExportService.ConvertSpanToJson(span);
+        var json = TelemetryExportService.ConvertSpanToJson(span, []);
 
         // Assert - deserialize back to verify OtlpTelemetryDataJson structure
         var data = JsonSerializer.Deserialize(json, OtlpJsonSerializerContext.Default.OtlpTelemetryDataJson);
@@ -811,7 +943,7 @@ public sealed class TelemetryExportServiceTests
         var logs = repository.GetLogs(GetLogsContext.ForResourceKey(repository.GetResources()[0].ResourceKey)).Items;
 
         // Act
-        var json = TelemetryExportService.ConvertSpanToJson(span, logs);
+        var json = TelemetryExportService.ConvertSpanToJson(span, [], logs);
 
         // Assert - verify both spans and logs are in the output
         var data = JsonSerializer.Deserialize(json, OtlpJsonSerializerContext.Default.OtlpTelemetryDataJson);
@@ -871,7 +1003,7 @@ public sealed class TelemetryExportServiceTests
         var logs = repository.GetLogs(GetLogsContext.ForResourceKey(repository.GetResources()[0].ResourceKey)).Items;
 
         // Act
-        var json = TelemetryExportService.ConvertTraceToJson(trace, logs);
+        var json = TelemetryExportService.ConvertTraceToJson(trace, [], logs);
 
         // Assert - verify both spans and logs are in the output
         var data = JsonSerializer.Deserialize(json, OtlpJsonSerializerContext.Default.OtlpTelemetryDataJson);
@@ -911,7 +1043,7 @@ public sealed class TelemetryExportServiceTests
         var trace = repository.GetTraces(GetTracesRequest.ForResourceKey(repository.GetResources()[0].ResourceKey)).PagedResult.Items[0];
 
         // Act
-        var json = TelemetryExportService.ConvertTraceToJson(trace);
+        var json = TelemetryExportService.ConvertTraceToJson(trace, []);
 
         // Assert - deserialize back to verify OtlpTelemetryDataJson structure
         var data = JsonSerializer.Deserialize(json, OtlpJsonSerializerContext.Default.OtlpTelemetryDataJson);
@@ -965,7 +1097,7 @@ public sealed class TelemetryExportServiceTests
         var consoleLogsManager = new ConsoleLogsManager(sessionStorage);
         await consoleLogsManager.EnsureInitializedAsync();
         var consoleLogsFetcher = new ConsoleLogsFetcher(dashboardClient, consoleLogsManager);
-        return new TelemetryExportService(repository, consoleLogsFetcher, dashboardClient);
+        return new TelemetryExportService(repository, consoleLogsFetcher, dashboardClient, Array.Empty<IOutgoingPeerResolver>());
     }
 
     private static Dictionary<string, HashSet<AspireDataType>> BuildAllResourcesSelection(TelemetryRepository repository)

--- a/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Api;
+using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Proto.Trace.V1;
@@ -44,7 +46,7 @@ public class TelemetryApiServiceTests
             });
         }
 
-        var service = new TelemetryApiService(repository);
+        var service = CreateService(repository);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
         // Act - stream spans
@@ -91,7 +93,7 @@ public class TelemetryApiServiceTests
             });
         }
 
-        var service = new TelemetryApiService(repository);
+        var service = CreateService(repository);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
         // Act - stream logs
@@ -136,7 +138,7 @@ public class TelemetryApiServiceTests
             }
         });
 
-        var service = new TelemetryApiService(repository);
+        var service = CreateService(repository);
 
         // Act - get spans with hasError=false
         var result = service.GetSpans(resourceNames: null, traceId: null, hasError: false, limit: null);
@@ -178,7 +180,7 @@ public class TelemetryApiServiceTests
             }
         });
 
-        var service = new TelemetryApiService(repository);
+        var service = CreateService(repository);
 
         // Act - get spans with hasError=true
         var result = service.GetSpans(resourceNames: null, traceId: null, hasError: true, limit: null);
@@ -237,7 +239,7 @@ public class TelemetryApiServiceTests
             }
         });
 
-        var service = new TelemetryApiService(repository);
+        var service = CreateService(repository);
 
         // Act - get traces with hasError=false (no error, should exclude the error trace)
         var result = service.GetTraces(resourceNames: null, hasError: false, limit: null);
@@ -297,7 +299,7 @@ public class TelemetryApiServiceTests
             }
         });
 
-        var service = new TelemetryApiService(repository);
+        var service = CreateService(repository);
 
         // Act - get traces with hasError=true (error only)
         var result = service.GetTraces(resourceNames: null, hasError: true, limit: null);
@@ -338,7 +340,7 @@ public class TelemetryApiServiceTests
             }
         });
 
-        var service = new TelemetryApiService(repository);
+        var service = CreateService(repository);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
 
         // Act - stream spans for a non-existent resource
@@ -385,7 +387,7 @@ public class TelemetryApiServiceTests
             }
         });
 
-        var service = new TelemetryApiService(repository);
+        var service = CreateService(repository);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
 
         // Act - stream logs for a non-existent resource
@@ -404,5 +406,17 @@ public class TelemetryApiServiceTests
 
         // Assert - should receive NO items because the resource doesn't exist
         Assert.Empty(receivedItems);
+    }
+
+    /// <summary>
+    /// Creates a TelemetryApiService instance for testing with optional custom dependencies.
+    /// </summary>
+    private static TelemetryApiService CreateService(
+        TelemetryRepository? repository = null,
+        IOutgoingPeerResolver[]? peerResolvers = null)
+    {
+        return new TelemetryApiService(
+            repository ?? CreateRepository(),
+            peerResolvers ?? []);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/ResourceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/ResourceTests.cs
@@ -138,8 +138,8 @@ public class ResourceTests
         // Act
         var resources = repository.GetResources();
 
-        var instance1Name = OtlpResource.GetResourceName(resources[0], resources);
-        var instance2Name = OtlpResource.GetResourceName(resources[1], resources);
+        var instance1Name = OtlpHelpers.GetResourceName(resources[0], resources);
+        var instance2Name = OtlpHelpers.GetResourceName(resources[1], resources);
 
         // Assert
         Assert.Equal("app1-19572b19", instance1Name);

--- a/tests/Aspire.Hosting.Tests/ExecutionConfigurationGathererTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExecutionConfigurationGathererTests.cs
@@ -538,8 +538,6 @@ public class ExecutionConfigurationGathererTests
 
     #endregion
 
-    #region Helper Methods
-
     private static X509Certificate2 CreateTestCertificate()
     {
         using var rsa = RSA.Create(2048);
@@ -589,6 +587,4 @@ public class ExecutionConfigurationGathererTests
 
         public bool UseForHttps => true;
     }
-
-    #endregion
 }


### PR DESCRIPTION
## Description

Refactor CLI MCP tools to get traces and structured logs from dashboard APIs.

This PR:
- Moves generating JSON returned from MCP into a shared location so it can be shared by dashboard and CLI
- Updates tools to get data from dashboard APIs. No more dashboard MCP forwarding! 🔥
- Fixes JSON returned from MCP to always resolve resource names correctly
- Remove `ResourceInfoJson.DisplayName`. It's not a display name. And it can be calculated from other data.
- Adds some Aspire attributes on export: `aspire.log_id` = aspire's internal id for logs, `aspire.destination` = span's matched destination resource name

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
