### PR TITLE
Lazy index docs in MCP tools and report progress

### DIFF
--- a/src/Aspire.Cli/Commands/AgentMcpCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentMcpCommand.cs
@@ -202,7 +202,7 @@ internal sealed class AgentMcpCommand : BaseCommand
             if (KnownMcpTools.IsDashboardTool(toolName))
             {
                 var args = request.Params?.Arguments;
-                return await CallDashboardToolAsync(toolName, tool, args, cancellationToken).ConfigureAwait(false);
+                return await CallDashboardToolAsync(toolName, tool, request.Params?.ProgressToken, args, cancellationToken).ConfigureAwait(false);
             }
 
             // If a tool is registered in _tools, it must be classified as either local or dashboard-backed.
@@ -265,6 +265,7 @@ internal sealed class AgentMcpCommand : BaseCommand
     private async ValueTask<CallToolResult> CallDashboardToolAsync(
         string toolName,
         CliMcpTool tool,
+        ProgressToken? progressToken,
         IReadOnlyDictionary<string, JsonElement>? arguments,
         CancellationToken cancellationToken)
     {
@@ -316,7 +317,8 @@ internal sealed class AgentMcpCommand : BaseCommand
             {
                 Notifier = new McpServerNotifier(_server!),
                 McpClient = mcpClient,
-                Arguments = arguments
+                Arguments = arguments,
+                ProgressToken = progressToken
             };
             var result = await tool.CallToolAsync(context, cancellationToken).ConfigureAwait(false);
             _logger.LogDebug("Tool {ToolName} completed successfully", toolName);

--- a/src/Aspire.Cli/Commands/AgentMcpCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentMcpCommand.cs
@@ -83,7 +83,7 @@ internal sealed class AgentMcpCommand : BaseCommand
             [KnownMcpTools.Doctor] = new DoctorTool(environmentChecker),
             [KnownMcpTools.RefreshTools] = new RefreshToolsTool(RefreshResourceToolMapAsync, SendToolsListChangedNotificationAsync),
             [KnownMcpTools.ListDocs] = new ListDocsTool(docsIndexService),
-            [KnownMcpTools.SearchDocs] = new SearchDocsTool(docsSearchService),
+            [KnownMcpTools.SearchDocs] = new SearchDocsTool(docsSearchService, docsIndexService),
             [KnownMcpTools.GetDoc] = new GetDocTool(docsIndexService)
         };
     }
@@ -123,19 +123,6 @@ internal sealed class AgentMcpCommand : BaseCommand
 
         // Keep a reference to the server for sending notifications
         _server = server;
-
-        // Start indexing aspire.dev documentation in the background (fire-and-forget)
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                await _docsIndexService.EnsureIndexedAsync(cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                _logger.LogWarning(ex, "Failed to index aspire.dev documentation in background");
-            }
-        }, cancellationToken);
 
         // Starts the MCP server, it's blocking until cancellation is requested
         await server.RunAsync(cancellationToken);
@@ -202,7 +189,14 @@ internal sealed class AgentMcpCommand : BaseCommand
             if (KnownMcpTools.IsLocalTool(toolName))
             {
                 var args = request.Params?.Arguments;
-                return await tool.CallToolAsync(null!, args, cancellationToken).ConfigureAwait(false);
+                var context = new CallToolContext
+                {
+                    Notifier = new McpServerNotifier(_server!),
+                    McpClient = null,
+                    Arguments = args,
+                    ProgressToken = request.Params?.ProgressToken
+                };
+                return await tool.CallToolAsync(context, cancellationToken).ConfigureAwait(false);
             }
 
             if (KnownMcpTools.IsDashboardTool(toolName))
@@ -318,7 +312,13 @@ internal sealed class AgentMcpCommand : BaseCommand
         try
         {
             _logger.LogDebug("Invoking CallToolAsync for tool {ToolName} with arguments: {Arguments}", toolName, arguments);
-            var result = await tool.CallToolAsync(mcpClient, arguments, cancellationToken).ConfigureAwait(false);
+            var context = new CallToolContext
+            {
+                Notifier = new McpServerNotifier(_server!),
+                McpClient = mcpClient,
+                Arguments = arguments
+            };
+            var result = await tool.CallToolAsync(context, cancellationToken).ConfigureAwait(false);
             _logger.LogDebug("Tool {ToolName} completed successfully", toolName);
             return result;
         }

--- a/src/Aspire.Cli/Mcp/Docs/DocsIndexService.cs
+++ b/src/Aspire.Cli/Mcp/Docs/DocsIndexService.cs
@@ -13,6 +13,11 @@ namespace Aspire.Cli.Mcp.Docs;
 internal interface IDocsIndexService
 {
     /// <summary>
+    /// Gets a value indicating whether the documentation has been indexed.
+    /// </summary>
+    bool IsIndexed { get; }
+
+    /// <summary>
     /// Ensures documentation is loaded and indexed.
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>
@@ -120,6 +125,9 @@ internal sealed partial class DocsIndexService(IDocsFetcher docsFetcher, IDocsCa
     // instruction reordering that could expose a partially-constructed list to other threads.
     private volatile List<IndexedDocument>? _indexedDocuments;
     private readonly SemaphoreSlim _indexLock = new(1, 1);
+
+    /// <inheritdoc />
+    public bool IsIndexed => _indexedDocuments is not null;
 
     public async ValueTask EnsureIndexedAsync(CancellationToken cancellationToken = default)
     {

--- a/src/Aspire.Cli/Mcp/IMcpNotifier.cs
+++ b/src/Aspire.Cli/Mcp/IMcpNotifier.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Mcp;
+
+/// <summary>
+/// Interface for sending MCP notifications.
+/// </summary>
+internal interface IMcpNotifier
+{
+    /// <summary>
+    /// Sends a notification to the MCP client.
+    /// </summary>
+    /// <param name="method">The notification method name.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task SendNotificationAsync(string method, CancellationToken cancellationToken = default);
+
+    Task SendNotificationAsync<TParams>(string method, TParams parameters, CancellationToken cancellationToken = default);
+}

--- a/src/Aspire.Cli/Mcp/McpServerNotifier.cs
+++ b/src/Aspire.Cli/Mcp/McpServerNotifier.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using ModelContextProtocol.Server;
+
+namespace Aspire.Cli.Mcp;
+
+/// <summary>
+/// Implementation of <see cref="IMcpNotifier"/> that wraps an <see cref="McpServer"/>.
+/// </summary>
+internal sealed class McpServerNotifier(McpServer server) : IMcpNotifier
+{
+    /// <inheritdoc />
+    public Task SendNotificationAsync(string method, CancellationToken cancellationToken = default)
+    {
+        return server.SendNotificationAsync(method, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task SendNotificationAsync<TParams>(string method, TParams parameters, CancellationToken cancellationToken = default)
+    {
+        return server.SendNotificationAsync(method, parameters, cancellationToken: cancellationToken);
+    }
+}

--- a/src/Aspire.Cli/Mcp/Tools/CallToolContext.cs
+++ b/src/Aspire.Cli/Mcp/Tools/CallToolContext.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using ModelContextProtocol.Protocol;
+
+namespace Aspire.Cli.Mcp.Tools;
+
+/// <summary>
+/// Provides context for executing MCP tools.
+/// </summary>
+internal sealed class CallToolContext
+{
+    /// <summary>
+    /// Gets the MCP notifier for sending notifications.
+    /// </summary>
+    public required IMcpNotifier Notifier { get; init; }
+
+    /// <summary>
+    /// Gets the MCP client instance to use for communicating with the dashboard.
+    /// </summary>
+    public required ModelContextProtocol.Client.McpClient? McpClient { get; init; }
+
+    /// <summary>
+    /// Gets the arguments passed to the tool.
+    /// </summary>
+    public required IReadOnlyDictionary<string, JsonElement>? Arguments { get; init; }
+
+    /// <summary>
+    /// Gets the progress token for reporting progress updates, if provided by the client.
+    /// </summary>
+    public ProgressToken? ProgressToken { get; init; }
+}

--- a/src/Aspire.Cli/Mcp/Tools/CallToolContext.cs
+++ b/src/Aspire.Cli/Mcp/Tools/CallToolContext.cs
@@ -29,5 +29,5 @@ internal sealed class CallToolContext
     /// <summary>
     /// Gets the progress token for reporting progress updates, if provided by the client.
     /// </summary>
-    public ProgressToken? ProgressToken { get; init; }
+    public required ProgressToken? ProgressToken { get; init; }
 }

--- a/src/Aspire.Cli/Mcp/Tools/CliMcpTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/CliMcpTool.cs
@@ -28,11 +28,10 @@ internal abstract class CliMcpTool
     public abstract JsonElement GetInputSchema();
 
     /// <summary>
-    /// Executes the tool with the provided arguments.
+    /// Executes the tool with the provided context.
     /// </summary>
-    /// <param name="mcpClient">The MCP client instance to use for communicating with the dashboard.</param>
-    /// <param name="arguments">The arguments passed to the tool.</param>
+    /// <param name="context">The call context containing the MCP server, client, and arguments.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The result of the tool execution.</returns>
-    public abstract ValueTask<CallToolResult> CallToolAsync(ModelContextProtocol.Client.McpClient mcpClient, IReadOnlyDictionary<string, JsonElement>? arguments, CancellationToken cancellationToken);
+    public abstract ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken);
 }

--- a/src/Aspire.Cli/Mcp/Tools/DocsToolHelper.cs
+++ b/src/Aspire.Cli/Mcp/Tools/DocsToolHelper.cs
@@ -35,9 +35,8 @@ internal static class DocsToolHelper
                     ProgressToken = progressToken.Value,
                     Progress = new ProgressNotificationValue
                     {
-                        Message = "Indexing Aspire documentation...",
-                        Progress = 1,
-                        Total = 2
+                        Message = "Indexing Aspire docs...",
+                        Progress = 1
                     }
                 }, cancellationToken).ConfigureAwait(false);
         }
@@ -53,9 +52,8 @@ internal static class DocsToolHelper
                     ProgressToken = progressToken.Value,
                     Progress = new ProgressNotificationValue
                     {
-                        Message = "Aspire documentation indexed.",
-                        Progress = 2,
-                        Total = 2
+                        Message = "Aspire docs indexed",
+                        Progress = 2
                     }
                 }, cancellationToken).ConfigureAwait(false);
         }

--- a/src/Aspire.Cli/Mcp/Tools/DocsToolHelper.cs
+++ b/src/Aspire.Cli/Mcp/Tools/DocsToolHelper.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Mcp.Docs;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+
+namespace Aspire.Cli.Mcp.Tools;
+
+/// <summary>
+/// Helper methods for documentation tool operations.
+/// </summary>
+internal static class DocsToolHelper
+{
+    /// <summary>
+    /// Ensures the documentation index is ready, sending progress notifications if indexing is needed.
+    /// </summary>
+    public static async ValueTask EnsureIndexedWithNotificationsAsync(
+        IDocsIndexService docsIndexService,
+        ProgressToken? progressToken,
+        IMcpNotifier notifier,
+        CancellationToken cancellationToken)
+    {
+        if (docsIndexService.IsIndexed)
+        {
+            return;
+        }
+
+        if (progressToken != null)
+        {
+            await notifier.SendNotificationAsync(
+                NotificationMethods.ProgressNotification,
+                new ProgressNotificationParams
+                {
+                    ProgressToken = progressToken.Value,
+                    Progress = new ProgressNotificationValue
+                    {
+                        Message = "Indexing Aspire documentation...",
+                        Progress = 1,
+                        Total = 2
+                    }
+                }, cancellationToken).ConfigureAwait(false);
+        }
+
+        await docsIndexService.EnsureIndexedAsync(cancellationToken).ConfigureAwait(false);
+
+        if (progressToken != null)
+        {
+            await notifier.SendNotificationAsync(
+                NotificationMethods.ProgressNotification,
+                new ProgressNotificationParams
+                {
+                    ProgressToken = progressToken.Value,
+                    Progress = new ProgressNotificationValue
+                    {
+                        Message = "Aspire documentation indexed.",
+                        Progress = 2,
+                        Total = 2
+                    }
+                }, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Aspire.Cli/Mcp/Tools/DoctorTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/DoctorTool.cs
@@ -28,11 +28,10 @@ internal sealed class DoctorTool(IEnvironmentChecker environmentChecker) : CliMc
             """).RootElement;
     }
 
-    public override async ValueTask<CallToolResult> CallToolAsync(ModelContextProtocol.Client.McpClient mcpClient, IReadOnlyDictionary<string, JsonElement>? arguments, CancellationToken cancellationToken)
+    public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
         // This tool does not use the MCP client or arguments
-        _ = mcpClient;
-        _ = arguments;
+        _ = context;
 
         try
         {

--- a/src/Aspire.Cli/Mcp/Tools/ExecuteResourceCommandTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ExecuteResourceCommandTool.cs
@@ -41,10 +41,9 @@ internal sealed class ExecuteResourceCommandTool(
             """).RootElement;
     }
 
-    public override async ValueTask<CallToolResult> CallToolAsync(ModelContextProtocol.Client.McpClient mcpClient, IReadOnlyDictionary<string, JsonElement>? arguments, CancellationToken cancellationToken)
+    public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
-        // This tool does not use the MCP client as it operates via backchannel
-        _ = mcpClient;
+        var arguments = context.Arguments;
 
         if (arguments is null ||
             !arguments.TryGetValue("resourceName", out var resourceNameElement) ||

--- a/src/Aspire.Cli/Mcp/Tools/GetDocTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/GetDocTool.cs
@@ -45,11 +45,10 @@ internal sealed class GetDocTool(IDocsIndexService docsIndexService) : CliMcpToo
     }
 
     public override async ValueTask<CallToolResult> CallToolAsync(
-        ModelContextProtocol.Client.McpClient mcpClient,
-        IReadOnlyDictionary<string, JsonElement>? arguments,
+        CallToolContext context,
         CancellationToken cancellationToken)
     {
-        _ = mcpClient;
+        var arguments = context.Arguments;
 
         if (arguments is null || !arguments.TryGetValue("slug", out var slugElement))
         {
@@ -75,6 +74,8 @@ internal sealed class GetDocTool(IDocsIndexService docsIndexService) : CliMcpToo
         {
             section = sectionElement.GetString();
         }
+
+        await DocsToolHelper.EnsureIndexedWithNotificationsAsync(_docsIndexService, context.ProgressToken, context.Notifier, cancellationToken).ConfigureAwait(false);
 
         var doc = await _docsIndexService.GetDocumentAsync(slug, section, cancellationToken).ConfigureAwait(false);
 

--- a/src/Aspire.Cli/Mcp/Tools/ListAppHostsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListAppHostsTool.cs
@@ -35,11 +35,10 @@ internal sealed class ListAppHostsTool(IAuxiliaryBackchannelMonitor auxiliaryBac
         return JsonDocument.Parse("{ \"type\": \"object\", \"properties\": {} }").RootElement;
     }
 
-    public override async ValueTask<CallToolResult> CallToolAsync(ModelContextProtocol.Client.McpClient mcpClient, IReadOnlyDictionary<string, JsonElement>? arguments, CancellationToken cancellationToken)
+    public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
         // This tool does not use the MCP client as it operates locally
-        _ = mcpClient;
-        _ = arguments;
+        _ = context;
 
         // Trigger an immediate scan to ensure we have the latest AppHost connections
         await auxiliaryBackchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Cli/Mcp/Tools/ListConsoleLogsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListConsoleLogsTool.cs
@@ -36,10 +36,9 @@ internal sealed class ListConsoleLogsTool(IAuxiliaryBackchannelMonitor auxiliary
             """).RootElement;
     }
 
-    public override async ValueTask<CallToolResult> CallToolAsync(ModelContextProtocol.Client.McpClient mcpClient, IReadOnlyDictionary<string, JsonElement>? arguments, CancellationToken cancellationToken)
+    public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
-        // This tool does not use the MCP client as it operates via backchannel
-        _ = mcpClient;
+        var arguments = context.Arguments;
 
         // Get the resource name from arguments
         string? resourceName = null;

--- a/src/Aspire.Cli/Mcp/Tools/ListDocsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListDocsTool.cs
@@ -39,12 +39,10 @@ internal sealed class ListDocsTool(IDocsIndexService docsIndexService) : CliMcpT
     }
 
     public override async ValueTask<CallToolResult> CallToolAsync(
-        ModelContextProtocol.Client.McpClient mcpClient,
-        IReadOnlyDictionary<string, JsonElement>? arguments,
+        CallToolContext context,
         CancellationToken cancellationToken)
     {
-        _ = mcpClient;
-        _ = arguments;
+        await DocsToolHelper.EnsureIndexedWithNotificationsAsync(_docsIndexService, context.ProgressToken, context.Notifier, cancellationToken).ConfigureAwait(false);
 
         var docs = await _docsIndexService.ListDocumentsAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Aspire.Cli/Mcp/Tools/ListIntegrationsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListIntegrationsTool.cs
@@ -67,11 +67,10 @@ internal sealed class ListIntegrationsTool(IPackagingService packagingService, C
             """).RootElement;
     }
 
-    public override async ValueTask<CallToolResult> CallToolAsync(ModelContextProtocol.Client.McpClient mcpClient, IReadOnlyDictionary<string, JsonElement>? arguments, CancellationToken cancellationToken)
+    public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
         // This tool does not use the MCP client as it operates locally
-        _ = mcpClient;
-        _ = arguments;
+        _ = context;
 
         try
         {

--- a/src/Aspire.Cli/Mcp/Tools/ListResourcesTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListResourcesTool.cs
@@ -55,11 +55,10 @@ internal sealed class ListResourcesTool(IAuxiliaryBackchannelMonitor auxiliaryBa
         return JsonDocument.Parse("{ \"type\": \"object\", \"properties\": {} }").RootElement;
     }
 
-    public override async ValueTask<CallToolResult> CallToolAsync(ModelContextProtocol.Client.McpClient mcpClient, IReadOnlyDictionary<string, JsonElement>? arguments, CancellationToken cancellationToken)
+    public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
         // This tool does not use the MCP client as it operates via backchannel
-        _ = mcpClient;
-        _ = arguments;
+        _ = context;
 
         var connection = await AppHostConnectionHelper.GetSelectedConnectionAsync(auxiliaryBackchannelMonitor, logger, cancellationToken).ConfigureAwait(false);
         if (connection is null)

--- a/src/Aspire.Cli/Mcp/Tools/ListStructuredLogsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListStructuredLogsTool.cs
@@ -28,21 +28,21 @@ internal sealed class ListStructuredLogsTool : CliMcpTool
             """).RootElement;
     }
 
-    public override async ValueTask<CallToolResult> CallToolAsync(ModelContextProtocol.Client.McpClient mcpClient, IReadOnlyDictionary<string, JsonElement>? arguments, CancellationToken cancellationToken)
+    public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
         // Convert JsonElement arguments to Dictionary<string, object?>
         Dictionary<string, object?>? convertedArgs = null;
-        if (arguments != null)
+        if (context.Arguments != null)
         {
             convertedArgs = new Dictionary<string, object?>();
-            foreach (var kvp in arguments)
+            foreach (var kvp in context.Arguments)
             {
                 convertedArgs[kvp.Key] = kvp.Value.ValueKind == JsonValueKind.Null ? null : kvp.Value;
             }
         }
 
         // Forward the call to the dashboard's MCP server
-        return await mcpClient.CallToolAsync(
+        return await context.McpClient!.CallToolAsync(
             Name,
             convertedArgs,
             serializerOptions: McpJsonUtilities.DefaultOptions,

--- a/src/Aspire.Cli/Mcp/Tools/ListTraceStructuredLogsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListTraceStructuredLogsTool.cs
@@ -29,21 +29,21 @@ internal sealed class ListTraceStructuredLogsTool : CliMcpTool
             """).RootElement;
     }
 
-    public override async ValueTask<CallToolResult> CallToolAsync(ModelContextProtocol.Client.McpClient mcpClient, IReadOnlyDictionary<string, JsonElement>? arguments, CancellationToken cancellationToken)
+    public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
         // Convert JsonElement arguments to Dictionary<string, object?>
         Dictionary<string, object?>? convertedArgs = null;
-        if (arguments != null)
+        if (context.Arguments != null)
         {
             convertedArgs = new Dictionary<string, object?>();
-            foreach (var kvp in arguments)
+            foreach (var kvp in context.Arguments)
             {
                 convertedArgs[kvp.Key] = kvp.Value.ValueKind == JsonValueKind.Null ? null : kvp.Value;
             }
         }
 
         // Forward the call to the dashboard's MCP server
-        return await mcpClient.CallToolAsync(
+        return await context.McpClient!.CallToolAsync(
             Name,
             convertedArgs,
             serializerOptions: McpJsonUtilities.DefaultOptions,

--- a/src/Aspire.Cli/Mcp/Tools/ListTracesTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ListTracesTool.cs
@@ -28,21 +28,21 @@ internal sealed class ListTracesTool : CliMcpTool
             """).RootElement;
     }
 
-    public override async ValueTask<CallToolResult> CallToolAsync(ModelContextProtocol.Client.McpClient mcpClient, IReadOnlyDictionary<string, JsonElement>? arguments, CancellationToken cancellationToken)
+    public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
         // Convert JsonElement arguments to Dictionary<string, object?>
         Dictionary<string, object?>? convertedArgs = null;
-        if (arguments != null)
+        if (context.Arguments != null)
         {
             convertedArgs = new Dictionary<string, object?>();
-            foreach (var kvp in arguments)
+            foreach (var kvp in context.Arguments)
             {
                 convertedArgs[kvp.Key] = kvp.Value.ValueKind == JsonValueKind.Null ? null : kvp.Value;
             }
         }
 
         // Forward the call to the dashboard's MCP server
-        return await mcpClient.CallToolAsync(
+        return await context.McpClient!.CallToolAsync(
             Name,
             convertedArgs,
             serializerOptions: McpJsonUtilities.DefaultOptions,

--- a/src/Aspire.Cli/Mcp/Tools/RefreshToolsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/RefreshToolsTool.cs
@@ -17,10 +17,9 @@ internal sealed class RefreshToolsTool(Func<CancellationToken, Task<int>> refres
         return JsonDocument.Parse("{ \"type\": \"object\", \"properties\": {} }").RootElement;
     }
 
-    public override async ValueTask<CallToolResult> CallToolAsync(ModelContextProtocol.Client.McpClient mcpClient, IReadOnlyDictionary<string, JsonElement>? arguments, CancellationToken cancellationToken)
+    public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
-        _ = mcpClient;
-        _ = arguments;
+        _ = context;
 
         var count = await refreshToolsAsync(cancellationToken).ConfigureAwait(false);
         await sendToolsListChangedNotificationAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Cli/Mcp/Tools/SelectAppHostTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/SelectAppHostTool.cs
@@ -32,11 +32,12 @@ internal sealed class SelectAppHostTool(IAuxiliaryBackchannelMonitor auxiliaryBa
             """).RootElement;
     }
 
-    public override ValueTask<CallToolResult> CallToolAsync(ModelContextProtocol.Client.McpClient mcpClient, IReadOnlyDictionary<string, JsonElement>? arguments, CancellationToken cancellationToken)
+    public override ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
         // This tool does not use the MCP client as it operates locally
-        _ = mcpClient;
         _ = cancellationToken;
+
+        var arguments = context.Arguments;
 
         if (arguments == null || !arguments.TryGetValue("appHostPath", out var appHostPathElement))
         {

--- a/tests/Aspire.Cli.Tests/Commands/DocsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DocsCommandTests.cs
@@ -170,6 +170,8 @@ public class DocsCommandTests(ITestOutputHelper outputHelper)
 
 internal sealed class TestDocsIndexService : IDocsIndexService
 {
+    public bool IsIndexed => true;
+
     public ValueTask EnsureIndexedAsync(CancellationToken cancellationToken = default)
     {
         return ValueTask.CompletedTask;

--- a/tests/Aspire.Cli.Tests/Mcp/AppHostConnectionSelectionLogicTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/AppHostConnectionSelectionLogicTests.cs
@@ -76,3 +76,4 @@ public class AppHostConnectionSelectionLogicTests
             isInScope);
     }
 }
+

--- a/tests/Aspire.Cli.Tests/Mcp/ExecuteResourceCommandToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ExecuteResourceCommandToolTests.cs
@@ -31,7 +31,7 @@ public class ExecuteResourceCommandToolTests
         var tool = new ExecuteResourceCommandTool(monitor, NullLogger<ExecuteResourceCommandTool>.Instance);
 
         var exception = await Assert.ThrowsAsync<ModelContextProtocol.McpProtocolException>(
-            () => tool.CallToolAsync(null!, CreateArguments("test-resource", "resource-start"), CancellationToken.None).AsTask()).DefaultTimeout();
+            () => tool.CallToolAsync(CallToolContextTestHelper.Create(CreateArguments("test-resource", "resource-start")), CancellationToken.None).AsTask()).DefaultTimeout();
 
         Assert.Contains("No Aspire AppHost", exception.Message);
         Assert.Contains("--detach", exception.Message);
@@ -48,7 +48,7 @@ public class ExecuteResourceCommandToolTests
         monitor.AddConnection("hash1", "socket.hash1", connection);
 
         var tool = new ExecuteResourceCommandTool(monitor, NullLogger<ExecuteResourceCommandTool>.Instance);
-        var result = await tool.CallToolAsync(null!, CreateArguments("api-service", "resource-start"), CancellationToken.None).DefaultTimeout();
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(CreateArguments("api-service", "resource-start")), CancellationToken.None).DefaultTimeout();
 
         Assert.True(result.IsError is null or false);
         Assert.NotNull(result.Content);
@@ -77,7 +77,7 @@ public class ExecuteResourceCommandToolTests
         var tool = new ExecuteResourceCommandTool(monitor, NullLogger<ExecuteResourceCommandTool>.Instance);
 
         var exception = await Assert.ThrowsAsync<ModelContextProtocol.McpProtocolException>(
-            () => tool.CallToolAsync(null!, CreateArguments("nonexistent", "resource-start"), CancellationToken.None).AsTask()).DefaultTimeout();
+            () => tool.CallToolAsync(CallToolContextTestHelper.Create(CreateArguments("nonexistent", "resource-start")), CancellationToken.None).AsTask()).DefaultTimeout();
 
         Assert.Contains("Resource not found", exception.Message);
     }
@@ -99,7 +99,7 @@ public class ExecuteResourceCommandToolTests
         var tool = new ExecuteResourceCommandTool(monitor, NullLogger<ExecuteResourceCommandTool>.Instance);
 
         var exception = await Assert.ThrowsAsync<ModelContextProtocol.McpProtocolException>(
-            () => tool.CallToolAsync(null!, CreateArguments("api-service", "resource-stop"), CancellationToken.None).AsTask()).DefaultTimeout();
+            () => tool.CallToolAsync(CallToolContextTestHelper.Create(CreateArguments("api-service", "resource-stop")), CancellationToken.None).AsTask()).DefaultTimeout();
 
         Assert.Contains("cancelled", exception.Message);
     }
@@ -117,15 +117,15 @@ public class ExecuteResourceCommandToolTests
         var tool = new ExecuteResourceCommandTool(monitor, NullLogger<ExecuteResourceCommandTool>.Instance);
 
         // Test with resource-start
-        var startResult = await tool.CallToolAsync(null!, CreateArguments("api-service", "resource-start"), CancellationToken.None).DefaultTimeout();
+        var startResult = await tool.CallToolAsync(CallToolContextTestHelper.Create(CreateArguments("api-service", "resource-start")), CancellationToken.None).DefaultTimeout();
         Assert.True(startResult.IsError is null or false);
 
         // Test with resource-stop
-        var stopResult = await tool.CallToolAsync(null!, CreateArguments("api-service", "resource-stop"), CancellationToken.None).DefaultTimeout();
+        var stopResult = await tool.CallToolAsync(CallToolContextTestHelper.Create(CreateArguments("api-service", "resource-stop")), CancellationToken.None).DefaultTimeout();
         Assert.True(stopResult.IsError is null or false);
 
         // Test with resource-restart
-        var restartResult = await tool.CallToolAsync(null!, CreateArguments("api-service", "resource-restart"), CancellationToken.None).DefaultTimeout();
+        var restartResult = await tool.CallToolAsync(CallToolContextTestHelper.Create(CreateArguments("api-service", "resource-restart")), CancellationToken.None).DefaultTimeout();
         Assert.True(restartResult.IsError is null or false);
     }
 
@@ -140,14 +140,15 @@ public class ExecuteResourceCommandToolTests
 
         // Test with null arguments
         var exception1 = await Assert.ThrowsAsync<ModelContextProtocol.McpProtocolException>(
-            () => tool.CallToolAsync(null!, null, CancellationToken.None).AsTask()).DefaultTimeout();
+            () => tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).AsTask()).DefaultTimeout();
         Assert.Contains("Missing required arguments", exception1.Message);
 
         // Test with only resourceName
         var partialArgs = JsonDocument.Parse("""{"resourceName": "test"}""").RootElement
             .EnumerateObject().ToDictionary(p => p.Name, p => p.Value.Clone());
         var exception2 = await Assert.ThrowsAsync<ModelContextProtocol.McpProtocolException>(
-            () => tool.CallToolAsync(null!, partialArgs, CancellationToken.None).AsTask()).DefaultTimeout();
+            () => tool.CallToolAsync(CallToolContextTestHelper.Create(partialArgs), CancellationToken.None).AsTask()).DefaultTimeout();
         Assert.Contains("Missing required arguments", exception2.Message);
     }
 }
+

--- a/tests/Aspire.Cli.Tests/Mcp/ListAppHostsToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListAppHostsToolTests.cs
@@ -20,7 +20,7 @@ public class ListAppHostsToolTests(ITestOutputHelper outputHelper)
         var executionContext = CreateCliExecutionContext(workspace.WorkspaceRoot);
 
         var tool = new ListAppHostsTool(monitor, executionContext);
-        var result = await tool.CallToolAsync(null!, null, CancellationToken.None).DefaultTimeout();
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).DefaultTimeout();
 
         Assert.Null(result.IsError);
         Assert.NotNull(result.Content);
@@ -55,7 +55,7 @@ public class ListAppHostsToolTests(ITestOutputHelper outputHelper)
         monitor.AddConnection("hash1", "socket.hash1", connection);
 
         var tool = new ListAppHostsTool(monitor, executionContext);
-        var result = await tool.CallToolAsync(null!, null, CancellationToken.None).DefaultTimeout();
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).DefaultTimeout();
 
         Assert.Null(result.IsError);
         var textContent = result.Content[0] as ModelContextProtocol.Protocol.TextContentBlock;
@@ -87,7 +87,7 @@ public class ListAppHostsToolTests(ITestOutputHelper outputHelper)
         monitor.AddConnection("hash2", "socket.hash2", connection);
 
         var tool = new ListAppHostsTool(monitor, executionContext);
-        var result = await tool.CallToolAsync(null!, null, CancellationToken.None).DefaultTimeout();
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).DefaultTimeout();
 
         Assert.Null(result.IsError);
         var textContent = result.Content[0] as ModelContextProtocol.Protocol.TextContentBlock;
@@ -130,7 +130,7 @@ public class ListAppHostsToolTests(ITestOutputHelper outputHelper)
         monitor.AddConnection("hash2", "socket.hash2", outOfScopeConnection);
 
         var tool = new ListAppHostsTool(monitor, executionContext);
-        var result = await tool.CallToolAsync(null!, null, CancellationToken.None).DefaultTimeout();
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).DefaultTimeout();
 
         Assert.Null(result.IsError);
         var textContent = result.Content[0] as ModelContextProtocol.Protocol.TextContentBlock;
@@ -154,12 +154,12 @@ public class ListAppHostsToolTests(ITestOutputHelper outputHelper)
         Assert.Equal(0, monitor.ScanCallCount);
 
         var tool = new ListAppHostsTool(monitor, executionContext);
-        await tool.CallToolAsync(null!, null, CancellationToken.None).DefaultTimeout();
+        await tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(1, monitor.ScanCallCount);
 
         // Call again to verify it scans each time
-        await tool.CallToolAsync(null!, null, CancellationToken.None).DefaultTimeout();
+        await tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(2, monitor.ScanCallCount);
     }
@@ -178,3 +178,4 @@ public class ListAppHostsToolTests(ITestOutputHelper outputHelper)
         return new AppHostAuxiliaryBackchannel(hash, socketPath, rpc, mcpInfo: null, appHostInfo, isInScope);
     }
 }
+

--- a/tests/Aspire.Cli.Tests/Mcp/ListConsoleLogsToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListConsoleLogsToolTests.cs
@@ -25,7 +25,7 @@ public class ListConsoleLogsToolTests
         };
 
         var exception = await Assert.ThrowsAsync<ModelContextProtocol.McpProtocolException>(
-            () => tool.CallToolAsync(null!, arguments, CancellationToken.None).AsTask()).DefaultTimeout();
+            () => tool.CallToolAsync(CallToolContextTestHelper.Create(arguments), CancellationToken.None).AsTask()).DefaultTimeout();
 
         Assert.Contains("No Aspire AppHost", exception.Message);
         Assert.Contains("--detach", exception.Message);
@@ -41,7 +41,7 @@ public class ListConsoleLogsToolTests
         var tool = new ListConsoleLogsTool(monitor, NullLogger<ListConsoleLogsTool>.Instance);
 
         var exception = await Assert.ThrowsAsync<ModelContextProtocol.McpProtocolException>(
-            () => tool.CallToolAsync(null!, null, CancellationToken.None).AsTask()).DefaultTimeout();
+            () => tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).AsTask()).DefaultTimeout();
 
         Assert.Contains("resourceName", exception.Message);
     }
@@ -63,7 +63,7 @@ public class ListConsoleLogsToolTests
             ["resourceName"] = JsonDocument.Parse("\"test-resource\"").RootElement
         };
 
-        var result = await tool.CallToolAsync(null!, arguments, CancellationToken.None).DefaultTimeout();
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(arguments), CancellationToken.None).DefaultTimeout();
 
         Assert.True(result.IsError is null or false);
         Assert.NotNull(result.Content);
@@ -98,7 +98,7 @@ public class ListConsoleLogsToolTests
             ["resourceName"] = JsonDocument.Parse("\"api-service\"").RootElement
         };
 
-        var result = await tool.CallToolAsync(null!, arguments, CancellationToken.None).DefaultTimeout();
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(arguments), CancellationToken.None).DefaultTimeout();
 
         Assert.True(result.IsError is null or false);
         var textContent = result.Content![0] as ModelContextProtocol.Protocol.TextContentBlock;
@@ -132,7 +132,7 @@ public class ListConsoleLogsToolTests
             ["resourceName"] = JsonDocument.Parse("\"api-service\"").RootElement
         };
 
-        var result = await tool.CallToolAsync(null!, arguments, CancellationToken.None).DefaultTimeout();
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(arguments), CancellationToken.None).DefaultTimeout();
 
         var textContent = result.Content![0] as ModelContextProtocol.Protocol.TextContentBlock;
         Assert.NotNull(textContent);
@@ -162,7 +162,7 @@ public class ListConsoleLogsToolTests
             ["resourceName"] = JsonDocument.Parse("\"api-service\"").RootElement
         };
 
-        var result = await tool.CallToolAsync(null!, arguments, CancellationToken.None).DefaultTimeout();
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(arguments), CancellationToken.None).DefaultTimeout();
 
         var textContent = result.Content![0] as ModelContextProtocol.Protocol.TextContentBlock;
         Assert.NotNull(textContent);
@@ -191,7 +191,7 @@ public class ListConsoleLogsToolTests
             ["resourceName"] = JsonDocument.Parse("\"api-service\"").RootElement
         };
 
-        var result = await tool.CallToolAsync(null!, arguments, CancellationToken.None).DefaultTimeout();
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(arguments), CancellationToken.None).DefaultTimeout();
 
         var textContent = result.Content![0] as ModelContextProtocol.Protocol.TextContentBlock;
         Assert.NotNull(textContent);
@@ -206,3 +206,4 @@ public class ListConsoleLogsToolTests
         return match.Success ? match.Groups[1].Value : string.Empty;
     }
 }
+

--- a/tests/Aspire.Cli.Tests/Mcp/ListDocsToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListDocsToolTests.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Mcp.Tools;
+using Aspire.Cli.Tests.TestServices;
+using Microsoft.AspNetCore.InternalTesting;
+using ModelContextProtocol.Protocol;
+
+namespace Aspire.Cli.Tests.Mcp;
+
+public class ListDocsToolTests
+{
+    [Fact]
+    public async Task ListDocsTool_CallToolAsync_ReturnsDocumentList()
+    {
+        var indexService = new TestDocsIndexService();
+        var tool = new ListDocsTool(indexService);
+
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).DefaultTimeout();
+
+        Assert.True(result.IsError is null or false);
+        Assert.NotNull(result.Content);
+        Assert.Single(result.Content);
+        var textContent = result.Content[0] as TextContentBlock;
+        Assert.NotNull(textContent);
+        Assert.Contains("Aspire Documentation Pages", textContent.Text);
+        Assert.Contains("Getting Started", textContent.Text);
+        Assert.Contains("App Host", textContent.Text);
+        Assert.Contains("Deploy to Azure", textContent.Text);
+    }
+
+    [Fact]
+    public async Task ListDocsTool_CallToolAsync_SendsProgressNotifications_WhenIndexingRequired()
+    {
+        var indexService = new TestDocsIndexService(documents: null, isIndexed: false);
+        var notifier = new TestMcpNotifier();
+        var tool = new ListDocsTool(indexService);
+
+        var context = CallToolContextTestHelper.Create(notifier: notifier, progressToken: "test-progress-token");
+        var result = await tool.CallToolAsync(context, CancellationToken.None).DefaultTimeout();
+
+        Assert.True(result.IsError is null or false);
+        Assert.Contains(NotificationMethods.ProgressNotification, notifier.Notifications);
+        // Should have two progress notifications: start and complete
+        Assert.Equal(2, notifier.Notifications.Count(n => n == NotificationMethods.ProgressNotification));
+    }
+
+    [Fact]
+    public async Task ListDocsTool_CallToolAsync_DoesNotSendProgressNotifications_WhenAlreadyIndexed()
+    {
+        var indexService = new TestDocsIndexService(); // IsIndexed = true by default
+        var notifier = new TestMcpNotifier();
+        var tool = new ListDocsTool(indexService);
+
+        var context = CallToolContextTestHelper.Create(notifier: notifier, progressToken: "test-progress-token");
+        var result = await tool.CallToolAsync(context, CancellationToken.None).DefaultTimeout();
+
+        Assert.True(result.IsError is null or false);
+        Assert.DoesNotContain(NotificationMethods.ProgressNotification, notifier.Notifications);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Mcp/ListIntegrationsToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListIntegrationsToolTests.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.InternalTesting;
 using System.Text.Json;
 using Aspire.Cli.Mcp.Tools;
+using Aspire.Cli.Tests.TestServices;
 
 namespace Aspire.Cli.Tests.Mcp;
 
@@ -49,7 +50,7 @@ public class ListIntegrationsToolTests
         var mockPackagingService = new MockPackagingService();
         var tool = new ListIntegrationsTool(mockPackagingService, TestExecutionContextFactory.CreateTestContext(), new MockAuxiliaryBackchannelMonitor());
 
-        var result = await tool.CallToolAsync(null!, null, CancellationToken.None).DefaultTimeout();
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).DefaultTimeout();
 
         Assert.True(result.IsError is null or false);
         Assert.NotNull(result.Content);
@@ -74,7 +75,7 @@ public class ListIntegrationsToolTests
         });
         var tool = new ListIntegrationsTool(mockPackagingService, TestExecutionContextFactory.CreateTestContext(), new MockAuxiliaryBackchannelMonitor());
 
-        var result = await tool.CallToolAsync(null!, null, CancellationToken.None).DefaultTimeout();
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).DefaultTimeout();
 
         Assert.True(result.IsError is null or false);
         Assert.NotNull(result.Content);
@@ -112,7 +113,7 @@ public class ListIntegrationsToolTests
         });
         var tool = new ListIntegrationsTool(mockPackagingService, TestExecutionContextFactory.CreateTestContext(), new MockAuxiliaryBackchannelMonitor());
 
-        var result = await tool.CallToolAsync(null!, null, CancellationToken.None).DefaultTimeout();
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).DefaultTimeout();
 
         Assert.True(result.IsError is null or false);
 
@@ -122,3 +123,4 @@ public class ListIntegrationsToolTests
         Assert.Equal(1, integrations.GetArrayLength());
     }
 }
+

--- a/tests/Aspire.Cli.Tests/Mcp/ListResourcesToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ListResourcesToolTests.cs
@@ -19,7 +19,7 @@ public class ListResourcesToolTests
         var tool = new ListResourcesTool(monitor, NullLogger<ListResourcesTool>.Instance);
 
         var exception = await Assert.ThrowsAsync<ModelContextProtocol.McpProtocolException>(
-            () => tool.CallToolAsync(null!, null, CancellationToken.None).AsTask()).DefaultTimeout();
+            () => tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).AsTask()).DefaultTimeout();
 
         Assert.Contains("No Aspire AppHost", exception.Message);
         Assert.Contains("--detach", exception.Message);
@@ -37,7 +37,7 @@ public class ListResourcesToolTests
         monitor.AddConnection("hash1", "socket.hash1", connection);
 
         var tool = new ListResourcesTool(monitor, NullLogger<ListResourcesTool>.Instance);
-        var result = await tool.CallToolAsync(null!, null, CancellationToken.None).DefaultTimeout();
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).DefaultTimeout();
 
         Assert.True(result.IsError is null or false);
         Assert.NotNull(result.Content);
@@ -82,7 +82,7 @@ public class ListResourcesToolTests
         monitor.AddConnection("hash1", "socket.hash1", connection);
 
         var tool = new ListResourcesTool(monitor, NullLogger<ListResourcesTool>.Instance);
-        var result = await tool.CallToolAsync(null!, null, CancellationToken.None).DefaultTimeout();
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).DefaultTimeout();
 
         Assert.True(result.IsError is null or false);
         var textContent = result.Content![0] as ModelContextProtocol.Protocol.TextContentBlock;
@@ -118,7 +118,7 @@ public class ListResourcesToolTests
         monitor.AddConnection("hash1", "socket.hash1", connection);
 
         var tool = new ListResourcesTool(monitor, NullLogger<ListResourcesTool>.Instance);
-        var result = await tool.CallToolAsync(null!, null, CancellationToken.None).DefaultTimeout();
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).DefaultTimeout();
 
         var textContent = result.Content![0] as ModelContextProtocol.Protocol.TextContentBlock;
         Assert.NotNull(textContent);
@@ -159,7 +159,7 @@ public class ListResourcesToolTests
         monitor.AddConnection("hash1", "socket.hash1", connection);
 
         var tool = new ListResourcesTool(monitor, NullLogger<ListResourcesTool>.Instance);
-        var result = await tool.CallToolAsync(null!, null, CancellationToken.None).DefaultTimeout();
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(), CancellationToken.None).DefaultTimeout();
 
         var textContent = result.Content![0] as ModelContextProtocol.Protocol.TextContentBlock;
         Assert.NotNull(textContent);
@@ -183,3 +183,4 @@ public class ListResourcesToolTests
         Assert.Equal("Running", resource.GetProperty("state").GetString());
     }
 }
+

--- a/tests/Aspire.Cli.Tests/Mcp/MockPackagingService.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/MockPackagingService.cs
@@ -77,3 +77,4 @@ internal sealed class MockAuxiliaryBackchannelMonitor : IAuxiliaryBackchannelMon
         return [];
     }
 }
+

--- a/tests/Aspire.Cli.Tests/Mcp/TestDocsIndexService.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/TestDocsIndexService.cs
@@ -17,6 +17,8 @@ internal sealed class TestDocsIndexService : IDocsIndexService
         new DocsListItem { Slug = "deployment/azure", Title = "Deploy to Azure", Summary = "Deploy your Aspire app to Azure" },
     ];
 
+    public bool IsIndexed => true;
+
     public ValueTask EnsureIndexedAsync(CancellationToken cancellationToken = default)
     {
         return ValueTask.CompletedTask;
@@ -58,3 +60,4 @@ internal sealed class TestDocsIndexService : IDocsIndexService
         return ValueTask.FromResult<IReadOnlyList<DocsSearchResult>>(results);
     }
 }
+

--- a/tests/Aspire.Cli.Tests/Mcp/TestDocsIndexService.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/TestDocsIndexService.cs
@@ -10,17 +10,39 @@ namespace Aspire.Cli.Tests.Mcp;
 /// </summary>
 internal sealed class TestDocsIndexService : IDocsIndexService
 {
-    private readonly List<DocsListItem> _documents =
+    private static readonly List<DocsListItem> s_defaultDocuments =
     [
         new DocsListItem { Slug = "getting-started", Title = "Getting Started", Summary = "Learn how to get started with Aspire" },
         new DocsListItem { Slug = "fundamentals/app-host", Title = "App Host", Summary = "Learn about the Aspire app host" },
         new DocsListItem { Slug = "deployment/azure", Title = "Deploy to Azure", Summary = "Deploy your Aspire app to Azure" },
     ];
 
-    public bool IsIndexed => true;
+    private readonly List<DocsListItem> _documents;
+    private bool _isIndexed;
+
+    /// <summary>
+    /// Creates a new instance with default documents and already indexed.
+    /// </summary>
+    public TestDocsIndexService() : this(s_defaultDocuments, isIndexed: true)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance with specified documents and indexing state.
+    /// </summary>
+    /// <param name="documents">The documents to return. If null, uses default documents.</param>
+    /// <param name="isIndexed">Whether the service starts in an indexed state.</param>
+    public TestDocsIndexService(IEnumerable<DocsListItem>? documents, bool isIndexed = true)
+    {
+        _documents = documents?.ToList() ?? [.. s_defaultDocuments];
+        _isIndexed = isIndexed;
+    }
+
+    public bool IsIndexed => _isIndexed;
 
     public ValueTask EnsureIndexedAsync(CancellationToken cancellationToken = default)
     {
+        _isIndexed = true;
         return ValueTask.CompletedTask;
     }
 

--- a/tests/Aspire.Cli.Tests/Mcp/TestMcpServerTransport.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/TestMcpServerTransport.cs
@@ -79,3 +79,4 @@ internal sealed class TestMcpServerTransport : IMcpTransportFactory, IDisposable
         CompletePipes();
     }
 }
+

--- a/tests/Aspire.Cli.Tests/TestServices/CallToolContextTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/CallToolContextTestHelper.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.Cli.Mcp.Tools;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+/// <summary>
+/// Provides helper methods for creating <see cref="CallToolContext"/> instances in tests.
+/// </summary>
+internal static class CallToolContextTestHelper
+{
+    /// <summary>
+    /// Creates a <see cref="CallToolContext"/> for testing with optional arguments.
+    /// </summary>
+    /// <param name="arguments">Optional arguments to pass to the tool.</param>
+    /// <returns>A new <see cref="CallToolContext"/> configured for testing.</returns>
+    public static CallToolContext Create(IReadOnlyDictionary<string, JsonElement>? arguments = null)
+    {
+        return Create(new TestMcpNotifier(), arguments);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="CallToolContext"/> for testing with a specific notifier and optional arguments.
+    /// </summary>
+    /// <param name="notifier">The notifier to use.</param>
+    /// <param name="arguments">Optional arguments to pass to the tool.</param>
+    /// <returns>A new <see cref="CallToolContext"/> configured for testing.</returns>
+    public static CallToolContext Create(TestMcpNotifier notifier, IReadOnlyDictionary<string, JsonElement>? arguments = null)
+    {
+        return new CallToolContext
+        {
+            Notifier = notifier,
+            McpClient = null,
+            Arguments = arguments
+        };
+    }
+}

--- a/tests/Aspire.Cli.Tests/TestServices/CallToolContextTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/CallToolContextTestHelper.cs
@@ -12,28 +12,23 @@ namespace Aspire.Cli.Tests.TestServices;
 internal static class CallToolContextTestHelper
 {
     /// <summary>
-    /// Creates a <see cref="CallToolContext"/> for testing with optional arguments.
+    /// Creates a <see cref="CallToolContext"/> for testing.
     /// </summary>
     /// <param name="arguments">Optional arguments to pass to the tool.</param>
+    /// <param name="notifier">Optional notifier to use. If null, a new <see cref="TestMcpNotifier"/> is created.</param>
+    /// <param name="progressToken">Optional progress token to include in the context.</param>
     /// <returns>A new <see cref="CallToolContext"/> configured for testing.</returns>
-    public static CallToolContext Create(IReadOnlyDictionary<string, JsonElement>? arguments = null)
-    {
-        return Create(new TestMcpNotifier(), arguments);
-    }
-
-    /// <summary>
-    /// Creates a <see cref="CallToolContext"/> for testing with a specific notifier and optional arguments.
-    /// </summary>
-    /// <param name="notifier">The notifier to use.</param>
-    /// <param name="arguments">Optional arguments to pass to the tool.</param>
-    /// <returns>A new <see cref="CallToolContext"/> configured for testing.</returns>
-    public static CallToolContext Create(TestMcpNotifier notifier, IReadOnlyDictionary<string, JsonElement>? arguments = null)
+    public static CallToolContext Create(
+        IReadOnlyDictionary<string, JsonElement>? arguments = null,
+        TestMcpNotifier? notifier = null,
+        string? progressToken = null)
     {
         return new CallToolContext
         {
-            Notifier = notifier,
+            Notifier = notifier ?? new TestMcpNotifier(),
             McpClient = null,
-            Arguments = arguments
+            Arguments = arguments,
+            ProgressToken = progressToken is not null ? new ModelContextProtocol.Protocol.ProgressToken(progressToken) : null
         };
     }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestMcpNotifier.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestMcpNotifier.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Mcp;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+/// <summary>
+/// A test implementation of <see cref="IMcpNotifier"/> that collects notifications.
+/// </summary>
+internal sealed class TestMcpNotifier : IMcpNotifier
+{
+    private readonly List<string> _notifications = [];
+
+    /// <summary>
+    /// Gets the list of notification methods that have been sent.
+    /// </summary>
+    public IReadOnlyList<string> Notifications => _notifications;
+
+    /// <inheritdoc />
+    public Task SendNotificationAsync(string method, CancellationToken cancellationToken = default)
+    {
+        _notifications.Add(method);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task SendNotificationAsync<TParams>(string method, TParams parameters, CancellationToken cancellationToken = default)
+    {
+        _notifications.Add(method);
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Description

Don't download/index docs when not needed.

PR:
- No longer indexes docs on MCP start
- Adds a helper method for indexing docs with [MCP progress notifications](https://modelcontextprotocol.info/specification/draft/basic/utilities/progress/). `Indexing Aspire docs...` displays immediately, `Aspire docs indexed` when finished.

![mcp-notifications](https://github.com/user-attachments/assets/626b7503-1e6c-4a68-a572-d8d7a2621be0)

Fixes https://github.com/dotnet/aspire/issues/14280

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
