### PR TITLE
Add VS Code launch.json with Aspire debugger configs for all playground apps

### DIFF
--- a/playground/AspireEventHub/.vscode/launch.json
+++ b/playground/AspireEventHub/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/AspireWithJavaScript/.vscode/launch.json
+++ b/playground/AspireWithJavaScript/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/AspireWithMaui/.vscode/launch.json
+++ b/playground/AspireWithMaui/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/AspireWithNode/.vscode/launch.json
+++ b/playground/AspireWithNode/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/AzureAIFoundryEndToEnd/.vscode/launch.json
+++ b/playground/AzureAIFoundryEndToEnd/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/AzureAppConfiguration/.vscode/launch.json
+++ b/playground/AzureAppConfiguration/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/AzureAppService/.vscode/launch.json
+++ b/playground/AzureAppService/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/AzureContainerApps/.vscode/launch.json
+++ b/playground/AzureContainerApps/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/AzureDataLakeEndToEnd/.vscode/launch.json
+++ b/playground/AzureDataLakeEndToEnd/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/AzureFunctionsEndToEnd/.vscode/launch.json
+++ b/playground/AzureFunctionsEndToEnd/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/AzureKusto/.vscode/launch.json
+++ b/playground/AzureKusto/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/AzureOpenAIEndToEnd/.vscode/launch.json
+++ b/playground/AzureOpenAIEndToEnd/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/AzureSearchEndToEnd/.vscode/launch.json
+++ b/playground/AzureSearchEndToEnd/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/AzureServiceBus/.vscode/launch.json
+++ b/playground/AzureServiceBus/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/AzureStorageEndToEnd/.vscode/launch.json
+++ b/playground/AzureStorageEndToEnd/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/BrowserTelemetry/.vscode/launch.json
+++ b/playground/BrowserTelemetry/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/CosmosEndToEnd/.vscode/launch.json
+++ b/playground/CosmosEndToEnd/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/CustomResources/.vscode/launch.json
+++ b/playground/CustomResources/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/DatabaseMigration/.vscode/launch.json
+++ b/playground/DatabaseMigration/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/DevTunnels/.vscode/launch.json
+++ b/playground/DevTunnels/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/DotnetTool/.vscode/launch.json
+++ b/playground/DotnetTool/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/ExternalServices/.vscode/launch.json
+++ b/playground/ExternalServices/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/FileBasedApps/.vscode/launch.json
+++ b/playground/FileBasedApps/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}/apphost.cs"
+        }
+    ]
+}

--- a/playground/GitHubModelsEndToEnd/.vscode/launch.json
+++ b/playground/GitHubModelsEndToEnd/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/HealthChecks/.vscode/launch.json
+++ b/playground/HealthChecks/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/OpenAIEndToEnd/.vscode/launch.json
+++ b/playground/OpenAIEndToEnd/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/OracleEndToEnd/.vscode/launch.json
+++ b/playground/OracleEndToEnd/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/ParameterEndToEnd/.vscode/launch.json
+++ b/playground/ParameterEndToEnd/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/PostgresEndToEnd/.vscode/launch.json
+++ b/playground/PostgresEndToEnd/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/ProxylessEndToEnd/.vscode/launch.json
+++ b/playground/ProxylessEndToEnd/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/Qdrant/.vscode/launch.json
+++ b/playground/Qdrant/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/Redis/.vscode/launch.json
+++ b/playground/Redis/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/SqlServerEndToEnd/.vscode/launch.json
+++ b/playground/SqlServerEndToEnd/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/SqlServerScript/.vscode/launch.json
+++ b/playground/SqlServerScript/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/Stress/.vscode/launch.json
+++ b/playground/Stress/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/TestShop/.vscode/launch.json
+++ b/playground/TestShop/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/TypeScriptAppHost/.vscode/launch.json
+++ b/playground/TypeScriptAppHost/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}/apphost.ts"
+        }
+    ]
+}

--- a/playground/bicep/.vscode/launch.json
+++ b/playground/bicep/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/cdk/.vscode/launch.json
+++ b/playground/cdk/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/deployers/.vscode/launch.json
+++ b/playground/deployers/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/kafka/.vscode/launch.json
+++ b/playground/kafka/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/keycloak/.vscode/launch.json
+++ b/playground/keycloak/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/milvus/.vscode/launch.json
+++ b/playground/milvus/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/mongo/.vscode/launch.json
+++ b/playground/mongo/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/mysql/.vscode/launch.json
+++ b/playground/mysql/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/nats/.vscode/launch.json
+++ b/playground/nats/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/orleans/.vscode/launch.json
+++ b/playground/orleans/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/pipelines/.vscode/launch.json
+++ b/playground/pipelines/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/publishers/.vscode/launch.json
+++ b/playground/publishers/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/python/.vscode/launch.json
+++ b/playground/python/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/seq/.vscode/launch.json
+++ b/playground/seq/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/signalr/.vscode/launch.json
+++ b/playground/signalr/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/waitfor/.vscode/launch.json
+++ b/playground/waitfor/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/webpubsub/.vscode/launch.json
+++ b/playground/webpubsub/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/withdockerfile/.vscode/launch.json
+++ b/playground/withdockerfile/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/playground/yarp/.vscode/launch.json
+++ b/playground/yarp/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run AppHost",
+            "type": "aspire",
+            "request": "launch",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}


### PR DESCRIPTION
## Description

Adds `.vscode/launch.json` files to all 56 playground applications with Aspire debugger configurations. This allows developers to easily debug any playground app by opening the folder in VS Code and pressing F5.

- For standard .NET AppHost projects: uses `"program": "${workspaceFolder}"`
- For file-based apps (FileBasedApps): uses `"program": "${workspaceFolder}/apphost.cs"`
- For TypeScript AppHost: uses `"program": "${workspaceFolder}/apphost.ts"`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No