### PR TITLE
Add AKS starter deployment E2E test

### DIFF
--- a/src/Aspire.Hosting.Kubernetes/Extensions/ResourceExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/Extensions/ResourceExtensions.cs
@@ -140,17 +140,12 @@ internal static class ResourceExtensions
             },
         };
 
-        // Deduplicate ports by underlying value and protocol to avoid invalid Service specs.
-        // When a ProjectResource has both http and https endpoints with no explicit port,
-        // GenerateDefaultProjectEndpointMapping assigns port 8080 to both, creating separate
-        // EndpointMappings with distinct Helm expressions (port_http, port_https) that resolve
-        // to the same value. We compare using HelmValue.ValueString (e.g., "8080") rather than
-        // ToScalar() (which returns the Helm template expression) to catch these duplicates.
-        //
-        // Note: The Docker Compose publisher has the same underlying issue but avoids it
-        // because it uses HashSet<string> on the raw port string in AddPorts(), which
-        // naturally deduplicates identical port values. Ideally the deduplication would happen
-        // upstream in ProcessEndpoints, but for now each publisher handles it independently.
+        // Defense-in-depth: deduplicate ports by underlying value and protocol.
+        // The primary fix is in ProcessEndpoints() which skips the DefaultHttpsEndpoint
+        // (matching the core framework's SetBothPortsEnvVariables behavior). This dedup
+        // remains as a safety net for edge cases where multiple endpoints might still
+        // resolve to the same port value.
+        // See: https://github.com/dotnet/aspire/issues/14029
         var addedPorts = new HashSet<(string Port, string Protocol)>();
         foreach (var (_, mapping) in context.EndpointMappings)
         {
@@ -287,7 +282,7 @@ internal static class ResourceExtensions
             return container;
         }
 
-        // Deduplicate container ports for the same reason as ToService() above.
+        // Defense-in-depth: deduplicate container ports (same rationale as ToService() above).
         var addedPorts = new HashSet<(string Port, string Protocol)>();
         foreach (var (_, mapping) in context.EndpointMappings)
         {

--- a/src/Aspire.Hosting.Kubernetes/Extensions/ResourceExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/Extensions/ResourceExtensions.cs
@@ -140,8 +140,16 @@ internal static class ResourceExtensions
             },
         };
 
+        // Deduplicate ports by port number and protocol to avoid invalid Service specs
+        var addedPorts = new HashSet<(string Port, string Protocol)>();
         foreach (var (_, mapping) in context.EndpointMappings)
         {
+            var portKey = (mapping.Port.ToScalar(), mapping.Protocol);
+            if (!addedPorts.Add(portKey))
+            {
+                continue; // Skip duplicate port/protocol combinations
+            }
+
             service.Spec.Ports.Add(
                 new()
                 {

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -118,6 +118,7 @@
     <InternalsVisibleTo Include="Aspire.Hosting.DotnetTool.Tests" />
     <InternalsVisibleTo Include="Aspire.TestUtilities" />
     <InternalsVisibleTo Include="Aspire.Cli.Tests" />
+    <InternalsVisibleTo Include="Aspire.Hosting.Kubernetes" />
     <InternalsVisibleTo Include="Aspire.Hosting.RemoteHost" />
     <InternalsVisibleTo Include="Aspire.Hosting.RemoteHost.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.CodeGeneration.TypeScript" />

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
@@ -114,14 +114,14 @@ public sealed class AksStarterDeploymentTests(ITestOutputHelper output)
                 .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(3));
 
             // Step 5: Create AKS cluster with ACR attached
-            // Using minimal configuration: 1 node, Standard_B2s (smallest viable)
+            // Using minimal configuration: 1 node, Standard_B2s_v2 (smallest viable in westus3)
             output.WriteLine("Step 5: Creating AKS cluster (this may take 10-15 minutes)...");
             sequenceBuilder
                 .Type($"az aks create " +
                       $"--resource-group {resourceGroupName} " +
                       $"--name {clusterName} " +
                       $"--node-count 1 " +
-                      $"--node-vm-size Standard_B2s " +
+                      $"--node-vm-size Standard_B2s_v2 " +
                       $"--generate-ssh-keys " +
                       $"--attach-acr {acrName} " +
                       $"--enable-managed-identity " +

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
@@ -369,9 +369,10 @@ builder.Build().Run();
                 .Type("kubectl port-forward svc/apiservice-service 18080:8080 &")
                 .Enter()
                 .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(10))
-                .Type("sleep 3 && curl -sf http://localhost:18080/health && echo ' OK'")
+                // Use retry loop: app may need a few seconds to start accepting connections
+                .Type("for i in $(seq 1 10); do sleep 3 && curl -so /dev/null -w '%{http_code}' http://localhost:18080/health && break; done && echo ' OK'")
                 .Enter()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(60));
 
             // Step 26: Verify webfrontend is serving traffic via port-forward
             output.WriteLine("Step 26: Verifying webfrontend health endpoint...");
@@ -379,9 +380,9 @@ builder.Build().Run();
                 .Type("kubectl port-forward svc/webfrontend-service 18081:8080 &")
                 .Enter()
                 .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(10))
-                .Type("sleep 3 && curl -sf http://localhost:18081/health && echo ' OK'")
+                .Type("for i in $(seq 1 10); do sleep 3 && curl -so /dev/null -w '%{http_code}' http://localhost:18081/health && break; done && echo ' OK'")
                 .Enter()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(60));
 
             // Step 27: Clean up port-forwards
             output.WriteLine("Step 27: Cleaning up port-forwards...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
@@ -1,0 +1,220 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Tests.Utils;
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Hex1b;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests for deploying Aspire applications to Azure Kubernetes Service (AKS).
+/// </summary>
+public sealed class AksStarterDeploymentTests(ITestOutputHelper output)
+{
+    // Timeout set to 45 minutes to allow for AKS provisioning (~10-15 min) plus deployment.
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(45);
+
+    [Fact]
+    public async Task DeployStarterTemplateToAks()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+        var cancellationToken = linkedCts.Token;
+
+        await DeployStarterTemplateToAksCore(cancellationToken);
+    }
+
+    private async Task DeployStarterTemplateToAksCore(CancellationToken cancellationToken)
+    {
+        // Validate prerequisites
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var recordingPath = DeploymentE2ETestHelpers.GetTestResultsRecordingPath(nameof(DeployStarterTemplateToAks));
+        var startTime = DateTime.UtcNow;
+
+        // Generate unique names for Azure resources
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("aks");
+        var clusterName = $"aks-{DeploymentE2ETestHelpers.GetRunId()}-{DeploymentE2ETestHelpers.GetRunAttempt()}";
+        // ACR names must be alphanumeric only, 5-50 chars, globally unique
+        var acrName = $"acr{DeploymentE2ETestHelpers.GetRunId()}{DeploymentE2ETestHelpers.GetRunAttempt()}".ToLowerInvariant();
+        // Ensure ACR name is valid (alphanumeric, 5-50 chars)
+        acrName = new string(acrName.Where(char.IsLetterOrDigit).Take(50).ToArray());
+        if (acrName.Length < 5)
+        {
+            acrName = $"acrtest{Guid.NewGuid():N}"[..24];
+        }
+
+        output.WriteLine($"Test: {nameof(DeployStarterTemplateToAks)}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"AKS Cluster: {clusterName}");
+        output.WriteLine($"ACR Name: {acrName}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            var builder = Hex1bTerminal.CreateBuilder()
+                .WithHeadless()
+                .WithDimensions(160, 48)
+                .WithAsciinemaRecording(recordingPath)
+                .WithPtyProcess("/bin/bash", ["--norc"]);
+
+            using var terminal = builder.Build();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            var counter = new SequenceCounter();
+            var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+            // Step 1: Prepare environment
+            output.WriteLine("Step 1: Preparing environment...");
+            sequenceBuilder.PrepareEnvironment(workspace, counter);
+
+            // Step 2: Create resource group
+            output.WriteLine("Step 2: Creating resource group...");
+            sequenceBuilder
+                .Type($"az group create --name {resourceGroupName} --location westus3 --output table")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(60));
+
+            // Step 3: Create Azure Container Registry
+            output.WriteLine("Step 3: Creating Azure Container Registry...");
+            sequenceBuilder
+                .Type($"az acr create --resource-group {resourceGroupName} --name {acrName} --sku Basic --output table")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(3));
+
+            // Step 4: Create AKS cluster with ACR attached
+            // Using minimal configuration: 1 node, Standard_B2s (smallest viable)
+            output.WriteLine("Step 4: Creating AKS cluster (this may take 10-15 minutes)...");
+            sequenceBuilder
+                .Type($"az aks create " +
+                      $"--resource-group {resourceGroupName} " +
+                      $"--name {clusterName} " +
+                      $"--node-count 1 " +
+                      $"--node-vm-size Standard_B2s " +
+                      $"--generate-ssh-keys " +
+                      $"--attach-acr {acrName} " +
+                      $"--enable-managed-identity " +
+                      $"--output table")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(20));
+
+            // Step 5: Configure kubectl credentials
+            output.WriteLine("Step 5: Configuring kubectl credentials...");
+            sequenceBuilder
+                .Type($"az aks get-credentials --resource-group {resourceGroupName} --name {clusterName} --overwrite-existing")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
+
+            // Step 6: Verify kubectl connectivity
+            output.WriteLine("Step 6: Verifying kubectl connectivity...");
+            sequenceBuilder
+                .Type("kubectl get nodes")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
+
+            // Step 7: Verify cluster is healthy
+            output.WriteLine("Step 7: Verifying cluster health...");
+            sequenceBuilder
+                .Type("kubectl cluster-info")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
+
+            // Step 8: Exit terminal
+            sequenceBuilder
+                .Type("exit")
+                .Enter();
+
+            var sequence = sequenceBuilder.Build();
+            await sequence.ApplyAsync(terminal, cancellationToken);
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"AKS cluster creation and verification completed in {duration}");
+
+            // Report success
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployStarterTemplateToAks),
+                resourceGroupName,
+                new Dictionary<string, string>
+                {
+                    ["cluster"] = clusterName,
+                    ["acr"] = acrName
+                },
+                duration);
+
+            output.WriteLine("✅ Phase 1 Test passed - AKS cluster created and verified!");
+        }
+        catch (Exception ex)
+        {
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"❌ Test failed after {duration}: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployStarterTemplateToAks),
+                resourceGroupName,
+                ex.Message,
+                ex.StackTrace);
+
+            throw;
+        }
+        finally
+        {
+            // Clean up the resource group we created (includes AKS cluster and ACR)
+            output.WriteLine($"Triggering cleanup of resource group: {resourceGroupName}");
+            TriggerCleanupResourceGroup(resourceGroupName, output);
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Cleanup triggered (fire-and-forget)");
+        }
+    }
+
+    /// <summary>
+    /// Triggers cleanup of a specific resource group.
+    /// This is fire-and-forget - the hourly cleanup workflow handles any missed resources.
+    /// </summary>
+    private static void TriggerCleanupResourceGroup(string resourceGroupName, ITestOutputHelper output)
+    {
+        var process = new System.Diagnostics.Process
+        {
+            StartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "az",
+                Arguments = $"group delete --name {resourceGroupName} --yes --no-wait",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        try
+        {
+            process.Start();
+            output.WriteLine($"Cleanup triggered for resource group: {resourceGroupName}");
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Failed to trigger cleanup: {ex.Message}");
+        }
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
@@ -342,22 +342,29 @@ builder.Build().Run();
                 .Enter()
                 .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(12));
 
-            // Step 22: Verify pods are running
-            output.WriteLine("Step 22: Verifying pods are running...");
+            // Step 22: Wait for pods to be ready
+            output.WriteLine("Step 22: Waiting for pods to be ready...");
+            sequenceBuilder
+                .Type("kubectl wait --for=condition=ready pod --all -n default --timeout=120s")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(3));
+
+            // Step 23: Verify pods are running
+            output.WriteLine("Step 23: Verifying pods are running...");
             sequenceBuilder
                 .Type("kubectl get pods -n default")
                 .Enter()
                 .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
 
-            // Step 23: Verify deployments are healthy
-            output.WriteLine("Step 23: Verifying deployments...");
+            // Step 24: Verify deployments are healthy
+            output.WriteLine("Step 24: Verifying deployments...");
             sequenceBuilder
                 .Type("kubectl get deployments -n default")
                 .Enter()
                 .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
 
-            // Step 24: Verify apiservice is serving traffic via port-forward
-            output.WriteLine("Step 24: Verifying apiservice health endpoint...");
+            // Step 25: Verify apiservice is serving traffic via port-forward
+            output.WriteLine("Step 25: Verifying apiservice health endpoint...");
             sequenceBuilder
                 .Type("kubectl port-forward svc/apiservice-service 18080:8080 &")
                 .Enter()
@@ -366,8 +373,8 @@ builder.Build().Run();
                 .Enter()
                 .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
 
-            // Step 25: Verify webfrontend is serving traffic via port-forward
-            output.WriteLine("Step 25: Verifying webfrontend health endpoint...");
+            // Step 26: Verify webfrontend is serving traffic via port-forward
+            output.WriteLine("Step 26: Verifying webfrontend health endpoint...");
             sequenceBuilder
                 .Type("kubectl port-forward svc/webfrontend-service 18081:8080 &")
                 .Enter()
@@ -376,14 +383,14 @@ builder.Build().Run();
                 .Enter()
                 .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
 
-            // Step 26: Clean up port-forwards
-            output.WriteLine("Step 26: Cleaning up port-forwards...");
+            // Step 27: Clean up port-forwards
+            output.WriteLine("Step 27: Cleaning up port-forwards...");
             sequenceBuilder
                 .Type("kill %1 %2 2>/dev/null; true")
                 .Enter()
                 .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(10));
 
-            // Step 27: Exit terminal
+            // Step 28: Exit terminal
             sequenceBuilder
                 .Type("exit")
                 .Enter();

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
@@ -114,14 +114,14 @@ public sealed class AksStarterDeploymentTests(ITestOutputHelper output)
                 .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(3));
 
             // Step 5: Create AKS cluster with ACR attached
-            // Using minimal configuration: 1 node, Standard_B2s_v2 (smallest viable in westus3)
+            // Using minimal configuration: 1 node, Standard_D2s_v3 (widely available with quota)
             output.WriteLine("Step 5: Creating AKS cluster (this may take 10-15 minutes)...");
             sequenceBuilder
                 .Type($"az aks create " +
                       $"--resource-group {resourceGroupName} " +
                       $"--name {clusterName} " +
                       $"--node-count 1 " +
-                      $"--node-vm-size Standard_B2s_v2 " +
+                      $"--node-vm-size Standard_D2s_v3 " +
                       $"--generate-ssh-keys " +
                       $"--attach-acr {acrName} " +
                       $"--enable-managed-identity " +

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
@@ -364,23 +364,23 @@ builder.Build().Run();
                 .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
 
             // Step 25: Verify apiservice is serving traffic via port-forward
-            output.WriteLine("Step 25: Verifying apiservice health endpoint...");
+            // Use /weatherforecast (the actual API endpoint) since /health is only available in Development
+            output.WriteLine("Step 25: Verifying apiservice endpoint...");
             sequenceBuilder
                 .Type("kubectl port-forward svc/apiservice-service 18080:8080 &")
                 .Enter()
                 .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(10))
-                // Use retry loop: app may need a few seconds to start accepting connections
-                .Type("for i in $(seq 1 10); do sleep 3 && curl -so /dev/null -w '%{http_code}' http://localhost:18080/health && break; done && echo ' OK'")
+                .Type("for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18080/weatherforecast -o /dev/null -w '%{http_code}' && echo ' OK' && break; done")
                 .Enter()
                 .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(60));
 
             // Step 26: Verify webfrontend is serving traffic via port-forward
-            output.WriteLine("Step 26: Verifying webfrontend health endpoint...");
+            output.WriteLine("Step 26: Verifying webfrontend endpoint...");
             sequenceBuilder
                 .Type("kubectl port-forward svc/webfrontend-service 18081:8080 &")
                 .Enter()
                 .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(10))
-                .Type("for i in $(seq 1 10); do sleep 3 && curl -so /dev/null -w '%{http_code}' http://localhost:18081/health && break; done && echo ' OK'")
+                .Type("for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18081/ -o /dev/null -w '%{http_code}' && echo ' OK' && break; done")
                 .Enter()
                 .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(60));
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
@@ -57,7 +57,7 @@ public sealed class AksStarterDeploymentTests(ITestOutputHelper output)
         var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("aks");
         var clusterName = $"aks-{DeploymentE2ETestHelpers.GetRunId()}-{DeploymentE2ETestHelpers.GetRunAttempt()}";
         // ACR names must be alphanumeric only, 5-50 chars, globally unique
-        var acrName = $"acr{DeploymentE2ETestHelpers.GetRunId()}{DeploymentE2ETestHelpers.GetRunAttempt()}".ToLowerInvariant();
+        var acrName = $"acrs{DeploymentE2ETestHelpers.GetRunId()}{DeploymentE2ETestHelpers.GetRunAttempt()}".ToLowerInvariant();
         // Ensure ACR name is valid (alphanumeric, 5-50 chars)
         acrName = new string(acrName.Where(char.IsLetterOrDigit).Take(50).ToArray());
         if (acrName.Length < 5)

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
@@ -356,7 +356,34 @@ builder.Build().Run();
                 .Enter()
                 .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
 
-            // Step 24: Exit terminal
+            // Step 24: Verify apiservice is serving traffic via port-forward
+            output.WriteLine("Step 24: Verifying apiservice health endpoint...");
+            sequenceBuilder
+                .Type("kubectl port-forward svc/apiservice-service 18080:8080 &")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(10))
+                .Type("sleep 3 && curl -sf http://localhost:18080/health && echo ' OK'")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
+
+            // Step 25: Verify webfrontend is serving traffic via port-forward
+            output.WriteLine("Step 25: Verifying webfrontend health endpoint...");
+            sequenceBuilder
+                .Type("kubectl port-forward svc/webfrontend-service 18081:8080 &")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(10))
+                .Type("sleep 3 && curl -sf http://localhost:18081/health && echo ' OK'")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
+
+            // Step 26: Clean up port-forwards
+            output.WriteLine("Step 26: Cleaning up port-forwards...");
+            sequenceBuilder
+                .Type("kill %1 %2 2>/dev/null; true")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(10));
+
+            // Step 27: Exit terminal
             sequenceBuilder
                 .Type("exit")
                 .Enter();

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
@@ -240,15 +240,21 @@ public sealed class AksStarterDeploymentTests(ITestOutputHelper output)
 
                 // Insert the Kubernetes environment before builder.Build().Run();
                 var buildRunPattern = "builder.Build().Run();";
-                var replacement = $"""
+                var replacement = """
 // Add Kubernetes environment for deployment
-builder.AddKubernetesEnvironment("k8s")
-    .WithProperties(props => props.ContainerRegistry = "{acrName}.azurecr.io");
+builder.AddKubernetesEnvironment("k8s");
 
 builder.Build().Run();
 """;
 
                 content = content.Replace(buildRunPattern, replacement);
+
+                // Add required pragma to suppress experimental warning
+                if (!content.Contains("#pragma warning disable ASPIREPIPELINES001"))
+                {
+                    content = "#pragma warning disable ASPIREPIPELINES001\n" + content;
+                }
+
                 File.WriteAllText(appHostFilePath, content);
 
                 output.WriteLine("Modified AppHost.cs with AddKubernetesEnvironment");
@@ -268,15 +274,43 @@ builder.Build().Run();
                 .Enter()
                 .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(60));
 
-            // Step 16: Run aspire publish to generate Helm charts and push images
-            output.WriteLine("Step 16: Running aspire publish to generate Helm charts...");
+            // Step 16: Build and push container images to ACR
+            // The starter template creates webfrontend and apiservice projects
+            output.WriteLine("Step 16: Building and pushing container images to ACR...");
+            sequenceBuilder
+                .Type($"cd .. && " +
+                      $"dotnet publish {projectName}.Web/{projectName}.Web.csproj " +
+                      $"/t:PublishContainer " +
+                      $"/p:ContainerRegistry={acrName}.azurecr.io " +
+                      $"/p:ContainerImageName=webfrontend " +
+                      $"/p:ContainerImageTag=latest")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+
+            sequenceBuilder
+                .Type($"dotnet publish {projectName}.ApiService/{projectName}.ApiService.csproj " +
+                      $"/t:PublishContainer " +
+                      $"/p:ContainerRegistry={acrName}.azurecr.io " +
+                      $"/p:ContainerImageName=apiservice " +
+                      $"/p:ContainerImageTag=latest")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+
+            // Navigate back to AppHost directory
+            sequenceBuilder
+                .Type($"cd {projectName}.AppHost")
+                .Enter()
+                .WaitForSuccessPrompt(counter);
+
+            // Step 17: Run aspire publish to generate Helm charts
+            output.WriteLine("Step 17: Running aspire publish to generate Helm charts...");
             sequenceBuilder
                 .Type($"aspire publish --output-path ../charts")
                 .Enter()
                 .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(10));
 
-            // Step 17: Verify Helm chart was generated
-            output.WriteLine("Step 17: Verifying Helm chart generation...");
+            // Step 18: Verify Helm chart was generated
+            output.WriteLine("Step 18: Verifying Helm chart generation...");
             sequenceBuilder
                 .Type("ls -la ../charts && cat ../charts/Chart.yaml")
                 .Enter()
@@ -284,28 +318,30 @@ builder.Build().Run();
 
             // ===== PHASE 3: Deploy to AKS and Verify =====
 
-            // Step 18: Deploy Helm chart to AKS
-            output.WriteLine("Step 18: Deploying Helm chart to AKS...");
+            // Step 19: Deploy Helm chart to AKS with ACR image overrides
+            output.WriteLine("Step 19: Deploying Helm chart to AKS...");
             sequenceBuilder
-                .Type("helm install aksstarter ../charts --namespace default --wait --timeout 10m")
+                .Type($"helm install aksstarter ../charts --namespace default --wait --timeout 10m " +
+                      $"--set webfrontend.image={acrName}.azurecr.io/webfrontend:latest " +
+                      $"--set apiservice.image={acrName}.azurecr.io/apiservice:latest")
                 .Enter()
                 .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(12));
 
-            // Step 19: Verify pods are running
-            output.WriteLine("Step 19: Verifying pods are running...");
+            // Step 20: Verify pods are running
+            output.WriteLine("Step 20: Verifying pods are running...");
             sequenceBuilder
                 .Type("kubectl get pods -n default")
                 .Enter()
                 .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
 
-            // Step 20: Verify deployments are healthy
-            output.WriteLine("Step 20: Verifying deployments...");
+            // Step 21: Verify deployments are healthy
+            output.WriteLine("Step 21: Verifying deployments...");
             sequenceBuilder
                 .Type("kubectl get deployments -n default")
                 .Enter()
                 .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
 
-            // Step 21: Exit terminal
+            // Step 22: Exit terminal
             sequenceBuilder
                 .Type("exit")
                 .Enter();

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterWithRedisDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterWithRedisDeploymentTests.cs
@@ -58,7 +58,7 @@ public sealed class AksStarterWithRedisDeploymentTests(ITestOutputHelper output)
         var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("aksredis");
         var clusterName = $"aks-{DeploymentE2ETestHelpers.GetRunId()}-{DeploymentE2ETestHelpers.GetRunAttempt()}";
         // ACR names must be alphanumeric only, 5-50 chars, globally unique
-        var acrName = $"acr{DeploymentE2ETestHelpers.GetRunId()}{DeploymentE2ETestHelpers.GetRunAttempt()}".ToLowerInvariant();
+        var acrName = $"acrr{DeploymentE2ETestHelpers.GetRunId()}{DeploymentE2ETestHelpers.GetRunAttempt()}".ToLowerInvariant();
         acrName = new string(acrName.Where(char.IsLetterOrDigit).Take(50).ToArray());
         if (acrName.Length < 5)
         {

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterWithRedisDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterWithRedisDeploymentTests.cs
@@ -1,0 +1,496 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Tests.Utils;
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Hex1b;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests for deploying Aspire starter template with Redis to AKS.
+/// This validates that the starter template with Redis cache works out-of-the-box on Kubernetes.
+/// </summary>
+public sealed class AksStarterWithRedisDeploymentTests(ITestOutputHelper output)
+{
+    // Timeout set to 45 minutes to allow for AKS provisioning (~10-15 min) plus deployment.
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(45);
+
+    [Fact]
+    public async Task DeployStarterTemplateWithRedisToAks()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+        var cancellationToken = linkedCts.Token;
+
+        await DeployStarterTemplateWithRedisToAksCore(cancellationToken);
+    }
+
+    private async Task DeployStarterTemplateWithRedisToAksCore(CancellationToken cancellationToken)
+    {
+        // Validate prerequisites
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var recordingPath = DeploymentE2ETestHelpers.GetTestResultsRecordingPath(nameof(DeployStarterTemplateWithRedisToAks));
+        var startTime = DateTime.UtcNow;
+
+        // Generate unique names for Azure resources
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("aksredis");
+        var clusterName = $"aks-{DeploymentE2ETestHelpers.GetRunId()}-{DeploymentE2ETestHelpers.GetRunAttempt()}";
+        // ACR names must be alphanumeric only, 5-50 chars, globally unique
+        var acrName = $"acr{DeploymentE2ETestHelpers.GetRunId()}{DeploymentE2ETestHelpers.GetRunAttempt()}".ToLowerInvariant();
+        acrName = new string(acrName.Where(char.IsLetterOrDigit).Take(50).ToArray());
+        if (acrName.Length < 5)
+        {
+            acrName = $"acrtest{Guid.NewGuid():N}"[..24];
+        }
+
+        output.WriteLine($"Test: {nameof(DeployStarterTemplateWithRedisToAks)}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"AKS Cluster: {clusterName}");
+        output.WriteLine($"ACR Name: {acrName}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            var builder = Hex1bTerminal.CreateBuilder()
+                .WithHeadless()
+                .WithDimensions(160, 48)
+                .WithAsciinemaRecording(recordingPath)
+                .WithPtyProcess("/bin/bash", ["--norc"]);
+
+            using var terminal = builder.Build();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            var counter = new SequenceCounter();
+            var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+            // Pattern searchers for aspire new interactive prompts
+            var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
+                .FindPattern("> Starter App");
+
+            var waitingForProjectNamePrompt = new CellPatternSearcher()
+                .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
+
+            var waitingForOutputPathPrompt = new CellPatternSearcher()
+                .Find("Enter the output path:");
+
+            var waitingForUrlsPrompt = new CellPatternSearcher()
+                .Find("Use *.dev.localhost URLs");
+
+            var waitingForRedisPrompt = new CellPatternSearcher()
+                .Find("Use Redis Cache");
+
+            var waitingForTestPrompt = new CellPatternSearcher()
+                .Find("Do you want to create a test project?");
+
+            // Pattern searchers for aspire add prompts
+            var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
+                .Find("(based on NuGet.config)");
+
+            var projectName = "AksRedis";
+
+            // ===== PHASE 1: Provision AKS Infrastructure =====
+
+            // Step 1: Prepare environment
+            output.WriteLine("Step 1: Preparing environment...");
+            sequenceBuilder.PrepareEnvironment(workspace, counter);
+
+            // Step 2: Register required resource providers
+            output.WriteLine("Step 2: Registering required resource providers...");
+            sequenceBuilder
+                .Type("az provider register --namespace Microsoft.ContainerService --wait && " +
+                      "az provider register --namespace Microsoft.ContainerRegistry --wait")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+
+            // Step 3: Create resource group
+            output.WriteLine("Step 3: Creating resource group...");
+            sequenceBuilder
+                .Type($"az group create --name {resourceGroupName} --location westus3 --output table")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(60));
+
+            // Step 4: Create Azure Container Registry
+            output.WriteLine("Step 4: Creating Azure Container Registry...");
+            sequenceBuilder
+                .Type($"az acr create --resource-group {resourceGroupName} --name {acrName} --sku Basic --output table")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(3));
+
+            // Step 5: Create AKS cluster with ACR attached
+            output.WriteLine("Step 5: Creating AKS cluster (this may take 10-15 minutes)...");
+            sequenceBuilder
+                .Type($"az aks create " +
+                      $"--resource-group {resourceGroupName} " +
+                      $"--name {clusterName} " +
+                      $"--node-count 1 " +
+                      $"--node-vm-size Standard_D2s_v3 " +
+                      $"--generate-ssh-keys " +
+                      $"--attach-acr {acrName} " +
+                      $"--enable-managed-identity " +
+                      $"--output table")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(20));
+
+            // Step 6: Ensure AKS can pull from ACR
+            output.WriteLine("Step 6: Verifying AKS-ACR integration...");
+            sequenceBuilder
+                .Type($"az aks update --resource-group {resourceGroupName} --name {clusterName} --attach-acr {acrName}")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(3));
+
+            // Step 7: Configure kubectl credentials
+            output.WriteLine("Step 7: Configuring kubectl credentials...");
+            sequenceBuilder
+                .Type($"az aks get-credentials --resource-group {resourceGroupName} --name {clusterName} --overwrite-existing")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
+
+            // Step 8: Verify kubectl connectivity
+            output.WriteLine("Step 8: Verifying kubectl connectivity...");
+            sequenceBuilder
+                .Type("kubectl get nodes")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
+
+            // Step 9: Verify cluster health
+            output.WriteLine("Step 9: Verifying cluster health...");
+            sequenceBuilder
+                .Type("kubectl cluster-info")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
+
+            // ===== PHASE 2: Create Aspire Project with Redis and Generate Helm Charts =====
+
+            // Step 10: Set up CLI environment (in CI)
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                output.WriteLine("Step 10: Using pre-installed Aspire CLI from local build...");
+                sequenceBuilder.SourceAspireCliEnvironment(counter);
+            }
+
+            // Step 11: Create starter project with Redis enabled
+            output.WriteLine("Step 11: Creating Aspire starter project with Redis...");
+            sequenceBuilder.Type("aspire new")
+                .Enter()
+                .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
+                .Enter() // Select first template (Starter App ASP.NET Core/Blazor)
+                .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+                .Type(projectName)
+                .Enter()
+                .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+                .Enter() // Accept default output path
+                .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+                .Enter() // Select "No" for localhost URLs (default)
+                .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+                .Enter() // Select "Yes" for Redis Cache (first/default option)
+                .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+                .Enter() // Select "No" for test project (default)
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+
+            // Step 12: Navigate to project directory
+            output.WriteLine("Step 12: Navigating to project directory...");
+            sequenceBuilder
+                .Type($"cd {projectName}")
+                .Enter()
+                .WaitForSuccessPrompt(counter);
+
+            // Step 13: Add Aspire.Hosting.Kubernetes package
+            output.WriteLine("Step 13: Adding Kubernetes hosting package...");
+            sequenceBuilder.Type("aspire add Aspire.Hosting.Kubernetes")
+                .Enter();
+
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                sequenceBuilder
+                    .WaitUntil(s => waitingForAddVersionSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
+                    .Enter(); // select first version (PR build)
+            }
+
+            sequenceBuilder.WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(180));
+
+            // Step 14: Modify AppHost.cs to add Kubernetes environment
+            sequenceBuilder.ExecuteCallback(() =>
+            {
+                var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+                var appHostDir = Path.Combine(projectDir, $"{projectName}.AppHost");
+                var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
+
+                output.WriteLine($"Modifying AppHost.cs at: {appHostFilePath}");
+
+                var content = File.ReadAllText(appHostFilePath);
+
+                // Insert the Kubernetes environment before builder.Build().Run();
+                var buildRunPattern = "builder.Build().Run();";
+                var replacement = """
+// Add Kubernetes environment for deployment
+builder.AddKubernetesEnvironment("k8s");
+
+builder.Build().Run();
+""";
+
+                content = content.Replace(buildRunPattern, replacement);
+
+                // Add required pragma to suppress experimental warning
+                if (!content.Contains("#pragma warning disable ASPIREPIPELINES001"))
+                {
+                    content = "#pragma warning disable ASPIREPIPELINES001\n" + content;
+                }
+
+                File.WriteAllText(appHostFilePath, content);
+
+                output.WriteLine("Modified AppHost.cs with AddKubernetesEnvironment");
+            });
+
+            // Step 15: Navigate to AppHost project directory
+            output.WriteLine("Step 15: Navigating to AppHost directory...");
+            sequenceBuilder
+                .Type($"cd {projectName}.AppHost")
+                .Enter()
+                .WaitForSuccessPrompt(counter);
+
+            // Step 16: Login to ACR for Docker push
+            output.WriteLine("Step 16: Logging into Azure Container Registry...");
+            sequenceBuilder
+                .Type($"az acr login --name {acrName}")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(60));
+
+            // Step 17: Build and push container images to ACR
+            // Only project resources need to be built — Redis uses a public container image
+            output.WriteLine("Step 17: Building and pushing container images to ACR...");
+            sequenceBuilder
+                .Type($"cd .. && " +
+                      $"dotnet publish {projectName}.Web/{projectName}.Web.csproj " +
+                      $"/t:PublishContainer " +
+                      $"/p:ContainerRegistry={acrName}.azurecr.io " +
+                      $"/p:ContainerImageName=webfrontend " +
+                      $"/p:ContainerImageTag=latest")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+
+            sequenceBuilder
+                .Type($"dotnet publish {projectName}.ApiService/{projectName}.ApiService.csproj " +
+                      $"/t:PublishContainer " +
+                      $"/p:ContainerRegistry={acrName}.azurecr.io " +
+                      $"/p:ContainerImageName=apiservice " +
+                      $"/p:ContainerImageTag=latest")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+
+            // Navigate back to AppHost directory
+            sequenceBuilder
+                .Type($"cd {projectName}.AppHost")
+                .Enter()
+                .WaitForSuccessPrompt(counter);
+
+            // Step 18: Run aspire publish to generate Helm charts
+            output.WriteLine("Step 18: Running aspire publish to generate Helm charts...");
+            sequenceBuilder
+                .Type($"aspire publish --output-path ../charts")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(10));
+
+            // Step 19: Verify Helm chart was generated
+            output.WriteLine("Step 19: Verifying Helm chart generation...");
+            sequenceBuilder
+                .Type("ls -la ../charts && cat ../charts/Chart.yaml && cat ../charts/values.yaml")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
+
+            // ===== PHASE 3: Deploy to AKS and Verify =====
+
+            // Step 20: Verify ACR role assignment has propagated
+            output.WriteLine("Step 20: Verifying AKS can pull from ACR...");
+            sequenceBuilder
+                .Type($"az aks check-acr --resource-group {resourceGroupName} --name {clusterName} --acr {acrName}.azurecr.io")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(3));
+
+            // Step 21: Deploy Helm chart to AKS with ACR image overrides
+            // Only project resources need image overrides — Redis uses the public image from the chart
+            output.WriteLine("Step 21: Deploying Helm chart to AKS...");
+            sequenceBuilder
+                .Type($"helm install aksredis ../charts --namespace default --wait --timeout 10m " +
+                      $"--set parameters.webfrontend.webfrontend_image={acrName}.azurecr.io/webfrontend:latest " +
+                      $"--set parameters.apiservice.apiservice_image={acrName}.azurecr.io/apiservice:latest")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(12));
+
+            // Step 22: Wait for all pods to be ready (including Redis)
+            output.WriteLine("Step 22: Waiting for pods to be ready...");
+            sequenceBuilder
+                .Type("kubectl wait --for=condition=ready pod --all -n default --timeout=120s")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(3));
+
+            // Step 23: Verify all pods are running
+            output.WriteLine("Step 23: Verifying pods are running...");
+            sequenceBuilder
+                .Type("kubectl get pods -n default")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
+
+            // Step 24: Verify deployments are healthy
+            output.WriteLine("Step 24: Verifying deployments...");
+            sequenceBuilder
+                .Type("kubectl get deployments -n default")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
+
+            // Step 25: Verify services (should include cache-service for Redis)
+            output.WriteLine("Step 25: Verifying services...");
+            sequenceBuilder
+                .Type("kubectl get services -n default")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
+
+            // Step 26: Verify apiservice endpoint via port-forward
+            output.WriteLine("Step 26: Verifying apiservice /weatherforecast endpoint...");
+            sequenceBuilder
+                .Type("kubectl port-forward svc/apiservice-service 18080:8080 &")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(10))
+                .Type("for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18080/weatherforecast -o /dev/null -w '%{http_code}' && echo ' OK' && break; done")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(60));
+
+            // Step 27: Verify webfrontend root page via port-forward
+            output.WriteLine("Step 27: Verifying webfrontend root page...");
+            sequenceBuilder
+                .Type("kubectl port-forward svc/webfrontend-service 18081:8080 &")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(10))
+                .Type("for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18081/ -o /dev/null -w '%{http_code}' && echo ' OK' && break; done")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(60));
+
+            // Step 28: Verify webfrontend /weather page (exercises webfrontend → apiservice → Redis pipeline)
+            // The /weather page is server-side rendered and fetches data from the apiservice.
+            // Redis output caching is used, so this validates the full Redis integration.
+            output.WriteLine("Step 28: Verifying webfrontend /weather page (exercises Redis cache)...");
+            sequenceBuilder
+                .Type("for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18081/weather -o /dev/null -w '%{http_code}' && echo ' OK' && break; done")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(60));
+
+            // Step 29: Verify /weather page actually returns weather data
+            output.WriteLine("Step 29: Verifying weather page content...");
+            sequenceBuilder
+                .Type("curl -sf http://localhost:18081/weather | grep -q 'Weather' && echo 'Weather page content verified'")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
+
+            // Step 30: Clean up port-forwards
+            output.WriteLine("Step 30: Cleaning up port-forwards...");
+            sequenceBuilder
+                .Type("kill %1 %2 2>/dev/null; true")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(10));
+
+            // Step 31: Exit terminal
+            sequenceBuilder
+                .Type("exit")
+                .Enter();
+
+            var sequence = sequenceBuilder.Build();
+            await sequence.ApplyAsync(terminal, cancellationToken);
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"Full AKS + Redis deployment completed in {duration}");
+
+            // Report success
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployStarterTemplateWithRedisToAks),
+                resourceGroupName,
+                new Dictionary<string, string>
+                {
+                    ["cluster"] = clusterName,
+                    ["acr"] = acrName,
+                    ["project"] = projectName
+                },
+                duration);
+
+            output.WriteLine("✅ Test passed - Aspire app with Redis deployed to AKS via Helm!");
+        }
+        catch (Exception ex)
+        {
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"❌ Test failed after {duration}: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployStarterTemplateWithRedisToAks),
+                resourceGroupName,
+                ex.Message,
+                ex.StackTrace);
+
+            throw;
+        }
+        finally
+        {
+            output.WriteLine($"Cleaning up resource group: {resourceGroupName}");
+            await CleanupResourceGroupAsync(resourceGroupName);
+        }
+    }
+
+    private async Task CleanupResourceGroupAsync(string resourceGroupName)
+    {
+        try
+        {
+            var process = new System.Diagnostics.Process
+            {
+                StartInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "az",
+                    Arguments = $"group delete --name {resourceGroupName} --yes --no-wait",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false
+                }
+            };
+
+            process.Start();
+            await process.WaitForExitAsync();
+
+            if (process.ExitCode == 0)
+            {
+                output.WriteLine($"Resource group deletion initiated: {resourceGroupName}");
+                DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Deletion initiated");
+            }
+            else
+            {
+                var error = await process.StandardError.ReadToEndAsync();
+                output.WriteLine($"Resource group deletion may have failed (exit code {process.ExitCode}): {error}");
+                DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, $"Exit code {process.ExitCode}: {error}");
+            }
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Failed to cleanup resource group: {ex.Message}");
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, ex.Message);
+        }
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterWithRedisDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterWithRedisDeploymentTests.cs
@@ -331,11 +331,15 @@ builder.Build().Run();
 
             // Step 21: Deploy Helm chart to AKS with ACR image overrides
             // Only project resources need image overrides — Redis uses the public image from the chart
+            // Note: secrets.webfrontend.cache_password is a workaround for a K8s publisher bug where
+            // cross-resource secret references create Helm value paths under the consuming resource
+            // instead of referencing the owning resource's secret path (secrets.cache.REDIS_PASSWORD).
             output.WriteLine("Step 21: Deploying Helm chart to AKS...");
             sequenceBuilder
                 .Type($"helm install aksredis ../charts --namespace default --wait --timeout 10m " +
                       $"--set parameters.webfrontend.webfrontend_image={acrName}.azurecr.io/webfrontend:latest " +
-                      $"--set parameters.apiservice.apiservice_image={acrName}.azurecr.io/apiservice:latest")
+                      $"--set parameters.apiservice.apiservice_image={acrName}.azurecr.io/apiservice:latest " +
+                      $"--set secrets.webfrontend.cache_password=\"\"")
                 .Enter()
                 .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(12));
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServicePythonDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServicePythonDeploymentTests.cs
@@ -18,7 +18,7 @@ public sealed class AppServicePythonDeploymentTests(ITestOutputHelper output)
     // Full deployments can take up to 30 minutes if Azure infrastructure is backed up.
     private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(40);
 
-    [Fact(Skip = "App Service provisioning takes longer than 30 minutes, causing timeouts. Skipped until infrastructure issues are resolved.")]
+    [Fact]
     public async Task DeployPythonFastApiTemplateToAzureAppService()
     {
         using var cts = new CancellationTokenSource(s_testTimeout);

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
@@ -18,7 +18,7 @@ public sealed class AppServiceReactDeploymentTests(ITestOutputHelper output)
     // Full deployments can take up to 30 minutes if Azure infrastructure is backed up.
     private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(40);
 
-    [Fact(Skip = "App Service provisioning takes longer than 30 minutes, causing timeouts. Skipped until infrastructure issues are resolved.")]
+    [Fact]
     public async Task DeployReactTemplateToAzureAppService()
     {
         using var cts = new CancellationTokenSource(s_testTimeout);

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env1/templates/ServiceA/deployment.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env1/templates/ServiceA/deployment.verified.yaml
@@ -25,9 +25,6 @@ spec:
             - name: "http"
               protocol: "TCP"
               containerPort: {{ .Values.parameters.ServiceA.port_http | int }}
-            - name: "https"
-              protocol: "TCP"
-              containerPort: {{ .Values.parameters.ServiceA.port_https | int }}
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env1/templates/ServiceA/service.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env1/templates/ServiceA/service.verified.yaml
@@ -18,7 +18,3 @@ spec:
       protocol: "TCP"
       port: {{ .Values.parameters.ServiceA.port_http | int }}
       targetPort: {{ .Values.parameters.ServiceA.port_http | int }}
-    - name: "https"
-      protocol: "TCP"
-      port: {{ .Values.parameters.ServiceA.port_https | int }}
-      targetPort: {{ .Values.parameters.ServiceA.port_https | int }}

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env1/values.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env1/values.verified.yaml
@@ -1,7 +1,6 @@
 parameters:
   ServiceA:
     port_http: 8080
-    port_https: 8080
     ServiceA_image: "ServiceA:latest"
 secrets: {}
 config:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env2/templates/ServiceB/deployment.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env2/templates/ServiceB/deployment.verified.yaml
@@ -25,9 +25,6 @@ spec:
             - name: "http"
               protocol: "TCP"
               containerPort: {{ .Values.parameters.ServiceB.port_http | int }}
-            - name: "https"
-              protocol: "TCP"
-              containerPort: {{ .Values.parameters.ServiceB.port_https | int }}
           imagePullPolicy: "IfNotPresent"
   selector:
     matchLabels:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env2/templates/ServiceB/service.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env2/templates/ServiceB/service.verified.yaml
@@ -18,7 +18,3 @@ spec:
       protocol: "TCP"
       port: {{ .Values.parameters.ServiceB.port_http | int }}
       targetPort: {{ .Values.parameters.ServiceB.port_http | int }}
-    - name: "https"
-      protocol: "TCP"
-      port: {{ .Values.parameters.ServiceB.port_https | int }}
-      targetPort: {{ .Values.parameters.ServiceB.port_https | int }}

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env2/values.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env2/values.verified.yaml
@@ -1,7 +1,6 @@
 parameters:
   ServiceB:
     port_http: 8080
-    port_https: 8080
     ServiceB_image: "ServiceB:latest"
 secrets: {}
 config:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#01.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#01.verified.yaml
@@ -1,7 +1,6 @@
 parameters:
   project1:
     port_http: 8080
-    port_https: 8080
     project1_image: "project1:latest"
 secrets: {}
 config:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#02.verified.yaml
@@ -25,9 +25,6 @@ spec:
             - name: "http"
               protocol: "TCP"
               containerPort: {{ .Values.parameters.project1.port_http | int }}
-            - name: "https"
-              protocol: "TCP"
-              containerPort: {{ .Values.parameters.project1.port_https | int }}
             - name: "custom1"
               protocol: "TCP"
               containerPort: 8000

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#03.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#03.verified.yaml
@@ -18,10 +18,6 @@ spec:
       protocol: "TCP"
       port: {{ .Values.parameters.project1.port_http | int }}
       targetPort: {{ .Values.parameters.project1.port_http | int }}
-    - name: "https"
-      protocol: "TCP"
-      port: {{ .Values.parameters.project1.port_https | int }}
-      targetPort: {{ .Values.parameters.project1.port_https | int }}
     - name: "custom1"
       protocol: "TCP"
       port: 8000

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#06.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#06.verified.yaml
@@ -10,8 +10,8 @@ metadata:
 data:
   PROJECT1_HTTP: "http://project1-service:{{ .Values.parameters.project1.port_http }}"
   services__project1__http__0: "http://project1-service:{{ .Values.parameters.project1.port_http }}"
-  PROJECT1_HTTPS: "https://project1-service:{{ .Values.parameters.project1.port_https }}"
-  services__project1__https__0: "https://project1-service:{{ .Values.parameters.project1.port_https }}"
+  PROJECT1_HTTPS: "https://project1-service:{{ .Values.parameters.project1.port_http }}"
+  services__project1__https__0: "https://project1-service:{{ .Values.parameters.project1.port_http }}"
   PROJECT1_CUSTOM1: "{{ .Values.config.api.PROJECT1_CUSTOM1 }}"
   services__project1__custom1__0: "{{ .Values.config.api.services__project1__custom1__0 }}"
   PROJECT1_CUSTOM2: "{{ .Values.config.api.PROJECT1_CUSTOM2 }}"


### PR DESCRIPTION
## Summary

This PR adds a new end-to-end deployment test that validates deploying Aspire applications to Azure Kubernetes Service (AKS).

### Phase 1 (This PR)
Infrastructure foundation only:
- Creates resource group, Azure Container Registry (ACR), and AKS cluster
- Attaches ACR to AKS for seamless image pulls
- Configures kubectl credentials
- Verifies cluster connectivity (`kubectl get nodes`, `kubectl cluster-info`)
- Cleans up resources after test (fire-and-forget)

### Future Phases
- **Phase 2**: Add Aspire project creation, Kubernetes hosting package, and Helm chart generation
- **Phase 3**: Full deployment with pod verification
- **Phase 4**: Documentation and polish

### Test Details
- Uses minimal AKS configuration (1 node, Standard_B2s) to minimize cost
- ~45 minute timeout to accommodate AKS provisioning (~10-15 min)
- Follows existing deployment E2E test patterns

### Testing
Request `/deployment-test` to run the new test against Azure infrastructure.