### PR TITLE
Refactor resource MCP refresh

### DIFF
--- a/src/Aspire.Cli/Commands/AgentMcpCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentMcpCommand.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 using Aspire.Cli.Backchannel;
@@ -32,8 +31,7 @@ namespace Aspire.Cli.Commands;
 internal sealed class AgentMcpCommand : BaseCommand
 {
     private readonly Dictionary<string, CliMcpTool> _knownTools;
-    private string? _selectedAppHostPath;
-    private Dictionary<string, (string ResourceName, Tool Tool)>? _resourceToolMap;
+    private readonly IMcpResourceToolRefreshService _resourceToolRefreshService;
     private McpServer? _server;
     private readonly IAuxiliaryBackchannelMonitor _auxiliaryBackchannelMonitor;
     private readonly CliExecutionContext _executionContext;
@@ -69,6 +67,7 @@ internal sealed class AgentMcpCommand : BaseCommand
         _loggerFactory = loggerFactory;
         _logger = logger;
         _docsIndexService = docsIndexService;
+        _resourceToolRefreshService = new McpResourceToolRefreshService(auxiliaryBackchannelMonitor, loggerFactory.CreateLogger<McpResourceToolRefreshService>());
         _knownTools = new Dictionary<string, CliMcpTool>
         {
             [KnownMcpTools.ListResources] = new ListResourcesTool(auxiliaryBackchannelMonitor, loggerFactory.CreateLogger<ListResourcesTool>()),
@@ -81,7 +80,7 @@ internal sealed class AgentMcpCommand : BaseCommand
             [KnownMcpTools.ListAppHosts] = new ListAppHostsTool(auxiliaryBackchannelMonitor, executionContext),
             [KnownMcpTools.ListIntegrations] = new ListIntegrationsTool(packagingService, executionContext, auxiliaryBackchannelMonitor),
             [KnownMcpTools.Doctor] = new DoctorTool(environmentChecker),
-            [KnownMcpTools.RefreshTools] = new RefreshToolsTool(RefreshResourceToolMapAsync, SendToolsListChangedNotificationAsync),
+            [KnownMcpTools.RefreshTools] = new RefreshToolsTool(_resourceToolRefreshService),
             [KnownMcpTools.ListDocs] = new ListDocsTool(docsIndexService),
             [KnownMcpTools.SearchDocs] = new SearchDocsTool(docsSearchService, docsIndexService),
             [KnownMcpTools.GetDoc] = new GetDocTool(docsIndexService)
@@ -121,13 +120,15 @@ internal sealed class AgentMcpCommand : BaseCommand
         var transport = _transportFactory.CreateTransport();
         await using var server = McpServer.Create(transport, options, _loggerFactory);
 
-        // Keep a reference to the server for sending notifications
+        // Configure the refresh service with the server
+        _resourceToolRefreshService.SetMcpServer(server);
         _server = server;
 
         // Starts the MCP server, it's blocking until cancellation is requested
         await server.RunAsync(cancellationToken);
 
         // Clear the server reference on exit
+        _resourceToolRefreshService.SetMcpServer(null);
         _server = null;
 
         return ExitCodeConstants.Success;
@@ -135,8 +136,6 @@ internal sealed class AgentMcpCommand : BaseCommand
 
     private async ValueTask<ListToolsResult> HandleListToolsAsync(RequestContext<ListToolsRequestParams> request, CancellationToken cancellationToken)
     {
-        _ = request;
-
         _logger.LogDebug("MCP ListTools request received");
 
         var tools = new List<Tool>();
@@ -150,15 +149,14 @@ internal sealed class AgentMcpCommand : BaseCommand
 
         try
         {
-            // Detect if the tools list should be refreshed due to AppHost selection change
-            if (_resourceToolMap is null || _selectedAppHostPath != _auxiliaryBackchannelMonitor.SelectedAppHostPath)
+            // Refresh resource tools if needed (e.g., AppHost selection changed or invalidated)
+            if (_resourceToolRefreshService.NeedsRefresh())
             {
-                await RefreshResourceToolMapAsync(cancellationToken);
-                await SendToolsListChangedNotificationAsync(cancellationToken).ConfigureAwait(false);
-                _selectedAppHostPath = _auxiliaryBackchannelMonitor.SelectedAppHostPath;
+                await _resourceToolRefreshService.RefreshResourceToolMapAsync(cancellationToken);
+                await _resourceToolRefreshService.SendToolsListChangedNotificationAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            tools.AddRange(_resourceToolMap.Select(x => new Tool
+            tools.AddRange(_resourceToolRefreshService.ResourceToolMap.Select(x => new Tool
             {
                 Name = x.Key,
                 Description = x.Value.Tool.Description,
@@ -213,17 +211,16 @@ internal sealed class AgentMcpCommand : BaseCommand
 
         var toolsRefreshed = false;
 
-        // Detect if the tools list should be refreshed due to AppHost selection change
-        if (_resourceToolMap is null || _selectedAppHostPath != _auxiliaryBackchannelMonitor.SelectedAppHostPath)
+        // Refresh resource tools if needed (e.g., AppHost selection changed or invalidated)
+        if (_resourceToolRefreshService.NeedsRefresh())
         {
-            await RefreshResourceToolMapAsync(cancellationToken);
-            _selectedAppHostPath = _auxiliaryBackchannelMonitor.SelectedAppHostPath;
+            await _resourceToolRefreshService.RefreshResourceToolMapAsync(cancellationToken);
+            await _resourceToolRefreshService.SendToolsListChangedNotificationAsync(cancellationToken).ConfigureAwait(false);
             toolsRefreshed = true;
-            await SendToolsListChangedNotificationAsync(cancellationToken).ConfigureAwait(false);
         }
 
         // Resource MCP tools are invoked via the AppHost backchannel (AppHost proxies to the resource MCP endpoint).
-        if (_resourceToolMap.TryGetValue(toolName, out var resourceAndTool))
+        if (_resourceToolRefreshService.ResourceToolMap.TryGetValue(toolName, out var resourceAndTool))
         {
             var connection = await GetSelectedConnectionAsync(cancellationToken).ConfigureAwait(false);
             if (connection == null)
@@ -255,7 +252,7 @@ internal sealed class AgentMcpCommand : BaseCommand
         // If we haven't refreshed yet, try refreshing once more in case the resource list changed
         if (!toolsRefreshed)
         {
-            _resourceToolMap = null;
+            _resourceToolRefreshService.InvalidateToolMap();
             return await HandleCallToolAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
@@ -329,81 +326,6 @@ internal sealed class AgentMcpCommand : BaseCommand
             _logger.LogError(ex, "Error occurred while calling tool {ToolName}", toolName);
             throw;
         }
-    }
-
-    private Task SendToolsListChangedNotificationAsync(CancellationToken cancellationToken)
-    {
-        var server = _server;
-        if (server is null)
-        {
-            throw new InvalidOperationException("MCP server is not running.");
-        }
-
-        return server.SendNotificationAsync(NotificationMethods.ToolListChangedNotification, cancellationToken);
-    }
-
-    [MemberNotNull(nameof(_resourceToolMap))]
-    private async Task<int> RefreshResourceToolMapAsync(CancellationToken cancellationToken)
-    {
-        var refreshedMap = new Dictionary<string, (string, Tool)>(StringComparer.Ordinal);
-
-        try
-        {
-            var connection = await GetSelectedConnectionAsync(cancellationToken).ConfigureAwait(false);
-
-            if (connection is not null)
-            {
-                // Collect initial snapshots from the stream
-                // The stream yields initial snapshots for all resources first
-                var resourcesWithTools = new List<ResourceSnapshot>();
-                var seenResources = new HashSet<string>(StringComparer.Ordinal);
-
-                await foreach (var snapshot in connection.WatchResourceSnapshotsAsync(cancellationToken).ConfigureAwait(false))
-                {
-                    // Stop after we've seen all resources once (initial batch)
-                    if (!seenResources.Add(snapshot.Name))
-                    {
-                        break;
-                    }
-
-                    if (snapshot.McpServer is not null)
-                    {
-                        resourcesWithTools.Add(snapshot);
-                    }
-                }
-
-                _logger.LogDebug("Resources with MCP tools received: {Count}", resourcesWithTools.Count);
-
-                foreach (var resource in resourcesWithTools)
-                {
-                    if (resource.McpServer is null)
-                    {
-                        continue;
-                    }
-
-                    foreach (var tool in resource.McpServer.Tools)
-                    {
-                        var exposedName = $"{resource.Name.Replace("-", "_")}_{tool.Name}";
-                        refreshedMap[exposedName] = (resource.Name, tool);
-
-                        _logger.LogDebug("{Tool}: {Description}", exposedName, tool.Description);
-                    }
-                }
-            }
-
-        }
-        catch (Exception ex)
-        {
-            // Don't fail refresh_tools if resource discovery fails; still emit notification.
-            _logger.LogDebug(ex, "Failed to refresh resource MCP tool routing map");
-        }
-        finally
-        {
-            // Ensure _resourceToolMap is always non-null when exiting, even if connection is null or an exception occurs.
-            _resourceToolMap = refreshedMap;
-        }
-
-        return _resourceToolMap.Count + KnownTools.Count;
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Commands/AgentMcpCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentMcpCommand.cs
@@ -34,11 +34,9 @@ internal sealed class AgentMcpCommand : BaseCommand
     private readonly IMcpResourceToolRefreshService _resourceToolRefreshService;
     private McpServer? _server;
     private readonly IAuxiliaryBackchannelMonitor _auxiliaryBackchannelMonitor;
-    private readonly CliExecutionContext _executionContext;
     private readonly IMcpTransportFactory _transportFactory;
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<AgentMcpCommand> _logger;
-    private readonly IDocsIndexService _docsIndexService;
 
     /// <summary>
     /// Gets the dictionary of known MCP tools. Exposed for testing purposes.
@@ -62,11 +60,9 @@ internal sealed class AgentMcpCommand : BaseCommand
         : base("mcp", AgentCommandStrings.McpCommand_Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _auxiliaryBackchannelMonitor = auxiliaryBackchannelMonitor;
-        _executionContext = executionContext;
         _transportFactory = transportFactory;
         _loggerFactory = loggerFactory;
         _logger = logger;
-        _docsIndexService = docsIndexService;
         _resourceToolRefreshService = new McpResourceToolRefreshService(auxiliaryBackchannelMonitor, loggerFactory.CreateLogger<McpResourceToolRefreshService>());
         _knownTools = new Dictionary<string, CliMcpTool>
         {

--- a/src/Aspire.Cli/Mcp/IMcpResourceToolRefreshService.cs
+++ b/src/Aspire.Cli/Mcp/IMcpResourceToolRefreshService.cs
@@ -12,15 +12,11 @@ namespace Aspire.Cli.Mcp;
 internal interface IMcpResourceToolRefreshService
 {
     /// <summary>
-    /// Gets the current resource tool map. Keys are exposed tool names, values are tuples of (ResourceName, Tool).
+    /// Attempts to get the current resource tool map if it is valid (not invalidated and AppHost hasn't changed).
     /// </summary>
-    IReadOnlyDictionary<string, (string ResourceName, Tool Tool)> ResourceToolMap { get; }
-
-    /// <summary>
-    /// Determines whether the resource tool map needs to be refreshed.
-    /// </summary>
-    /// <returns><c>true</c> if the tool map needs refresh; otherwise, <c>false</c>.</returns>
-    bool NeedsRefresh();
+    /// <param name="resourceToolMap">When this method returns <c>true</c>, contains the current resource tool map.</param>
+    /// <returns><c>true</c> if the tool map is valid and no refresh is needed; otherwise, <c>false</c>.</returns>
+    bool TryGetResourceToolMap(out IReadOnlyDictionary<string, ResourceToolEntry> resourceToolMap);
 
     /// <summary>
     /// Marks the resource tool map as needing a refresh.
@@ -31,8 +27,8 @@ internal interface IMcpResourceToolRefreshService
     /// Refreshes the resource tool map by discovering MCP tools from connected resources.
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The count of resource tools discovered.</returns>
-    Task<int> RefreshResourceToolMapAsync(CancellationToken cancellationToken);
+    /// <returns>The refreshed resource tool map.</returns>
+    Task<IReadOnlyDictionary<string, ResourceToolEntry>> RefreshResourceToolMapAsync(CancellationToken cancellationToken);
 
     /// <summary>
     /// Sends a tools list changed notification to connected MCP clients.
@@ -46,3 +42,10 @@ internal interface IMcpResourceToolRefreshService
     /// <param name="server">The MCP server, or null to clear.</param>
     void SetMcpServer(McpServer? server);
 }
+
+/// <summary>
+/// Represents an entry in the resource tool map.
+/// </summary>
+/// <param name="ResourceName">The name of the resource that exposes the tool.</param>
+/// <param name="Tool">The MCP tool definition.</param>
+internal sealed record ResourceToolEntry(string ResourceName, Tool Tool);

--- a/src/Aspire.Cli/Mcp/IMcpResourceToolRefreshService.cs
+++ b/src/Aspire.Cli/Mcp/IMcpResourceToolRefreshService.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace Aspire.Cli.Mcp;
+
+/// <summary>
+/// Service responsible for refreshing resource-based MCP tools and sending tool list change notifications.
+/// </summary>
+internal interface IMcpResourceToolRefreshService
+{
+    /// <summary>
+    /// Gets the current resource tool map. Keys are exposed tool names, values are tuples of (ResourceName, Tool).
+    /// </summary>
+    IReadOnlyDictionary<string, (string ResourceName, Tool Tool)> ResourceToolMap { get; }
+
+    /// <summary>
+    /// Determines whether the resource tool map needs to be refreshed.
+    /// </summary>
+    /// <returns><c>true</c> if the tool map needs refresh; otherwise, <c>false</c>.</returns>
+    bool NeedsRefresh();
+
+    /// <summary>
+    /// Marks the resource tool map as needing a refresh.
+    /// </summary>
+    void InvalidateToolMap();
+
+    /// <summary>
+    /// Refreshes the resource tool map by discovering MCP tools from connected resources.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The count of resource tools discovered.</returns>
+    Task<int> RefreshResourceToolMapAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Sends a tools list changed notification to connected MCP clients.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task SendToolsListChangedNotificationAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Sets the MCP server instance used for sending notifications.
+    /// </summary>
+    /// <param name="server">The MCP server, or null to clear.</param>
+    void SetMcpServer(McpServer? server);
+}

--- a/src/Aspire.Cli/Mcp/KnownMcpTools.cs
+++ b/src/Aspire.Cli/Mcp/KnownMcpTools.cs
@@ -24,6 +24,27 @@ internal static class KnownMcpTools
     internal const string SearchDocs = "search_docs";
     internal const string GetDoc = "get_doc";
 
+    /// <summary>
+    /// Gets all known MCP tool names.
+    /// </summary>
+    public static IReadOnlyList<string> All { get; } =
+    [
+        ListResources,
+        ListConsoleLogs,
+        ExecuteResourceCommand,
+        ListStructuredLogs,
+        ListTraces,
+        ListTraceStructuredLogs,
+        SelectAppHost,
+        ListAppHosts,
+        ListIntegrations,
+        Doctor,
+        RefreshTools,
+        ListDocs,
+        SearchDocs,
+        GetDoc
+    ];
+
     public static bool IsLocalTool(string toolName) => toolName is
         SelectAppHost or
         ListAppHosts or

--- a/src/Aspire.Cli/Mcp/McpResourceToolRefreshService.cs
+++ b/src/Aspire.Cli/Mcp/McpResourceToolRefreshService.cs
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Aspire.Cli.Backchannel;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace Aspire.Cli.Mcp;
+
+/// <summary>
+/// Service responsible for refreshing resource-based MCP tools and sending tool list change notifications.
+/// </summary>
+internal sealed class McpResourceToolRefreshService : IMcpResourceToolRefreshService
+{
+    private readonly IAuxiliaryBackchannelMonitor _auxiliaryBackchannelMonitor;
+    private readonly ILogger _logger;
+    private McpServer? _server;
+    private Dictionary<string, (string ResourceName, Tool Tool)> _resourceToolMap = new(StringComparer.Ordinal);
+    private bool _invalidated = true;
+    private string? _selectedAppHostPath;
+
+    public McpResourceToolRefreshService(
+        IAuxiliaryBackchannelMonitor auxiliaryBackchannelMonitor,
+        ILogger<McpResourceToolRefreshService> logger)
+    {
+        _auxiliaryBackchannelMonitor = auxiliaryBackchannelMonitor;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<string, (string ResourceName, Tool Tool)> ResourceToolMap => _resourceToolMap;
+
+    /// <inheritdoc/>
+    public bool NeedsRefresh() => _invalidated || _selectedAppHostPath != _auxiliaryBackchannelMonitor.SelectedAppHostPath;
+
+    /// <inheritdoc/>
+    public void InvalidateToolMap()
+    {
+        _resourceToolMap.Clear();
+        _invalidated = true;
+    }
+
+    /// <inheritdoc/>
+    public void SetMcpServer(McpServer? server)
+    {
+        _server = server;
+    }
+
+    /// <inheritdoc/>
+    public async Task SendToolsListChangedNotificationAsync(CancellationToken cancellationToken)
+    {
+        if (_server is { } server)
+        {
+            await server.SendNotificationAsync(NotificationMethods.ToolListChangedNotification, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<int> RefreshResourceToolMapAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Refreshing resource tool map.");
+
+        var refreshedMap = new Dictionary<string, (string, Tool)>(StringComparer.Ordinal);
+
+        string? selectedAppHostPath = null;
+        try
+        {
+            var connection = await AppHostConnectionHelper.GetSelectedConnectionAsync(_auxiliaryBackchannelMonitor, _logger, cancellationToken).ConfigureAwait(false);
+
+            if (connection is not null)
+            {
+                selectedAppHostPath = connection.AppHostInfo?.AppHostPath;
+
+                var allResources = await connection.GetResourceSnapshotsAsync(cancellationToken).ConfigureAwait(false);
+                var resourcesWithTools = allResources.Where(r => r.McpServer is not null).ToList();
+
+                _logger.LogDebug("Resources with MCP tools received: {Count}", resourcesWithTools.Count);
+
+                foreach (var resource in resourcesWithTools)
+                {
+                    Debug.Assert(resource.McpServer is not null);
+
+                    foreach (var tool in resource.McpServer.Tools)
+                    {
+                        var exposedName = $"{resource.Name.Replace("-", "_")}_{tool.Name}";
+                        refreshedMap[exposedName] = (resource.Name, tool);
+
+                        _logger.LogDebug("{Tool}: {Description}", exposedName, tool.Description);
+                    }
+                }
+            }
+            else
+            {
+                _logger.LogDebug("Unable to refresh resource tool map because they're no selected connection.");
+            }
+        }
+        catch (Exception ex)
+        {
+            // Don't fail refresh_tools if resource discovery fails; still emit notification.
+            _logger.LogDebug(ex, "Failed to refresh resource MCP tool routing map.");
+        }
+        finally
+        {
+            _resourceToolMap = refreshedMap;
+            _selectedAppHostPath = selectedAppHostPath;
+            _invalidated = false;
+        }
+
+        return _resourceToolMap.Count;
+    }
+}

--- a/src/Aspire.Cli/Mcp/McpResourceToolRefreshService.cs
+++ b/src/Aspire.Cli/Mcp/McpResourceToolRefreshService.cs
@@ -93,7 +93,7 @@ internal sealed class McpResourceToolRefreshService : IMcpResourceToolRefreshSer
             }
             else
             {
-                _logger.LogDebug("Unable to refresh resource tool map because they're no selected connection.");
+                _logger.LogDebug("Unable to refresh resource tool map because there's no selected connection.");
             }
         }
         catch (Exception ex)

--- a/src/Aspire.Cli/Mcp/McpResourceToolRefreshService.cs
+++ b/src/Aspire.Cli/Mcp/McpResourceToolRefreshService.cs
@@ -51,7 +51,6 @@ internal sealed class McpResourceToolRefreshService : IMcpResourceToolRefreshSer
     {
         lock (_lock)
         {
-            _resourceToolMap.Clear();
             _invalidated = true;
         }
     }

--- a/src/Aspire.Cli/Mcp/Tools/RefreshToolsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/RefreshToolsTool.cs
@@ -21,10 +21,10 @@ internal sealed class RefreshToolsTool(IMcpResourceToolRefreshService refreshSer
     {
         _ = context;
 
-        var resourceToolCount = await refreshService.RefreshResourceToolMapAsync(cancellationToken).ConfigureAwait(false);
+        var resourceToolMap = await refreshService.RefreshResourceToolMapAsync(cancellationToken).ConfigureAwait(false);
         await refreshService.SendToolsListChangedNotificationAsync(cancellationToken).ConfigureAwait(false);
 
-        var totalToolCount = KnownMcpTools.All.Count + resourceToolCount;
+        var totalToolCount = KnownMcpTools.All.Count + resourceToolMap.Count;
         return new CallToolResult
         {
             Content = [new TextContentBlock { Text = $"Tools refreshed: {totalToolCount} tools available" }]

--- a/src/Aspire.Cli/Mcp/Tools/RefreshToolsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/RefreshToolsTool.cs
@@ -6,7 +6,7 @@ using ModelContextProtocol.Protocol;
 
 namespace Aspire.Cli.Mcp.Tools;
 
-internal sealed class RefreshToolsTool(Func<CancellationToken, Task<int>> refreshToolsAsync, Func<CancellationToken, Task> sendToolsListChangedNotificationAsync) : CliMcpTool
+internal sealed class RefreshToolsTool(IMcpResourceToolRefreshService refreshService) : CliMcpTool
 {
     public override string Name => KnownMcpTools.RefreshTools;
 
@@ -21,12 +21,13 @@ internal sealed class RefreshToolsTool(Func<CancellationToken, Task<int>> refres
     {
         _ = context;
 
-        var count = await refreshToolsAsync(cancellationToken).ConfigureAwait(false);
-        await sendToolsListChangedNotificationAsync(cancellationToken).ConfigureAwait(false);
+        var resourceToolCount = await refreshService.RefreshResourceToolMapAsync(cancellationToken).ConfigureAwait(false);
+        await refreshService.SendToolsListChangedNotificationAsync(cancellationToken).ConfigureAwait(false);
 
+        var totalToolCount = KnownMcpTools.All.Count + resourceToolCount;
         return new CallToolResult
         {
-            Content = [new TextContentBlock { Text = $"Tools refreshed: {count} tools available" }]
+            Content = [new TextContentBlock { Text = $"Tools refreshed: {totalToolCount} tools available" }]
         };
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/AgentMcpCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AgentMcpCommandTests.cs
@@ -337,8 +337,8 @@ public class AgentMcpCommandTests(ITestOutputHelper outputHelper) : IAsyncLifeti
         var textContent = result.Content[0] as TextContentBlock;
         Assert.NotNull(textContent);
 
-        // Verify the exact text content with the correct tool count
-        var expectedToolCount = _agentMcpCommand.KnownTools.Count;
+        // Verify the text content indicates refresh success (resource tool count is 0 in this test, so total = known tools)
+        var expectedToolCount = KnownMcpTools.All.Count;
         Assert.Equal($"Tools refreshed: {expectedToolCount} tools available", textContent.Text);
 
         // Assert - Verify the ToolListChanged notification was received


### PR DESCRIPTION
## Description

Refactor AgentMcpCommand to split tracking and refreshing resource MCPs out into their own type.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
