### PR TITLE
Auto-discover CLI E2E test recordings

### DIFF
--- a/.github/workflows/cli-e2e-recording-comment.yml
+++ b/.github/workflows/cli-e2e-recording-comment.yml
@@ -104,22 +104,13 @@ jobs:
             
             console.log(`Total artifacts found: ${allArtifacts.length}`);
             
-            // Filter for CLI E2E test logs (they contain recordings)
+            // Filter for CLI E2E recording artifacts (simple pattern match)
+            // These are uploaded by the run-tests workflow with name: cli-e2e-recordings-{TestName}
             const cliE2eArtifacts = allArtifacts.filter(a => 
-              a.name.startsWith('logs-') && 
-              a.name.includes('Tests-ubuntu-latest') &&
-              (a.name.includes('SmokeTests') || 
-               a.name.includes('EmptyAppHostTemplateTests') ||
-               a.name.includes('JsReactTemplateTests') ||
-               a.name.includes('PythonReactTemplateTests') ||
-               a.name.includes('DockerDeploymentTests') ||
-               a.name.includes('TypeScriptPolyglotTests') ||
-               a.name.includes('DoctorCommandTests') ||
-               a.name.includes('StartStopTests') ||
-               a.name.includes('PsCommandTests'))
+              a.name.startsWith('cli-e2e-recordings-')
             );
             
-            console.log(`Found ${cliE2eArtifacts.length} CLI E2E artifacts`);
+            console.log(`Found ${cliE2eArtifacts.length} CLI E2E recording artifacts`);
             
             // Create recordings directory
             const recordingsDir = 'recordings';

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -516,6 +516,25 @@ jobs:
             artifacts/bin/Aspire.Templates.Tests/Debug/net8.0/logs/**
             artifacts/log/test-logs/**
 
+      - name: Copy CLI E2E recordings for upload
+        if: always()
+        shell: bash
+        run: |
+          mkdir -p cli-e2e-recordings
+          find testresults -name "*.cast" -exec cp {} cli-e2e-recordings/ \; 2>/dev/null || true
+          if [ -n "$(ls -A cli-e2e-recordings 2>/dev/null)" ]; then
+            echo "Found recordings:"
+            ls -la cli-e2e-recordings/
+          fi
+
+      - name: Upload CLI E2E recordings
+        if: always()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: cli-e2e-recordings-${{ inputs.testShortName }}
+          path: cli-e2e-recordings/*.cast
+          if-no-files-found: ignore
+
       - name: Generate test results summary
         if: always()
         shell: pwsh


### PR DESCRIPTION
## Summary

This PR improves the CLI E2E test recording workflow to automatically discover recordings without requiring a hardcoded list of test class names.

## Changes

### `.github/workflows/run-tests.yml`
- Added step to copy `.cast` files to a dedicated folder
- Upload recordings as `cli-e2e-recordings-{TestName}` artifacts (only if recordings exist)

### `.github/workflows/cli-e2e-recording-comment.yml`
- Simplified artifact filtering to match `cli-e2e-recordings-*` pattern
- Removed hardcoded list of test class names

## Benefits

- New CLI E2E tests automatically have their recordings included in PR comments
- No workflow changes needed when adding new tests
- Cleaner separation of concerns - recordings have their own dedicated artifacts