### PR TITLE
Only export env values with FromSpec

### DIFF
--- a/src/Aspire.Dashboard/Model/ExportHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ExportHelpers.cs
@@ -79,7 +79,7 @@ internal static class ExportHelpers
     /// <returns>A result containing the .env file content and suggested file name.</returns>
     public static ExportResult GetEnvironmentVariablesAsEnvFile(ResourceViewModel resource, IDictionary<string, ResourceViewModel> resourceByName)
     {
-        var envContent = EnvHelpers.ConvertToEnvFormat(resource.Environment.Select(e => new KeyValuePair<string, string?>(e.Name, e.Value)));
+        var envContent = EnvHelpers.ConvertToEnvFormat(resource.Environment.Where(e => e.FromSpec).Select(e => new KeyValuePair<string, string?>(e.Name, e.Value)));
         var fileName = $"{ResourceViewModel.GetResourceName(resource, resourceByName)}.env";
         return new ExportResult(envContent, fileName);
     }

--- a/src/Aspire.Dashboard/Model/ResourceMenuBuilder.cs
+++ b/src/Aspire.Dashboard/Model/ResourceMenuBuilder.cs
@@ -124,7 +124,7 @@ public sealed class ResourceMenuBuilder
             }
         });
 
-        if (resource.Environment.Length > 0)
+        if (resource.Environment.Any(e => e.FromSpec))
         {
             menuItems.Add(new MenuButtonItem
             {

--- a/tests/Aspire.Dashboard.Tests/Model/ExportHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ExportHelpersTests.cs
@@ -42,7 +42,8 @@ public sealed class ExportHelpersTests
             resourceType: "Container",
             state: KnownResourceState.Running,
             environment: [
-                new EnvironmentVariableViewModel("MY_VAR", "my-value", fromSpec: false)
+                new EnvironmentVariableViewModel("MY_VAR", "my-value", fromSpec: true),
+                new EnvironmentVariableViewModel("RUNTIME_VAR", "runtime-value", fromSpec: false)
             ]);
 
         var resourceByName = new Dictionary<string, ResourceViewModel>(StringComparer.OrdinalIgnoreCase) { [resource.Name] = resource };
@@ -52,6 +53,12 @@ public sealed class ExportHelpersTests
 
         // Assert
         Assert.Equal("Test Resource.env", result.FileName);
-        Assert.Contains("MY_VAR=my-value", result.Content);
+        Assert.Equal(
+            """
+            MY_VAR=my-value
+
+            """,
+            result.Content,
+            ignoreLineEndingDifferences: true);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceMenuBuilderTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceMenuBuilderTests.cs
@@ -183,6 +183,73 @@ public sealed class ResourceMenuBuilderTests
             e => Assert.Equal("Localized:ResourceActionMetricsText", e.Text));
     }
 
+    [Fact]
+    public void AddMenuItems_WithFromSpecEnvVars_ExportEnvMenuItemShown()
+    {
+        // Arrange
+        var resource = ModelTestHelpers.CreateResource(
+            environment: [
+                new EnvironmentVariableViewModel("SPEC_VAR", "spec-value", fromSpec: true),
+                new EnvironmentVariableViewModel("RUNTIME_VAR", "runtime-value", fromSpec: false)
+            ]);
+        var repository = TelemetryTestHelpers.CreateRepository();
+        var aiContextProvider = new TestAIContextProvider();
+        var resourceMenuBuilder = CreateResourceMenuBuilder(repository, aiContextProvider);
+
+        // Act
+        var menuItems = new List<MenuButtonItem>();
+        resourceMenuBuilder.AddMenuItems(
+            menuItems,
+            resource,
+            new Dictionary<string, ResourceViewModel>(StringComparer.OrdinalIgnoreCase) { [resource.Name] = resource },
+            EventCallback.Empty,
+            EventCallback<CommandViewModel>.Empty,
+            (_, _) => false,
+            showViewDetails: true,
+            showConsoleLogsItem: true,
+            showUrls: true);
+
+        // Assert
+        Assert.Collection(menuItems,
+            e => Assert.Equal("Localized:ActionViewDetailsText", e.Text),
+            e => Assert.Equal("Localized:ResourceActionConsoleLogsText", e.Text),
+            e => Assert.Equal("Localized:ExportJson", e.Text),
+            e => Assert.Equal("Localized:ExportEnv", e.Text));
+    }
+
+    [Fact]
+    public void AddMenuItems_WithoutFromSpecEnvVars_ExportEnvMenuItemNotShown()
+    {
+        // Arrange - only runtime env vars (fromSpec: false), no spec env vars
+        var resource = ModelTestHelpers.CreateResource(
+            environment: [
+                new EnvironmentVariableViewModel("RUNTIME_VAR1", "value1", fromSpec: false),
+                new EnvironmentVariableViewModel("RUNTIME_VAR2", "value2", fromSpec: false)
+            ]);
+        var repository = TelemetryTestHelpers.CreateRepository();
+        var aiContextProvider = new TestAIContextProvider();
+        var resourceMenuBuilder = CreateResourceMenuBuilder(repository, aiContextProvider);
+
+        // Act
+        var menuItems = new List<MenuButtonItem>();
+        resourceMenuBuilder.AddMenuItems(
+            menuItems,
+            resource,
+            new Dictionary<string, ResourceViewModel>(StringComparer.OrdinalIgnoreCase) { [resource.Name] = resource },
+            EventCallback.Empty,
+            EventCallback<CommandViewModel>.Empty,
+            (_, _) => false,
+            showViewDetails: true,
+            showConsoleLogsItem: true,
+            showUrls: true);
+
+        // Assert - ExportEnv should NOT be in the menu
+        Assert.Collection(menuItems,
+            e => Assert.Equal("Localized:ActionViewDetailsText", e.Text),
+            e => Assert.Equal("Localized:ResourceActionConsoleLogsText", e.Text),
+            e => Assert.Equal("Localized:ExportJson", e.Text));
+    }
+
     private sealed class TestNavigationManager : NavigationManager
     {
     }


### PR DESCRIPTION
## Description

The export env feature should only export env vars with `FromSpec=true`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
