### PR TITLE
Add AutoVerify to tests

### DIFF
--- a/tests/Shared/TestModuleInitializer.cs
+++ b/tests/Shared/TestModuleInitializer.cs
@@ -31,5 +31,8 @@ sealed class TestModuleInitializer
                         "Snapshots"),
                     typeName: type.Name,
                     methodName: method.Name));
+
+        // auto-accept baseline changes when running locally
+        VerifierSettings.AutoVerify(includeBuildServer: false, throwException: true);
     }
 }


### PR DESCRIPTION
- when a Verify test fails, it auto-accepts the changes, so you can see the diff
- It fails the test (throwException: true)
- It doesn't do this on "build servers"
    - https://github.com/VerifyTests/DiffEngine/blob/fef0776f63f0cfa1ac070f16d0925dee89faf9de/src/DiffEngine/BuildServerDetector.cs is the checks for what is considered a "build server"
