### PR TITLE
Update Azure.Core to latest version - lift all runtime dependencies to latest

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -175,17 +175,18 @@
     <!-- playground apps dependencies for javascript -->
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <!-- Pinned versions for Component Governance - Remove when root dependencies are updated -->
-    <PackageVersion Include="Azure.Core" Version="1.50.0" />
+    <PackageVersion Include="Azure.Core" Version="1.51.1" />
     <PackageVersion Include="Azure.Identity" Version="1.17.1" />
     <!-- https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3313 -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <!-- tools/scripts dependencies -->
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="$(MicrosoftExtensionsFileSystemGlobbingVersion)" />
   </ItemGroup>
-  <!-- The following 2 groups are for packages that need to switch based on the .NET TFM being used.
-       The dependencies on any of these two groups should not be updated manually and should instead use arcade's dependency flow to get updated.-->
+
+  <!-- This group is for packages that are common between net8, net9, and net10.
+       The dependencies on this group should not be updated manually and should instead use arcade's dependency flow to get updated.-->
   <ItemGroup>
-    <!-- dotnet/extensions dependencies ** Common between net8 and net9 ** -->
+    <!-- dotnet/extensions dependencies ** Common between net8, net9, and net10 ** -->
     <PackageVersion Include="Microsoft.Extensions.AI" Version="$(MicrosoftExtensionsAIVersion)" />
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="$(MicrosoftExtensionsAIOpenAIVersion)" />
     <PackageVersion Include="Microsoft.Extensions.AI.AzureAIInference" Version="$(MicrosoftExtensionsAIAzureAIInferenceVersion)" />
@@ -195,6 +196,23 @@
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="$(MicrosoftExtensionsServiceDiscoveryVersion)" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="$(MicrosoftExtensionsServiceDiscoveryYarpVersion)" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="$(MicrosoftExtensionsTimeProviderTestingVersion)" />
+    <!-- Runtime dependencies ** Common between all TFMs because other dependencies (like Azure.Core) are lifting to the latest versions, so we need to as well ** -->
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsPreviewVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingPreviewVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsPreviewVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderPreviewVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPreviewVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPreviewVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPreviewVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="$(MicrosoftExtensionsPrimitivesPreviewVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsHttpPreviewVersion)" />
+    <PackageVersion Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1PreviewVersion)" />
+    <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonPreviewVersion)" />
+  </ItemGroup>
+
+  <!-- The following groups are for packages that need to switch based on the .NET TFM being used.
+       The dependencies on any of these two groups should not be updated manually and should instead use arcade's dependency flow to get updated.-->
+  <ItemGroup>
     <!-- EF -->
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Cosmos" Version="$(MicrosoftEntityFrameworkCoreCosmosLTSVersion)" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(MicrosoftEntityFrameworkCoreDesignLTSVersion)" />
@@ -218,18 +236,6 @@
     <PackageVersion Include="Microsoft.Extensions.Features" Version="$(MicrosoftExtensionsFeaturesLTSVersion)" />
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="$(MicrosoftExtensionsFileProvidersEmbeddedLTSVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="$(MicrosoftAspNetCoreSignalRClientLTSVersion)" />
-    <!-- Runtime -->
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsLTSVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingLTSVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsLTSVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderLTSVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsLTSVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsLTSVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsLTSVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="$(MicrosoftExtensionsPrimitivesLTSVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsHttpLTSVersion)" />
-    <PackageVersion Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1LTSVersion)" />
-    <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonLTSVersion)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <!-- EF -->
@@ -254,26 +260,8 @@
     <PackageVersion Update="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftExtensionsDiagnosticsHealthChecksVersion)" />
     <PackageVersion Update="Microsoft.Extensions.Features" Version="$(MicrosoftExtensionsFeaturesVersion)" />
     <PackageVersion Update="Microsoft.AspNetCore.SignalR.Client" Version="$(MicrosoftAspNetCoreSignalRClientVersion)" />
-    <!-- Runtime -->
-    <PackageVersion Update="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsVersion)" />
-    <PackageVersion Update="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingVersion)" />
-    <PackageVersion Update="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsVersion)" />
-    <PackageVersion Update="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderVersion)" />
-    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsVersion)" />
-    <PackageVersion Update="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
-    <PackageVersion Update="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsVersion)" />
-    <PackageVersion Update="Microsoft.Extensions.Primitives" Version="$(MicrosoftExtensionsPrimitivesVersion)" />
-    <PackageVersion Update="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsHttpVersion)" />
-    <PackageVersion Update="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" />
-    <PackageVersion Update="System.Text.Json" Version="$(SystemTextJsonVersion)" />
-    <PackageVersion Update="System.Threading.Channels" Version="$(SystemThreadingChannelsVersion)" />
   </ItemGroup>
-  <!-- These are 9.x versions which are STS so should ONLY be referenced by netfx projects -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageVersion Include="Microsoft.Bcl.Memory" Version="$(MicrosoftBclMemoryVersion)" />
-    <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="$(MicrosoftBclTimeProviderVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0' Or '$(ForceLatestDotnetVersions)' == 'true'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <!-- EF -->
     <PackageVersion Update="Microsoft.EntityFrameworkCore.Cosmos" Version="$(MicrosoftEntityFrameworkCoreCosmosPreviewVersion)" />
     <PackageVersion Update="Microsoft.EntityFrameworkCore.Design" Version="$(MicrosoftEntityFrameworkCoreDesignPreviewVersion)" />
@@ -295,17 +283,5 @@
     <PackageVersion Update="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftExtensionsDiagnosticsHealthChecksPreviewVersion)" />
     <PackageVersion Update="Microsoft.Extensions.Features" Version="$(MicrosoftExtensionsFeaturesPreviewVersion)" />
     <PackageVersion Update="Microsoft.AspNetCore.SignalR.Client" Version="$(MicrosoftAspNetCoreSignalRClientPreviewVersion)" />
-    <!-- Runtime -->
-    <PackageVersion Update="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsPreviewVersion)" />
-    <PackageVersion Update="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingPreviewVersion)" />
-    <PackageVersion Update="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsPreviewVersion)" />
-    <PackageVersion Update="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderPreviewVersion)" />
-    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPreviewVersion)" />
-    <PackageVersion Update="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPreviewVersion)" />
-    <PackageVersion Update="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPreviewVersion)" />
-    <PackageVersion Update="Microsoft.Extensions.Primitives" Version="$(MicrosoftExtensionsPrimitivesPreviewVersion)" />
-    <PackageVersion Update="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsHttpPreviewVersion)" />
-    <PackageVersion Update="System.Formats.Asn1" Version="$(SystemFormatsAsn1PreviewVersion)" />
-    <PackageVersion Update="System.Text.Json" Version="$(SystemTextJsonPreviewVersion)" />
   </ItemGroup>
 </Project>

--- a/playground/AzureAIFoundryEndToEnd/AzureAIFoundryEndToEnd.WebStory/AzureAIFoundryEndToEnd.WebStory.csproj
+++ b/playground/AzureAIFoundryEndToEnd/AzureAIFoundryEndToEnd.WebStory/AzureAIFoundryEndToEnd.WebStory.csproj
@@ -4,9 +4,6 @@
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-
-    <!-- MEAI has transitive dependencies that pull versions to 10.0 so we need pull our dependency versions for this package as well -->
-    <ForceLatestDotnetVersions>true</ForceLatestDotnetVersions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/playground/AzureOpenAIEndToEnd/AzureOpenAIEndToEnd.WebStory/AzureOpenAIEndToEnd.WebStory.csproj
+++ b/playground/AzureOpenAIEndToEnd/AzureOpenAIEndToEnd.WebStory/AzureOpenAIEndToEnd.WebStory.csproj
@@ -4,9 +4,6 @@
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-
-    <!-- MEAI has transitive dependencies that pull versions to 10.0 so we need pull our dependency versions for this package as well -->
-    <ForceLatestDotnetVersions>true</ForceLatestDotnetVersions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/playground/GitHubModelsEndToEnd/GitHubModelsEndToEnd.WebStory/GitHubModelsEndToEnd.WebStory.csproj
+++ b/playground/GitHubModelsEndToEnd/GitHubModelsEndToEnd.WebStory/GitHubModelsEndToEnd.WebStory.csproj
@@ -4,9 +4,6 @@
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-
-    <!-- MEAI has transitive dependencies that pull versions to 10.0 so we need pull our dependency versions for this package as well -->
-    <ForceLatestDotnetVersions>true</ForceLatestDotnetVersions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.WebStory/OpenAIEndToEnd.WebStory.csproj
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.WebStory/OpenAIEndToEnd.WebStory.csproj
@@ -4,9 +4,6 @@
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-
-    <!-- MEAI has transitive dependencies that pull versions to 10.0 so we need pull our dependency versions for this package as well -->
-    <ForceLatestDotnetVersions>true</ForceLatestDotnetVersions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Azure.AI.Inference/Aspire.Azure.AI.Inference.csproj
+++ b/src/Components/Aspire.Azure.AI.Inference/Aspire.Azure.AI.Inference.csproj
@@ -9,8 +9,6 @@
     <NoWarn>$(NoWarn);SYSLIB1100;SYSLIB1101</NoWarn>
     <!-- In preview until Azure.AI.Inference is shipped stable. -->
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    <!-- MEAI has transitive dependencies that pull versions to 10.0 so we need pull our dependency versions for this package as well -->
-    <ForceLatestDotnetVersions>true</ForceLatestDotnetVersions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Azure.AI.OpenAI/Aspire.Azure.AI.OpenAI.csproj
+++ b/src/Components/Aspire.Azure.AI.OpenAI/Aspire.Azure.AI.OpenAI.csproj
@@ -10,8 +10,6 @@
     <NoWarn>$(NoWarn);SYSLIB1100;SYSLIB1101;AOAI001</NoWarn>
     <!-- In preview until the public API is validated and the Microsoft.Extensions.AI integration is designed.. -->
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    <!-- MEAI has transitive dependencies that pull versions to 10.0 so we need pull our dependency versions for this package as well -->
-    <ForceLatestDotnetVersions>true</ForceLatestDotnetVersions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.OpenAI/Aspire.OpenAI.csproj
+++ b/src/Components/Aspire.OpenAI/Aspire.OpenAI.csproj
@@ -8,8 +8,6 @@
     <NoWarn>$(NoWarn);SYSLIB1100;SYSLIB1101</NoWarn>
     <!-- In preview until the public API is validated and the Microsoft.Extensions.AI integration is designed. -->
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    <!-- MEAI has transitive dependencies that pull versions to 10.0 so we need pull our dependency versions for this package as well -->
-    <ForceLatestDotnetVersions>true</ForceLatestDotnetVersions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Azure.AI.Inference.Tests/Aspire.Azure.AI.Inference.Tests.csproj
+++ b/tests/Aspire.Azure.AI.Inference.Tests/Aspire.Azure.AI.Inference.Tests.csproj
@@ -2,9 +2,6 @@
 
     <PropertyGroup>
         <TargetFrameworks>$(AllTargetFrameworks)</TargetFrameworks>
-
-        <!-- MEAI has transitive dependencies that pull versions to 10.0 so we need pull our dependency versions for this package as well -->
-        <ForceLatestDotnetVersions>true</ForceLatestDotnetVersions>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/Aspire.Azure.AI.OpenAI.Tests/Aspire.Azure.AI.OpenAI.Tests.csproj
+++ b/tests/Aspire.Azure.AI.OpenAI.Tests/Aspire.Azure.AI.OpenAI.Tests.csproj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(AllTargetFrameworks)</TargetFrameworks>
-
-    <!-- MEAI has transitive dependencies that pull versions to 10.0 so we need pull our dependency versions for this package as well -->
-    <ForceLatestDotnetVersions>true</ForceLatestDotnetVersions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -1072,7 +1072,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         // Act
         using var app = builder.Build();
         await app.StartAsync();
-        await app.StopAsync();
+        await app.WaitForShutdownAsync();
 
         if (step == "diagnostics")
         {
@@ -1159,7 +1159,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         // Act
         using var app = builder.Build();
         await app.StartAsync();
-        await app.StopAsync();
+        await app.WaitForShutdownAsync();
 
         // In diagnostics mode, verify the deployment graph shows correct dependencies
         var logs = mockActivityReporter.LoggedMessages

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelTests.cs
@@ -28,10 +28,6 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
             return Task.CompletedTask;
         });
 
-        // Register the auxiliary backchannel service
-        builder.Services.AddSingleton<AuxiliaryBackchannelService>();
-        builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<AuxiliaryBackchannelService>());
-
         using var app = builder.Build();
 
         await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(60));
@@ -71,10 +67,6 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
             }
             return Task.CompletedTask;
         });
-
-        // Register the auxiliary backchannel service
-        builder.Services.AddSingleton<AuxiliaryBackchannelService>();
-        builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<AuxiliaryBackchannelService>());
 
         using var app = builder.Build();
 
@@ -118,10 +110,6 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         // When the Dashboard is not part of the app model, null should be returned
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(outputHelper);
 
-        // Register the auxiliary backchannel service
-        builder.Services.AddSingleton<AuxiliaryBackchannelService>();
-        builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<AuxiliaryBackchannelService>());
-
         using var app = builder.Build();
 
         await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(60));
@@ -156,10 +144,6 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
     {
         // This test verifies that GetAppHostInformationAsync returns the AppHost path
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(outputHelper);
-
-        // Register the auxiliary backchannel service
-        builder.Services.AddSingleton<AuxiliaryBackchannelService>();
-        builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<AuxiliaryBackchannelService>());
 
         using var app = builder.Build();
 
@@ -201,10 +185,6 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         // This test verifies that multiple clients can invoke RPC methods concurrently
         // When the Dashboard is not part of the app model, null should be returned
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(outputHelper);
-
-        // Register the auxiliary backchannel service
-        builder.Services.AddSingleton<AuxiliaryBackchannelService>();
-        builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<AuxiliaryBackchannelService>());
 
         using var app = builder.Build();
 
@@ -249,10 +229,6 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         // This test verifies that GetAppHostInformationAsync returns the full file path with extension
         // For .csproj-based AppHosts, it should include the .csproj extension
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(outputHelper);
-
-        // Register the auxiliary backchannel service
-        builder.Services.AddSingleton<AuxiliaryBackchannelService>();
-        builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<AuxiliaryBackchannelService>());
 
         using var app = builder.Build();
 
@@ -300,10 +276,6 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         // to avoid Windows reserved device name issues (AUX is reserved on Windows < 11)
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(outputHelper);
 
-        // Register the auxiliary backchannel service
-        builder.Services.AddSingleton<AuxiliaryBackchannelService>();
-        builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<AuxiliaryBackchannelService>());
-
         using var app = builder.Build();
 
         await app.StartAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
@@ -334,10 +306,6 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Add a simple container resource (without MCP)
         builder.AddContainer("mycontainer", "nginx");
-
-        // Register the auxiliary backchannel service
-        builder.Services.AddSingleton<AuxiliaryBackchannelService>();
-        builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<AuxiliaryBackchannelService>());
 
         using var app = builder.Build();
 
@@ -380,10 +348,6 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         // Add a simple container resource (without MCP)
         builder.AddContainer("mycontainer", "nginx");
 
-        // Register the auxiliary backchannel service
-        builder.Services.AddSingleton<AuxiliaryBackchannelService>();
-        builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<AuxiliaryBackchannelService>());
-
         using var app = builder.Build();
 
         await app.StartAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
@@ -420,10 +384,6 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
     {
         // This test verifies that StopAppHostAsync initiates AppHost shutdown
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(outputHelper);
-
-        // Register the auxiliary backchannel service
-        builder.Services.AddSingleton<AuxiliaryBackchannelService>();
-        builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<AuxiliaryBackchannelService>());
 
         using var app = builder.Build();
 
@@ -474,10 +434,6 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         // This test verifies that GetCapabilitiesAsync returns both v1 and v2 capabilities
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(outputHelper);
 
-        // Register the auxiliary backchannel service
-        builder.Services.AddSingleton<AuxiliaryBackchannelService>();
-        builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<AuxiliaryBackchannelService>());
-
         using var app = builder.Build();
 
         await app.StartAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
@@ -515,10 +471,6 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
     {
         // This test verifies that the v2 GetAppHostInfoAsync returns AppHost info
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(outputHelper);
-
-        // Register the auxiliary backchannel service
-        builder.Services.AddSingleton<AuxiliaryBackchannelService>();
-        builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<AuxiliaryBackchannelService>());
 
         using var app = builder.Build();
 
@@ -562,10 +514,6 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Add a simple parameter resource
         builder.AddParameter("myparam");
-
-        // Register the auxiliary backchannel service
-        builder.Services.AddSingleton<AuxiliaryBackchannelService>();
-        builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<AuxiliaryBackchannelService>());
 
         using var app = builder.Build();
 

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelTests.cs
@@ -38,6 +38,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Get the service and verify it started
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
+        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
         Assert.NotNull(service.SocketPath);
         Assert.True(File.Exists(service.SocketPath));
 
@@ -81,15 +82,16 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
+        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
         Assert.NotNull(service.SocketPath);
 
         // Connect multiple clients concurrently
         var client1Socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
         var client2Socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
         var client3Socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
-        
+
         var endpoint = new UnixDomainSocketEndPoint(service.SocketPath);
-        
+
         await client1Socket.ConnectAsync(endpoint).WaitAsync(TimeSpan.FromSeconds(60));
         await client2Socket.ConnectAsync(endpoint).WaitAsync(TimeSpan.FromSeconds(60));
         await client3Socket.ConnectAsync(endpoint).WaitAsync(TimeSpan.FromSeconds(60));
@@ -126,6 +128,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
+        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
         Assert.NotNull(service.SocketPath);
 
         // Connect a client
@@ -164,6 +167,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
+        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
         Assert.NotNull(service.SocketPath);
 
         // Connect a client
@@ -208,6 +212,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
+        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
         Assert.NotNull(service.SocketPath);
 
         // Create multiple clients and invoke RPC methods concurrently
@@ -255,6 +260,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
+        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
         Assert.NotNull(service.SocketPath);
 
         // Connect a client
@@ -275,10 +281,10 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         Assert.NotNull(appHostInfo);
         Assert.NotNull(appHostInfo.AppHostPath);
         Assert.NotEmpty(appHostInfo.AppHostPath);
-        
+
         // The path should be an absolute path
         Assert.True(Path.IsPathRooted(appHostInfo.AppHostPath), $"Expected absolute path but got: {appHostInfo.AppHostPath}");
-        
+
         // In test scenarios where assembly metadata is not available, we may get a path without extension
         // (falling back to AppHost:Path). In real scenarios with proper metadata, we should get .csproj or .cs
         // So we just verify the path is non-empty and rooted
@@ -304,12 +310,13 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
+        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
         Assert.NotNull(service.SocketPath);
 
         // Verify that the socket path uses "auxi.sock." prefix
         var fileName = Path.GetFileName(service.SocketPath);
         Assert.StartsWith("auxi.sock.", fileName);
-        
+
         // Verify that the socket file can be created (not blocked by Windows reserved names)
         Assert.True(File.Exists(service.SocketPath), $"Socket file should exist at: {service.SocketPath}");
 
@@ -338,6 +345,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
+        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
         Assert.NotNull(service.SocketPath);
 
         // Connect a client
@@ -382,6 +390,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
+        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
         Assert.NotNull(service.SocketPath);
 
         // Connect a client
@@ -422,6 +431,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
+        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
         Assert.NotNull(service.SocketPath);
 
         // Connect a client
@@ -474,6 +484,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
+        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
         Assert.NotNull(service.SocketPath);
 
         // Connect a client
@@ -515,6 +526,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
+        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
         Assert.NotNull(service.SocketPath);
 
         // Connect a client
@@ -561,6 +573,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
+        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
         Assert.NotNull(service.SocketPath);
 
         // Connect a client

--- a/tests/Aspire.OpenAI.Tests/Aspire.OpenAI.Tests.csproj
+++ b/tests/Aspire.OpenAI.Tests/Aspire.OpenAI.Tests.csproj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(AllTargetFrameworks)</TargetFrameworks>
-
-    <!-- MEAI has transitive dependencies that pull versions to 10.0 so we need pull our dependency versions for this package as well -->
-    <ForceLatestDotnetVersions>true</ForceLatestDotnetVersions>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update to Azure.Core 1.51.1

Use latest versions for all dotnet/runtime nuget packages. This simplifies our dependency management. Too many of our dependencies are using v10 runtime packages it makes it hard to keep using transitive pinning and central package management. Aligning with the rest of the ecosystem and just always using latest.

Remove ForceLatestDotnetVersions property from multiple project files