### PR TITLE
Fix aspire doctor to only warn about multiple dev certs when any is untrusted

### DIFF
--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -149,20 +149,6 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger) : IEnvironmen
                 });
             }
         }
-        // Check for orphaned trusted certificates (in Root store but not in My store, or multiple certs in Root store for single cert in My store)
-        // This can happen when old certificates were trusted but the certificate in My store was regenerated
-        else if (trustedCount > 1)
-        {
-            results.Add(new EnvironmentCheckResult
-            {
-                Category = "sdk",
-                Name = "dev-certs",
-                Status = EnvironmentCheckStatus.Pass,
-                Message = $"HTTPS development certificate is trusted ({trustedCount} trusted certificates found)",
-                Details = "Having multiple trusted development certificates in the root store is unusual. You may want to clean up old certificates by running 'dotnet dev-certs https --clean'.",
-                Link = "https://aka.ms/aspire-prerequisites#dev-certs"
-            });
-        }
         else if (trustedCount == 0)
         {
             // Single certificate that's not trusted - provide diagnostic info

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
@@ -2,18 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Utils.EnvironmentChecker;
+using Aspire.Hosting.Utils;
 
 namespace Aspire.Cli.Tests.Utils;
 
 public class DevCertsCheckTests
 {
+    private const int MinVersion = X509Certificate2Extensions.MinimumCertificateVersionSupportingContainerTrust;
+
     [Fact]
     public void EvaluateCertificateResults_MultipleCerts_AllTrusted_ReturnsPass()
     {
         var certs = new List<CertificateInfo>
         {
-            new(CertificateTrustLevel.Full, "AAAA1111BBBB2222", 4),
-            new(CertificateTrustLevel.Full, "CCCC3333DDDD4444", 4),
+            new(CertificateTrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
+            new(CertificateTrustLevel.Full, "CCCC3333DDDD4444", MinVersion),
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
@@ -28,8 +31,8 @@ public class DevCertsCheckTests
     {
         var certs = new List<CertificateInfo>
         {
-            new(CertificateTrustLevel.None, "AAAA1111BBBB2222", 4),
-            new(CertificateTrustLevel.None, "CCCC3333DDDD4444", 4),
+            new(CertificateTrustLevel.None, "AAAA1111BBBB2222", MinVersion),
+            new(CertificateTrustLevel.None, "CCCC3333DDDD4444", MinVersion),
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
@@ -44,8 +47,8 @@ public class DevCertsCheckTests
     {
         var certs = new List<CertificateInfo>
         {
-            new(CertificateTrustLevel.Full, "AAAA1111BBBB2222", 4),
-            new(CertificateTrustLevel.None, "CCCC3333DDDD4444", 4),
+            new(CertificateTrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
+            new(CertificateTrustLevel.None, "CCCC3333DDDD4444", MinVersion),
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
@@ -60,7 +63,7 @@ public class DevCertsCheckTests
     {
         var certs = new List<CertificateInfo>
         {
-            new(CertificateTrustLevel.Full, "AAAA1111BBBB2222", 4),
+            new(CertificateTrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
@@ -75,7 +78,7 @@ public class DevCertsCheckTests
     {
         var certs = new List<CertificateInfo>
         {
-            new(CertificateTrustLevel.None, "AAAA1111BBBB2222", 4),
+            new(CertificateTrustLevel.None, "AAAA1111BBBB2222", MinVersion),
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
@@ -90,7 +93,7 @@ public class DevCertsCheckTests
     {
         var certs = new List<CertificateInfo>
         {
-            new(CertificateTrustLevel.Partial, "AAAA1111BBBB2222", 4),
+            new(CertificateTrustLevel.Partial, "AAAA1111BBBB2222", MinVersion),
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
@@ -105,7 +108,7 @@ public class DevCertsCheckTests
     {
         var certs = new List<CertificateInfo>
         {
-            new(CertificateTrustLevel.Full, "AAAA1111BBBB2222", 2),
+            new(CertificateTrustLevel.Full, "AAAA1111BBBB2222", MinVersion - 1),
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
@@ -121,8 +124,8 @@ public class DevCertsCheckTests
     {
         var certs = new List<CertificateInfo>
         {
-            new(CertificateTrustLevel.Full, "AAAA1111BBBB2222", 4),
-            new(CertificateTrustLevel.Full, "CCCC3333DDDD4444", 5),
+            new(CertificateTrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
+            new(CertificateTrustLevel.Full, "CCCC3333DDDD4444", MinVersion + 1),
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
@@ -139,8 +142,8 @@ public class DevCertsCheckTests
         // Partially trusted counts as trusted (not None), so all certs are "trusted"
         var certs = new List<CertificateInfo>
         {
-            new(CertificateTrustLevel.Partial, "AAAA1111BBBB2222", 4),
-            new(CertificateTrustLevel.Partial, "CCCC3333DDDD4444", 4),
+            new(CertificateTrustLevel.Partial, "AAAA1111BBBB2222", MinVersion),
+            new(CertificateTrustLevel.Partial, "CCCC3333DDDD4444", MinVersion),
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
@@ -155,9 +158,9 @@ public class DevCertsCheckTests
     {
         var certs = new List<CertificateInfo>
         {
-            new(CertificateTrustLevel.Full, "AAAA1111BBBB2222", 4),
-            new(CertificateTrustLevel.Full, "CCCC3333DDDD4444", 4),
-            new(CertificateTrustLevel.None, "EEEE5555FFFF6666", 4),
+            new(CertificateTrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
+            new(CertificateTrustLevel.Full, "CCCC3333DDDD4444", MinVersion),
+            new(CertificateTrustLevel.None, "EEEE5555FFFF6666", MinVersion),
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
@@ -1,0 +1,169 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Utils.EnvironmentChecker;
+
+namespace Aspire.Cli.Tests.Utils;
+
+public class DevCertsCheckTests
+{
+    [Fact]
+    public void EvaluateCertificateResults_MultipleCerts_AllTrusted_ReturnsPass()
+    {
+        var certs = new List<CertificateInfo>
+        {
+            new(CertificateTrustLevel.Full, "AAAA1111BBBB2222", 4),
+            new(CertificateTrustLevel.Full, "CCCC3333DDDD4444", 4),
+        };
+
+        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+
+        var devCertsResult = Assert.Single(results, r => r.Name == "dev-certs");
+        Assert.Equal(EnvironmentCheckStatus.Pass, devCertsResult.Status);
+        Assert.Contains("trusted", devCertsResult.Message);
+    }
+
+    [Fact]
+    public void EvaluateCertificateResults_MultipleCerts_NoneTrusted_ReturnsWarning()
+    {
+        var certs = new List<CertificateInfo>
+        {
+            new(CertificateTrustLevel.None, "AAAA1111BBBB2222", 4),
+            new(CertificateTrustLevel.None, "CCCC3333DDDD4444", 4),
+        };
+
+        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+
+        var devCertsResult = Assert.Single(results, r => r.Name == "dev-certs");
+        Assert.Equal(EnvironmentCheckStatus.Warning, devCertsResult.Status);
+        Assert.Contains("none are trusted", devCertsResult.Message);
+    }
+
+    [Fact]
+    public void EvaluateCertificateResults_MultipleCerts_SomeUntrusted_ReturnsWarning()
+    {
+        var certs = new List<CertificateInfo>
+        {
+            new(CertificateTrustLevel.Full, "AAAA1111BBBB2222", 4),
+            new(CertificateTrustLevel.None, "CCCC3333DDDD4444", 4),
+        };
+
+        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+
+        var devCertsResult = Assert.Single(results, r => r.Name == "dev-certs");
+        Assert.Equal(EnvironmentCheckStatus.Warning, devCertsResult.Status);
+        Assert.Contains("Multiple HTTPS development certificates found", devCertsResult.Message);
+    }
+
+    [Fact]
+    public void EvaluateCertificateResults_SingleCert_Trusted_ReturnsPass()
+    {
+        var certs = new List<CertificateInfo>
+        {
+            new(CertificateTrustLevel.Full, "AAAA1111BBBB2222", 4),
+        };
+
+        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+
+        var devCertsResult = Assert.Single(results, r => r.Name == "dev-certs");
+        Assert.Equal(EnvironmentCheckStatus.Pass, devCertsResult.Status);
+        Assert.Contains("trusted", devCertsResult.Message);
+    }
+
+    [Fact]
+    public void EvaluateCertificateResults_SingleCert_Untrusted_ReturnsWarning()
+    {
+        var certs = new List<CertificateInfo>
+        {
+            new(CertificateTrustLevel.None, "AAAA1111BBBB2222", 4),
+        };
+
+        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+
+        var devCertsResult = Assert.Single(results, r => r.Name == "dev-certs");
+        Assert.Equal(EnvironmentCheckStatus.Warning, devCertsResult.Status);
+        Assert.Contains("not trusted", devCertsResult.Message);
+    }
+
+    [Fact]
+    public void EvaluateCertificateResults_SingleCert_PartiallyTrusted_ReturnsWarning()
+    {
+        var certs = new List<CertificateInfo>
+        {
+            new(CertificateTrustLevel.Partial, "AAAA1111BBBB2222", 4),
+        };
+
+        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+
+        var devCertsResult = Assert.Single(results, r => r.Name == "dev-certs");
+        Assert.Equal(EnvironmentCheckStatus.Warning, devCertsResult.Status);
+        Assert.Contains("partially trusted", devCertsResult.Message);
+    }
+
+    [Fact]
+    public void EvaluateCertificateResults_OldTrustedCert_ReturnsVersionWarning()
+    {
+        var certs = new List<CertificateInfo>
+        {
+            new(CertificateTrustLevel.Full, "AAAA1111BBBB2222", 2),
+        };
+
+        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+
+        Assert.Equal(2, results.Count);
+        var versionResult = Assert.Single(results, r => r.Name == "dev-certs-version");
+        Assert.Equal(EnvironmentCheckStatus.Warning, versionResult.Status);
+        Assert.Contains("older version", versionResult.Message);
+    }
+
+    [Fact]
+    public void EvaluateCertificateResults_MultipleCerts_AllTrusted_NoVersionWarning()
+    {
+        var certs = new List<CertificateInfo>
+        {
+            new(CertificateTrustLevel.Full, "AAAA1111BBBB2222", 4),
+            new(CertificateTrustLevel.Full, "CCCC3333DDDD4444", 5),
+        };
+
+        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+
+        // Should only have the pass result, no version warning
+        var devCertsResult = Assert.Single(results);
+        Assert.Equal("dev-certs", devCertsResult.Name);
+        Assert.Equal(EnvironmentCheckStatus.Pass, devCertsResult.Status);
+    }
+
+    [Fact]
+    public void EvaluateCertificateResults_MultipleCerts_AllPartiallyTrusted_ReturnsPass()
+    {
+        // Partially trusted counts as trusted (not None), so all certs are "trusted"
+        var certs = new List<CertificateInfo>
+        {
+            new(CertificateTrustLevel.Partial, "AAAA1111BBBB2222", 4),
+            new(CertificateTrustLevel.Partial, "CCCC3333DDDD4444", 4),
+        };
+
+        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+
+        // Should not have a "Multiple certs" warning since all are trusted
+        var devCertsResult = Assert.Single(results, r => r.Name == "dev-certs");
+        Assert.NotEqual(EnvironmentCheckStatus.Warning, devCertsResult.Status);
+    }
+
+    [Fact]
+    public void EvaluateCertificateResults_ThreeCerts_TwoTrustedOneNot_ReturnsWarning()
+    {
+        var certs = new List<CertificateInfo>
+        {
+            new(CertificateTrustLevel.Full, "AAAA1111BBBB2222", 4),
+            new(CertificateTrustLevel.Full, "CCCC3333DDDD4444", 4),
+            new(CertificateTrustLevel.None, "EEEE5555FFFF6666", 4),
+        };
+
+        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+
+        var devCertsResult = Assert.Single(results, r => r.Name == "dev-certs");
+        Assert.Equal(EnvironmentCheckStatus.Warning, devCertsResult.Status);
+        Assert.Contains("3 certificates", devCertsResult.Message);
+    }
+}


### PR DESCRIPTION
## Summary

Previously, `aspire doctor` always showed a warning when multiple dev certificates were found, even if all were trusted. This changes the behavior so that:

- **Multiple certs, all trusted** → Pass (no warning)
- **Multiple certs, some untrusted** → Warning
- **Multiple certs, none trusted** → Warning

## Changes

### `src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs`
- Extracted certificate evaluation logic into a testable `internal static EvaluateCertificateResults` method
- Added `CertificateInfo` record to decouple evaluation from the X509 certificate store
- Changed the multiple-cert `else` branch to `else if (trustedCount < certInfos.Count)` so the warning only fires when at least one cert is untrusted

### `tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs` (new)
- 10 unit tests covering all certificate evaluation scenarios:
  - Multiple certs: all trusted (Pass), none trusted (Warning), some untrusted (Warning), all partially trusted (Pass)
  - Single cert: trusted (Pass), untrusted (Warning), partially trusted (Warning), old version (Warning)
  - Edge cases: three certs with mixed trust, multiple certs with no version warning