### PR TITLE
Fall back to code-insiders when code is not found in start-code scripts

### DIFF
--- a/start-code.cmd
+++ b/start-code.cmd
@@ -4,8 +4,17 @@ SETLOCAL
 :: This command launches a Visual Studio Code with environment variables required to use a local version of the .NET Core SDK.
 :: Set VSCODE_CMD environment variable to use a different VS Code variant (e.g., code-insiders).
 
-IF ["%VSCODE_CMD%"] == [""] SET VSCODE_CMD=code
+IF NOT ["%VSCODE_CMD%"] == [""] GOTO find_vscode
 
+:: Try 'code' first, then fall back to 'code-insiders'
+FOR /f "delims=" %%a IN ('where.exe code 2^>nul') DO @SET VSCODE_CMD=code& GOTO find_vscode
+FOR /f "delims=" %%a IN ('where.exe code-insiders 2^>nul') DO @SET VSCODE_CMD=code-insiders& GOTO find_vscode
+
+echo [ERROR] Neither 'code' nor 'code-insiders' is installed or can't be found.
+echo.
+exit /b 1
+
+:find_vscode
 FOR /f "delims=" %%a IN ('where.exe %VSCODE_CMD%') DO @SET vscode=%%a& GOTO break
 :break
 

--- a/start-code.cmd
+++ b/start-code.cmd
@@ -1,14 +1,31 @@
 @ECHO OFF
-SETLOCAL
+SETLOCAL EnableDelayedExpansion
 
 :: This command launches a Visual Studio Code with environment variables required to use a local version of the .NET Core SDK.
 :: Set VSCODE_CMD environment variable to use a different VS Code variant (e.g., code-insiders).
 
 IF NOT ["%VSCODE_CMD%"] == [""] GOTO find_vscode
 
-:: Try 'code' first, then fall back to 'code-insiders'
-FOR /f "delims=" %%a IN ('where.exe code 2^>nul') DO @SET VSCODE_CMD=code& GOTO find_vscode
-FOR /f "delims=" %%a IN ('where.exe code-insiders 2^>nul') DO @SET VSCODE_CMD=code-insiders& GOTO find_vscode
+:: Check which VS Code variants are available
+SET _has_code=
+SET _has_insiders=
+FOR /f "delims=" %%a IN ('where.exe code 2^>nul') DO @SET _has_code=1
+FOR /f "delims=" %%a IN ('where.exe code-insiders 2^>nul') DO @SET _has_insiders=1
+
+IF DEFINED _has_code IF DEFINED _has_insiders (
+    echo Both 'code' and 'code-insiders' are installed.
+    echo   1^) code
+    echo   2^) code-insiders
+    SET /P _choice="Select [1]: "
+    IF NOT DEFINED _choice SET _choice=1
+    IF "!_choice!"=="1" SET VSCODE_CMD=code& GOTO find_vscode
+    IF "!_choice!"=="2" SET VSCODE_CMD=code-insiders& GOTO find_vscode
+    echo [ERROR] Invalid selection.
+    exit /b 1
+)
+
+IF DEFINED _has_code SET VSCODE_CMD=code& GOTO find_vscode
+IF DEFINED _has_insiders SET VSCODE_CMD=code-insiders& GOTO find_vscode
 
 echo [ERROR] Neither 'code' nor 'code-insiders' is installed or can't be found.
 echo.

--- a/start-code.cmd
+++ b/start-code.cmd
@@ -15,7 +15,7 @@ echo.
 exit /b 1
 
 :find_vscode
-FOR /f "delims=" %%a IN ('where.exe %VSCODE_CMD%') DO @SET vscode=%%a& GOTO break
+FOR /f "delims=" %%a IN ('where.exe %VSCODE_CMD% 2^>nul') DO @SET vscode=%%a& GOTO break
 :break
 
 IF ["%vscode%"] == [""] (

--- a/start-code.sh
+++ b/start-code.sh
@@ -28,7 +28,10 @@ then
 fi
 
 if [ -n "${VSCODE_CMD:-}" ]; then
-    : # Use the explicitly set command
+    if ! command -v "$VSCODE_CMD" &> /dev/null; then
+        echo "[ERROR] The specified VS Code command '$VSCODE_CMD' is not installed or cannot be found in PATH."
+        exit 1
+    fi
 elif command -v code &> /dev/null; then
     VSCODE_CMD="code"
 elif command -v code-insiders &> /dev/null; then

--- a/start-code.sh
+++ b/start-code.sh
@@ -27,10 +27,14 @@ then
     set -- '.';
 fi
 
-VSCODE_CMD="${VSCODE_CMD:-code}"
-
-if ! command -v "$VSCODE_CMD" &> /dev/null; then
-    echo "[ERROR] $VSCODE_CMD is not installed or can't be found."
+if [ -n "${VSCODE_CMD:-}" ]; then
+    : # Use the explicitly set command
+elif command -v code &> /dev/null; then
+    VSCODE_CMD="code"
+elif command -v code-insiders &> /dev/null; then
+    VSCODE_CMD="code-insiders"
+else
+    echo "[ERROR] Neither 'code' nor 'code-insiders' is installed or can be found."
     exit 1
 fi
 

--- a/start-code.sh
+++ b/start-code.sh
@@ -32,6 +32,16 @@ if [ -n "${VSCODE_CMD:-}" ]; then
         echo "[ERROR] The specified VS Code command '$VSCODE_CMD' is not installed or cannot be found in PATH."
         exit 1
     fi
+elif command -v code &> /dev/null && command -v code-insiders &> /dev/null; then
+    echo "Both 'code' and 'code-insiders' are installed."
+    echo "  1) code"
+    echo "  2) code-insiders"
+    read -rp "Select [1]: " choice
+    case "${choice:-1}" in
+        1) VSCODE_CMD="code" ;;
+        2) VSCODE_CMD="code-insiders" ;;
+        *) echo "[ERROR] Invalid selection."; exit 1 ;;
+    esac
 elif command -v code &> /dev/null; then
     VSCODE_CMD="code"
 elif command -v code-insiders &> /dev/null; then


### PR DESCRIPTION
Both `start-code.sh` and `start-code.cmd` now automatically try `code-insiders` if `code` is not installed. The `VSCODE_CMD` environment variable still takes precedence when explicitly set.