### PR TITLE
Add --no-build and --no-restore flags to aspire run command

### DIFF
--- a/src/Aspire.Cli/Commands/ExecCommand.cs
+++ b/src/Aspire.Cli/Commands/ExecCommand.cs
@@ -182,6 +182,7 @@ internal class ExecCommand : BaseCommand
                     projectFile: effectiveAppHostProjectFile,
                     watch: false,
                     noBuild: false,
+                    noRestore: false,
                     args: args,
                     env: env,
                     backchannelCompletionSource: backchannelCompletionSource,

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -55,6 +55,11 @@ internal abstract class PipelineCommandBase : BaseCommand
         Description = "The environment to use for the operation. The default is 'Production'."
     };
 
+    protected static readonly Option<bool> s_noBuildOption = new("--no-build")
+    {
+        Description = PublishCommandStrings.NoBuildArgumentDescription
+    };
+
     protected abstract string OperationCompletedPrefix { get; }
     protected abstract string OperationFailedPrefix { get; }
 
@@ -88,6 +93,7 @@ internal abstract class PipelineCommandBase : BaseCommand
         Options.Add(s_logLevelOption);
         Options.Add(s_environmentOption);
         Options.Add(s_includeExceptionDetailsOption);
+        Options.Add(s_noBuildOption);
 
         // In the publish and deploy commands we forward all unrecognized tokens
         // through to the underlying tooling when we launch the app host.
@@ -103,6 +109,7 @@ internal abstract class PipelineCommandBase : BaseCommand
     {
         var debugMode = parseResult.GetValue(RootCommand.DebugOption);
         var waitForDebugger = parseResult.GetValue(RootCommand.WaitForDebuggerOption);
+        var noBuild = parseResult.GetValue(s_noBuildOption);
 
         Task<int>? pendingRun = null;
         PublishContext? publishContext = null;
@@ -156,7 +163,8 @@ internal abstract class PipelineCommandBase : BaseCommand
                 Arguments = GetRunArguments(fullyQualifiedOutputPath, unmatchedTokens, parseResult),
                 BackchannelCompletionSource = backchannelCompletionSource,
                 WorkingDirectory = ExecutionContext.WorkingDirectory,
-                Debug = debugMode
+                Debug = debugMode,
+                NoBuild = noBuild
             };
 
             pendingRun = project.PublishAsync(publishContext, cancellationToken);

--- a/src/Aspire.Cli/Projects/AppHostProjectContext.cs
+++ b/src/Aspire.Cli/Projects/AppHostProjectContext.cs
@@ -33,6 +33,11 @@ internal sealed class AppHostProjectContext
     public bool NoBuild { get; init; }
 
     /// <summary>
+    /// Gets whether to skip restoring packages before running.
+    /// </summary>
+    public bool NoRestore { get; init; }
+
+    /// <summary>
     /// Gets whether to wait for a debugger to attach.
     /// </summary>
     public bool WaitForDebugger { get; init; }

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -239,7 +239,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
 
         try
         {
-            if (!watch)
+            if (!watch && !context.NoBuild)
             {
                 // Build in CLI if either not running under extension host, or the extension reports 'build-dotnet-using-cli' capability.
                 var extensionHasBuildCapability = extensionBackchannel is not null && await extensionBackchannel.HasCapabilityAsync(KnownCapabilities.BuildDotnetUsingCli, cancellationToken);
@@ -252,7 +252,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
                         StandardErrorCallback = buildOutputCollector.AppendError,
                     };
 
-                    var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, _interactionService, effectiveAppHostFile, buildOptions, context.WorkingDirectory, cancellationToken);
+                    var buildExitCode = await AppHostHelper.BuildAppHostAsync(_runner, _interactionService, effectiveAppHostFile, context.NoRestore, buildOptions, context.WorkingDirectory, cancellationToken);
 
                     if (buildExitCode != 0)
                     {
@@ -314,10 +314,14 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         // Start the apphost - the runner will signal the backchannel when ready
         try
         {
+            // noBuild: true if either watch mode is off (we already built above) or --no-build was passed
+            // noRestore: only relevant when noBuild is false (since --no-build implies --no-restore)
+            var noBuild = !watch || context.NoBuild;
             return await _runner.RunAsync(
                 effectiveAppHostFile,
                 watch,
-                !watch,
+                noBuild,
+                context.NoRestore,
                 context.UnmatchedTokens,
                 env,
                 backchannelCompletionSource,
@@ -385,30 +389,34 @@ internal sealed class DotNetAppHostProject : IAppHostProject
                 throw exception;
             }
 
-            // Build the apphost
-            var buildOutputCollector = new OutputCollector(_fileLoggerProvider, "Build");
-            var buildOptions = new DotNetCliRunnerInvocationOptions
+            // Build the apphost (unless --no-build is specified)
+            if (!context.NoBuild)
             {
-                StandardOutputCallback = buildOutputCollector.AppendOutput,
-                StandardErrorCallback = buildOutputCollector.AppendError,
-            };
+                var buildOutputCollector = new OutputCollector(_fileLoggerProvider, "Build");
+                var buildOptions = new DotNetCliRunnerInvocationOptions
+                {
+                    StandardOutputCallback = buildOutputCollector.AppendOutput,
+                    StandardErrorCallback = buildOutputCollector.AppendError,
+                };
 
-            var buildExitCode = await AppHostHelper.BuildAppHostAsync(
-                _runner,
-                _interactionService,
-                effectiveAppHostFile,
-                buildOptions,
-                context.WorkingDirectory,
-                cancellationToken);
+                var buildExitCode = await AppHostHelper.BuildAppHostAsync(
+                    _runner,
+                    _interactionService,
+                    effectiveAppHostFile,
+                    noRestore: false,
+                    buildOptions,
+                    context.WorkingDirectory,
+                    cancellationToken);
 
-            if (buildExitCode != 0)
-            {
-                // Set OutputCollector so PipelineCommandBase can display errors
-                context.OutputCollector = buildOutputCollector;
-                // Signal the backchannel completion source so the caller doesn't wait forever
-                context.BackchannelCompletionSource?.TrySetException(
-                    new InvalidOperationException("The app host build failed."));
-                return ExitCodeConstants.FailedToBuildArtifacts;
+                if (buildExitCode != 0)
+                {
+                    // Set OutputCollector so PipelineCommandBase can display errors
+                    context.OutputCollector = buildOutputCollector;
+                    // Signal the backchannel completion source so the caller doesn't wait forever
+                    context.BackchannelCompletionSource?.TrySetException(
+                        new InvalidOperationException("The app host build failed."));
+                    return ExitCodeConstants.FailedToBuildArtifacts;
+                }
             }
         }
 
@@ -433,6 +441,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
             effectiveAppHostFile,
             watch: false,
             noBuild: true,
+            noRestore: false,
             context.Arguments,
             env,
             context.BackchannelCompletionSource,

--- a/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
@@ -425,7 +425,7 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
             StandardErrorCallback = outputCollector.AppendError
         };
 
-        var exitCode = await _dotNetCliRunner.BuildAsync(projectFile, options, cancellationToken);
+        var exitCode = await _dotNetCliRunner.BuildAsync(projectFile, noRestore: false, options, cancellationToken);
 
         return (exitCode == 0, outputCollector);
     }

--- a/src/Aspire.Cli/Projects/IAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/IAppHostProject.cs
@@ -120,6 +120,11 @@ internal sealed class PublishContext
     /// Gets whether debug logging is enabled.
     /// </summary>
     public bool Debug { get; init; }
+
+    /// <summary>
+    /// Gets whether to skip building before running.
+    /// </summary>
+    public bool NoBuild { get; init; }
 }
 
 /// <summary>

--- a/src/Aspire.Cli/Resources/PublishCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/PublishCommandStrings.Designer.cs
@@ -86,7 +86,16 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("InputPromptLoading", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Do not build or restore the project before running..
+        /// </summary>
+        public static string NoBuildArgumentDescription {
+            get {
+                return ResourceManager.GetString("NoBuildArgumentDescription", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to PUBLISHING COMPLETED.
         /// </summary>

--- a/src/Aspire.Cli/Resources/PublishCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/PublishCommandStrings.resx
@@ -141,4 +141,7 @@
   <data name="InputPromptLoading" xml:space="preserve">
     <value>Loading...</value>
   </data>
+  <data name="NoBuildArgumentDescription" xml:space="preserve">
+    <value>Do not build or restore the project before running.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/RunCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/RunCommandStrings.Designer.cs
@@ -296,5 +296,17 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("IsolatedModeRunningInstanceWarning", resourceCulture);
             }
         }
+
+        public static string NoBuildArgumentDescription {
+            get {
+                return ResourceManager.GetString("NoBuildArgumentDescription", resourceCulture);
+            }
+        }
+
+        public static string NoBuildNotSupportedWithWatchMode {
+            get {
+                return ResourceManager.GetString("NoBuildNotSupportedWithWatchMode", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/RunCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/RunCommandStrings.resx
@@ -247,4 +247,10 @@
   <data name="IsolatedModeRunningInstanceWarning" xml:space="preserve">
     <value>A running instance of this AppHost was found and will be stopped. To run multiple isolated instances simultaneously, run from different directories such as git worktree directories.</value>
   </data>
+  <data name="NoBuildArgumentDescription" xml:space="preserve">
+    <value>Do not build or restore the project before running.</value>
+  </data>
+  <data name="NoBuildNotSupportedWithWatchMode" xml:space="preserve">
+    <value>The --no-build option cannot be used when watch mode is enabled.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.cs.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Probíhá načítání...</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>PUBLISHING COMPLETED</source>
         <target state="translated">PUBLIKOVÁNÍ DOKONČENO</target>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.de.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Wird geladen...</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>PUBLISHING COMPLETED</source>
         <target state="translated">VERÖFFENTLICHUNG ABGESCHLOSSEN</target>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.es.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Cargando...</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>PUBLISHING COMPLETED</source>
         <target state="translated">PUBLICACIÓN COMPLETADA</target>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.fr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Chargement en cours… Merci de patienter.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>PUBLISHING COMPLETED</source>
         <target state="translated">PUBLICATION EFFECTUÉE</target>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.it.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Caricamento in corso...</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>PUBLISHING COMPLETED</source>
         <target state="translated">PUBBLICAZIONE COMPLETATA</target>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.ja.xlf
@@ -17,6 +17,11 @@
         <target state="translated">読み込んでいます...</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>PUBLISHING COMPLETED</source>
         <target state="translated">発行が完了しました</target>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.ko.xlf
@@ -17,6 +17,11 @@
         <target state="translated">로드 중...</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>PUBLISHING COMPLETED</source>
         <target state="translated">게시 완료</target>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.pl.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Trwa ładowanie...</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>PUBLISHING COMPLETED</source>
         <target state="translated">UKOŃCZONO PUBLIKOWANIE</target>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Carregando...</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>PUBLISHING COMPLETED</source>
         <target state="translated">PUBLICAÇÃO CONCLUÍDA</target>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.ru.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Загрузка…</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>PUBLISHING COMPLETED</source>
         <target state="translated">ПУБЛИКАЦИЯ ЗАВЕРШЕНА</target>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.tr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Yükleniyor...</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>PUBLISHING COMPLETED</source>
         <target state="translated">YAYIMLAMA TAMAMLANDI</target>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="translated">正在加载...</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>PUBLISHING COMPLETED</source>
         <target state="translated">已完成发布</target>

--- a/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PublishCommandStrings.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="translated">正在載入...</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OperationCompletedPrefix">
         <source>PUBLISHING COMPLETED</source>
         <target state="translated">發佈完成</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.cs.xlf
@@ -132,6 +132,16 @@
         <target state="translated">Protokoly</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoBuildNotSupportedWithWatchMode">
+        <source>The --no-build option cannot be used when watch mode is enabled.</source>
+        <target state="new">The --no-build option cannot be used when watch mode is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]CTRL+C[/] to stop the apphost and exit.</source>
         <target state="translated">Stisknutím kláves [bold]Ctrl+C[/] zastavíte hostitele aplikací a provedete ukončení.</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.de.xlf
@@ -132,6 +132,16 @@
         <target state="translated">Protokolle</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoBuildNotSupportedWithWatchMode">
+        <source>The --no-build option cannot be used when watch mode is enabled.</source>
+        <target state="new">The --no-build option cannot be used when watch mode is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]CTRL+C[/] to stop the apphost and exit.</source>
         <target state="translated">Drücken Sie [bold]STRG+C[/], um den App-Host zu beenden und zu verlassen.</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.es.xlf
@@ -132,6 +132,16 @@
         <target state="translated">Registros</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoBuildNotSupportedWithWatchMode">
+        <source>The --no-build option cannot be used when watch mode is enabled.</source>
+        <target state="new">The --no-build option cannot be used when watch mode is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]CTRL+C[/] to stop the apphost and exit.</source>
         <target state="translated">Presione [bold]CTRL+C[/] para detener el apphost y salir.</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.fr.xlf
@@ -132,6 +132,16 @@
         <target state="translated">Journaux</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoBuildNotSupportedWithWatchMode">
+        <source>The --no-build option cannot be used when watch mode is enabled.</source>
+        <target state="new">The --no-build option cannot be used when watch mode is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]CTRL+C[/] to stop the apphost and exit.</source>
         <target state="translated">Appuyez sur [bold]CTRL+C[/] pour arrêter l’apphost et quitter.</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.it.xlf
@@ -132,6 +132,16 @@
         <target state="translated">Log</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoBuildNotSupportedWithWatchMode">
+        <source>The --no-build option cannot be used when watch mode is enabled.</source>
+        <target state="new">The --no-build option cannot be used when watch mode is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]CTRL+C[/] to stop the apphost and exit.</source>
         <target state="translated">Premere [bold]CTRL+C[/] per arrestare l'apphost e uscire.</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ja.xlf
@@ -132,6 +132,16 @@
         <target state="translated">ログ</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoBuildNotSupportedWithWatchMode">
+        <source>The --no-build option cannot be used when watch mode is enabled.</source>
+        <target state="new">The --no-build option cannot be used when watch mode is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]CTRL+C[/] to stop the apphost and exit.</source>
         <target state="translated">[bold]Ctrl+C[/] キーを押して AppHost を停止して終了します。</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ko.xlf
@@ -132,6 +132,16 @@
         <target state="translated">로그</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoBuildNotSupportedWithWatchMode">
+        <source>The --no-build option cannot be used when watch mode is enabled.</source>
+        <target state="new">The --no-build option cannot be used when watch mode is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]CTRL+C[/] to stop the apphost and exit.</source>
         <target state="translated">앱 호스트를 중지하고 종료하려면 [bold]CTRL+C[/]를 누르세요.</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pl.xlf
@@ -132,6 +132,16 @@
         <target state="translated">Dzienniki</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoBuildNotSupportedWithWatchMode">
+        <source>The --no-build option cannot be used when watch mode is enabled.</source>
+        <target state="new">The --no-build option cannot be used when watch mode is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]CTRL+C[/] to stop the apphost and exit.</source>
         <target state="translated">Naciśnij klawisze [bold]CTRL+C[/], aby zatrzymać hosta aplikacji i zakończyć.</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pt-BR.xlf
@@ -132,6 +132,16 @@
         <target state="translated">Logs</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoBuildNotSupportedWithWatchMode">
+        <source>The --no-build option cannot be used when watch mode is enabled.</source>
+        <target state="new">The --no-build option cannot be used when watch mode is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]CTRL+C[/] to stop the apphost and exit.</source>
         <target state="translated">Pressione [bold]CTRL+C[/] para interromper o apphost e sair.</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ru.xlf
@@ -132,6 +132,16 @@
         <target state="translated">Журналы</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoBuildNotSupportedWithWatchMode">
+        <source>The --no-build option cannot be used when watch mode is enabled.</source>
+        <target state="new">The --no-build option cannot be used when watch mode is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]CTRL+C[/] to stop the apphost and exit.</source>
         <target state="translated">Нажмите клавиши [bold]CTRL+C[/], чтобы остановить хост приложений и выйти.</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.tr.xlf
@@ -132,6 +132,16 @@
         <target state="translated">Günlükler</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoBuildNotSupportedWithWatchMode">
+        <source>The --no-build option cannot be used when watch mode is enabled.</source>
+        <target state="new">The --no-build option cannot be used when watch mode is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]CTRL+C[/] to stop the apphost and exit.</source>
         <target state="translated">Apphost'u durdurmak ve çıkmak için [bold]CTRL+C[/] tuşlarına basın.</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hans.xlf
@@ -132,6 +132,16 @@
         <target state="translated">日志</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoBuildNotSupportedWithWatchMode">
+        <source>The --no-build option cannot be used when watch mode is enabled.</source>
+        <target state="new">The --no-build option cannot be used when watch mode is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]CTRL+C[/] to stop the apphost and exit.</source>
         <target state="translated">按 [bold]Ctrl+C[/] 以停止应用主机并退出。</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hant.xlf
@@ -132,6 +132,16 @@
         <target state="translated">記錄</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoBuildArgumentDescription">
+        <source>Do not build or restore the project before running.</source>
+        <target state="new">Do not build or restore the project before running.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoBuildNotSupportedWithWatchMode">
+        <source>The --no-build option cannot be used when watch mode is enabled.</source>
+        <target state="new">The --no-build option cannot be used when watch mode is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PressCtrlCToStopAppHost">
         <source>Press [bold]CTRL+C[/] to stop the apphost and exit.</source>
         <target state="translated">按 [bold]CTRL+C[/] 停止 apphost 並結束。</target>

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -65,13 +65,14 @@ internal static class AppHostHelper
         return appHostInformationResult;
     }
 
-    internal static async Task<int> BuildAppHostAsync(IDotNetCliRunner runner, IInteractionService interactionService, FileInfo projectFile, DotNetCliRunnerInvocationOptions options, DirectoryInfo workingDirectory, CancellationToken cancellationToken)
+    internal static async Task<int> BuildAppHostAsync(IDotNetCliRunner runner, IInteractionService interactionService, FileInfo projectFile, bool noRestore, DotNetCliRunnerInvocationOptions options, DirectoryInfo workingDirectory, CancellationToken cancellationToken)
     {
         var relativePath = Path.GetRelativePath(workingDirectory.FullName, projectFile.FullName);
         return await interactionService.ShowStatusAsync(
             $":hammer_and_wrench:  {InteractionServiceStrings.BuildingAppHost} {relativePath}",
             () => runner.BuildAsync(
                 projectFile,
+                noRestore,
                 options,
                 cancellationToken));
     }

--- a/tests/Aspire.Cli.Tests/Commands/DeployCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DeployCommandTests.cs
@@ -111,7 +111,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
             {
                 var runner = new TestDotNetCliRunner
                 {
-                    BuildAsyncCallback = (projectFile, options, cancellationToken) =>
+                    BuildAsyncCallback = (projectFile, noRestore, options, cancellationToken) =>
                     {
                         return 1; // Simulate a build failure
                     }
@@ -146,7 +146,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
                 var runner = new TestDotNetCliRunner
                 {
                     // Simulate a successful build
-                    BuildAsyncCallback = (projectFile, options, cancellationToken) => 0,
+                    BuildAsyncCallback = (projectFile, noRestore, options, cancellationToken) => 0,
 
                     // Simulate a successful app host information retrieval
                     GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
@@ -155,7 +155,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
                     },
 
                     // Simulate apphost running successfully and establishing a backchannel
-                    RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, cancellationToken) =>
+                    RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken) =>
                     {
                         Assert.True(options.NoLaunchProfile);
 
@@ -214,7 +214,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
                 var runner = new TestDotNetCliRunner
                 {
                     // Simulate a successful build
-                    BuildAsyncCallback = (projectFile, options, cancellationToken) => 0,
+                    BuildAsyncCallback = (projectFile, noRestore, options, cancellationToken) => 0,
 
                     // Simulate a successful app host information retrieval
                     GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
@@ -223,7 +223,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
                     },
 
                     // Simulate apphost running successfully and establishing a backchannel
-                    RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, cancellationToken) =>
+                    RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken) =>
                     {
                         Assert.True(options.NoLaunchProfile);
 
@@ -287,7 +287,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
                 var runner = new TestDotNetCliRunner
                 {
                     // Simulate a successful build
-                    BuildAsyncCallback = (projectFile, options, cancellationToken) => 0,
+                    BuildAsyncCallback = (projectFile, noRestore, options, cancellationToken) => 0,
 
                     // Simulate a successful app host information retrieval
                     GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
@@ -296,7 +296,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
                         },
 
                     // Simulate apphost running and verify --step deploy flag is passed
-                    RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, cancellationToken) =>
+                    RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken) =>
                         {
                             Assert.Contains("--operation", args);
                             Assert.Contains("publish", args);
@@ -355,7 +355,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
                 var runner = new TestDotNetCliRunner
                 {
                     // Simulate a successful build
-                    BuildAsyncCallback = (projectFile, options, cancellationToken) => 0,
+                    BuildAsyncCallback = (projectFile, noRestore, options, cancellationToken) => 0,
 
                     // Simulate a successful app host information retrieval
                     GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
@@ -364,7 +364,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
                     },
 
                     // Simulate apphost running but deployment fails
-                    RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, cancellationToken) =>
+                    RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken) =>
                     {
                         var deployModeCompleted = new TaskCompletionSource();
                         var backchannel = new TestAppHostBackchannel

--- a/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DoCommandTests.cs
@@ -42,7 +42,7 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
                 var runner = new TestDotNetCliRunner
                 {
                     // Simulate a successful build
-                    BuildAsyncCallback = (projectFile, options, cancellationToken) => 0,
+                    BuildAsyncCallback = (projectFile, noRestore, options, cancellationToken) => 0,
 
                     // Simulate a successful app host information retrieval
                     GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
@@ -51,7 +51,7 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
                     },
 
                     // Simulate apphost running successfully and establishing a backchannel
-                    RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, cancellationToken) =>
+                    RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken) =>
                     {
                         Assert.True(options.NoLaunchProfile);
 
@@ -99,14 +99,14 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
             {
                 var runner = new TestDotNetCliRunner
                 {
-                    BuildAsyncCallback = (projectFile, options, cancellationToken) => 0,
+                    BuildAsyncCallback = (projectFile, noRestore, options, cancellationToken) => 0,
 
                     GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
                     {
                         return (0, true, VersionHelper.GetDefaultTemplateVersion());
                     },
 
-                    RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, cancellationToken) =>
+                    RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken) =>
                     {
                         // Verify that --step deploy is passed
                         Assert.Contains("--step", args);
@@ -152,14 +152,14 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
             {
                 var runner = new TestDotNetCliRunner
                 {
-                    BuildAsyncCallback = (projectFile, options, cancellationToken) => 0,
+                    BuildAsyncCallback = (projectFile, noRestore, options, cancellationToken) => 0,
 
                     GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
                     {
                         return (0, true, VersionHelper.GetDefaultTemplateVersion());
                     },
 
-                    RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, cancellationToken) =>
+                    RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken) =>
                     {
                         // Verify that --step publish is passed
                         Assert.Contains("--step", args);
@@ -205,14 +205,14 @@ public class DoCommandTests(ITestOutputHelper outputHelper)
             {
                 var runner = new TestDotNetCliRunner
                 {
-                    BuildAsyncCallback = (projectFile, options, cancellationToken) => 0,
+                    BuildAsyncCallback = (projectFile, noRestore, options, cancellationToken) => 0,
 
                     GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
                     {
                         return (0, true, VersionHelper.GetDefaultTemplateVersion());
                     },
 
-                    RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, cancellationToken) =>
+                    RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken) =>
                     {
                         // Verify output path is included
                         Assert.Contains("--output-path", args);

--- a/tests/Aspire.Cli.Tests/Commands/ExecCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ExecCommandTests.cs
@@ -149,7 +149,7 @@ public class ExecCommandTests
 
             options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner
             {
-                RunAsyncCallback = (projectFile, watch, noBuild, args, env, backchannelCompletionSource, runnerOptions, cancellationToken) =>
+                RunAsyncCallback = (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, runnerOptions, cancellationToken) =>
                 {
                     var backchannel = new TestAppHostBackchannel();
                     backchannelCompletionSource?.SetResult(backchannel);

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -574,7 +574,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         var runner = new TestDotNetCliRunner();
 
         // Simulate successful build
-        runner.BuildAsyncCallback = (projectFile, options, cancellationToken) => 0;
+        runner.BuildAsyncCallback = (projectFile, noRestore, options, cancellationToken) => 0;
 
         // Simulate compatible app host
         runner.GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
@@ -583,7 +583,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         };
 
         // Simulate successful app host run with the prompt backchannel
-        runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, cancellationToken) =>
+        runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken) =>
         {
             backchannelCompletionSource?.SetResult(promptBackchannel);
             await promptBackchannel.WaitForCompletion().DefaultTimeout();

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandTests.cs
@@ -99,7 +99,7 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.BuildAsyncCallback = (projectFile, options, cancellationToken) =>
+                runner.BuildAsyncCallback = (projectFile, noRestore, options, cancellationToken) =>
                 {
                     return 1; // Simulate a build failure
                 };
@@ -132,10 +132,10 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
                 var runner = new TestDotNetCliRunner();
 
                 // Simulate a successful build
-                runner.BuildAsyncCallback = (projectFile, options, cancellationToken) => 0;
+                runner.BuildAsyncCallback = (projectFile, noRestore, options, cancellationToken) => 0;
 
                 // Simulate apphost starting but crashing before backchannel is established
-                runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, cancellationToken) =>
+                runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken) =>
                 {
                     // Simulate a delay to mimic apphost starting
                     await Task.Delay(100, cancellationToken);
@@ -175,7 +175,7 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
                 var runner = new TestDotNetCliRunner();
 
                 // Simulate a successful build
-                runner.BuildAsyncCallback = (projectFile, options, cancellationToken) => 0;
+                runner.BuildAsyncCallback = (projectFile, noRestore, options, cancellationToken) => 0;
 
                 // Simulate a successful app host information retrieval
                 runner.GetAppHostInformationAsyncCallback = (projectFile, options, cancellationToken) =>
@@ -184,7 +184,7 @@ public class PublishCommandTests(ITestOutputHelper outputHelper)
                 };
 
                 // Simulate apphost running successfully and establishing a backchannel
-                runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, cancellationToken) =>
+                runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken) =>
                 {
                     Assert.True(options.NoLaunchProfile);
 

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -204,13 +204,13 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         {
             var runner = new TestDotNetCliRunner();
             // Fake the build command to always succeed.
-            runner.BuildAsyncCallback = (projectFile, options, ct) => 0;
+            runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) => 0;
 
             // Fake apphost information to return a compatable app host.
             runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
 
             // public Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, string[] args, IDictionary<string, string>? env, TaskCompletionSource<AppHostCliBackchannel>? backchannelCompletionSource, CancellationToken cancellationToken)
-            runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, ct) =>
+            runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, ct) =>
             {
                 // Make a backchannel and return it, but don't return from the run call until the backchannel
                 var backchannel = sp.GetRequiredService<IAppHostCliBackchannel>();
@@ -266,10 +266,10 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var runnerFactory = (IServiceProvider sp) =>
         {
             var runner = new TestDotNetCliRunner();
-            runner.BuildAsyncCallback = (projectFile, options, ct) => 0;
+            runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) => 0;
             runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
 
-            runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, ct) =>
+            runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, ct) =>
             {
                 var backchannel = sp.GetRequiredService<IAppHostCliBackchannel>();
                 backchannelCompletionSource!.SetResult(backchannel);
@@ -329,13 +329,13 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         {
             var runner = new TestDotNetCliRunner();
             // Fake the build command to always succeed.
-            runner.BuildAsyncCallback = (projectFile, options, ct) => 0;
+            runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) => 0;
 
             // Fake apphost information to return a compatible app host.
             runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
 
             // Configure the runner to establish a backchannel but simulate dashboard failure
-            runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, ct) =>
+            runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, ct) =>
             {
                 // Set up the backchannel
                 var backchannel = sp.GetRequiredService<IAppHostCliBackchannel>();
@@ -389,7 +389,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         };
 
         var testRunner = new TestDotNetCliRunner();
-        testRunner.BuildAsyncCallback = (projectFile, options, ct) => 0;
+        testRunner.BuildAsyncCallback = (projectFile, noRestore, options, ct) => 0;
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var appHostDirectoryPath = Path.Combine(workspace.WorkspaceRoot.FullName, "src", "MyApp.AppHost");
@@ -399,7 +399,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         File.WriteAllText(appHostProjectFile.FullName, "<Project></Project>");
 
         var options = new DotNetCliRunnerInvocationOptions();
-        await AppHostHelper.BuildAppHostAsync(testRunner, testInteractionService, appHostProjectFile, options, workspace.WorkspaceRoot, CancellationToken.None).DefaultTimeout();
+        await AppHostHelper.BuildAppHostAsync(testRunner, testInteractionService, appHostProjectFile, noRestore: false, options, workspace.WorkspaceRoot, CancellationToken.None).DefaultTimeout();
     }
 
     [Fact]
@@ -427,13 +427,13 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var runnerFactory = (IServiceProvider sp) =>
         {
             var runner = new TestDotNetCliRunner();
-            runner.BuildAsyncCallback = (projectFile, options, ct) =>
+            runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) =>
             {
                 buildCalled = true;
                 return 0;
             };
             runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
-            runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, ct) =>
+            runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, ct) =>
             {
                 var backchannel = sp.GetRequiredService<IAppHostCliBackchannel>();
                 backchannelCompletionSource!.SetResult(backchannel);
@@ -497,13 +497,13 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var runnerFactory = (IServiceProvider sp) =>
         {
             var runner = new TestDotNetCliRunner();
-            runner.BuildAsyncCallback = (projectFile, options, ct) =>
+            runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) =>
             {
                 buildCalled = true;
                 return 0;
             };
             runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
-            runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, ct) =>
+            runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, ct) =>
             {
                 var backchannel = sp.GetRequiredService<IAppHostCliBackchannel>();
                 backchannelCompletionSource!.SetResult(backchannel);
@@ -567,13 +567,13 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         var runnerFactory = (IServiceProvider sp) => {
             var runner = new TestDotNetCliRunner();
-            runner.BuildAsyncCallback = (projectFile, options, ct) => {
+            runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) => {
                 buildCalled = true;
                 buildCalledTcs.TrySetResult();
                 return 0;
             };
             runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
-            runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, ct) => {
+            runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, ct) => {
                 var backchannel = sp.GetRequiredService<IAppHostCliBackchannel>();
                 backchannelCompletionSource!.SetResult(backchannel);
                 await Task.Delay(Timeout.InfiniteTimeSpan, ct);
@@ -626,12 +626,12 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         {
             var runner = new TestDotNetCliRunner();
             // Fake the build command to always succeed.
-            runner.BuildAsyncCallback = (projectFile, options, ct) => 0;
+            runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) => 0;
 
             // Fake apphost information to return a compatible app host.
             runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
 
-            runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, ct) =>
+            runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, ct) =>
             {
                 watchModeUsed = watch;
                 // Make a backchannel and return it
@@ -683,12 +683,12 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         {
             var runner = new TestDotNetCliRunner();
             // Fake the build command to always succeed.
-            runner.BuildAsyncCallback = (projectFile, options, ct) => 0;
+            runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) => 0;
 
             // Fake apphost information to return a compatible app host.
             runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
 
-            runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, ct) =>
+            runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, ct) =>
             {
                 watchModeUsed = watch;
                 // Make a backchannel and return it
@@ -742,12 +742,12 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         {
             var runner = new TestDotNetCliRunner();
             // Fake the build command to always succeed.
-            runner.BuildAsyncCallback = (projectFile, options, ct) => 0;
+            runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) => 0;
 
             // Fake apphost information to return a compatible app host.
             runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
 
-            runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, ct) =>
+            runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, ct) =>
             {
                 watchModeUsed = watch;
                 // Make a backchannel and return it
@@ -801,12 +801,12 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         {
             var runner = new TestDotNetCliRunner();
             // Fake the build command to always succeed.
-            runner.BuildAsyncCallback = (projectFile, options, ct) => 0;
+            runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) => 0;
 
             // Fake apphost information to return a compatible app host.
             runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
 
-            runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, ct) =>
+            runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, ct) =>
             {
                 watchModeUsed = watch;
                 // Make a backchannel and return it
@@ -890,6 +890,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             projectFile: projectFile,
             watch: true, // This should add --non-interactive
             noBuild: false,
+            noRestore: false,
             args: ["--operation", "inspect"],
             env: new Dictionary<string, string>(),
             null,
@@ -935,6 +936,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             projectFile: projectFile,
             watch: false, // This should NOT add --non-interactive
             noBuild: false,
+            noRestore: false,
             args: ["--operation", "inspect"],
             env: new Dictionary<string, string>(),
             null,
@@ -984,6 +986,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             projectFile: projectFile,
             watch: true, // This should add --verbose when debug is true
             noBuild: false,
+            noRestore: false,
             args: ["--operation", "inspect"],
             env: new Dictionary<string, string>(),
             null,
@@ -1028,6 +1031,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             projectFile: projectFile,
             watch: true, // This should NOT add --verbose when debug is false
             noBuild: false,
+            noRestore: false,
             args: ["--operation", "inspect"],
             env: new Dictionary<string, string>(),
             null,
@@ -1073,6 +1077,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             projectFile: projectFile,
             watch: false, // This should NOT add --verbose because it's not in watch mode
             noBuild: false,
+            noRestore: false,
             args: ["--operation", "inspect"],
             env: new Dictionary<string, string>(),
             null,
@@ -1118,6 +1123,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             projectFile: projectFile,
             watch: true, // This should set DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER=true
             noBuild: false,
+            noRestore: false,
             args: ["--operation", "inspect"],
             env: new Dictionary<string, string>(),
             null,
@@ -1164,6 +1170,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             projectFile: projectFile,
             watch: false, // This should NOT set DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER
             noBuild: false,
+            noRestore: false,
             args: ["--operation", "inspect"],
             env: new Dictionary<string, string>(),
             null,
@@ -1204,6 +1211,67 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task RunCommand_WithNoBuildOption_SkipsBuildAndPassesNoBuildAndNoRestoreToRunner()
+    {
+        var buildCalled = false;
+        var noBuildPassedToRunner = false;
+        var noRestorePassedToRunner = false;
+
+        var backchannelFactory = (IServiceProvider sp) =>
+        {
+            var backchannel = new TestAppHostBackchannel();
+            backchannel.GetAppHostLogEntriesAsyncCallback = ReturnLogEntriesUntilCancelledAsync;
+            return backchannel;
+        };
+
+        var runnerFactory = (IServiceProvider sp) =>
+        {
+            var runner = new TestDotNetCliRunner();
+            runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) =>
+            {
+                buildCalled = true;
+                return 0;
+            };
+            runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
+
+            runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, ct) =>
+            {
+                noBuildPassedToRunner = noBuild;
+                noRestorePassedToRunner = noRestore;
+                var backchannel = sp.GetRequiredService<IAppHostCliBackchannel>();
+                backchannelCompletionSource!.SetResult(backchannel);
+                await Task.Delay(100, ct);
+                return 0;
+            };
+
+            return runner;
+        };
+
+        var projectLocatorFactory = (IServiceProvider sp) => new TestProjectLocator();
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = projectLocatorFactory;
+            options.AppHostBackchannelFactory = backchannelFactory;
+            options.DotNetCliRunnerFactory = runnerFactory;
+        });
+
+        var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("run --no-build");
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromSeconds(2));
+
+        var exitCode = await result.InvokeAsync(cancellationToken: cts.Token).DefaultTimeout();
+
+        Assert.False(buildCalled, "Build should be skipped when --no-build is specified");
+        Assert.True(noBuildPassedToRunner, "noBuild=true should be passed to the runner when --no-build is specified");
+        Assert.True(noRestorePassedToRunner, "noRestore=true should be passed to the runner when --no-build is specified (--no-build implies --no-restore)");
+    }
+
+    [Fact]
     public async Task RunCommand_WithIsolatedOption_SetsRandomizePortsAndIsolatesUserSecrets()
     {
         var tcs = new TaskCompletionSource<Dictionary<string, string>>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1227,7 +1295,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             var runnerFactory = (IServiceProvider sp) =>
             {
                 var runner = new TestDotNetCliRunner();
-                runner.BuildAsyncCallback = (projectFile, options, ct) => 0;
+                runner.BuildAsyncCallback = (projectFile, noRestore, options, ct) => 0;
                 runner.GetAppHostInformationAsyncCallback = (projectFile, options, ct) => (0, true, VersionHelper.GetDefaultTemplateVersion());
 
                 // Return UserSecretsId when GetProjectItemsAndPropertiesAsync is called
@@ -1238,7 +1306,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
                     return (0, doc);
                 };
 
-                runner.RunAsyncCallback = async (projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, ct) =>
+                runner.RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, ct) =>
                 {
                     // Capture environment variables
                     tcs.SetResult(env?.ToDictionary() ?? []);
@@ -1299,6 +1367,52 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             {
                 Directory.Delete(originalSecretsDir);
             }
+        }
+    }
+
+    [Fact]
+    public async Task RunCommand_WithNoBuildAndWatchModeEnabled_ReturnsInvalidCommandError()
+    {
+        // This test verifies that when --no-build is specified and watch mode is enabled
+        // (via feature flag), the CLI returns an error because this combination is not supported
+        // (dotnet watch doesn't support --no-build)
+
+        var projectLocatorFactory = (IServiceProvider sp) => new TestProjectLocator();
+
+        // Create a features factory that enables DefaultWatchEnabled
+        var featuresFactory = (IServiceProvider sp) => new TestFeatures()
+            .SetFeature(KnownFeatures.DefaultWatchEnabled, true);
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = projectLocatorFactory;
+            options.FeatureFlagsFactory = featuresFactory;
+        });
+
+        var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("run --no-build");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        // Should return InvalidCommand error because --no-build is not supported with watch mode enabled
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+    }
+
+    private sealed class TestFeatures : IFeatures
+    {
+        private readonly Dictionary<string, bool> _features = new();
+
+        public TestFeatures SetFeature(string featureName, bool value)
+        {
+            _features[featureName] = value;
+            return this;
+        }
+
+        public bool IsFeatureEnabled(string featureName, bool defaultValue = false)
+        {
+            return _features.TryGetValue(featureName, out var value) ? value : defaultValue;
         }
     }
 }

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
@@ -55,6 +55,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             projectFile: projectFile,
             watch: false,
             noBuild: false,
+            noRestore: false,
             args: ["--operation", "inspect"],
             env: new Dictionary<string, string>(),
             null,
@@ -88,7 +89,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             },
             0);
 
-        var exitCode = await runner.BuildAsync(projectFile, options, CancellationToken.None).DefaultTimeout();
+        var exitCode = await runner.BuildAsync(projectFile, noRestore: false, options, CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(0, exitCode);
     }
@@ -127,7 +128,65 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             },
             0);
 
-        var exitCode = await runner.BuildAsync(projectFile, options, CancellationToken.None).DefaultTimeout();
+        var exitCode = await runner.BuildAsync(projectFile, noRestore: false, options, CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task BuildAsyncIncludesNoRestoreFlagWhenNoRestoreIsTrue()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var options = new DotNetCliRunnerInvocationOptions();
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var runner = DotNetCliRunnerTestHelper.Create(
+            provider,
+            executionContext,
+            (args, env, _, _) =>
+            {
+                // Verify that --no-restore is included when noRestore is true
+                Assert.Contains("build", args);
+                Assert.Contains("--no-restore", args);
+            },
+            0);
+
+        var exitCode = await runner.BuildAsync(projectFile, noRestore: true, options, CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task BuildAsyncDoesNotIncludeNoRestoreFlagWhenNoRestoreIsFalse()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var options = new DotNetCliRunnerInvocationOptions();
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var runner = DotNetCliRunnerTestHelper.Create(
+            provider,
+            executionContext,
+            (args, env, _, _) =>
+            {
+                // Verify that --no-restore is NOT included when noRestore is false
+                Assert.Contains("build", args);
+                Assert.DoesNotContain("--no-restore", args);
+            },
+            0);
+
+        var exitCode = await runner.BuildAsync(projectFile, noRestore: false, options, CancellationToken.None).DefaultTimeout();
 
         Assert.Equal(0, exitCode);
     }
@@ -160,6 +219,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             projectFile: projectFile,
             watch: false,
             noBuild: false, // This should inject the environment variable
+            noRestore: false,
             args: ["--operation", "inspect"],
             env: new Dictionary<string, string>(),
             null,
@@ -200,6 +260,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             projectFile: projectFile,
             watch: false,
             noBuild: true, // This should NOT inject the environment variable
+            noRestore: false,
             args: ["--operation", "inspect"],
             env: new Dictionary<string, string>(),
             null,
@@ -245,6 +306,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             projectFile: projectFile,
             watch: false,
             noBuild: false,
+            noRestore: false,
             args: ["--operation", "inspect"],
             env: existingEnv,
             null,
@@ -316,6 +378,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             projectFile: projectFile,
             watch: false,
             noBuild: false,
+            noRestore: false,
             args: ["--operation", "inspect"],
             env: new Dictionary<string, string>(),
             null,
@@ -357,6 +420,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             projectFile: projectFile,
             watch: false,
             noBuild: false,
+            noRestore: false,
             args: ["--operation", "inspect"],
             env: new Dictionary<string, string>(),
             null,
@@ -403,6 +467,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             projectFile: projectFile,
             watch: false,
             noBuild: false,
+            noRestore: false,
             args: ["--operation", "inspect"],
             env: userEnv,
             null,
@@ -449,6 +514,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             projectFile: projectFile,
             watch: false,
             noBuild: false,
+            noRestore: false,
             args: [],
             env: null,
             backchannelCompletionSource: new TaskCompletionSource<IAppHostCliBackchannel>(),
@@ -751,6 +817,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             projectFile: appHostFile,
             watch: false,
             noBuild: false,
+            noRestore: false,
             args: [],
             env: new Dictionary<string, string>(),
             null,
@@ -795,6 +862,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             projectFile: appHostFile,
             watch: false,
             noBuild: false,
+            noRestore: false,
             args: [],
             env: new Dictionary<string, string>(),
             null,
@@ -839,6 +907,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             projectFile: projectFile,
             watch: true, // This will generate empty strings for verboseSwitch when Debug=false
             noBuild: false,
+            noRestore: false,
             args: [],
             env: new Dictionary<string, string>(),
             null,
@@ -889,6 +958,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             projectFile: appHostFile,
             watch: false,
             noBuild: false,
+            noRestore: false,
             args: [],
             env: new Dictionary<string, string>(),
             null,
@@ -937,6 +1007,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             projectFile: projectFile,
             watch: true,
             noBuild: false,
+            noRestore: false,
             args: [],
             env: new Dictionary<string, string>(),
             null,
@@ -984,6 +1055,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             projectFile: projectFile,
             watch: true,
             noBuild: false,
+            noRestore: false,
             args: [],
             env: new Dictionary<string, string>(),
             null,
@@ -1206,5 +1278,160 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
         // Assert
         Assert.Equal(expectedResult, result);
         Assert.Equal(expectedVersion, version);
+    }
+
+    [Fact]
+    public async Task RunAsyncIncludesNoBuildFlagWhenNoBuildIsTrue()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var options = new DotNetCliRunnerInvocationOptions();
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var runner = DotNetCliRunnerTestHelper.Create(
+            provider,
+            executionContext,
+            (args, env, _, _) =>
+            {
+                // Verify that --no-build is included when noBuild is true
+                Assert.Contains("run", args);
+                Assert.Contains("--no-build", args);
+            },
+            0);
+
+        var exitCode = await runner.RunAsync(
+            projectFile: projectFile,
+            watch: false,
+            noBuild: true, // This should add --no-build
+            noRestore: false,
+            args: ["--operation", "inspect"],
+            env: new Dictionary<string, string>(),
+            null,
+            options,
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task RunAsyncDoesNotIncludeNoBuildFlagWhenNoBuildIsFalse()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var options = new DotNetCliRunnerInvocationOptions();
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var runner = DotNetCliRunnerTestHelper.Create(
+            provider,
+            executionContext,
+            (args, env, _, _) =>
+            {
+                // Verify that --no-build is NOT included when noBuild is false
+                Assert.Contains("run", args);
+                Assert.DoesNotContain("--no-build", args);
+            },
+            0);
+
+        var exitCode = await runner.RunAsync(
+            projectFile: projectFile,
+            watch: false,
+            noBuild: false, // This should NOT add --no-build
+            noRestore: false,
+            args: ["--operation", "inspect"],
+            env: new Dictionary<string, string>(),
+            null,
+            options,
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task RunAsyncIncludesNoRestoreFlagWhenNoRestoreIsTrueAndNoBuildIsFalse()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var options = new DotNetCliRunnerInvocationOptions();
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var runner = DotNetCliRunnerTestHelper.Create(
+            provider,
+            executionContext,
+            (args, env, _, _) =>
+            {
+                // Verify that --no-restore is included when noRestore is true and noBuild is false
+                Assert.Contains("run", args);
+                Assert.Contains("--no-restore", args);
+                Assert.DoesNotContain("--no-build", args);
+            },
+            0);
+
+        var exitCode = await runner.RunAsync(
+            projectFile: projectFile,
+            watch: false,
+            noBuild: false,
+            noRestore: true, // This should add --no-restore
+            args: ["--operation", "inspect"],
+            env: new Dictionary<string, string>(),
+            null,
+            options,
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task RunAsyncDoesNotIncludeNoRestoreFlagWhenNoBuildIsTrue()
+    {
+        // --no-build implies --no-restore, so we should not include --no-restore when --no-build is specified
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var options = new DotNetCliRunnerInvocationOptions();
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var runner = DotNetCliRunnerTestHelper.Create(
+            provider,
+            executionContext,
+            (args, env, _, _) =>
+            {
+                // Verify that --no-restore is NOT included when noBuild is true (because --no-build implies --no-restore)
+                Assert.Contains("run", args);
+                Assert.Contains("--no-build", args);
+                Assert.DoesNotContain("--no-restore", args);
+            },
+            0);
+
+        var exitCode = await runner.RunAsync(
+            projectFile: projectFile,
+            watch: false,
+            noBuild: true, // --no-build implies --no-restore
+            noRestore: true, // This should be ignored because noBuild is true
+            args: ["--operation", "inspect"],
+            env: new Dictionary<string, string>(),
+            null,
+            options,
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
     }
 }

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -454,7 +454,7 @@ public class DotNetTemplateFactoryTests
         public Task<int> NewProjectAsync(string templateName, string projectName, string outputPath, string[] extraArgs, DotNetCliRunnerInvocationOptions? options, CancellationToken cancellationToken)
             => throw new NotImplementedException();
 
-        public Task<int> BuildAsync(FileInfo projectFile, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
+        public Task<int> BuildAsync(FileInfo projectFile, bool noRestore, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
             => throw new NotImplementedException();
 
         public Task<int> AddPackageAsync(FileInfo projectFile, string packageName, string version, string? packageSourceUrl, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
@@ -478,7 +478,7 @@ public class DotNetTemplateFactoryTests
         public Task<(int ExitCode, JsonDocument? Output)> GetProjectItemsAndPropertiesAsync(FileInfo projectFile, string[] items, string[] properties, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
             => throw new NotImplementedException();
 
-        public Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, string[] args, IDictionary<string, string>? env, TaskCompletionSource<IAppHostCliBackchannel>? backchannelCompletionSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
+        public Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, bool noRestore, string[] args, IDictionary<string, string>? env, TaskCompletionSource<IAppHostCliBackchannel>? backchannelCompletionSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
             => throw new NotImplementedException();
 
         public Task<(int ExitCode, string[] ConfigPaths)> GetNuGetConfigPathsAsync(DirectoryInfo workingDirectory, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)

--- a/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
@@ -13,13 +13,13 @@ internal sealed class TestDotNetCliRunner : IDotNetCliRunner
 {
     public Func<FileInfo, string, string, string?, DotNetCliRunnerInvocationOptions, CancellationToken, int>? AddPackageAsyncCallback { get; set; }
     public Func<FileInfo, FileInfo, DotNetCliRunnerInvocationOptions, CancellationToken, int>? AddProjectToSolutionAsyncCallback { get; set; }
-    public Func<FileInfo, DotNetCliRunnerInvocationOptions, CancellationToken, int>? BuildAsyncCallback { get; set; }
+    public Func<FileInfo, bool, DotNetCliRunnerInvocationOptions, CancellationToken, int>? BuildAsyncCallback { get; set; }
     public Func<FileInfo, DotNetCliRunnerInvocationOptions, CancellationToken, (int ExitCode, bool IsAspireHost, string? AspireHostingVersion)>? GetAppHostInformationAsyncCallback { get; set; }
     public Func<DirectoryInfo, DotNetCliRunnerInvocationOptions, CancellationToken, (int ExitCode, string[] ConfigPaths)>? GetNuGetConfigPathsAsyncCallback { get; set; }
     public Func<FileInfo, string[], string[], DotNetCliRunnerInvocationOptions, CancellationToken, (int ExitCode, JsonDocument? Output)>? GetProjectItemsAndPropertiesAsyncCallback { get; set; }
     public Func<string, string, string?, bool, DotNetCliRunnerInvocationOptions, CancellationToken, (int ExitCode, string? TemplateVersion)>? InstallTemplateAsyncCallback { get; set; }
     public Func<string, string, string, DotNetCliRunnerInvocationOptions, CancellationToken, int>? NewProjectAsyncCallback { get; set; }
-    public Func<FileInfo, bool, bool, string[], IDictionary<string, string>?, TaskCompletionSource<IAppHostCliBackchannel>?, DotNetCliRunnerInvocationOptions, CancellationToken, Task<int>>? RunAsyncCallback { get; set; }
+    public Func<FileInfo, bool, bool, bool, string[], IDictionary<string, string>?, TaskCompletionSource<IAppHostCliBackchannel>?, DotNetCliRunnerInvocationOptions, CancellationToken, Task<int>>? RunAsyncCallback { get; set; }
     public Func<DirectoryInfo, string, bool, int, int, FileInfo?, bool, DotNetCliRunnerInvocationOptions, CancellationToken, (int ExitCode, NuGetPackage[]? Packages)>? SearchPackagesAsyncCallback { get; set; }
     public Func<FileInfo, DotNetCliRunnerInvocationOptions, CancellationToken, (int ExitCode, IReadOnlyList<FileInfo> Projects)>? GetSolutionProjectsAsyncCallback { get; set; }
     public Func<FileInfo, FileInfo, DotNetCliRunnerInvocationOptions, CancellationToken, int>? AddProjectReferenceAsyncCallback { get; set; }
@@ -38,10 +38,10 @@ internal sealed class TestDotNetCliRunner : IDotNetCliRunner
             : Task.FromResult(0); // If not overridden, just return success.
     }
 
-    public Task<int> BuildAsync(FileInfo projectFilePath, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
+    public Task<int> BuildAsync(FileInfo projectFilePath, bool noRestore, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         return BuildAsyncCallback != null
-            ? Task.FromResult(BuildAsyncCallback(projectFilePath, options, cancellationToken))
+            ? Task.FromResult(BuildAsyncCallback(projectFilePath, noRestore, options, cancellationToken))
             : throw new NotImplementedException();
     }
 
@@ -91,10 +91,10 @@ internal sealed class TestDotNetCliRunner : IDotNetCliRunner
             : Task.FromResult(0); // If not overridden, just return success.
     }
 
-    public Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, string[] args, IDictionary<string, string>? env, TaskCompletionSource<IAppHostCliBackchannel>? backchannelCompletionSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
+    public Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, bool noRestore, string[] args, IDictionary<string, string>? env, TaskCompletionSource<IAppHostCliBackchannel>? backchannelCompletionSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         return RunAsyncCallback != null
-            ? RunAsyncCallback(projectFile, watch, noBuild, args, env, backchannelCompletionSource, options, cancellationToken)
+            ? RunAsyncCallback(projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken)
             : throw new NotImplementedException();
     }
 


### PR DESCRIPTION
## Description

Add support for --no-build and --no-restore flags on the aspire CLI run command, matching the behavior of dotnet run:

- --no-build: Skip building the project before running (implies --no-restore)
- --no-restore: Skip restoring packages before running

## Motivation

There are lots of ways to build .net code. Aspire currently does a build unless you use watch regardless of the build state. 

We're teaching coding agents to use aspire as part of their workflow, and they can iterate **VERY FAST** by doing targeted builds rather than building the whole application.

So we need a way to tell aspire not to build.

## Details

Implementation:
- Add options to RunCommand.cs with localized descriptions
- Add NoRestore property to AppHostProjectContext
- Wire up flags through DotNetAppHostProject to DotNetCliRunner
- Update IDotNetCliRunner interface with noRestore parameter

Tests:
- Add RunCommandTests to verify CLI options are parsed correctly
- Add DotNetCliRunnerTests to verify flags are passed to dotnet run
- Verify --no-build implies --no-restore


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [ ] No
