### PR TITLE
Increase az aks update timeout from 3 to 5 minutes in AKS E2E tests

### DIFF
--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
@@ -160,7 +160,7 @@ public sealed class AksStarterDeploymentTests(ITestOutputHelper output)
             sequenceBuilder
                 .Type($"az aks update --resource-group {resourceGroupName} --name {clusterName} --attach-acr {acrName}")
                 .Enter()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(3));
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
 
             // Step 7: Configure kubectl credentials
             output.WriteLine("Step 7: Configuring kubectl credentials...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterWithRedisDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterWithRedisDeploymentTests.cs
@@ -159,7 +159,7 @@ public sealed class AksStarterWithRedisDeploymentTests(ITestOutputHelper output)
             sequenceBuilder
                 .Type($"az aks update --resource-group {resourceGroupName} --name {clusterName} --attach-acr {acrName}")
                 .Enter()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(3));
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
 
             // Step 7: Configure kubectl credentials
             output.WriteLine("Step 7: Configuring kubectl credentials...");


### PR DESCRIPTION
## Fix

Increases the `WaitForSuccessPrompt` timeout for the `az aks update --attach-acr` step from **3 minutes to 5 minutes** in both AKS deployment E2E tests.

## Root Cause

The nightly deployment E2E test `AksStarterWithRedisDeploymentTests.DeployStarterTemplateWithRedisToAks` failed on 2026-02-08 ([workflow run](https://github.com/dotnet/aspire/actions/runs/21791909175)) with:

```
System.TimeoutException: WaitUntil timed out after 00:03:00 waiting for condition.
```

The `az aks update --attach-acr` command was still reconciling addons (`ReconcilingAddons ..` spinner) when the 3-minute timeout expired. This Azure operation can realistically take 3–6 minutes depending on Azure-side latency. The next nightly run (2026-02-09) passed, confirming this is a flaky timing issue.

## Changes

- `AksStarterWithRedisDeploymentTests.cs`: 3min → 5min timeout on step 6
- `AksStarterDeploymentTests.cs`: 3min → 5min timeout on step 6 (same vulnerability)

Fixes #14397