### PR TITLE
Improve detach mode: fix pipe handle inheritance and unify log naming

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -6,6 +6,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnablePackageValidation>false</EnablePackageValidation>
     <AssemblyName>aspire</AssemblyName>
     <RootNamespace>Aspire.Cli</RootNamespace>

--- a/src/Aspire.Cli/Commands/CacheCommand.cs
+++ b/src/Aspire.Cli/Commands/CacheCommand.cs
@@ -45,7 +45,7 @@ internal sealed class CacheCommand : BaseCommand
             {
                 var cacheDirectory = ExecutionContext.CacheDirectory;
                 var filesDeleted = 0;
-                
+
                 // Delete cache files and subdirectories
                 if (cacheDirectory.Exists)
                 {
@@ -110,14 +110,13 @@ internal sealed class CacheCommand : BaseCommand
 
                 // Also clear the logs directory (skip current process's log file)
                 var logsDirectory = ExecutionContext.LogsDirectory;
-                // Log files are named cli-{timestamp}-{pid}.log, so we need to check the suffix
-                var currentLogFileSuffix = $"-{Environment.ProcessId}.log";
+                var currentLogFilePath = ExecutionContext.LogFilePath;
                 if (logsDirectory.Exists)
                 {
                     foreach (var file in logsDirectory.GetFiles("*", SearchOption.AllDirectories))
                     {
                         // Skip the current process's log file to avoid deleting it while in use
-                        if (file.Name.EndsWith(currentLogFileSuffix, StringComparison.OrdinalIgnoreCase))
+                        if (file.FullName.Equals(currentLogFilePath, StringComparison.OrdinalIgnoreCase))
                         {
                             continue;
                         }

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -889,7 +889,7 @@ internal sealed class RunCommand : BaseCommand
                 pid,
                 childProcess.Id,
                 dashboardUrls?.BaseUrlWithLoginToken,
-                _fileLoggerProvider.LogFilePath);
+                childLogFile);
             var json = JsonSerializer.Serialize(result, RunCommandJsonContext.RelaxedEscaping.DetachOutputInfo);
             _interactionService.DisplayRawText(json);
         }
@@ -902,7 +902,7 @@ internal sealed class RunCommand : BaseCommand
                 appHostRelativePath,
                 dashboardUrls?.BaseUrlWithLoginToken,
                 codespacesUrl: null,
-                _fileLoggerProvider.LogFilePath,
+                childLogFile,
                 isExtensionHost,
                 pid);
             _ansiConsole.WriteLine();

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.Unix.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.Unix.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Cli.Processes;
+
+internal static partial class DetachedProcessLauncher
+{
+    /// <summary>
+    /// Unix implementation using Process.Start with stdio redirection.
+    /// On Linux/macOS, .NET creates pipes with O_CLOEXEC so grandchild processes
+    /// never inherit them across execve(). We just close the parent-side pipe
+    /// streams immediately after start to suppress child output.
+    /// </summary>
+    private static Process StartUnix(string fileName, IReadOnlyList<string> arguments, string workingDirectory)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = false,
+            WorkingDirectory = workingDirectory
+        };
+
+        foreach (var arg in arguments)
+        {
+            startInfo.ArgumentList.Add(arg);
+        }
+
+        var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start detached process");
+
+        // Close the parent's read-end of the pipes. The child's write-end has
+        // O_CLOEXEC set by .NET, so when the child calls execve() to launch the
+        // AppHost grandchild, the pipe fds are automatically closed.
+        process.StandardOutput.Close();
+        process.StandardError.Close();
+
+        return process;
+    }
+}

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.Windows.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.Windows.cs
@@ -1,0 +1,256 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
+
+namespace Aspire.Cli.Processes;
+
+internal static partial class DetachedProcessLauncher
+{
+    /// <summary>
+    /// Windows implementation using CreateProcess with STARTUPINFOEX and
+    /// PROC_THREAD_ATTRIBUTE_HANDLE_LIST to prevent handle inheritance to grandchildren.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    private static Process StartWindows(string fileName, IReadOnlyList<string> arguments, string workingDirectory)
+    {
+        // Open NUL device for stdout/stderr — child writes go nowhere
+        using var nulHandle = CreateFileW(
+            "NUL",
+            GenericWrite,
+            FileShareWrite,
+            nint.Zero,
+            OpenExisting,
+            0,
+            nint.Zero);
+
+        if (nulHandle.IsInvalid)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to open NUL device");
+        }
+
+        // Mark the NUL handle as inheritable (required for STARTUPINFO hStdOutput assignment)
+        if (!SetHandleInformation(nulHandle, HandleFlagInherit, HandleFlagInherit))
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to set NUL handle inheritance");
+        }
+
+        // Initialize a process thread attribute list with 1 slot (HANDLE_LIST)
+        var attrListSize = nint.Zero;
+        InitializeProcThreadAttributeList(nint.Zero, 1, 0, ref attrListSize);
+
+        var attrList = Marshal.AllocHGlobal(attrListSize);
+        try
+        {
+            if (!InitializeProcThreadAttributeList(attrList, 1, 0, ref attrListSize))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to initialize process thread attribute list");
+            }
+
+            try
+            {
+                // Whitelist only the NUL handle for inheritance.
+                // The grandchild (AppHost) will inherit this harmless handle instead of
+                // any pipes from the caller's process tree.
+                var handles = new[] { nulHandle.DangerousGetHandle() };
+                var pinnedHandles = GCHandle.Alloc(handles, GCHandleType.Pinned);
+                try
+                {
+                    if (!UpdateProcThreadAttribute(
+                        attrList,
+                        0,
+                        s_procThreadAttributeHandleList,
+                        pinnedHandles.AddrOfPinnedObject(),
+                        (nint)(nint.Size * handles.Length),
+                        nint.Zero,
+                        nint.Zero))
+                    {
+                        throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to update process thread attribute list");
+                    }
+
+                    var nulRawHandle = nulHandle.DangerousGetHandle();
+
+                    var si = new STARTUPINFOEX();
+                    si.cb = Marshal.SizeOf<STARTUPINFOEX>();
+                    si.dwFlags = StartfUseStdHandles;
+                    si.hStdInput = nint.Zero;
+                    si.hStdOutput = nulRawHandle;
+                    si.hStdError = nulRawHandle;
+                    si.lpAttributeList = attrList;
+
+                    // Build the command line string: "fileName" arg1 arg2 ...
+                    var commandLine = BuildCommandLine(fileName, arguments);
+
+                    var flags = CreateUnicodeEnvironment | ExtendedStartupInfoPresent | CreateNoWindow;
+
+                    if (!CreateProcessW(
+                        null,
+                        commandLine,
+                        nint.Zero,
+                        nint.Zero,
+                        bInheritHandles: true, // TRUE but HANDLE_LIST restricts what's actually inherited
+                        flags,
+                        nint.Zero,
+                        workingDirectory,
+                        ref si,
+                        out var pi))
+                    {
+                        throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to create detached process");
+                    }
+
+                    // Close the process and thread handles — we only need the PID
+                    CloseHandle(pi.hProcess);
+                    CloseHandle(pi.hThread);
+
+                    return Process.GetProcessById(pi.dwProcessId);
+                }
+                finally
+                {
+                    pinnedHandles.Free();
+                }
+            }
+            finally
+            {
+                DeleteProcThreadAttributeList(attrList);
+            }
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(attrList);
+        }
+    }
+
+    private static StringBuilder BuildCommandLine(string fileName, IReadOnlyList<string> arguments)
+    {
+        var sb = new StringBuilder();
+
+        // Quote the executable path
+        sb.Append('"').Append(fileName).Append('"');
+
+        foreach (var arg in arguments)
+        {
+            sb.Append(' ');
+            if (arg.Contains(' ') || arg.Contains('"'))
+            {
+                sb.Append('"').Append(arg.Replace("\"", "\\\"")).Append('"');
+            }
+            else
+            {
+                sb.Append(arg);
+            }
+        }
+
+        return sb;
+    }
+
+    // --- Constants ---
+    private const uint GenericWrite = 0x40000000;
+    private const uint FileShareWrite = 0x00000002;
+    private const uint OpenExisting = 3;
+    private const uint HandleFlagInherit = 0x00000001;
+    private const uint StartfUseStdHandles = 0x00000100;
+    private const uint CreateUnicodeEnvironment = 0x00000400;
+    private const uint ExtendedStartupInfoPresent = 0x00080000;
+    private const uint CreateNoWindow = 0x08000000;
+    private static readonly nint s_procThreadAttributeHandleList = (nint)0x00020002;
+
+    // --- Structs ---
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct STARTUPINFOEX
+    {
+        public int cb;
+        public nint lpReserved;
+        public nint lpDesktop;
+        public nint lpTitle;
+        public int dwX;
+        public int dwY;
+        public int dwXSize;
+        public int dwYSize;
+        public int dwXCountChars;
+        public int dwYCountChars;
+        public int dwFillAttribute;
+        public uint dwFlags;
+        public ushort wShowWindow;
+        public ushort cbReserved2;
+        public nint lpReserved2;
+        public nint hStdInput;
+        public nint hStdOutput;
+        public nint hStdError;
+        public nint lpAttributeList;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PROCESS_INFORMATION
+    {
+        public nint hProcess;
+        public nint hThread;
+        public int dwProcessId;
+        public int dwThreadId;
+    }
+
+    // --- P/Invoke declarations ---
+
+    [LibraryImport("kernel32.dll", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+    private static partial SafeFileHandle CreateFileW(
+        string lpFileName,
+        uint dwDesiredAccess,
+        uint dwShareMode,
+        nint lpSecurityAttributes,
+        uint dwCreationDisposition,
+        uint dwFlagsAndAttributes,
+        nint hTemplateFile);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SetHandleInformation(
+        SafeFileHandle hObject,
+        uint dwMask,
+        uint dwFlags);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool InitializeProcThreadAttributeList(
+        nint lpAttributeList,
+        int dwAttributeCount,
+        int dwFlags,
+        ref nint lpSize);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool UpdateProcThreadAttribute(
+        nint lpAttributeList,
+        uint dwFlags,
+        nint attribute,
+        nint lpValue,
+        nint cbSize,
+        nint lpPreviousValue,
+        nint lpReturnSize);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    private static partial void DeleteProcThreadAttributeList(nint lpAttributeList);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+#pragma warning disable CA1838 // CreateProcessW requires a mutable command line buffer
+    private static extern bool CreateProcessW(
+        string? lpApplicationName,
+        StringBuilder lpCommandLine,
+        nint lpProcessAttributes,
+        nint lpThreadAttributes,
+        bool bInheritHandles,
+        uint dwCreationFlags,
+        nint lpEnvironment,
+        string? lpCurrentDirectory,
+        ref STARTUPINFOEX lpStartupInfo,
+        out PROCESS_INFORMATION lpProcessInformation);
+#pragma warning restore CA1838
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool CloseHandle(nint hObject);
+}

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.Windows.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.Windows.cs
@@ -103,11 +103,19 @@ internal static partial class DetachedProcessLauncher
                         throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to create detached process");
                     }
 
-                    // Close the process and thread handles — we only need the PID
-                    CloseHandle(pi.hProcess);
-                    CloseHandle(pi.hThread);
+                    Process detachedProcess;
+                    try
+                    {
+                        detachedProcess = Process.GetProcessById(pi.dwProcessId);
+                    }
+                    finally
+                    {
+                        // Close the process and thread handles returned by CreateProcess.
+                        CloseHandle(pi.hProcess);
+                        CloseHandle(pi.hThread);
+                    }
 
-                    return Process.GetProcessById(pi.dwProcessId);
+                    return detachedProcess;
                 }
                 finally
                 {

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Cli.Processes;
+
+// ============================================================================
+// DetachedProcessLauncher — Platform-aware child process launcher for --detach
+// ============================================================================
+//
+// When `aspire run --detach` is used, the CLI spawns a child CLI process which
+// in turn spawns the AppHost (the "grandchild"). Two constraints must hold:
+//
+// 1. The child's stdout/stderr must NOT appear on the parent's console.
+//    The parent renders its own summary UX (dashboard URL, PID, log path) and
+//    if the child's output (spinners, "Press CTRL+C", etc.) bleeds through, it
+//    corrupts the parent's terminal — and breaks E2E tests that pattern-match
+//    on the parent's output.
+//
+// 2. No pipe or handle from the parent→child stdio redirection may leak into
+//    the grandchild (AppHost). If it does, callers that wait for the CLI's
+//    stdout to close (e.g. Node.js `execSync`, shell `$(...)` substitution)
+//    will hang until the AppHost exits — which defeats the purpose of --detach.
+//
+// These two constraints conflict when using .NET's Process.Start:
+//
+//   • RedirectStandardOutput = true  → solves (1) but violates (2) on Windows,
+//     because .NET calls CreateProcess with bInheritHandles=TRUE, and the pipe
+//     write-handle is duplicated into the child. The child passes it to the
+//     grandchild (AppHost), keeping the pipe alive.
+//
+//   • RedirectStandardOutput = false → solves (2) but violates (1), because
+//     the child inherits the parent's console and writes directly to it.
+//
+// The solution is platform-specific:
+//
+// ┌─────────┬────────────────────────────────────────────────────────────────┐
+// │ Windows │ P/Invoke CreateProcess with STARTUPINFOEX and an explicit     │
+// │         │ PROC_THREAD_ATTRIBUTE_HANDLE_LIST. This lets us set           │
+// │         │ bInheritHandles=TRUE (required to assign hStdOutput to NUL)   │
+// │         │ while restricting inheritance to ONLY the NUL handle — so the │
+// │         │ grandchild inherits nothing useful. Child stdout/stderr go to │
+// │         │ the NUL device. This is the same approach used by Docker's    │
+// │         │ Windows container runtime (microsoft/hcsshim).                │
+// │         │                                                               │
+// │ Linux / │ Process.Start with RedirectStandard{Output,Error} = true,     │
+// │ macOS   │ then immediately close the pipe streams. On Unix, .NET        │
+// │         │ creates pipes with O_CLOEXEC, so the grandchild never         │
+// │         │ inherits them across execve() — unlike Windows, this is safe. │
+// │         │ This is the same model used by runc (opencontainers/runc),    │
+// │         │ which relies on O_CLOEXEC + close-on-exec to prevent fd leaks │
+// │         │ into container init processes.                                 │
+// └─────────┴────────────────────────────────────────────────────────────────┘
+//
+
+/// <summary>
+/// Launches a child process with stdout/stderr suppressed and no handle/fd
+/// inheritance to grandchild processes. Used by <c>aspire run --detach</c>.
+/// </summary>
+internal static partial class DetachedProcessLauncher
+{
+    /// <summary>
+    /// Starts a detached child process with stdout/stderr going to the null device
+    /// and no inheritable handles/fds leaking to grandchildren.
+    /// </summary>
+    /// <param name="fileName">The executable path (e.g. dotnet or the native CLI).</param>
+    /// <param name="arguments">The command-line arguments for the child process.</param>
+    /// <param name="workingDirectory">The working directory for the child process.</param>
+    /// <returns>A <see cref="Process"/> object representing the launched child.</returns>
+    public static Process Start(string fileName, IReadOnlyList<string> arguments, string workingDirectory)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return StartWindows(fileName, arguments, workingDirectory);
+        }
+
+        return StartUnix(fileName, arguments, workingDirectory);
+    }
+}

--- a/src/Aspire.Cli/Processes/DetachedProcessLauncher.cs
+++ b/src/Aspire.Cli/Processes/DetachedProcessLauncher.cs
@@ -45,12 +45,12 @@ namespace Aspire.Cli.Processes;
 // │         │ Windows container runtime (microsoft/hcsshim).                │
 // │         │                                                               │
 // │ Linux / │ Process.Start with RedirectStandard{Output,Error} = true,     │
-// │ macOS   │ then immediately close the pipe streams. On Unix, .NET        │
-// │         │ creates pipes with O_CLOEXEC, so the grandchild never         │
-// │         │ inherits them across execve() — unlike Windows, this is safe. │
-// │         │ This is the same model used by runc (opencontainers/runc),    │
-// │         │ which relies on O_CLOEXEC + close-on-exec to prevent fd leaks │
-// │         │ into container init processes.                                 │
+// │ macOS   │ then immediately close the parent's read-end pipe streams.    │
+// │         │ The original pipe fds have O_CLOEXEC, but dup2 onto fd 0/1/2 │
+// │         │ clears it — so grandchildren inherit the pipe as their stdio. │
+// │         │ With no reader, writes produce harmless EPIPE. The critical   │
+// │         │ difference from Windows is that no caller gets stuck waiting  │
+// │         │ on a pipe handle — closing the read-end is sufficient.        │
 // └─────────┴────────────────────────────────────────────────────────────────┘
 //
 

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -553,6 +553,15 @@ public class Program
 
     public static async Task<int> Main(string[] args)
     {
+        // When launched as a detach child (--log-file is specified), suppress all console
+        // output. The parent uses RedirectStandardOutput=false to avoid creating inheritable
+        // pipe handles, so the child must silence itself to prevent output bleed.
+        if (ParseLogFileOption(args) is not null)
+        {
+            Console.SetOut(TextWriter.Null);
+            Console.SetError(TextWriter.Null);
+        }
+
         // Setup handling of CTRL-C as early as possible so that if
         // we get a CTRL-C anywhere that is not handled by Spectre Console
         // already that we know to trigger cancellation.

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -96,7 +96,7 @@ public class Program
     /// Parses --log-file from raw args before the host is built.
     /// Used by --detach to tell the child CLI where to write its log.
     /// </summary>
-    private static string? ParseLogFileOption(string[]? args)
+    internal static string? ParseLogFileOption(string[]? args)
     {
         if (args is null)
         {
@@ -105,6 +105,11 @@ public class Program
 
         for (var i = 0; i < args.Length; i++)
         {
+            if (args[i] == "--")
+            {
+                break;
+            }
+
             if (args[i] == "--log-file" && i + 1 < args.Length)
             {
                 return args[i + 1];
@@ -731,4 +736,3 @@ internal class AspirePlaygroundEnricher : IProfileEnricher
         profile.Capabilities.Interactive = true;
     }
 }
-

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -553,15 +553,6 @@ public class Program
 
     public static async Task<int> Main(string[] args)
     {
-        // When launched as a detach child (--log-file is specified), suppress all console
-        // output. The parent uses RedirectStandardOutput=false to avoid creating inheritable
-        // pipe handles, so the child must silence itself to prevent output bleed.
-        if (ParseLogFileOption(args) is not null)
-        {
-            Console.SetOut(TextWriter.Null);
-            Console.SetError(TextWriter.Null);
-        }
-
         // Setup handling of CTRL-C as early as possible so that if
         // we get a CTRL-C anywhere that is not handled by Spectre Console
         // already that we know to trigger cancellation.

--- a/src/Aspire.Cli/Resources/RunCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/RunCommandStrings.Designer.cs
@@ -255,6 +255,12 @@ namespace Aspire.Cli.Resources {
             }
         }
         
+        public static string AppHostFailedToBuild {
+            get {
+                return ResourceManager.GetString("AppHostFailedToBuild", resourceCulture);
+            }
+        }
+        
         public static string TimeoutWaitingForAppHost {
             get {
                 return ResourceManager.GetString("TimeoutWaitingForAppHost", resourceCulture);

--- a/src/Aspire.Cli/Resources/RunCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/RunCommandStrings.resx
@@ -226,6 +226,9 @@
   <data name="AppHostExitedWithCode" xml:space="preserve">
     <value>AppHost process exited with code {0}.</value>
   </data>
+  <data name="AppHostFailedToBuild" xml:space="preserve">
+    <value>AppHost failed to build.</value>
+  </data>
   <data name="TimeoutWaitingForAppHost" xml:space="preserve">
     <value>Timeout waiting for AppHost to start.</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.cs.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Proces AppHost byl ukončen s kódem {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostFailedToBuild">
+        <source>AppHost failed to build.</source>
+        <target state="new">AppHost failed to build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStartedSuccessfully">
         <source>AppHost started successfully.</source>
         <target state="translated">Hostitel aplikací (AppHost) se úspěšně spustil.</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.de.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Der AppHost-Prozess wurde mit Code {0} beendet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostFailedToBuild">
+        <source>AppHost failed to build.</source>
+        <target state="new">AppHost failed to build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStartedSuccessfully">
         <source>AppHost started successfully.</source>
         <target state="translated">Der AppHost wurde erfolgreich gestartet.</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.es.xlf
@@ -37,6 +37,11 @@
         <target state="translated">El proceso AppHost se cerró con código {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostFailedToBuild">
+        <source>AppHost failed to build.</source>
+        <target state="new">AppHost failed to build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStartedSuccessfully">
         <source>AppHost started successfully.</source>
         <target state="translated">AppHost se ha iniciado correctamente.</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.fr.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Processus AppHost arrêté avec le code {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostFailedToBuild">
+        <source>AppHost failed to build.</source>
+        <target state="new">AppHost failed to build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStartedSuccessfully">
         <source>AppHost started successfully.</source>
         <target state="translated">AppHost a démarré correctement.</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.it.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Processo AppHost terminato con codice {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostFailedToBuild">
+        <source>AppHost failed to build.</source>
+        <target state="new">AppHost failed to build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStartedSuccessfully">
         <source>AppHost started successfully.</source>
         <target state="translated">AppHost avviato correttamente.</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ja.xlf
@@ -37,6 +37,11 @@
         <target state="translated">AppHost プロセスが終了し、コード {0} を返しました。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostFailedToBuild">
+        <source>AppHost failed to build.</source>
+        <target state="new">AppHost failed to build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStartedSuccessfully">
         <source>AppHost started successfully.</source>
         <target state="translated">AppHost が正常に起動しました。</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ko.xlf
@@ -37,6 +37,11 @@
         <target state="translated">AppHost 프로세스가 {0} 코드로 종료되었습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostFailedToBuild">
+        <source>AppHost failed to build.</source>
+        <target state="new">AppHost failed to build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStartedSuccessfully">
         <source>AppHost started successfully.</source>
         <target state="translated">AppHost를 시작했습니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pl.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Proces hosta aplikacji zakończył się z kodem {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostFailedToBuild">
+        <source>AppHost failed to build.</source>
+        <target state="new">AppHost failed to build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStartedSuccessfully">
         <source>AppHost started successfully.</source>
         <target state="translated">Host aplikacji został pomyślnie uruchomiony.</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pt-BR.xlf
@@ -37,6 +37,11 @@
         <target state="translated">O processo AppHost foi encerrado com o código {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostFailedToBuild">
+        <source>AppHost failed to build.</source>
+        <target state="new">AppHost failed to build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStartedSuccessfully">
         <source>AppHost started successfully.</source>
         <target state="translated">AppHost iniciado com sucesso.</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ru.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Процесс AppHost завершился с кодом {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostFailedToBuild">
+        <source>AppHost failed to build.</source>
+        <target state="new">AppHost failed to build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStartedSuccessfully">
         <source>AppHost started successfully.</source>
         <target state="translated">Запуск AppHost выполнен.</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.tr.xlf
@@ -37,6 +37,11 @@
         <target state="translated">AppHost işlemi {0} koduyla sonlandırıldı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostFailedToBuild">
+        <source>AppHost failed to build.</source>
+        <target state="new">AppHost failed to build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStartedSuccessfully">
         <source>AppHost started successfully.</source>
         <target state="translated">AppHost başarıyla başlatıldı.</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hans.xlf
@@ -37,6 +37,11 @@
         <target state="translated">AppHost 进程已退出，代码为 {0}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostFailedToBuild">
+        <source>AppHost failed to build.</source>
+        <target state="new">AppHost failed to build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStartedSuccessfully">
         <source>AppHost started successfully.</source>
         <target state="translated">已成功启动 AppHost。</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hant.xlf
@@ -37,6 +37,11 @@
         <target state="translated">AppHost 程序以返回碼 {0} 結束。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AppHostFailedToBuild">
+        <source>AppHost failed to build.</source>
+        <target state="new">AppHost failed to build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStartedSuccessfully">
         <source>AppHost started successfully.</source>
         <target state="translated">已成功啟動 AppHost。</target>

--- a/tests/Aspire.Cli.Tests/ProgramTests.cs
+++ b/tests/Aspire.Cli.Tests/ProgramTests.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Tests;
+
+public class ProgramTests
+{
+    [Fact]
+    public void ParseLogFileOption_ReturnsNull_WhenArgsAreNull()
+    {
+        var result = Program.ParseLogFileOption(null);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseLogFileOption_ReturnsValue_WhenOptionAppearsBeforeDelimiter()
+    {
+        var result = Program.ParseLogFileOption(["run", "--log-file", "cli.log", "--", "--log-file", "app.log"]);
+
+        Assert.Equal("cli.log", result);
+    }
+
+    [Fact]
+    public void ParseLogFileOption_IgnoresValue_WhenOptionAppearsAfterDelimiter()
+    {
+        var result = Program.ParseLogFileOption(["run", "--", "--log-file", "app.log"]);
+
+        Assert.Null(result);
+    }
+}


### PR DESCRIPTION
## Description

When running `aspire run --detach`, the child CLI process inherited pipe handles from stdout/stderr redirection. This kept pipes open until the AppHost grandchild died, preventing callers using synchronous process APIs (e.g. Node.js `execSync`) from detecting that the CLI had exited. This is primarily a Windows issue due to how handle inheritance works.

### Changes

- **Stop redirecting child stdout/stderr** — removes pipe handle inheritance. The child writes to its own log file instead.
- **New `--log-file` hidden option** — parent passes an explicit log file path to the child so the parent knows where to point on failure.
- **Unified log filename generation** — new `FileLoggerProvider.GenerateLogFilePath` static helper used by both the normal logger and the detach child path. Format: `cli_20260210T074038_12345.log` (with optional suffix).
- **Better error messages** — maps `FailedToBuildArtifacts` exit code to a friendly message. Points to the child's log file on failure.
- **Cache cleanup fix** — updated log file suffix pattern to match the new naming format.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
