### PR TITLE
Bump the microsoft_docker_images group across 3 directories with 1 update

### DIFF
--- a/playground/publishers/Publishers.AppHost/qots/Dockerfile
+++ b/playground/publishers/Publishers.AppHost/qots/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN go build qots.go
 
 # Stage 2: Run the Go program
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20251206
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20260102
 WORKDIR /app
 COPY --from=builder /app/qots .
 CMD ["./qots"]

--- a/playground/withdockerfile/WithDockerfile.AppHost/dynamic-async.Dockerfile
+++ b/playground/withdockerfile/WithDockerfile.AppHost/dynamic-async.Dockerfile
@@ -3,6 +3,6 @@ WORKDIR /app
 COPY . .
 RUN go build -o qots .
 
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20260102
 COPY --from=builder /app/qots /qots
 ENTRYPOINT ["/qots"]

--- a/playground/withdockerfile/WithDockerfile.AppHost/dynamic-sync.Dockerfile
+++ b/playground/withdockerfile/WithDockerfile.AppHost/dynamic-sync.Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN echo "Built at 20260119162134" > /build-info.txt
 RUN go build -o qots .
 
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20260102
 COPY --from=builder /app/qots /qots
 COPY --from=builder /build-info.txt /build-info.txt
 ENTRYPOINT ["/qots"]

--- a/playground/withdockerfile/WithDockerfile.AppHost/qots/Dockerfile
+++ b/playground/withdockerfile/WithDockerfile.AppHost/qots/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN go build qots.go
 
 # Stage 2: Run the Go program
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20251206
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20260102
 WORKDIR /app
 RUN --mount=type=secret,id=SECRET_ASENV cp /run/secrets/SECRET_ASENV /app/SECRET_ASENV
 COPY --from=builder /app/qots .


### PR DESCRIPTION
Updates cbl-mariner/base/core from 2.0.20251206 to 2.0.20260102 across playground Dockerfiles.