### PR TITLE
Add AspireExport coverage for Azure KeyVault hosting integration

### DIFF
--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -8,6 +8,7 @@ using Aspire.Hosting.Azure;
 using Azure.Provisioning;
 using Azure.Provisioning.Expressions;
 using Azure.Provisioning.KeyVault;
+using System.Collections.Frozen;
 using System.Text.RegularExpressions;
 
 namespace Aspire.Hosting;
@@ -167,7 +168,7 @@ public static partial class AzureKeyVaultResourceExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    [AspireExportIgnore]
+    [AspireExportIgnore(Reason = "KeyVaultBuiltInRole is an Azure.Provisioning type not compatible with ATS. Use the string-based overload instead.")]
     public static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureKeyVaultResource> target,
@@ -178,12 +179,41 @@ public static partial class AzureKeyVaultResourceExtensions
     }
 
     /// <summary>
+    /// Assigns the specified roles to the given resource, granting it the necessary permissions
+    /// on the target Azure Key Vault resource. This replaces the default role assignments for the resource.
+    /// </summary>
+    /// <param name="builder">The resource to which the specified roles will be assigned.</param>
+    /// <param name="target">The target Azure Key Vault resource.</param>
+    /// <param name="roles">The built-in Key Vault role names to be assigned (e.g., "KeyVaultSecretsUser", "KeyVaultReader").</param>
+    /// <returns>The updated <see cref="IResourceBuilder{T}"/> with the applied role assignments.</returns>
+    /// <exception cref="ArgumentException">Thrown when a role name is not a valid Key Vault built-in role.</exception>
+    [AspireExport("withRoleAssignments", Description = "Assigns Key Vault roles to a resource")]
+    internal static IResourceBuilder<T> WithRoleAssignments<T>(
+        this IResourceBuilder<T> builder,
+        IResourceBuilder<AzureKeyVaultResource> target,
+        params string[] roles)
+        where T : IResource
+    {
+        var builtInRoles = new KeyVaultBuiltInRole[roles.Length];
+        for (var i = 0; i < roles.Length; i++)
+        {
+            if (!s_keyVaultRolesByName.TryGetValue(roles[i], out var role))
+            {
+                throw new ArgumentException($"'{roles[i]}' is not a valid Key Vault built-in role. Valid roles: {string.Join(", ", s_keyVaultRolesByName.Keys)}.", nameof(roles));
+            }
+            builtInRoles[i] = role;
+        }
+
+        return builder.WithRoleAssignments(target, builtInRoles);
+    }
+
+    /// <summary>
     /// Gets a secret reference for the specified secret name from the Azure Key Vault resource.
     /// </summary>
     /// <param name="builder">The Azure Key Vault resource builder.</param>
     /// <param name="secretName">The name of the secret.</param>
     /// <returns>A reference to the secret.</returns>
-    [AspireExportIgnore]
+    [AspireExport("getSecret", Description = "Gets a secret reference from the Azure Key Vault")]
     public static IAzureKeyVaultSecretReference GetSecret(this IResourceBuilder<AzureKeyVaultResource> builder, string secretName)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -214,7 +244,7 @@ public static partial class AzureKeyVaultResourceExtensions
     /// <param name="name">The name of the secret. Must follow Azure Key Vault naming rules.</param>
     /// <param name="parameterResource">The parameter resource containing the secret value.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExportIgnore]
+    [AspireExportIgnore(Reason = "Raw ParameterResource overload; use the IResourceBuilder<ParameterResource> variant instead.")]
     public static IResourceBuilder<AzureKeyVaultSecretResource> AddSecret(this IResourceBuilder<AzureKeyVaultResource> builder, string name, ParameterResource parameterResource)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -274,7 +304,7 @@ public static partial class AzureKeyVaultResourceExtensions
     /// <param name="secretName">The name of the secret. Must follow Azure Key Vault naming rules.</param>
     /// <param name="parameterResource">The parameter resource containing the secret value.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExportIgnore]
+    [AspireExportIgnore(Reason = "Raw ParameterResource overload; use the IResourceBuilder<ParameterResource> variant instead.")]
     public static IResourceBuilder<AzureKeyVaultSecretResource> AddSecret(this IResourceBuilder<AzureKeyVaultResource> builder, [ResourceName] string name, string secretName, ParameterResource parameterResource)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -309,6 +339,23 @@ public static partial class AzureKeyVaultResourceExtensions
 
         return builder.ApplicationBuilder.AddResource(secret).ExcludeFromManifest();
     }
+
+    private static readonly FrozenDictionary<string, KeyVaultBuiltInRole> s_keyVaultRolesByName = new Dictionary<string, KeyVaultBuiltInRole>(StringComparer.OrdinalIgnoreCase)
+    {
+        [nameof(KeyVaultBuiltInRole.KeyVaultAdministrator)] = KeyVaultBuiltInRole.KeyVaultAdministrator,
+        [nameof(KeyVaultBuiltInRole.KeyVaultCertificateUser)] = KeyVaultBuiltInRole.KeyVaultCertificateUser,
+        [nameof(KeyVaultBuiltInRole.KeyVaultCertificatesOfficer)] = KeyVaultBuiltInRole.KeyVaultCertificatesOfficer,
+        [nameof(KeyVaultBuiltInRole.KeyVaultContributor)] = KeyVaultBuiltInRole.KeyVaultContributor,
+        [nameof(KeyVaultBuiltInRole.KeyVaultCryptoOfficer)] = KeyVaultBuiltInRole.KeyVaultCryptoOfficer,
+        [nameof(KeyVaultBuiltInRole.KeyVaultCryptoServiceEncryptionUser)] = KeyVaultBuiltInRole.KeyVaultCryptoServiceEncryptionUser,
+        [nameof(KeyVaultBuiltInRole.KeyVaultCryptoServiceReleaseUser)] = KeyVaultBuiltInRole.KeyVaultCryptoServiceReleaseUser,
+        [nameof(KeyVaultBuiltInRole.KeyVaultCryptoUser)] = KeyVaultBuiltInRole.KeyVaultCryptoUser,
+        [nameof(KeyVaultBuiltInRole.KeyVaultDataAccessAdministrator)] = KeyVaultBuiltInRole.KeyVaultDataAccessAdministrator,
+        [nameof(KeyVaultBuiltInRole.KeyVaultReader)] = KeyVaultBuiltInRole.KeyVaultReader,
+        [nameof(KeyVaultBuiltInRole.KeyVaultSecretsOfficer)] = KeyVaultBuiltInRole.KeyVaultSecretsOfficer,
+        [nameof(KeyVaultBuiltInRole.KeyVaultSecretsUser)] = KeyVaultBuiltInRole.KeyVaultSecretsUser,
+        [nameof(KeyVaultBuiltInRole.ManagedHsmContributor)] = KeyVaultBuiltInRole.ManagedHsmContributor,
+    }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     private static void ValidateSecretName(string secretName)
     {

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -58,6 +58,7 @@ public static partial class AzureKeyVaultResourceExtensions
     /// </code>
     /// </example>
     /// </remarks>
+    [AspireExport("addAzureKeyVault", Description = "Adds an Azure Key Vault resource")]
     public static IResourceBuilder<AzureKeyVaultResource> AddAzureKeyVault(this IDistributedApplicationBuilder builder, [ResourceName] string name)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -166,6 +167,7 @@ public static partial class AzureKeyVaultResourceExtensions
     /// </code>
     /// </example>
     /// </remarks>
+    [AspireExportIgnore]
     public static IResourceBuilder<T> WithRoleAssignments<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureKeyVaultResource> target,
@@ -181,6 +183,7 @@ public static partial class AzureKeyVaultResourceExtensions
     /// <param name="builder">The Azure Key Vault resource builder.</param>
     /// <param name="secretName">The name of the secret.</param>
     /// <returns>A reference to the secret.</returns>
+    [AspireExportIgnore]
     public static IAzureKeyVaultSecretReference GetSecret(this IResourceBuilder<AzureKeyVaultResource> builder, string secretName)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -195,6 +198,7 @@ public static partial class AzureKeyVaultResourceExtensions
     /// <param name="name">The name of the secret. Must follow Azure Key Vault naming rules.</param>
     /// <param name="parameterResource">The parameter resource containing the secret value.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    [AspireExport("addSecret", Description = "Adds a secret to the Azure Key Vault from a parameter resource")]
     public static IResourceBuilder<AzureKeyVaultSecretResource> AddSecret(this IResourceBuilder<AzureKeyVaultResource> builder, string name, IResourceBuilder<ParameterResource> parameterResource)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -210,6 +214,7 @@ public static partial class AzureKeyVaultResourceExtensions
     /// <param name="name">The name of the secret. Must follow Azure Key Vault naming rules.</param>
     /// <param name="parameterResource">The parameter resource containing the secret value.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    [AspireExportIgnore]
     public static IResourceBuilder<AzureKeyVaultSecretResource> AddSecret(this IResourceBuilder<AzureKeyVaultResource> builder, string name, ParameterResource parameterResource)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -230,6 +235,7 @@ public static partial class AzureKeyVaultResourceExtensions
     /// <param name="name">The name of the secret. Must follow Azure Key Vault naming rules.</param>
     /// <param name="value">The reference expression containing the secret value.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    [AspireExport("addSecretFromExpression", Description = "Adds a secret to the Azure Key Vault from a reference expression")]
     public static IResourceBuilder<AzureKeyVaultSecretResource> AddSecret(this IResourceBuilder<AzureKeyVaultResource> builder, string name, ReferenceExpression value)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -251,6 +257,7 @@ public static partial class AzureKeyVaultResourceExtensions
     /// <param name="secretName">The name of the secret. Must follow Azure Key Vault naming rules.</param>
     /// <param name="parameterResource">The parameter resource containing the secret value.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    [AspireExport("addSecretWithName", Description = "Adds a named secret to the Azure Key Vault from a parameter resource")]
     public static IResourceBuilder<AzureKeyVaultSecretResource> AddSecret(this IResourceBuilder<AzureKeyVaultResource> builder, [ResourceName] string name, string secretName, IResourceBuilder<ParameterResource> parameterResource)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -267,6 +274,7 @@ public static partial class AzureKeyVaultResourceExtensions
     /// <param name="secretName">The name of the secret. Must follow Azure Key Vault naming rules.</param>
     /// <param name="parameterResource">The parameter resource containing the secret value.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    [AspireExportIgnore]
     public static IResourceBuilder<AzureKeyVaultSecretResource> AddSecret(this IResourceBuilder<AzureKeyVaultResource> builder, [ResourceName] string name, string secretName, ParameterResource parameterResource)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -288,6 +296,7 @@ public static partial class AzureKeyVaultResourceExtensions
     /// <param name="secretName">The name of the secret. Must follow Azure Key Vault naming rules.</param>
     /// <param name="value">The reference expression containing the secret value.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    [AspireExport("addSecretWithNameFromExpression", Description = "Adds a named secret to the Azure Key Vault from a reference expression")]
     public static IResourceBuilder<AzureKeyVaultSecretResource> AddSecret(this IResourceBuilder<AzureKeyVaultResource> builder, [ResourceName] string name, string secretName, ReferenceExpression value)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Azure/IAzureKeyVaultSecretReference.cs
+++ b/src/Aspire.Hosting.Azure/IAzureKeyVaultSecretReference.cs
@@ -8,6 +8,7 @@ namespace Aspire.Hosting.Azure;
 /// <summary>
 /// Represents a reference to a secret in an Azure Key Vault resource.
 /// </summary>
+[AspireExport]
 public interface IAzureKeyVaultSecretReference : IValueProvider, IManifestExpressionProvider, IValueWithReferences
 {
     /// <summary>

--- a/src/Aspire.Hosting/Ats/AspireExportIgnoreAttribute.cs
+++ b/src/Aspire.Hosting/Ats/AspireExportIgnoreAttribute.cs
@@ -39,4 +39,12 @@ namespace Aspire.Hosting;
 [Experimental("ASPIREATS001")]
 public sealed class AspireExportIgnoreAttribute : Attribute
 {
+    /// <summary>
+    /// Gets or sets the reason why this member is excluded from ATS export.
+    /// </summary>
+    /// <remarks>
+    /// Use this property to document why an API cannot be exported to polyglot app hosts,
+    /// distinguishing reviewed-but-incompatible members from those not yet reviewed.
+    /// </remarks>
+    public string? Reason { get; set; }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureKeyVaultTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureKeyVaultTests.cs
@@ -497,4 +497,116 @@ public class AzureKeyVaultTests
         // The redirect annotation should take precedence over emulator
         Assert.Equal("https://redirected-vault.vault.azure.net", connectionStringValue);
     }
+
+    [Fact]
+    public void WithRoleAssignments_StringOverload_ValidRoles_DoesNotThrow()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var kv = builder.AddAzureKeyVault("myKeyVault");
+        var container = builder.AddContainer("myContainer", "nginx");
+
+        var exception = Record.Exception(() =>
+            container.WithRoleAssignments(kv, "KeyVaultSecretsUser", "KeyVaultReader"));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void WithRoleAssignments_StringOverload_SingleRole_DoesNotThrow()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var kv = builder.AddAzureKeyVault("myKeyVault");
+        var container = builder.AddContainer("myContainer", "nginx");
+
+        var exception = Record.Exception(() =>
+            container.WithRoleAssignments(kv, "KeyVaultAdministrator"));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void WithRoleAssignments_StringOverload_InvalidRole_ThrowsArgumentException()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var kv = builder.AddAzureKeyVault("myKeyVault");
+        var container = builder.AddContainer("myContainer", "nginx");
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            container.WithRoleAssignments(kv, "NotARealRole"));
+
+        Assert.Contains("'NotARealRole' is not a valid Key Vault built-in role", exception.Message);
+        Assert.Contains("Valid roles:", exception.Message);
+    }
+
+    [Fact]
+    public void WithRoleAssignments_StringOverload_MixedValidAndInvalidRoles_ThrowsOnInvalid()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var kv = builder.AddAzureKeyVault("myKeyVault");
+        var container = builder.AddContainer("myContainer", "nginx");
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            container.WithRoleAssignments(kv, "KeyVaultReader", "InvalidRole"));
+
+        Assert.Contains("'InvalidRole'", exception.Message);
+    }
+
+    [Fact]
+    public void WithRoleAssignments_StringOverload_CaseInsensitive()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var kv = builder.AddAzureKeyVault("myKeyVault");
+        var container = builder.AddContainer("myContainer", "nginx");
+
+        var exception = Record.Exception(() =>
+            container.WithRoleAssignments(kv, "keyvaultsecretsuser", "KEYVAULTREADER"));
+
+        Assert.Null(exception);
+    }
+
+    [Theory]
+    [InlineData("KeyVaultAdministrator")]
+    [InlineData("KeyVaultCertificateUser")]
+    [InlineData("KeyVaultCertificatesOfficer")]
+    [InlineData("KeyVaultContributor")]
+    [InlineData("KeyVaultCryptoOfficer")]
+    [InlineData("KeyVaultCryptoServiceEncryptionUser")]
+    [InlineData("KeyVaultCryptoServiceReleaseUser")]
+    [InlineData("KeyVaultCryptoUser")]
+    [InlineData("KeyVaultDataAccessAdministrator")]
+    [InlineData("KeyVaultReader")]
+    [InlineData("KeyVaultSecretsOfficer")]
+    [InlineData("KeyVaultSecretsUser")]
+    [InlineData("ManagedHsmContributor")]
+    public void WithRoleAssignments_StringOverload_AllBuiltInRoles_AreAccepted(string roleName)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var kv = builder.AddAzureKeyVault("myKeyVault");
+        var container = builder.AddContainer("myContainer", "nginx");
+
+        var exception = Record.Exception(() =>
+            container.WithRoleAssignments(kv, roleName));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void WithRoleAssignments_StringOverload_EmptyRoles_DoesNotThrow()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var kv = builder.AddAzureKeyVault("myKeyVault");
+        var container = builder.AddContainer("myContainer", "nginx");
+
+        var exception = Record.Exception(() =>
+            container.WithRoleAssignments(kv, Array.Empty<string>()));
+
+        Assert.Null(exception);
+    }
 }


### PR DESCRIPTION
## Description

Adds ATS (Aspire Type System) export coverage for the Azure KeyVault hosting integration, enabling polyglot (TypeScript) app hosts to use KeyVault APIs.

### Changes

- **`GetSecret`**: Changed from `[AspireExportIgnore]` to `[AspireExport("getSecret")]` so polyglot app hosts can retrieve secret references
- **`WithRoleAssignments` (string-based overload)**: New `internal` method accepting string role names instead of `KeyVaultBuiltInRole` enum values, exported as `[AspireExport("withRoleAssignments")]`. Uses a `FrozenDictionary` for case-insensitive role name validation
- **`IAzureKeyVaultSecretReference`**: Added `[AspireExport]` attribute to the interface
- **`AspireExportIgnoreAttribute.Reason`**: Added `Reason` property to document why members are excluded from ATS export
- **`[AspireExportIgnore]` annotations**: Added `Reason` explanations to all ignored overloads (e.g., `KeyVaultBuiltInRole` enum incompatibility, raw `ParameterResource` overloads)
- **Unit tests**: Added 7 tests for the string-based `WithRoleAssignments` overload covering valid roles, invalid roles, case insensitivity, and all 13 built-in role names

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
    - The new string-based `WithRoleAssignments` overload is `internal` (accessed via ATS layer only). The `Reason` property on `AspireExportIgnoreAttribute` is public but the attribute itself is already `[Experimental]`.
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No