### PR TITLE
Make Ubuntu runner not identify as WSL2

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -109,6 +109,7 @@ jobs:
       - name: Trust HTTPS development certificate (Linux)
         if: inputs.os == 'ubuntu-latest'
         run: ${{ env.DOTNET_SCRIPT }} dev-certs https --trust
+        continue-on-error: true
         env:
           WSL_INTEROP: ""
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -109,7 +109,6 @@ jobs:
       - name: Trust HTTPS development certificate (Linux)
         if: inputs.os == 'ubuntu-latest'
         run: ${{ env.DOTNET_SCRIPT }} dev-certs https --trust
-        continue-on-error: true
         env:
           WSL_INTEROP: ""
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -109,6 +109,8 @@ jobs:
       - name: Trust HTTPS development certificate (Linux)
         if: inputs.os == 'ubuntu-latest'
         run: ${{ env.DOTNET_SCRIPT }} dev-certs https --trust
+        env:
+          WSL_INTEROP: ""
 
       - name: Verify Docker is running
         # nested docker containers not supported on windows

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -108,7 +108,14 @@ jobs:
 
       - name: Trust HTTPS development certificate (Linux)
         if: inputs.os == 'ubuntu-latest'
-        run: ${{ env.DOTNET_SCRIPT }} dev-certs https --trust
+        # Allow the task to succeed on partial trust
+        run: |
+          EXIT_CODE=0
+          ${{ env.DOTNET_SCRIPT }} dev-certs https --trust || EXIT_CODE=$?
+          if [ $EXIT_CODE -ne 0 ] && [ $EXIT_CODE -ne 4 ]; then
+            echo "dev-certs https --trust failed with exit code $EXIT_CODE"
+            exit $EXIT_CODE
+          fi
         env:
           WSL_INTEROP: ""
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -108,7 +108,8 @@ jobs:
 
       - name: Trust HTTPS development certificate (Linux)
         if: inputs.os == 'ubuntu-latest'
-        # Allow the task to succeed on partial trust
+        # Allow the task to succeed on partial trust.
+        # Remove this workaround once https://github.com/dotnet/aspnetcore/pull/65392 has shipped
         run: |
           EXIT_CODE=0
           ${{ env.DOTNET_SCRIPT }} dev-certs https --trust || EXIT_CODE=$?


### PR DESCRIPTION
## Description

Ensure our Ubuntu runner doesn't try to exercise a broken WSL code path in `dotnet dev-certs https --trust`.