### PR TITLE
Add override options for staging feed and quality in configuration schema and implement related tests

### DIFF
--- a/extension/schemas/aspire-global-settings.schema.json
+++ b/extension/schemas/aspire-global-settings.schema.json
@@ -294,6 +294,19 @@
     "sdkVersion": {
       "description": "The Aspire SDK version used for this polyglot AppHost project. Determines the version of Aspire.Hosting packages to use.",
       "type": "string"
+    },
+    "overrideStagingFeed": {
+      "description": "Override the NuGet feed URL used by the staging channel. When set, this URL is used instead of the default SHA-based build-specific feed.",
+      "type": "string"
+    },
+    "overrideStagingQuality": {
+      "description": "Override the package quality filter for the staging channel. Set to \"Prerelease\" when staging builds are not yet marked as stable to use the shared daily feed instead of the SHA-based feed. Valid values: \"Stable\", \"Prerelease\", \"Both\".",
+      "type": "string",
+      "enum": [
+        "Stable",
+        "Prerelease",
+        "Both"
+      ]
     }
   },
   "additionalProperties": false

--- a/extension/schemas/aspire-global-settings.schema.json
+++ b/extension/schemas/aspire-global-settings.schema.json
@@ -307,6 +307,10 @@
         "Prerelease",
         "Both"
       ]
+    },
+    "stagingVersionPrefix": {
+      "description": "Filter staging channel packages to a specific Major.Minor version (e.g., \"13.2\"). When set, only packages matching this version prefix are shown, preventing newer daily versions from being selected.",
+      "type": "string"
     }
   },
   "additionalProperties": false

--- a/extension/schemas/aspire-settings.schema.json
+++ b/extension/schemas/aspire-settings.schema.json
@@ -311,6 +311,10 @@
         "Prerelease",
         "Both"
       ]
+    },
+    "stagingVersionPrefix": {
+      "description": "Filter staging channel packages to a specific Major.Minor version (e.g., \"13.2\"). When set, only packages matching this version prefix are shown, preventing newer daily versions from being selected.",
+      "type": "string"
     }
   },
   "additionalProperties": false

--- a/extension/schemas/aspire-settings.schema.json
+++ b/extension/schemas/aspire-settings.schema.json
@@ -298,6 +298,19 @@
     "sdkVersion": {
       "description": "The Aspire SDK version used for this polyglot AppHost project. Determines the version of Aspire.Hosting packages to use.",
       "type": "string"
+    },
+    "overrideStagingFeed": {
+      "description": "Override the NuGet feed URL used by the staging channel. When set, this URL is used instead of the default SHA-based build-specific feed.",
+      "type": "string"
+    },
+    "overrideStagingQuality": {
+      "description": "Override the package quality filter for the staging channel. Set to \"Prerelease\" when staging builds are not yet marked as stable to use the shared daily feed instead of the SHA-based feed. Valid values: \"Stable\", \"Prerelease\", \"Both\".",
+      "type": "string",
+      "enum": [
+        "Stable",
+        "Prerelease",
+        "Both"
+      ]
     }
   },
   "additionalProperties": false

--- a/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
@@ -482,4 +482,157 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         Assert.True(stableIndex < dailyIndex, "stable should come before daily");
         Assert.True(dailyIndex < pr12345Index, "daily should come before pr-12345");
     }
+
+    [Fact]
+    public async Task GetChannelsAsync_WhenStagingQualityPrerelease_AndNoFeedOverride_UsesSharedFeed()
+    {
+        // Arrange
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempDir = workspace.WorkspaceRoot;
+        var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
+        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        
+        var features = new TestFeatures();
+        features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
+        
+        // Set quality to Prerelease but do NOT set overrideStagingFeed
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["overrideStagingQuality"] = "Prerelease"
+            })
+            .Build();
+
+        var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), features, configuration);
+
+        // Act
+        var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
+
+        // Assert
+        var stagingChannel = channels.First(c => c.Name == "staging");
+        Assert.Equal(PackageChannelQuality.Prerelease, stagingChannel.Quality);
+        Assert.False(stagingChannel.ConfigureGlobalPackagesFolder);
+        
+        var aspireMapping = stagingChannel.Mappings!.FirstOrDefault(m => m.PackageFilter == "Aspire*");
+        Assert.NotNull(aspireMapping);
+        Assert.Equal("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json", aspireMapping.Source);
+    }
+
+    [Fact]
+    public async Task GetChannelsAsync_WhenStagingQualityBoth_AndNoFeedOverride_UsesSharedFeed()
+    {
+        // Arrange
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempDir = workspace.WorkspaceRoot;
+        var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
+        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        
+        var features = new TestFeatures();
+        features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
+        
+        // Set quality to Both but do NOT set overrideStagingFeed
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["overrideStagingQuality"] = "Both"
+            })
+            .Build();
+
+        var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), features, configuration);
+
+        // Act
+        var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
+
+        // Assert
+        var stagingChannel = channels.First(c => c.Name == "staging");
+        Assert.Equal(PackageChannelQuality.Both, stagingChannel.Quality);
+        Assert.False(stagingChannel.ConfigureGlobalPackagesFolder);
+        
+        var aspireMapping = stagingChannel.Mappings!.FirstOrDefault(m => m.PackageFilter == "Aspire*");
+        Assert.NotNull(aspireMapping);
+        Assert.Equal("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json", aspireMapping.Source);
+    }
+
+    [Fact]
+    public async Task GetChannelsAsync_WhenStagingQualityPrerelease_WithFeedOverride_UsesFeedOverride()
+    {
+        // Arrange
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempDir = workspace.WorkspaceRoot;
+        var hivesDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "hives"));
+        var cacheDir = new DirectoryInfo(Path.Combine(tempDir.FullName, ".aspire", "cache"));
+        var executionContext = new CliExecutionContext(tempDir, hivesDir, cacheDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        
+        var features = new TestFeatures();
+        features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
+        
+        // Set both quality override AND feed override — feed override should win
+        var customFeed = "https://custom-feed.example.com/v3/index.json";
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["overrideStagingQuality"] = "Prerelease",
+                ["overrideStagingFeed"] = customFeed
+            })
+            .Build();
+
+        var packagingService = new PackagingService(executionContext, new FakeNuGetPackageCache(), features, configuration);
+
+        // Act
+        var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
+
+        // Assert
+        var stagingChannel = channels.First(c => c.Name == "staging");
+        Assert.Equal(PackageChannelQuality.Prerelease, stagingChannel.Quality);
+        // When an explicit feed override is provided, globalPackagesFolder stays enabled
+        Assert.True(stagingChannel.ConfigureGlobalPackagesFolder);
+        
+        var aspireMapping = stagingChannel.Mappings!.FirstOrDefault(m => m.PackageFilter == "Aspire*");
+        Assert.NotNull(aspireMapping);
+        Assert.Equal(customFeed, aspireMapping.Source);
+    }
+
+    [Fact]
+    public async Task NuGetConfigMerger_WhenStagingUsesSharedFeed_DoesNotAddGlobalPackagesFolder()
+    {
+        // Arrange
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var tempDir = workspace.WorkspaceRoot;
+        
+        var features = new TestFeatures();
+        features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
+        
+        // Quality=Prerelease with no feed override → shared feed mode
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["overrideStagingQuality"] = "Prerelease"
+            })
+            .Build();
+
+        var packagingService = new PackagingService(
+            new CliExecutionContext(tempDir, tempDir, tempDir, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log"), 
+            new FakeNuGetPackageCache(), 
+            features, 
+            configuration);
+
+        var channels = await packagingService.GetChannelsAsync().DefaultTimeout();
+        var stagingChannel = channels.First(c => c.Name == "staging");
+
+        // Act
+        await NuGetConfigMerger.CreateOrUpdateAsync(tempDir, stagingChannel).DefaultTimeout();
+
+        // Assert
+        var nugetConfigPath = Path.Combine(tempDir.FullName, "nuget.config");
+        Assert.True(File.Exists(nugetConfigPath));
+        
+        var configContent = await File.ReadAllTextAsync(nugetConfigPath);
+        Assert.DoesNotContain("globalPackagesFolder", configContent);
+        Assert.DoesNotContain(".nugetpackages", configContent);
+        
+        // Verify it still has the shared feed URL
+        Assert.Contains("dotnet9", configContent);
+    }
 }


### PR DESCRIPTION
## Description

cc: @mitchdenny 

### Problem

  The staging channel constructs a SHA-specific NuGet feed URL (darc-pub-dotnet-aspire-{hash}) for package resolution. These feeds are only created by DARC for stable-quality builds. When staging builds aren't yet marked as stable, the SHA-specific feed doesn't exist
  (or is empty), causing aspire new and aspire update to fail for users on the staging channel.

### Solution

  When overrideStagingQuality is set to Prerelease or Both and no explicit overrideStagingFeed is provided, the staging channel now falls back to the shared dotnet9 daily feed instead of constructing a SHA-based feed. This also disables configureGlobalPackagesFolder
  since package isolation isn't needed with the shared feed.

  The logic: SHA-specific feeds only contain stable builds, so a non-Stable quality without an explicit feed override can only work with the shared feed — making this a natural signal rather than requiring a new config key.

### How to enable

   // ~/.aspire/globalsettings.json
   {
     "overrideStagingQuality": "Prerelease",
     "features": { "stagingChannelEnabled": true }
   }

### Changes

   - src/Aspire.Cli/Packaging/PackagingService.cs — CreateStagingChannel() computes whether to use the shared feed based on quality + feed override state; GetStagingFeedUrl() returns the dotnet9 feed when appropriate; configureGlobalPackagesFolder is disabled for
  shared feed mode.
   - tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs — 4 new tests covering: Prerelease→shared feed, Both→shared feed, feed override takes precedence, and NuGet config omits globalPackagesFolder in shared feed mode.
   - extension/schemas/aspire-{global-,}settings.schema.json — Added overrideStagingFeed and overrideStagingQuality property definitions for IntelliSense support.

### Rollback

  Once staging builds are published as stable again, remove overrideStagingQuality from settings. The code is safe to leave in — the default quality is Stable, so the shared-feed path is never taken unless explicitly configured.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
