### PR TITLE
Fix AllocatedEndpoint API

### DIFF
--- a/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
@@ -154,7 +154,9 @@ public static partial class DevTunnelsResourceBuilderExtensions
                     var exception = new DistributedApplicationException($"Error trying to create the dev tunnel resource '{tunnelResource.TunnelId}' this port belongs to: {ex.Message}", ex);
                     foreach (var portResource in tunnelResource.Ports)
                     {
+#pragma warning disable CS0618 // Type or member is obsolete
                         portResource.TunnelEndpointAnnotation.AllocatedEndpointSnapshot.SetException(exception);
+#pragma warning restore CS0618 // Type or member is obsolete
                     }
                     throw;
                 }
@@ -209,7 +211,9 @@ public static partial class DevTunnelsResourceBuilderExtensions
                     catch (Exception ex)
                     {
                         portLogger.LogError(ex, "Error trying to create dev tunnel port '{Port}' on tunnel '{Tunnel}': {Error}", portResource.TargetEndpoint.Port, portResource.DevTunnel.TunnelId, ex.Message);
+#pragma warning disable CS0618 // Type or member is obsolete
                         portResource.TunnelEndpointAnnotation.AllocatedEndpointSnapshot.SetException(ex);
+#pragma warning restore CS0618 // Type or member is obsolete
                         throw;
                     }
 

--- a/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
@@ -300,6 +300,10 @@ public class NetworkEndpointSnapshotList : IEnumerable<NetworkEndpointSnapshot>
     /// </summary>
     public void AddOrUpdateAllocatedEndpoint(NetworkIdentifier networkID, AllocatedEndpoint endpoint)
     {
+        if (endpoint.NetworkID != networkID)
+        {
+            throw new ArgumentException($"AllocatedEndpoint must use the same network as the {nameof(networkID)} parameter", nameof(endpoint));
+        }
         var nes = GetSnapshotFor(networkID);
         nes.Snapshot.SetValue(endpoint);
     }

--- a/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
@@ -288,7 +288,7 @@ public class NetworkEndpointSnapshotList : IEnumerable<NetworkEndpointSnapshot>
     }
 
     /// <summary>
-    /// Adds and AllocatedEndpoint value associated with a specific network to the snapshot list.
+    /// Adds or updates an AllocatedEndpoint value associated with a specific network in the snapshot list.
     /// </summary>
     public void AddOrUpdateAllocatedEndpoint(NetworkIdentifier networkID, AllocatedEndpoint endpoint)
     {

--- a/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
@@ -204,8 +204,10 @@ public sealed class EndpointAnnotation : IResourceAnnotation
     /// </summary>
     public AllocatedEndpoint? AllocatedEndpoint
     {
+#pragma warning disable CS0618 // Type or member is obsolete (AllocatedEndpointSnapshot)
         get
         {
+
             if (!AllocatedEndpointSnapshot.IsValueSet)
             {
                 return null;
@@ -225,14 +227,20 @@ public sealed class EndpointAnnotation : IResourceAnnotation
             }
             else
             {
+                if (_networkID != value.NetworkID)
+                {
+                    throw new InvalidOperationException($"The default AllocatedEndpoint's network ID must match the EndpointAnnotation network ID ('{_networkID}'). The attempted AllocatedEndpoint belongs to '{value.NetworkID}'.");
+                }
                 AllocatedEndpointSnapshot.SetValue(value);
             }
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     /// <summary>
     /// Gets the <see cref="AllocatedEndpointSnapshot"/> for the default <see cref="AllocatedEndpoint"/>.
     /// </summary>
+    [Obsolete("This property will be marked as internal in future Aspire release. Use AllocatedEndpoint and AllAllocatedEndpoints properties to access and change allocated endpoints associated with an EndpointAnnotation.")]
     public ValueSnapshot<AllocatedEndpoint> AllocatedEndpointSnapshot { get; } = new();
 
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -141,8 +141,10 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
     /// </summary>
     public string Url => AllocatedEndpoint.UriString;
 
+#pragma warning disable CS0618 // Type or member is obsolete
     internal ValueSnapshot<AllocatedEndpoint> AllocatedEndpointSnapshot =>
         EndpointAnnotation.AllocatedEndpointSnapshot;
+#pragma warning restore CS0618 // Type or member is obsolete
 
     internal AllocatedEndpoint AllocatedEndpoint =>
         GetAllocatedEndpoint()

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -307,21 +307,8 @@ public class EndpointReferenceExpression(EndpointReference endpointReference, En
 
         async ValueTask<string?> ResolveValueWithAllocatedAddress()
         {
-            // We are going to take the first snapshot that matches the context network ID. In general there might be multiple endpoints for a single service,
-            // and in future we might need some sort of policy to choose between them, but for now we just take the first one.
             var endpointSnapshots = Endpoint.EndpointAnnotation.AllAllocatedEndpoints;
-            var nes = endpointSnapshots.Where(nes => nes.NetworkID == networkContext).FirstOrDefault();
-            if (nes is null)
-            {
-                nes = new NetworkEndpointSnapshot(new ValueSnapshot<AllocatedEndpoint>(), networkContext);
-                if (!endpointSnapshots.TryAdd(networkContext, nes.Snapshot))
-                {
-                    // Someone else added it first, use theirs.
-                    nes = endpointSnapshots.Where(nes => nes.NetworkID == networkContext).First();
-                }
-            }
-
-            var allocatedEndpoint = await nes.Snapshot.GetValueAsync(cancellationToken).ConfigureAwait(false);
+            var allocatedEndpoint = await endpointSnapshots.GetAllocatedEndpointAsync(networkContext, cancellationToken).ConfigureAwait(false);
 
             return Property switch
             {

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -994,9 +994,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                                 targetPortExpression: $$$"""{{- portForServing "{{{svc.Metadata.Name}}}" -}}""",
                                 KnownNetworkIdentifiers.DefaultAspireContainerNetwork
                             );
-                            var snapshot = new ValueSnapshot<AllocatedEndpoint>();
-                            snapshot.SetValue(allocatedEndpoint);
-                            sp.EndpointAnnotation.AllAllocatedEndpoints.TryAdd(allocatedEndpoint.NetworkID, snapshot);
+                            sp.EndpointAnnotation.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(allocatedEndpoint.NetworkID, allocatedEndpoint);
                         }
                     }
                 }
@@ -1056,9 +1054,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                         targetPortExpression: $$$"""{{- portForServing "{{{ts.Service.Name}}}" -}}""",
                         networkID
                     );
-                    var snapshot = new ValueSnapshot<AllocatedEndpoint>();
-                    snapshot.SetValue(tunnelAllocatedEndpoint);
-                    endpoint.AllAllocatedEndpoints.TryAdd(networkID, snapshot);
+                    endpoint.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(networkID, tunnelAllocatedEndpoint);
                 }
             }
         }

--- a/tests/Aspire.Hosting.Azure.Tests/AzurePostgresExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzurePostgresExtensionsTests.cs
@@ -371,9 +371,7 @@ public class AzurePostgresExtensionsTests
                 c.WithEndpoint("tcp", e =>
                 {
                     e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5432);
-                    var snapshot = new ValueSnapshot<AllocatedEndpoint>();
-                    snapshot.SetValue(new AllocatedEndpoint(e, "postgres.dev.internal", 5432, EndpointBindingMode.SingleAddress, targetPortExpression: null, networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
-                    e.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
+                    e.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, new AllocatedEndpoint(e, "postgres.dev.internal", 5432, EndpointBindingMode.SingleAddress, targetPortExpression: null, networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
                 });
             });
 

--- a/tests/Aspire.Hosting.Containers.Tests/ContainerResourceTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/ContainerResourceTests.cs
@@ -102,10 +102,7 @@ public class ContainerResourceTests
                 e.AllocatedEndpoint = new(e, "localhost", 1234, targetPortExpression: "1234");
 
                 // For container-container lookup we need to add an AllocatedEndpoint on the container network side
-                var ccae = new AllocatedEndpoint(e, "c1.dev.internal", 2234, EndpointBindingMode.SingleAddress, targetPortExpression: "2234", KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
-                var snapshot = new ValueSnapshot<AllocatedEndpoint>();
-                snapshot.SetValue(ccae);
-                e.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
+                e.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, new AllocatedEndpoint(e, "c1.dev.internal", 2234, EndpointBindingMode.SingleAddress, targetPortExpression: "2234", KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
             });
 
         var c2 = appBuilder.AddContainer("container", "none")
@@ -113,10 +110,7 @@ public class ContainerResourceTests
              {
                  e.UriScheme = "http";
                  // We only care about the container-side endpoint for this test
-                 var snapshot = new ValueSnapshot<AllocatedEndpoint>();
-                 var ae = new AllocatedEndpoint(e, "container.dev.internal", 5678, EndpointBindingMode.SingleAddress, targetPortExpression: "5678", KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
-                 snapshot.SetValue(ae);
-                 e.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
+                 e.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, new AllocatedEndpoint(e, "container.dev.internal", 5678, EndpointBindingMode.SingleAddress, targetPortExpression: "5678", KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
              })
              .WithArgs(context =>
              {

--- a/tests/Aspire.Hosting.Maui.Tests/MauiPlatformExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Maui.Tests/MauiPlatformExtensionsTests.cs
@@ -636,7 +636,7 @@ public class MauiPlatformExtensionsTests
 
             foreach (var endpointAnnotation in endpointAnnotations)
             {
-                endpointAnnotation.AllocatedEndpointSnapshot.SetValue(new AllocatedEndpoint(endpointAnnotation, "localhost", 1234));
+                endpointAnnotation.AllocatedEndpoint = new AllocatedEndpoint(endpointAnnotation, "localhost", 1234);
             }
 
             var envVars = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(

--- a/tests/Aspire.Hosting.Milvus.Tests/AddMilvusTests.cs
+++ b/tests/Aspire.Hosting.Milvus.Tests/AddMilvusTests.cs
@@ -99,9 +99,7 @@ public class AddMilvusTests(ITestOutputHelper testOutputHelper)
             .WithEndpoint("grpc", e =>
             {
                 e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", MilvusPortGrpc);
-                var snapshot = new ValueSnapshot<AllocatedEndpoint>();
-                snapshot.SetValue(new AllocatedEndpoint(e, "my-milvus.dev.internal", MilvusPortGrpc, EndpointBindingMode.SingleAddress, targetPortExpression: null, networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
-                e.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
+                e.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, new AllocatedEndpoint(e, "my-milvus.dev.internal", MilvusPortGrpc, EndpointBindingMode.SingleAddress, targetPortExpression: null, networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
             });
 
         var projectA = appBuilder.AddProject<ProjectA>("projecta", o => o.ExcludeLaunchProfile = true)

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresMcpBuilderTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresMcpBuilderTests.cs
@@ -78,9 +78,7 @@ public class PostgresMcpBuilderTests
             .WithEndpoint("tcp", e =>
             {
                 e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5432);
-                var snapshot = new ValueSnapshot<AllocatedEndpoint>();
-                snapshot.SetValue(new AllocatedEndpoint(e, "postgres.dev.internal", 5432, EndpointBindingMode.SingleAddress, targetPortExpression: null, networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
-                e.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
+                e.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, new AllocatedEndpoint(e, "postgres.dev.internal", 5432, EndpointBindingMode.SingleAddress, targetPortExpression: null, networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
             })
             .AddDatabase("db")
             .WithPostgresMcp();

--- a/tests/Aspire.Hosting.Qdrant.Tests/AddQdrantTests.cs
+++ b/tests/Aspire.Hosting.Qdrant.Tests/AddQdrantTests.cs
@@ -172,16 +172,12 @@ public class AddQdrantTests(ITestOutputHelper testOutputHelper)
             .WithEndpoint("grpc", e =>
             {
                 e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 6334);
-                var snapshot = new ValueSnapshot<AllocatedEndpoint>();
-                snapshot.SetValue(new AllocatedEndpoint(e, "my-qdrant.dev.internal", 6334, EndpointBindingMode.SingleAddress, targetPortExpression: null, networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
-                e.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
+                e.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, new AllocatedEndpoint(e, "my-qdrant.dev.internal", 6334, EndpointBindingMode.SingleAddress, targetPortExpression: null, networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
             })
             .WithEndpoint("http", e =>
             {
                 e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 6333);
-                var snapshot = new ValueSnapshot<AllocatedEndpoint>();
-                snapshot.SetValue(new AllocatedEndpoint(e, "my-qdrant.dev.internal", 6333, EndpointBindingMode.SingleAddress, targetPortExpression: null, networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
-                e.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
+                e.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, new AllocatedEndpoint(e, "my-qdrant.dev.internal", 6333, EndpointBindingMode.SingleAddress, targetPortExpression: null, networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
             });
 
         var projectA = appBuilder.AddProject<ProjectA>("projecta", o => o.ExcludeLaunchProfile = true)

--- a/tests/Aspire.Hosting.Redis.Tests/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/AddRedisTests.cs
@@ -304,23 +304,17 @@ public class AddRedisTests(ITestOutputHelper testOutputHelper)
         redis1.WithEndpoint("tcp", e =>
         {
             e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5001);
-            var snapshot = new ValueSnapshot<AllocatedEndpoint>();
-            snapshot.SetValue(new AllocatedEndpoint(e, "myredis1.dev.internal", 5001, EndpointBindingMode.SingleAddress, targetPortExpression: null, networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
-            e.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
+            e.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, new AllocatedEndpoint(e, "myredis1.dev.internal", 5001, EndpointBindingMode.SingleAddress, targetPortExpression: null, networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
         });
         redis2.WithEndpoint("tcp", e =>
         {
             e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5002);
-            var snapshot = new ValueSnapshot<AllocatedEndpoint>();
-            snapshot.SetValue(new AllocatedEndpoint(e, "myredis2.dev.internal", 5002, EndpointBindingMode.SingleAddress, targetPortExpression: null, networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
-            e.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
+            e.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, new AllocatedEndpoint(e, "myredis2.dev.internal", 5002, EndpointBindingMode.SingleAddress, targetPortExpression: null, networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
         });
         redis3.WithEndpoint("tcp", e =>
         {
             e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5003);
-            var snapshot = new ValueSnapshot<AllocatedEndpoint>();
-            snapshot.SetValue(new AllocatedEndpoint(e, "myredis3.dev.internal", 5003, EndpointBindingMode.SingleAddress, targetPortExpression: null, networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
-            e.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
+            e.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, new AllocatedEndpoint(e, "myredis3.dev.internal", 5003, EndpointBindingMode.SingleAddress, targetPortExpression: null, networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
         });
 
         var redisInsight = Assert.Single(builder.Resources.OfType<RedisInsightResource>());
@@ -734,9 +728,7 @@ public class AddRedisTests(ITestOutputHelper testOutputHelper)
             .WithEndpoint("tcp", e =>
             {
                 e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 6379);
-                var snapshot = new ValueSnapshot<AllocatedEndpoint>();
-                snapshot.SetValue(new AllocatedEndpoint(e, "redis.dev.internal", 6379, EndpointBindingMode.SingleAddress, targetPortExpression: null, networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
-                e.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
+                e.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, new AllocatedEndpoint(e, "redis.dev.internal", 6379, EndpointBindingMode.SingleAddress, targetPortExpression: null, networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
             })
             .WithRedisInsight();
 

--- a/tests/Aspire.Hosting.Tests/EndpointReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/EndpointReferenceTests.cs
@@ -330,9 +330,7 @@ public class EndpointReferenceTests
             : ("host.docker.internal", port);
 
         var containerEndpoint = new AllocatedEndpoint(annotation, containerHost, containerPort, EndpointBindingMode.SingleAddress, targetPortExpression: targetPort.ToString(), KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
-        var snapshot = new ValueSnapshot<AllocatedEndpoint>();
-        snapshot.SetValue(containerEndpoint);
-        annotation.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
+        annotation.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, containerEndpoint);
 
         var expression = destination.GetEndpoint(annotation.Name).Property(property);
 

--- a/tests/Aspire.Hosting.Tests/EndpointReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/EndpointReferenceTests.cs
@@ -372,14 +372,8 @@ public class EndpointReferenceTests
 
         var waitStarted = new SemaphoreSlim(0, 1);
 
-        async ValueTask<string?> GetAndCheckEndpointRefValue()
-        {
-            var url = await endpointRef.GetValueAsync(CancellationToken.None);
-            return url;
-        }
-
 #pragma warning disable CA2012 // Use ValueTasks correctly
-        var consumer = new WithWaitStartedNotification<string?>(waitStarted, GetAndCheckEndpointRefValue().GetAwaiter());
+        var consumer = new WithWaitStartedNotification<string?>(waitStarted, endpointRef.GetValueAsync(CancellationToken.None).GetAwaiter());
 #pragma warning restore CA2012 // Use ValueTasks correctly
 
         await Task.WhenAll

--- a/tests/Aspire.Hosting.Tests/EndpointReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/EndpointReferenceTests.cs
@@ -286,6 +286,21 @@ public class EndpointReferenceTests
         Assert.Null(targetPort);
     }
 
+    [Fact]
+    public void AllocatedEndpoint_ThrowsWhenNetworkIdDoesNotMatch()
+    {
+        var annotation = new EndpointAnnotation(ProtocolType.Tcp, KnownNetworkIdentifiers.LocalhostNetwork, uriScheme: "http", name: "http");
+
+        // Create an AllocatedEndpoint with a different network ID.
+        var mismatchedEndpoint = new AllocatedEndpoint(
+            annotation, "localhost", 8080,
+            EndpointBindingMode.SingleAddress,
+            targetPortExpression: null,
+            networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => annotation.AllocatedEndpoint = mismatchedEndpoint);
+    }
+
     [Theory]
     [InlineData(EndpointProperty.Url, ResourceKind.Host, ResourceKind.Host, "blah://localhost:1234")]
     [InlineData(EndpointProperty.Url, ResourceKind.Host, ResourceKind.Container, "blah://localhost:1234")]

--- a/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
@@ -96,10 +96,7 @@ public class ExpressionResolverTests
                 if (sourceIsContainer)
                 {
                     // Note: on the container network side the port and target port are always the same for AllocatedEndpoint.
-                    var ae = new AllocatedEndpoint(e, containerHost, 22345, EndpointBindingMode.SingleAddress, targetPortExpression: "22345", KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
-                    var snapshot = new ValueSnapshot<AllocatedEndpoint>();
-                    snapshot.SetValue(ae);
-                    e.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
+                    e.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, new AllocatedEndpoint(e, containerHost, 22345, EndpointBindingMode.SingleAddress, targetPortExpression: "22345", KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
                 }
             })
             .WithEndpoint("endpoint2", e =>
@@ -108,10 +105,7 @@ public class ExpressionResolverTests
                 e.AllocatedEndpoint = new(e, "localhost", 12346, targetPortExpression: "10001");
                 if (sourceIsContainer)
                 {
-                    var ae = new AllocatedEndpoint(e, containerHost, 22346, EndpointBindingMode.SingleAddress, targetPortExpression: "22346", KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
-                    var snapshot = new ValueSnapshot<AllocatedEndpoint>();
-                    snapshot.SetValue(ae);
-                    e.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
+                    e.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, new AllocatedEndpoint(e, containerHost, 22346, EndpointBindingMode.SingleAddress, targetPortExpression: "22346", KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
                 }
             })
              .WithEndpoint("endpoint3", e =>
@@ -120,10 +114,7 @@ public class ExpressionResolverTests
                  e.AllocatedEndpoint = new(e, "host with space", 12347);
                  if (sourceIsContainer)
                  {
-                     var ae = new AllocatedEndpoint(e, containerHost, 22347, EndpointBindingMode.SingleAddress, targetPortExpression: "22346", KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
-                     var snapshot = new ValueSnapshot<AllocatedEndpoint>();
-                     snapshot.SetValue(ae);
-                     e.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
+                     e.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, new AllocatedEndpoint(e, containerHost, 22347, EndpointBindingMode.SingleAddress, targetPortExpression: "22346", KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
                  }
              });
 

--- a/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
@@ -114,7 +114,7 @@ public class ExpressionResolverTests
                  e.AllocatedEndpoint = new(e, "host with space", 12347);
                  if (sourceIsContainer)
                  {
-                     e.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, new AllocatedEndpoint(e, containerHost, 22347, EndpointBindingMode.SingleAddress, targetPortExpression: "22346", KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
+                     e.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, new AllocatedEndpoint(e, containerHost, 22347, EndpointBindingMode.SingleAddress, targetPortExpression: "22347", KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
                  }
              });
 

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -229,10 +229,7 @@ public class WithEnvironmentTests
                                {
                                    ep.AllocatedEndpoint = new AllocatedEndpoint(ep, "localhost", 17454);
 
-                                   var ae = new AllocatedEndpoint(ep, "container1.dev.internal", 10005, EndpointBindingMode.SingleAddress, networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
-                                   var snapshot = new ValueSnapshot<AllocatedEndpoint>();
-                                   snapshot.SetValue(ae);
-                                   ep.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, snapshot);
+                                   ep.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, new AllocatedEndpoint(ep, "container1.dev.internal", 10005, EndpointBindingMode.SingleAddress, networkID: KnownNetworkIdentifiers.DefaultAspireContainerNetwork));
                                });
 
         var endpoint = container.GetEndpoint("primary");
@@ -307,8 +304,7 @@ public class WithEnvironmentTests
                                .WithHttpEndpoint(name: "primary")
                                .WithEndpoint("primary", ep =>
                                {
-                                   var endpointSnapshot = new ValueSnapshot<AllocatedEndpoint>();
-                                   endpointSnapshot.SetValue(new AllocatedEndpoint(
+                                   ep.AllAllocatedEndpoints.AddOrUpdateAllocatedEndpoint(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, new AllocatedEndpoint(
                                        ep,
                                        "localhost",
                                        90,
@@ -316,7 +312,6 @@ public class WithEnvironmentTests
                                        """{{- portForServing "container1_primary" -}}""",
                                        KnownNetworkIdentifiers.DefaultAspireContainerNetwork
                                    ));
-                                   ep.AllAllocatedEndpoints.TryAdd(KnownNetworkIdentifiers.DefaultAspireContainerNetwork, endpointSnapshot);
                                });
 
         var endpoint = container.GetEndpoint("primary");


### PR DESCRIPTION
While working on local app run and container tunnel improvements, I discovered to my dismay that the AllocatedEndpoint management API (specifically, `NetworkEndpointSnapshotList.TryAdd()` is quite broken. It will not properly reuse existing snapshots. The result is that it is not possible to properly wait for an AllocatedEndpoint to appear in the system. 

The fix proposed here is to add a better API (namely upsert + asynchronous, cancellable get) and obsolete the old API.
