### PR TITLE
Stop ViteApps (build only containers) from getting Azure managed identities and roles

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
@@ -126,7 +126,9 @@ internal sealed class AzureResourcePreparer(
             //   - if a compute resource has RoleAssignmentAnnotations, use them
             //   - if the resource doesn't, copy the DefaultRoleAssignments to RoleAssignmentAnnotations to apply the defaults
             var resourceSnapshot = appModel.GetComputeResources()
-                .Concat(appModel.Resources.OfType<AzureUserAssignedIdentityResource>())
+                .Concat(appModel.Resources
+                    .OfType<AzureUserAssignedIdentityResource>()
+                    .Where(r => !r.IsExcludedFromPublish()))
                 .ToArray(); // avoid modifying the collection while iterating
             foreach (var resource in resourceSnapshot)
             {

--- a/tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj
+++ b/tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Aspire.Hosting.JavaScript\Aspire.Hosting.JavaScript.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.AIFoundry\Aspire.Hosting.Azure.AIFoundry.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.AppConfiguration\Aspire.Hosting.Azure.AppConfiguration.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.AppService\Aspire.Hosting.Azure.AppService.csproj" />


### PR DESCRIPTION
These resources don't get deployed, so they should be filtered from getting role assignments and managed identities added for them.