### PR TITLE
Fix Azure ServiceBus sku when using private endpoints

### DIFF
--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -62,7 +62,7 @@ public static class AzureServiceBusExtensions
                 {
                     var skuParameter = new ProvisioningParameter("sku", typeof(string))
                     {
-                        Value = "Standard"
+                        Value = hasPrivateEndpoint ? "Premium" : "Standard"
                     };
                     infrastructure.Add(skuParameter);
                     var resource = new AzureProvisioning.ServiceBusNamespace(infrastructure.AspireResource.GetBicepIdentifier())

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePrivateEndpointLockdownTests.AddAzureServiceBus_WithPrivateEndpoint_GeneratesCorrectBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzurePrivateEndpointLockdownTests.AddAzureServiceBus_WithPrivateEndpoint_GeneratesCorrectBicep.verified.bicep
@@ -1,7 +1,7 @@
 ﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-param sku string = 'Standard'
+param sku string = 'Premium'
 
 resource servicebus 'Microsoft.ServiceBus/namespaces@2024-01-01' = {
   name: take('servicebus-${uniqueString(resourceGroup().id)}', 50)


### PR DESCRIPTION
Standard SKU doesn't work with private endpoints. It needs to be Premium.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
https://github.com/microsoft/aspire.dev/issues/376