### PR TITLE
Add dashboard time format setting with 12/24-hour override

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -94,6 +94,7 @@
     <Compile Include="$(SharedDir)Model\ResourceSourceViewModel.cs" Link="Model\ResourceSourceViewModel.cs" />
     <Compile Include="$(SharedDir)DashboardUrls.cs" Link="Utils\DashboardUrls.cs" />
     <Compile Include="$(SharedDir)FormatHelpers.cs" Link="Utils\FormatHelpers.cs" />
+    <Compile Include="$(SharedDir)DateFormatStringsHelpers.cs" Link="Utils\DateFormatStringsHelpers.cs" />
     <Compile Include="$(SharedDir)TimeProviderExtensions.cs" Link="Extensions\TimeProviderExtensions.cs" />
     <Compile Include="$(SharedDir)UserSecrets\UserSecretsPathHelper.cs" Link="Utils\UserSecretsPathHelper.cs" />
     <Compile Include="$(SharedDir)UserSecrets\IsolatedUserSecretsHelper.cs" Link="Utils\IsolatedUserSecretsHelper.cs" />

--- a/src/Aspire.Cli/Resources/ExportCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ExportCommandStrings.Designer.cs
@@ -61,20 +61,20 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Export telemetry and resource data to a zip file.
-        /// </summary>
-        internal static string Description {
-            get {
-                return ResourceManager.GetString("Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Dashboard is not available. Telemetry data (structured logs, traces) will not be included in the export..
         /// </summary>
         internal static string DashboardNotAvailable {
             get {
                 return ResourceManager.GetString("DashboardNotAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Export telemetry and resource data to a zip file.
+        /// </summary>
+        internal static string Description {
+            get {
+                return ResourceManager.GetString("Description", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -283,6 +283,7 @@
     <Compile Include="$(SharedDir)ColorGenerator.cs" Link="Utils\ColorGenerator.cs" />
     <Compile Include="$(SharedDir)EnumerableExtensions.cs" Link="Utils\EnumerableExtensions.cs" />
     <Compile Include="$(SharedDir)FormatHelpers.cs" Link="Utils\FormatHelpers.cs" />
+    <Compile Include="$(SharedDir)DateFormatStringsHelpers.cs" Link="Utils\DateFormatStringsHelpers.cs" />
     <Compile Include="$(SharedDir)TimeProviderExtensions.cs" Link="Extensions\TimeProviderExtensions.cs" />
     <Compile Include="$(SharedDir)LocaleHelpers.cs" Link="Utils\LocaleHelpers.cs" />
     <Compile Include="$(SharedDir)CompareHelpers.cs" Link="Utils\CompareHelpers.cs" />

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -32,6 +32,17 @@
             <p class="setting-subtext">@Loc[nameof(Dialogs.SettingsDialogLanguagePageReloads)]</p>
         </div>
 
+        <div class="input-container">
+            <FluentSelect
+                TOption="TimeFormat"
+                Label="@Loc[nameof(Dialogs.SettingsDialogTimeFormat)]"
+                Items="@(Enum.GetValues<TimeFormat>())"
+                OptionText="@(i => FormatTimeFormatOption(i))"
+                @bind-SelectedOption="@_timeFormat"
+                @bind-SelectedOption:after="OnTimeFormatChanged"
+                Position="SelectPosition.Below" />
+        </div>
+
         <div>
             <span class="setting-title">@Loc[nameof(Dialogs.SettingsDialogDashboardLogsAndTelemetry)]</span>
             <div>

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -33,14 +33,16 @@
         </div>
 
         <div class="input-container">
-            <FluentSelect
-                TOption="TimeFormat"
-                Label="@Loc[nameof(Dialogs.SettingsDialogTimeFormat)]"
-                Items="@(Enum.GetValues<TimeFormat>())"
-                OptionText="@(i => FormatTimeFormatOption(i))"
-                @bind-SelectedOption="@_timeFormat"
-                @bind-SelectedOption:after="OnTimeFormatChanged"
-                Position="SelectPosition.Below" />
+            <FluentRadioGroup TValue="TimeFormat"
+                              Label="@Loc[nameof(Dialogs.SettingsDialogTimeFormat)]"
+                              @bind-Value="@_timeFormat"
+                              @bind-Value:after="OnTimeFormatChanged"
+                              Orientation="Orientation.Vertical">
+                @foreach (var format in Enum.GetValues<TimeFormat>())
+                {
+                    <FluentRadio Value="@format">@FormatTimeFormatOption(format)</FluentRadio>
+                }
+            </FluentRadioGroup>
         </div>
 
         <div>

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -15,6 +15,7 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
     private string? _currentSetting;
     private List<CultureInfo> _languageOptions = null!;
     private CultureInfo? _selectedUiCulture;
+    private TimeFormat _timeFormat;
 
     private IDisposable? _themeChangedSubscription;
 
@@ -33,6 +34,12 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
     [CascadingParameter]
     public FluentDialog Dialog { get; set; } = default!;
 
+    [Inject]
+    public required BrowserTimeProvider TimeProvider { get; init; }
+
+    [Inject]
+    public required ILocalStorage LocalStorage { get; init; }
+
     protected override void OnInitialized()
     {
         _languageOptions = GlobalizationHelpers.OrderedLocalizedCultures;
@@ -41,6 +48,8 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
             ? matchedCulture :
             // Otherwise, Blazor has fallen back to a supported language
             CultureInfo.CurrentUICulture;
+
+        _timeFormat = TimeProvider.TimeFormat;
 
         _currentSetting = ThemeManager.SelectedTheme ?? ThemeManager.ThemeSettingSystem;
 
@@ -105,6 +114,26 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
         };
         await DialogService.ShowDialogAsync<ManageDataDialog>(parameters);
     }
+
+    private async Task OnTimeFormatChanged()
+    {
+        TimeProvider.SetTimeFormat(_timeFormat);
+        await LocalStorage.SetAsync(BrowserStorageKeys.TimeFormat, _timeFormat);
+
+        // Reload the page to ensure all components pick up the new format
+        var uri = new Uri(NavigationManager.Uri)
+            .GetComponents(UriComponents.PathAndQuery, UriFormat.Unescaped);
+
+        NavigationManager.NavigateTo(uri, forceLoad: true);
+    }
+
+    private string FormatTimeFormatOption(TimeFormat format) => format switch
+    {
+        TimeFormat.System => Loc[nameof(Dashboard.Resources.Dialogs.SettingsDialogTimeFormatSystem)],
+        TimeFormat.TwelveHour => Loc[nameof(Dashboard.Resources.Dialogs.SettingsDialogTimeFormatTwelveHour)],
+        TimeFormat.TwentyFourHour => Loc[nameof(Dashboard.Resources.Dialogs.SettingsDialogTimeFormatTwentyFourHour)],
+        _ => format.ToString()
+    };
 
     public void Dispose()
     {

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -117,7 +117,7 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
 
     private async Task OnTimeFormatChanged()
     {
-        TimeProvider.SetTimeFormat(_timeFormat);
+        TimeProvider.SetConfiguredTimeFormat(_timeFormat);
         await LocalStorage.SetAsync(BrowserStorageKeys.TimeFormat, _timeFormat);
 
         // Reload the page to ensure all components pick up the new format

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -49,7 +49,7 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
             // Otherwise, Blazor has fallen back to a supported language
             CultureInfo.CurrentUICulture;
 
-        _timeFormat = TimeProvider.TimeFormat;
+        _timeFormat = TimeProvider.ConfiguredTimeFormat;
 
         _currentSetting = ThemeManager.SelectedTheme ?? ThemeManager.ThemeSettingSystem;
 

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -114,6 +114,12 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
         TimeProvider.SetBrowserTimeZone(result.TimeZone);
         TelemetryContextProvider.SetBrowserUserAgent(result.UserAgent);
 
+        var timeFormatResult = await LocalStorage.GetAsync<TimeFormat>(BrowserStorageKeys.TimeFormat);
+        if (timeFormatResult.Success)
+        {
+            TimeProvider.SetTimeFormat(timeFormatResult.Value);
+        }
+
         await DisplayUnsecuredEndpointsMessageAsync();
 
         _aiDisplayChangedSubscription = AIContextProvider.OnDisplayChanged(() => InvokeAsync(StateHasChanged));

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -112,12 +112,13 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
 
         var result = await JS.InvokeAsync<BrowserInfo>("window.getBrowserInfo");
         TimeProvider.SetBrowserTimeZone(result.TimeZone);
+        TimeProvider.SetBrowserTimeFormat(result.Is24HourTime ? TimeFormat.TwentyFourHour : TimeFormat.TwelveHour);
         TelemetryContextProvider.SetBrowserUserAgent(result.UserAgent);
 
         var timeFormatResult = await LocalStorage.GetAsync<TimeFormat>(BrowserStorageKeys.TimeFormat);
         if (timeFormatResult.Success)
         {
-            TimeProvider.SetTimeFormat(timeFormatResult.Value);
+            TimeProvider.SetConfiguredTimeFormat(timeFormatResult.Value);
         }
 
         await DisplayUnsecuredEndpointsMessageAsync();

--- a/src/Aspire.Dashboard/Model/BrowserInfo.cs
+++ b/src/Aspire.Dashboard/Model/BrowserInfo.cs
@@ -7,4 +7,5 @@ public sealed class BrowserInfo
 {
     public string? TimeZone { get; set; }
     public string? UserAgent { get; set; }
+    public bool Is24HourTime { get; set; }
 }

--- a/src/Aspire.Dashboard/Model/BrowserTimeProvider.cs
+++ b/src/Aspire.Dashboard/Model/BrowserTimeProvider.cs
@@ -36,4 +36,18 @@ public class BrowserTimeProvider : TimeProvider
         _logger.LogDebug("Browser time zone set to '{TimeZone}' with UTC offset {UtcOffset}.", timeZoneInfo.Id, timeZoneInfo.BaseUtcOffset);
         _browserLocalTimeZone = timeZoneInfo;
     }
+
+    public TimeFormat TimeFormat { get; private set; } = TimeFormat.System;
+
+    public void SetTimeFormat(TimeFormat timeFormat)
+    {
+        TimeFormat = timeFormat;
+    }
+}
+
+public enum TimeFormat
+{
+    System,
+    TwelveHour,
+    TwentyFourHour
 }

--- a/src/Aspire.Dashboard/Model/BrowserTimeProvider.cs
+++ b/src/Aspire.Dashboard/Model/BrowserTimeProvider.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Utils;
+
 namespace Aspire.Dashboard.Model;
 
 /// <summary>
@@ -10,7 +12,7 @@ namespace Aspire.Dashboard.Model;
 /// - BrowserTimeProvider must be scoped to the user's session.
 /// - The built-in TimeProvider registration must be singleton for the system time (used by auth).
 /// </summary>
-public class BrowserTimeProvider : TimeProvider
+public class BrowserTimeProvider : TimeProvider, ITimeFormatProvider
 {
     private readonly ILogger _logger;
     private TimeZoneInfo? _browserLocalTimeZone;
@@ -37,17 +39,30 @@ public class BrowserTimeProvider : TimeProvider
         _browserLocalTimeZone = timeZoneInfo;
     }
 
-    public TimeFormat TimeFormat { get; private set; } = TimeFormat.System;
+    public TimeFormat TimeFormat { get; set; } = TimeFormat.System;
 
-    public void SetTimeFormat(TimeFormat timeFormat)
+    public TimeFormat ResolvedTimeFormat
+    {
+        get
+        {
+            if (TimeFormat == TimeFormat.System)
+            {
+                return _browserTimeFormat ?? TimeFormat.System;
+            }
+
+            return TimeFormat;
+        }
+    }
+
+    private TimeFormat? _browserTimeFormat;
+
+    public void SetBrowserTimeFormat(TimeFormat timeFormat)
+    {
+        _browserTimeFormat = timeFormat;
+    }
+
+    public void SetConfiguredTimeFormat(TimeFormat timeFormat)
     {
         TimeFormat = timeFormat;
     }
-}
-
-public enum TimeFormat
-{
-    System,
-    TwelveHour,
-    TwentyFourHour
 }

--- a/src/Aspire.Dashboard/Model/BrowserTimeProvider.cs
+++ b/src/Aspire.Dashboard/Model/BrowserTimeProvider.cs
@@ -16,6 +16,9 @@ public class BrowserTimeProvider : TimeProvider, ITimeFormatProvider
 {
     private readonly ILogger _logger;
     private TimeZoneInfo? _browserLocalTimeZone;
+    private TimeFormat? _browserTimeFormat;
+
+    public TimeFormat ConfiguredTimeFormat { get; set; } = TimeFormat.System;
 
     public BrowserTimeProvider(ILoggerFactory loggerFactory)
     {
@@ -39,22 +42,18 @@ public class BrowserTimeProvider : TimeProvider, ITimeFormatProvider
         _browserLocalTimeZone = timeZoneInfo;
     }
 
-    public TimeFormat TimeFormat { get; set; } = TimeFormat.System;
-
     public TimeFormat ResolvedTimeFormat
     {
         get
         {
-            if (TimeFormat == TimeFormat.System)
+            if (ConfiguredTimeFormat == TimeFormat.System)
             {
                 return _browserTimeFormat ?? TimeFormat.System;
             }
 
-            return TimeFormat;
+            return ConfiguredTimeFormat;
         }
     }
-
-    private TimeFormat? _browserTimeFormat;
 
     public void SetBrowserTimeFormat(TimeFormat timeFormat)
     {
@@ -63,6 +62,6 @@ public class BrowserTimeProvider : TimeProvider, ITimeFormatProvider
 
     public void SetConfiguredTimeFormat(TimeFormat timeFormat)
     {
-        TimeFormat = timeFormat;
+        ConfiguredTimeFormat = timeFormat;
     }
 }

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -1319,5 +1319,41 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("TextVisualizerSelectFormatType", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Time Format.
+        /// </summary>
+        public static string SettingsDialogTimeFormat {
+            get {
+                return ResourceManager.GetString("SettingsDialogTimeFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to System.
+        /// </summary>
+        public static string SettingsDialogTimeFormatSystem {
+            get {
+                return ResourceManager.GetString("SettingsDialogTimeFormatSystem", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 12-Hour.
+        /// </summary>
+        public static string SettingsDialogTimeFormatTwelveHour {
+            get {
+                return ResourceManager.GetString("SettingsDialogTimeFormatTwelveHour", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 24-Hour.
+        /// </summary>
+        public static string SettingsDialogTimeFormatTwentyFourHour {
+            get {
+                return ResourceManager.GetString("SettingsDialogTimeFormatTwentyFourHour", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -1321,7 +1321,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Time Format.
+        ///   Looks up a localized string similar to Time format.
         /// </summary>
         public static string SettingsDialogTimeFormat {
             get {
@@ -1339,7 +1339,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 12-Hour.
+        ///   Looks up a localized string similar to 12-hour.
         /// </summary>
         public static string SettingsDialogTimeFormatTwelveHour {
             get {
@@ -1348,7 +1348,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 24-Hour.
+        ///   Looks up a localized string similar to 24-hour.
         /// </summary>
         public static string SettingsDialogTimeFormatTwentyFourHour {
             get {

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -549,4 +549,16 @@
   <data name="ManageDataResource" xml:space="preserve">
     <value>Resource</value>
   </data>
+  <data name="SettingsDialogTimeFormat" xml:space="preserve">
+    <value>Time Format</value>
+  </data>
+  <data name="SettingsDialogTimeFormatSystem" xml:space="preserve">
+    <value>System</value>
+  </data>
+  <data name="SettingsDialogTimeFormatTwelveHour" xml:space="preserve">
+    <value>12-Hour</value>
+  </data>
+  <data name="SettingsDialogTimeFormatTwentyFourHour" xml:space="preserve">
+    <value>24-Hour</value>
+  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -550,15 +550,15 @@
     <value>Resource</value>
   </data>
   <data name="SettingsDialogTimeFormat" xml:space="preserve">
-    <value>Time Format</value>
+    <value>Time format</value>
   </data>
   <data name="SettingsDialogTimeFormatSystem" xml:space="preserve">
     <value>System</value>
   </data>
   <data name="SettingsDialogTimeFormatTwelveHour" xml:space="preserve">
-    <value>12-Hour</value>
+    <value>12-hour</value>
   </data>
   <data name="SettingsDialogTimeFormatTwentyFourHour" xml:space="preserve">
-    <value>24-Hour</value>
+    <value>24-hour</value>
   </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -637,6 +637,26 @@
         <target state="translated">Motiv</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormat">
+        <source>Time Format</source>
+        <target state="new">Time Format</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatSystem">
+        <source>System</source>
+        <target state="new">System</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwelveHour">
+        <source>12-Hour</source>
+        <target state="new">12-Hour</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
+        <source>24-Hour</source>
+        <target state="new">24-Hour</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="translated">Verze: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -638,8 +638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormat">
-        <source>Time Format</source>
-        <target state="new">Time Format</target>
+        <source>Time format</source>
+        <target state="new">Time format</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatSystem">
@@ -648,13 +648,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwelveHour">
-        <source>12-Hour</source>
-        <target state="new">12-Hour</target>
+        <source>12-hour</source>
+        <target state="new">12-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
-        <source>24-Hour</source>
-        <target state="new">24-Hour</target>
+        <source>24-hour</source>
+        <target state="new">24-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogVersion">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -637,6 +637,26 @@
         <target state="translated">Design</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormat">
+        <source>Time Format</source>
+        <target state="new">Time Format</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatSystem">
+        <source>System</source>
+        <target state="new">System</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwelveHour">
+        <source>12-Hour</source>
+        <target state="new">12-Hour</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
+        <source>24-Hour</source>
+        <target state="new">24-Hour</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="translated">Version: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -638,8 +638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormat">
-        <source>Time Format</source>
-        <target state="new">Time Format</target>
+        <source>Time format</source>
+        <target state="new">Time format</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatSystem">
@@ -648,13 +648,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwelveHour">
-        <source>12-Hour</source>
-        <target state="new">12-Hour</target>
+        <source>12-hour</source>
+        <target state="new">12-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
-        <source>24-Hour</source>
-        <target state="new">24-Hour</target>
+        <source>24-hour</source>
+        <target state="new">24-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogVersion">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -637,6 +637,26 @@
         <target state="translated">Tema</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormat">
+        <source>Time Format</source>
+        <target state="new">Time Format</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatSystem">
+        <source>System</source>
+        <target state="new">System</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwelveHour">
+        <source>12-Hour</source>
+        <target state="new">12-Hour</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
+        <source>24-Hour</source>
+        <target state="new">24-Hour</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="translated">Versión: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -638,8 +638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormat">
-        <source>Time Format</source>
-        <target state="new">Time Format</target>
+        <source>Time format</source>
+        <target state="new">Time format</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatSystem">
@@ -648,13 +648,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwelveHour">
-        <source>12-Hour</source>
-        <target state="new">12-Hour</target>
+        <source>12-hour</source>
+        <target state="new">12-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
-        <source>24-Hour</source>
-        <target state="new">24-Hour</target>
+        <source>24-hour</source>
+        <target state="new">24-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogVersion">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -637,6 +637,26 @@
         <target state="translated">Thème</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormat">
+        <source>Time Format</source>
+        <target state="new">Time Format</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatSystem">
+        <source>System</source>
+        <target state="new">System</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwelveHour">
+        <source>12-Hour</source>
+        <target state="new">12-Hour</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
+        <source>24-Hour</source>
+        <target state="new">24-Hour</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="translated">Version : {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -638,8 +638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormat">
-        <source>Time Format</source>
-        <target state="new">Time Format</target>
+        <source>Time format</source>
+        <target state="new">Time format</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatSystem">
@@ -648,13 +648,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwelveHour">
-        <source>12-Hour</source>
-        <target state="new">12-Hour</target>
+        <source>12-hour</source>
+        <target state="new">12-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
-        <source>24-Hour</source>
-        <target state="new">24-Hour</target>
+        <source>24-hour</source>
+        <target state="new">24-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogVersion">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -637,6 +637,26 @@
         <target state="translated">Tema</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormat">
+        <source>Time Format</source>
+        <target state="new">Time Format</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatSystem">
+        <source>System</source>
+        <target state="new">System</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwelveHour">
+        <source>12-Hour</source>
+        <target state="new">12-Hour</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
+        <source>24-Hour</source>
+        <target state="new">24-Hour</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="translated">Versione: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -638,8 +638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormat">
-        <source>Time Format</source>
-        <target state="new">Time Format</target>
+        <source>Time format</source>
+        <target state="new">Time format</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatSystem">
@@ -648,13 +648,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwelveHour">
-        <source>12-Hour</source>
-        <target state="new">12-Hour</target>
+        <source>12-hour</source>
+        <target state="new">12-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
-        <source>24-Hour</source>
-        <target state="new">24-Hour</target>
+        <source>24-hour</source>
+        <target state="new">24-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogVersion">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -637,6 +637,26 @@
         <target state="translated">テーマ</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormat">
+        <source>Time Format</source>
+        <target state="new">Time Format</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatSystem">
+        <source>System</source>
+        <target state="new">System</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwelveHour">
+        <source>12-Hour</source>
+        <target state="new">12-Hour</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
+        <source>24-Hour</source>
+        <target state="new">24-Hour</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="translated">バージョン: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -638,8 +638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormat">
-        <source>Time Format</source>
-        <target state="new">Time Format</target>
+        <source>Time format</source>
+        <target state="new">Time format</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatSystem">
@@ -648,13 +648,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwelveHour">
-        <source>12-Hour</source>
-        <target state="new">12-Hour</target>
+        <source>12-hour</source>
+        <target state="new">12-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
-        <source>24-Hour</source>
-        <target state="new">24-Hour</target>
+        <source>24-hour</source>
+        <target state="new">24-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogVersion">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -637,6 +637,26 @@
         <target state="translated">테마</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormat">
+        <source>Time Format</source>
+        <target state="new">Time Format</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatSystem">
+        <source>System</source>
+        <target state="new">System</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwelveHour">
+        <source>12-Hour</source>
+        <target state="new">12-Hour</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
+        <source>24-Hour</source>
+        <target state="new">24-Hour</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="translated">버전: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -638,8 +638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormat">
-        <source>Time Format</source>
-        <target state="new">Time Format</target>
+        <source>Time format</source>
+        <target state="new">Time format</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatSystem">
@@ -648,13 +648,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwelveHour">
-        <source>12-Hour</source>
-        <target state="new">12-Hour</target>
+        <source>12-hour</source>
+        <target state="new">12-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
-        <source>24-Hour</source>
-        <target state="new">24-Hour</target>
+        <source>24-hour</source>
+        <target state="new">24-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogVersion">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -637,6 +637,26 @@
         <target state="translated">Motyw</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormat">
+        <source>Time Format</source>
+        <target state="new">Time Format</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatSystem">
+        <source>System</source>
+        <target state="new">System</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwelveHour">
+        <source>12-Hour</source>
+        <target state="new">12-Hour</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
+        <source>24-Hour</source>
+        <target state="new">24-Hour</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="translated">Wersja: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -638,8 +638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormat">
-        <source>Time Format</source>
-        <target state="new">Time Format</target>
+        <source>Time format</source>
+        <target state="new">Time format</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatSystem">
@@ -648,13 +648,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwelveHour">
-        <source>12-Hour</source>
-        <target state="new">12-Hour</target>
+        <source>12-hour</source>
+        <target state="new">12-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
-        <source>24-Hour</source>
-        <target state="new">24-Hour</target>
+        <source>24-hour</source>
+        <target state="new">24-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogVersion">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -637,6 +637,26 @@
         <target state="translated">Tema</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormat">
+        <source>Time Format</source>
+        <target state="new">Time Format</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatSystem">
+        <source>System</source>
+        <target state="new">System</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwelveHour">
+        <source>12-Hour</source>
+        <target state="new">12-Hour</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
+        <source>24-Hour</source>
+        <target state="new">24-Hour</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="translated">Versão: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -638,8 +638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormat">
-        <source>Time Format</source>
-        <target state="new">Time Format</target>
+        <source>Time format</source>
+        <target state="new">Time format</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatSystem">
@@ -648,13 +648,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwelveHour">
-        <source>12-Hour</source>
-        <target state="new">12-Hour</target>
+        <source>12-hour</source>
+        <target state="new">12-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
-        <source>24-Hour</source>
-        <target state="new">24-Hour</target>
+        <source>24-hour</source>
+        <target state="new">24-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogVersion">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -637,6 +637,26 @@
         <target state="translated">Тема</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormat">
+        <source>Time Format</source>
+        <target state="new">Time Format</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatSystem">
+        <source>System</source>
+        <target state="new">System</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwelveHour">
+        <source>12-Hour</source>
+        <target state="new">12-Hour</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
+        <source>24-Hour</source>
+        <target state="new">24-Hour</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="translated">Версия: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -638,8 +638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormat">
-        <source>Time Format</source>
-        <target state="new">Time Format</target>
+        <source>Time format</source>
+        <target state="new">Time format</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatSystem">
@@ -648,13 +648,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwelveHour">
-        <source>12-Hour</source>
-        <target state="new">12-Hour</target>
+        <source>12-hour</source>
+        <target state="new">12-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
-        <source>24-Hour</source>
-        <target state="new">24-Hour</target>
+        <source>24-hour</source>
+        <target state="new">24-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogVersion">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -637,6 +637,26 @@
         <target state="translated">Tema</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormat">
+        <source>Time Format</source>
+        <target state="new">Time Format</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatSystem">
+        <source>System</source>
+        <target state="new">System</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwelveHour">
+        <source>12-Hour</source>
+        <target state="new">12-Hour</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
+        <source>24-Hour</source>
+        <target state="new">24-Hour</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="translated">Sürüm: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -638,8 +638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormat">
-        <source>Time Format</source>
-        <target state="new">Time Format</target>
+        <source>Time format</source>
+        <target state="new">Time format</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatSystem">
@@ -648,13 +648,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwelveHour">
-        <source>12-Hour</source>
-        <target state="new">12-Hour</target>
+        <source>12-hour</source>
+        <target state="new">12-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
-        <source>24-Hour</source>
-        <target state="new">24-Hour</target>
+        <source>24-hour</source>
+        <target state="new">24-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogVersion">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -637,6 +637,26 @@
         <target state="translated">主题</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormat">
+        <source>Time Format</source>
+        <target state="new">Time Format</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatSystem">
+        <source>System</source>
+        <target state="new">System</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwelveHour">
+        <source>12-Hour</source>
+        <target state="new">12-Hour</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
+        <source>24-Hour</source>
+        <target state="new">24-Hour</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="translated">版本: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -638,8 +638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormat">
-        <source>Time Format</source>
-        <target state="new">Time Format</target>
+        <source>Time format</source>
+        <target state="new">Time format</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatSystem">
@@ -648,13 +648,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwelveHour">
-        <source>12-Hour</source>
-        <target state="new">12-Hour</target>
+        <source>12-hour</source>
+        <target state="new">12-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
-        <source>24-Hour</source>
-        <target state="new">24-Hour</target>
+        <source>24-hour</source>
+        <target state="new">24-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogVersion">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -637,6 +637,26 @@
         <target state="translated">佈景主題</target>
         <note />
       </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormat">
+        <source>Time Format</source>
+        <target state="new">Time Format</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatSystem">
+        <source>System</source>
+        <target state="new">System</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwelveHour">
+        <source>12-Hour</source>
+        <target state="new">12-Hour</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
+        <source>24-Hour</source>
+        <target state="new">24-Hour</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="translated">版本: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -638,8 +638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormat">
-        <source>Time Format</source>
-        <target state="new">Time Format</target>
+        <source>Time format</source>
+        <target state="new">Time format</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatSystem">
@@ -648,13 +648,13 @@
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwelveHour">
-        <source>12-Hour</source>
-        <target state="new">12-Hour</target>
+        <source>12-hour</source>
+        <target state="new">12-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogTimeFormatTwentyFourHour">
-        <source>24-Hour</source>
-        <target state="new">24-Hour</target>
+        <source>24-hour</source>
+        <target state="new">24-hour</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsDialogVersion">

--- a/src/Aspire.Dashboard/Utils/BrowserStorageKeys.cs
+++ b/src/Aspire.Dashboard/Utils/BrowserStorageKeys.cs
@@ -10,6 +10,7 @@ internal static class BrowserStorageKeys
 {
     public const string UnsecuredTelemetryMessageDismissedKey = "Aspire_Telemetry_UnsecuredMessageDismissed";
     public const string UnsecuredEndpointMessageDismissedKey = "Aspire_Security_UnsecuredEndpointMessageDismissed";
+    public const string TimeFormat = "Aspire_TimeFormat";
 
     public const string TracesPageState = "Aspire_PageState_Traces";
     public const string StructuredLogsPageState = "Aspire_PageState_StructuredLogs";

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -314,11 +314,12 @@ window.unregisterGlobalKeydownListener = function (obj) {
 };
 
 window.getBrowserInfo = function () {
-    const options = Intl.DateTimeFormat().resolvedOptions();
+    const options = Intl.DateTimeFormat(undefined, { hour: 'numeric' }).resolvedOptions();
 
     return {
         timeZone: options.timeZone,
-        userAgent: navigator.userAgent
+        userAgent: navigator.userAgent,
+        is24HourTime: options.hourCycle === "h23" || options.hourCycle === "h24"
     };
 };
 

--- a/src/Shared/DateFormatStringsHelpers.cs
+++ b/src/Shared/DateFormatStringsHelpers.cs
@@ -15,6 +15,8 @@ internal static partial class DateFormatStringsHelpers
     private readonly record struct CultureDetailsKey(string LongTimePattern, string ShortDatePattern, string NumberDecimalSeparator, TimeFormat timeFormat);
     private sealed record MillisecondFormatStrings(CachedTimeFormatStrings LongTimePattern, CachedTimeFormatStrings ShortDateLongTimePattern);
     private sealed record CachedTimeFormatStrings(string None, string TruncatedMilliseconds, string FullMilliseconds);
+
+    // Cache of format strings for each culture and 12h/24h override combination. Each entry is lazily initialized on demand.
     private static readonly ConcurrentDictionary<CultureDetailsKey, MillisecondFormatStrings> s_formatStrings = new();
 
     // Colon and dot are the only time separators used by registered cultures. Regex checks for both.

--- a/src/Shared/DateFormatStringsHelpers.cs
+++ b/src/Shared/DateFormatStringsHelpers.cs
@@ -1,0 +1,125 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Aspire.Dashboard.Utils;
+
+internal static partial class DateFormatStringsHelpers
+{
+    // There are an unbound number of CultureInfo instances so we don't want to use it as the key.
+    // Someone could have also customized their culture so we don't want to use the name as the key.
+    // This struct contains required information from the culture that is used in cached format strings.
+    private readonly record struct CultureDetailsKey(string LongTimePattern, string ShortDatePattern, string NumberDecimalSeparator, TimeFormat timeFormat);
+    private sealed record MillisecondFormatStrings(CachedTimeFormatStrings LongTimePattern, CachedTimeFormatStrings ShortDateLongTimePattern);
+    private sealed record CachedTimeFormatStrings(string None, string TruncatedMilliseconds, string FullMilliseconds);
+    private static readonly ConcurrentDictionary<CultureDetailsKey, MillisecondFormatStrings> s_formatStrings = new();
+
+    // Colon and dot are the only time separators used by registered cultures. Regex checks for both.
+    [GeneratedRegex(@"(:ss|\.ss|:s|\.s)")]
+    private static partial Regex MatchSecondsInTimeFormatPattern();
+
+    // Matches 24-hour format specifiers: HH or H (but not h).
+    [GeneratedRegex(@"HH?")]
+    private static partial Regex MatchHourIn24HourTimeFormatPattern();
+
+    // Matches 12-hour format specifiers: hh or h (but not H).
+    [GeneratedRegex(@"hh?")]
+    private static partial Regex MatchHourIn12HourTimeFormatPattern();
+
+    // Matches AM/PM designator with optional leading whitespace.
+    [GeneratedRegex(@"\s*tt")]
+    private static partial Regex MatchAmPmDesignator();
+
+    private static MillisecondFormatStrings GetDateFormatStrings(CultureInfo cultureInfo, TimeFormat timeFormat)
+    {
+        var key = new CultureDetailsKey(cultureInfo.DateTimeFormat.LongTimePattern, cultureInfo.DateTimeFormat.ShortDatePattern, cultureInfo.NumberFormat.NumberDecimalSeparator, timeFormat);
+
+        return s_formatStrings.GetOrAdd(key, static k =>
+        {
+            var (none, truncated, full) = GetTimePatterns(k);
+            return new MillisecondFormatStrings(
+                new CachedTimeFormatStrings(none, truncated, full),
+                new CachedTimeFormatStrings(
+                    k.ShortDatePattern + " " + none,
+                    k.ShortDatePattern + " " + truncated,
+                    k.ShortDatePattern + " " + full));
+        });
+
+        static (string None, string Truncated, string Full) GetTimePatterns(CultureDetailsKey key)
+        {
+            // From https://learn.microsoft.com/dotnet/standard/base-types/how-to-display-milliseconds-in-date-and-time-values
+
+            // Intentionally use fff here instead of FFF so output has a consistent length.
+            return (
+                FormatPattern(key, millisecondFormat: null),
+                FormatPattern(key, "fff"),
+                FormatPattern(key, "FFFFFFF"));
+        }
+
+        static string FormatPattern(CultureDetailsKey key, string? millisecondFormat)
+        {
+            // Gets the long time pattern, which is something like "h:mm:ss tt" (en-US), "H:mm:ss" (ja-JP), "HH:mm:ss" (fr-FR).
+            var longTimePattern = key.LongTimePattern;
+
+            // Apply 12h/24h override if requested.
+            longTimePattern = key.timeFormat switch
+            {
+                TimeFormat.TwelveHour => ConvertTo12Hour(longTimePattern),
+                TimeFormat.TwentyFourHour => ConvertTo24Hour(longTimePattern),
+                _ => longTimePattern // System: use culture's pattern as-is
+            };
+
+            if (millisecondFormat is null)
+            {
+                return longTimePattern;
+            }
+
+            return MatchSecondsInTimeFormatPattern().Replace(longTimePattern, $"$1'{key.NumberDecimalSeparator}'{millisecondFormat}");
+        }
+
+        static string ConvertTo12Hour(string pattern)
+        {
+            // Replace H/HH with h (24h -> 12h).
+            pattern = MatchHourIn24HourTimeFormatPattern().Replace(pattern, "h");
+
+            // Add AM/PM designator if not already present.
+            if (!pattern.Contains("tt"))
+            {
+                pattern += " tt";
+            }
+
+            return pattern;
+        }
+
+        static string ConvertTo24Hour(string pattern)
+        {
+            // Replace h/hh with H (12h -> 24h).
+            pattern = MatchHourIn12HourTimeFormatPattern().Replace(pattern, "H");
+
+            // Remove AM/PM designator.
+            pattern = MatchAmPmDesignator().Replace(pattern, "").TrimEnd();
+
+            return pattern;
+        }
+    }
+
+    internal static string GetLongTimePattern(CultureInfo cultureInfo, TimeFormat timeFormat, MillisecondsDisplay millisecondsDisplay)
+        => GetPattern(GetDateFormatStrings(cultureInfo, timeFormat).LongTimePattern, millisecondsDisplay);
+
+    internal static string GetShortDateLongTimePattern(CultureInfo cultureInfo, TimeFormat timeFormat, MillisecondsDisplay millisecondsDisplay)
+        => GetPattern(GetDateFormatStrings(cultureInfo, timeFormat).ShortDateLongTimePattern, millisecondsDisplay);
+
+    private static string GetPattern(CachedTimeFormatStrings patterns, MillisecondsDisplay millisecondsDisplay)
+    {
+        return millisecondsDisplay switch
+        {
+            MillisecondsDisplay.None => patterns.None,
+            MillisecondsDisplay.Truncated => patterns.TruncatedMilliseconds,
+            MillisecondsDisplay.Full => patterns.FullMilliseconds,
+            _ => throw new ArgumentException($"Unexpected {nameof(MillisecondsDisplay)} value: {millisecondsDisplay}.", nameof(millisecondsDisplay))
+        };
+    }
+}

--- a/src/Shared/FormatHelpers.cs
+++ b/src/Shared/FormatHelpers.cs
@@ -15,6 +15,18 @@ public enum MillisecondsDisplay
     Full
 }
 
+public enum TimeFormat
+{
+    System,
+    TwelveHour,
+    TwentyFourHour
+}
+
+public interface ITimeFormatProvider
+{
+    TimeFormat ResolvedTimeFormat { get; }
+}
+
 internal static partial class FormatHelpers
 {
     // Limit size of very long data that is written in large grids.
@@ -89,9 +101,9 @@ internal static partial class FormatHelpers
         cultureInfo ??= CultureInfo.CurrentCulture;
         var local = timeProvider.ToLocal(value);
 
-        if (timeProvider.TimeFormat != TimeFormat.System)
+        if (TryGetExplicitTimeFormat(timeProvider, out var timeFormat))
         {
-            return local.ToString(GetForcedTimePattern(timeProvider.TimeFormat, millisecondsDisplay, cultureInfo), cultureInfo);
+            return local.ToString(GetForcedTimePattern(timeFormat, millisecondsDisplay, cultureInfo), cultureInfo);
         }
 
         // Long time
@@ -109,9 +121,9 @@ internal static partial class FormatHelpers
         cultureInfo ??= CultureInfo.CurrentCulture;
         var local = timeProvider.ToLocal(value);
 
-        if (timeProvider.TimeFormat != TimeFormat.System)
+        if (TryGetExplicitTimeFormat(timeProvider, out var timeFormat))
         {
-            var timePattern = GetForcedTimePattern(timeProvider.TimeFormat, millisecondsDisplay, cultureInfo);
+            var timePattern = GetForcedTimePattern(timeFormat, millisecondsDisplay, cultureInfo);
             return local.ToString($"{cultureInfo.DateTimeFormat.ShortDatePattern} {timePattern}", cultureInfo);
         }
 
@@ -123,6 +135,18 @@ internal static partial class FormatHelpers
             MillisecondsDisplay.Full => local.ToString(GetShortDateLongTimePatternWithMilliseconds(cultureInfo).FullMilliseconds, cultureInfo),
             _ => throw new NotImplementedException()
         };
+    }
+
+    private static bool TryGetExplicitTimeFormat(TimeProvider timeProvider, out TimeFormat timeFormat)
+    {
+        if (timeProvider is ITimeFormatProvider tfp && tfp.ResolvedTimeFormat is { } resolved && resolved is not TimeFormat.System)
+        {
+            timeFormat = resolved;
+            return true;
+        }
+
+        timeFormat = default;
+        return false;
     }
 
     public static string FormatTimeWithOptionalDate(TimeProvider timeProvider, DateTime value, MillisecondsDisplay millisecondsDisplay = MillisecondsDisplay.None, CultureInfo? cultureInfo = null)

--- a/src/Shared/FormatHelpers.cs
+++ b/src/Shared/FormatHelpers.cs
@@ -89,6 +89,11 @@ internal static partial class FormatHelpers
         cultureInfo ??= CultureInfo.CurrentCulture;
         var local = timeProvider.ToLocal(value);
 
+        if (timeProvider.TimeFormat != TimeFormat.System)
+        {
+            return local.ToString(GetForcedTimePattern(timeProvider.TimeFormat, millisecondsDisplay, cultureInfo), cultureInfo);
+        }
+
         // Long time
         return millisecondsDisplay switch
         {
@@ -103,6 +108,12 @@ internal static partial class FormatHelpers
     {
         cultureInfo ??= CultureInfo.CurrentCulture;
         var local = timeProvider.ToLocal(value);
+
+        if (timeProvider.TimeFormat != TimeFormat.System)
+        {
+            var timePattern = GetForcedTimePattern(timeProvider.TimeFormat, millisecondsDisplay, cultureInfo);
+            return local.ToString($"{cultureInfo.DateTimeFormat.ShortDatePattern} {timePattern}", cultureInfo);
+        }
 
         // Short date, long time
         return millisecondsDisplay switch
@@ -165,5 +176,26 @@ internal static partial class FormatHelpers
     public static string CombineWithSeparator(string separator, params string?[] parts)
     {
         return string.Join(separator, parts.Where(p => !string.IsNullOrEmpty(p)));
+    }
+
+    private static string GetForcedTimePattern(TimeFormat timeFormat, MillisecondsDisplay millisecondsDisplay, CultureInfo cultureInfo)
+    {
+        var timeSeparator = cultureInfo.DateTimeFormat.TimeSeparator;
+        var decimalSeparator = cultureInfo.NumberFormat.NumberDecimalSeparator;
+
+        var secondsPattern = millisecondsDisplay switch
+        {
+            MillisecondsDisplay.None => "ss",
+            MillisecondsDisplay.Truncated => $"ss'{decimalSeparator}'fff",
+            MillisecondsDisplay.Full => $"ss'{decimalSeparator}'FFFFFFF",
+            _ => throw new NotImplementedException()
+        };
+
+        return timeFormat switch
+        {
+            TimeFormat.TwelveHour => $"h'{timeSeparator}'mm'{timeSeparator}'{secondsPattern} tt",
+            TimeFormat.TwentyFourHour => $"H'{timeSeparator}'mm'{timeSeparator}'{secondsPattern}",
+            _ => throw new NotImplementedException()
+        };
     }
 }

--- a/src/Shared/FormatHelpers.cs
+++ b/src/Shared/FormatHelpers.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Concurrent;
 using System.Globalization;
-using System.Text.RegularExpressions;
 using Aspire.Dashboard.Extensions;
 
 namespace Aspire.Dashboard.Utils;
@@ -27,65 +25,12 @@ public interface ITimeFormatProvider
     TimeFormat ResolvedTimeFormat { get; }
 }
 
-internal static partial class FormatHelpers
+internal static class FormatHelpers
 {
     // Limit size of very long data that is written in large grids.
     public const int ColumnMaximumTextLength = 250;
     public const int TooltipMaximumTextLength = 1500;
     public const string Ellipsis = "…";
-
-    // There are an unbound number of CultureInfo instances so we don't want to use it as the key.
-    // Someone could have also customized their culture so we don't want to use the name as the key.
-    // This struct contains required information from the culture that is used in cached format strings.
-    private readonly record struct CultureDetailsKey(string LongTimePattern, string ShortDatePattern, string NumberDecimalSeparator);
-    private sealed record MillisecondFormatStrings(MillisecondFormatString LongTimePattern, MillisecondFormatString ShortDateLongTimePattern);
-    private sealed record MillisecondFormatString(string TruncatedMilliseconds, string FullMilliseconds);
-    private static readonly ConcurrentDictionary<CultureDetailsKey, MillisecondFormatStrings> s_formatStrings = new();
-
-    // Colon and dot are the only time separators used by registered cultures. Regex checks for both.
-    [GeneratedRegex(@"(:ss|\.ss|:s|\.s)")]
-    private static partial Regex MatchSecondsInTimeFormatPattern();
-
-    private static MillisecondFormatStrings GetMillisecondFormatStrings(CultureInfo cultureInfo)
-    {
-        var key = new CultureDetailsKey(cultureInfo.DateTimeFormat.LongTimePattern, cultureInfo.DateTimeFormat.ShortDatePattern, cultureInfo.NumberFormat.NumberDecimalSeparator);
-
-        return s_formatStrings.GetOrAdd(key, static k =>
-        {
-            var (truncated, full) = GetLongTimePatternWithMillisecondsCore(k);
-            return new MillisecondFormatStrings(
-                new MillisecondFormatString(truncated, full),
-                new MillisecondFormatString(
-                    k.ShortDatePattern + " " + truncated,
-                    k.ShortDatePattern + " " + full));
-        });
-
-        static (string Truncated, string Full) GetLongTimePatternWithMillisecondsCore(CultureDetailsKey key)
-        {
-            // From https://learn.microsoft.com/dotnet/standard/base-types/how-to-display-milliseconds-in-date-and-time-values
-
-            // Create a format similar to .fff but based on the current culture.
-            // Intentionally use fff here instead of FFF so output has a consistent length.
-            var truncatedMillisecondFormat = "fff";
-
-            // Append millisecond pattern to current culture's long time pattern.
-            return (
-                FormatPattern(key, truncatedMillisecondFormat),
-                FormatPattern(key, "FFFFFFF"));
-        }
-
-        static string FormatPattern(CultureDetailsKey key, string millisecondFormat)
-        {
-            // Gets the long time pattern, which is something like "h:mm:ss tt" (en-US), "H:mm:ss" (ja-JP), "HH:mm:ss" (fr-FR).
-            var longTimePattern = key.LongTimePattern;
-
-            return MatchSecondsInTimeFormatPattern().Replace(longTimePattern, $"$1'{key.NumberDecimalSeparator}'{millisecondFormat}");
-        }
-    }
-
-    private static MillisecondFormatString GetLongTimePatternWithMilliseconds(CultureInfo cultureInfo) => GetMillisecondFormatStrings(cultureInfo).LongTimePattern;
-
-    private static MillisecondFormatString GetShortDateLongTimePatternWithMilliseconds(CultureInfo cultureInfo) => GetMillisecondFormatStrings(cultureInfo).ShortDateLongTimePattern;
 
     /// <summary>
     /// Formats a DateTime as a local time string (HH:mm:ss.fff) for console output.
@@ -100,53 +45,30 @@ internal static partial class FormatHelpers
     {
         cultureInfo ??= CultureInfo.CurrentCulture;
         var local = timeProvider.ToLocal(value);
+        var timeFormat = GetResolvedTimeFormat(timeProvider);
+        var pattern = DateFormatStringsHelpers.GetLongTimePattern(cultureInfo, timeFormat, millisecondsDisplay);
 
-        if (TryGetExplicitTimeFormat(timeProvider, out var timeFormat))
-        {
-            return local.ToString(GetForcedTimePattern(timeFormat, millisecondsDisplay, cultureInfo), cultureInfo);
-        }
-
-        // Long time
-        return millisecondsDisplay switch
-        {
-            MillisecondsDisplay.None => local.ToString("T", cultureInfo),
-            MillisecondsDisplay.Truncated => local.ToString(GetLongTimePatternWithMilliseconds(cultureInfo).TruncatedMilliseconds, cultureInfo),
-            MillisecondsDisplay.Full => local.ToString(GetLongTimePatternWithMilliseconds(cultureInfo).FullMilliseconds, cultureInfo),
-            _ => throw new NotImplementedException()
-        };
+        return local.ToString(pattern, cultureInfo);
     }
 
     public static string FormatDateTime(TimeProvider timeProvider, DateTime value, MillisecondsDisplay millisecondsDisplay = MillisecondsDisplay.None, CultureInfo? cultureInfo = null)
     {
         cultureInfo ??= CultureInfo.CurrentCulture;
         var local = timeProvider.ToLocal(value);
+        var timeFormat = GetResolvedTimeFormat(timeProvider);
+        var pattern = DateFormatStringsHelpers.GetShortDateLongTimePattern(cultureInfo, timeFormat, millisecondsDisplay);
 
-        if (TryGetExplicitTimeFormat(timeProvider, out var timeFormat))
-        {
-            var timePattern = GetForcedTimePattern(timeFormat, millisecondsDisplay, cultureInfo);
-            return local.ToString($"{cultureInfo.DateTimeFormat.ShortDatePattern} {timePattern}", cultureInfo);
-        }
-
-        // Short date, long time
-        return millisecondsDisplay switch
-        {
-            MillisecondsDisplay.None => local.ToString("G", cultureInfo),
-            MillisecondsDisplay.Truncated => local.ToString(GetShortDateLongTimePatternWithMilliseconds(cultureInfo).TruncatedMilliseconds, cultureInfo),
-            MillisecondsDisplay.Full => local.ToString(GetShortDateLongTimePatternWithMilliseconds(cultureInfo).FullMilliseconds, cultureInfo),
-            _ => throw new NotImplementedException()
-        };
+        return local.ToString(pattern, cultureInfo);
     }
 
-    private static bool TryGetExplicitTimeFormat(TimeProvider timeProvider, out TimeFormat timeFormat)
+    private static TimeFormat GetResolvedTimeFormat(TimeProvider timeProvider)
     {
-        if (timeProvider is ITimeFormatProvider tfp && tfp.ResolvedTimeFormat is { } resolved && resolved is not TimeFormat.System)
+        if (timeProvider is ITimeFormatProvider tfp)
         {
-            timeFormat = resolved;
-            return true;
+            return tfp.ResolvedTimeFormat;
         }
 
-        timeFormat = default;
-        return false;
+        return TimeFormat.System;
     }
 
     public static string FormatTimeWithOptionalDate(TimeProvider timeProvider, DateTime value, MillisecondsDisplay millisecondsDisplay = MillisecondsDisplay.None, CultureInfo? cultureInfo = null)
@@ -200,26 +122,5 @@ internal static partial class FormatHelpers
     public static string CombineWithSeparator(string separator, params string?[] parts)
     {
         return string.Join(separator, parts.Where(p => !string.IsNullOrEmpty(p)));
-    }
-
-    private static string GetForcedTimePattern(TimeFormat timeFormat, MillisecondsDisplay millisecondsDisplay, CultureInfo cultureInfo)
-    {
-        var timeSeparator = cultureInfo.DateTimeFormat.TimeSeparator;
-        var decimalSeparator = cultureInfo.NumberFormat.NumberDecimalSeparator;
-
-        var secondsPattern = millisecondsDisplay switch
-        {
-            MillisecondsDisplay.None => "ss",
-            MillisecondsDisplay.Truncated => $"ss'{decimalSeparator}'fff",
-            MillisecondsDisplay.Full => $"ss'{decimalSeparator}'FFFFFFF",
-            _ => throw new NotImplementedException()
-        };
-
-        return timeFormat switch
-        {
-            TimeFormat.TwelveHour => $"h'{timeSeparator}'mm'{timeSeparator}'{secondsPattern} tt",
-            TimeFormat.TwentyFourHour => $"H'{timeSeparator}'mm'{timeSeparator}'{secondsPattern}",
-            _ => throw new NotImplementedException()
-        };
     }
 }

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -100,6 +100,74 @@ public class FormatHelpersTests
         return date;
     }
 
+    [Theory]
+    [InlineData("2009-06-15T13:45:30.0000000Z", TimeFormat.TwelveHour, "1:45:30 PM")]
+    [InlineData("2009-06-15T13:45:30.0000000Z", TimeFormat.TwentyFourHour, "13:45:30")]
+    public void FormatTime_WithTimeFormatPreference(string value, TimeFormat format, string expected)
+    {
+        var date = GetLocalDateTime(value);
+        var provider = CreateTimeProvider();
+        provider.SetTimeFormat(format);
+
+        // Use a culture that would normally be opposite
+        var culture = format == TimeFormat.TwelveHour ? CultureInfo.GetCultureInfo("de-DE") : CultureInfo.GetCultureInfo("en-US");
+
+        Assert.Equal(expected, FormatHelpers.FormatTime(provider, date, MillisecondsDisplay.None, culture));
+    }
+
+    [Theory]
+    [InlineData("2009-06-15T13:45:30.0000000Z", TimeFormat.TwelveHour, "6/15/2009 1:45:30 PM")] // en-US date pattern + 12h time
+    [InlineData("2009-06-15T13:45:30.0000000Z", TimeFormat.TwentyFourHour, "6/15/2009 13:45:30")] // en-US date pattern + 24h time
+    public void FormatDateTime_WithTimeFormatPreference_EnUS(string value, TimeFormat format, string expected)
+    {
+        var date = GetLocalDateTime(value);
+        var provider = CreateTimeProvider();
+        provider.SetTimeFormat(format);
+
+        Assert.Equal(expected, FormatHelpers.FormatDateTime(provider, date, MillisecondsDisplay.None, CultureInfo.GetCultureInfo("en-US")));
+    }
+
+    [Theory]
+    [InlineData("fi-FI", TimeFormat.TwentyFourHour, MillisecondsDisplay.None, "15.6.2009 13.45.30")]
+    [InlineData("fi-FI", TimeFormat.TwentyFourHour, MillisecondsDisplay.Truncated, "15.6.2009 13.45.30,123")]
+    [InlineData("de-DE", TimeFormat.TwentyFourHour, MillisecondsDisplay.Truncated, "15.06.2009 13:45:30,123")]
+    [InlineData("en-US", TimeFormat.TwelveHour, MillisecondsDisplay.Truncated, "6/15/2009 1:45:30.123 PM")]
+    public void FormatDateTime_WithTimeFormatPreference_UsesCultureSeparators(string cultureName, TimeFormat format, MillisecondsDisplay includeMilliseconds, string expected)
+    {
+        var date = GetLocalDateTime("2009-06-15T13:45:30.1234567Z");
+        var provider = CreateTimeProvider();
+        provider.SetTimeFormat(format);
+
+        Assert.Equal(expected, FormatHelpers.FormatDateTime(provider, date, includeMilliseconds, CultureInfo.GetCultureInfo(cultureName)));
+    }
+
+    [Fact]
+    public void FormatTime_TwelveHour_UsesAmPm_EvenIfCultureIs24Hour()
+    {
+        // en-GB is typically 24-hour.
+        var date = GetLocalDateTime("2009-06-15T13:45:30.0000000Z");
+        var provider = CreateTimeProvider();
+        provider.SetTimeFormat(TimeFormat.TwelveHour);
+
+        // en-GB has AM/PM designators "am"/"pm" even if standard pattern is 24h.
+        var result = FormatHelpers.FormatTime(provider, date, MillisecondsDisplay.None, CultureInfo.GetCultureInfo("en-GB"));
+        Assert.Contains("pm", result.ToLowerInvariant());
+        Assert.DoesNotContain("13", result);
+    }
+
+    [Fact]
+    public void FormatTime_TwentyFourHour_Uses13_EvenIfCultureIs12Hour()
+    {
+        // en-US is typically 12-hour.
+        var date = GetLocalDateTime("2009-06-15T13:45:30.0000000Z");
+        var provider = CreateTimeProvider();
+        provider.SetTimeFormat(TimeFormat.TwentyFourHour);
+
+        var result = FormatHelpers.FormatTime(provider, date, MillisecondsDisplay.None, CultureInfo.GetCultureInfo("en-US"));
+        Assert.Contains("13", result);
+        Assert.DoesNotContain("PM", result);
+    }
+
     private static BrowserTimeProvider CreateTimeProvider()
     {
         return new BrowserTimeProvider(NullLoggerFactory.Instance);

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -107,7 +107,7 @@ public class FormatHelpersTests
     {
         var date = GetLocalDateTime(value);
         var provider = CreateTimeProvider();
-        provider.SetTimeFormat(format);
+        provider.SetConfiguredTimeFormat(format);
 
         // Use a culture that would normally be opposite
         var culture = format == TimeFormat.TwelveHour ? CultureInfo.GetCultureInfo("de-DE") : CultureInfo.GetCultureInfo("en-US");
@@ -122,7 +122,7 @@ public class FormatHelpersTests
     {
         var date = GetLocalDateTime(value);
         var provider = CreateTimeProvider();
-        provider.SetTimeFormat(format);
+        provider.SetConfiguredTimeFormat(format);
 
         Assert.Equal(expected, FormatHelpers.FormatDateTime(provider, date, MillisecondsDisplay.None, CultureInfo.GetCultureInfo("en-US")));
     }
@@ -136,7 +136,7 @@ public class FormatHelpersTests
     {
         var date = GetLocalDateTime("2009-06-15T13:45:30.1234567Z");
         var provider = CreateTimeProvider();
-        provider.SetTimeFormat(format);
+        provider.SetConfiguredTimeFormat(format);
 
         Assert.Equal(expected, FormatHelpers.FormatDateTime(provider, date, includeMilliseconds, CultureInfo.GetCultureInfo(cultureName)));
     }
@@ -147,7 +147,7 @@ public class FormatHelpersTests
         // en-GB is typically 24-hour.
         var date = GetLocalDateTime("2009-06-15T13:45:30.0000000Z");
         var provider = CreateTimeProvider();
-        provider.SetTimeFormat(TimeFormat.TwelveHour);
+        provider.SetConfiguredTimeFormat(TimeFormat.TwelveHour);
 
         // en-GB has AM/PM designators "am"/"pm" even if standard pattern is 24h.
         var result = FormatHelpers.FormatTime(provider, date, MillisecondsDisplay.None, CultureInfo.GetCultureInfo("en-GB"));
@@ -161,11 +161,49 @@ public class FormatHelpersTests
         // en-US is typically 12-hour.
         var date = GetLocalDateTime("2009-06-15T13:45:30.0000000Z");
         var provider = CreateTimeProvider();
-        provider.SetTimeFormat(TimeFormat.TwentyFourHour);
+        provider.SetConfiguredTimeFormat(TimeFormat.TwentyFourHour);
 
         var result = FormatHelpers.FormatTime(provider, date, MillisecondsDisplay.None, CultureInfo.GetCultureInfo("en-US"));
         Assert.Contains("13", result);
         Assert.DoesNotContain("PM", result);
+    }
+
+    [Theory]
+    [InlineData(true, "13:45:30")]   // Browser reports 24-hour → use 24-hour
+    [InlineData(false, "1:45:30 PM")] // Browser reports 12-hour → use 12-hour
+    public void FormatTime_SystemFormat_UsesBrowserTimeFormat(bool is24HourTime, string expected)
+    {
+        var date = GetLocalDateTime("2009-06-15T13:45:30.0000000Z");
+        var provider = CreateTimeProvider();
+        provider.SetBrowserTimeFormat(is24HourTime);
+        // TimeFormat stays at System (default)
+
+        Assert.Equal(expected, FormatHelpers.FormatTime(provider, date, MillisecondsDisplay.None, CultureInfo.GetCultureInfo("en-US")));
+    }
+
+    [Theory]
+    [InlineData(true, "6/15/2009 13:45:30")]   // Browser reports 24-hour
+    [InlineData(false, "6/15/2009 1:45:30 PM")] // Browser reports 12-hour
+    public void FormatDateTime_SystemFormat_UsesBrowserTimeFormat(bool is24HourTime, string expected)
+    {
+        var date = GetLocalDateTime("2009-06-15T13:45:30.0000000Z");
+        var provider = CreateTimeProvider();
+        provider.SetBrowserTimeFormat(is24HourTime);
+
+        Assert.Equal(expected, FormatHelpers.FormatDateTime(provider, date, MillisecondsDisplay.None, CultureInfo.GetCultureInfo("en-US")));
+    }
+
+    [Fact]
+    public void FormatTime_SystemFormat_NoBrowserFormat_FallsBackToCulture()
+    {
+        // When browser hasn't reported its format yet, fall back to culture-based formatting.
+        var date = GetLocalDateTime("2009-06-15T13:45:30.0000000Z");
+        var provider = CreateTimeProvider();
+        // Don't call SetBrowserTimeFormat — BrowserTimeFormat stays null
+
+        // de-DE is a 24-hour culture, so the culture pattern should be used.
+        var result = FormatHelpers.FormatTime(provider, date, MillisecondsDisplay.None, CultureInfo.GetCultureInfo("de-DE"));
+        Assert.Contains("13", result);
     }
 
     private static BrowserTimeProvider CreateTimeProvider()

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -172,7 +172,7 @@ public class FormatHelpersTests
         var provider = CreateTimeProvider();
         provider.SetConfiguredTimeFormat(format);
 
-        Assert.Equal(expected, FormatHelpers.FormatDateTime(provider, date, MillisecondsDisplay.None, CultureInfo.GetCultureInfo("en-US")));
+        Assert.Equal(expected, FormatHelpers.FormatDateTime(provider, date, MillisecondsDisplay.None, CultureInfo.GetCultureInfo("en-US")), ignoreWhiteSpaceDifferences: true);
     }
 
     [Theory]
@@ -194,7 +194,7 @@ public class FormatHelpersTests
         var provider = CreateTimeProvider();
         provider.SetConfiguredTimeFormat(format);
 
-        Assert.Equal(expected, FormatHelpers.FormatDateTime(provider, date, includeMilliseconds, CultureInfo.GetCultureInfo(cultureName)));
+        Assert.Equal(expected, FormatHelpers.FormatDateTime(provider, date, includeMilliseconds, CultureInfo.GetCultureInfo(cultureName)), ignoreWhiteSpaceDifferences: true);
     }
 
     [Fact]
@@ -234,7 +234,7 @@ public class FormatHelpersTests
         provider.SetBrowserTimeFormat(browserTimeFormat);
         // TimeFormat stays at System (default)
 
-        Assert.Equal(expected, FormatHelpers.FormatTime(provider, date, MillisecondsDisplay.None, CultureInfo.GetCultureInfo("en-US")));
+        Assert.Equal(expected, FormatHelpers.FormatTime(provider, date, MillisecondsDisplay.None, CultureInfo.GetCultureInfo("en-US")), ignoreWhiteSpaceDifferences: true);
     }
 
     [Theory]
@@ -246,7 +246,7 @@ public class FormatHelpersTests
         var provider = CreateTimeProvider();
         provider.SetBrowserTimeFormat(browserTimeFormat);
 
-        Assert.Equal(expected, FormatHelpers.FormatDateTime(provider, date, MillisecondsDisplay.None, CultureInfo.GetCultureInfo("en-US")));
+        Assert.Equal(expected, FormatHelpers.FormatDateTime(provider, date, MillisecondsDisplay.None, CultureInfo.GetCultureInfo("en-US")), ignoreWhiteSpaceDifferences: true);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -34,52 +34,100 @@ public class FormatHelpersTests
     }
 
     [Theory]
-    [InlineData("06/15/2009 13:45:30.000", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.0000000Z")]
-    [InlineData("06/15/2009 13:45:30.123", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.1234567Z")]
-    [InlineData("06/15/2009 13:45:30.1234567", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z")]
-    [InlineData("06/15/2009 13:45:30", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z")]
-    [InlineData("06/15/2009 13:45:30", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z")]
-    public void FormatDateTime_WithMilliseconds_InvariantCulture(string expected, MillisecondsDisplay includeMilliseconds, string value)
+    [InlineData("06/15/2009 13:45:30.000", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.0000000Z", TimeFormat.TwentyFourHour)]
+    [InlineData("06/15/2009 13:45:30.123", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwentyFourHour)]
+    [InlineData("06/15/2009 13:45:30.1234567", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwentyFourHour)]
+    [InlineData("06/15/2009 13:45:30", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z", TimeFormat.TwentyFourHour)]
+    [InlineData("06/15/2009 13:45:30", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwentyFourHour)]
+    [InlineData("06/15/2009 1:45:30.000 PM", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.0000000Z", TimeFormat.TwelveHour)]
+    [InlineData("06/15/2009 1:45:30.123 PM", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwelveHour)]
+    [InlineData("06/15/2009 1:45:30.1234567 PM", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwelveHour)]
+    [InlineData("06/15/2009 1:45:30 PM", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z", TimeFormat.TwelveHour)]
+    [InlineData("06/15/2009 1:45:30 PM", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwelveHour)]
+    [InlineData("06/15/2009 13:45:30.000", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.0000000Z", TimeFormat.System)]
+    [InlineData("06/15/2009 13:45:30.123", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.1234567Z", TimeFormat.System)]
+    [InlineData("06/15/2009 13:45:30.1234567", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z", TimeFormat.System)]
+    [InlineData("06/15/2009 13:45:30", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z", TimeFormat.System)]
+    [InlineData("06/15/2009 13:45:30", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z", TimeFormat.System)]
+    public void FormatDateTime_WithMilliseconds_InvariantCulture(string expected, MillisecondsDisplay includeMilliseconds, string value, TimeFormat timeFormat)
     {
         var date = GetLocalDateTime(value);
-        Assert.Equal(expected, FormatHelpers.FormatDateTime(CreateTimeProvider(), date, includeMilliseconds, cultureInfo: CultureInfo.InvariantCulture));
+        var provider = CreateTimeProvider();
+        provider.SetConfiguredTimeFormat(timeFormat);
+        Assert.Equal(expected, FormatHelpers.FormatDateTime(provider, date, includeMilliseconds, cultureInfo: CultureInfo.InvariantCulture));
     }
 
     [Theory]
-    [InlineData("15.06.2009 13:45:30,000", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.0000000Z")]
-    [InlineData("15.06.2009 13:45:30,123", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.1234567Z")]
-    [InlineData("15.06.2009 13:45:30,1234567", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z")]
-    [InlineData("15.06.2009 13:45:30", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z")]
-    [InlineData("15.06.2009 13:45:30", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z")]
-    public void FormatDateTime_WithMilliseconds_GermanCulture(string expected, MillisecondsDisplay includeMilliseconds, string value)
+    [InlineData("15.06.2009 13:45:30,000", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.0000000Z", TimeFormat.TwentyFourHour)]
+    [InlineData("15.06.2009 13:45:30,123", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwentyFourHour)]
+    [InlineData("15.06.2009 13:45:30,1234567", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwentyFourHour)]
+    [InlineData("15.06.2009 13:45:30", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z", TimeFormat.TwentyFourHour)]
+    [InlineData("15.06.2009 13:45:30", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwentyFourHour)]
+    [InlineData("15.06.2009 1:45:30,000 PM", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.0000000Z", TimeFormat.TwelveHour)]
+    [InlineData("15.06.2009 1:45:30,123 PM", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwelveHour)]
+    [InlineData("15.06.2009 1:45:30,1234567 PM", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwelveHour)]
+    [InlineData("15.06.2009 1:45:30 PM", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z", TimeFormat.TwelveHour)]
+    [InlineData("15.06.2009 1:45:30 PM", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwelveHour)]
+    [InlineData("15.06.2009 13:45:30,000", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.0000000Z", TimeFormat.System)]
+    [InlineData("15.06.2009 13:45:30,123", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.1234567Z", TimeFormat.System)]
+    [InlineData("15.06.2009 13:45:30,1234567", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z", TimeFormat.System)]
+    [InlineData("15.06.2009 13:45:30", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z", TimeFormat.System)]
+    [InlineData("15.06.2009 13:45:30", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z", TimeFormat.System)]
+    public void FormatDateTime_WithMilliseconds_GermanCulture(string expected, MillisecondsDisplay includeMilliseconds, string value, TimeFormat timeFormat)
     {
         var date = GetLocalDateTime(value);
-        Assert.Equal(expected, FormatHelpers.FormatDateTime(CreateTimeProvider(), date, includeMilliseconds, cultureInfo: CultureInfo.GetCultureInfo("de-DE")));
+        var provider = CreateTimeProvider();
+        provider.SetConfiguredTimeFormat(timeFormat);
+        Assert.Equal(expected, FormatHelpers.FormatDateTime(provider, date, includeMilliseconds, cultureInfo: CultureInfo.GetCultureInfo("de-DE")));
     }
 
     [Theory]
-    [InlineData("15.6.2009 13.45.30,000", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.0000000Z")]
-    [InlineData("15.6.2009 13.45.30,123", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.1234567Z")]
-    [InlineData("15.6.2009 13.45.30,1234567", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z")]
-    [InlineData("15.6.2009 13.45.30", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z")]
-    [InlineData("15.6.2009 13.45.30", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z")]
-    public void FormatDateTime_WithMilliseconds_FinnishCulture(string expected, MillisecondsDisplay includeMilliseconds, string value)
+    [InlineData("15.6.2009 13.45.30,000", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.0000000Z", TimeFormat.TwentyFourHour)]
+    [InlineData("15.6.2009 13.45.30,123", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwentyFourHour)]
+    [InlineData("15.6.2009 13.45.30,1234567", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwentyFourHour)]
+    [InlineData("15.6.2009 13.45.30", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z", TimeFormat.TwentyFourHour)]
+    [InlineData("15.6.2009 13.45.30", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwentyFourHour)]
+    [InlineData("15.6.2009 1.45.30,000 ip.", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.0000000Z", TimeFormat.TwelveHour)]
+    [InlineData("15.6.2009 1.45.30,123 ip.", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwelveHour)]
+    [InlineData("15.6.2009 1.45.30,1234567 ip.", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwelveHour)]
+    [InlineData("15.6.2009 1.45.30 ip.", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z", TimeFormat.TwelveHour)]
+    [InlineData("15.6.2009 1.45.30 ip.", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwelveHour)]
+    [InlineData("15.6.2009 13.45.30,000", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.0000000Z", TimeFormat.System)]
+    [InlineData("15.6.2009 13.45.30,123", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.1234567Z", TimeFormat.System)]
+    [InlineData("15.6.2009 13.45.30,1234567", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z", TimeFormat.System)]
+    [InlineData("15.6.2009 13.45.30", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z", TimeFormat.System)]
+    [InlineData("15.6.2009 13.45.30", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z", TimeFormat.System)]
+    public void FormatDateTime_WithMilliseconds_FinnishCulture(string expected, MillisecondsDisplay includeMilliseconds, string value, TimeFormat timeFormat)
     {
         var date = GetLocalDateTime(value);
-        Assert.Equal(expected, FormatHelpers.FormatDateTime(CreateTimeProvider(), date, includeMilliseconds, cultureInfo: CultureInfo.GetCultureInfo("fi-FI")));
+        var provider = CreateTimeProvider();
+        provider.SetConfiguredTimeFormat(timeFormat);
+        Assert.Equal(expected, FormatHelpers.FormatDateTime(provider, date, includeMilliseconds, cultureInfo: CultureInfo.GetCultureInfo("fi-FI")));
     }
 
     [Theory]
-    [InlineData("15/06/2009 1:45:30.000 pm", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.0000000Z")]
-    [InlineData("15/06/2009 1:45:30.123 pm", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.1234567Z")]
-    [InlineData("15/06/2009 1:45:30.1234567 pm", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z")]
-    [InlineData("15/06/2009 1:45:30 pm", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z")]
-    [InlineData("15/06/2009 1:45:30 pm", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z")]
-    public void FormatDateTime_WithMilliseconds_NewZealandCulture(string expected, MillisecondsDisplay includeMilliseconds, string value)
+    [InlineData("15/06/2009 1:45:30.000 pm", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.0000000Z", TimeFormat.TwelveHour)]
+    [InlineData("15/06/2009 1:45:30.123 pm", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwelveHour)]
+    [InlineData("15/06/2009 1:45:30.1234567 pm", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwelveHour)]
+    [InlineData("15/06/2009 1:45:30 pm", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z", TimeFormat.TwelveHour)]
+    [InlineData("15/06/2009 1:45:30 pm", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwelveHour)]
+    [InlineData("15/06/2009 13:45:30.000", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.0000000Z", TimeFormat.TwentyFourHour)]
+    [InlineData("15/06/2009 13:45:30.123", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwentyFourHour)]
+    [InlineData("15/06/2009 13:45:30.1234567", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwentyFourHour)]
+    [InlineData("15/06/2009 13:45:30", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z", TimeFormat.TwentyFourHour)]
+    [InlineData("15/06/2009 13:45:30", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z", TimeFormat.TwentyFourHour)]
+    [InlineData("15/06/2009 1:45:30.000 pm", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.0000000Z", TimeFormat.System)]
+    [InlineData("15/06/2009 1:45:30.123 pm", MillisecondsDisplay.Truncated, "2009-06-15T13:45:30.1234567Z", TimeFormat.System)]
+    [InlineData("15/06/2009 1:45:30.1234567 pm", MillisecondsDisplay.Full, "2009-06-15T13:45:30.1234567Z", TimeFormat.System)]
+    [InlineData("15/06/2009 1:45:30 pm", MillisecondsDisplay.None, "2009-06-15T13:45:30.0000000Z", TimeFormat.System)]
+    [InlineData("15/06/2009 1:45:30 pm", MillisecondsDisplay.None, "2009-06-15T13:45:30.1234567Z", TimeFormat.System)]
+    public void FormatDateTime_WithMilliseconds_NewZealandCulture(string expected, MillisecondsDisplay includeMilliseconds, string value, TimeFormat timeFormat)
     {
         var date = GetLocalDateTime(value);
+        var provider = CreateTimeProvider();
+        provider.SetConfiguredTimeFormat(timeFormat);
         // macOS formats with uppercase AM/PM, so ignore case
-        Assert.Equal(expected, FormatHelpers.FormatDateTime(CreateTimeProvider(), date, includeMilliseconds, cultureInfo: CultureInfo.GetCultureInfo("en-NZ")), ignoreWhiteSpaceDifferences: true, ignoreCase: true);
+        Assert.Equal(expected, FormatHelpers.FormatDateTime(provider, date, includeMilliseconds, cultureInfo: CultureInfo.GetCultureInfo("en-NZ")), ignoreWhiteSpaceDifferences: true, ignoreCase: true);
     }
 
     [Theory]
@@ -130,8 +178,16 @@ public class FormatHelpersTests
     [Theory]
     [InlineData("fi-FI", TimeFormat.TwentyFourHour, MillisecondsDisplay.None, "15.6.2009 13.45.30")]
     [InlineData("fi-FI", TimeFormat.TwentyFourHour, MillisecondsDisplay.Truncated, "15.6.2009 13.45.30,123")]
+    [InlineData("fi-FI", TimeFormat.TwelveHour, MillisecondsDisplay.None, "15.6.2009 1.45.30 ip.")]
+    [InlineData("fi-FI", TimeFormat.TwelveHour, MillisecondsDisplay.Truncated, "15.6.2009 1.45.30,123 ip.")]
+    [InlineData("fi-FI", TimeFormat.System, MillisecondsDisplay.None, "15.6.2009 13.45.30")]
+    [InlineData("fi-FI", TimeFormat.System, MillisecondsDisplay.Truncated, "15.6.2009 13.45.30,123")]
     [InlineData("de-DE", TimeFormat.TwentyFourHour, MillisecondsDisplay.Truncated, "15.06.2009 13:45:30,123")]
+    [InlineData("de-DE", TimeFormat.TwelveHour, MillisecondsDisplay.Truncated, "15.06.2009 1:45:30,123 PM")]
+    [InlineData("de-DE", TimeFormat.System, MillisecondsDisplay.Truncated, "15.06.2009 13:45:30,123")]
+    [InlineData("en-US", TimeFormat.TwentyFourHour, MillisecondsDisplay.Truncated, "6/15/2009 13:45:30.123")]
     [InlineData("en-US", TimeFormat.TwelveHour, MillisecondsDisplay.Truncated, "6/15/2009 1:45:30.123 PM")]
+    [InlineData("en-US", TimeFormat.System, MillisecondsDisplay.Truncated, "6/15/2009 1:45:30.123 PM")]
     public void FormatDateTime_WithTimeFormatPreference_UsesCultureSeparators(string cultureName, TimeFormat format, MillisecondsDisplay includeMilliseconds, string expected)
     {
         var date = GetLocalDateTime("2009-06-15T13:45:30.1234567Z");
@@ -169,26 +225,26 @@ public class FormatHelpersTests
     }
 
     [Theory]
-    [InlineData(true, "13:45:30")]   // Browser reports 24-hour → use 24-hour
-    [InlineData(false, "1:45:30 PM")] // Browser reports 12-hour → use 12-hour
-    public void FormatTime_SystemFormat_UsesBrowserTimeFormat(bool is24HourTime, string expected)
+    [InlineData(TimeFormat.TwentyFourHour, "13:45:30")]   // Browser reports 24-hour → use 24-hour
+    [InlineData(TimeFormat.TwelveHour, "1:45:30 PM")] // Browser reports 12-hour → use 12-hour
+    public void FormatTime_SystemFormat_UsesBrowserTimeFormat(TimeFormat browserTimeFormat, string expected)
     {
         var date = GetLocalDateTime("2009-06-15T13:45:30.0000000Z");
         var provider = CreateTimeProvider();
-        provider.SetBrowserTimeFormat(is24HourTime);
+        provider.SetBrowserTimeFormat(browserTimeFormat);
         // TimeFormat stays at System (default)
 
         Assert.Equal(expected, FormatHelpers.FormatTime(provider, date, MillisecondsDisplay.None, CultureInfo.GetCultureInfo("en-US")));
     }
 
     [Theory]
-    [InlineData(true, "6/15/2009 13:45:30")]   // Browser reports 24-hour
-    [InlineData(false, "6/15/2009 1:45:30 PM")] // Browser reports 12-hour
-    public void FormatDateTime_SystemFormat_UsesBrowserTimeFormat(bool is24HourTime, string expected)
+    [InlineData(TimeFormat.TwentyFourHour, "6/15/2009 13:45:30")]   // Browser reports 24-hour
+    [InlineData(TimeFormat.TwelveHour, "6/15/2009 1:45:30 PM")] // Browser reports 12-hour
+    public void FormatDateTime_SystemFormat_UsesBrowserTimeFormat(TimeFormat browserTimeFormat, string expected)
     {
         var date = GetLocalDateTime("2009-06-15T13:45:30.0000000Z");
         var provider = CreateTimeProvider();
-        provider.SetBrowserTimeFormat(is24HourTime);
+        provider.SetBrowserTimeFormat(browserTimeFormat);
 
         Assert.Equal(expected, FormatHelpers.FormatDateTime(provider, date, MillisecondsDisplay.None, CultureInfo.GetCultureInfo("en-US")));
     }

--- a/tmp-fmt/Program.cs
+++ b/tmp-fmt/Program.cs
@@ -1,2 +1,0 @@
-﻿// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");

--- a/tmp-fmt/Program.cs
+++ b/tmp-fmt/Program.cs
@@ -1,0 +1,2 @@
+﻿// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");


### PR DESCRIPTION
## Description

add a Settings dialog option for time format (System, 12-hour, 24-hour) and persist the selection in browser local storage.

update BrowserTimeProvider and MainLayout startup flow to restore the saved preference, and apply it through FormatHelpers for time/date-time rendering while preserving culture-specific separators.

add localization resources for the new setting and tests covering forced 12/24-hour formatting behavior across cultures.

Fixes #11478

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [ ] No
