### PR TITLE
Warn when persistent containers lack user secrets configuration

### DIFF
--- a/src/Aspire.Hosting/BuiltInDistributedApplicationEventSubscriptionHandlers.cs
+++ b/src/Aspire.Hosting/BuiltInDistributedApplicationEventSubscriptionHandlers.cs
@@ -98,7 +98,10 @@ internal static class BuiltInDistributedApplicationEventSubscriptionHandlers
         {
             if (resource.GetContainerLifetimeType() == ContainerLifetime.Persistent)
             {
-                logger.LogWarning(MessageStrings.PersistentContainerWithoutUserSecrets, resource.Name);
+                if (logger.IsEnabled(LogLevel.Warning))
+                {
+                    logger.LogWarning(MessageStrings.PersistentContainerWithoutUserSecrets, resource.Name);
+                }
             }
         }
 

--- a/src/Aspire.Hosting/BuiltInDistributedApplicationEventSubscriptionHandlers.cs
+++ b/src/Aspire.Hosting/BuiltInDistributedApplicationEventSubscriptionHandlers.cs
@@ -1,11 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREUSERSECRETS001
+
 using Aspire;
 using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp;
+using Aspire.Hosting.Resources;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 internal static class BuiltInDistributedApplicationEventSubscriptionHandlers
 {
@@ -74,6 +78,28 @@ internal static class BuiltInDistributedApplicationEventSubscriptionHandlers
         foreach (var resourceWithContainerImage in resourcesWithContainerImages)
         {
             resourceWithContainerImage.Annotation.Registry = options.ContainerRegistryOverride;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public static Task WarnPersistentContainersWithoutUserSecrets(BeforeStartEvent beforeStartEvent, CancellationToken _)
+    {
+        var userSecretsManager = beforeStartEvent.Services.GetRequiredService<IUserSecretsManager>();
+
+        if (userSecretsManager.IsAvailable)
+        {
+            return Task.CompletedTask;
+        }
+
+        var logger = beforeStartEvent.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Aspire.Hosting");
+
+        foreach (var resource in beforeStartEvent.Model.Resources)
+        {
+            if (resource.GetContainerLifetimeType() == ContainerLifetime.Persistent)
+            {
+                logger.LogWarning(MessageStrings.PersistentContainerWithoutUserSecrets, resource.Name);
+            }
         }
 
         return Task.CompletedTask;

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -496,6 +496,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
             _innerBuilder.Services.AddSingleton<IKubernetesService, KubernetesService>();
 
             Eventing.Subscribe<BeforeStartEvent>(BuiltInDistributedApplicationEventSubscriptionHandlers.InitializeDcpAnnotations);
+            Eventing.Subscribe<BeforeStartEvent>(BuiltInDistributedApplicationEventSubscriptionHandlers.WarnPersistentContainersWithoutUserSecrets);
         }
 
         // Publishing support

--- a/src/Aspire.Hosting/Resources/MessageStrings.Designer.cs
+++ b/src/Aspire.Hosting/Resources/MessageStrings.Designer.cs
@@ -160,6 +160,15 @@ namespace Aspire.Hosting.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Resource &apos;{0}&apos; has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run &apos;dotnet user-secrets init&apos; in the AppHost directory to configure user secrets..
+        /// </summary>
+        internal static string PersistentContainerWithoutUserSecrets {
+            get {
+                return ResourceManager.GetString("PersistentContainerWithoutUserSecrets", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Resource &apos;{0}&apos; may fail to start: {1}.
         /// </summary>
         internal static string ResourceMayFailToStart {

--- a/src/Aspire.Hosting/Resources/MessageStrings.resx
+++ b/src/Aspire.Hosting/Resources/MessageStrings.resx
@@ -150,6 +150,9 @@
   <data name="RequiredCommandValidationFailedWithLink" xml:space="preserve">
     <value>Command '{0}' validation failed: {1}. For installation instructions, see: {2}</value>
   </data>
+  <data name="PersistentContainerWithoutUserSecrets" xml:space="preserve">
+    <value>Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</value>
+  </data>
   <data name="ResourceMayFailToStart" xml:space="preserve">
     <value>Resource '{0}' may fail to start: {1}</value>
   </data>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.cs.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.cs.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Chybějící příkaz</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerWithoutUserSecrets">
+        <source>Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</source>
+        <target state="new">Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCommandNotFound">
         <source>Required command '{0}' was not found on PATH or at the specified location.</source>
         <target state="translated">Požadovaný příkaz {0} nebyl nalezen v cestě PATH nebo v zadaném umístění.</target>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.de.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.de.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Fehlender Befehl</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerWithoutUserSecrets">
+        <source>Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</source>
+        <target state="new">Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCommandNotFound">
         <source>Required command '{0}' was not found on PATH or at the specified location.</source>
         <target state="translated">Der erforderliche Befehl „{0}“ wurde weder im PATH noch an dem angegebenen Speicherort gefunden.</target>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.es.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.es.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Falta un comando</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerWithoutUserSecrets">
+        <source>Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</source>
+        <target state="new">Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCommandNotFound">
         <source>Required command '{0}' was not found on PATH or at the specified location.</source>
         <target state="translated">No se encontró el comando necesario "{0}" en PATH o en la ubicación especificada.</target>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.fr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.fr.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Commande manquante</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerWithoutUserSecrets">
+        <source>Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</source>
+        <target state="new">Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCommandNotFound">
         <source>Required command '{0}' was not found on PATH or at the specified location.</source>
         <target state="translated">La commande requise « {0} » est introuvable dans le CHEMIN ou à l’emplacement spécifié.</target>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.it.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.it.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Comando mancante</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerWithoutUserSecrets">
+        <source>Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</source>
+        <target state="new">Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCommandNotFound">
         <source>Required command '{0}' was not found on PATH or at the specified location.</source>
         <target state="translated">Non è possibile trovare il comando richiesto '{0}' in PATH o nel percorso specificato.</target>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.ja.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.ja.xlf
@@ -37,6 +37,11 @@
         <target state="translated">コマンドがありません</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerWithoutUserSecrets">
+        <source>Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</source>
+        <target state="new">Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCommandNotFound">
         <source>Required command '{0}' was not found on PATH or at the specified location.</source>
         <target state="translated">必要なコマンド '{0}' が PATH または指定された場所に見つかりませんでした。</target>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.ko.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.ko.xlf
@@ -37,6 +37,11 @@
         <target state="translated">명령이 없음</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerWithoutUserSecrets">
+        <source>Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</source>
+        <target state="new">Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCommandNotFound">
         <source>Required command '{0}' was not found on PATH or at the specified location.</source>
         <target state="translated">PATH 또는 지정된 위치에서 필수 명령 '{0}'을(를) 찾을 수 없습니다.</target>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.pl.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.pl.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Brakujące polecenie</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerWithoutUserSecrets">
+        <source>Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</source>
+        <target state="new">Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCommandNotFound">
         <source>Required command '{0}' was not found on PATH or at the specified location.</source>
         <target state="translated">Nie znaleziono wymaganego polecenia „{0}” w ścieżce PATH lub w podanej lokalizacji.</target>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.pt-BR.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.pt-BR.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Comando ausente</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerWithoutUserSecrets">
+        <source>Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</source>
+        <target state="new">Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCommandNotFound">
         <source>Required command '{0}' was not found on PATH or at the specified location.</source>
         <target state="translated">O comando obrigatório ''{0}'' não foi encontrado em PATH ou no local especificado.</target>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.ru.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.ru.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Отсутствует команда</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerWithoutUserSecrets">
+        <source>Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</source>
+        <target state="new">Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCommandNotFound">
         <source>Required command '{0}' was not found on PATH or at the specified location.</source>
         <target state="translated">Требуемая команда "{0}" не найдена в PATH или в указанном расположении.</target>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.tr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.tr.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Eksik komut</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerWithoutUserSecrets">
+        <source>Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</source>
+        <target state="new">Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCommandNotFound">
         <source>Required command '{0}' was not found on PATH or at the specified location.</source>
         <target state="translated">Gerekli '{0}' komutu PATH'de veya belirtilen konumda bulunamadı.</target>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.zh-Hans.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.zh-Hans.xlf
@@ -37,6 +37,11 @@
         <target state="translated">缺少命令</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerWithoutUserSecrets">
+        <source>Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</source>
+        <target state="new">Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCommandNotFound">
         <source>Required command '{0}' was not found on PATH or at the specified location.</source>
         <target state="translated">在 PATH 或指定位置找不到所需命令 "{0}"。</target>

--- a/src/Aspire.Hosting/Resources/xlf/MessageStrings.zh-Hant.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/MessageStrings.zh-Hant.xlf
@@ -37,6 +37,11 @@
         <target state="translated">遺漏命令</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerWithoutUserSecrets">
+        <source>Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</source>
+        <target state="new">Resource '{0}' has a persistent lifetime but the AppHost project does not have user secrets configured. Generated parameter values (such as passwords) may change on each restart, causing persistent containers to be recreated. Run 'dotnet user-secrets init' in the AppHost directory to configure user secrets.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RequiredCommandNotFound">
         <source>Required command '{0}' was not found on PATH or at the specified location.</source>
         <target state="translated">在 PATH 或指定的位置找不到必要的命令 '{0}'。</target>

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -1173,24 +1173,6 @@ public class ParameterProcessorTests
         }
     }
 
-    private sealed class MockUserSecretsManager : IUserSecretsManager
-    {
-        public bool IsAvailable => true;
-        public string FilePath => "/mock/path/secrets.json";
-
-        public bool TrySetSecret(string name, string value) => true;
-
-        public void GetOrSetSecret(IConfigurationManager configuration, string name, Func<string> valueGenerator)
-        {
-            // Mock implementation - do nothing
-        }
-
-        public Task SaveStateAsync(JsonObject state, CancellationToken cancellationToken = default)
-        {
-            return Task.CompletedTask;
-        }
-    }
-
     private static ParameterResource CreateParameterResource(string name, string value, bool secret = false)
     {
         var configuration = new ConfigurationBuilder()

--- a/tests/Aspire.Hosting.Tests/PersistentContainerWarningTests.cs
+++ b/tests/Aspire.Hosting.Tests/PersistentContainerWarningTests.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREUSERSECRETS001
+
+using Aspire.Hosting.UserSecrets;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+
+namespace Aspire.Hosting.Tests;
+
+public class PersistentContainerWarningTests
+{
+    [Fact]
+    public async Task PersistentContainerWithoutUserSecrets_LogsWarning()
+    {
+        var testSink = new TestSink();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IUserSecretsManager>(NoopUserSecretsManager.Instance);
+        services.AddLogging(logging => logging.AddProvider(new TestLoggerProvider(testSink)));
+        var serviceProvider = services.BuildServiceProvider();
+
+        var resources = new ResourceCollection();
+        var container = new ContainerResource("my-container");
+        container.Annotations.Add(new ContainerLifetimeAnnotation { Lifetime = ContainerLifetime.Persistent });
+        resources.Add(container);
+
+        var model = new DistributedApplicationModel(resources);
+        var beforeStartEvent = new BeforeStartEvent(serviceProvider, model);
+
+        await BuiltInDistributedApplicationEventSubscriptionHandlers.WarnPersistentContainersWithoutUserSecrets(beforeStartEvent, CancellationToken.None);
+
+        Assert.Contains(testSink.Writes, w => w.LogLevel == LogLevel.Warning && w.Message?.Contains("my-container") == true);
+    }
+
+    [Fact]
+    public async Task PersistentContainerWithUserSecrets_DoesNotLogWarning()
+    {
+        var testSink = new TestSink();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IUserSecretsManager>(new FakeAvailableUserSecretsManager());
+        services.AddLogging(logging => logging.AddProvider(new TestLoggerProvider(testSink)));
+        var serviceProvider = services.BuildServiceProvider();
+
+        var resources = new ResourceCollection();
+        var container = new ContainerResource("my-container");
+        container.Annotations.Add(new ContainerLifetimeAnnotation { Lifetime = ContainerLifetime.Persistent });
+        resources.Add(container);
+
+        var model = new DistributedApplicationModel(resources);
+        var beforeStartEvent = new BeforeStartEvent(serviceProvider, model);
+
+        await BuiltInDistributedApplicationEventSubscriptionHandlers.WarnPersistentContainersWithoutUserSecrets(beforeStartEvent, CancellationToken.None);
+
+        Assert.DoesNotContain(testSink.Writes, w => w.LogLevel == LogLevel.Warning);
+    }
+
+    [Fact]
+    public async Task SessionContainerWithoutUserSecrets_DoesNotLogWarning()
+    {
+        var testSink = new TestSink();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IUserSecretsManager>(NoopUserSecretsManager.Instance);
+        services.AddLogging(logging => logging.AddProvider(new TestLoggerProvider(testSink)));
+        var serviceProvider = services.BuildServiceProvider();
+
+        var resources = new ResourceCollection();
+        resources.Add(new ContainerResource("my-container"));
+
+        var model = new DistributedApplicationModel(resources);
+        var beforeStartEvent = new BeforeStartEvent(serviceProvider, model);
+
+        await BuiltInDistributedApplicationEventSubscriptionHandlers.WarnPersistentContainersWithoutUserSecrets(beforeStartEvent, CancellationToken.None);
+
+        Assert.DoesNotContain(testSink.Writes, w => w.LogLevel == LogLevel.Warning);
+    }
+
+    private sealed class FakeAvailableUserSecretsManager : IUserSecretsManager
+    {
+        public bool IsAvailable => true;
+        public string FilePath => string.Empty;
+        public bool TrySetSecret(string name, string value) => true;
+        public void GetOrSetSecret(Microsoft.Extensions.Configuration.IConfigurationManager configuration, string name, Func<string> valueGenerator) { }
+        public Task SaveStateAsync(System.Text.Json.Nodes.JsonObject state, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+}

--- a/tests/Aspire.Hosting.Tests/PersistentContainerWarningTests.cs
+++ b/tests/Aspire.Hosting.Tests/PersistentContainerWarningTests.cs
@@ -3,6 +3,7 @@
 
 #pragma warning disable ASPIREUSERSECRETS001
 
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.UserSecrets;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -42,7 +43,7 @@ public class PersistentContainerWarningTests(ITestOutputHelper testOutputHelper)
         var testSink = new TestSink();
 
         var services = new ServiceCollection();
-        services.AddSingleton<IUserSecretsManager>(new FakeAvailableUserSecretsManager());
+        services.AddSingleton<IUserSecretsManager>(new MockUserSecretsManager());
         services.AddLogging(logging => logging.AddProvider(new TestLoggerProvider(testSink)));
         services.AddLogging(logging => logging.AddXunit(testOutputHelper));
         var serviceProvider = services.BuildServiceProvider();
@@ -80,14 +81,5 @@ public class PersistentContainerWarningTests(ITestOutputHelper testOutputHelper)
         await BuiltInDistributedApplicationEventSubscriptionHandlers.WarnPersistentContainersWithoutUserSecrets(beforeStartEvent, CancellationToken.None);
 
         Assert.DoesNotContain(testSink.Writes, w => w.LogLevel == LogLevel.Warning);
-    }
-
-    private sealed class FakeAvailableUserSecretsManager : IUserSecretsManager
-    {
-        public bool IsAvailable => true;
-        public string FilePath => string.Empty;
-        public bool TrySetSecret(string name, string value) => true;
-        public void GetOrSetSecret(Microsoft.Extensions.Configuration.IConfigurationManager configuration, string name, Func<string> valueGenerator) { }
-        public Task SaveStateAsync(System.Text.Json.Nodes.JsonObject state, CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 }

--- a/tests/Aspire.Hosting.Tests/PersistentContainerWarningTests.cs
+++ b/tests/Aspire.Hosting.Tests/PersistentContainerWarningTests.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging.Testing;
 
 namespace Aspire.Hosting.Tests;
 
-public class PersistentContainerWarningTests
+public class PersistentContainerWarningTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
     public async Task PersistentContainerWithoutUserSecrets_LogsWarning()
@@ -20,6 +20,7 @@ public class PersistentContainerWarningTests
         var services = new ServiceCollection();
         services.AddSingleton<IUserSecretsManager>(NoopUserSecretsManager.Instance);
         services.AddLogging(logging => logging.AddProvider(new TestLoggerProvider(testSink)));
+        services.AddLogging(logging => logging.AddXunit(testOutputHelper));
         var serviceProvider = services.BuildServiceProvider();
 
         var resources = new ResourceCollection();
@@ -43,6 +44,7 @@ public class PersistentContainerWarningTests
         var services = new ServiceCollection();
         services.AddSingleton<IUserSecretsManager>(new FakeAvailableUserSecretsManager());
         services.AddLogging(logging => logging.AddProvider(new TestLoggerProvider(testSink)));
+        services.AddLogging(logging => logging.AddXunit(testOutputHelper));
         var serviceProvider = services.BuildServiceProvider();
 
         var resources = new ResourceCollection();
@@ -66,6 +68,7 @@ public class PersistentContainerWarningTests
         var services = new ServiceCollection();
         services.AddSingleton<IUserSecretsManager>(NoopUserSecretsManager.Instance);
         services.AddLogging(logging => logging.AddProvider(new TestLoggerProvider(testSink)));
+        services.AddLogging(logging => logging.AddXunit(testOutputHelper));
         var serviceProvider = services.BuildServiceProvider();
 
         var resources = new ResourceCollection();

--- a/tests/Aspire.Hosting.Tests/Utils/MockUserSecretsManager.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/MockUserSecretsManager.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREUSERSECRETS001
+
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Configuration;
+
+namespace Aspire.Hosting.Tests.Utils;
+
+internal sealed class MockUserSecretsManager : IUserSecretsManager
+{
+    public bool IsAvailable => true;
+
+    public string FilePath => "/mock/path/secrets.json";
+
+    public bool TrySetSecret(string name, string value) => true;
+
+    public void GetOrSetSecret(IConfigurationManager configuration, string name, Func<string> valueGenerator)
+    {
+    }
+
+    public Task SaveStateAsync(JsonObject state, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #14466

When a container resource has `ContainerLifetime.Persistent` but the AppHost project doesn't have user secrets configured (`UserSecretsId`), generated parameter values (such as passwords) cannot be persisted. On each restart, a new password is generated, which changes the container's environment variables, causing DCP to compute a different lifecycle key — triggering a full container recreation instead of reusing the persistent container.

This PR adds a `BeforeStartEvent` handler that detects this misconfiguration and logs a warning per affected persistent container, guiding users to run `dotnet user-secrets init` in the AppHost directory.

### Root Cause Chain

1. `RunAsEmulator()` (e.g., Service Bus) creates sub-resources with `CreateDefaultPasswordParameter()`
2. `CreateGeneratedParameter()` wraps the default in `UserSecretsParameterDefault`
3. `UserSecretsParameterDefault.GetDefaultValue()` calls `TrySetSecret()` → returns `false` silently via `NoopUserSecretsManager`
4. Password value is generated fresh every restart (not read back from secrets)
5. Container spec env vars change → DCP lifecycle key changes → container is recreated

### Changes

| File | Change |
|------|--------|
| `BuiltInDistributedApplicationEventSubscriptionHandlers.cs` | New `WarnPersistentContainersWithoutUserSecrets` handler |
| `DistributedApplicationBuilder.cs` | Register handler on `BeforeStartEvent` (run-mode only) |
| `MessageStrings.resx` + `.Designer.cs` | Localizable warning message |
| `PersistentContainerWarningTests.cs` | 3 tests covering warning/no-warning scenarios |

### Known Limitations

1. **Containers with persistent storage but session lifetime are not covered.** Containers using `WithDataVolume()` or `WithBindMount()` without `ContainerLifetime.Persistent` also persist state (e.g., initialized databases retain old passwords), but won't receive this warning since they have `ContainerLifetime.Session`. This is a different problem scope worth a follow-up issue.

2. **False positives for persistent containers without generated secrets.** The warning fires for any persistent container when user secrets aren't configured, even if the container doesn't use generated parameters (e.g., a Redis container with no password). This was a deliberate trade-off for simplicity — having user secrets configured is good practice for any project using persistent containers, and the warning is actionable.