### PR TITLE
Fix Windows pipeline image to use windows.vs2022.amd64.open

### DIFF
--- a/eng/pipelines/templates/public-pipeline-template.yml
+++ b/eng/pipelines/templates/public-pipeline-template.yml
@@ -86,7 +86,7 @@ stages:
 
           pool:
             name: $(DncEngPublicBuildPool)
-            demands: ImageOverride -equals windows.vs2022.amd64.open
+            demands: ImageOverride -equals windows.vs2026preview.scout.amd64.open
 
           variables:
             - name: _buildScript

--- a/eng/pipelines/templates/public-pipeline-template.yml
+++ b/eng/pipelines/templates/public-pipeline-template.yml
@@ -86,7 +86,7 @@ stages:
 
           pool:
             name: $(DncEngPublicBuildPool)
-            demands: ImageOverride -equals 1es-windows-2022-open
+            demands: ImageOverride -equals windows.vs2022.amd64.open
 
           variables:
             - name: _buildScript


### PR DESCRIPTION
Follow-up to #14486. Use windows.vs2022.amd64.open instead of 1es-windows-2022-open, which is the smaller image without the kitchen sink dependencies.