### PR TITLE
Update pipeline images from vs2022preview to vs2026preview.scout

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -120,7 +120,7 @@ extends:
         justificationForDisabling: 'see https://portal.microsofticm.com/imp/v3/incidents/incident/482258316/summary'
       sourceAnalysisPool:
         name: NetCore1ESPool-Internal
-        image: windows.vs2022preview.amd64
+        image: windows.vs2026preview.scout.amd64
         os: windows
       tsa:
         enabled: true
@@ -214,7 +214,7 @@ extends:
 
             pool:
               name: NetCore1ESPool-Internal
-              image: windows.vs2022preview.amd64
+              image: windows.vs2026preview.scout.amd64
               os: windows
 
             variables:

--- a/eng/pipelines/release-publish-nuget.yml
+++ b/eng/pipelines/release-publish-nuget.yml
@@ -63,7 +63,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: NetCore1ESPool-Internal
-        image: windows.vs2022preview.amd64
+        image: windows.vs2026preview.scout.amd64
         os: windows
 
     stages:
@@ -74,7 +74,7 @@ extends:
             displayName: 'Validate Release Inputs'
             pool:
               name: NetCore1ESPool-Internal
-              image: windows.vs2022preview.amd64
+              image: windows.vs2026preview.scout.amd64
               os: windows
             steps:
               - checkout: none
@@ -109,7 +109,7 @@ extends:
             displayName: 'Extract BAR Build ID from Build Tags'
             pool:
               name: NetCore1ESPool-Internal
-              image: windows.vs2022preview.amd64
+              image: windows.vs2026preview.scout.amd64
               os: windows
             steps:
               - checkout: none
@@ -164,7 +164,7 @@ extends:
             timeoutInMinutes: 60
             pool:
               name: NetCore1ESPool-Internal
-              image: windows.vs2022preview.amd64
+              image: windows.vs2026preview.scout.amd64
               os: windows
             steps:
               - checkout: self
@@ -439,7 +439,7 @@ extends:
             displayName: 'Print Release Summary'
             pool:
               name: NetCore1ESPool-Internal
-              image: windows.vs2022preview.amd64
+              image: windows.vs2026preview.scout.amd64
               os: windows
             steps:
               - checkout: none

--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -39,7 +39,7 @@ jobs:
         pool:
           ${{ if eq(parameters.agentOs, 'windows') }}:
             name: NetCore1ESPool-Internal
-            image: windows.vs2022preview.amd64
+            image: windows.vs2026preview.scout.amd64
             os: windows
           ${{ if eq(parameters.agentOs, 'linux') }}:
             name: NetCore1ESPool-Internal


### PR DESCRIPTION
Replace deprecated \windows.vs2022preview.amd64\ images with \windows.vs2026preview.scout.amd64\ in internal pipeline definitions to fix broken builds.

### Changes
- \ng/pipelines/azure-pipelines.yml\ (2 occurrences)
- \ng/pipelines/release-publish-nuget.yml\ (5 occurrences)
- \ng/pipelines/templates/build_sign_native.yml\ (1 occurrence)