### PR TITLE
Fix MCP server tools/list infinite loop caused by notification race condition

### DIFF
--- a/playground/PostgresEndToEnd/PostgresEndToEnd.JavaService/dependency-reduced-pom.xml
+++ b/playground/PostgresEndToEnd/PostgresEndToEnd.JavaService/dependency-reduced-pom.xml
@@ -43,6 +43,45 @@
       </plugin>
     </plugins>
   </build>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-server</artifactId>
+        <version>9.4.57.v20241219</version>
+      </dependency>
+      <dependency>
+        <groupId>org.postgresql</groupId>
+        <artifactId>postgresql</artifactId>
+        <version>42.7.2</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http2</artifactId>
+        <version>4.1.124.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>com.nimbusds</groupId>
+        <artifactId>nimbus-jose-jwt</artifactId>
+        <version>9.37.2</version>
+      </dependency>
+      <dependency>
+        <groupId>io.projectreactor.netty</groupId>
+        <artifactId>reactor-netty-core</artifactId>
+        <version>1.0.39</version>
+      </dependency>
+      <dependency>
+        <groupId>io.projectreactor.netty</groupId>
+        <artifactId>reactor-netty-http</artifactId>
+        <version>1.0.39</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>4.1.118.Final</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <properties>
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.source>17</maven.compiler.source>

--- a/src/Aspire.Cli/Mcp/IMcpResourceToolRefreshService.cs
+++ b/src/Aspire.Cli/Mcp/IMcpResourceToolRefreshService.cs
@@ -27,8 +27,8 @@ internal interface IMcpResourceToolRefreshService
     /// Refreshes the resource tool map by discovering MCP tools from connected resources.
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The refreshed resource tool map.</returns>
-    Task<IReadOnlyDictionary<string, ResourceToolEntry>> RefreshResourceToolMapAsync(CancellationToken cancellationToken);
+    /// <returns>A tuple containing the refreshed resource tool map and a flag indicating whether the tool set changed.</returns>
+    Task<(IReadOnlyDictionary<string, ResourceToolEntry> ToolMap, bool Changed)> RefreshResourceToolMapAsync(CancellationToken cancellationToken);
 
     /// <summary>
     /// Sends a tools list changed notification to connected MCP clients.

--- a/src/Aspire.Cli/Mcp/McpResourceToolRefreshService.cs
+++ b/src/Aspire.Cli/Mcp/McpResourceToolRefreshService.cs
@@ -117,8 +117,8 @@ internal sealed class McpResourceToolRefreshService : IMcpResourceToolRefreshSer
 
         lock (_lock)
         {
-            var changed = !_resourceToolMap.Keys.OrderBy(k => k, StringComparer.Ordinal)
-                .SequenceEqual(refreshedMap.Keys.OrderBy(k => k, StringComparer.Ordinal), StringComparer.Ordinal);
+            var changed = _resourceToolMap.Count != refreshedMap.Count
+                || !_resourceToolMap.Keys.ToHashSet(StringComparer.Ordinal).SetEquals(refreshedMap.Keys);
 
             _resourceToolMap = refreshedMap;
             _selectedAppHostPath = selectedAppHostPath;

--- a/src/Aspire.Cli/Mcp/McpResourceToolRefreshService.cs
+++ b/src/Aspire.Cli/Mcp/McpResourceToolRefreshService.cs
@@ -71,7 +71,7 @@ internal sealed class McpResourceToolRefreshService : IMcpResourceToolRefreshSer
     }
 
     /// <inheritdoc/>
-    public async Task<IReadOnlyDictionary<string, ResourceToolEntry>> RefreshResourceToolMapAsync(CancellationToken cancellationToken)
+    public async Task<(IReadOnlyDictionary<string, ResourceToolEntry> ToolMap, bool Changed)> RefreshResourceToolMapAsync(CancellationToken cancellationToken)
     {
         _logger.LogDebug("Refreshing resource tool map.");
 
@@ -117,10 +117,13 @@ internal sealed class McpResourceToolRefreshService : IMcpResourceToolRefreshSer
 
         lock (_lock)
         {
+            var changed = !_resourceToolMap.Keys.OrderBy(k => k, StringComparer.Ordinal)
+                .SequenceEqual(refreshedMap.Keys.OrderBy(k => k, StringComparer.Ordinal), StringComparer.Ordinal);
+
             _resourceToolMap = refreshedMap;
             _selectedAppHostPath = selectedAppHostPath;
             _invalidated = false;
-            return _resourceToolMap;
+            return (_resourceToolMap, changed);
         }
     }
 }

--- a/src/Aspire.Cli/Mcp/McpResourceToolRefreshService.cs
+++ b/src/Aspire.Cli/Mcp/McpResourceToolRefreshService.cs
@@ -120,12 +120,26 @@ internal sealed class McpResourceToolRefreshService : IMcpResourceToolRefreshSer
             var changed = _resourceToolMap.Count != refreshedMap.Count;
             if (!changed)
             {
+                // Check for deleted tools (in old but not in new).
                 foreach (var key in _resourceToolMap.Keys)
                 {
                     if (!refreshedMap.ContainsKey(key))
                     {
                         changed = true;
                         break;
+                    }
+                }
+
+                // Check for new tools (in new but not in old).
+                if (!changed)
+                {
+                    foreach (var key in refreshedMap.Keys)
+                    {
+                        if (!_resourceToolMap.ContainsKey(key))
+                        {
+                            changed = true;
+                            break;
+                        }
                     }
                 }
             }

--- a/src/Aspire.Cli/Mcp/McpResourceToolRefreshService.cs
+++ b/src/Aspire.Cli/Mcp/McpResourceToolRefreshService.cs
@@ -117,8 +117,18 @@ internal sealed class McpResourceToolRefreshService : IMcpResourceToolRefreshSer
 
         lock (_lock)
         {
-            var changed = _resourceToolMap.Count != refreshedMap.Count
-                || !_resourceToolMap.Keys.ToHashSet(StringComparer.Ordinal).SetEquals(refreshedMap.Keys);
+            var changed = _resourceToolMap.Count != refreshedMap.Count;
+            if (!changed)
+            {
+                foreach (var key in _resourceToolMap.Keys)
+                {
+                    if (!refreshedMap.ContainsKey(key))
+                    {
+                        changed = true;
+                        break;
+                    }
+                }
+            }
 
             _resourceToolMap = refreshedMap;
             _selectedAppHostPath = selectedAppHostPath;

--- a/src/Aspire.Cli/Mcp/McpResourceToolRefreshService.cs
+++ b/src/Aspire.Cli/Mcp/McpResourceToolRefreshService.cs
@@ -95,10 +95,15 @@ internal sealed class McpResourceToolRefreshService : IMcpResourceToolRefreshSer
                 {
                     Debug.Assert(resource.McpServer is not null);
 
+                    // Use DisplayName (the app-model name, e.g. "db1-mcp") rather than Name
+                    // (the DCP runtime ID, e.g. "db1-mcp-ypnvhwvw") because the AppHost resolves
+                    // resources by their app-model name in CallResourceMcpToolAsync.
+                    var routedResourceName = resource.DisplayName ?? resource.Name;
+
                     foreach (var tool in resource.McpServer.Tools)
                     {
-                        var exposedName = $"{resource.Name.Replace("-", "_")}_{tool.Name}";
-                        refreshedMap[exposedName] = new ResourceToolEntry(resource.Name, tool);
+                        var exposedName = $"{routedResourceName.Replace("-", "_")}_{tool.Name}";
+                        refreshedMap[exposedName] = new ResourceToolEntry(routedResourceName, tool);
 
                         _logger.LogDebug("{Tool}: {Description}", exposedName, tool.Description);
                     }
@@ -150,4 +155,5 @@ internal sealed class McpResourceToolRefreshService : IMcpResourceToolRefreshSer
             return (_resourceToolMap, changed);
         }
     }
+
 }

--- a/src/Aspire.Cli/Mcp/Tools/RefreshToolsTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/RefreshToolsTool.cs
@@ -19,7 +19,7 @@ internal sealed class RefreshToolsTool(IMcpResourceToolRefreshService refreshSer
 
     public override async ValueTask<CallToolResult> CallToolAsync(CallToolContext context, CancellationToken cancellationToken)
     {
-        var resourceToolMap = await refreshService.RefreshResourceToolMapAsync(cancellationToken).ConfigureAwait(false);
+        var (resourceToolMap, _) = await refreshService.RefreshResourceToolMapAsync(cancellationToken).ConfigureAwait(false);
         await refreshService.SendToolsListChangedNotificationAsync(cancellationToken).ConfigureAwait(false);
 
         var totalToolCount = KnownMcpTools.All.Count + resourceToolMap.Count;

--- a/tests/Aspire.Cli.Tests/Commands/AgentMcpCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AgentMcpCommandTests.cs
@@ -408,8 +408,6 @@ public class AgentMcpCommandTests(ITestOutputHelper outputHelper) : IAsyncLifeti
         Assert.NotNull(dbMcpTool);
 
         // Assert - no tools/list_changed notification should have been sent.
-        // Use a bounded wait via TryRead to catch any late-arriving notification
-        // without relying on an arbitrary Task.Delay.
         using var timeoutCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
         var notificationChannel = Channel.CreateUnbounded<JsonRpcNotification>();
         await using var channelHandler = _mcpClient.RegisterNotificationHandler(


### PR DESCRIPTION
## Description

Replaces #14376, retargeted to `release/13.2`.

`HandleListToolsAsync` was sending `tools/list_changed` notifications as a side effect of handling `tools/list` requests. When container MCP tools (e.g., db-mcp) oscillated between available/unavailable during enumeration, this created a tight feedback loop: `tools/list` → `tools/list_changed` → `tools/list` → … (~1,742 calls in ~2m44s until the client killed the server).

**Changes:**

- **Remove notification from list handler** — `HandleListToolsAsync` no longer sends `tools/list_changed`. The client already receives the fresh list since it initiated the request.
- **Add change detection to `RefreshResourceToolMapAsync`** — Returns `(ToolMap, Changed)` tuple. Compares old vs new tool key sets via zero-allocation iteration (count check + bidirectional `ContainsKey`) before reporting a change.
- **Gate notifications in `HandleCallToolAsync`** — Only sends `tools/list_changed` when the tool set actually changed during a refresh triggered by a tool call.
- **`RefreshToolsTool` unchanged semantically** — Still always notifies since it's an explicit user action.

Fixes #14375