### PR TITLE
[release/13.2] Manually update DCP to 0.22.5

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.22.4">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.22.5">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>f1dbae0486549c8e25572c82524e533ce40e3bc1</Sha>
+      <Sha>c59fb51a7d618ee78dcd1b7b2582e89e609fcb76</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.22.4">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.22.5">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>f1dbae0486549c8e25572c82524e533ce40e3bc1</Sha>
+      <Sha>c59fb51a7d618ee78dcd1b7b2582e89e609fcb76</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.22.4">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.22.5">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>f1dbae0486549c8e25572c82524e533ce40e3bc1</Sha>
+      <Sha>c59fb51a7d618ee78dcd1b7b2582e89e609fcb76</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.22.4">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.22.5">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>f1dbae0486549c8e25572c82524e533ce40e3bc1</Sha>
+      <Sha>c59fb51a7d618ee78dcd1b7b2582e89e609fcb76</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.22.4">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.22.5">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>f1dbae0486549c8e25572c82524e533ce40e3bc1</Sha>
+      <Sha>c59fb51a7d618ee78dcd1b7b2582e89e609fcb76</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.22.4">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.22.5">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>f1dbae0486549c8e25572c82524e533ce40e3bc1</Sha>
+      <Sha>c59fb51a7d618ee78dcd1b7b2582e89e609fcb76</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.22.4">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.22.5">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>f1dbae0486549c8e25572c82524e533ce40e3bc1</Sha>
+      <Sha>c59fb51a7d618ee78dcd1b7b2582e89e609fcb76</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.DependencyInjection.AutoActivation" Version="10.2.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,13 +30,13 @@
     <!-- Package versions defined directly in <reporoot>/Directory.Packages.props -->
     <MicrosoftDotnetSdkInternalVersion>8.0.100-rtm.23512.16</MicrosoftDotnetSdkInternalVersion>
     <!-- DCP -->
-    <MicrosoftDeveloperControlPlanedarwinamd64Version>0.22.4</MicrosoftDeveloperControlPlanedarwinamd64Version>
-    <MicrosoftDeveloperControlPlanedarwinarm64Version>0.22.4</MicrosoftDeveloperControlPlanedarwinarm64Version>
-    <MicrosoftDeveloperControlPlanelinuxamd64Version>0.22.4</MicrosoftDeveloperControlPlanelinuxamd64Version>
-    <MicrosoftDeveloperControlPlanelinuxarm64Version>0.22.4</MicrosoftDeveloperControlPlanelinuxarm64Version>
-    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.22.4</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
-    <MicrosoftDeveloperControlPlanewindowsamd64Version>0.22.4</MicrosoftDeveloperControlPlanewindowsamd64Version>
-    <MicrosoftDeveloperControlPlanewindowsarm64Version>0.22.4</MicrosoftDeveloperControlPlanewindowsarm64Version>
+    <MicrosoftDeveloperControlPlanedarwinamd64Version>0.22.5</MicrosoftDeveloperControlPlanedarwinamd64Version>
+    <MicrosoftDeveloperControlPlanedarwinarm64Version>0.22.5</MicrosoftDeveloperControlPlanedarwinarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxamd64Version>0.22.5</MicrosoftDeveloperControlPlanelinuxamd64Version>
+    <MicrosoftDeveloperControlPlanelinuxarm64Version>0.22.5</MicrosoftDeveloperControlPlanelinuxarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.22.5</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
+    <MicrosoftDeveloperControlPlanewindowsamd64Version>0.22.5</MicrosoftDeveloperControlPlanewindowsamd64Version>
+    <MicrosoftDeveloperControlPlanewindowsarm64Version>0.22.5</MicrosoftDeveloperControlPlanewindowsarm64Version>
     <!-- Other -->
     <MicrosoftDotNetRemoteExecutorVersion>11.0.0-beta.25610.3</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetXUnitV3ExtensionsVersion>11.0.0-beta.25610.3</MicrosoftDotNetXUnitV3ExtensionsVersion>


### PR DESCRIPTION
0.22.5 has fixes for a session folder cleanup regression related to unifying DCP to a single binary.

Full release details here: https://github.com/microsoft/dcp/releases/tag/v0.22.5