### PR TITLE
Add ACA deployment E2E tests for custom and existing ACR

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -534,7 +534,7 @@ jobs:
           ${CANCELLED_LIST}"
           fi
           
-          # Check for recordings and upload them (only for failed tests)
+          # Check for recordings and upload them
           RECORDINGS_DIR="cast_files"
           
           if [ -d "$RECORDINGS_DIR" ] && compgen -G "$RECORDINGS_DIR"/*.cast > /dev/null; then

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCustomRegistryDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCustomRegistryDeploymentTests.cs
@@ -1,0 +1,322 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Tests.Utils;
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Hex1b;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests for deploying Aspire applications to Azure Container Apps
+/// with a custom Azure Container Registry created via AddAzureContainerRegistry.
+/// </summary>
+public sealed class AcaCustomRegistryDeploymentTests(ITestOutputHelper output)
+{
+    // Timeout set to 40 minutes to allow for Azure provisioning.
+    // Full deployments can take up to 30 minutes if Azure infrastructure is backed up.
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(40);
+
+    [Fact]
+    public async Task DeployStarterTemplateWithCustomRegistry()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+        var cancellationToken = linkedCts.Token;
+
+        await DeployStarterTemplateWithCustomRegistryCore(cancellationToken);
+    }
+
+    private async Task DeployStarterTemplateWithCustomRegistryCore(CancellationToken cancellationToken)
+    {
+        // Validate prerequisites
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var recordingPath = DeploymentE2ETestHelpers.GetTestResultsRecordingPath(nameof(DeployStarterTemplateWithCustomRegistry));
+        var startTime = DateTime.UtcNow;
+        var deploymentUrls = new Dictionary<string, string>();
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("aca-custom-acr");
+        var projectName = "AcaCustomAcr";
+
+        output.WriteLine($"Test: {nameof(DeployStarterTemplateWithCustomRegistry)}");
+        output.WriteLine($"Project Name: {projectName}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            var builder = Hex1bTerminal.CreateBuilder()
+                .WithHeadless()
+                .WithDimensions(160, 48)
+                .WithAsciinemaRecording(recordingPath)
+                .WithPtyProcess("/bin/bash", ["--norc"]);
+
+            using var terminal = builder.Build();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            // Pattern searchers for aspire new interactive prompts
+            var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
+                .FindPattern("> Starter App");
+
+            var waitingForProjectNamePrompt = new CellPatternSearcher()
+                .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
+
+            var waitingForOutputPathPrompt = new CellPatternSearcher()
+                .Find("Enter the output path:");
+
+            var waitingForUrlsPrompt = new CellPatternSearcher()
+                .Find("Use *.dev.localhost URLs");
+
+            var waitingForRedisPrompt = new CellPatternSearcher()
+                .Find("Use Redis Cache");
+
+            var waitingForTestPrompt = new CellPatternSearcher()
+                .Find("Do you want to create a test project?");
+
+            // Pattern searchers for aspire add prompts
+            var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
+                .Find("(based on NuGet.config)");
+
+            // Pattern searcher for deployment success
+            var waitingForPipelineSucceeded = new CellPatternSearcher()
+                .Find("PIPELINE SUCCEEDED");
+
+            var counter = new SequenceCounter();
+            var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+            // Step 1: Prepare environment
+            output.WriteLine("Step 1: Preparing environment...");
+            sequenceBuilder.PrepareEnvironment(workspace, counter);
+
+            // Step 2: Set up CLI environment (in CI)
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                output.WriteLine("Step 2: Using pre-installed Aspire CLI from local build...");
+                sequenceBuilder.SourceAspireCliEnvironment(counter);
+            }
+
+            // Step 3: Create starter project using aspire new with interactive prompts
+            output.WriteLine("Step 3: Creating starter project...");
+            sequenceBuilder.Type("aspire new")
+                .Enter()
+                .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
+                .Enter() // Select first template (Starter App ASP.NET Core/Blazor)
+                .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+                .Type(projectName)
+                .Enter()
+                .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+                .Enter() // Accept default output path
+                .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+                .Enter() // Select "No" for localhost URLs (default)
+                .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+                // For Redis prompt, default is "Yes" so we need to select "No" by pressing Down
+                .Key(Hex1b.Input.Hex1bKey.DownArrow)
+                .Enter() // Select "No" for Redis Cache
+                .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+                .Enter() // Select "No" for test project (default)
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+
+            // Step 4: Navigate to project directory
+            output.WriteLine("Step 4: Navigating to project directory...");
+            sequenceBuilder
+                .Type($"cd {projectName}")
+                .Enter()
+                .WaitForSuccessPrompt(counter);
+
+            // Step 5: Add Aspire.Hosting.Azure.AppContainers package
+            output.WriteLine("Step 5: Adding Azure Container Apps hosting package...");
+            sequenceBuilder.Type("aspire add Aspire.Hosting.Azure.AppContainers")
+                .Enter();
+
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                sequenceBuilder
+                    .WaitUntil(s => waitingForAddVersionSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
+                    .Enter();
+            }
+
+            sequenceBuilder.WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(180));
+
+            // Step 6: Add Aspire.Hosting.Azure.ContainerRegistry package
+            output.WriteLine("Step 6: Adding Azure Container Registry hosting package...");
+            sequenceBuilder.Type("aspire add Aspire.Hosting.Azure.ContainerRegistry")
+                .Enter();
+
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                sequenceBuilder
+                    .WaitUntil(s => waitingForAddVersionSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
+                    .Enter();
+            }
+
+            sequenceBuilder.WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(180));
+
+            // Step 7: Modify AppHost.cs to add custom ACR and ACA environment
+            sequenceBuilder.ExecuteCallback(() =>
+            {
+                var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+                var appHostDir = Path.Combine(projectDir, $"{projectName}.AppHost");
+                var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
+
+                output.WriteLine($"Looking for AppHost.cs at: {appHostFilePath}");
+
+                var content = File.ReadAllText(appHostFilePath);
+
+                var buildRunPattern = "builder.Build().Run();";
+                var replacement = """
+// Add custom Azure Container Registry and Container App Environment
+var acr = builder.AddAzureContainerRegistry("myacr");
+builder.AddAzureContainerAppEnvironment("infra").WithAzureContainerRegistry(acr);
+
+builder.Build().Run();
+""";
+
+                content = content.Replace(buildRunPattern, replacement);
+                File.WriteAllText(appHostFilePath, content);
+
+                output.WriteLine($"Modified AppHost.cs at: {appHostFilePath}");
+            });
+
+            // Step 8: Navigate to AppHost project directory
+            output.WriteLine("Step 8: Navigating to AppHost directory...");
+            sequenceBuilder
+                .Type($"cd {projectName}.AppHost")
+                .Enter()
+                .WaitForSuccessPrompt(counter);
+
+            // Step 9: Set environment variables for deployment
+            sequenceBuilder.Type($"unset ASPIRE_PLAYGROUND && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}")
+                .Enter()
+                .WaitForSuccessPrompt(counter);
+
+            // Step 10: Deploy to Azure Container Apps using aspire deploy
+            output.WriteLine("Step 10: Starting Azure Container Apps deployment...");
+            sequenceBuilder
+                .Type("aspire deploy --clear-cache")
+                .Enter()
+                .WaitUntil(s => waitingForPipelineSucceeded.Search(s).Count > 0, TimeSpan.FromMinutes(30))
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
+
+            // Step 11: Extract deployment URLs and verify endpoints with retry
+            output.WriteLine("Step 11: Verifying deployed endpoints...");
+            sequenceBuilder
+                .Type($"RG_NAME=\"{resourceGroupName}\" && " +
+                      "echo \"Resource group: $RG_NAME\" && " +
+                      "if ! az group show -n \"$RG_NAME\" &>/dev/null; then echo \"❌ Resource group not found\"; exit 1; fi && " +
+                      // Get external endpoints only (exclude .internal. which are not publicly accessible)
+                      "urls=$(az containerapp list -g \"$RG_NAME\" --query \"[].properties.configuration.ingress.fqdn\" -o tsv 2>/dev/null | grep -v '\\.internal\\.') && " +
+                      "if [ -z \"$urls\" ]; then echo \"❌ No external container app endpoints found\"; exit 1; fi && " +
+                      "failed=0 && " +
+                      "for url in $urls; do " +
+                      "echo \"Checking https://$url...\"; " +
+                      "success=0; " +
+                      "for i in $(seq 1 18); do " +
+                      "STATUS=$(curl -s -o /dev/null -w \"%{http_code}\" \"https://$url\" --max-time 10 2>/dev/null); " +
+                      "if [ \"$STATUS\" = \"200\" ] || [ \"$STATUS\" = \"302\" ]; then echo \"  ✅ $STATUS (attempt $i)\"; success=1; break; fi; " +
+                      "echo \"  Attempt $i: $STATUS, retrying in 10s...\"; sleep 10; " +
+                      "done; " +
+                      "if [ \"$success\" -eq 0 ]; then echo \"  ❌ Failed after 18 attempts\"; failed=1; fi; " +
+                      "done && " +
+                      "if [ \"$failed\" -ne 0 ]; then echo \"❌ One or more endpoint checks failed\"; exit 1; fi")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+
+            // Step 12: Verify custom ACR was created
+            output.WriteLine("Step 12: Verifying custom ACR was created...");
+            sequenceBuilder
+                .Type($"az acr list -g \"{resourceGroupName}\" --query \"[].name\" -o tsv")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
+
+            // Step 13: Exit terminal
+            sequenceBuilder
+                .Type("exit")
+                .Enter();
+
+            var sequence = sequenceBuilder.Build();
+            await sequence.ApplyAsync(terminal, cancellationToken);
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"Deployment completed in {duration}");
+
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployStarterTemplateWithCustomRegistry),
+                resourceGroupName,
+                deploymentUrls,
+                duration);
+
+            output.WriteLine("✅ Test passed!");
+        }
+        catch (Exception ex)
+        {
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"❌ Test failed after {duration}: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployStarterTemplateWithCustomRegistry),
+                resourceGroupName,
+                ex.Message,
+                ex.StackTrace);
+
+            throw;
+        }
+        finally
+        {
+            output.WriteLine($"Triggering cleanup of resource group: {resourceGroupName}");
+            TriggerCleanupResourceGroup(resourceGroupName, output);
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Cleanup triggered (fire-and-forget)");
+        }
+    }
+
+    /// <summary>
+    /// Triggers cleanup of a specific resource group.
+    /// This is fire-and-forget - the hourly cleanup workflow handles any missed resources.
+    /// </summary>
+    private static void TriggerCleanupResourceGroup(string resourceGroupName, ITestOutputHelper output)
+    {
+        var process = new System.Diagnostics.Process
+        {
+            StartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "az",
+                Arguments = $"group delete --name {resourceGroupName} --yes --no-wait",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        try
+        {
+            process.Start();
+            output.WriteLine($"Cleanup triggered for resource group: {resourceGroupName}");
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Failed to trigger cleanup: {ex.Message}");
+        }
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaExistingRegistryDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaExistingRegistryDeploymentTests.cs
@@ -1,0 +1,352 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Tests.Utils;
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Hex1b;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests for deploying Aspire applications to Azure Container Apps
+/// using a pre-existing Azure Container Registry referenced via AsExisting.
+/// </summary>
+public sealed class AcaExistingRegistryDeploymentTests(ITestOutputHelper output)
+{
+    // Timeout set to 40 minutes to allow for ACR pre-creation and Azure provisioning.
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(40);
+
+    [Fact]
+    public async Task DeployStarterTemplateWithExistingRegistry()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+        var cancellationToken = linkedCts.Token;
+
+        await DeployStarterTemplateWithExistingRegistryCore(cancellationToken);
+    }
+
+    private async Task DeployStarterTemplateWithExistingRegistryCore(CancellationToken cancellationToken)
+    {
+        // Validate prerequisites
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var recordingPath = DeploymentE2ETestHelpers.GetTestResultsRecordingPath(nameof(DeployStarterTemplateWithExistingRegistry));
+        var startTime = DateTime.UtcNow;
+        var deploymentUrls = new Dictionary<string, string>();
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("aca-existing-acr");
+        var projectName = "AcaExistingAcr";
+
+        // ACR names must be alphanumeric only, 5-50 chars, globally unique
+        var runId = DeploymentE2ETestHelpers.GetRunId();
+        var attempt = DeploymentE2ETestHelpers.GetRunAttempt();
+        var acrName = $"e2eexistingacr{runId}{attempt}";
+        // Truncate to 50 chars max (ACR name limit)
+        if (acrName.Length > 50)
+        {
+            acrName = acrName[..50];
+        }
+
+        output.WriteLine($"Test: {nameof(DeployStarterTemplateWithExistingRegistry)}");
+        output.WriteLine($"Project Name: {projectName}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"Pre-created ACR Name: {acrName}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            var builder = Hex1bTerminal.CreateBuilder()
+                .WithHeadless()
+                .WithDimensions(160, 48)
+                .WithAsciinemaRecording(recordingPath)
+                .WithPtyProcess("/bin/bash", ["--norc"]);
+
+            using var terminal = builder.Build();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            // Pattern searchers for aspire new interactive prompts
+            var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
+                .FindPattern("> Starter App");
+
+            var waitingForProjectNamePrompt = new CellPatternSearcher()
+                .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
+
+            var waitingForOutputPathPrompt = new CellPatternSearcher()
+                .Find("Enter the output path:");
+
+            var waitingForUrlsPrompt = new CellPatternSearcher()
+                .Find("Use *.dev.localhost URLs");
+
+            var waitingForRedisPrompt = new CellPatternSearcher()
+                .Find("Use Redis Cache");
+
+            var waitingForTestPrompt = new CellPatternSearcher()
+                .Find("Do you want to create a test project?");
+
+            // Pattern searchers for aspire add prompts
+            var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
+                .Find("(based on NuGet.config)");
+
+            // Pattern searcher for deployment success
+            var waitingForPipelineSucceeded = new CellPatternSearcher()
+                .Find("PIPELINE SUCCEEDED");
+
+            var counter = new SequenceCounter();
+            var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+            // Step 1: Prepare environment
+            output.WriteLine("Step 1: Preparing environment...");
+            sequenceBuilder.PrepareEnvironment(workspace, counter);
+
+            // Step 2: Set up CLI environment (in CI)
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                output.WriteLine("Step 2: Using pre-installed Aspire CLI from local build...");
+                sequenceBuilder.SourceAspireCliEnvironment(counter);
+            }
+
+            // Step 3: Pre-create resource group and ACR via az CLI
+            output.WriteLine("Step 3: Pre-creating resource group and ACR...");
+            sequenceBuilder
+                .Type($"az group create --name {resourceGroupName} --location westus3 -o none")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(60));
+
+            sequenceBuilder
+                .Type($"az acr create --name {acrName} --resource-group {resourceGroupName} --sku Basic --admin-enabled false -o none")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(3));
+
+            output.WriteLine($"Pre-created ACR: {acrName} in resource group: {resourceGroupName}");
+
+            // Step 4: Create starter project using aspire new with interactive prompts
+            output.WriteLine("Step 4: Creating starter project...");
+            sequenceBuilder.Type("aspire new")
+                .Enter()
+                .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
+                .Enter() // Select first template (Starter App ASP.NET Core/Blazor)
+                .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+                .Type(projectName)
+                .Enter()
+                .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+                .Enter() // Accept default output path
+                .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+                .Enter() // Select "No" for localhost URLs (default)
+                .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+                // For Redis prompt, default is "Yes" so we need to select "No" by pressing Down
+                .Key(Hex1b.Input.Hex1bKey.DownArrow)
+                .Enter() // Select "No" for Redis Cache
+                .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+                .Enter() // Select "No" for test project (default)
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+
+            // Step 5: Navigate to project directory
+            output.WriteLine("Step 5: Navigating to project directory...");
+            sequenceBuilder
+                .Type($"cd {projectName}")
+                .Enter()
+                .WaitForSuccessPrompt(counter);
+
+            // Step 6: Add Aspire.Hosting.Azure.AppContainers package
+            output.WriteLine("Step 6: Adding Azure Container Apps hosting package...");
+            sequenceBuilder.Type("aspire add Aspire.Hosting.Azure.AppContainers")
+                .Enter();
+
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                sequenceBuilder
+                    .WaitUntil(s => waitingForAddVersionSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
+                    .Enter();
+            }
+
+            sequenceBuilder.WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(180));
+
+            // Step 7: Add Aspire.Hosting.Azure.ContainerRegistry package
+            output.WriteLine("Step 7: Adding Azure Container Registry hosting package...");
+            sequenceBuilder.Type("aspire add Aspire.Hosting.Azure.ContainerRegistry")
+                .Enter();
+
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                sequenceBuilder
+                    .WaitUntil(s => waitingForAddVersionSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
+                    .Enter();
+            }
+
+            sequenceBuilder.WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(180));
+
+            // Step 8: Modify AppHost.cs to reference the existing ACR
+            sequenceBuilder.ExecuteCallback(() =>
+            {
+                var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+                var appHostDir = Path.Combine(projectDir, $"{projectName}.AppHost");
+                var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
+
+                output.WriteLine($"Looking for AppHost.cs at: {appHostFilePath}");
+
+                var content = File.ReadAllText(appHostFilePath);
+
+                var buildRunPattern = "builder.Build().Run();";
+                var replacement = """
+// Reference existing Azure Container Registry via parameters
+var acrName = builder.AddParameter("acrName");
+var acrResourceGroup = builder.AddParameter("acrResourceGroup");
+var acr = builder.AddAzureContainerRegistry("existingacr").AsExisting(acrName, acrResourceGroup);
+builder.AddAzureContainerAppEnvironment("infra").WithAzureContainerRegistry(acr);
+
+builder.Build().Run();
+""";
+
+                content = content.Replace(buildRunPattern, replacement);
+                File.WriteAllText(appHostFilePath, content);
+
+                output.WriteLine($"Modified AppHost.cs at: {appHostFilePath}");
+            });
+
+            // Step 9: Navigate to AppHost project directory
+            output.WriteLine("Step 9: Navigating to AppHost directory...");
+            sequenceBuilder
+                .Type($"cd {projectName}.AppHost")
+                .Enter()
+                .WaitForSuccessPrompt(counter);
+
+            // Step 10: Set environment variables for deployment including ACR parameters
+            sequenceBuilder.Type(
+                    $"unset ASPIRE_PLAYGROUND && " +
+                    $"export AZURE__LOCATION=westus3 && " +
+                    $"export AZURE__RESOURCEGROUP={resourceGroupName} && " +
+                    $"export Parameters__acrName={acrName} && " +
+                    $"export Parameters__acrResourceGroup={resourceGroupName}")
+                .Enter()
+                .WaitForSuccessPrompt(counter);
+
+            // Step 11: Deploy to Azure Container Apps using aspire deploy
+            output.WriteLine("Step 11: Starting Azure Container Apps deployment...");
+            sequenceBuilder
+                .Type("aspire deploy --clear-cache")
+                .Enter()
+                .WaitUntil(s => waitingForPipelineSucceeded.Search(s).Count > 0, TimeSpan.FromMinutes(30))
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
+
+            // Step 12: Extract deployment URLs and verify endpoints with retry
+            output.WriteLine("Step 12: Verifying deployed endpoints...");
+            sequenceBuilder
+                .Type($"RG_NAME=\"{resourceGroupName}\" && " +
+                      "echo \"Resource group: $RG_NAME\" && " +
+                      "if ! az group show -n \"$RG_NAME\" &>/dev/null; then echo \"❌ Resource group not found\"; exit 1; fi && " +
+                      "urls=$(az containerapp list -g \"$RG_NAME\" --query \"[].properties.configuration.ingress.fqdn\" -o tsv 2>/dev/null | grep -v '\\.internal\\.') && " +
+                      "if [ -z \"$urls\" ]; then echo \"❌ No external container app endpoints found\"; exit 1; fi && " +
+                      "failed=0 && " +
+                      "for url in $urls; do " +
+                      "echo \"Checking https://$url...\"; " +
+                      "success=0; " +
+                      "for i in $(seq 1 18); do " +
+                      "STATUS=$(curl -s -o /dev/null -w \"%{http_code}\" \"https://$url\" --max-time 10 2>/dev/null); " +
+                      "if [ \"$STATUS\" = \"200\" ] || [ \"$STATUS\" = \"302\" ]; then echo \"  ✅ $STATUS (attempt $i)\"; success=1; break; fi; " +
+                      "echo \"  Attempt $i: $STATUS, retrying in 10s...\"; sleep 10; " +
+                      "done; " +
+                      "if [ \"$success\" -eq 0 ]; then echo \"  ❌ Failed after 18 attempts\"; failed=1; fi; " +
+                      "done && " +
+                      "if [ \"$failed\" -ne 0 ]; then echo \"❌ One or more endpoint checks failed\"; exit 1; fi")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+
+            // Step 13: Verify the pre-existing ACR is still present
+            output.WriteLine("Step 13: Verifying pre-existing ACR...");
+            sequenceBuilder
+                .Type($"az acr show --name {acrName} --resource-group {resourceGroupName} --query name -o tsv")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
+
+            // Step 14: Exit terminal
+            sequenceBuilder
+                .Type("exit")
+                .Enter();
+
+            var sequence = sequenceBuilder.Build();
+            await sequence.ApplyAsync(terminal, cancellationToken);
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"Deployment completed in {duration}");
+
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployStarterTemplateWithExistingRegistry),
+                resourceGroupName,
+                deploymentUrls,
+                duration);
+
+            output.WriteLine("✅ Test passed!");
+        }
+        catch (Exception ex)
+        {
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"❌ Test failed after {duration}: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployStarterTemplateWithExistingRegistry),
+                resourceGroupName,
+                ex.Message,
+                ex.StackTrace);
+
+            throw;
+        }
+        finally
+        {
+            output.WriteLine($"Triggering cleanup of resource group: {resourceGroupName}");
+            TriggerCleanupResourceGroup(resourceGroupName, output);
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Cleanup triggered (fire-and-forget)");
+        }
+    }
+
+    /// <summary>
+    /// Triggers cleanup of a specific resource group.
+    /// This is fire-and-forget - the hourly cleanup workflow handles any missed resources.
+    /// </summary>
+    private static void TriggerCleanupResourceGroup(string resourceGroupName, ITestOutputHelper output)
+    {
+        var process = new System.Diagnostics.Process
+        {
+            StartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "az",
+                Arguments = $"group delete --name {resourceGroupName} --yes --no-wait",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        try
+        {
+            process.Start();
+            output.WriteLine($"Cleanup triggered for resource group: {resourceGroupName}");
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Failed to trigger cleanup: {ex.Message}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add two new deployment E2E tests that validate Azure Container Apps deployments with explicit Azure Container Registry configuration.

### New Tests

**AcaCustomRegistryDeploymentTests** — Tests deploying a starter app to ACA using `AddAzureContainerRegistry` + `WithAzureContainerRegistry` to create and attach a custom registry, instead of relying on the default ACR created by `AddAzureContainerAppEnvironment`.

**AcaExistingRegistryDeploymentTests** — Tests deploying a starter app to ACA using a pre-existing ACR. The test pre-creates an ACR via `az acr create`, then references it in the AppHost via `AsExisting()` with parameters passed through environment variables.

### Test Flow
Both tests follow the established `AcaStarterDeploymentTests` pattern:
1. Create a starter project via `aspire new`
2. Add `Aspire.Hosting.Azure.AppContainers` and `Aspire.Hosting.Azure.ContainerRegistry` packages
3. Inject AppHost code to wire up the ACR and ACA environment
4. Deploy via `aspire deploy --clear-cache`
5. Verify endpoints return 200/302
6. Verify ACR was created/exists
7. Cleanup resource group

### Key APIs Exercised
- `AddAzureContainerRegistry("myacr")` — custom registry creation
- `WithAzureContainerRegistry(acr)` — attach registry to ACA environment
- `AsExisting(nameParam, rgParam)` — reference pre-existing ACR