### PR TITLE
Add backchannel log replay for TUI support

### DIFF
--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -989,6 +989,16 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
     #endregion
 
     /// <summary>
+    /// Streams AppHost log entries from the hosting process.
+    /// Delegates to <see cref="AppHostRpcTarget.GetAppHostLogEntriesAsync"/>.
+    /// </summary>
+    public IAsyncEnumerable<BackchannelLogEntry> GetAppHostLogEntriesAsync(CancellationToken cancellationToken = default)
+    {
+        var rpcTarget = serviceProvider.GetRequiredService<AppHostRpcTarget>();
+        return rpcTarget.GetAppHostLogEntriesAsync(cancellationToken);
+    }
+
+    /// <summary>
     /// Converts a JsonElement to its underlying CLR type for proper serialization.
     /// </summary>
     private static object? ConvertJsonElementToObject(JsonElement element)

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -188,7 +188,8 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
         _innerBuilder.Services.AddSingleton(TimeProvider.System);
 
-        _innerBuilder.Services.AddSingleton<ILoggerProvider, BackchannelLoggerProvider>();
+        _innerBuilder.Services.AddSingleton<BackchannelLoggerProvider>();
+        _innerBuilder.Services.AddSingleton<ILoggerProvider>(sp => sp.GetRequiredService<BackchannelLoggerProvider>());
         _innerBuilder.Logging.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.Warning);
         _innerBuilder.Logging.AddFilter("Microsoft.AspNetCore.Server.Kestrel", LogLevel.Error);
         _innerBuilder.Logging.AddFilter("Aspire.Hosting.Dashboard", LogLevel.Error);

--- a/tests/Aspire.Hosting.Tests/Backchannel/BackchannelLoggerProviderTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/BackchannelLoggerProviderTests.cs
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.Backchannel;
+
+public class BackchannelLoggerProviderTests
+{
+    [Fact]
+    public void Subscribe_ReturnsBufferedEntries()
+    {
+        using var provider = new BackchannelLoggerProvider();
+
+        var logger = provider.CreateLogger("TestCategory");
+        logger.LogInformation("Message 1");
+        logger.LogWarning("Message 2");
+        logger.LogError("Message 3");
+
+        var (snapshot, subscriberId, _) = provider.Subscribe();
+        provider.Unsubscribe(subscriberId);
+
+        Assert.Equal(3, snapshot.Count);
+        Assert.Equal("Message 1", snapshot[0].Message);
+        Assert.Equal("Message 2", snapshot[1].Message);
+        Assert.Equal("Message 3", snapshot[2].Message);
+        Assert.Equal("TestCategory", snapshot[0].CategoryName);
+        Assert.Equal(LogLevel.Information, snapshot[0].LogLevel);
+        Assert.Equal(LogLevel.Warning, snapshot[1].LogLevel);
+        Assert.Equal(LogLevel.Error, snapshot[2].LogLevel);
+    }
+
+    [Fact]
+    public void ReplayBuffer_EvictsOldestWhenFull()
+    {
+        using var provider = new BackchannelLoggerProvider();
+
+        var logger = provider.CreateLogger("TestCategory");
+
+        // Write 1001 entries — the first should be evicted
+        for (var i = 0; i < 1001; i++)
+        {
+            logger.LogInformation("Message {Index}", i);
+        }
+
+        var (snapshot, subscriberId, _) = provider.Subscribe();
+        provider.Unsubscribe(subscriberId);
+
+        Assert.Equal(1000, snapshot.Count);
+        // First entry should be "Message 1" (index 0 was evicted)
+        Assert.Equal("Message 1", snapshot[0].Message);
+        Assert.Equal("Message 1000", snapshot[999].Message);
+    }
+
+    [Fact]
+    public void Subscribe_ReturnsIndependentSnapshot()
+    {
+        using var provider = new BackchannelLoggerProvider();
+
+        var logger = provider.CreateLogger("TestCategory");
+        logger.LogInformation("Before snapshot");
+
+        var (snapshot1, sub1, _) = provider.Subscribe();
+        provider.Unsubscribe(sub1);
+
+        logger.LogInformation("After snapshot");
+
+        var (snapshot2, sub2, _) = provider.Subscribe();
+        provider.Unsubscribe(sub2);
+
+        // First snapshot should not be affected by subsequent writes
+        Assert.Single(snapshot1);
+        Assert.Equal(2, snapshot2.Count);
+    }
+
+    [Fact]
+    public async Task ConcurrentSubscribers_ReceiveSameEntries()
+    {
+        using var provider = new BackchannelLoggerProvider();
+
+        var logger = provider.CreateLogger("TestCategory");
+        logger.LogInformation("Historical");
+
+        // Two subscribers connect concurrently
+        var (snapshot1, sub1, channel1) = provider.Subscribe();
+        var (snapshot2, sub2, channel2) = provider.Subscribe();
+
+        // Both see the historical entry
+        Assert.Single(snapshot1);
+        Assert.Single(snapshot2);
+
+        // New entries arrive after both subscribe
+        logger.LogInformation("Live 1");
+        logger.LogInformation("Live 2");
+
+        // Both subscribers receive both live entries
+        Assert.True(channel1.Reader.TryRead(out var entry1a));
+        Assert.Equal("Live 1", entry1a!.Message);
+        Assert.True(channel1.Reader.TryRead(out var entry1b));
+        Assert.Equal("Live 2", entry1b!.Message);
+
+        Assert.True(channel2.Reader.TryRead(out var entry2a));
+        Assert.Equal("Live 1", entry2a!.Message);
+        Assert.True(channel2.Reader.TryRead(out var entry2b));
+        Assert.Equal("Live 2", entry2b!.Message);
+
+        provider.Unsubscribe(sub1);
+        provider.Unsubscribe(sub2);
+
+        // Channels are completed after unsubscribe
+        await channel1.Reader.Completion;
+        await channel2.Reader.Completion;
+    }
+}


### PR DESCRIPTION
## Summary

Adds server-side backchannel plumbing to support a rich TUI monitor experience in 13.3. These changes are purely additive — they add new RPC methods and enhance the log streaming infrastructure so that AppHosts built with 13.2 already expose the APIs the TUI will consume.

## Changes

### BackchannelLoggerProvider (enhanced)
- Added circular replay buffer (1000 entries) so late-connecting clients see log history
- Added pub-sub subscriber model: `Subscribe()` atomically returns a snapshot of buffered entries plus a per-subscriber channel for live entries
- Multiple concurrent TUI clients can connect without entry loss or draining — each gets an independent snapshot and live stream
- `Dispose()` uses `TryComplete()` to handle the DI forwarding double-disposal pattern

### AppHostRpcTarget (new method)
- Added `GetAppHostLogEntriesAsync()` — replays buffered entries then streams live entries via per-subscriber channel
- Uses `Subscribe()`/`Unsubscribe()` lifecycle with proper cleanup in `finally` block
- Linked cancellation token respects both client disconnect and AppHost shutdown

### AuxiliaryBackchannelRpcTarget (new method)
- Added `GetAppHostLogEntriesAsync()` delegate that forwards to `AppHostRpcTarget`
- Enables auxiliary backchannel clients (CLI/TUI) to access log streaming

### DistributedApplicationBuilder (DI registration)
- Changed from `AddSingleton<ILoggerProvider, BackchannelLoggerProvider>()` to forwarding pattern
- Enables `AppHostRpcTarget` to resolve `BackchannelLoggerProvider` directly for subscriber management

### Tests (new file)
- 4 new tests: replay buffer fill, eviction at 1000 capacity, snapshot isolation, concurrent subscriber fan-out

## Risk Assessment

- **Low risk**: All changes are additive — new methods, enhanced buffer, new subscriber model
- **Backward compatible**: Existing backchannel contracts unchanged; new methods are simply unused until a TUI client connects
- **No breaking changes**: The DI forwarding pattern preserves existing `ILoggerProvider` resolution

## 5 files changed, +193 / -57 lines