### PR TITLE
Update Hex1b packages from 0.78.0 to 0.87.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -98,9 +98,9 @@
     <PackageVersion Include="Grpc.AspNetCore" Version="2.71.0" />
     <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.71.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.72.0" />
-    <PackageVersion Include="Hex1b" Version="0.78.0" />
-    <PackageVersion Include="Hex1b.McpServer" Version="0.78.0" />
-    <PackageVersion Include="Hex1b.Tool" Version="0.78.0" />
+    <PackageVersion Include="Hex1b" Version="0.87.0" />
+    <PackageVersion Include="Hex1b.McpServer" Version="0.87.0" />
+    <PackageVersion Include="Hex1b.Tool" Version="0.87.0" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="KubernetesClient" Version="18.0.5" />
     <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />


### PR DESCRIPTION
## Summary

Update the Hex1b package family to the latest stable version (0.87.0):

| Package | Current | New |
|---------|---------|-----|
| Hex1b | 0.78.0 | 0.87.0 |
| Hex1b.McpServer | 0.78.0 | 0.87.0 |
| Hex1b.Tool | 0.78.0 | 0.87.0 |

## Changes

- `Directory.Packages.props`: Updated 3 Hex1b package versions (0.78.0 → 0.87.0)

Build verified locally (including `Aspire.Deployment.EndToEnd.Tests` and `Aspire.Cli.EndToEnd.Tests`).