### PR TITLE
Allow skipping additional options in aspire mcp init

### DIFF
--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -176,7 +176,8 @@ internal class ConsoleInteractionService : IInteractionService
             .Title(promptText)
             .UseConverter(item => choiceFormatter(item).EscapeMarkup())
             .AddChoices(choices)
-            .PageSize(10);
+            .PageSize(10)
+            .Required(false);
 
         var result = await _outConsole.PromptAsync(prompt, cancellationToken);
         return result;


### PR DESCRIPTION
## Summary
- Fixes #14460: `aspire mcp init` multi-select prompt for additional options now allows pressing Enter with nothing selected
- Sets `MultiSelectionPrompt.Required(false)` in `ConsoleInteractionService.PromptForSelectionsAsync()`

## Test plan
- [ ] Run `aspire mcp init` and verify pressing Enter with no additional options selected proceeds without error
- [ ] Run `aspire mcp init` and verify selecting one or more options still works as before