### PR TITLE
Fix permission denied error in Azure Pipelines

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
@@ -165,8 +165,9 @@ public class ProjectResource : Resource, IResourceWithEnvironment, IResourceWith
 
         var projectDir = Path.GetDirectoryName(projectMetadata.ProjectPath)!;
 
-        // Create a unique temporary Dockerfile path for this resource using the directory service
-        // using a file name, so the file is created in a new, empty directory.
+        // Create a unique temporary Dockerfile path for this resource using the directory service.
+        // Passing a file name causes CreateTempFile to create the file in a new, empty subdirectory,
+        // which avoids Docker/buildx scanning the entire temporary directory.
         var directoryService = ctx.Services.GetRequiredService<IFileSystemService>();
         var tempDockerfilePath = directoryService.TempDirectory.CreateTempFile("Dockerfile").Path;
 

--- a/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
@@ -163,10 +163,12 @@ public class ProjectResource : Resource, IResourceWithEnvironment, IResourceWith
         // Add COPY --from: statements for each source
         stage.AddContainerFiles(this, containerWorkingDir, logger);
 
-        // Get the directory service to create temp Dockerfile
         var projectDir = Path.GetDirectoryName(projectMetadata.ProjectPath)!;
+
+        // Create a unique temporary Dockerfile path for this resource using the directory service
+        // using a file name, so the file is created in a new, empty directory.
         var directoryService = ctx.Services.GetRequiredService<IFileSystemService>();
-        var tempDockerfilePath = directoryService.TempDirectory.CreateTempFile().Path;
+        var tempDockerfilePath = directoryService.TempDirectory.CreateTempFile("Dockerfile").Path;
 
         var builtSuccessfully = false;
         try

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -718,8 +718,9 @@ public static class ContainerResourceBuilderExtensions
         var fullyQualifiedContextPath = Path.GetFullPath(contextPath, builder.ApplicationBuilder.AppHostDirectory)
                                            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
-        // Create a unique temporary Dockerfile path for this resource using the directory service
-        // using a file name, so the file is created in a new, empty directory.
+        // Create a unique temporary Dockerfile path for this resource using the directory service.
+        // Passing a file name causes CreateTempFile to create the file in a new, empty subdirectory,
+        // which avoids Docker/buildx scanning the entire temporary directory.
         var directoryService = builder.ApplicationBuilder.FileSystemService;
         var tempDockerfilePath = directoryService.TempDirectory.CreateTempFile("Dockerfile").Path;
 

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -719,8 +719,9 @@ public static class ContainerResourceBuilderExtensions
                                            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
         // Create a unique temporary Dockerfile path for this resource using the directory service
+        // using a file name, so the file is created in a new, empty directory.
         var directoryService = builder.ApplicationBuilder.FileSystemService;
-        var tempDockerfilePath = directoryService.TempDirectory.CreateTempFile().Path;
+        var tempDockerfilePath = directoryService.TempDirectory.CreateTempFile("Dockerfile").Path;
 
         var imageName = ImageNameGenerator.GenerateImageName(builder);
         var imageTag = ImageNameGenerator.GenerateImageTag(builder);


### PR DESCRIPTION
When we generate temporary dockerfiles, we are generating them directly under the TEMP directory. This can cause issues in some environments because docker build will walk all the files and folders next to the dockerfile as context to the build. For example, in AzDO pipelines, we can get an error like "ERROR: error from sender: lstat /tmp/.mount_azsec-KdAJKO: permission denied".

To fix this, we generate the Dockerfile in a subdirectory of TEMP, so it is the only file passed as context to docker build.

Fix #14523