### PR TITLE
Handle malformed MCP JSON config files gracefully

### DIFF
--- a/src/Aspire.Cli/Agents/ClaudeCode/ClaudeCodeAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/ClaudeCode/ClaudeCodeAgentEnvironmentScanner.cs
@@ -179,34 +179,7 @@ internal sealed class ClaudeCodeAgentEnvironmentScanner : IAgentEnvironmentScann
     private static bool HasAspireServerConfigured(DirectoryInfo repoRoot)
     {
         var configFilePath = Path.Combine(repoRoot.FullName, McpConfigFileName);
-
-        if (!File.Exists(configFilePath))
-        {
-            return false;
-        }
-
-        try
-        {
-            var content = File.ReadAllText(configFilePath);
-            var config = JsonNode.Parse(content)?.AsObject();
-
-            if (config is null)
-            {
-                return false;
-            }
-
-            if (config.TryGetPropertyValue("mcpServers", out var serversNode) && serversNode is JsonObject servers)
-            {
-                return servers.ContainsKey(AspireServerName);
-            }
-
-            return false;
-        }
-        catch (JsonException)
-        {
-            // If the JSON is malformed, assume aspire is not configured
-            return false;
-        }
+        return McpConfigFileHelper.HasServerConfigured(configFilePath, "mcpServers", AspireServerName);
     }
 
     /// <summary>
@@ -215,32 +188,7 @@ internal sealed class ClaudeCodeAgentEnvironmentScanner : IAgentEnvironmentScann
     private static bool HasPlaywrightServerConfigured(DirectoryInfo repoRoot)
     {
         var configFilePath = Path.Combine(repoRoot.FullName, McpConfigFileName);
-        
-        if (!File.Exists(configFilePath))
-        {
-            return false;
-        }
-
-        try
-        {
-            var content = File.ReadAllText(configFilePath);
-            var config = JsonNode.Parse(content)?.AsObject();
-            if (config is null)
-            {
-                return false;
-            }
-
-            if (config.TryGetPropertyValue("mcpServers", out var serversNode) && serversNode is JsonObject servers)
-            {
-                return servers.ContainsKey("playwright");
-            }
-
-            return false;
-        }
-        catch (JsonException)
-        {
-            return false;
-        }
+        return McpConfigFileHelper.HasServerConfigured(configFilePath, "mcpServers", "playwright");
     }
 
     /// <summary>
@@ -261,25 +209,7 @@ internal sealed class ClaudeCodeAgentEnvironmentScanner : IAgentEnvironmentScann
         CancellationToken cancellationToken)
     {
         var configFilePath = Path.Combine(repoRoot.FullName, McpConfigFileName);
-        JsonObject config;
-
-        // Read existing config or create new
-        if (File.Exists(configFilePath))
-        {
-            var existingContent = await File.ReadAllTextAsync(configFilePath, cancellationToken);
-            try
-            {
-                config = JsonNode.Parse(existingContent)?.AsObject() ?? new JsonObject();
-            }
-            catch (JsonException ex)
-            {
-                throw new InvalidOperationException(string.Format(System.Globalization.CultureInfo.CurrentCulture, AgentCommandStrings.MalformedConfigFileError, configFilePath), ex);
-            }
-        }
-        else
-        {
-            config = new JsonObject();
-        }
+        var config = await McpConfigFileHelper.ReadConfigAsync(configFilePath, cancellationToken);
 
         // Ensure "mcpServers" object exists
         if (!config.ContainsKey("mcpServers") || config["mcpServers"] is not JsonObject)
@@ -309,25 +239,7 @@ internal sealed class ClaudeCodeAgentEnvironmentScanner : IAgentEnvironmentScann
         CancellationToken cancellationToken)
     {
         var configFilePath = Path.Combine(repoRoot.FullName, McpConfigFileName);
-        JsonObject config;
-
-        // Read existing config or create new
-        if (File.Exists(configFilePath))
-        {
-            var existingContent = await File.ReadAllTextAsync(configFilePath, cancellationToken);
-            try
-            {
-                config = JsonNode.Parse(existingContent)?.AsObject() ?? new JsonObject();
-            }
-            catch (JsonException ex)
-            {
-                throw new InvalidOperationException(string.Format(System.Globalization.CultureInfo.CurrentCulture, AgentCommandStrings.MalformedConfigFileError, configFilePath), ex);
-            }
-        }
-        else
-        {
-            config = new JsonObject();
-        }
+        var config = await McpConfigFileHelper.ReadConfigAsync(configFilePath, cancellationToken);
 
         // Ensure "mcpServers" object exists
         if (!config.ContainsKey("mcpServers") || config["mcpServers"] is not JsonObject)

--- a/src/Aspire.Cli/Agents/ClaudeCode/ClaudeCodeAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/ClaudeCode/ClaudeCodeAgentEnvironmentScanner.cs
@@ -267,7 +267,14 @@ internal sealed class ClaudeCodeAgentEnvironmentScanner : IAgentEnvironmentScann
         if (File.Exists(configFilePath))
         {
             var existingContent = await File.ReadAllTextAsync(configFilePath, cancellationToken);
-            config = JsonNode.Parse(existingContent)?.AsObject() ?? new JsonObject();
+            try
+            {
+                config = JsonNode.Parse(existingContent)?.AsObject() ?? new JsonObject();
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException(string.Format(System.Globalization.CultureInfo.CurrentCulture, AgentCommandStrings.MalformedConfigFileError, configFilePath), ex);
+            }
         }
         else
         {
@@ -308,7 +315,14 @@ internal sealed class ClaudeCodeAgentEnvironmentScanner : IAgentEnvironmentScann
         if (File.Exists(configFilePath))
         {
             var existingContent = await File.ReadAllTextAsync(configFilePath, cancellationToken);
-            config = JsonNode.Parse(existingContent)?.AsObject() ?? new JsonObject();
+            try
+            {
+                config = JsonNode.Parse(existingContent)?.AsObject() ?? new JsonObject();
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException(string.Format(System.Globalization.CultureInfo.CurrentCulture, AgentCommandStrings.MalformedConfigFileError, configFilePath), ex);
+            }
         }
         else
         {

--- a/src/Aspire.Cli/Agents/CopilotCli/CopilotCliAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/CopilotCli/CopilotCliAgentEnvironmentScanner.cs
@@ -162,34 +162,7 @@ internal sealed class CopilotCliAgentEnvironmentScanner : IAgentEnvironmentScann
     private static bool HasAspireServerConfigured(DirectoryInfo homeDirectory)
     {
         var configFilePath = GetMcpConfigFilePath(homeDirectory);
-
-        if (!File.Exists(configFilePath))
-        {
-            return false;
-        }
-
-        try
-        {
-            var content = File.ReadAllText(configFilePath);
-            var config = JsonNode.Parse(content)?.AsObject();
-
-            if (config is null)
-            {
-                return false;
-            }
-
-            if (config.TryGetPropertyValue("mcpServers", out var serversNode) && serversNode is JsonObject servers)
-            {
-                return servers.ContainsKey(AspireServerName);
-            }
-
-            return false;
-        }
-        catch (JsonException)
-        {
-            // If the JSON is malformed, assume aspire is not configured
-            return false;
-        }
+        return McpConfigFileHelper.HasServerConfigured(configFilePath, "mcpServers", AspireServerName);
     }
 
     /// <summary>
@@ -223,25 +196,7 @@ internal sealed class CopilotCliAgentEnvironmentScanner : IAgentEnvironmentScann
             Directory.CreateDirectory(configDirectory);
         }
 
-        JsonObject config;
-
-        // Read existing config or create new
-        if (File.Exists(configFilePath))
-        {
-            var existingContent = await File.ReadAllTextAsync(configFilePath, cancellationToken);
-            try
-            {
-                config = JsonNode.Parse(existingContent)?.AsObject() ?? new JsonObject();
-            }
-            catch (JsonException ex)
-            {
-                throw new InvalidOperationException(string.Format(System.Globalization.CultureInfo.CurrentCulture, AgentCommandStrings.MalformedConfigFileError, configFilePath), ex);
-            }
-        }
-        else
-        {
-            config = new JsonObject();
-        }
+        var config = await McpConfigFileHelper.ReadConfigAsync(configFilePath, cancellationToken);
 
         // Ensure "mcpServers" object exists
         if (!config.ContainsKey("mcpServers") || config["mcpServers"] is not JsonObject)
@@ -285,25 +240,7 @@ internal sealed class CopilotCliAgentEnvironmentScanner : IAgentEnvironmentScann
             Directory.CreateDirectory(configDirectory);
         }
 
-        JsonObject config;
-
-        // Read existing config or create new
-        if (File.Exists(configFilePath))
-        {
-            var existingContent = await File.ReadAllTextAsync(configFilePath, cancellationToken);
-            try
-            {
-                config = JsonNode.Parse(existingContent)?.AsObject() ?? new JsonObject();
-            }
-            catch (JsonException ex)
-            {
-                throw new InvalidOperationException(string.Format(System.Globalization.CultureInfo.CurrentCulture, AgentCommandStrings.MalformedConfigFileError, configFilePath), ex);
-            }
-        }
-        else
-        {
-            config = new JsonObject();
-        }
+        var config = await McpConfigFileHelper.ReadConfigAsync(configFilePath, cancellationToken);
 
         // Ensure "mcpServers" object exists
         if (!config.ContainsKey("mcpServers") || config["mcpServers"] is not JsonObject)
@@ -333,31 +270,6 @@ internal sealed class CopilotCliAgentEnvironmentScanner : IAgentEnvironmentScann
     private static bool HasPlaywrightServerConfigured(DirectoryInfo homeDirectory)
     {
         var configFilePath = GetMcpConfigFilePath(homeDirectory);
-        
-        if (!File.Exists(configFilePath))
-        {
-            return false;
-        }
-
-        try
-        {
-            var content = File.ReadAllText(configFilePath);
-            var config = JsonNode.Parse(content)?.AsObject();
-            if (config is null)
-            {
-                return false;
-            }
-
-            if (config.TryGetPropertyValue("mcpServers", out var serversNode) && serversNode is JsonObject servers)
-            {
-                return servers.ContainsKey("playwright");
-            }
-
-            return false;
-        }
-        catch (JsonException)
-        {
-            return false;
-        }
+        return McpConfigFileHelper.HasServerConfigured(configFilePath, "mcpServers", "playwright");
     }
 }

--- a/src/Aspire.Cli/Agents/CopilotCli/CopilotCliAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/CopilotCli/CopilotCliAgentEnvironmentScanner.cs
@@ -229,7 +229,14 @@ internal sealed class CopilotCliAgentEnvironmentScanner : IAgentEnvironmentScann
         if (File.Exists(configFilePath))
         {
             var existingContent = await File.ReadAllTextAsync(configFilePath, cancellationToken);
-            config = JsonNode.Parse(existingContent)?.AsObject() ?? new JsonObject();
+            try
+            {
+                config = JsonNode.Parse(existingContent)?.AsObject() ?? new JsonObject();
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException(string.Format(System.Globalization.CultureInfo.CurrentCulture, AgentCommandStrings.MalformedConfigFileError, configFilePath), ex);
+            }
         }
         else
         {
@@ -284,7 +291,14 @@ internal sealed class CopilotCliAgentEnvironmentScanner : IAgentEnvironmentScann
         if (File.Exists(configFilePath))
         {
             var existingContent = await File.ReadAllTextAsync(configFilePath, cancellationToken);
-            config = JsonNode.Parse(existingContent)?.AsObject() ?? new JsonObject();
+            try
+            {
+                config = JsonNode.Parse(existingContent)?.AsObject() ?? new JsonObject();
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException(string.Format(System.Globalization.CultureInfo.CurrentCulture, AgentCommandStrings.MalformedConfigFileError, configFilePath), ex);
+            }
         }
         else
         {

--- a/src/Aspire.Cli/Agents/McpConfigFileHelper.cs
+++ b/src/Aspire.Cli/Agents/McpConfigFileHelper.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Aspire.Cli.Resources;
+
+namespace Aspire.Cli.Agents;
+
+/// <summary>
+/// Provides shared methods for reading and parsing MCP configuration files across agent environment scanners.
+/// </summary>
+internal static class McpConfigFileHelper
+{
+    /// <summary>
+    /// Checks if a specific server is configured in an MCP config file under the given container key.
+    /// </summary>
+    /// <param name="configFilePath">The path to the MCP configuration file.</param>
+    /// <param name="serverContainerKey">The JSON property name that holds the servers object (e.g., "servers", "mcpServers", "mcp").</param>
+    /// <param name="serverName">The name of the server to check for.</param>
+    /// <param name="preprocessContent">Optional function to preprocess file content before parsing (e.g., to strip JSONC comments).</param>
+    /// <returns><c>true</c> if the server is configured; <c>false</c> otherwise (including when the file is missing or malformed).</returns>
+    public static bool HasServerConfigured(string configFilePath, string serverContainerKey, string serverName, Func<string, string>? preprocessContent = null)
+    {
+        if (!File.Exists(configFilePath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var content = File.ReadAllText(configFilePath);
+
+            if (preprocessContent is not null)
+            {
+                content = preprocessContent(content);
+            }
+
+            var config = JsonNode.Parse(content)?.AsObject();
+
+            if (config is null)
+            {
+                return false;
+            }
+
+            if (config.TryGetPropertyValue(serverContainerKey, out var serversNode) && serversNode is JsonObject servers)
+            {
+                return servers.ContainsKey(serverName);
+            }
+
+            return false;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Reads an existing MCP config file and parses it into a <see cref="JsonObject"/>, or creates a new one if the file doesn't exist.
+    /// </summary>
+    /// <param name="configFilePath">The path to the MCP configuration file.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <param name="preprocessContent">Optional function to preprocess file content before parsing (e.g., to strip JSONC comments).</param>
+    /// <returns>The parsed <see cref="JsonObject"/> from the file, or a new empty <see cref="JsonObject"/> if the file doesn't exist.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the file exists but contains malformed JSON, wrapping the underlying <see cref="JsonException"/>.</exception>
+    public static async Task<JsonObject> ReadConfigAsync(string configFilePath, CancellationToken cancellationToken, Func<string, string>? preprocessContent = null)
+    {
+        if (!File.Exists(configFilePath))
+        {
+            return new JsonObject();
+        }
+
+        var content = await File.ReadAllTextAsync(configFilePath, cancellationToken);
+
+        if (preprocessContent is not null)
+        {
+            content = preprocessContent(content);
+        }
+
+        try
+        {
+            return JsonNode.Parse(content)?.AsObject() ?? new JsonObject();
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException(
+                string.Format(CultureInfo.CurrentCulture, AgentCommandStrings.MalformedConfigFileError, configFilePath), ex);
+        }
+    }
+}

--- a/src/Aspire.Cli/Agents/OpenCode/OpenCodeAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/OpenCode/OpenCodeAgentEnvironmentScanner.cs
@@ -212,7 +212,14 @@ internal sealed class OpenCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
 
             // Remove comments for parsing
             var jsonContent = RemoveJsonComments(existingContent);
-            config = JsonNode.Parse(jsonContent)?.AsObject() ?? new JsonObject();
+            try
+            {
+                config = JsonNode.Parse(jsonContent)?.AsObject() ?? new JsonObject();
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException(string.Format(System.Globalization.CultureInfo.CurrentCulture, AgentCommandStrings.MalformedConfigFileError, configFilePath), ex);
+            }
         }
         else
         {
@@ -260,7 +267,14 @@ internal sealed class OpenCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
 
             // Remove comments for parsing
             var jsonContent = RemoveJsonComments(existingContent);
-            config = JsonNode.Parse(jsonContent)?.AsObject() ?? new JsonObject();
+            try
+            {
+                config = JsonNode.Parse(jsonContent)?.AsObject() ?? new JsonObject();
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException(string.Format(System.Globalization.CultureInfo.CurrentCulture, AgentCommandStrings.MalformedConfigFileError, configFilePath), ex);
+            }
         }
         else
         {

--- a/src/Aspire.Cli/Agents/VsCode/VsCodeAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/VsCode/VsCodeAgentEnvironmentScanner.cs
@@ -300,7 +300,14 @@ internal sealed class VsCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
         if (File.Exists(mcpConfigPath))
         {
             var existingContent = await File.ReadAllTextAsync(mcpConfigPath, cancellationToken);
-            config = JsonNode.Parse(existingContent)?.AsObject() ?? new JsonObject();
+            try
+            {
+                config = JsonNode.Parse(existingContent)?.AsObject() ?? new JsonObject();
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException(string.Format(System.Globalization.CultureInfo.CurrentCulture, AgentCommandStrings.MalformedConfigFileError, mcpConfigPath), ex);
+            }
         }
         else
         {
@@ -348,7 +355,14 @@ internal sealed class VsCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
         if (File.Exists(mcpConfigPath))
         {
             var existingContent = await File.ReadAllTextAsync(mcpConfigPath, cancellationToken);
-            config = JsonNode.Parse(existingContent)?.AsObject() ?? new JsonObject();
+            try
+            {
+                config = JsonNode.Parse(existingContent)?.AsObject() ?? new JsonObject();
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException(string.Format(System.Globalization.CultureInfo.CurrentCulture, AgentCommandStrings.MalformedConfigFileError, mcpConfigPath), ex);
+            }
         }
         else
         {

--- a/src/Aspire.Cli/Agents/VsCode/VsCodeAgentEnvironmentScanner.cs
+++ b/src/Aspire.Cli/Agents/VsCode/VsCodeAgentEnvironmentScanner.cs
@@ -205,34 +205,7 @@ internal sealed class VsCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
     private static bool HasAspireServerConfigured(DirectoryInfo vsCodeFolder)
     {
         var mcpConfigPath = Path.Combine(vsCodeFolder.FullName, McpConfigFileName);
-
-        if (!File.Exists(mcpConfigPath))
-        {
-            return false;
-        }
-
-        try
-        {
-            var content = File.ReadAllText(mcpConfigPath);
-            var config = JsonNode.Parse(content)?.AsObject();
-
-            if (config is null)
-            {
-                return false;
-            }
-
-            if (config.TryGetPropertyValue("servers", out var serversNode) && serversNode is JsonObject servers)
-            {
-                return servers.ContainsKey(AspireServerName);
-            }
-
-            return false;
-        }
-        catch (JsonException)
-        {
-            // If the JSON is malformed, assume aspire is not configured
-            return false;
-        }
+        return McpConfigFileHelper.HasServerConfigured(mcpConfigPath, "servers", AspireServerName);
     }
 
     /// <summary>
@@ -241,33 +214,7 @@ internal sealed class VsCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
     private static bool HasPlaywrightServerConfigured(DirectoryInfo vsCodeFolder)
     {
         var mcpConfigPath = Path.Combine(vsCodeFolder.FullName, McpConfigFileName);
-        
-        if (!File.Exists(mcpConfigPath))
-        {
-            return false;
-        }
-
-        try
-        {
-            var content = File.ReadAllText(mcpConfigPath);
-            var config = JsonNode.Parse(content)?.AsObject();
-            if (config is null)
-            {
-                return false;
-            }
-
-            if (config.TryGetPropertyValue("servers", out var serversNode) && serversNode is JsonObject servers)
-            {
-                return servers.ContainsKey("playwright");
-            }
-
-            return false;
-        }
-        catch (JsonException)
-        {
-            // If the JSON is malformed, assume playwright is not configured
-            return false;
-        }
+        return McpConfigFileHelper.HasServerConfigured(mcpConfigPath, "servers", "playwright");
     }
 
     /// <summary>
@@ -294,25 +241,7 @@ internal sealed class VsCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
         }
 
         var mcpConfigPath = Path.Combine(vsCodeFolder.FullName, McpConfigFileName);
-        JsonObject config;
-
-        // Read existing config or create new
-        if (File.Exists(mcpConfigPath))
-        {
-            var existingContent = await File.ReadAllTextAsync(mcpConfigPath, cancellationToken);
-            try
-            {
-                config = JsonNode.Parse(existingContent)?.AsObject() ?? new JsonObject();
-            }
-            catch (JsonException ex)
-            {
-                throw new InvalidOperationException(string.Format(System.Globalization.CultureInfo.CurrentCulture, AgentCommandStrings.MalformedConfigFileError, mcpConfigPath), ex);
-            }
-        }
-        else
-        {
-            config = new JsonObject();
-        }
+        var config = await McpConfigFileHelper.ReadConfigAsync(mcpConfigPath, cancellationToken);
 
         // Ensure "servers" object exists
         if (!config.ContainsKey("servers") || config["servers"] is not JsonObject)
@@ -349,25 +278,7 @@ internal sealed class VsCodeAgentEnvironmentScanner : IAgentEnvironmentScanner
         }
 
         var mcpConfigPath = Path.Combine(vsCodeFolder.FullName, McpConfigFileName);
-        JsonObject config;
-
-        // Read existing config or create new
-        if (File.Exists(mcpConfigPath))
-        {
-            var existingContent = await File.ReadAllTextAsync(mcpConfigPath, cancellationToken);
-            try
-            {
-                config = JsonNode.Parse(existingContent)?.AsObject() ?? new JsonObject();
-            }
-            catch (JsonException ex)
-            {
-                throw new InvalidOperationException(string.Format(System.Globalization.CultureInfo.CurrentCulture, AgentCommandStrings.MalformedConfigFileError, mcpConfigPath), ex);
-            }
-        }
-        else
-        {
-            config = new JsonObject();
-        }
+        var config = await McpConfigFileHelper.ReadConfigAsync(mcpConfigPath, cancellationToken);
 
         // Ensure "servers" object exists
         if (!config.ContainsKey("servers") || config["servers"] is not JsonObject)

--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -141,7 +141,14 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
         // Apply all selected applicators
         foreach (var applicator in selectedApplicators)
         {
-            await applicator.ApplyAsync(cancellationToken);
+            try
+            {
+                await applicator.ApplyAsync(cancellationToken);
+            }
+            catch (InvalidOperationException ex)
+            {
+                _interactionService.DisplayError(ex.Message);
+            }
         }
 
         _interactionService.DisplaySuccess(McpCommandStrings.InitCommand_ConfigurationComplete);

--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -159,7 +159,11 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
             }
         }
 
-        if (!hasErrors)
+        if (hasErrors)
+        {
+            _interactionService.DisplayMessage("warning", AgentCommandStrings.ConfigurationCompletedWithErrors);
+        }
+        else
         {
             _interactionService.DisplaySuccess(McpCommandStrings.InitCommand_ConfigurationComplete);
         }

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
@@ -140,5 +140,14 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("SkippedMalformedConfigFile", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Configuration completed with errors. Please fix the reported issues and re-run the command..
+        /// </summary>
+        internal static string ConfigurationCompletedWithErrors {
+            get {
+                return ResourceManager.GetString("ConfigurationCompletedWithErrors", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
@@ -122,5 +122,14 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("ConfigUpdatesSelectPrompt", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command..
+        /// </summary>
+        internal static string MalformedConfigFileError {
+            get {
+                return ResourceManager.GetString("MalformedConfigFileError", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
@@ -131,5 +131,14 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("MalformedConfigFileError", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Skipping update of '{0}'..
+        /// </summary>
+        internal static string SkippedMalformedConfigFile {
+            get {
+                return ResourceManager.GetString("SkippedMalformedConfigFile", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.resx
@@ -84,4 +84,7 @@
   <data name="MalformedConfigFileError" xml:space="preserve">
     <value>The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</value>
   </data>
+  <data name="SkippedMalformedConfigFile" xml:space="preserve">
+    <value>Skipping update of '{0}'.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.resx
@@ -87,4 +87,7 @@
   <data name="SkippedMalformedConfigFile" xml:space="preserve">
     <value>Skipping update of '{0}'.</value>
   </data>
+  <data name="ConfigurationCompletedWithErrors" xml:space="preserve">
+    <value>Configuration completed with errors. Please fix the reported issues and re-run the command.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.resx
@@ -81,4 +81,7 @@
   <data name="ConfigUpdatesSelectPrompt" xml:space="preserve">
     <value>The following agent configurations use the deprecated 'mcp start' command. Update them?</value>
   </data>
+  <data name="MalformedConfigFileError" xml:space="preserve">
+    <value>The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
@@ -47,6 +47,11 @@
         <target state="new">Skipping update of '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationCompletedWithErrors">
+        <source>Configuration completed with errors. Please fix the reported issues and re-run the command.</source>
+        <target state="new">Configuration completed with errors. Please fix the reported issues and re-run the command.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Spusťte server MCP (Model Context Protocol).</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkippedMalformedConfigFile">
+        <source>Skipping update of '{0}'.</source>
+        <target state="new">Skipping update of '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Inicializujte konfiguraci prostředí agentů pro zjištěné agenty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MalformedConfigFileError">
+        <source>The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</source>
+        <target state="new">The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">Spusťte server MCP (Model Context Protocol).</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
@@ -47,6 +47,11 @@
         <target state="new">Skipping update of '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationCompletedWithErrors">
+        <source>Configuration completed with errors. Please fix the reported issues and re-run the command.</source>
+        <target state="new">Configuration completed with errors. Please fix the reported issues and re-run the command.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Starten Sie den MCP-Server (Model Context Protocol).</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkippedMalformedConfigFile">
+        <source>Skipping update of '{0}'.</source>
+        <target state="new">Skipping update of '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Initialisieren Sie die Agent-Umgebungskonfiguration für erkannte Agenten.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MalformedConfigFileError">
+        <source>The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</source>
+        <target state="new">The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">Starten Sie den MCP-Server (Model Context Protocol).</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
@@ -47,6 +47,11 @@
         <target state="new">Skipping update of '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationCompletedWithErrors">
+        <source>Configuration completed with errors. Please fix the reported issues and re-run the command.</source>
+        <target state="new">Configuration completed with errors. Please fix the reported issues and re-run the command.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Inicialice la configuración del entorno del agente para los agentes detectados.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MalformedConfigFileError">
+        <source>The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</source>
+        <target state="new">The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">Inicie el servidor MCP (protocolo de contexto de modelo).</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Inicie el servidor MCP (protocolo de contexto de modelo).</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkippedMalformedConfigFile">
+        <source>Skipping update of '{0}'.</source>
+        <target state="new">Skipping update of '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
@@ -47,6 +47,11 @@
         <target state="new">Skipping update of '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationCompletedWithErrors">
+        <source>Configuration completed with errors. Please fix the reported issues and re-run the command.</source>
+        <target state="new">Configuration completed with errors. Please fix the reported issues and re-run the command.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Initialiser la configuration de l’environnement des agents détectés.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MalformedConfigFileError">
+        <source>The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</source>
+        <target state="new">The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">Démarrez le serveur MCP (Model Context Protocol).</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Démarrez le serveur MCP (Model Context Protocol).</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkippedMalformedConfigFile">
+        <source>Skipping update of '{0}'.</source>
+        <target state="new">Skipping update of '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
@@ -47,6 +47,11 @@
         <target state="new">Skipping update of '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationCompletedWithErrors">
+        <source>Configuration completed with errors. Please fix the reported issues and re-run the command.</source>
+        <target state="new">Configuration completed with errors. Please fix the reported issues and re-run the command.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Avviare il server MCP (Model Context Protocol).</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkippedMalformedConfigFile">
+        <source>Skipping update of '{0}'.</source>
+        <target state="new">Skipping update of '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Consente di inizializzare la configurazione dell'ambiente agente per gli agenti rilevati.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MalformedConfigFileError">
+        <source>The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</source>
+        <target state="new">The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">Avviare il server MCP (Model Context Protocol).</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
@@ -47,6 +47,11 @@
         <target state="new">Skipping update of '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationCompletedWithErrors">
+        <source>Configuration completed with errors. Please fix the reported issues and re-run the command.</source>
+        <target state="new">Configuration completed with errors. Please fix the reported issues and re-run the command.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
@@ -42,6 +42,11 @@
         <target state="translated">MCP (モデル コンテキスト プロトコル) サーバーを起動します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkippedMalformedConfigFile">
+        <source>Skipping update of '{0}'.</source>
+        <target state="new">Skipping update of '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
@@ -32,6 +32,11 @@
         <target state="translated">検出されたエージェントのエージェント環境構成を初期化します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MalformedConfigFileError">
+        <source>The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</source>
+        <target state="new">The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">MCP (モデル コンテキスト プロトコル) サーバーを起動します。</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
@@ -47,6 +47,11 @@
         <target state="new">Skipping update of '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationCompletedWithErrors">
+        <source>Configuration completed with errors. Please fix the reported issues and re-run the command.</source>
+        <target state="new">Configuration completed with errors. Please fix the reported issues and re-run the command.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
@@ -32,6 +32,11 @@
         <target state="translated">감지된 에이전트에 대한 에이전트 환경 구성을 초기화합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MalformedConfigFileError">
+        <source>The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</source>
+        <target state="new">The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">MCP(모델 컨텍스트 프로토콜) 서버를 시작합니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
@@ -42,6 +42,11 @@
         <target state="translated">MCP(모델 컨텍스트 프로토콜) 서버를 시작합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkippedMalformedConfigFile">
+        <source>Skipping update of '{0}'.</source>
+        <target state="new">Skipping update of '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
@@ -47,6 +47,11 @@
         <target state="new">Skipping update of '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationCompletedWithErrors">
+        <source>Configuration completed with errors. Please fix the reported issues and re-run the command.</source>
+        <target state="new">Configuration completed with errors. Please fix the reported issues and re-run the command.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Uruchom serwer MCP (Model Context Protocol).</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkippedMalformedConfigFile">
+        <source>Skipping update of '{0}'.</source>
+        <target state="new">Skipping update of '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Zainicjuj konfigurację środowiska agenta dla wykrytych agentów.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MalformedConfigFileError">
+        <source>The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</source>
+        <target state="new">The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">Uruchom serwer MCP (Model Context Protocol).</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
@@ -47,6 +47,11 @@
         <target state="new">Skipping update of '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationCompletedWithErrors">
+        <source>Configuration completed with errors. Please fix the reported issues and re-run the command.</source>
+        <target state="new">Configuration completed with errors. Please fix the reported issues and re-run the command.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Inicialize a configuração de ambiente do agente para agentes detectados.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MalformedConfigFileError">
+        <source>The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</source>
+        <target state="new">The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">Inicie o servidor MCP (Protocolo de Contexto de Modelo).</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Inicie o servidor MCP (Protocolo de Contexto de Modelo).</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkippedMalformedConfigFile">
+        <source>Skipping update of '{0}'.</source>
+        <target state="new">Skipping update of '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
@@ -47,6 +47,11 @@
         <target state="new">Skipping update of '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationCompletedWithErrors">
+        <source>Configuration completed with errors. Please fix the reported issues and re-run the command.</source>
+        <target state="new">Configuration completed with errors. Please fix the reported issues and re-run the command.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Инициализировать конфигурацию среды агента для обнаруженных агентов.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MalformedConfigFileError">
+        <source>The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</source>
+        <target state="new">The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">Запуск сервера MCP (протокол контекста модели).</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Запуск сервера MCP (протокол контекста модели).</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkippedMalformedConfigFile">
+        <source>Skipping update of '{0}'.</source>
+        <target state="new">Skipping update of '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
@@ -47,6 +47,11 @@
         <target state="new">Skipping update of '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationCompletedWithErrors">
+        <source>Configuration completed with errors. Please fix the reported issues and re-run the command.</source>
+        <target state="new">Configuration completed with errors. Please fix the reported issues and re-run the command.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Tespit edilen aracılar için aracı ortam yapılandırmasını başlatın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MalformedConfigFileError">
+        <source>The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</source>
+        <target state="new">The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">MCP (Model Bağlam Protokolü) sunucusunu başlat.</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
@@ -42,6 +42,11 @@
         <target state="translated">MCP (Model Bağlam Protokolü) sunucusunu başlat.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkippedMalformedConfigFile">
+        <source>Skipping update of '{0}'.</source>
+        <target state="new">Skipping update of '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
@@ -47,6 +47,11 @@
         <target state="new">Skipping update of '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationCompletedWithErrors">
+        <source>Configuration completed with errors. Please fix the reported issues and re-run the command.</source>
+        <target state="new">Configuration completed with errors. Please fix the reported issues and re-run the command.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
@@ -42,6 +42,11 @@
         <target state="translated">启动 MCP (模型上下文协议)服务器。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkippedMalformedConfigFile">
+        <source>Skipping update of '{0}'.</source>
+        <target state="new">Skipping update of '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
@@ -32,6 +32,11 @@
         <target state="translated">初始化检测到的智能体的智能体环境配置。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MalformedConfigFileError">
+        <source>The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</source>
+        <target state="new">The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">启动 MCP (模型上下文协议)服务器。</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
@@ -47,6 +47,11 @@
         <target state="new">Skipping update of '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigurationCompletedWithErrors">
+        <source>Configuration completed with errors. Please fix the reported issues and re-run the command.</source>
+        <target state="new">Configuration completed with errors. Please fix the reported issues and re-run the command.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
@@ -32,6 +32,11 @@
         <target state="translated">為偵測到的代理程式初始化代理程式環境設定。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MalformedConfigFileError">
+        <source>The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</source>
+        <target state="new">The configuration file '{0}' contains malformed JSON. Please fix the file manually and re-run the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">啟動 MCP (模型內容通訊協定) 伺服器。</target>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
@@ -42,6 +42,11 @@
         <target state="translated">啟動 MCP (模型內容通訊協定) 伺服器。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SkippedMalformedConfigFile">
+        <source>Skipping update of '{0}'.</source>
+        <target state="new">Skipping update of '{0}'.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/tests/Aspire.Cli.EndToEnd.Tests/AgentCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/AgentCommandTests.cs
@@ -359,6 +359,9 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
         // Pattern for the skip message
         var skippingMessage = new CellPatternSearcher().Find("Skipping");
 
+        // Pattern for the partial success warning message
+        var completedWithErrors = new CellPatternSearcher().Find("completed with errors");
+
         // Pattern for the agent environment selection prompt
         var agentSelectPrompt = new CellPatternSearcher().Find("agent environments");
 
@@ -407,7 +410,8 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
             {
                 var hasError = malformedError.Search(s).Count > 0;
                 var hasSkip = skippingMessage.Search(s).Count > 0;
-                return hasError && hasSkip;
+                var hasCompletedWithErrors = completedWithErrors.Search(s).Count > 0;
+                return hasError && hasSkip && hasCompletedWithErrors;
             }, TimeSpan.FromSeconds(30))
             .WaitForErrorPrompt(counter);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/AgentCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/AgentCommandTests.cs
@@ -315,5 +315,106 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
 
         await pendingRun;
     }
+
+    /// <summary>
+    /// Tests that aspire agent init gracefully handles malformed JSON in MCP config files.
+    /// When a .vscode/mcp.json file contains invalid JSON, the command should:
+    /// - Display an error message identifying the malformed file
+    /// - Display a "Skipping" message
+    /// - NOT overwrite the malformed file
+    /// - Exit with a non-zero exit code
+    /// </summary>
+    [Fact]
+    public async Task AgentInitCommand_WithMalformedMcpJson_ShowsErrorAndExitsNonZero()
+    {
+        var workspace = TemporaryWorkspace.Create(output);
+
+        var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
+        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
+        var isCI = CliE2ETestHelpers.IsRunningInCI;
+        var recordingPath = CliE2ETestHelpers.GetTestResultsRecordingPath(
+            nameof(AgentInitCommand_WithMalformedMcpJson_ShowsErrorAndExitsNonZero));
+
+        var builder = Hex1bTerminal.CreateBuilder()
+            .WithHeadless()
+            .WithDimensions(160, 48)
+            .WithAsciinemaRecording(recordingPath)
+            .WithPtyProcess("/bin/bash", ["--norc"]);
+
+        using var terminal = builder.Build();
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        // Set up paths
+        var vscodePath = Path.Combine(workspace.WorkspaceRoot.FullName, ".vscode");
+        var mcpConfigPath = Path.Combine(vscodePath, "mcp.json");
+        var malformedContent = "{ invalid json content";
+
+        // Patterns for agent init prompts
+        var workspacePathPrompt = new CellPatternSearcher().Find("workspace:");
+
+        // Pattern for the malformed JSON error message
+        var malformedError = new CellPatternSearcher().Find("malformed JSON");
+
+        // Pattern for the skip message
+        var skippingMessage = new CellPatternSearcher().Find("Skipping");
+
+        // Pattern for the agent environment selection prompt
+        var agentSelectPrompt = new CellPatternSearcher().Find("VS Code");
+
+        var counter = new SequenceCounter();
+        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+        sequenceBuilder.PrepareEnvironment(workspace, counter);
+
+        if (isCI)
+        {
+            sequenceBuilder.InstallAspireCliFromPullRequest(prNumber, counter);
+            sequenceBuilder.SourceAspireCliEnvironment(counter);
+            sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
+        }
+
+        // Step 1: Create .vscode folder with malformed mcp.json
+        sequenceBuilder
+            .CreateVsCodeFolder(vscodePath)
+            .CreateMalformedMcpConfig(mcpConfigPath, malformedContent);
+
+        // Verify the malformed config was created
+        sequenceBuilder
+            .VerifyFileContains(mcpConfigPath, "invalid json");
+
+        // Step 2: Run aspire agent init
+        sequenceBuilder
+            .Type("aspire agent init")
+            .Enter()
+            .WaitUntil(s => workspacePathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .Wait(500)
+            .Enter() // Accept default workspace path
+            .WaitUntil(s => agentSelectPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .Type(" ") // Select VS Code option
+            .Enter()
+            // After selection, wait for the error about malformed JSON and non-zero exit
+            .WaitUntil(s =>
+            {
+                var hasError = malformedError.Search(s).Count > 0;
+                var hasSkip = skippingMessage.Search(s).Count > 0;
+                return hasError && hasSkip;
+            }, TimeSpan.FromSeconds(30))
+            .WaitForErrorPrompt(counter);
+
+        // Step 3: Verify the malformed file was NOT overwritten
+        sequenceBuilder
+            .VerifyFileContains(mcpConfigPath, "invalid json");
+
+        sequenceBuilder
+            .Type("exit")
+            .Enter();
+
+        var sequence = sequenceBuilder.Build();
+
+        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+        await pendingRun;
+    }
 }
 

--- a/tests/Aspire.Cli.Tests/Agents/ClaudeCodeAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/ClaudeCodeAgentEnvironmentScannerTests.cs
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.InternalTesting;
+using Aspire.Cli.Agents;
+using Aspire.Cli.Agents.ClaudeCode;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
+using Semver;
+
+namespace Aspire.Cli.Tests.Agents;
+
+public class ClaudeCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task ApplyAsync_WithMalformedMcpJson_ThrowsInvalidOperationException()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        workspace.CreateDirectory(".claude");
+
+        // Create a malformed .mcp.json at the workspace root
+        var mcpJsonPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".mcp.json");
+        await File.WriteAllTextAsync(mcpJsonPath, "{ invalid json content");
+
+        var claudeCodeCliRunner = new FakeClaudeCodeCliRunner(new SemVersion(1, 0, 0));
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var scanner = new ClaudeCodeAgentEnvironmentScanner(claudeCodeCliRunner, executionContext, NullLogger<ClaudeCodeAgentEnvironmentScanner>.Instance);
+        var context = CreateScanContext(workspace.WorkspaceRoot);
+
+        await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
+
+        // The scan should succeed (HasServerConfigured catches JsonException)
+        Assert.NotEmpty(context.Applicators);
+        var aspireApplicator = context.Applicators.First(a => a.Description.Contains("Aspire MCP"));
+
+        // Applying should throw with a descriptive message
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => aspireApplicator.ApplyAsync(CancellationToken.None)).DefaultTimeout();
+        Assert.Contains(mcpJsonPath, ex.Message);
+        Assert.Contains("malformed JSON", ex.Message);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_WithEmptyMcpJson_ThrowsInvalidOperationException()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        workspace.CreateDirectory(".claude");
+
+        // Create an empty .mcp.json
+        var mcpJsonPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".mcp.json");
+        await File.WriteAllTextAsync(mcpJsonPath, "");
+
+        var claudeCodeCliRunner = new FakeClaudeCodeCliRunner(new SemVersion(1, 0, 0));
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var scanner = new ClaudeCodeAgentEnvironmentScanner(claudeCodeCliRunner, executionContext, NullLogger<ClaudeCodeAgentEnvironmentScanner>.Instance);
+        var context = CreateScanContext(workspace.WorkspaceRoot);
+
+        await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
+
+        Assert.NotEmpty(context.Applicators);
+        var aspireApplicator = context.Applicators.First(a => a.Description.Contains("Aspire MCP"));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => aspireApplicator.ApplyAsync(CancellationToken.None)).DefaultTimeout();
+        Assert.Contains(mcpJsonPath, ex.Message);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_WithMalformedMcpJson_DoesNotOverwriteFile()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        workspace.CreateDirectory(".claude");
+
+        // Create a malformed .mcp.json with content the user may want to preserve
+        var mcpJsonPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".mcp.json");
+        var originalContent = "{ \"mcpServers\": { \"my-server\": { \"command\": \"test\" } }";
+        await File.WriteAllTextAsync(mcpJsonPath, originalContent);
+
+        var claudeCodeCliRunner = new FakeClaudeCodeCliRunner(new SemVersion(1, 0, 0));
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var scanner = new ClaudeCodeAgentEnvironmentScanner(claudeCodeCliRunner, executionContext, NullLogger<ClaudeCodeAgentEnvironmentScanner>.Instance);
+        var context = CreateScanContext(workspace.WorkspaceRoot);
+
+        await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
+
+        Assert.NotEmpty(context.Applicators);
+        var aspireApplicator = context.Applicators.First(a => a.Description.Contains("Aspire MCP"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => aspireApplicator.ApplyAsync(CancellationToken.None)).DefaultTimeout();
+
+        // The original file content should be preserved
+        var currentContent = await File.ReadAllTextAsync(mcpJsonPath);
+        Assert.Equal(originalContent, currentContent);
+    }
+
+    private static AgentEnvironmentScanContext CreateScanContext(
+        DirectoryInfo workingDirectory)
+    {
+        return new AgentEnvironmentScanContext
+        {
+            WorkingDirectory = workingDirectory,
+            RepositoryRoot = workingDirectory
+        };
+    }
+
+    private static CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory)
+    {
+        return new CliExecutionContext(
+            workingDirectory: workingDirectory,
+            hivesDirectory: workingDirectory,
+            cacheDirectory: workingDirectory,
+            sdksDirectory: workingDirectory,
+            logsDirectory: workingDirectory,
+            logFilePath: "test.log",
+            debugMode: false,
+            environmentVariables: new Dictionary<string, string?>(),
+            homeDirectory: workingDirectory);
+    }
+
+    private sealed class FakeClaudeCodeCliRunner(SemVersion? version) : IClaudeCodeCliRunner
+    {
+        public Task<SemVersion?> GetVersionAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(version);
+        }
+    }
+}

--- a/tests/Aspire.Cli.Tests/Agents/OpenCodeAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/OpenCodeAgentEnvironmentScannerTests.cs
@@ -1,0 +1,108 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.InternalTesting;
+using Aspire.Cli.Agents;
+using Aspire.Cli.Agents.OpenCode;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
+using Semver;
+
+namespace Aspire.Cli.Tests.Agents;
+
+public class OpenCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task ApplyAsync_WithMalformedOpenCodeJsonc_ThrowsInvalidOperationException()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Create a malformed opencode.jsonc at the workspace root
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, "opencode.jsonc");
+        await File.WriteAllTextAsync(configPath, "{ invalid json content");
+
+        var openCodeCliRunner = new FakeOpenCodeCliRunner(new SemVersion(1, 0, 0));
+        var scanner = new OpenCodeAgentEnvironmentScanner(openCodeCliRunner, NullLogger<OpenCodeAgentEnvironmentScanner>.Instance);
+        var context = CreateScanContext(workspace.WorkspaceRoot);
+
+        await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
+
+        // The scan should succeed (HasServerConfigured catches JsonException)
+        Assert.NotEmpty(context.Applicators);
+        var aspireApplicator = context.Applicators.First(a => a.Description.Contains("Aspire MCP"));
+
+        // Applying should throw with a descriptive message
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => aspireApplicator.ApplyAsync(CancellationToken.None)).DefaultTimeout();
+        Assert.Contains(configPath, ex.Message);
+        Assert.Contains("malformed JSON", ex.Message);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_WithEmptyOpenCodeJsonc_ThrowsInvalidOperationException()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Create an empty opencode.jsonc
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, "opencode.jsonc");
+        await File.WriteAllTextAsync(configPath, "");
+
+        var openCodeCliRunner = new FakeOpenCodeCliRunner(new SemVersion(1, 0, 0));
+        var scanner = new OpenCodeAgentEnvironmentScanner(openCodeCliRunner, NullLogger<OpenCodeAgentEnvironmentScanner>.Instance);
+        var context = CreateScanContext(workspace.WorkspaceRoot);
+
+        await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
+
+        Assert.NotEmpty(context.Applicators);
+        var aspireApplicator = context.Applicators.First(a => a.Description.Contains("Aspire MCP"));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => aspireApplicator.ApplyAsync(CancellationToken.None)).DefaultTimeout();
+        Assert.Contains(configPath, ex.Message);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_WithMalformedOpenCodeJsonc_DoesNotOverwriteFile()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Create a malformed opencode.jsonc with content the user may want to preserve
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, "opencode.jsonc");
+        var originalContent = "{ \"mcp\": { \"my-server\": { \"command\": [\"test\"] } }";
+        await File.WriteAllTextAsync(configPath, originalContent);
+
+        var openCodeCliRunner = new FakeOpenCodeCliRunner(new SemVersion(1, 0, 0));
+        var scanner = new OpenCodeAgentEnvironmentScanner(openCodeCliRunner, NullLogger<OpenCodeAgentEnvironmentScanner>.Instance);
+        var context = CreateScanContext(workspace.WorkspaceRoot);
+
+        await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
+
+        Assert.NotEmpty(context.Applicators);
+        var aspireApplicator = context.Applicators.First(a => a.Description.Contains("Aspire MCP"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => aspireApplicator.ApplyAsync(CancellationToken.None)).DefaultTimeout();
+
+        // The original file content should be preserved
+        var currentContent = await File.ReadAllTextAsync(configPath);
+        Assert.Equal(originalContent, currentContent);
+    }
+
+    private static AgentEnvironmentScanContext CreateScanContext(
+        DirectoryInfo workingDirectory)
+    {
+        return new AgentEnvironmentScanContext
+        {
+            WorkingDirectory = workingDirectory,
+            RepositoryRoot = workingDirectory
+        };
+    }
+
+    private sealed class FakeOpenCodeCliRunner(SemVersion? version) : IOpenCodeCliRunner
+    {
+        public Task<SemVersion?> GetVersionAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(version);
+        }
+    }
+}

--- a/tests/Aspire.Cli.Tests/Agents/VsCodeAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/VsCodeAgentEnvironmentScannerTests.cs
@@ -288,6 +288,88 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
         Assert.Equal("npx", playwrightServer["command"]?.GetValue<string>());
     }
 
+    [Fact]
+    public async Task ApplyAsync_WithMalformedMcpJson_ThrowsInvalidOperationException()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var vsCodeFolder = workspace.CreateDirectory(".vscode");
+
+        // Create a malformed mcp.json
+        var mcpJsonPath = Path.Combine(vsCodeFolder.FullName, "mcp.json");
+        await File.WriteAllTextAsync(mcpJsonPath, "{ invalid json content");
+
+        var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, executionContext, NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var context = CreateScanContext(workspace.WorkspaceRoot);
+
+        await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
+
+        // The scan should succeed (Has*ServerConfigured catches JsonException)
+        Assert.NotEmpty(context.Applicators);
+        var aspireApplicator = context.Applicators.First(a => a.Description.Contains("Aspire MCP"));
+
+        // Applying should throw with a descriptive message
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => aspireApplicator.ApplyAsync(CancellationToken.None)).DefaultTimeout();
+        Assert.Contains(mcpJsonPath, ex.Message);
+        Assert.Contains("malformed JSON", ex.Message);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_WithEmptyMcpJson_ThrowsInvalidOperationException()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var vsCodeFolder = workspace.CreateDirectory(".vscode");
+
+        // Create an empty mcp.json (this is the exact scenario from the issue)
+        var mcpJsonPath = Path.Combine(vsCodeFolder.FullName, "mcp.json");
+        await File.WriteAllTextAsync(mcpJsonPath, "");
+
+        var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, executionContext, NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var context = CreateScanContext(workspace.WorkspaceRoot);
+
+        await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
+
+        Assert.NotEmpty(context.Applicators);
+        var aspireApplicator = context.Applicators.First(a => a.Description.Contains("Aspire MCP"));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => aspireApplicator.ApplyAsync(CancellationToken.None)).DefaultTimeout();
+        Assert.Contains(mcpJsonPath, ex.Message);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_WithMalformedMcpJson_DoesNotOverwriteFile()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var vsCodeFolder = workspace.CreateDirectory(".vscode");
+
+        // Create a malformed mcp.json with content the user may want to preserve
+        var mcpJsonPath = Path.Combine(vsCodeFolder.FullName, "mcp.json");
+        var originalContent = "{ \"servers\": { \"my-server\": { \"command\": \"test\" } }";
+        await File.WriteAllTextAsync(mcpJsonPath, originalContent);
+
+        var vsCodeCliRunner = new FakeVsCodeCliRunner(null);
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var scanner = new VsCodeAgentEnvironmentScanner(vsCodeCliRunner, executionContext, NullLogger<VsCodeAgentEnvironmentScanner>.Instance);
+        var context = CreateScanContext(workspace.WorkspaceRoot);
+
+        await scanner.ScanAsync(context, CancellationToken.None).DefaultTimeout();
+
+        Assert.NotEmpty(context.Applicators);
+        var aspireApplicator = context.Applicators.First(a => a.Description.Contains("Aspire MCP"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => aspireApplicator.ApplyAsync(CancellationToken.None)).DefaultTimeout();
+
+        // The original file content should be preserved
+        var currentContent = await File.ReadAllTextAsync(mcpJsonPath);
+        Assert.Equal(originalContent, currentContent);
+    }
+
     /// <summary>
     /// A fake implementation of <see cref="IVsCodeCliRunner"/> for testing.
     /// </summary>


### PR DESCRIPTION
## Summary

When `aspire mcp init` or `aspire agent init` encounters an MCP config file (e.g., `.vscode/mcp.json`) containing empty or malformed JSON, the CLI previously crashed with an unhandled `JsonReaderException`.

## Changes

- **4 agent environment scanners** (VsCode, CopilotCli, ClaudeCode, OpenCode): Wrapped `JsonNode.Parse()` calls in `Apply*ConfigurationAsync` methods with try-catch for `JsonException`. On malformed JSON, a descriptive `InvalidOperationException` is thrown with the file path.
- **AgentInitCommand**: Catches `InvalidOperationException` from `ApplyAsync` and displays a user-friendly error message, then continues with remaining applicators.
- **Resource string**: Added `MalformedConfigFileError` to `AgentCommandStrings` for the error message.
- **Tests**: Added 3 test cases in `VsCodeAgentEnvironmentScannerTests` covering malformed JSON, empty files, and verifying the file is not overwritten.

## Key design decision

The malformed file is **NOT overwritten**. The user may have valuable content they accidentally broke (e.g., a missing quote). The error message tells them which file has invalid JSON so they can fix it manually.

Fixes #14394