### PR TITLE
Fix TryGetResourceToolMap cache miss causing perpetual tools/list refresh loop

### DIFF
--- a/src/Aspire.Cli/Backchannel/IAuxiliaryBackchannelMonitor.cs
+++ b/src/Aspire.Cli/Backchannel/IAuxiliaryBackchannelMonitor.cs
@@ -32,6 +32,11 @@ internal interface IAuxiliaryBackchannelMonitor
     IAppHostAuxiliaryBackchannel? SelectedConnection { get; }
 
     /// <summary>
+    /// Gets the AppHost path of the currently resolved connection, or <c>null</c> if no connection is available.
+    /// </summary>
+    string? ResolvedAppHostPath => SelectedConnection?.AppHostInfo?.AppHostPath;
+
+    /// <summary>
     /// Gets all connections that are within the scope of the specified working directory.
     /// </summary>
     /// <param name="workingDirectory">The working directory to check against.</param>

--- a/src/Aspire.Cli/Mcp/McpResourceToolRefreshService.cs
+++ b/src/Aspire.Cli/Mcp/McpResourceToolRefreshService.cs
@@ -20,7 +20,7 @@ internal sealed class McpResourceToolRefreshService : IMcpResourceToolRefreshSer
     private McpServer? _server;
     private Dictionary<string, ResourceToolEntry> _resourceToolMap = new(StringComparer.Ordinal);
     private bool _invalidated = true;
-    private string? _selectedAppHostPath;
+    private string? _lastRefreshedAppHostPath;
 
     public McpResourceToolRefreshService(
         IAuxiliaryBackchannelMonitor auxiliaryBackchannelMonitor,
@@ -35,7 +35,7 @@ internal sealed class McpResourceToolRefreshService : IMcpResourceToolRefreshSer
     {
         lock (_lock)
         {
-            if (_invalidated || _selectedAppHostPath != _auxiliaryBackchannelMonitor.SelectedAppHostPath)
+            if (_invalidated || _lastRefreshedAppHostPath != _auxiliaryBackchannelMonitor.ResolvedAppHostPath)
             {
                 resourceToolMap = null!;
                 return false;
@@ -150,7 +150,7 @@ internal sealed class McpResourceToolRefreshService : IMcpResourceToolRefreshSer
             }
 
             _resourceToolMap = refreshedMap;
-            _selectedAppHostPath = selectedAppHostPath;
+            _lastRefreshedAppHostPath = selectedAppHostPath;
             _invalidated = false;
             return (_resourceToolMap, changed);
         }

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostAuxiliaryBackchannel.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostAuxiliaryBackchannel.cs
@@ -46,6 +46,12 @@ internal sealed class TestAppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackcha
     /// </summary>
     public Func<string, string, IReadOnlyDictionary<string, JsonElement>?, CancellationToken, Task<CallToolResult>>? CallResourceMcpToolHandler { get; set; }
 
+    /// <summary>
+    /// Gets or sets the function to call when GetResourceSnapshotsAsync is invoked.
+    /// If null, returns the ResourceSnapshots list.
+    /// </summary>
+    public Func<CancellationToken, Task<List<ResourceSnapshot>>>? GetResourceSnapshotsHandler { get; set; }
+
     public Task<DashboardUrlsState?> GetDashboardUrlsAsync(CancellationToken cancellationToken = default)
     {
         return Task.FromResult(DashboardUrlsState);
@@ -53,6 +59,11 @@ internal sealed class TestAppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackcha
 
     public Task<List<ResourceSnapshot>> GetResourceSnapshotsAsync(CancellationToken cancellationToken = default)
     {
+        if (GetResourceSnapshotsHandler is not null)
+        {
+            return GetResourceSnapshotsHandler(cancellationToken);
+        }
+
         return Task.FromResult(ResourceSnapshots);
     }
 


### PR DESCRIPTION
## Summary

Fixes #14538

`TryGetResourceToolMap` always returned false because it compared `_selectedAppHostPath` against `_auxiliaryBackchannelMonitor.SelectedAppHostPath`, which is only set by explicit `select_apphost` tool calls (usually `null`). After `RefreshResourceToolMapAsync` sets `_selectedAppHostPath` to the actual AppHost path, the comparison `null != "/path/to/AppHost"` always failed — so **every** `tools/list` call triggered a full refresh instead of using the cached map.

This caused ~3,800 refresh cycles per 3.5 seconds and generated **~130GB of log data** in a 4-hour session.

## Root Cause

```csharp
// Before: SelectedAppHostPath is only set by explicit select_apphost (usually null)
if (_invalidated || _selectedAppHostPath != _auxiliaryBackchannelMonitor.SelectedAppHostPath)
```

## Fix

```csharp
// After: SelectedConnection uses full selection logic (explicit > in-scope > fallback)
if (_invalidated || _selectedAppHostPath != _auxiliaryBackchannelMonitor.SelectedConnection?.AppHostInfo?.AppHostPath)
```

Uses `SelectedConnection` which applies the same selection logic that `RefreshResourceToolMapAsync` uses via `GetSelectedConnectionAsync`, ensuring the comparison matches.

## Testing

- Added `McpServer_ListTools_CachesResourceToolMap_WhenConnectionUnchanged` test verifying that `GetResourceSnapshotsAsync` is only called once across two consecutive `ListToolsAsync` calls (proving cache hit on second call)
- All 9 AgentMcpCommand tests pass

## Related

- #14375 / #14494 — Fixed a different notification path in the same loop (sending `tools/list_changed` from the list handler). This PR fixes the remaining cache-miss bug.