### PR TITLE
Suppress error notifications for extension prompt cancellation in CLI

### DIFF
--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -54,7 +54,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                     var taskFunction = await _extensionTaskChannel.Reader.ReadAsync().ConfigureAwait(false);
                     await taskFunction.Invoke();
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not ExtensionOperationCanceledException)
                 {
                     await Backchannel.DisplayErrorAsync(ex.Message.RemoveSpectreFormatting(), _cancellationToken);
                     _consoleInteractionService.DisplayError(ex.Message);
@@ -148,7 +148,10 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                 catch (Exception ex)
                 {
                     tcs.SetException(ex);
-                    DisplayError(ex.Message);
+                    if (ex is not ExtensionOperationCanceledException)
+                    {
+                        DisplayError(ex.Message);
+                    }
                 }
             }, cancellationToken).ConfigureAwait(false);
 
@@ -177,7 +180,10 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                 catch (Exception ex)
                 {
                     tcs.SetException(ex);
-                    DisplayError(ex.Message);
+                    if (ex is not ExtensionOperationCanceledException)
+                    {
+                        DisplayError(ex.Message);
+                    }
                 }
             }, cancellationToken).ConfigureAwait(false);
 
@@ -206,7 +212,10 @@ internal class ExtensionInteractionService : IExtensionInteractionService
                 catch (Exception ex)
                 {
                     tcs.SetException(ex);
-                    DisplayError(ex.Message);
+                    if (ex is not ExtensionOperationCanceledException)
+                    {
+                        DisplayError(ex.Message);
+                    }
                 }
             }, cancellationToken).ConfigureAwait(false);
 

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -606,7 +606,7 @@ public class Program
             // Don't log or display cancellation exceptions.
             // Check both Ctrl+C cancellation (cts.IsCancellationRequested) and
             // extension prompt cancellation (ExtensionOperationCanceledException).
-            if (!(ex is OperationCanceledException && (cts.IsCancellationRequested || ex is ExtensionOperationCanceledException)))
+            if (!(ex is OperationCanceledException && cts.IsCancellationRequested) && ex is not ExtensionOperationCanceledException)
             {
                 logger.LogError(ex, "An unexpected error occurred.");
 

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -604,7 +604,9 @@ public class Program
             // Allows logging of exceptions to telemetry.
 
             // Don't log or display cancellation exceptions.
-            if (!(ex is OperationCanceledException && cts.IsCancellationRequested))
+            // Check both Ctrl+C cancellation (cts.IsCancellationRequested) and
+            // extension prompt cancellation (ExtensionOperationCanceledException).
+            if (!(ex is OperationCanceledException && (cts.IsCancellationRequested || ex is ExtensionOperationCanceledException)))
             {
                 logger.LogError(ex, "An unexpected error occurred.");
 


### PR DESCRIPTION
## Description

When a user cancels an input prompt in the VS Code extension (e.g., dismissing the template selection during `aspire new`), the CLI's `ExtensionBackchannel` throws `ExtensionOperationCanceledException`. Previously, the `ExtensionInteractionService` catch blocks in `ConfirmAsync`, `PromptForSelectionAsync`, and `PromptForSelectionsAsync` would call `DisplayError` before re-throwing the exception, causing an error notification to appear in VS Code even though the cancellation was user-initiated.

This PR fixes the issue by suppressing `DisplayError` calls when the exception is `ExtensionOperationCanceledException`:

- **ExtensionInteractionService**: Skip `DisplayError` when the exception is `ExtensionOperationCanceledException` in prompt catch blocks (`ConfirmAsync`, `PromptForSelectionAsync`, `PromptForSelectionsAsync`) and the task channel reader's catch block.
- **Program.cs**: Add `ExtensionOperationCanceledException` to the global exception handler's cancellation suppression check as a safety net, so any uncaught extension cancellation exceptions are also silently handled.

(tested manually)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No