### PR TITLE
Fix JSON-RPC error on disconnect and auto-restart Aspire debug session on AppHost restart

### DIFF
--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -29,6 +29,8 @@ export class AspireDebugSession implements vscode.DebugAdapter {
   private _trackedDebugAdapters: string[] = [];
   private _rpcClient?: ICliRpcClient;
   private readonly _disposables: vscode.Disposable[] = [];
+  private _disposed = false;
+  private _userInitiatedStop = false;
 
   public readonly onDidSendMessage = this._onDidSendMessage.event;
   public readonly debugSessionId: string;
@@ -105,6 +107,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     }
     else if (message.command === 'disconnect' || message.command === 'terminate') {
       this.sendMessageWithEmoji("🔌", disconnectingFromSession);
+      this._userInitiatedStop = true;
       this.dispose();
 
       this.sendEvent({
@@ -173,7 +176,9 @@ export class AspireDebugSession implements vscode.DebugAdapter {
 
     this._disposables.push({
       dispose: () => {
-        this._rpcClient?.stopCli();
+        this._rpcClient?.stopCli().catch((err) => {
+          extensionLogOutputChannel.info(`stopCli failed (connection may already be closed): ${err}`);
+        });
         extensionLogOutputChannel.info(`Requested Aspire CLI exit with args: ${args.join(' ')}`);
       }
     });
@@ -219,9 +224,16 @@ export class AspireDebugSession implements vscode.DebugAdapter {
 
       const disposable = vscode.debug.onDidTerminateDebugSession(async session => {
         if (this._appHostDebugSession && session.id === this._appHostDebugSession.id) {
-          // We should also dispose of the parent Aspire debug session whenever the AppHost stops.
+          const shouldRestart = !this._userInitiatedStop;
+          const config = this.configuration;
+          // Always dispose the current Aspire debug session when the AppHost stops.
           this.dispose();
           disposable.dispose();
+
+          if (shouldRestart) {
+            extensionLogOutputChannel.info('AppHost terminated unexpectedly, restarting Aspire debug session');
+            await vscode.debug.startDebugging(undefined, config);
+          }
         }
       });
 
@@ -281,11 +293,15 @@ export class AspireDebugSession implements vscode.DebugAdapter {
   }
 
   dispose(): void {
+    if (this._disposed) {
+      return;
+    }
+    
+    this._disposed = true;
     extensionLogOutputChannel.info('Stopping the Aspire debug session');
     vscode.debug.stopDebugging(this._session);
     this._disposables.forEach(disposable => disposable.dispose());
     this._trackedDebugAdapters = [];
-    this._rpcClient?.stopCli();
   }
 
   private sendResponse(request: any, body: any = {}) {

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -295,7 +295,6 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     if (this._disposed) {
       return;
     }
-    
     this._disposed = true;
     extensionLogOutputChannel.info('Stopping the Aspire debug session');
     vscode.debug.stopDebugging(this._session);

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -228,7 +228,6 @@ export class AspireDebugSession implements vscode.DebugAdapter {
           const config = this.configuration;
           // Always dispose the current Aspire debug session when the AppHost stops.
           this.dispose();
-          disposable.dispose();
 
           if (shouldRestart) {
             extensionLogOutputChannel.info('AppHost terminated unexpectedly, restarting Aspire debug session');


### PR DESCRIPTION
## Description

This PR fixes two issues in the Aspire VS Code extension debug session:

1. **Fixed unexpected JSON-RPC connection lost error on debug session disconnect**: When stopping or restarting the Aspire debug session, the CLI process is killed which closes the JSON-RPC connection. Previously this triggered an error notification to the user. Now, `stopCli()` failures during dispose are caught and logged gracefully, and the `dispose()` method is guarded against double-disposal to prevent redundant `stopCli` calls.

2. **Restarting the AppHost resource now restarts the Aspire debug session**: Previously, when the AppHost debug session terminated (e.g., due to a resource restart), the Aspire debug session would simply dispose without restarting. Now, if the AppHost terminates and the stop was not user-initiated (i.e., the user didn't explicitly disconnect), the Aspire debug session automatically restarts by launching a new debug session with the same configuration.

(Tested manually. The unexpected JSON-RPC connection lost error was happening on every restart before)

### Changes
- Added `_disposed` flag to prevent double-disposal of the debug session
- Added `_userInitiatedStop` flag to distinguish user-initiated stops from AppHost-initiated terminations
- Wrapped `stopCli()` call in error handler since the connection may already be closed during dispose
- Removed duplicate `stopCli()` call from `dispose()` (already handled by disposables)
- When AppHost terminates unexpectedly (not user-initiated), automatically restart the Aspire debug session

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No