### PR TITLE
Copy .npmrc in JavaScript docker files before doing install

### DIFF
--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -706,10 +706,17 @@ public static class JavaScriptHostingExtensions
 
         installCommand ??= GetDefaultNpmInstallCommand(resource);
 
+        var workingDirectory = resource.Resource.WorkingDirectory;
+        var packageFilesSourcePattern = "package*.json";
+        if (File.Exists(Path.Combine(workingDirectory, ".npmrc")))
+        {
+            packageFilesSourcePattern += " .npmrc";
+        }
+
         resource
             .WithAnnotation(new JavaScriptPackageManagerAnnotation("npm", runScriptCommand: "run", cacheMount: "/root/.npm")
             {
-                PackageFilesPatterns = { new CopyFilePattern("package*.json", "./") }
+                PackageFilesPatterns = { new CopyFilePattern(packageFilesSourcePattern, "./") }
             })
             .WithAnnotation(new JavaScriptInstallCommandAnnotation([installCommand, .. installArgs ?? []]))
             .WithRequiredCommand("npm", "https://docs.npmjs.com/downloading-and-installing-node-js-and-npm");
@@ -761,6 +768,14 @@ public static class JavaScriptHostingExtensions
         if (File.Exists(Path.Combine(workingDirectory, "bun.lockb")))
         {
             packageFilesSourcePattern += " bun.lockb";
+        }
+        if (File.Exists(Path.Combine(workingDirectory, "bunfig.toml")))
+        {
+            packageFilesSourcePattern += " bunfig.toml";
+        }
+        if (File.Exists(Path.Combine(workingDirectory, ".npmrc")))
+        {
+            packageFilesSourcePattern += " .npmrc";
         }
 
         resource
@@ -835,6 +850,14 @@ public static class JavaScriptHostingExtensions
         {
             packageFilesSourcePattern += " .yarnrc.yml";
         }
+        if (File.Exists(Path.Combine(workingDirectory, ".yarnrc")))
+        {
+            packageFilesSourcePattern += " .yarnrc";
+        }
+        if (File.Exists(Path.Combine(workingDirectory, ".npmrc")))
+        {
+            packageFilesSourcePattern += " .npmrc";
+        }
         packageManager.PackageFilesPatterns.Add(new CopyFilePattern(packageFilesSourcePattern, "./"));
 
         if (hasYarnBerryDir)
@@ -893,6 +916,10 @@ public static class JavaScriptHostingExtensions
         if (hasPnpmLock)
         {
             packageFilesSourcePattern += " pnpm-lock.yaml";
+        }
+        if (File.Exists(Path.Combine(workingDirectory, ".npmrc")))
+        {
+            packageFilesSourcePattern += " .npmrc";
         }
 
         resource

--- a/tests/Aspire.Hosting.JavaScript.Tests/AddJavaScriptAppTests.cs
+++ b/tests/Aspire.Hosting.JavaScript.Tests/AddJavaScriptAppTests.cs
@@ -233,7 +233,7 @@ public class AddJavaScriptAppTests
         var dockerfilePath = Path.Combine(tempDir.Path, "js.Dockerfile");
         var dockerfileContents = File.ReadAllText(dockerfilePath);
 
-        Assert.Contains("COPY package.json .npmrc .yarnrc ./", dockerfileContents);
+        Assert.Contains("COPY package.json .yarnrc .npmrc ./", dockerfileContents);
     }
 
     [Fact]
@@ -256,6 +256,6 @@ public class AddJavaScriptAppTests
         var dockerfilePath = Path.Combine(tempDir.Path, "js.Dockerfile");
         var dockerfileContents = File.ReadAllText(dockerfilePath);
 
-        Assert.Contains("COPY package.json .npmrc bunfig.toml ./", dockerfileContents);
+        Assert.Contains("COPY package.json bunfig.toml .npmrc ./", dockerfileContents);
     }
 }


### PR DESCRIPTION
When building JavaScript apps in an environment that uses authenticated feeds, we aren't copying the feed and auth information into the docker image before doing the install command. This causes the build to fail.

The fix is to look for .npmrc, bunfig.toml, and .yarnrc files and copy them, if present.

Fix #14529

cc @tekgiant