### PR TITLE
Enable container tunnel by default

### DIFF
--- a/playground/yarp/Yarp.AppHost/Properties/launchSettings.json
+++ b/playground/yarp/Yarp.AppHost/Properties/launchSettings.json
@@ -12,8 +12,7 @@
         "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "https://localhost:18100",
         //"ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "https://localhost:17299",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17299",
-        "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
-        "ASPIRE_ENABLE_CONTAINER_TUNNEL": "true"
+        "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
       }
     },
     "http": {
@@ -29,8 +28,7 @@
         //"ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:17300",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17300",
         "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
-        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
-        "ASPIRE_ENABLE_CONTAINER_TUNNEL": "true"
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
 using Aspire.Hosting.ApplicationModel;
 using Confluent.Kafka;
 using HealthChecks.Kafka;
@@ -215,7 +214,7 @@ public static class KafkaBuilderExtensions
         var advertisedListeners = context.ExecutionContext.IsRunMode
             // In run mode, PLAINTEXT_INTERNAL assumes kafka is being accessed over a default Aspire container network and hardcodes the resource address
             // This will need to be refactored once updated service discovery APIs are available
-            ? ReferenceExpression.Create($"PLAINTEXT://localhost:29092,PLAINTEXT_HOST://localhost:{primaryEndpoint.Port.ToString(CultureInfo.InvariantCulture)},PLAINTEXT_INTERNAL://{resource.Name}:{internalEndpoint.Property(EndpointProperty.TargetPort)}")
+            ? ReferenceExpression.Create($"PLAINTEXT://localhost:29092,PLAINTEXT_HOST://localhost:{primaryEndpoint.Property(EndpointProperty.Port)},PLAINTEXT_INTERNAL://{resource.Name}:{internalEndpoint.Property(EndpointProperty.TargetPort)}")
             : ReferenceExpression.Create($"PLAINTEXT://{primaryEndpoint.Property(EndpointProperty.Host)}:29092,PLAINTEXT_HOST://{primaryEndpoint.Property(EndpointProperty.HostAndPort)},PLAINTEXT_INTERNAL://{internalEndpoint.Property(EndpointProperty.HostAndPort)}");
 
         context.EnvironmentVariables["KAFKA_ADVERTISED_LISTENERS"] = advertisedListeners;

--- a/src/Aspire.Hosting.Kafka/KafkaServerResource.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaServerResource.cs
@@ -23,7 +23,7 @@ public class KafkaServerResource(string name) : ContainerResource(name), IResour
     /// Gets the primary endpoint for the Kafka broker. This endpoint is used for host processes to Kafka broker communication.
     /// To connect to the Kafka broker from a container, use <see cref="InternalEndpoint"/>.
     /// </summary>
-    public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
+    public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName, KnownNetworkIdentifiers.LocalhostNetwork);
 
     /// <summary>
     /// Gets the host endpoint reference for the primary endpoint.
@@ -39,7 +39,7 @@ public class KafkaServerResource(string name) : ContainerResource(name), IResour
     /// Gets the internal endpoint for the Kafka broker. This endpoint is used for container to broker communication.
     /// To connect to the Kafka broker from a host process, use <see cref="PrimaryEndpoint"/>.
     /// </summary>
-    public EndpointReference InternalEndpoint => _internalEndpoint ??= new(this, InternalEndpointName);
+    public EndpointReference InternalEndpoint => _internalEndpoint ??= new(this, InternalEndpointName, KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
 
     /// <summary>
     /// Gets the connection string expression for the Kafka broker.

--- a/src/Aspire.Hosting.Maui/Aspire.Hosting.Maui.csproj
+++ b/src/Aspire.Hosting.Maui/Aspire.Hosting.Maui.csproj
@@ -18,8 +18,6 @@
   <ItemGroup>
     <Compile Include="..\Shared\IConfigurationExtensions.cs" Link="Shared\IConfigurationExtensions.cs" />
     <Compile Include="..\Shared\KnownConfigNames.cs" Link="Shared\KnownConfigNames.cs" />
-    <Compile Include="..\Shared\KnownResourceNames.cs" Link="Shared\KnownResourceNames.cs" />
-    <Compile Include="..\Shared\KnownEndpointNames.cs" Link="Shared\KnownEndpointNames.cs" />
     <Compile Include="..\Shared\OtlpEndpointResolver.cs" Link="Shared\OtlpEndpointResolver.cs" />
     <Compile Include="..\Shared\PathNormalizer.cs" Link="Shared\PathNormalizer.cs" />
     <Compile Include="..\Shared\StringComparers.cs" Link="Shared\StringComparers.cs" />

--- a/src/Aspire.Hosting.Maui/Aspire.Hosting.Maui.csproj
+++ b/src/Aspire.Hosting.Maui/Aspire.Hosting.Maui.csproj
@@ -18,6 +18,8 @@
   <ItemGroup>
     <Compile Include="..\Shared\IConfigurationExtensions.cs" Link="Shared\IConfigurationExtensions.cs" />
     <Compile Include="..\Shared\KnownConfigNames.cs" Link="Shared\KnownConfigNames.cs" />
+    <Compile Include="..\Shared\KnownResourceNames.cs" Link="Shared\KnownResourceNames.cs" />
+    <Compile Include="..\Shared\KnownEndpointNames.cs" Link="Shared\KnownEndpointNames.cs" />
     <Compile Include="..\Shared\OtlpEndpointResolver.cs" Link="Shared\OtlpEndpointResolver.cs" />
     <Compile Include="..\Shared\PathNormalizer.cs" Link="Shared\PathNormalizer.cs" />
     <Compile Include="..\Shared\StringComparers.cs" Link="Shared\StringComparers.cs" />

--- a/src/Aspire.Hosting/ApplicationModel/HostUrl.cs
+++ b/src/Aspire.Hosting/ApplicationModel/HostUrl.cs
@@ -55,12 +55,13 @@ public record HostUrl(string Url) : IValueProvider, IManifestExpressionProvider
                     // Determine what hostname means that we want to contact the host machine from the container. If using the new tunnel feature, this needs to be the address of the tunnel instance.
                     // Otherwise we want to try and determine the container runtime appropriate hostname (host.docker.internal or host.containers.internal).
                     uri.Host = options.Value.EnableAspireContainerTunnel? KnownHostNames.DefaultContainerTunnelHostName : dcpInfo?.Containers?.ContainerHostName ?? KnownHostNames.DockerDesktopHostBridge;
+                    var model = context.ExecutionContext.ServiceProvider.GetService<DistributedApplicationModel>();
 
-                    if (options.Value.EnableAspireContainerTunnel)
+                    if (options.Value.EnableAspireContainerTunnel && model is { })
                     {
                         // If we're running with the container tunnel enabled, we need to lookup the port on the tunnel that corresponds to the
                         // target port on the host machine.
-                        var model = context.ExecutionContext.ServiceProvider.GetRequiredService<DistributedApplicationModel>();
+                        
                         var targetEndpoint = model.Resources.Where(r => !r.IsContainer())
                             .OfType<IResourceWithEndpoints>()
                             .Select(r =>

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -1349,7 +1349,7 @@ public static class ResourceExtensions
     /// <param name="newDependencies">The set of newly discovered dependencies in this invocation (not present in <paramref name="dependencies"/> at the moment of invocation).</param>
     /// <param name="executionContext">The execution context for resolving environment variables and arguments.</param>
     /// <param name="cancellationToken">A cancellation token to observe while gathering dependencies.</param>
-    internal static async Task GatherDirectDependenciesAsync(
+    private static async Task GatherDirectDependenciesAsync(
         IResource resource,
         HashSet<IResource> dependencies,
         HashSet<IResource> newDependencies,

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -1263,6 +1263,33 @@ public static class ResourceExtensions
         return GetDependenciesAsync([resource], executionContext, mode, cancellationToken);
     }
 
+    /// <summary>
+    /// Efficiently computes the set of resources that the specified source set of resources depends on.
+    /// </summary>
+    /// <param name="resources">The source set of resources to compute dependencies for.</param>
+    /// <param name="executionContext">The execution context for resolving environment variables and arguments.</param>
+    /// <param name="mode">Specifies whether to discover only direct dependencies or the full transitive closure.</param>
+    /// <param name="cancellationToken">A cancellation token to observe while computing dependencies.</param>
+    /// <returns>A set of all resources that the specified resource depends on.</returns>
+    /// <remarks>
+    /// <para>
+    /// Dependencies are computed from multiple sources:
+    /// <list type="bullet">
+    /// <item>Parent resources via <see cref="IResourceWithParent"/></item>
+    /// <item>Wait dependencies via <see cref="WaitAnnotation"/></item>
+    /// <item>Connection string redirects via <see cref="ConnectionStringRedirectAnnotation"/></item>
+    /// <item>References to endpoints in environment variables and command-line arguments (via <see cref="IValueWithReferences"/>)</item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// When <paramref name="mode"/> is <see cref="ResourceDependencyDiscoveryMode.DirectOnly"/>, only the immediate
+    /// dependencies are returned. When <paramref name="mode"/> is <see cref="ResourceDependencyDiscoveryMode.Recursive"/>,
+    /// all transitive dependencies are included.
+    /// </para>
+    /// <para>
+    /// This method invokes environment variable and command-line argument callbacks to discover all references.
+    /// </para>
+    /// </remarks>
     internal static async Task<IReadOnlySet<IResource>> GetDependenciesAsync(
         IEnumerable<IResource> resources,
         DistributedApplicationExecutionContext executionContext,
@@ -1271,6 +1298,7 @@ public static class ResourceExtensions
     {
         var dependencies = new HashSet<IResource>();
         var newDependencies = new HashSet<IResource>();
+        var toProcess = new Queue<IResource>();
 
         foreach (var resource in resources)
         {
@@ -1280,7 +1308,12 @@ public static class ResourceExtensions
             if (mode == ResourceDependencyDiscoveryMode.Recursive)
             {
                 // Compute transitive closure by recursively processing dependencies
-                var toProcess = new Queue<IResource>(dependencies);
+
+                foreach(var nd in newDependencies)
+                {
+                    toProcess.Enqueue(nd);
+                }
+
                 while (toProcess.Count > 0)
                 {
                     var dep = toProcess.Dequeue();
@@ -1311,10 +1344,12 @@ public static class ResourceExtensions
     /// <summary>
     /// Gathers direct dependencies of a given resource.
     /// </summary>
-    /// <returns>
-    /// Newly discovered dependencies (not already in <paramref name="dependencies"/>).
-    /// </returns>
-    private static async Task GatherDirectDependenciesAsync(
+    /// <param name="resource">The resource to gather dependencies for.</param>
+    /// <param name="dependencies">The set of dependencies (where dependency resources will be placed).</param>
+    /// <param name="newDependencies">The set of newly discovered dependencies in this invocation (not present in <paramref name="dependencies"/> at the moment of invocation).</param>
+    /// <param name="executionContext">The execution context for resolving environment variables and arguments.</param>
+    /// <param name="cancellationToken">A cancellation token to observe while gathering dependencies.</param>
+    internal static async Task GatherDirectDependenciesAsync(
         IResource resource,
         HashSet<IResource> dependencies,
         HashSet<IResource> newDependencies,

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -22,6 +22,7 @@
     <Compile Include="$(SharedDir)IConfigurationExtensions.cs" Link="Utils\IConfigurationExtensions.cs" />
     <Compile Include="$(SharedDir)KnownFormats.cs" Link="Utils\KnownFormats.cs" />
     <Compile Include="$(SharedDir)KnownResourceNames.cs" Link="Utils\KnownResourceNames.cs" />
+    <Compile Include="$(SharedDir)KnownEndpointNames.cs" Link="Utils\KnownEndpointNames.cs" />
     <Compile Include="$(SharedDir)EnvironmentVariableNameEncoder.cs" Link="ApplicationModel\EnvironmentVariableNameEncoder.cs" />
     <Compile Include="$(SharedDir)KnownConfigNames.cs" Link="Utils\KnownConfigNames.cs" />
     <Compile Include="$(SharedDir)OtlpEndpointResolver.cs" Link="Utils\OtlpEndpointResolver.cs" />

--- a/src/Aspire.Hosting/AspireEventSource.cs
+++ b/src/Aspire.Hosting/AspireEventSource.cs
@@ -370,4 +370,22 @@ internal sealed class AspireEventSource : EventSource
             WriteEvent(42, kind, resourceName);
         }
     }
+
+    [Event(43, Level = EventLevel.Informational, Message = "DCP Service object preparation starting...")]
+    public void DcpServiceObjectPreparationStart()
+    {
+        if (IsEnabled())
+        {
+            WriteEvent(43);
+        }
+    }
+
+    [Event(44, Level = EventLevel.Informational, Message = "DCP Service object preparation completed")]
+    public void DcpServiceObjectPreparationStop()
+    {
+        if (IsEnabled())
+        {
+            WriteEvent(44);
+        }
+    }
 }

--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -44,8 +44,6 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
                                              ) : IDistributedApplicationEventingSubscriber, IAsyncDisposable
 {
     // Internal for testing
-    internal const string OtlpGrpcEndpointName = "otlp-grpc";
-    internal const string OtlpHttpEndpointName = "otlp-http";
     internal const string McpEndpointName = "mcp";
 
     // Fallback defaults for framework versions and TFM
@@ -436,7 +434,7 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
         if (otlpGrpcEndpointUrl != null)
         {
             var address = BindingAddress.Parse(otlpGrpcEndpointUrl);
-            dashboardResource.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, name: OtlpGrpcEndpointName, uriScheme: address.Scheme, port: address.Port, isProxied: true, transport: "http2")
+            dashboardResource.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, name: KnownEndpointNames.OtlpGrpcEndpointName, uriScheme: address.Scheme, port: address.Port, isProxied: true, transport: "http2")
             {
                 TargetHost = address.Host
             });
@@ -445,7 +443,7 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
         if (otlpHttpEndpointUrl != null)
         {
             var address = BindingAddress.Parse(otlpHttpEndpointUrl);
-            dashboardResource.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, name: OtlpHttpEndpointName, uriScheme: address.Scheme, port: address.Port, isProxied: true)
+            dashboardResource.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, name: KnownEndpointNames.OtlpHttpEndpointName, uriScheme: address.Scheme, port: address.Port, isProxied: true)
             {
                 TargetHost = address.Host
             });
@@ -660,13 +658,13 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
         static ReferenceExpression GetTargetUrlExpression(EndpointReference e) =>
             ReferenceExpression.Create($"{e.Property(EndpointProperty.Scheme)}://{e.EndpointAnnotation.TargetHost}:{e.Property(EndpointProperty.TargetPort)}");
 
-        var otlpGrpc = dashboardResource.GetEndpoint(OtlpGrpcEndpointName, KnownNetworkIdentifiers.LocalhostNetwork);
+        var otlpGrpc = dashboardResource.GetEndpoint(KnownEndpointNames.OtlpGrpcEndpointName, KnownNetworkIdentifiers.LocalhostNetwork);
         if (otlpGrpc.Exists)
         {
             context.EnvironmentVariables[DashboardConfigNames.DashboardOtlpGrpcUrlName.EnvVarName] = GetTargetUrlExpression(otlpGrpc);
         }
 
-        var otlpHttp = dashboardResource.GetEndpoint(OtlpHttpEndpointName, KnownNetworkIdentifiers.LocalhostNetwork);
+        var otlpHttp = dashboardResource.GetEndpoint(KnownEndpointNames.OtlpHttpEndpointName, KnownNetworkIdentifiers.LocalhostNetwork);
         if (otlpHttp.Exists)
         {
             context.EnvironmentVariables[DashboardConfigNames.DashboardOtlpHttpUrlName.EnvVarName] = GetTargetUrlExpression(otlpHttp);

--- a/src/Aspire.Hosting/Dcp/DcpOptions.cs
+++ b/src/Aspire.Hosting/Dcp/DcpOptions.cs
@@ -109,7 +109,7 @@ internal sealed class DcpOptions
     /// <summary>
     /// Enables Aspire container tunnel for container-to-host connectivity across all container orchestrators.
     /// </summary>
-    public bool EnableAspireContainerTunnel { get; set; }
+    public bool EnableAspireContainerTunnel { get; set; } = true;
 }
 
 internal class ValidateDcpOptions : IValidateOptions<DcpOptions>

--- a/src/Aspire.Hosting/Dcp/KubernetesService.cs
+++ b/src/Aspire.Hosting/Dcp/KubernetesService.cs
@@ -535,7 +535,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
             {
                 // Handle exceptions caused by races between writing and reading the configuration file.
                 // If the file is loaded while it is still being written, this can result in a YamlException being thrown.
-                ShouldHandle = new PredicateBuilder().Handle<KubeConfigException>().Handle<YamlException>(),
+                ShouldHandle = new PredicateBuilder().Handle<KubeConfigException>().Handle<YamlException>().Handle<IOException>(),
                 BackoffType = DelayBackoffType.Constant,
                 MaxRetryAttempts = dcpOptions.Value.KubernetesConfigReadRetryCount,
                 MaxDelay = TimeSpan.FromMilliseconds(dcpOptions.Value.KubernetesConfigReadRetryIntervalMilliseconds),

--- a/src/Aspire.Hosting/Dcp/OtlpEndpointReferenceGatherer.cs
+++ b/src/Aspire.Hosting/Dcp/OtlpEndpointReferenceGatherer.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.Dcp;
+
+/// <summary>
+/// For containers, it replaces OTLP endpoint environemnt variable value with a reference to dashboard OTLP ingestion endpoint.
+/// </summary>
+/// <remarks>
+/// In run mode, the dashboard plays the role of an OTLP collector, but the dashboard resouce is added dynamically,
+/// just before the application started. That is why the OTLP configuration extension methods use configuration only.
+/// OTOH, DCP has full model to work with, and can replace the OTLP endpoint environment variables with references
+/// to the dashboard OTLP ingestion endpoint. For containers this allows DCP to tunnel these properly into container networks.
+/// </remarks>
+internal class OtlpEndpointReferenceGatherer : IExecutionConfigurationGatherer
+{
+    public async ValueTask GatherAsync(IExecutionConfigurationGathererContext context, IResource resource, ILogger resourceLogger, DistributedApplicationExecutionContext executionContext, CancellationToken cancellationToken = default)
+    {
+        if (!resource.IsContainer() || !resource.TryGetAnnotationsOfType<OtlpExporterAnnotation>(out _))
+        {
+            // This gatherer is only relevant for container resources that emit OTEL telemetry.
+            return;
+        }
+
+        if (!context.EnvironmentVariables.TryGetValue(OtlpConfigurationExtensions.OtlpEndpointEnvironmentVariableName, out _))
+        {
+            // If the OTLP endpoint is not set, do not try to set it.
+            return;
+        }
+
+        var model = executionContext.ServiceProvider.GetRequiredService<DistributedApplicationModel>();
+        var dashboardResource = model.Resources.SingleOrDefault(r => StringComparers.ResourceName.Equals(r.Name, KnownResourceNames.AspireDashboard)) as IResourceWithEndpoints;
+        if (dashboardResource == null)
+        {
+            Debug.Fail("We should have a dashboard resource in the model");
+            return;
+        }
+
+        if (!dashboardResource.TryGetEndpoints(out var dashboardEndpoints))
+        {
+            Debug.Fail("Dashboard does not have any endpoints??");
+            return;
+        }
+
+        var grpcEndpoint = dashboardEndpoints.FirstOrDefault(e => e.Name == KnownEndpointNames.OtlpGrpcEndpointName);
+        var httpEndpoint = dashboardEndpoints.FirstOrDefault(e => e.Name == KnownEndpointNames.OtlpHttpEndpointName);
+        var resourceNetwork = resource.GetDefaultResourceNetwork();
+
+        var endpointReference = (grpcEndpoint, httpEndpoint) switch
+        {
+            (not null, _) => new EndpointReference(dashboardResource, grpcEndpoint, resourceNetwork),
+            (_, not null) => new EndpointReference(dashboardResource, httpEndpoint, resourceNetwork),
+            _ => null
+        };
+        Debug.Assert(endpointReference != null, "Dashboard should have at least one OTLP endpoint");
+
+        if (endpointReference is not null)
+        {
+            ValueProviderContext vpc = new() { ExecutionContext = executionContext, Caller = resource, Network = resourceNetwork };
+            var url = await endpointReference.GetValueAsync(vpc, cancellationToken).ConfigureAwait(false);
+            Debug.Assert(url is not null, $"We should be able to get a URL value from the reference dashboard endpoint '{endpointReference.EndpointName}'");
+            if (url is not null)
+            {
+                context.EnvironmentVariables[OtlpConfigurationExtensions.OtlpEndpointEnvironmentVariableName] = url;
+            }
+        }
+    }
+}

--- a/src/Shared/KnownEndpointNames.cs
+++ b/src/Shared/KnownEndpointNames.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting;
+
+internal static class KnownEndpointNames
+{
+    public static string OtlpGrpcEndpointName = "otlp-grpc";
+    public static string OtlpHttpEndpointName = "otlp-http";
+}

--- a/src/Shared/OtlpEndpointResolver.cs
+++ b/src/Shared/OtlpEndpointResolver.cs
@@ -1,13 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
-using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Dashboard;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using ModelContextProtocol.Protocol;
 
 namespace Aspire.Hosting;
 

--- a/src/Shared/OtlpEndpointResolver.cs
+++ b/src/Shared/OtlpEndpointResolver.cs
@@ -1,7 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Dashboard;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Protocol;
 
 namespace Aspire.Hosting;
 

--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
+    <PackageReference Include="Polly.Core" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Verify.XunitV3" />
   </ItemGroup>

--- a/tests/Aspire.Hosting.Tests/ContainerTunnelTests.cs
+++ b/tests/Aspire.Hosting.Tests/ContainerTunnelTests.cs
@@ -1,10 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using Aspire.Hosting.Testing;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Aspire.Hosting.Yarp.Transforms;
 using Aspire.TestUtilities;
-using Aspire.Hosting.Testing;
 using Microsoft.AspNetCore.InternalTesting;
 
 namespace Aspire.Hosting.Tests;
@@ -21,7 +21,7 @@ public class ContainerTunnelTests(ITestOutputHelper testOutputHelper)
 
         var servicea = builder.AddProject<Projects.ServiceA>($"{testName}-servicea");
 
-        var yarp = builder.AddYarp(testName).WithConfiguration(conf =>
+        var yarp = builder.AddYarp($"{testName}-yarp").WithConfiguration(conf =>
         {
             conf.AddRoute("/servicea/{**catch-all}", servicea).WithTransformPathRemovePrefix("/servicea");
         });
@@ -31,7 +31,6 @@ public class ContainerTunnelTests(ITestOutputHelper testOutputHelper)
         // Use extra long timeout because if this is first time the tunnel is being used,
         // getting the base images and building the tunnel (client) proxy image may take a while. 
         await app.StartAsync().DefaultTimeout(TestConstants.ExtraLongTimeoutDuration);
-
         await app.WaitForTextAsync("Application started.").DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
 
         using var clientA = app.CreateHttpClient(yarp.Resource.Name, "http");
@@ -42,4 +41,44 @@ public class ContainerTunnelTests(ITestOutputHelper testOutputHelper)
 
         await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
     }
+
+    [Fact]
+    [RequiresFeature(TestFeature.Docker)]
+    public async Task ProxylessEndpointWorksWithContainerTunnel()
+    {
+        var port = await Helpers.Network.GetAvailablePortAsync();
+
+        const string testName = "proxyless-endpoint-works-with-container-tunnel";
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        builder.Configuration[KnownConfigNames.EnableContainerTunnel] = "true";
+
+        var servicea = builder.AddProject<Projects.ServiceA>($"{testName}-servicea")
+            .WithEndpoint("http", e =>
+            {
+                e.Port = port;
+                e.TargetPort = port;
+                e.IsProxied = false;
+            });
+
+        var yarp = builder.AddYarp($"{testName}-yarp").WithConfiguration(conf =>
+        {
+            conf.AddRoute("/servicea/{**catch-all}", servicea).WithTransformPathRemovePrefix("/servicea");
+        });
+
+        await using var app = builder.Build();
+
+        // Use extra long timeout because if this is first time the tunnel is being used,
+        // getting the base images and building the tunnel (client) proxy image may take a while. 
+        await app.StartAsync().DefaultTimeout(TestConstants.ExtraLongTimeoutDuration);
+        await app.WaitForTextAsync("Application started.").DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
+
+        using var clientA = app.CreateHttpClient(yarp.Resource.Name, "http");
+        var response = await clientA.GetAsync("/servicea/").DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        Assert.True(response.IsSuccessStatusCode);
+        var body = await response.Content.ReadAsStringAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        Assert.Equal("Hello World!", body);
+
+        await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
+    }
+
 }

--- a/tests/Aspire.Hosting.Tests/ContainerTunnelTests.cs
+++ b/tests/Aspire.Hosting.Tests/ContainerTunnelTests.cs
@@ -27,7 +27,11 @@ public class ContainerTunnelTests(ITestOutputHelper testOutputHelper)
         });
 
         using var app = builder.Build();
-        await app.StartAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
+
+        // Use extra long timeout because if this is first time the tunnel is being used,
+        // getting the base images and building the tunnel (client) proxy image may take a while. 
+        await app.StartAsync().DefaultTimeout(TestConstants.ExtraLongTimeoutDuration);
+
         await app.WaitForTextAsync("Application started.").DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
 
         using var clientA = app.CreateHttpClient(yarp.Resource.Name, "http");

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
@@ -139,7 +139,7 @@ public class DashboardLifecycleHookTests(ITestOutputHelper testOutputHelper)
 
         var httpEndpoint = new EndpointReference(dashboardResource, "http");
         httpEndpoint.EndpointAnnotation.AllocatedEndpoint = new(httpEndpoint.EndpointAnnotation, "localhost", 8080);
-        var otlpGrpcEndpoint = new EndpointReference(dashboardResource, DashboardEventHandlers.OtlpGrpcEndpointName);
+        var otlpGrpcEndpoint = new EndpointReference(dashboardResource, KnownEndpointNames.OtlpGrpcEndpointName);
         otlpGrpcEndpoint.EndpointAnnotation.AllocatedEndpoint = new(otlpGrpcEndpoint.EndpointAnnotation, "localhost", 4317);
 
         var context = new DistributedApplicationExecutionContext(new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run) { ServiceProvider = TestServiceProvider.Instance });

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
@@ -693,11 +693,11 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
     {
         foreach (var endpoint in dashboard.Annotations.OfType<EndpointAnnotation>())
         {
-            if (endpoint.Name == DashboardEventHandlers.OtlpGrpcEndpointName)
+            if (endpoint.Name == KnownEndpointNames.OtlpGrpcEndpointName)
             {
                 endpoint.AllocatedEndpoint = new(endpoint, "localhost", otlpGrpcPort, targetPortExpression: otlpGrpcPort.ToString());
             }
-            else if (endpoint.Name == DashboardEventHandlers.OtlpHttpEndpointName)
+            else if (endpoint.Name == KnownEndpointNames.OtlpHttpEndpointName)
             {
                 endpoint.AllocatedEndpoint = new(endpoint, "localhost", otlpHttpPort, targetPortExpression: otlpHttpPort.ToString());
             }

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIRECERTIFICATES001
@@ -1501,11 +1501,12 @@ public class DistributedApplicationTests
         const string testName = "proxyless-endpoint-works";
         using var testProgram = CreateTestProgram(testName);
 
+        var port = await Network.GetAvailablePortAsync();
         testProgram.ServiceABuilder
             .WithEndpoint("http", e =>
             {
-                e.Port = 1234;
-                e.TargetPort = 1234;
+                e.Port = port;
+                e.TargetPort = port;
                 e.IsProxied = false;
             });
 
@@ -1537,11 +1538,12 @@ public class DistributedApplicationTests
         const string testName = "proxyless-and-proxied-endpoints";
         using var testProgram = CreateTestProgram(testName);
 
+        var port = await Network.GetAvailablePortAsync();
         testProgram.ServiceABuilder
             .WithEndpoint("http", e =>
             {
-                e.Port = 1234;
-                e.TargetPort = 1234;
+                e.Port = port;
+                e.TargetPort = port;
                 e.IsProxied = false;
             }, createIfNotExists: false)
             .WithEndpoint("https", e =>
@@ -1607,7 +1609,8 @@ public class DistributedApplicationTests
         const string testName = "proxyless-container";
         using var builder = TestDistributedApplicationBuilder.Create(_testOutputHelper);
 
-        var redis = builder.AddRedis($"{testName}-redis", 1234).WithEndpoint("tcp", endpoint =>
+        var port = await Network.GetAvailablePortAsync();
+        var redis = builder.AddRedis($"{testName}-redis", port).WithEndpoint("tcp", endpoint =>
         {
             endpoint.IsProxied = false;
         });
@@ -1638,7 +1641,7 @@ public class DistributedApplicationTests
         var env = Assert.Single(service.Spec.Env!, e => e.Name == $"ConnectionStrings__{testName}-redis");
         var sslVal = redis.Resource.TlsEnabled ? ",ssl=true" : string.Empty;
 #pragma warning disable CS0618 // Type or member is obsolete
-        Assert.Equal($"localhost:1234,password={redis.Resource.PasswordParameter?.Value}{sslVal}", env.Value);
+        Assert.Equal($"localhost:{port},password={redis.Resource.PasswordParameter?.Value}{sslVal}", env.Value);
 #pragma warning restore CS0618 // Type or member is obsolete
 
         var list = await s.ListAsync<Container>().DefaultTimeout();
@@ -1646,11 +1649,11 @@ public class DistributedApplicationTests
         if (redis.Resource.TlsEnabled)
         {
             Assert.Equal(2, redisContainer.Spec.Ports!.Count);
-            Assert.Contains(redisContainer.Spec.Ports!, p => p.HostPort == 1234);
+            Assert.Contains(redisContainer.Spec.Ports!, p => p.HostPort == port);
         }
         else
         {
-            Assert.Equal(1234, Assert.Single(redisContainer.Spec.Ports!).HostPort);
+            Assert.Equal(port, Assert.Single(redisContainer.Spec.Ports!).HostPort);
         }
 
         var otherRedisEnv = Assert.Single(service.Spec.Env!, e => e.Name == $"ConnectionStrings__{testName}-redisNoPort");
@@ -1680,7 +1683,8 @@ public class DistributedApplicationTests
         const string testName = "endpoint-proxy-support";
         using var builder = TestDistributedApplicationBuilder.Create(_testOutputHelper);
 
-        var redis = builder.AddRedis($"{testName}-redis", 1234).WithEndpointProxySupport(false);
+        var port = await Network.GetAvailablePortAsync();
+        var redis = builder.AddRedis($"{testName}-redis", port).WithEndpointProxySupport(false);
 
         // Since port is not specified, this instance will use the container target port (6379) as the host port.
         var redisNoPort = builder.AddRedis($"{testName}-redisNoPort").WithEndpointProxySupport(false);
@@ -1710,7 +1714,7 @@ public class DistributedApplicationTests
         var env = Assert.Single(service.Spec.Env!, e => e.Name == $"ConnectionStrings__{testName}-redis");
         var sslVal = redis.Resource.TlsEnabled ? ",ssl=true" : string.Empty;
 #pragma warning disable CS0618 // Type or member is obsolete
-        Assert.Equal($"localhost:1234,password={redis.Resource.PasswordParameter!.Value}{sslVal}", env.Value);
+        Assert.Equal($"localhost:{port},password={redis.Resource.PasswordParameter!.Value}{sslVal}", env.Value);
 #pragma warning restore CS0618 // Type or member is obsolete
 
         var list = await s.ListAsync<Container>().DefaultTimeout();
@@ -1718,11 +1722,11 @@ public class DistributedApplicationTests
         if (redis.Resource.TlsEnabled)
         {
             Assert.Equal(2, redisContainer.Spec.Ports!.Count);
-            Assert.Contains(redisContainer.Spec.Ports!, p => p.HostPort == 1234);
+            Assert.Contains(redisContainer.Spec.Ports!, p => p.HostPort == port);
         }
         else
         {
-            Assert.Equal(1234, Assert.Single(redisContainer.Spec.Ports!).HostPort);
+            Assert.Equal(port, Assert.Single(redisContainer.Spec.Ports!).HostPort);
         }
 
         var otherRedisEnv = Assert.Single(service.Spec.Env!, e => e.Name == $"ConnectionStrings__{testName}-redisNoPort");

--- a/tests/Aspire.Hosting.Tests/Helpers/Network.cs
+++ b/tests/Aspire.Hosting.Tests/Helpers/Network.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Net.Sockets;
+using Polly;
+using Polly.Retry;
+using Polly.Timeout;
+
+namespace Aspire.Hosting.Tests.Helpers;
+
+internal static class Network
+{
+    /// <summary>
+    /// Finds an available (unoccupied) TCP port on the specified network address by attempting
+    /// to bind a socket to randomly chosen ports within the given range.
+    /// </summary>
+    /// <param name="minPort">The inclusive lower bound of the random port range.</param>
+    /// <param name="maxPort">The inclusive upper bound of the random port range.</param>
+    /// <param name="address">The network address to bind to (e.g. "127.0.0.1").</param>
+    /// <returns>An available port number.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no available port is found within the timeout period.</exception>
+    public static async Task<int> GetAvailablePortAsync(
+        int minPort = 10000,
+        int maxPort = 20000,
+        string address = "127.0.0.1")
+    {
+        var triedPorts = new List<int>();
+        var random = new Random();
+        var ipAddress = IPAddress.Parse(address);
+
+        var pipeline = new ResiliencePipelineBuilder<int>()
+            .AddTimeout(new TimeoutStrategyOptions { Timeout = TimeSpan.FromSeconds(10) })
+            .AddRetry(new RetryStrategyOptions<int>
+            {
+                ShouldHandle = new PredicateBuilder<int>().Handle<SocketException>(),
+                BackoffType = DelayBackoffType.Exponential,
+                Delay = TimeSpan.FromMilliseconds(50),
+                MaxDelay = TimeSpan.FromSeconds(2),
+                MaxRetryAttempts = int.MaxValue,
+            })
+            .Build();
+
+        try
+        {
+            return await pipeline.ExecuteAsync(async (ct) =>
+            {
+                var port = random.Next(minPort, maxPort + 1);
+                triedPorts.Add(port);
+
+                using var socket = new Socket(ipAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+                socket.Bind(new IPEndPoint(ipAddress, port));
+                socket.Close();
+
+                return port;
+            });
+        }
+        catch (TimeoutRejectedException)
+        {
+            throw new InvalidOperationException(
+                $"Could not find an available port on address '{address}' after 10 seconds. " +
+                $"Tried ports: {string.Join(", ", triedPorts)}");
+        }
+    }
+}

--- a/tests/Aspire.Hosting.Tests/ResourceDependencyTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceDependencyTests.cs
@@ -591,4 +591,289 @@ public class ResourceDependencyTests
         Assert.Contains(b.Resource, dependencies);
         Assert.Contains(c.Resource, dependencies);
     }
+
+    #region Multi-Resource GetDependenciesAsync Tests
+
+    [Fact]
+    public async Task MultiResourceIndependentResourcesDependenciesAreMerged()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // A -> X, B -> Y (independent dependencies)
+        var x = builder.AddContainer("x", "alpine")
+            .WithHttpEndpoint(8001, 8001, "http");
+        var y = builder.AddContainer("y", "alpine")
+            .WithHttpEndpoint(8002, 8002, "http");
+        var a = builder.AddContainer("a", "alpine").WithEnvironment("X_URL", x.GetEndpoint("http"));
+        var b = builder.AddContainer("b", "alpine").WithEnvironment("Y_URL", y.GetEndpoint("http"));
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await ResourceExtensions.GetDependenciesAsync(
+            [a.Resource, b.Resource], executionContext);
+
+        Assert.Contains(x.Resource, dependencies);
+        Assert.Contains(y.Resource, dependencies);
+        Assert.Equal(2, dependencies.Count);
+    }
+
+    [Fact]
+    public async Task MultiResourceOverlappingDependenciesAreDeduplicatedAndCombined()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // A -> X, B -> X (shared dependency)
+        var x = builder.AddContainer("x", "alpine")
+            .WithHttpEndpoint(8001, 8001, "http");
+        var a = builder.AddContainer("a", "alpine").WithEnvironment("X_URL", x.GetEndpoint("http"));
+        var b = builder.AddContainer("b", "alpine").WithEnvironment("X_URL", x.GetEndpoint("http"));
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await ResourceExtensions.GetDependenciesAsync(
+            [a.Resource, b.Resource], executionContext);
+
+        Assert.Contains(x.Resource, dependencies);
+        Assert.Single(dependencies); // X should only appear once
+    }
+
+    [Fact]
+    public async Task MultiResourceInputResourceExcludedEvenIfOtherInputDependsOnIt()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // A -> B, but both A and B are inputs
+        var b = builder.AddContainer("b", "alpine")
+            .WithHttpEndpoint(8080, 8080, "http");
+        var a = builder.AddContainer("a", "alpine")
+            .WithReference(b.GetEndpoint("http"));
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await ResourceExtensions.GetDependenciesAsync(
+            [a.Resource, b.Resource], executionContext);
+
+        // B should be excluded because it's an input resource
+        Assert.DoesNotContain(a.Resource, dependencies);
+        Assert.DoesNotContain(b.Resource, dependencies);
+        Assert.Empty(dependencies);
+    }
+
+    [Fact]
+    public async Task MultiResourceTransitiveDependencyThroughInputIsStillIncluded()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // A -> B -> C, inputs are [A, B]
+        var c = builder.AddRedis("c");
+        var b = builder.AddContainer("b", "alpine")
+            .WithHttpEndpoint(8080, 8080, "http")
+            .WithReference(c);
+        var a = builder.AddContainer("a", "alpine")
+            .WithReference(b.GetEndpoint("http"));
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await ResourceExtensions.GetDependenciesAsync(
+            [a.Resource, b.Resource], executionContext);
+
+        // C should be included (as dependency of B)
+        Assert.Contains(c.Resource, dependencies);
+        // A and B are inputs, so excluded
+        Assert.DoesNotContain(a.Resource, dependencies);
+        Assert.DoesNotContain(b.Resource, dependencies);
+    }
+
+    [Fact]
+    public async Task MultiResourceEmptyInputReturnsEmptySet()
+    {
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await ResourceExtensions.GetDependenciesAsync(
+            Array.Empty<IResource>(), executionContext);
+
+        Assert.Empty(dependencies);
+    }
+
+    [Fact]
+    public async Task MultiResourceAllInputsHaveNoDependenciesReturnsEmptySet()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var a = builder.AddContainer("a", "alpine");
+        var b = builder.AddContainer("b", "alpine");
+        var c = builder.AddContainer("c", "alpine");
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await ResourceExtensions.GetDependenciesAsync(
+            [a.Resource, b.Resource, c.Resource], executionContext);
+
+        Assert.Empty(dependencies);
+    }
+
+    [Fact]
+    public async Task MultiResourceDiamondWithMultipleInputsHandledCorrectly()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // Diamond: A -> B -> D, A -> C -> D
+        // Input: [A, C] - should get B, D (C is excluded as input)
+        var d = builder.AddContainer("d", "alpine")
+            .WithHttpEndpoint(8080, 8080, "http");
+        var b = builder.AddContainer("b", "alpine")
+            .WithHttpEndpoint(8081, 8081, "http")
+            .WaitFor(d);
+        var c = builder.AddContainer("c", "alpine")
+            .WithHttpEndpoint(8082, 8082, "http")
+            .WaitFor(d);
+        var a = builder.AddContainer("a", "alpine")
+            .WaitFor(b)
+            .WaitFor(c);
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await ResourceExtensions.GetDependenciesAsync(
+            [a.Resource, c.Resource], executionContext);
+
+        Assert.Contains(b.Resource, dependencies);
+        Assert.Contains(d.Resource, dependencies);
+        Assert.DoesNotContain(a.Resource, dependencies);
+        Assert.DoesNotContain(c.Resource, dependencies);
+        Assert.Equal(2, dependencies.Count);
+    }
+
+    [Fact]
+    public async Task MultiResourceDirectOnlyModeWithMultipleResources()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // A -> B -> C, D -> E -> F
+        var c = builder.AddRedis("c");
+        var b = builder.AddContainer("b", "alpine")
+            .WithHttpEndpoint(8080, 8080, "http")
+            .WithReference(c);
+        var a = builder.AddContainer("a", "alpine")
+            .WithReference(b.GetEndpoint("http"));
+
+        var f = builder.AddRedis("f");
+        var e = builder.AddContainer("e", "alpine")
+            .WithHttpEndpoint(8081, 8081, "http")
+            .WithReference(f);
+        var d = builder.AddContainer("d", "alpine")
+            .WithReference(e.GetEndpoint("http"));
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await ResourceExtensions.GetDependenciesAsync(
+            [a.Resource, d.Resource], executionContext, ResourceDependencyDiscoveryMode.DirectOnly);
+
+        // DirectOnly should only include B and E (direct deps), not C and F
+        Assert.Contains(b.Resource, dependencies);
+        Assert.Contains(e.Resource, dependencies);
+        Assert.DoesNotContain(c.Resource, dependencies);
+        Assert.DoesNotContain(f.Resource, dependencies);
+        Assert.Equal(2, dependencies.Count);
+    }
+
+    [Fact]
+    public async Task MultiResourceCircularReferenceAmongInputsHandledCorrectly()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // A -> B -> C -> A (circular), plus D as external dependency
+        var d = builder.AddContainer("d", "alpine")
+            .WithHttpEndpoint(8083, 8083, "http"); ;
+        var a = builder.AddContainer("a", "alpine")
+            .WithHttpEndpoint(8080, 8080, "http");
+        var b = builder.AddContainer("b", "alpine")
+            .WithHttpEndpoint(8081, 8081, "http")
+            .WithEnvironment("A_URL", a.GetEndpoint("http"));
+        var c = builder.AddContainer("c", "alpine")
+            .WithHttpEndpoint(8082, 8082, "http")
+            .WithEnvironment("B_URL", b.GetEndpoint("http"))
+            .WithEnvironment("D_URL", d.GetEndpoint("http"));
+        a.WithEnvironment("C_URL", c.GetEndpoint("http"));
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        // All three circular resources as input
+        var dependencies = await ResourceExtensions.GetDependenciesAsync(
+            [a.Resource, b.Resource, c.Resource], executionContext);
+
+        // Only D should remain as a dependency (A, B, C are all inputs)
+        Assert.Contains(d.Resource, dependencies);
+        Assert.DoesNotContain(a.Resource, dependencies);
+        Assert.DoesNotContain(b.Resource, dependencies);
+        Assert.DoesNotContain(c.Resource, dependencies);
+        Assert.Single(dependencies);
+    }
+
+    [Fact]
+    public async Task MultiResourceParentChildBothAsInputsExcludesBoth()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // Simulate parent-child-like relationship using WaitFor
+        var parent = builder.AddContainer("parent", "alpine");
+        var child = builder.AddContainer("child", "alpine")
+            .WaitFor(parent);
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        // Both parent and child as inputs
+        var dependencies = await ResourceExtensions.GetDependenciesAsync(
+            [parent.Resource, child.Resource], executionContext);
+
+        // Both are inputs, so neither should appear
+        Assert.DoesNotContain(parent.Resource, dependencies);
+        Assert.DoesNotContain(child.Resource, dependencies);
+        Assert.Empty(dependencies);
+    }
+
+    [Fact]
+    public async Task MultiResourceCombinesDependenciesFromDifferentSourceTypes()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // A uses WaitFor(X), B uses WithReference(Y), C uses WithEnvironment(Z endpoint)
+        var x = builder.AddContainer("x", "alpine");
+        var y = builder.AddContainer("y", "alpine")
+            .WithHttpEndpoint(8001, 8001, "http");
+        var z = builder.AddContainer("z", "alpine")
+            .WithHttpEndpoint(8080, 8080, "http");
+
+        var a = builder.AddContainer("a", "alpine").WaitFor(x);
+        var b = builder.AddContainer("b", "alpine")
+            .WithEnvironment("Y_URL", y.GetEndpoint("http"));
+        var c = builder.AddContainer("c", "alpine")
+            .WithEnvironment("Z_URL", z.GetEndpoint("http"));
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var dependencies = await ResourceExtensions.GetDependenciesAsync(
+            [a.Resource, b.Resource, c.Resource], executionContext);
+
+        Assert.Contains(x.Resource, dependencies);
+        Assert.Contains(y.Resource, dependencies);
+        Assert.Contains(z.Resource, dependencies);
+        Assert.Equal(3, dependencies.Count);
+    }
+
+    [Fact]
+    public async Task MultiResourceSingleResourceBehavesLikeSingleResourceMethod()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // Chain: A -> B -> C
+        var c = builder.AddRedis("c");
+        var b = builder.AddContainer("b", "alpine")
+            .WithHttpEndpoint(5000, 5000, "http")
+            .WithReference(c);
+        var a = builder.AddContainer("a", "alpine")
+            .WithReference(b.GetEndpoint("http"));
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+
+        // Compare single-resource method with multi-resource method using single input
+        var singleDeps = await a.Resource.GetResourceDependenciesAsync(executionContext);
+        var multiDeps = await ResourceExtensions.GetDependenciesAsync([a.Resource], executionContext);
+
+        Assert.Equal(singleDeps.Count, multiDeps.Count);
+        foreach (var dep in singleDeps)
+        {
+            Assert.Contains(dep, multiDeps);
+        }
+    }
+
+    #endregion
 }

--- a/tests/Aspire.Hosting.Tests/WaitForTests.cs
+++ b/tests/Aspire.Hosting.Tests/WaitForTests.cs
@@ -19,11 +19,10 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     public async Task ResourceThatFailsToStartDueToExceptionDoesNotCauseStartAsyncToThrow()
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
-        var throwingResource = builder.AddContainer("throwingresource", "doesnotmatter")
-                              .WithEnvironment(ctx => throw new InvalidOperationException("BOOM!"));
-        var dependingContainerResource = builder.AddContainer("dependingcontainerresource", "doesnotmatter")
+        var throwingResource = builder.AddContainer("throwingresource", "nonexistent");
+        var dependingContainerResource = builder.AddContainer("dependingcontainerresource", "nonexistent2")
                                        .WaitFor(throwingResource);
-        var dependingExecutableResource = builder.AddExecutable("dependingexecutableresource", "doesnotmatter", "alsodoesntmatter")
+        var dependingExecutableResource = builder.AddExecutable("dependingexecutableresource", "nonexistent", "nonexistentdir")
                                        .WaitFor(throwingResource);
 
         var abortCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);

--- a/tools/perf/Measure-StartupPerformance.ps1
+++ b/tools/perf/Measure-StartupPerformance.ps1
@@ -93,8 +93,6 @@ Set-StrictMode -Version Latest
 
 # Constants
 $EventSourceName = 'Microsoft-Aspire-Hosting'
-$DcpModelCreationStartEventId = 17
-$DcpModelCreationStopEventId = 18
 
 # Get repository root (script is in tools/perf)
 $ScriptDir = $PSScriptRoot
@@ -244,37 +242,37 @@ function Invoke-PerformanceIteration {
                 $launchSettings = $jsonContent | ConvertFrom-Json
 
                 # Try to find a suitable profile (prefer 'http' for simplicity, then first available)
-                $profile = $null
+                $launchProfile = $null
                 if ($launchSettings.profiles.http) {
-                    $profile = $launchSettings.profiles.http
+                    $launchProfile = $launchSettings.profiles.http
                     Write-Verbose "Using 'http' launch profile"
                 }
                 elseif ($launchSettings.profiles.https) {
-                    $profile = $launchSettings.profiles.https
+                    $launchProfile = $launchSettings.profiles.https
                     Write-Verbose "Using 'https' launch profile"
                 }
                 else {
                     # Use first profile that has environmentVariables
                     foreach ($prop in $launchSettings.profiles.PSObject.Properties) {
                         if ($prop.Value.environmentVariables) {
-                            $profile = $prop.Value
+                            $launchProfile = $prop.Value
                             Write-Verbose "Using '$($prop.Name)' launch profile"
                             break
                         }
                     }
                 }
 
-                if ($profile -and $profile.environmentVariables) {
-                    foreach ($prop in $profile.environmentVariables.PSObject.Properties) {
+                if ($launchProfile -and $launchProfile.environmentVariables) {
+                    foreach ($prop in $launchProfile.environmentVariables.PSObject.Properties) {
                         $envVars[$prop.Name] = $prop.Value
                         Write-Verbose "  Environment: $($prop.Name)=$($prop.Value)"
                     }
                 }
 
                 # Use applicationUrl to set ASPNETCORE_URLS if not already set
-                if ($profile -and $profile.applicationUrl -and -not $envVars.ContainsKey('ASPNETCORE_URLS')) {
-                    $envVars['ASPNETCORE_URLS'] = $profile.applicationUrl
-                    Write-Verbose "  Environment: ASPNETCORE_URLS=$($profile.applicationUrl) (from applicationUrl)"
+                if ($launchProfile -and $launchProfile.applicationUrl -and -not $envVars.ContainsKey('ASPNETCORE_URLS')) {
+                    $envVars['ASPNETCORE_URLS'] = $launchProfile.applicationUrl
+                    Write-Verbose "  Environment: ASPNETCORE_URLS=$($launchProfile.applicationUrl) (from applicationUrl)"
                 }
             }
             catch {
@@ -670,8 +668,6 @@ function Main {
     else {
         Write-Warning "No traces were collected."
     }
-
-    return $results
 }
 
 # Run the script


### PR DESCRIPTION
This PR enables Aspire container tunnel feature by default. This allows containers to consume resources on the host network. Without the tunnel (current default) it only works with Docker Desktop, because other container orchestrators lack the necessary bridging functionality. 

To make it happen I made several changes and bug fixes to app model APIs,`DcpExecutor`, and tests. Most importantly:

1. There is a new API for efficiently computing dependencies of a set of resources.
2. If dashboard resource is present in the workload, dashboard endpoints become part of the model. This allows them to be tunneled into container network space.
3. DCP model creation is now done as a "set of interdependent Tasks", with finer granularity and greater parallelism. This allows us to treat tunnel-dependent vs tunnel-independent containers differently and shorten overall application startup time (with a caveat--see below).
4. Fixed the case where the tunnel could not be used for proxy-less services and added a test for it.
5. Fixed https://github.com/dotnet/aspire/issues/12998
6. Added a test utitlity for finding an un-occupied IP port for testing and modified some `DistributedApplicationTests` to use it--it should help us get those out of quarantined status.

CAVEAT: with this change, containers that use host resources will commence their startup after a delay (measured on my devbox VM as roughly 3-4 seconds in "warm" case). An example of such container is our Yarp integration, which pushes OTEL telemetry to the dashboard. This is because some of the endpoints they use are now provided by the tunnel, specifically the tunnel proxy container, that needs to start up and allocate these endpoints. Previously these contaienrs were leveraging Docker Desktop host connectivity, which required only textual replacement of the endpoint address `localhost` --> `host.docker.internal`. This drawback has to be weighted against the fact that the tunnel provides uniform behavior regardless of the container orchestrator and that we need to get more feedback about it from the users, which we won't get if the tunnel remains off by default.
Making the tunnel as fast as Docker Desktop-based solution is possible, but the plan for that requires making the tunnel itself persistent, which in turn requires persistent Executables, which is tracked here: https://github.com/microsoft/dcp/issues/13