### PR TITLE
Allow docker build secrets to be files

### DIFF
--- a/src/Aspire.Hosting/Publishing/BuildImageSecretValue.cs
+++ b/src/Aspire.Hosting/Publishing/BuildImageSecretValue.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aspire.Hosting.Publishing;
+
+/// <summary>
+/// Specifies the type of a build secret.
+/// </summary>
+[Experimental("ASPIRECONTAINERRUNTIME001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public enum BuildImageSecretType
+{
+    /// <summary>
+    /// The secret value is provided via an environment variable.
+    /// </summary>
+    Environment,
+
+    /// <summary>
+    /// The secret value is a file path.
+    /// </summary>
+    File
+}
+
+/// <summary>
+/// Represents a resolved build secret with its value and type.
+/// </summary>
+/// <param name="Value">The resolved secret value. For <see cref="BuildImageSecretType.Environment"/> secrets, this is the secret content.
+/// For <see cref="BuildImageSecretType.File"/> secrets, this is the file path.</param>
+/// <param name="Type">The type of the build secret, indicating whether it is environment-based or file-based.</param>
+[Experimental("ASPIRECONTAINERRUNTIME001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public record BuildImageSecretValue(string? Value, BuildImageSecretType Type);

--- a/src/Aspire.Hosting/Publishing/ContainerRuntimeBase.cs
+++ b/src/Aspire.Hosting/Publishing/ContainerRuntimeBase.cs
@@ -241,22 +241,22 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
     /// <param name="buildSecrets">The build secrets to include.</param>
     /// <param name="requireValue">Whether to require a non-null value for secrets (default: false).</param>
     /// <returns>A string containing the formatted build secrets.</returns>
-    protected static string BuildSecretsString(Dictionary<string, BuildImageSecretValue> buildSecrets, bool requireValue = false)
+    internal static string BuildSecretsString(Dictionary<string, BuildImageSecretValue> buildSecrets, bool requireValue = false)
     {
         var result = string.Empty;
         foreach (var buildSecret in buildSecrets)
         {
             if (buildSecret.Value.Type == BuildImageSecretType.File)
             {
-                result += $" --secret \"id={buildSecret.Key},src={buildSecret.Value.Value}\"";
+                result += $" --secret \"id={buildSecret.Key},type=file,src={buildSecret.Value.Value}\"";
             }
             else if (requireValue && buildSecret.Value.Value is null)
             {
-                result += $" --secret \"id={buildSecret.Key}\"";
+                result += $" --secret \"id={buildSecret.Key},type=env\"";
             }
             else
             {
-                result += $" --secret \"id={buildSecret.Key},env={buildSecret.Key.ToUpperInvariant()}\"";
+                result += $" --secret \"id={buildSecret.Key},type=env,env={buildSecret.Key.ToUpperInvariant()}\"";
             }
         }
         return result;

--- a/src/Aspire.Hosting/Publishing/IContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/IContainerRuntime.cs
@@ -34,7 +34,7 @@ public interface IContainerRuntime
     /// <param name="buildSecrets">Build secrets to pass to the build process.</param>
     /// <param name="stage">The target build stage.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-    Task BuildImageAsync(string contextPath, string dockerfilePath, ContainerImageBuildOptions? options, Dictionary<string, string?> buildArguments, Dictionary<string, string?> buildSecrets, string? stage, CancellationToken cancellationToken);
+    Task BuildImageAsync(string contextPath, string dockerfilePath, ContainerImageBuildOptions? options, Dictionary<string, string?> buildArguments, Dictionary<string, BuildImageSecretValue> buildSecrets, string? stage, CancellationToken cancellationToken);
 
     /// <summary>
     /// Tags a container image with a new name.

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
@@ -440,10 +440,12 @@ internal sealed class ResourceContainerImageManager(
         }
 
         // Resolve build secrets
-        var resolvedBuildSecrets = new Dictionary<string, string?>();
+        var resolvedBuildSecrets = new Dictionary<string, BuildImageSecretValue>();
         foreach (var buildSecret in dockerfileBuildAnnotation.BuildSecrets)
         {
-            resolvedBuildSecrets[buildSecret.Key] = await ResolveValue(buildSecret.Value, cancellationToken).ConfigureAwait(false);
+            var secretType = buildSecret.Value is FileInfo ? BuildImageSecretType.File : BuildImageSecretType.Environment;
+            var resolvedValue = await ResolveValue(buildSecret.Value, cancellationToken).ConfigureAwait(false);
+            resolvedBuildSecrets[buildSecret.Key] = new BuildImageSecretValue(resolvedValue, secretType);
         }
 
         // ensure outputPath is created if specified since docker/podman won't create it for us

--- a/tests/Aspire.Hosting.Tests/Publishing/FakeContainerRuntime.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/FakeContainerRuntime.cs
@@ -26,9 +26,9 @@ public sealed class FakeContainerRuntime(bool shouldFail = false, bool isRunning
     public List<(string contextPath, string dockerfilePath, ContainerImageBuildOptions? options)> BuildImageCalls { get; } = [];
     public List<(string registryServer, string username, string password)> LoginToRegistryCalls { get; } = [];
     public Dictionary<string, string?>? CapturedBuildArguments { get; private set; }
-    public Dictionary<string, string?>? CapturedBuildSecrets { get; private set; }
+    public Dictionary<string, BuildImageSecretValue>? CapturedBuildSecrets { get; private set; }
     public string? CapturedStage { get; private set; }
-    public Func<string, string, ContainerImageBuildOptions?, Dictionary<string, string?>, Dictionary<string, string?>, string?, CancellationToken, Task>? BuildImageAsyncCallback { get; set; }
+    public Func<string, string, ContainerImageBuildOptions?, Dictionary<string, string?>, Dictionary<string, BuildImageSecretValue>, string?, CancellationToken, Task>? BuildImageAsyncCallback { get; set; }
 
     public Task<bool> CheckIfRunningAsync(CancellationToken cancellationToken)
     {
@@ -70,7 +70,7 @@ public sealed class FakeContainerRuntime(bool shouldFail = false, bool isRunning
         return Task.CompletedTask;
     }
 
-    public async Task BuildImageAsync(string contextPath, string dockerfilePath, ContainerImageBuildOptions? options, Dictionary<string, string?> buildArguments, Dictionary<string, string?> buildSecrets, string? stage, CancellationToken cancellationToken)
+    public async Task BuildImageAsync(string contextPath, string dockerfilePath, ContainerImageBuildOptions? options, Dictionary<string, string?> buildArguments, Dictionary<string, BuildImageSecretValue> buildSecrets, string? stage, CancellationToken cancellationToken)
     {
         // Capture the arguments for verification in tests
         CapturedBuildArguments = buildArguments;

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
@@ -891,6 +891,59 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public void BuildSecretsStringFormatsEnvSecretCorrectly()
+    {
+        var secrets = new Dictionary<string, BuildImageSecretValue>
+        {
+            ["MY_SECRET"] = new BuildImageSecretValue("secret-value", BuildImageSecretType.Environment)
+        };
+
+        var result = ContainerRuntimeBase<DockerContainerRuntime>.BuildSecretsString(secrets);
+
+        Assert.Equal(" --secret \"id=MY_SECRET,type=env,env=MY_SECRET\"", result);
+    }
+
+    [Fact]
+    public void BuildSecretsStringFormatsFileSecretCorrectly()
+    {
+        var secrets = new Dictionary<string, BuildImageSecretValue>
+        {
+            ["npmrc"] = new BuildImageSecretValue("/path/to/.npmrc", BuildImageSecretType.File)
+        };
+
+        var result = ContainerRuntimeBase<DockerContainerRuntime>.BuildSecretsString(secrets);
+
+        Assert.Equal(" --secret \"id=npmrc,type=file,src=/path/to/.npmrc\"", result);
+    }
+
+    [Fact]
+    public void BuildSecretsStringFormatsNullEnvSecretWithRequireValue()
+    {
+        var secrets = new Dictionary<string, BuildImageSecretValue>
+        {
+            ["MY_SECRET"] = new BuildImageSecretValue(null, BuildImageSecretType.Environment)
+        };
+
+        var result = ContainerRuntimeBase<DockerContainerRuntime>.BuildSecretsString(secrets, requireValue: true);
+
+        Assert.Equal(" --secret \"id=MY_SECRET,type=env\"", result);
+    }
+
+    [Fact]
+    public void BuildSecretsStringFormatsMixedSecretTypes()
+    {
+        var secrets = new Dictionary<string, BuildImageSecretValue>
+        {
+            ["ENV_TOKEN"] = new BuildImageSecretValue("token-value", BuildImageSecretType.Environment),
+            ["npmrc"] = new BuildImageSecretValue("/app/.npmrc", BuildImageSecretType.File)
+        };
+
+        var result = ContainerRuntimeBase<DockerContainerRuntime>.BuildSecretsString(secrets);
+
+        Assert.Equal(" --secret \"id=ENV_TOKEN,type=env,env=ENV_TOKEN\" --secret \"id=npmrc,type=file,src=/app/.npmrc\"", result);
+    }
+
+    [Fact]
     public async Task MultipleAnnotations_AppliedInOrder()
     {
         using var builder = TestDistributedApplicationBuilder.Create(output);


### PR DESCRIPTION
## Description

This allows people to pass .npmrc files as docker secrets without baking auth credentials into this image.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
