### PR TITLE
Stop command exits with 0 when no AppHost is running

### DIFF
--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -68,8 +68,8 @@ internal sealed class StopCommand : BaseCommand
 
         if (!result.Success)
         {
-            _interactionService.DisplayError(result.ErrorMessage ?? StopCommandStrings.NoRunningAppHostsFound);
-            return ExitCodeConstants.FailedToFindProject;
+            _interactionService.DisplayMessage("information", StopCommandStrings.NoRunningAppHostsFound);
+            return ExitCodeConstants.Success;
         }
 
         var selectedConnection = result.Connection!;


### PR DESCRIPTION
## Summary

When running `aspire stop` and no AppHost is running, the command now returns exit code 0 and displays an informational message instead of exit code 7 (`FailedToFindProject`) with an error message.

Stopping nothing is not an error condition - it's an idempotent success.

## Changes

- Changed `StopCommand` to return `ExitCodeConstants.Success` (0) instead of `ExitCodeConstants.FailedToFindProject` (7) when no running AppHost is found
- Changed from `DisplayError` to `DisplayMessage("information", ...)` for the no-running-AppHost case, matching the pattern used by `PsCommand`

Addresses part of https://github.com/dotnet/aspire/issues/14238