### PR TITLE
Suppress update notification when running with --detach

### DIFF
--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -66,6 +66,9 @@ internal sealed class RunCommand : BaseCommand
     private readonly IAppHostProjectFactory _projectFactory;
     private readonly IAuxiliaryBackchannelMonitor _backchannelMonitor;
     private readonly Diagnostics.FileLoggerProvider _fileLoggerProvider;
+    private bool _isDetachMode;
+
+    protected override bool UpdateNotificationsEnabled => !_isDetachMode;
 
     private static readonly Option<FileInfo?> s_projectOption = new("--project")
     {
@@ -150,6 +153,7 @@ internal sealed class RunCommand : BaseCommand
     {
         var passedAppHostProjectFile = parseResult.GetValue(s_projectOption);
         var detach = parseResult.GetValue(s_detachOption);
+        _isDetachMode = detach;
         var format = parseResult.GetValue(s_formatOption);
         var isolated = parseResult.GetValue(s_isolatedOption);
         var noBuild = parseResult.GetValue(s_noBuildOption);

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -91,12 +91,12 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     public async Task RunCommand_WithDetachFlag_DoesNotShowUpdateNotification()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var trackingNotifier = new TrackingCliUpdateNotifier();
+        var testNotifier = new TestCliUpdateNotifier();
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
             options.ProjectLocatorFactory = _ => new NoProjectFileProjectLocator();
-            options.CliUpdateNotifierFactory = _ => trackingNotifier;
+            options.CliUpdateNotifierFactory = _ => testNotifier;
         });
         var provider = services.BuildServiceProvider();
 
@@ -105,19 +105,19 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         await result.InvokeAsync().DefaultTimeout();
 
-        Assert.False(trackingNotifier.NotifyWasCalled, "Update notification should not be shown when --detach is used");
+        Assert.False(testNotifier.NotifyWasCalled, "Update notification should not be shown when --detach is used");
     }
 
     [Fact]
     public async Task RunCommand_WithoutDetachFlag_ShowsUpdateNotification()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var trackingNotifier = new TrackingCliUpdateNotifier();
+        var testNotifier = new TestCliUpdateNotifier();
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
             options.ProjectLocatorFactory = _ => new NoProjectFileProjectLocator();
-            options.CliUpdateNotifierFactory = _ => trackingNotifier;
+            options.CliUpdateNotifierFactory = _ => testNotifier;
         });
         var provider = services.BuildServiceProvider();
 
@@ -126,7 +126,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
 
         await result.InvokeAsync().DefaultTimeout();
 
-        Assert.True(trackingNotifier.NotifyWasCalled, "Update notification should be shown when --detach is not used");
+        Assert.True(testNotifier.NotifyWasCalled, "Update notification should be shown when --detach is not used");
     }
 
     [Fact]
@@ -1495,23 +1495,4 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         }
     }
 
-    private sealed class TrackingCliUpdateNotifier : ICliUpdateNotifier
-    {
-        public bool NotifyWasCalled { get; private set; }
-
-        public Task CheckForCliUpdatesAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
-        {
-            return Task.CompletedTask;
-        }
-
-        public void NotifyIfUpdateAvailable()
-        {
-            NotifyWasCalled = true;
-        }
-
-        public bool IsUpdateAvailable()
-        {
-            return false;
-        }
-    }
 }

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -10,7 +10,6 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
-using Aspire.Cli.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console;
 using Microsoft.AspNetCore.InternalTesting;
@@ -979,27 +978,6 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
         => _innerService.DisplayVersionUpdateNotification(newerVersion, updateCommand);
     public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false) 
         => _innerService.WriteConsoleLog(message, lineNumber, type, isErrorMessage);
-}
-
-// Test implementation of ICliUpdateNotifier
-internal sealed class TestCliUpdateNotifier : ICliUpdateNotifier
-{
-    public Func<bool>? IsUpdateAvailableCallback { get; set; }
-
-    public Task CheckForCliUpdatesAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
-    {
-        return Task.CompletedTask;
-    }
-
-    public void NotifyIfUpdateAvailable()
-    {
-        // No-op for tests
-    }
-
-    public bool IsUpdateAvailable()
-    {
-        return IsUpdateAvailableCallback?.Invoke() ?? false;
-    }
 }
 
 // Test implementation of IProjectUpdater

--- a/tests/Aspire.Cli.Tests/TestServices/TestCliUpdateNotifier.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestCliUpdateNotifier.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Utils;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+internal sealed class TestCliUpdateNotifier : ICliUpdateNotifier
+{
+    public bool NotifyWasCalled { get; private set; }
+
+    public Func<bool>? IsUpdateAvailableCallback { get; set; }
+
+    public Task CheckForCliUpdatesAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    public void NotifyIfUpdateAvailable()
+    {
+        NotifyWasCalled = true;
+    }
+
+    public bool IsUpdateAvailable()
+    {
+        return IsUpdateAvailableCallback?.Invoke() ?? false;
+    }
+}


### PR DESCRIPTION
## Summary

When running `aspire run --detach`, the parent process no longer displays the update notification message before exiting. The update check is not useful in detach mode since the parent exits immediately after spawning the child process.

## Changes

- Added `_isDetachMode` field to `RunCommand` set when `--detach` flag is parsed
- Overrode `UpdateNotificationsEnabled` property to return `false` when in detach mode

Addresses part of https://github.com/dotnet/aspire/issues/14238