### PR TITLE
Redirect human-readable messages to stderr when --format json is used

### DIFF
--- a/src/Aspire.Cli/Commands/ConfigCommand.cs
+++ b/src/Aspire.Cli/Commands/ConfigCommand.cs
@@ -414,7 +414,8 @@ internal sealed class ConfigCommand : BaseCommand
                 // Use DisplayRawText to avoid Spectre.Console word wrapping which breaks JSON strings
                 if (InteractionService is ConsoleInteractionService consoleService)
                 {
-                    consoleService.DisplayRawText(json);
+                    // Structured output always goes to stdout.
+                    consoleService.DisplayRawText(json, ConsoleOutput.Standard);
                 }
                 else
                 {

--- a/src/Aspire.Cli/Commands/DocsGetCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsGetCommand.cs
@@ -81,13 +81,15 @@ internal sealed partial class DocsGetCommand : BaseCommand
         if (format is OutputFormat.Json)
         {
             var json = JsonSerializer.Serialize(doc, JsonSourceGenerationContext.RelaxedEscaping.DocsContent);
-            InteractionService.DisplayRawText(json);
+            // Structured output always goes to stdout.
+            InteractionService.DisplayRawText(json, ConsoleOutput.Standard);
         }
         else
         {
             // Format the markdown for better terminal readability
             var formatted = FormatMarkdownForTerminal(doc.Content);
-            InteractionService.DisplayRawText(formatted);
+            // Structured output always goes to stdout.
+            InteractionService.DisplayRawText(formatted, ConsoleOutput.Standard);
         }
 
         return ExitCodeConstants.Success;

--- a/src/Aspire.Cli/Commands/DocsListCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsListCommand.cs
@@ -68,7 +68,8 @@ internal sealed class DocsListCommand : BaseCommand
         if (format is OutputFormat.Json)
         {
             var json = JsonSerializer.Serialize(docs.ToArray(), JsonSourceGenerationContext.RelaxedEscaping.DocsListItemArray);
-            InteractionService.DisplayRawText(json);
+            // Structured output always goes to stdout.
+            InteractionService.DisplayRawText(json, ConsoleOutput.Standard);
         }
         else
         {

--- a/src/Aspire.Cli/Commands/DocsSearchCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsSearchCommand.cs
@@ -82,7 +82,8 @@ internal sealed class DocsSearchCommand : BaseCommand
         if (format is OutputFormat.Json)
         {
             var json = JsonSerializer.Serialize(response.Results.ToArray(), JsonSourceGenerationContext.RelaxedEscaping.SearchResultArray);
-            InteractionService.DisplayRawText(json);
+            // Structured output always goes to stdout.
+            InteractionService.DisplayRawText(json, ConsoleOutput.Standard);
         }
         else
         {

--- a/src/Aspire.Cli/Commands/DoctorCommand.cs
+++ b/src/Aspire.Cli/Commands/DoctorCommand.cs
@@ -83,7 +83,8 @@ internal sealed class DoctorCommand : BaseCommand
 
         var json = System.Text.Json.JsonSerializer.Serialize(response, JsonSourceGenerationContext.RelaxedEscaping.DoctorCheckResponse);
         // Use DisplayRawText to write directly to console without any formatting
-        InteractionService.DisplayRawText(json);
+        // Structured output always goes to stdout.
+        InteractionService.DisplayRawText(json, ConsoleOutput.Standard);
     }
 
     private void OutputHumanReadable(IReadOnlyList<EnvironmentCheckResult> results)

--- a/src/Aspire.Cli/Commands/ExtensionInternalCommand.cs
+++ b/src/Aspire.Cli/Commands/ExtensionInternalCommand.cs
@@ -48,7 +48,8 @@ internal sealed class ExtensionInternalCommand : BaseCommand
                     SelectedProjectFile = result.SelectedProjectFile?.FullName,
                     AllProjectFileCandidates = result.AllProjectFileCandidates.Select(f => f.FullName).ToList()
                 }, BackchannelJsonSerializerContext.Default.AppHostProjectSearchResultPoco);
-                InteractionService.DisplayRawText(json);
+                // Structured output always goes to stdout.
+                InteractionService.DisplayRawText(json, ConsoleOutput.Standard);
                 return ExitCodeConstants.Success;
             }
             catch

--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -220,7 +220,8 @@ internal sealed class LogsCommand : BaseCommand
                 }).ToArray()
             };
             var json = JsonSerializer.Serialize(logsOutput, LogsCommandJsonContext.Snapshot.LogsOutput);
-            _interactionService.DisplayRawText(json);
+            // Structured output always goes to stdout.
+            _interactionService.DisplayRawText(json, ConsoleOutput.Standard);
         }
         else
         {
@@ -327,7 +328,8 @@ internal sealed class LogsCommand : BaseCommand
                 IsError = logLine.IsError
             };
             var output = JsonSerializer.Serialize(logLineJson, LogsCommandJsonContext.Ndjson.LogLineJson);
-            _interactionService.DisplayRawText(output);
+            // Structured output always goes to stdout.
+            _interactionService.DisplayRawText(output, ConsoleOutput.Standard);
         }
         else if (_hostEnvironment.SupportsAnsi)
         {

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -118,7 +118,8 @@ internal sealed class PsCommand : BaseCommand
         if (format == OutputFormat.Json)
         {
             var json = JsonSerializer.Serialize(appHostInfos, PsCommandJsonContext.RelaxedEscaping.ListAppHostDisplayInfo);
-            _interactionService.DisplayRawText(json);
+            // Structured output always goes to stdout.
+            _interactionService.DisplayRawText(json, ConsoleOutput.Standard);
         }
         else
         {

--- a/src/Aspire.Cli/Commands/ResourcesCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourcesCommand.cs
@@ -176,7 +176,8 @@ internal sealed class ResourcesCommand : BaseCommand
         {
             var output = new ResourcesOutput { Resources = resourceList.ToArray() };
             var json = JsonSerializer.Serialize(output, ResourcesCommandJsonContext.RelaxedEscaping.ResourcesOutput);
-            _interactionService.DisplayRawText(json);
+            // Structured output always goes to stdout.
+            _interactionService.DisplayRawText(json, ConsoleOutput.Standard);
         }
         else
         {
@@ -213,7 +214,8 @@ internal sealed class ResourcesCommand : BaseCommand
             {
                 // NDJSON output - compact, one object per line for streaming
                 var json = JsonSerializer.Serialize(resourceJson, ResourcesCommandJsonContext.Ndjson.ResourceJson);
-                _interactionService.DisplayRawText(json);
+                // Structured output always goes to stdout.
+                _interactionService.DisplayRawText(json, ConsoleOutput.Standard);
             }
             else
             {

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -628,7 +628,7 @@ internal sealed class RunCommand : BaseCommand
         // Only content explicitly sent to stdout (JSON results) appears on stdout.
         if (format == OutputFormat.Json)
         {
-            _interactionService.DefaultConsole = ConsoleOutput.Error;
+            _interactionService.Console = ConsoleOutput.Error;
         }
 
         // Failure mode 1: Project not found
@@ -881,7 +881,8 @@ internal sealed class RunCommand : BaseCommand
                 dashboardUrls?.BaseUrlWithLoginToken,
                 childLogFile);
             var json = JsonSerializer.Serialize(result, RunCommandJsonContext.RelaxedEscaping.DetachOutputInfo);
-            _interactionService.DisplayRawText(json);
+            // Structured output always goes to stdout.
+            _interactionService.DisplayRawText(json, ConsoleOutput.Standard);
         }
         else
         {

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -628,7 +628,7 @@ internal sealed class RunCommand : BaseCommand
         // so that only the JSON result appears on stdout.
         if (format == OutputFormat.Json)
         {
-            _interactionService.UseStderrForMessages = true;
+            _interactionService.DefaultConsole = ConsoleOutput.Error;
         }
 
         // Failure mode 1: Project not found

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -632,9 +632,15 @@ internal sealed class RunCommand : BaseCommand
         }
 
         // Failure mode 1: Project not found
+        // When outputting JSON, use Throw instead of Prompt to avoid polluting stdout
+        // with interactive selection UI. The user should specify --project explicitly.
+        var multipleAppHostBehavior = format == OutputFormat.Json
+            ? MultipleAppHostProjectsFoundBehavior.Throw
+            : MultipleAppHostProjectsFoundBehavior.Prompt;
+
         var searchResult = await _projectLocator.UseOrFindAppHostProjectFileAsync(
             passedAppHostProjectFile,
-            MultipleAppHostProjectsFoundBehavior.Prompt,
+            multipleAppHostBehavior,
             createSettingsFile: false,
             cancellationToken);
 

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -624,8 +624,8 @@ internal sealed class RunCommand : BaseCommand
     {
         var format = parseResult.GetValue(s_formatOption);
 
-        // When outputting JSON, redirect human-readable messages to stderr
-        // so that only the JSON result appears on stdout.
+        // When outputting JSON, write all console to stderr by default.
+        // Only content explicitly sent to stdout (JSON results) appears on stdout.
         if (format == OutputFormat.Json)
         {
             _interactionService.DefaultConsole = ConsoleOutput.Error;

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -624,6 +624,13 @@ internal sealed class RunCommand : BaseCommand
     {
         var format = parseResult.GetValue(s_formatOption);
 
+        // When outputting JSON, redirect human-readable messages to stderr
+        // so that only the JSON result appears on stdout.
+        if (format == OutputFormat.Json)
+        {
+            _interactionService.UseStderrForMessages = true;
+        }
+
         // Failure mode 1: Project not found
         var searchResult = await _projectLocator.UseOrFindAppHostProjectFileAsync(
             passedAppHostProjectFile,

--- a/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
@@ -171,7 +171,8 @@ internal sealed class TelemetryLogsCommand : BaseCommand
 
         if (format == OutputFormat.Json)
         {
-            _interactionService.DisplayRawText(json);
+            // Structured output always goes to stdout.
+            _interactionService.DisplayRawText(json, ConsoleOutput.Standard);
         }
         else
         {
@@ -199,7 +200,8 @@ internal sealed class TelemetryLogsCommand : BaseCommand
         {
             if (format == OutputFormat.Json)
             {
-                _interactionService.DisplayRawText(line);
+                // Structured output always goes to stdout.
+                _interactionService.DisplayRawText(line, ConsoleOutput.Standard);
             }
             else
             {

--- a/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
@@ -172,7 +172,8 @@ internal sealed class TelemetrySpansCommand : BaseCommand
 
         if (format == OutputFormat.Json)
         {
-            _interactionService.DisplayRawText(json);
+            // Structured output always goes to stdout.
+            _interactionService.DisplayRawText(json, ConsoleOutput.Standard);
         }
         else
         {
@@ -201,7 +202,8 @@ internal sealed class TelemetrySpansCommand : BaseCommand
         {
             if (format == OutputFormat.Json)
             {
-                _interactionService.DisplayRawText(line);
+                // Structured output always goes to stdout.
+                _interactionService.DisplayRawText(line, ConsoleOutput.Standard);
             }
             else
             {

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -131,7 +131,8 @@ internal sealed class TelemetryTracesCommand : BaseCommand
 
             if (format == OutputFormat.Json)
             {
-                _interactionService.DisplayRawText(json);
+                // Structured output always goes to stdout.
+                _interactionService.DisplayRawText(json, ConsoleOutput.Standard);
             }
             else
             {
@@ -199,7 +200,8 @@ internal sealed class TelemetryTracesCommand : BaseCommand
 
             if (format == OutputFormat.Json)
             {
-                _interactionService.DisplayRawText(json);
+                // Structured output always goes to stdout.
+                _interactionService.DisplayRawText(json, ConsoleOutput.Standard);
             }
             else
             {

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -22,18 +22,13 @@ internal class ConsoleInteractionService : IInteractionService
     private readonly CliExecutionContext _executionContext;
     private readonly ICliHostEnvironment _hostEnvironment;
     private int _inStatus;
-    private bool _useStderrForMessages;
 
     /// <summary>
-    /// Console used for human-readable messages; routes to stderr when structured output mode is active.
+    /// Console used for human-readable messages; routes to stderr when <see cref="DefaultConsole"/> is set to <see cref="ConsoleOutput.Error"/>.
     /// </summary>
-    private IAnsiConsole MessageConsole => _useStderrForMessages ? _errorConsole : _outConsole;
+    private IAnsiConsole MessageConsole => DefaultConsole == ConsoleOutput.Error ? _errorConsole : _outConsole;
 
-    public bool UseStderrForMessages
-    {
-        get => _useStderrForMessages;
-        set => _useStderrForMessages = value;
-    }
+    public ConsoleOutput DefaultConsole { get; set; }
 
     public ConsoleInteractionService(ConsoleEnvironment consoleEnvironment, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment)
     {
@@ -230,10 +225,11 @@ internal class ConsoleInteractionService : IInteractionService
         MessageConsole.Profile.Out.Writer.WriteLine(message);
     }
 
-    public void DisplayRawText(string text)
+    public void DisplayRawText(string text, ConsoleOutput console = ConsoleOutput.Standard)
     {
         // Write raw text directly to avoid console wrapping
-        _outConsole.Profile.Out.Writer.WriteLine(text);
+        var target = console == ConsoleOutput.Error ? _errorConsole : _outConsole;
+        target.Profile.Out.Writer.WriteLine(text);
     }
 
     public void DisplayMarkdown(string markdown)

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -24,11 +24,11 @@ internal class ConsoleInteractionService : IInteractionService
     private int _inStatus;
 
     /// <summary>
-    /// Console used for human-readable messages; routes to stderr when <see cref="DefaultConsole"/> is set to <see cref="ConsoleOutput.Error"/>.
+    /// Console used for human-readable messages; routes to stderr when <see cref="Console"/> is set to <see cref="ConsoleOutput.Error"/>.
     /// </summary>
-    private IAnsiConsole MessageConsole => DefaultConsole == ConsoleOutput.Error ? _errorConsole : _outConsole;
+    private IAnsiConsole MessageConsole => Console == ConsoleOutput.Error ? _errorConsole : _outConsole;
 
-    public ConsoleOutput DefaultConsole { get; set; }
+    public ConsoleOutput Console { get; set; }
 
     public ConsoleInteractionService(ConsoleEnvironment consoleEnvironment, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment)
     {
@@ -225,10 +225,12 @@ internal class ConsoleInteractionService : IInteractionService
         MessageConsole.Profile.Out.Writer.WriteLine(message);
     }
 
-    public void DisplayRawText(string text, ConsoleOutput console = ConsoleOutput.Standard)
+    public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null)
     {
-        // Write raw text directly to avoid console wrapping
-        var target = console == ConsoleOutput.Error ? _errorConsole : _outConsole;
+        // Write raw text directly to avoid console wrapping.
+        // When consoleOverride is null, respect the Console setting.
+        var effectiveConsole = consoleOverride ?? Console;
+        var target = effectiveConsole == ConsoleOutput.Error ? _errorConsole : _outConsole;
         target.Profile.Out.Writer.WriteLine(text);
     }
 

--- a/src/Aspire.Cli/Interaction/ConsoleOutput.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleOutput.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Interaction;
+
+/// <summary>
+/// Specifies which console output stream to use.
+/// </summary>
+internal enum ConsoleOutput
+{
+    /// <summary>
+    /// Standard output (stdout).
+    /// </summary>
+    Standard,
+
+    /// <summary>
+    /// Standard error (stderr).
+    /// </summary>
+    Error
+}

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -299,11 +299,17 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         _consoleInteractionService.DisplayPlainText(text);
     }
 
-    public void DisplayRawText(string text)
+    public ConsoleOutput DefaultConsole
+    {
+        get => _consoleInteractionService.DefaultConsole;
+        set => _consoleInteractionService.DefaultConsole = value;
+    }
+
+    public void DisplayRawText(string text, ConsoleOutput console = ConsoleOutput.Standard)
     {
         var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayPlainTextAsync(text, _cancellationToken));
         Debug.Assert(result);
-        _consoleInteractionService.DisplayRawText(text);
+        _consoleInteractionService.DisplayRawText(text, console);
     }
 
     public void DisplayMarkdown(string markdown)

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -299,17 +299,17 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         _consoleInteractionService.DisplayPlainText(text);
     }
 
-    public ConsoleOutput DefaultConsole
+    public ConsoleOutput Console
     {
-        get => _consoleInteractionService.DefaultConsole;
-        set => _consoleInteractionService.DefaultConsole = value;
+        get => _consoleInteractionService.Console;
+        set => _consoleInteractionService.Console = value;
     }
 
-    public void DisplayRawText(string text, ConsoleOutput console = ConsoleOutput.Standard)
+    public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null)
     {
         var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayPlainTextAsync(text, _cancellationToken));
         Debug.Assert(result);
-        _consoleInteractionService.DisplayRawText(text, console);
+        _consoleInteractionService.DisplayRawText(text, consoleOverride);
     }
 
     public void DisplayMarkdown(string markdown)

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -18,7 +18,7 @@ internal interface IInteractionService
     void DisplayError(string errorMessage);
     void DisplayMessage(string emoji, string message);
     void DisplayPlainText(string text);
-    void DisplayRawText(string text, ConsoleOutput console = ConsoleOutput.Standard);
+    void DisplayRawText(string text, ConsoleOutput? consoleOverride = null);
     void DisplayMarkdown(string markdown);
     void DisplayMarkupLine(string markup);
     void DisplaySuccess(string message);
@@ -32,7 +32,7 @@ internal interface IInteractionService
     /// When set to <see cref="ConsoleOutput.Error"/>, display methods route output to stderr
     /// so that structured output (e.g., JSON) on stdout remains parseable.
     /// </summary>
-    ConsoleOutput DefaultConsole { get; set; }
+    ConsoleOutput Console { get; set; }
 
     void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null);
     void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false);

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -18,7 +18,7 @@ internal interface IInteractionService
     void DisplayError(string errorMessage);
     void DisplayMessage(string emoji, string message);
     void DisplayPlainText(string text);
-    void DisplayRawText(string text);
+    void DisplayRawText(string text, ConsoleOutput console = ConsoleOutput.Standard);
     void DisplayMarkdown(string markdown);
     void DisplayMarkupLine(string markup);
     void DisplaySuccess(string message);
@@ -28,10 +28,11 @@ internal interface IInteractionService
     void DisplayEmptyLine();
 
     /// <summary>
-    /// When true, routes human-readable messages to stderr instead of stdout
+    /// Gets or sets the default console output stream for human-readable messages.
+    /// When set to <see cref="ConsoleOutput.Error"/>, display methods route output to stderr
     /// so that structured output (e.g., JSON) on stdout remains parseable.
     /// </summary>
-    bool UseStderrForMessages { get => false; set { } }
+    ConsoleOutput DefaultConsole { get; set; }
 
     void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null);
     void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false);

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -27,6 +27,12 @@ internal interface IInteractionService
     void DisplayCancellationMessage();
     void DisplayEmptyLine();
 
+    /// <summary>
+    /// When true, routes human-readable messages to stderr instead of stdout
+    /// so that structured output (e.g., JSON) on stdout remains parseable.
+    /// </summary>
+    bool UseStderrForMessages { get => false; set { } }
+
     void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null);
     void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false);
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/MultipleAppHostTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/MultipleAppHostTests.cs
@@ -1,0 +1,108 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests for Aspire CLI behavior when multiple AppHost projects are found.
+/// Each test class runs as a separate CI job for parallelization.
+/// </summary>
+public sealed class MultipleAppHostTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task MultipleAppHostsShowsSelectionPrompt()
+    {
+        var workspace = TemporaryWorkspace.Create(output);
+
+        var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
+        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
+        var isCI = CliE2ETestHelpers.IsRunningInCI;
+        var recordingPath = CliE2ETestHelpers.GetTestResultsRecordingPath(nameof(MultipleAppHostsShowsSelectionPrompt));
+
+        var builder = Hex1bTerminal.CreateBuilder()
+            .WithHeadless()
+            .WithDimensions(160, 48)
+            .WithAsciinemaRecording(recordingPath)
+            .WithPtyProcess("/bin/bash", ["--norc"]);
+
+        using var terminal = builder.Build();
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        // Pattern searcher for the apphost selection prompt
+        var waitingForAppHostSelectionPrompt = new CellPatternSearcher()
+            .Find("Select an apphost to use:");
+
+        // After selecting, `aspire run` will try to build the single-file apphost.
+        // We expect it to fail since these are minimal stubs, but that's fine —
+        // we only need to verify the selection prompt appears.
+
+        var counter = new SequenceCounter();
+        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+        sequenceBuilder.PrepareEnvironment(workspace, counter);
+
+        if (isCI)
+        {
+            sequenceBuilder.InstallAspireCliFromPullRequest(prNumber, counter);
+            sequenceBuilder.SourceAspireCliEnvironment(counter);
+            sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
+        }
+
+        // Create two single-file AppHost directories so the CLI detects multiple apphosts.
+        // A single-file apphost is a .cs file with "#:sdk Aspire.AppHost.Sdk" and no sibling .csproj.
+        var appHost1Dir = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost1");
+        var appHost2Dir = Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost2");
+
+        sequenceBuilder.ExecuteCallback(() =>
+        {
+            Directory.CreateDirectory(appHost1Dir);
+            File.WriteAllText(Path.Combine(appHost1Dir, "apphost.cs"),
+                """
+                #:sdk Aspire.AppHost.Sdk
+                var builder = DistributedApplication.CreateBuilder(args);
+                builder.Build().Run();
+                """);
+
+            Directory.CreateDirectory(appHost2Dir);
+            File.WriteAllText(Path.Combine(appHost2Dir, "apphost.cs"),
+                """
+                #:sdk Aspire.AppHost.Sdk
+                var builder = DistributedApplication.CreateBuilder(args);
+                builder.Build().Run();
+                """);
+        });
+
+        // Run aspire run from the workspace root — should find both apphosts and prompt
+        sequenceBuilder.Type("aspire run")
+            .Enter()
+            .WaitUntil(s => waitingForAppHostSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
+            // Select the first apphost by pressing Enter
+            .Enter()
+            // The selected apphost will attempt to build/run; it may fail since these
+            // are minimal stubs. Wait for the shell prompt (success or error) either way.
+            .WaitUntil(snapshot =>
+            {
+                var promptSearcher = new CellPatternSearcher()
+                    .FindPattern(counter.Value.ToString())
+                    .RightText("] $ ");
+
+                return promptSearcher.Search(snapshot).Count > 0;
+            }, TimeSpan.FromMinutes(2))
+            .IncrementSequence(counter)
+            .Type("exit")
+            .Enter();
+
+        var sequence = sequenceBuilder.Build();
+
+        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+        await pendingRun;
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/MultipleAppHostTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/MultipleAppHostTests.cs
@@ -93,27 +93,10 @@ public sealed class MultipleAppHostTests(ITestOutputHelper output)
             .WaitForSuccessPrompt(counter);
 
         // First: launch the apphost with --detach (interactive, no JSON)
-        var waitForDetachedMessage = new CellPatternSearcher()
-            .Find("The apphost is running in the background.");
-
+        // Just wait for the command to complete (WaitForSuccessPrompt waits for the shell prompt)
         sequenceBuilder
             .Type("aspire run --detach")
             .Enter()
-            .WaitUntil(s =>
-            {
-                if (waitForDetachedMessage.Search(s).Count > 0)
-                {
-                    return true;
-                }
-
-                var sdkError = new CellPatternSearcher().Find("Could not resolve SDK");
-                if (sdkError.Search(s).Count > 0)
-                {
-                    throw new InvalidOperationException("AppHost SDK resolution failed.");
-                }
-
-                return false;
-            }, TimeSpan.FromMinutes(3))
             .WaitForSuccessPrompt(counter);
 
         sequenceBuilder.ClearScreen(counter);

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -896,6 +896,8 @@ internal sealed class TestNewCommandPrompter(IInteractionService interactionServ
 
 internal sealed class OrderTrackingInteractionService(List<string> operationOrder) : IInteractionService
 {
+    public ConsoleOutput DefaultConsole { get; set; }
+
     public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action)
     {
         return action();
@@ -950,7 +952,7 @@ internal sealed class OrderTrackingInteractionService(List<string> operationOrde
     public void DisplaySubtleMessage(string message, bool escapeMarkup = true) { }
     public void DisplayEmptyLine() { }
     public void DisplayPlainText(string text) { }
-    public void DisplayRawText(string text) { }
+    public void DisplayRawText(string text, ConsoleOutput console = ConsoleOutput.Standard) { }
     public void DisplayMarkdown(string markdown) { }
     public void DisplayMarkupLine(string markup) { }
     public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false) { }

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -896,7 +896,7 @@ internal sealed class TestNewCommandPrompter(IInteractionService interactionServ
 
 internal sealed class OrderTrackingInteractionService(List<string> operationOrder) : IInteractionService
 {
-    public ConsoleOutput DefaultConsole { get; set; }
+    public ConsoleOutput Console { get; set; }
 
     public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action)
     {
@@ -952,7 +952,7 @@ internal sealed class OrderTrackingInteractionService(List<string> operationOrde
     public void DisplaySubtleMessage(string message, bool escapeMarkup = true) { }
     public void DisplayEmptyLine() { }
     public void DisplayPlainText(string text) { }
-    public void DisplayRawText(string text, ConsoleOutput console = ConsoleOutput.Standard) { }
+    public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) { }
     public void DisplayMarkdown(string markdown) { }
     public void DisplayMarkupLine(string markup) { }
     public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false) { }

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -850,7 +850,7 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
     private readonly Queue<(string response, ResponseType type)> _responses = new();
     private bool _shouldCancel;
 
-    public ConsoleOutput DefaultConsole { get; set; }
+    public ConsoleOutput Console { get; set; }
     public List<StringPromptCall> StringPromptCalls { get; } = [];
     public List<object> SelectionPromptCalls { get; } = []; // Using object to handle generic types
     public List<BooleanPromptCall> BooleanPromptCalls { get; } = [];
@@ -947,7 +947,7 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
     public void DisplayCancellationMessage() { }
     public void DisplayEmptyLine() { }
     public void DisplayPlainText(string text) { }
-    public void DisplayRawText(string text, ConsoleOutput console = ConsoleOutput.Standard) { }
+    public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) { }
     public void DisplayMarkdown(string markdown) { }
     public void DisplayMarkupLine(string markup) { }
 
@@ -956,7 +956,7 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
     public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false)
     {
         var messageType = isErrorMessage ? "error" : "info";
-        Console.WriteLine($"#{lineNumber} [{messageType}] {message}");
+        System.Console.WriteLine($"#{lineNumber} [{messageType}] {message}");
     }
 }
 

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -850,6 +850,7 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
     private readonly Queue<(string response, ResponseType type)> _responses = new();
     private bool _shouldCancel;
 
+    public ConsoleOutput DefaultConsole { get; set; }
     public List<StringPromptCall> StringPromptCalls { get; } = [];
     public List<object> SelectionPromptCalls { get; } = []; // Using object to handle generic types
     public List<BooleanPromptCall> BooleanPromptCalls { get; } = [];
@@ -946,7 +947,7 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
     public void DisplayCancellationMessage() { }
     public void DisplayEmptyLine() { }
     public void DisplayPlainText(string text) { }
-    public void DisplayRawText(string text) { }
+    public void DisplayRawText(string text, ConsoleOutput console = ConsoleOutput.Standard) { }
     public void DisplayMarkdown(string markdown) { }
     public void DisplayMarkupLine(string markup) { }
 

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -941,10 +941,10 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
 {
     private readonly IInteractionService _innerService;
 
-    public ConsoleOutput DefaultConsole
+    public ConsoleOutput Console
     {
-        get => _innerService.DefaultConsole;
-        set => _innerService.DefaultConsole = value;
+        get => _innerService.Console;
+        set => _innerService.Console = value;
     }
 
     public Action? OnCancellationMessageDisplayed { get; set; }
@@ -969,7 +969,7 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
     public void DisplayError(string errorMessage) => _innerService.DisplayError(errorMessage);
     public void DisplayMessage(string emoji, string message) => _innerService.DisplayMessage(emoji, message);
     public void DisplayPlainText(string text) => _innerService.DisplayPlainText(text);
-    public void DisplayRawText(string text, ConsoleOutput console = ConsoleOutput.Standard) => _innerService.DisplayRawText(text, console);
+    public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) => _innerService.DisplayRawText(text, consoleOverride);
     public void DisplayMarkdown(string markdown) => _innerService.DisplayMarkdown(markdown);
     public void DisplayMarkupLine(string markup) => _innerService.DisplayMarkupLine(markup);
     public void DisplaySuccess(string message) => _innerService.DisplaySuccess(message);

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -941,6 +941,12 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
 {
     private readonly IInteractionService _innerService;
 
+    public ConsoleOutput DefaultConsole
+    {
+        get => _innerService.DefaultConsole;
+        set => _innerService.DefaultConsole = value;
+    }
+
     public Action? OnCancellationMessageDisplayed { get; set; }
 
     public CancellationTrackingInteractionService(IInteractionService innerService)
@@ -963,7 +969,7 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
     public void DisplayError(string errorMessage) => _innerService.DisplayError(errorMessage);
     public void DisplayMessage(string emoji, string message) => _innerService.DisplayMessage(emoji, message);
     public void DisplayPlainText(string text) => _innerService.DisplayPlainText(text);
-    public void DisplayRawText(string text) => _innerService.DisplayRawText(text);
+    public void DisplayRawText(string text, ConsoleOutput console = ConsoleOutput.Standard) => _innerService.DisplayRawText(text, console);
     public void DisplayMarkdown(string markdown) => _innerService.DisplayMarkdown(markdown);
     public void DisplayMarkupLine(string markup) => _innerService.DisplayMarkupLine(markup);
     public void DisplaySuccess(string message) => _innerService.DisplaySuccess(message);

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -409,7 +409,7 @@ public class DotNetTemplateFactoryTests
 
     private sealed class TestInteractionService : IInteractionService
     {
-        public ConsoleOutput DefaultConsole { get; set; }
+        public ConsoleOutput Console { get; set; }
 
         public Task<T> PromptForSelectionAsync<T>(string prompt, IEnumerable<T> choices, Func<T, string> displaySelector, CancellationToken cancellationToken) where T : notnull
             => throw new NotImplementedException();
@@ -439,7 +439,7 @@ public class DotNetTemplateFactoryTests
         public void DisplayCancellationMessage() { }
         public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;
         public void DisplayPlainText(string text) { }
-        public void DisplayRawText(string text, ConsoleOutput console = ConsoleOutput.Standard) { }
+        public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) { }
         public void DisplayMarkdown(string markdown) { }
         public void DisplayMarkupLine(string markup) { }
         public void DisplaySubtleMessage(string message, bool escapeMarkup = true) { }

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -409,6 +409,8 @@ public class DotNetTemplateFactoryTests
 
     private sealed class TestInteractionService : IInteractionService
     {
+        public ConsoleOutput DefaultConsole { get; set; }
+
         public Task<T> PromptForSelectionAsync<T>(string prompt, IEnumerable<T> choices, Func<T, string> displaySelector, CancellationToken cancellationToken) where T : notnull
             => throw new NotImplementedException();
 
@@ -437,7 +439,7 @@ public class DotNetTemplateFactoryTests
         public void DisplayCancellationMessage() { }
         public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;
         public void DisplayPlainText(string text) { }
-        public void DisplayRawText(string text) { }
+        public void DisplayRawText(string text, ConsoleOutput console = ConsoleOutput.Standard) { }
         public void DisplayMarkdown(string markdown) { }
         public void DisplayMarkupLine(string markup) { }
         public void DisplaySubtleMessage(string message, bool escapeMarkup = true) { }

--- a/tests/Aspire.Cli.Tests/TestServices/TestConsoleInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestConsoleInteractionService.cs
@@ -10,6 +10,7 @@ namespace Aspire.Cli.Tests.TestServices;
 
 internal sealed class TestConsoleInteractionService : IInteractionService
 {
+    public ConsoleOutput DefaultConsole { get; set; }
     public Action<string>? DisplayErrorCallback { get; set; }
     public Action<string>? DisplaySubtleMessageCallback { get; set; }
     public Action<string>? DisplayConsoleWriteLineMessage { get; set; }
@@ -113,7 +114,7 @@ internal sealed class TestConsoleInteractionService : IInteractionService
     {
     }
 
-    public void DisplayRawText(string text)
+    public void DisplayRawText(string text, ConsoleOutput console = ConsoleOutput.Standard)
     {
     }
 

--- a/tests/Aspire.Cli.Tests/TestServices/TestConsoleInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestConsoleInteractionService.cs
@@ -10,7 +10,7 @@ namespace Aspire.Cli.Tests.TestServices;
 
 internal sealed class TestConsoleInteractionService : IInteractionService
 {
-    public ConsoleOutput DefaultConsole { get; set; }
+    public ConsoleOutput Console { get; set; }
     public Action<string>? DisplayErrorCallback { get; set; }
     public Action<string>? DisplaySubtleMessageCallback { get; set; }
     public Action<string>? DisplayConsoleWriteLineMessage { get; set; }
@@ -114,7 +114,7 @@ internal sealed class TestConsoleInteractionService : IInteractionService
     {
     }
 
-    public void DisplayRawText(string text, ConsoleOutput console = ConsoleOutput.Standard)
+    public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null)
     {
     }
 

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -11,7 +11,7 @@ namespace Aspire.Cli.Tests.TestServices;
 
 internal sealed class TestExtensionInteractionService(IServiceProvider serviceProvider) : IExtensionInteractionService
 {
-    public ConsoleOutput DefaultConsole { get; set; }
+    public ConsoleOutput Console { get; set; }
     public Action<string>? DisplayErrorCallback { get; set; }
     public Action<string>? DisplaySubtleMessageCallback { get; set; }
     public Action<string>? DisplayConsoleWriteLineMessage { get; set; }
@@ -127,7 +127,7 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
     {
     }
 
-    public void DisplayRawText(string text, ConsoleOutput console = ConsoleOutput.Standard)
+    public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null)
     {
     }
 

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -11,6 +11,7 @@ namespace Aspire.Cli.Tests.TestServices;
 
 internal sealed class TestExtensionInteractionService(IServiceProvider serviceProvider) : IExtensionInteractionService
 {
+    public ConsoleOutput DefaultConsole { get; set; }
     public Action<string>? DisplayErrorCallback { get; set; }
     public Action<string>? DisplaySubtleMessageCallback { get; set; }
     public Action<string>? DisplayConsoleWriteLineMessage { get; set; }
@@ -126,7 +127,7 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
     {
     }
 
-    public void DisplayRawText(string text)
+    public void DisplayRawText(string text, ConsoleOutput console = ConsoleOutput.Standard)
     {
     }
 


### PR DESCRIPTION
## Summary

When running `aspire run --detach --format json`, human-readable messages like "Finding apphosts..." and "Stopping previous instance..." were written to stdout alongside the JSON output, making it impossible to parse the JSON programmatically.

## Changes

- Added `UseStderrForMessages` property to `IInteractionService` with a default no-op implementation
- `ConsoleInteractionService` routes all human-readable display methods (`DisplayMessage`, `DisplaySuccess`, `DisplayError`, `ShowStatusAsync`, etc.) through a `MessageConsole` property that returns `_errorConsole` (stderr) when the flag is set
- `DisplayRawText` remains on stdout — this is used for the structured JSON output
- `ExecuteDetachedAsync` in `RunCommand` sets `UseStderrForMessages = true` when `--format json` is specified

## Before

```
$ aspire run --detach --format json
🔍 Finding apphosts...
apphost.cs

🛑 Stopping previous instance (AppHost PID: 89136, CLI PID: 15160)
✔  Running instance stopped successfully.
{
  "appHostPath": "...",
  ...
}
```

## After

```
$ aspire run --detach --format json
{"appHostPath":"...","appHostPid":70740,"cliPid":64920,...}
```

Human-readable messages still appear on stderr so users can see progress when running interactively, but `stdout | jq` now works correctly.

Fixes #14423