### PR TITLE
Stop running AppHost before adding packages

### DIFF
--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -213,7 +213,7 @@ internal sealed class AddCommand : BaseCommand
             // which prevents 'dotnet add package' from modifying the project.
             if (_features.IsFeatureEnabled(KnownFeatures.RunningInstanceDetectionEnabled, defaultValue: true))
             {
-                var runningInstanceResult = await project.CheckAndHandleRunningInstanceAsync(
+                var runningInstanceResult = await project.FindAndStopRunningInstanceAsync(
                     effectiveAppHostProjectFile,
                     ExecutionContext.HomeDirectory,
                     cancellationToken);

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -218,7 +218,11 @@ internal sealed class AddCommand : BaseCommand
                     ExecutionContext.HomeDirectory,
                     cancellationToken);
 
-                if (runningInstanceResult == RunningInstanceResult.StopFailed)
+                if (runningInstanceResult == RunningInstanceResult.InstanceStopped)
+                {
+                    InteractionService.DisplayMessage("info", AddCommandStrings.StoppedRunningInstance);
+                }
+                else if (runningInstanceResult == RunningInstanceResult.StopFailed)
                 {
                     InteractionService.DisplayError(AddCommandStrings.UnableToStopRunningInstances);
                     return ExitCodeConstants.FailedToAddPackage;

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -220,7 +220,7 @@ internal sealed class AddCommand : BaseCommand
 
                 if (runningInstanceResult == RunningInstanceResult.InstanceStopped)
                 {
-                    InteractionService.DisplayMessage("info", AddCommandStrings.StoppedRunningInstance);
+                    InteractionService.DisplayMessage("information_source", AddCommandStrings.StoppedRunningInstance);
                 }
                 else if (runningInstanceResult == RunningInstanceResult.StopFailed)
                 {

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -208,6 +208,14 @@ internal sealed class AddCommand : BaseCommand
                 Source = source
             };
 
+            // Stop any running AppHost instance before adding the package.
+            // A running AppHost (especially in detach mode) locks project files,
+            // which prevents 'dotnet add package' from modifying the project.
+            await project.CheckAndHandleRunningInstanceAsync(
+                effectiveAppHostProjectFile,
+                ExecutionContext.HomeDirectory,
+                cancellationToken);
+
             var success = await InteractionService.ShowStatusAsync(
                 AddCommandStrings.AddingAspireIntegration,
                 async () => await project.AddPackageAsync(context, cancellationToken)

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -228,7 +228,7 @@ internal sealed class RunCommand : BaseCommand
                 // Even if we fail to stop we won't block the apphost starting
                 // to make sure we don't ever break flow. It should mostly stop
                 // just fine though.
-                var runningInstanceResult = await project.CheckAndHandleRunningInstanceAsync(effectiveAppHostFile, ExecutionContext.HomeDirectory, cancellationToken);
+                var runningInstanceResult = await project.FindAndStopRunningInstanceAsync(effectiveAppHostFile, ExecutionContext.HomeDirectory, cancellationToken);
 
                 // If in isolated mode and a running instance was stopped, warn the user
                 if (isolated && runningInstanceResult == RunningInstanceResult.InstanceStopped)

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -486,7 +486,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
     }
 
     /// <inheritdoc />
-    public async Task<RunningInstanceResult> CheckAndHandleRunningInstanceAsync(FileInfo appHostFile, DirectoryInfo homeDirectory, CancellationToken cancellationToken)
+    public async Task<RunningInstanceResult> FindAndStopRunningInstanceAsync(FileInfo appHostFile, DirectoryInfo homeDirectory, CancellationToken cancellationToken)
     {
         var matchingSockets = AppHostHelper.FindMatchingSockets(appHostFile.FullName, homeDirectory.FullName);
 

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -951,7 +951,7 @@ internal sealed class GuestAppHostProject : IAppHostProject
     }
 
     /// <inheritdoc />
-    public async Task<RunningInstanceResult> CheckAndHandleRunningInstanceAsync(FileInfo appHostFile, DirectoryInfo homeDirectory, CancellationToken cancellationToken)
+    public async Task<RunningInstanceResult> FindAndStopRunningInstanceAsync(FileInfo appHostFile, DirectoryInfo homeDirectory, CancellationToken cancellationToken)
     {
         // For guest projects, we use the AppHost server's path to compute the socket path
         // The AppHost server is created in a subdirectory of the guest apphost directory

--- a/src/Aspire.Cli/Projects/IAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/IAppHostProject.cs
@@ -215,17 +215,17 @@ internal interface IAppHostProject
     Task<UpdatePackagesResult> UpdatePackagesAsync(UpdatePackagesContext context, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Checks for and handles any running instance of this AppHost.
+    /// Finds any running instance of this AppHost and stops it.
     /// </summary>
     /// <param name="appHostFile">The AppHost file to check for running instances.</param>
     /// <param name="homeDirectory">The user's home directory for computing socket paths.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The result indicating what happened with the running instance check.</returns>
-    Task<RunningInstanceResult> CheckAndHandleRunningInstanceAsync(FileInfo appHostFile, DirectoryInfo homeDirectory, CancellationToken cancellationToken);
+    Task<RunningInstanceResult> FindAndStopRunningInstanceAsync(FileInfo appHostFile, DirectoryInfo homeDirectory, CancellationToken cancellationToken);
 }
 
 /// <summary>
-/// Result of checking for and handling a running instance.
+/// Result of finding and stopping a running instance.
 /// </summary>
 internal enum RunningInstanceResult
 {

--- a/src/Aspire.Cli/Resources/AddCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.Designer.cs
@@ -188,5 +188,13 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("UsePrereleasePackages", resourceCulture);
             }
         }
+
+        public static string UnableToStopRunningInstances
+        {
+            get
+            {
+                return ResourceManager.GetString("UnableToStopRunningInstances", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/AddCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.Designer.cs
@@ -189,6 +189,14 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        public static string StoppedRunningInstance
+        {
+            get
+            {
+                return ResourceManager.GetString("StoppedRunningInstance", resourceCulture);
+            }
+        }
+
         public static string UnableToStopRunningInstances
         {
             get

--- a/src/Aspire.Cli/Resources/AddCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.resx
@@ -172,4 +172,7 @@
   <data name="UsePrereleasePackages" xml:space="preserve">
     <value>Use pre-release packages</value>
   </data>
+  <data name="UnableToStopRunningInstances" xml:space="preserve">
+    <value>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/AddCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.resx
@@ -172,6 +172,9 @@
   <data name="UsePrereleasePackages" xml:space="preserve">
     <value>Use pre-release packages</value>
   </data>
+  <data name="StoppedRunningInstance" xml:space="preserve">
+    <value>Stopped a running Aspire AppHost instance to allow package modification.</value>
+  </data>
   <data name="UnableToStopRunningInstances" xml:space="preserve">
     <value>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Zdroj NuGet, který se má použít pro integraci</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnableToStopRunningInstances">
+        <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
+        <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedNumberOfPackagesFound">
         <source>Unexpected number of packages found.</source>
         <target state="translated">Byl nalezen neočekávaný počet balíčků.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
@@ -72,6 +72,10 @@
         <target state="translated">Zdroj NuGet, který se má použít pro integraci</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoppedRunningInstance" translate="yes" xml:space="preserve">
+          <source>Stopped a running Aspire AppHost instance to allow package modification.</source>
+          <target state="new">Stopped a running Aspire AppHost instance to allow package modification.</target><note />
+        </trans-unit>
       <trans-unit id="UnableToStopRunningInstances">
         <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
         <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
@@ -72,6 +72,10 @@
         <target state="translated">Die NuGet-Quelle, die für die Integration verwendet werden soll.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoppedRunningInstance" translate="yes" xml:space="preserve">
+          <source>Stopped a running Aspire AppHost instance to allow package modification.</source>
+          <target state="new">Stopped a running Aspire AppHost instance to allow package modification.</target><note />
+        </trans-unit>
       <trans-unit id="UnableToStopRunningInstances">
         <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
         <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Die NuGet-Quelle, die für die Integration verwendet werden soll.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnableToStopRunningInstances">
+        <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
+        <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedNumberOfPackagesFound">
         <source>Unexpected number of packages found.</source>
         <target state="translated">Unerwartete Anzahl gefundener Pakete.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
@@ -72,6 +72,10 @@
         <target state="translated">El origen de NuGet que se utilizará para la integración.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoppedRunningInstance" translate="yes" xml:space="preserve">
+          <source>Stopped a running Aspire AppHost instance to allow package modification.</source>
+          <target state="new">Stopped a running Aspire AppHost instance to allow package modification.</target><note />
+        </trans-unit>
       <trans-unit id="UnableToStopRunningInstances">
         <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
         <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
@@ -72,6 +72,11 @@
         <target state="translated">El origen de NuGet que se utilizará para la integración.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnableToStopRunningInstances">
+        <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
+        <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedNumberOfPackagesFound">
         <source>Unexpected number of packages found.</source>
         <target state="translated">Se encontró un número inesperado de paquetes.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
@@ -72,6 +72,10 @@
         <target state="translated">Source NuGet à utiliser pour l’intégration.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoppedRunningInstance" translate="yes" xml:space="preserve">
+          <source>Stopped a running Aspire AppHost instance to allow package modification.</source>
+          <target state="new">Stopped a running Aspire AppHost instance to allow package modification.</target><note />
+        </trans-unit>
       <trans-unit id="UnableToStopRunningInstances">
         <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
         <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Source NuGet à utiliser pour l’intégration.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnableToStopRunningInstances">
+        <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
+        <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedNumberOfPackagesFound">
         <source>Unexpected number of packages found.</source>
         <target state="translated">Nombre inattendu de packages trouvés.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Origine NuGet da usare per l'integrazione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnableToStopRunningInstances">
+        <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
+        <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedNumberOfPackagesFound">
         <source>Unexpected number of packages found.</source>
         <target state="translated">È stato trovato un numero imprevisto di pacchetti.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
@@ -72,6 +72,10 @@
         <target state="translated">Origine NuGet da usare per l'integrazione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoppedRunningInstance" translate="yes" xml:space="preserve">
+          <source>Stopped a running Aspire AppHost instance to allow package modification.</source>
+          <target state="new">Stopped a running Aspire AppHost instance to allow package modification.</target><note />
+        </trans-unit>
       <trans-unit id="UnableToStopRunningInstances">
         <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
         <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
@@ -72,6 +72,11 @@
         <target state="translated">統合に使用する NuGet ソース。</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnableToStopRunningInstances">
+        <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
+        <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedNumberOfPackagesFound">
         <source>Unexpected number of packages found.</source>
         <target state="translated">予期しない数のパッケージが見つかりました。</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
@@ -72,6 +72,10 @@
         <target state="translated">統合に使用する NuGet ソース。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoppedRunningInstance" translate="yes" xml:space="preserve">
+          <source>Stopped a running Aspire AppHost instance to allow package modification.</source>
+          <target state="new">Stopped a running Aspire AppHost instance to allow package modification.</target><note />
+        </trans-unit>
       <trans-unit id="UnableToStopRunningInstances">
         <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
         <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
@@ -72,6 +72,10 @@
         <target state="translated">통합에 사용할 NuGet 원본입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoppedRunningInstance" translate="yes" xml:space="preserve">
+          <source>Stopped a running Aspire AppHost instance to allow package modification.</source>
+          <target state="new">Stopped a running Aspire AppHost instance to allow package modification.</target><note />
+        </trans-unit>
       <trans-unit id="UnableToStopRunningInstances">
         <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
         <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
@@ -72,6 +72,11 @@
         <target state="translated">통합에 사용할 NuGet 원본입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnableToStopRunningInstances">
+        <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
+        <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedNumberOfPackagesFound">
         <source>Unexpected number of packages found.</source>
         <target state="translated">예기치 않은 수의 패키지를 발견했습니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
@@ -72,6 +72,10 @@
         <target state="translated">Źródło NuGet do użycia na potrzeby integracji.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoppedRunningInstance" translate="yes" xml:space="preserve">
+          <source>Stopped a running Aspire AppHost instance to allow package modification.</source>
+          <target state="new">Stopped a running Aspire AppHost instance to allow package modification.</target><note />
+        </trans-unit>
       <trans-unit id="UnableToStopRunningInstances">
         <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
         <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Źródło NuGet do użycia na potrzeby integracji.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnableToStopRunningInstances">
+        <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
+        <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedNumberOfPackagesFound">
         <source>Unexpected number of packages found.</source>
         <target state="translated">Znaleziono nieoczekiwaną liczbę pakietów.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
@@ -72,6 +72,11 @@
         <target state="translated">A fonte do NuGet a ser usada para a integração.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnableToStopRunningInstances">
+        <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
+        <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedNumberOfPackagesFound">
         <source>Unexpected number of packages found.</source>
         <target state="translated">Número inesperado de pacotes encontrados.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
@@ -72,6 +72,10 @@
         <target state="translated">A fonte do NuGet a ser usada para a integração.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoppedRunningInstance" translate="yes" xml:space="preserve">
+          <source>Stopped a running Aspire AppHost instance to allow package modification.</source>
+          <target state="new">Stopped a running Aspire AppHost instance to allow package modification.</target><note />
+        </trans-unit>
       <trans-unit id="UnableToStopRunningInstances">
         <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
         <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
@@ -72,6 +72,10 @@
         <target state="translated">Источник NuGet, который следует использовать для интеграции.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoppedRunningInstance" translate="yes" xml:space="preserve">
+          <source>Stopped a running Aspire AppHost instance to allow package modification.</source>
+          <target state="new">Stopped a running Aspire AppHost instance to allow package modification.</target><note />
+        </trans-unit>
       <trans-unit id="UnableToStopRunningInstances">
         <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
         <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Источник NuGet, который следует использовать для интеграции.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnableToStopRunningInstances">
+        <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
+        <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedNumberOfPackagesFound">
         <source>Unexpected number of packages found.</source>
         <target state="translated">Обнаружено неожиданное количество пакетов.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Tümleştirme için kullanılacak NuGet kaynağı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnableToStopRunningInstances">
+        <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
+        <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedNumberOfPackagesFound">
         <source>Unexpected number of packages found.</source>
         <target state="translated">Beklenmeyen sayıda paket bulundu.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
@@ -72,6 +72,10 @@
         <target state="translated">Tümleştirme için kullanılacak NuGet kaynağı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoppedRunningInstance" translate="yes" xml:space="preserve">
+          <source>Stopped a running Aspire AppHost instance to allow package modification.</source>
+          <target state="new">Stopped a running Aspire AppHost instance to allow package modification.</target><note />
+        </trans-unit>
       <trans-unit id="UnableToStopRunningInstances">
         <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
         <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
@@ -72,6 +72,10 @@
         <target state="translated">用于集成的 NuGet 源。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoppedRunningInstance" translate="yes" xml:space="preserve">
+          <source>Stopped a running Aspire AppHost instance to allow package modification.</source>
+          <target state="new">Stopped a running Aspire AppHost instance to allow package modification.</target><note />
+        </trans-unit>
       <trans-unit id="UnableToStopRunningInstances">
         <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
         <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
@@ -72,6 +72,11 @@
         <target state="translated">用于集成的 NuGet 源。</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnableToStopRunningInstances">
+        <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
+        <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedNumberOfPackagesFound">
         <source>Unexpected number of packages found.</source>
         <target state="translated">找到意外数量的包。</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
@@ -72,6 +72,11 @@
         <target state="translated">用於整合的 NuGet 來源。</target>
         <note />
       </trans-unit>
+      <trans-unit id="UnableToStopRunningInstances">
+        <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
+        <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnexpectedNumberOfPackagesFound">
         <source>Unexpected number of packages found.</source>
         <target state="translated">找到意外的套件數量。</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
@@ -72,6 +72,10 @@
         <target state="translated">用於整合的 NuGet 來源。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoppedRunningInstance" translate="yes" xml:space="preserve">
+          <source>Stopped a running Aspire AppHost instance to allow package modification.</source>
+          <target state="new">Stopped a running Aspire AppHost instance to allow package modification.</target><note />
+        </trans-unit>
       <trans-unit id="UnableToStopRunningInstances">
         <source>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</source>
         <target state="new">Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</target>

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -289,4 +289,126 @@ public sealed class StartStopTests(ITestOutputHelper output)
 
         await pendingRun;
     }
+
+    [Fact]
+    public async Task AddPackageInteractiveWhileAppHostRunningDetached()
+    {
+        var workspace = TemporaryWorkspace.Create(output);
+
+        var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
+        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
+        var isCI = CliE2ETestHelpers.IsRunningInCI;
+        var recordingPath = CliE2ETestHelpers.GetTestResultsRecordingPath(nameof(AddPackageInteractiveWhileAppHostRunningDetached));
+
+        var builder = Hex1bTerminal.CreateBuilder()
+            .WithHeadless()
+            .WithDimensions(160, 48)
+            .WithAsciinemaRecording(recordingPath)
+            .WithPtyProcess("/bin/bash", ["--norc"]);
+
+        using var terminal = builder.Build();
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        // Pattern searchers for aspire new prompts
+        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
+            .Find("> Starter App");
+
+        var waitingForProjectNamePrompt = new CellPatternSearcher()
+            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
+
+        var waitingForOutputPathPrompt = new CellPatternSearcher()
+            .Find("Enter the output path:");
+
+        var waitingForUrlsPrompt = new CellPatternSearcher()
+            .Find("Use *.dev.localhost URLs");
+
+        var waitingForRedisPrompt = new CellPatternSearcher()
+            .Find("Use Redis Cache");
+
+        var waitingForTestPrompt = new CellPatternSearcher()
+            .Find("Do you want to create a test project?");
+
+        // Pattern searchers for detach/add/stop
+        var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
+            .Find("AppHost started successfully.");
+
+        var waitForIntegrationSelectionPrompt = new CellPatternSearcher()
+            .Find("Select an integration to add:");
+
+        var waitForVersionSelectionPrompt = new CellPatternSearcher()
+            .Find("Select a version of");
+
+        var waitForPackageAddedSuccessfully = new CellPatternSearcher()
+            .Find("was added successfully.");
+
+        var counter = new SequenceCounter();
+        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+        sequenceBuilder.PrepareEnvironment(workspace, counter);
+
+        if (isCI)
+        {
+            sequenceBuilder.InstallAspireCliFromPullRequest(prNumber, counter);
+            sequenceBuilder.SourceAspireCliEnvironment(counter);
+            sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
+        }
+
+        // Create a new project using aspire new
+        sequenceBuilder.Type("aspire new")
+            .Enter()
+            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .Enter() // select first template (Starter App)
+            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Type("AspireAddInteractiveApp")
+            .Enter()
+            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Navigate to the AppHost directory
+        sequenceBuilder.Type("cd AspireAddInteractiveApp/AspireAddInteractiveApp.AppHost")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Start the AppHost in detached mode (locks the project file)
+        sequenceBuilder.Type("aspire run --detach")
+            .Enter()
+            .WaitUntil(s => waitForAppHostStartedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(3))
+            .WaitForSuccessPrompt(counter);
+
+        // Run aspire add interactively (no integration argument) while AppHost is running.
+        // This exercises the interactive package selection flow and verifies the
+        // running instance is auto-stopped before modifying the project.
+        sequenceBuilder.Type("aspire add")
+            .Enter()
+            .WaitUntil(s => waitForIntegrationSelectionPrompt.Search(s).Count > 0, TimeSpan.FromMinutes(1))
+            .Type("mongodb") // type to filter the list
+            .Enter() // select the filtered result
+            .WaitUntil(s => waitForVersionSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .Enter() // Accept the default version
+            .WaitUntil(s => waitForPackageAddedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(2))
+            .WaitForSuccessPrompt(counter);
+
+        // Clean up: stop if still running
+        sequenceBuilder.Type("aspire stop")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Exit the shell
+        sequenceBuilder.Type("exit")
+            .Enter();
+
+        var sequence = sequenceBuilder.Build();
+
+        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+        await pendingRun;
+    }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -218,11 +218,11 @@ public sealed class StartStopTests(ITestOutputHelper output)
         var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
             .Find("AppHost started successfully.");
 
+        var waitForVersionSelectionPrompt = new CellPatternSearcher()
+            .Find("Select a version of Aspire.Hosting.MongoDB:");
+
         var waitForPackageAddedSuccessfully = new CellPatternSearcher()
             .Find("was added successfully.");
-
-        var waitForAppHostStoppedSuccessfully = new CellPatternSearcher()
-            .Find("AppHost stopped successfully.");
 
         var counter = new SequenceCounter();
         var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
@@ -269,6 +269,8 @@ public sealed class StartStopTests(ITestOutputHelper output)
         // running instance before modifying the project, then succeed
         sequenceBuilder.Type("aspire add mongodb --non-interactive")
             .Enter()
+            .WaitUntil(s => waitForVersionSelectionPrompt.Search(s).Count > 0, TimeSpan.FromMinutes(1))
+            .Enter() // Accept the default version
             .WaitUntil(s => waitForPackageAddedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(2))
             .WaitForSuccessPrompt(counter);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -275,9 +275,19 @@ public sealed class StartStopTests(ITestOutputHelper output)
             .WaitForSuccessPrompt(counter);
 
         // Clean up: stop if still running (the add command may have stopped it)
+        // aspire stop may return a non-zero exit code if no instances are found
+        // (already stopped by aspire add), so wait for any prompt pattern.
         sequenceBuilder.Type("aspire stop")
             .Enter()
-            .WaitForSuccessPrompt(counter);
+            .WaitUntil(s =>
+            {
+                // Match any prompt (OK or ERR) for the current counter value
+                var promptSearcher = new CellPatternSearcher()
+                    .FindPattern(counter.Value.ToString())
+                    .RightText("] $ ");
+                return promptSearcher.Search(s).Count > 0;
+            }, TimeSpan.FromMinutes(1))
+            .IncrementSequence(counter);
 
         // Exit the shell
         sequenceBuilder.Type("exit")
@@ -397,9 +407,19 @@ public sealed class StartStopTests(ITestOutputHelper output)
             .WaitForSuccessPrompt(counter);
 
         // Clean up: stop if still running
+        // aspire stop may return a non-zero exit code if no instances are found
+        // (already stopped by aspire add), so wait for any prompt pattern.
         sequenceBuilder.Type("aspire stop")
             .Enter()
-            .WaitForSuccessPrompt(counter);
+            .WaitUntil(s =>
+            {
+                // Match any prompt (OK or ERR) for the current counter value
+                var promptSearcher = new CellPatternSearcher()
+                    .FindPattern(counter.Value.ToString())
+                    .RightText("] $ ");
+                return promptSearcher.Search(s).Count > 0;
+            }, TimeSpan.FromMinutes(1))
+            .IncrementSequence(counter);
 
         // Exit the shell
         sequenceBuilder.Type("exit")

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -174,4 +174,117 @@ public sealed class StartStopTests(ITestOutputHelper output)
 
         await pendingRun;
     }
+
+    [Fact]
+    public async Task AddPackageWhileAppHostRunningDetached()
+    {
+        var workspace = TemporaryWorkspace.Create(output);
+
+        var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
+        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
+        var isCI = CliE2ETestHelpers.IsRunningInCI;
+        var recordingPath = CliE2ETestHelpers.GetTestResultsRecordingPath(nameof(AddPackageWhileAppHostRunningDetached));
+
+        var builder = Hex1bTerminal.CreateBuilder()
+            .WithHeadless()
+            .WithDimensions(160, 48)
+            .WithAsciinemaRecording(recordingPath)
+            .WithPtyProcess("/bin/bash", ["--norc"]);
+
+        using var terminal = builder.Build();
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        // Pattern searchers for aspire new prompts
+        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
+            .Find("> Starter App");
+
+        var waitingForProjectNamePrompt = new CellPatternSearcher()
+            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
+
+        var waitingForOutputPathPrompt = new CellPatternSearcher()
+            .Find("Enter the output path:");
+
+        var waitingForUrlsPrompt = new CellPatternSearcher()
+            .Find("Use *.dev.localhost URLs");
+
+        var waitingForRedisPrompt = new CellPatternSearcher()
+            .Find("Use Redis Cache");
+
+        var waitingForTestPrompt = new CellPatternSearcher()
+            .Find("Do you want to create a test project?");
+
+        // Pattern searchers for detach/add/stop
+        var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
+            .Find("AppHost started successfully.");
+
+        var waitForPackageAddedSuccessfully = new CellPatternSearcher()
+            .Find("was added successfully.");
+
+        var waitForAppHostStoppedSuccessfully = new CellPatternSearcher()
+            .Find("AppHost stopped successfully.");
+
+        var counter = new SequenceCounter();
+        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+        sequenceBuilder.PrepareEnvironment(workspace, counter);
+
+        if (isCI)
+        {
+            sequenceBuilder.InstallAspireCliFromPullRequest(prNumber, counter);
+            sequenceBuilder.SourceAspireCliEnvironment(counter);
+            sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
+        }
+
+        // Create a new project using aspire new
+        sequenceBuilder.Type("aspire new")
+            .Enter()
+            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .Enter() // select first template (Starter App)
+            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Type("AspireAddTestApp")
+            .Enter()
+            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Navigate to the AppHost directory
+        sequenceBuilder.Type("cd AspireAddTestApp/AspireAddTestApp.AppHost")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Start the AppHost in detached mode (locks the project file)
+        sequenceBuilder.Type("aspire run --detach")
+            .Enter()
+            .WaitUntil(s => waitForAppHostStartedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(3))
+            .WaitForSuccessPrompt(counter);
+
+        // Add a package while the AppHost is running - this should auto-stop the
+        // running instance before modifying the project, then succeed
+        sequenceBuilder.Type("aspire add mongodb --non-interactive")
+            .Enter()
+            .WaitUntil(s => waitForPackageAddedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(2))
+            .WaitForSuccessPrompt(counter);
+
+        // Clean up: stop if still running (the add command may have stopped it)
+        sequenceBuilder.Type("aspire stop")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Exit the shell
+        sequenceBuilder.Type("exit")
+            .Enter();
+
+        var sequence = sequenceBuilder.Build();
+
+        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+        await pendingRun;
+    }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -276,17 +276,15 @@ public sealed class StartStopTests(ITestOutputHelper output)
 
         // Clean up: stop if still running (the add command may have stopped it)
         // aspire stop may return a non-zero exit code if no instances are found
-        // (already stopped by aspire add), so wait for any prompt pattern.
+        // (already stopped by aspire add), so wait for known output patterns.
+        var waitForStopResult = new CellPatternSearcher()
+            .Find("No running AppHosts found");
+        var waitForStoppedSuccessfully = new CellPatternSearcher()
+            .Find("AppHost stopped successfully.");
+
         sequenceBuilder.Type("aspire stop")
             .Enter()
-            .WaitUntil(s =>
-            {
-                // Match any prompt (OK or ERR) for the current counter value
-                var promptSearcher = new CellPatternSearcher()
-                    .FindPattern(counter.Value.ToString())
-                    .RightText("] $ ");
-                return promptSearcher.Search(s).Count > 0;
-            }, TimeSpan.FromMinutes(1))
+            .WaitUntil(s => waitForStopResult.Search(s).Count > 0 || waitForStoppedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(1))
             .IncrementSequence(counter);
 
         // Exit the shell
@@ -408,17 +406,15 @@ public sealed class StartStopTests(ITestOutputHelper output)
 
         // Clean up: stop if still running
         // aspire stop may return a non-zero exit code if no instances are found
-        // (already stopped by aspire add), so wait for any prompt pattern.
+        // (already stopped by aspire add), so wait for known output patterns.
+        var waitForStopResult2 = new CellPatternSearcher()
+            .Find("No running AppHosts found");
+        var waitForStoppedSuccessfully2 = new CellPatternSearcher()
+            .Find("AppHost stopped successfully.");
+
         sequenceBuilder.Type("aspire stop")
             .Enter()
-            .WaitUntil(s =>
-            {
-                // Match any prompt (OK or ERR) for the current counter value
-                var promptSearcher = new CellPatternSearcher()
-                    .FindPattern(counter.Value.ToString())
-                    .RightText("] $ ");
-                return promptSearcher.Search(s).Count > 0;
-            }, TimeSpan.FromMinutes(1))
+            .WaitUntil(s => waitForStopResult2.Search(s).Count > 0 || waitForStoppedSuccessfully2.Search(s).Count > 0, TimeSpan.FromMinutes(1))
             .IncrementSequence(counter);
 
         // Exit the shell

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -218,9 +218,6 @@ public sealed class StartStopTests(ITestOutputHelper output)
         var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
             .Find("AppHost started successfully.");
 
-        var waitForVersionSelectionPrompt = new CellPatternSearcher()
-            .Find("Select a version of Aspire.Hosting.MongoDB:");
-
         var waitForPackageAddedSuccessfully = new CellPatternSearcher()
             .Find("was added successfully.");
 
@@ -266,12 +263,11 @@ public sealed class StartStopTests(ITestOutputHelper output)
             .WaitForSuccessPrompt(counter);
 
         // Add a package while the AppHost is running - this should auto-stop the
-        // running instance before modifying the project, then succeed
+        // running instance before modifying the project, then succeed.
+        // --non-interactive skips the version selection prompt.
         sequenceBuilder.Type("aspire add mongodb --non-interactive")
             .Enter()
-            .WaitUntil(s => waitForVersionSelectionPrompt.Search(s).Count > 0, TimeSpan.FromMinutes(1))
-            .Enter() // Accept the default version
-            .WaitUntil(s => waitForPackageAddedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(2))
+            .WaitUntil(s => waitForPackageAddedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(3))
             .WaitForSuccessPrompt(counter);
 
         // Clean up: stop if still running (the add command may have stopped it)

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostProjectFactory.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostProjectFactory.cs
@@ -173,7 +173,7 @@ internal sealed class TestAppHostProjectFactory : IAppHostProjectFactory
         public Task<UpdatePackagesResult> UpdatePackagesAsync(UpdatePackagesContext context, CancellationToken cancellationToken)
             => throw new NotImplementedException();
 
-        public Task<RunningInstanceResult> CheckAndHandleRunningInstanceAsync(FileInfo appHostFile, DirectoryInfo homeDirectory, CancellationToken cancellationToken)
+        public Task<RunningInstanceResult> FindAndStopRunningInstanceAsync(FileInfo appHostFile, DirectoryInfo homeDirectory, CancellationToken cancellationToken)
             => Task.FromResult(RunningInstanceResult.NoRunningInstance);
 
         private static bool IsValidSingleFileAppHost(FileInfo candidateFile)


### PR DESCRIPTION
## Summary

When running `aspire add` while an AppHost is running in detached mode, the project file is locked by the build server, causing `dotnet add package` to fail. The add command now stops any running AppHost instance before attempting to add the package.

## Changes

- Added a call to `project.CheckAndHandleRunningInstanceAsync()` in `AddCommand` before invoking `AddPackageAsync()`
- Uses the same running instance detection pattern already used by the `RunCommand`
- The `CheckAndHandleRunningInstanceAsync` method displays user-visible messages about stopping the instance (via `RunningInstanceManager`)

Addresses part of https://github.com/dotnet/aspire/issues/14238