### PR TITLE
Fix aspire stop --non-interactive with multiple AppHosts

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -35,6 +35,33 @@ internal sealed class AppHostConnectionResolver(
     ILogger logger)
 {
     /// <summary>
+    /// Resolves all running AppHost connections using socket-first discovery.
+    /// Used when stopping all running AppHosts (e.g., via --all flag).
+    /// </summary>
+    /// <param name="scanningMessage">Message to display while scanning for AppHosts.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>All resolved connections, or an empty array if none found.</returns>
+    public async Task<AppHostConnectionResult[]> ResolveAllConnectionsAsync(
+        string scanningMessage,
+        CancellationToken cancellationToken)
+    {
+        var connections = await interactionService.ShowStatusAsync(
+            scanningMessage,
+            async () =>
+            {
+                await backchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
+                return backchannelMonitor.Connections.ToList();
+            });
+
+        if (connections.Count == 0)
+        {
+            return [];
+        }
+
+        return connections.Select(c => new AppHostConnectionResult { Connection = c }).ToArray();
+    }
+
+    /// <summary>
     /// Resolves an AppHost connection using socket-first discovery.
     /// </summary>
     /// <param name="projectFile">Optional project file. If specified, uses fast path to find matching socket.</param>

--- a/src/Aspire.Cli/Resources/StopCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/StopCommandStrings.Designer.cs
@@ -116,5 +116,17 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("MultipleAppHostsNonInteractive", resourceCulture);
             }
         }
+
+        public static string AllAndProjectMutuallyExclusive {
+            get {
+                return ResourceManager.GetString("AllAndProjectMutuallyExclusive", resourceCulture);
+            }
+        }
+
+        public static string AllAndResourceMutuallyExclusive {
+            get {
+                return ResourceManager.GetString("AllAndResourceMutuallyExclusive", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/StopCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/StopCommandStrings.Designer.cs
@@ -104,5 +104,17 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("NoInScopeAppHostsShowingAll", resourceCulture);
             }
         }
+
+        public static string AllOptionDescription {
+            get {
+                return ResourceManager.GetString("AllOptionDescription", resourceCulture);
+            }
+        }
+
+        public static string MultipleAppHostsNonInteractive {
+            get {
+                return ResourceManager.GetString("MultipleAppHostsNonInteractive", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/StopCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/StopCommandStrings.resx
@@ -151,6 +151,12 @@
     <value>Stop all running AppHosts.</value>
   </data>
   <data name="MultipleAppHostsNonInteractive" xml:space="preserve">
-    <value>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</value>
+    <value>Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</value>
+  </data>
+  <data name="AllAndProjectMutuallyExclusive" xml:space="preserve">
+    <value>The {0} and {1} options cannot be used together.</value>
+  </data>
+  <data name="AllAndResourceMutuallyExclusive" xml:space="preserve">
+    <value>The {0} option cannot be used with a resource argument.</value>
   </data>
 </root>

--- a/src/Aspire.Cli/Resources/StopCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/StopCommandStrings.resx
@@ -147,4 +147,10 @@
   <data name="NoInScopeAppHostsShowingAll" xml:space="preserve">
     <value>No running AppHosts found in the current directory. Showing all running AppHosts:</value>
   </data>
+  <data name="AllOptionDescription" xml:space="preserve">
+    <value>Stop all running AppHosts.</value>
+  </data>
+  <data name="MultipleAppHostsNonInteractive" xml:space="preserve">
+    <value>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../StopCommandStrings.resx">
     <body>
+      <trans-unit id="AllOptionDescription">
+        <source>Stop all running AppHosts.</source>
+        <target state="new">Stop all running AppHosts.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
         <source>AppHost stopped successfully.</source>
         <target state="translated">Hostitel aplikací se úspěšně zastavil.</target>
@@ -15,6 +20,11 @@
       <trans-unit id="FailedToStopAppHost">
         <source>Failed to stop the AppHost.</source>
         <target state="translated">Nepovedlo se zastavit hostitele aplikací.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.cs.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
-        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
-        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
+        <source>Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">
@@ -60,6 +60,16 @@
       <trans-unit id="StoppingAppHost">
         <source>Stopping Aspire apphost...</source>
         <target state="translated">Spouští se hostitel aplikací Aspire...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndProjectMutuallyExclusive">
+        <source>The {0} and {1} options cannot be used together.</source>
+        <target state="new">The {0} and {1} options cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndResourceMutuallyExclusive">
+        <source>The {0} option cannot be used with a resource argument.</source>
+        <target state="new">The {0} option cannot be used with a resource argument.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../StopCommandStrings.resx">
     <body>
+      <trans-unit id="AllOptionDescription">
+        <source>Stop all running AppHosts.</source>
+        <target state="new">Stop all running AppHosts.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
         <source>AppHost stopped successfully.</source>
         <target state="translated">AppHost wurde erfolgreich beendet.</target>
@@ -15,6 +20,11 @@
       <trans-unit id="FailedToStopAppHost">
         <source>Failed to stop the AppHost.</source>
         <target state="translated">Beim Beenden des AppHost ist ein Fehler aufgetreten.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.de.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
-        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
-        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
+        <source>Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">
@@ -60,6 +60,16 @@
       <trans-unit id="StoppingAppHost">
         <source>Stopping Aspire apphost...</source>
         <target state="translated">Aspire-AppHost wird beendet …</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndProjectMutuallyExclusive">
+        <source>The {0} and {1} options cannot be used together.</source>
+        <target state="new">The {0} and {1} options cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndResourceMutuallyExclusive">
+        <source>The {0} option cannot be used with a resource argument.</source>
+        <target state="new">The {0} option cannot be used with a resource argument.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.es.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
-        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
-        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
+        <source>Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">
@@ -60,6 +60,16 @@
       <trans-unit id="StoppingAppHost">
         <source>Stopping Aspire apphost...</source>
         <target state="translated">Deteniendo apphost de Aspire...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndProjectMutuallyExclusive">
+        <source>The {0} and {1} options cannot be used together.</source>
+        <target state="new">The {0} and {1} options cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndResourceMutuallyExclusive">
+        <source>The {0} option cannot be used with a resource argument.</source>
+        <target state="new">The {0} option cannot be used with a resource argument.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../StopCommandStrings.resx">
     <body>
+      <trans-unit id="AllOptionDescription">
+        <source>Stop all running AppHosts.</source>
+        <target state="new">Stop all running AppHosts.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
         <source>AppHost stopped successfully.</source>
         <target state="translated">AppHost se detuvo correctamente.</target>
@@ -15,6 +20,11 @@
       <trans-unit id="FailedToStopAppHost">
         <source>Failed to stop the AppHost.</source>
         <target state="translated">No se pudo detener AppHost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.fr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
-        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
-        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
+        <source>Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">
@@ -60,6 +60,16 @@
       <trans-unit id="StoppingAppHost">
         <source>Stopping Aspire apphost...</source>
         <target state="translated">Arrêt d'Aspire apphost...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndProjectMutuallyExclusive">
+        <source>The {0} and {1} options cannot be used together.</source>
+        <target state="new">The {0} and {1} options cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndResourceMutuallyExclusive">
+        <source>The {0} option cannot be used with a resource argument.</source>
+        <target state="new">The {0} option cannot be used with a resource argument.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../StopCommandStrings.resx">
     <body>
+      <trans-unit id="AllOptionDescription">
+        <source>Stop all running AppHosts.</source>
+        <target state="new">Stop all running AppHosts.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
         <source>AppHost stopped successfully.</source>
         <target state="translated">AppHost s’est arrêtée avec succès.</target>
@@ -15,6 +20,11 @@
       <trans-unit id="FailedToStopAppHost">
         <source>Failed to stop the AppHost.</source>
         <target state="translated">Échec de l'arrêt d’AppHost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.it.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
-        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
-        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
+        <source>Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">
@@ -60,6 +60,16 @@
       <trans-unit id="StoppingAppHost">
         <source>Stopping Aspire apphost...</source>
         <target state="translated">Arresto dell'apphost Aspire in corso...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndProjectMutuallyExclusive">
+        <source>The {0} and {1} options cannot be used together.</source>
+        <target state="new">The {0} and {1} options cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndResourceMutuallyExclusive">
+        <source>The {0} option cannot be used with a resource argument.</source>
+        <target state="new">The {0} option cannot be used with a resource argument.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../StopCommandStrings.resx">
     <body>
+      <trans-unit id="AllOptionDescription">
+        <source>Stop all running AppHosts.</source>
+        <target state="new">Stop all running AppHosts.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
         <source>AppHost stopped successfully.</source>
         <target state="translated">AppHost è stato interrotto.</target>
@@ -15,6 +20,11 @@
       <trans-unit id="FailedToStopAppHost">
         <source>Failed to stop the AppHost.</source>
         <target state="translated">Non è possibile arrestare AppHost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ja.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
-        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
-        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
+        <source>Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">
@@ -60,6 +60,16 @@
       <trans-unit id="StoppingAppHost">
         <source>Stopping Aspire apphost...</source>
         <target state="translated">Aspire apphost を停止しています...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndProjectMutuallyExclusive">
+        <source>The {0} and {1} options cannot be used together.</source>
+        <target state="new">The {0} and {1} options cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndResourceMutuallyExclusive">
+        <source>The {0} option cannot be used with a resource argument.</source>
+        <target state="new">The {0} option cannot be used with a resource argument.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../StopCommandStrings.resx">
     <body>
+      <trans-unit id="AllOptionDescription">
+        <source>Stop all running AppHosts.</source>
+        <target state="new">Stop all running AppHosts.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
         <source>AppHost stopped successfully.</source>
         <target state="translated">AppHost が正常に停止しました。</target>
@@ -15,6 +20,11 @@
       <trans-unit id="FailedToStopAppHost">
         <source>Failed to stop the AppHost.</source>
         <target state="translated">AppHost を停止できませんでした。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../StopCommandStrings.resx">
     <body>
+      <trans-unit id="AllOptionDescription">
+        <source>Stop all running AppHosts.</source>
+        <target state="new">Stop all running AppHosts.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
         <source>AppHost stopped successfully.</source>
         <target state="translated">AppHost가 중지되었습니다.</target>
@@ -15,6 +20,11 @@
       <trans-unit id="FailedToStopAppHost">
         <source>Failed to stop the AppHost.</source>
         <target state="translated">AppHost를 중지하지 못했습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ko.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
-        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
-        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
+        <source>Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">
@@ -60,6 +60,16 @@
       <trans-unit id="StoppingAppHost">
         <source>Stopping Aspire apphost...</source>
         <target state="translated">Aspire AppHost를 중지하는 중...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndProjectMutuallyExclusive">
+        <source>The {0} and {1} options cannot be used together.</source>
+        <target state="new">The {0} and {1} options cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndResourceMutuallyExclusive">
+        <source>The {0} option cannot be used with a resource argument.</source>
+        <target state="new">The {0} option cannot be used with a resource argument.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../StopCommandStrings.resx">
     <body>
+      <trans-unit id="AllOptionDescription">
+        <source>Stop all running AppHosts.</source>
+        <target state="new">Stop all running AppHosts.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
         <source>AppHost stopped successfully.</source>
         <target state="translated">Host aplikacji został pomyślnie zatrzymany.</target>
@@ -15,6 +20,11 @@
       <trans-unit id="FailedToStopAppHost">
         <source>Failed to stop the AppHost.</source>
         <target state="translated">Nie można zatrzymać hosta aplikacji.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.pl.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
-        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
-        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
+        <source>Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">
@@ -60,6 +60,16 @@
       <trans-unit id="StoppingAppHost">
         <source>Stopping Aspire apphost...</source>
         <target state="translated">Trwa zatrzymywanie hosta Aspire...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndProjectMutuallyExclusive">
+        <source>The {0} and {1} options cannot be used together.</source>
+        <target state="new">The {0} and {1} options cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndResourceMutuallyExclusive">
+        <source>The {0} option cannot be used with a resource argument.</source>
+        <target state="new">The {0} option cannot be used with a resource argument.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../StopCommandStrings.resx">
     <body>
+      <trans-unit id="AllOptionDescription">
+        <source>Stop all running AppHosts.</source>
+        <target state="new">Stop all running AppHosts.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
         <source>AppHost stopped successfully.</source>
         <target state="translated">AppHost interrompido com sucesso.</target>
@@ -15,6 +20,11 @@
       <trans-unit id="FailedToStopAppHost">
         <source>Failed to stop the AppHost.</source>
         <target state="translated">Falha ao parar o AppHost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.pt-BR.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
-        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
-        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
+        <source>Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">
@@ -60,6 +60,16 @@
       <trans-unit id="StoppingAppHost">
         <source>Stopping Aspire apphost...</source>
         <target state="translated">Parando o apphost Aspire...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndProjectMutuallyExclusive">
+        <source>The {0} and {1} options cannot be used together.</source>
+        <target state="new">The {0} and {1} options cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndResourceMutuallyExclusive">
+        <source>The {0} option cannot be used with a resource argument.</source>
+        <target state="new">The {0} option cannot be used with a resource argument.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ru.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
-        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
-        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
+        <source>Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">
@@ -60,6 +60,16 @@
       <trans-unit id="StoppingAppHost">
         <source>Stopping Aspire apphost...</source>
         <target state="translated">Остановка хоста приложений Aspire...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndProjectMutuallyExclusive">
+        <source>The {0} and {1} options cannot be used together.</source>
+        <target state="new">The {0} and {1} options cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndResourceMutuallyExclusive">
+        <source>The {0} option cannot be used with a resource argument.</source>
+        <target state="new">The {0} option cannot be used with a resource argument.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../StopCommandStrings.resx">
     <body>
+      <trans-unit id="AllOptionDescription">
+        <source>Stop all running AppHosts.</source>
+        <target state="new">Stop all running AppHosts.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
         <source>AppHost stopped successfully.</source>
         <target state="translated">Хост приложений остановлен.</target>
@@ -15,6 +20,11 @@
       <trans-unit id="FailedToStopAppHost">
         <source>Failed to stop the AppHost.</source>
         <target state="translated">Не удалось остановить хост приложений.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.tr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
-        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
-        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
+        <source>Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">
@@ -60,6 +60,16 @@
       <trans-unit id="StoppingAppHost">
         <source>Stopping Aspire apphost...</source>
         <target state="translated">Aspire apphost durduruluyor...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndProjectMutuallyExclusive">
+        <source>The {0} and {1} options cannot be used together.</source>
+        <target state="new">The {0} and {1} options cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndResourceMutuallyExclusive">
+        <source>The {0} option cannot be used with a resource argument.</source>
+        <target state="new">The {0} option cannot be used with a resource argument.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../StopCommandStrings.resx">
     <body>
+      <trans-unit id="AllOptionDescription">
+        <source>Stop all running AppHosts.</source>
+        <target state="new">Stop all running AppHosts.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
         <source>AppHost stopped successfully.</source>
         <target state="translated">AppHost başarıyla durduruldu.</target>
@@ -15,6 +20,11 @@
       <trans-unit id="FailedToStopAppHost">
         <source>Failed to stop the AppHost.</source>
         <target state="translated">AppHost durdurulamadı.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../StopCommandStrings.resx">
     <body>
+      <trans-unit id="AllOptionDescription">
+        <source>Stop all running AppHosts.</source>
+        <target state="new">Stop all running AppHosts.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
         <source>AppHost stopped successfully.</source>
         <target state="translated">已成功停止 AppHost。</target>
@@ -15,6 +20,11 @@
       <trans-unit id="FailedToStopAppHost">
         <source>Failed to stop the AppHost.</source>
         <target state="translated">停止 AppHost 失败。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.zh-Hans.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
-        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
-        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
+        <source>Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">
@@ -60,6 +60,16 @@
       <trans-unit id="StoppingAppHost">
         <source>Stopping Aspire apphost...</source>
         <target state="translated">正在停止 Aspire AppHost...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndProjectMutuallyExclusive">
+        <source>The {0} and {1} options cannot be used together.</source>
+        <target state="new">The {0} and {1} options cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndResourceMutuallyExclusive">
+        <source>The {0} option cannot be used with a resource argument.</source>
+        <target state="new">The {0} option cannot be used with a resource argument.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../StopCommandStrings.resx">
     <body>
+      <trans-unit id="AllOptionDescription">
+        <source>Stop all running AppHosts.</source>
+        <target state="new">Stop all running AppHosts.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AppHostStoppedSuccessfully">
         <source>AppHost stopped successfully.</source>
         <target state="translated">已成功停止 AppHost。</target>
@@ -15,6 +20,11 @@
       <trans-unit id="FailedToStopAppHost">
         <source>Failed to stop the AppHost.</source>
         <target state="translated">無法停止 AppHost。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleAppHostsNonInteractive">
+        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">

--- a/src/Aspire.Cli/Resources/xlf/StopCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/StopCommandStrings.zh-Hant.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsNonInteractive">
-        <source>Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</source>
-        <target state="new">Multiple AppHosts are running. Use --project to specify which one to stop, or use --all to stop all of them.</target>
+        <source>Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</source>
+        <target state="new">Multiple AppHosts are running. Use {0} to specify which one to stop, or use {1} to stop all of them.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleAppHostsRunning">
@@ -60,6 +60,16 @@
       <trans-unit id="StoppingAppHost">
         <source>Stopping Aspire apphost...</source>
         <target state="translated">正在停止 Aspire AppHost...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndProjectMutuallyExclusive">
+        <source>The {0} and {1} options cannot be used together.</source>
+        <target state="new">The {0} and {1} options cannot be used together.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AllAndResourceMutuallyExclusive">
+        <source>The {0} option cannot be used with a resource argument.</source>
+        <target state="new">The {0} option cannot be used with a resource argument.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Utils/CliHostEnvironment.cs
+++ b/src/Aspire.Cli/Utils/CliHostEnvironment.cs
@@ -67,22 +67,20 @@ internal sealed class CliHostEnvironment : ICliHostEnvironment
 
     public CliHostEnvironment(IConfiguration configuration, bool nonInteractive)
     {
-        // Check if ASPIRE_PLAYGROUND is set to force interactive mode
-        var playgroundMode = IsPlaygroundMode(configuration);
-
-        // If ASPIRE_PLAYGROUND is set, force interactive mode and ANSI support
-        if (playgroundMode)
-        {
-            SupportsInteractiveInput = true;
-            SupportsInteractiveOutput = true;
-            SupportsAnsi = true;
-        }
-        // If --non-interactive is explicitly set, disable interactive input and output
-        else if (nonInteractive)
+        // If --non-interactive is explicitly set, disable interactive input and output.
+        // This takes precedence over all other settings including ASPIRE_PLAYGROUND.
+        if (nonInteractive)
         {
             SupportsInteractiveInput = false;
             SupportsInteractiveOutput = false;
             SupportsAnsi = DetectAnsiSupport(configuration);
+        }
+        // Check if ASPIRE_PLAYGROUND is set to force interactive mode
+        else if (IsPlaygroundMode(configuration))
+        {
+            SupportsInteractiveInput = true;
+            SupportsInteractiveOutput = true;
+            SupportsAnsi = true;
         }
         else
         {

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
@@ -218,6 +218,31 @@ internal static class CliE2ETestHelpers
             .IncrementSequence(counter);
     }
 
+    /// <summary>
+    /// Waits for any prompt (success or error) matching the current sequence counter.
+    /// Use this when the command is expected to return a non-zero exit code.
+    /// </summary>
+    internal static Hex1bTerminalInputSequenceBuilder WaitForAnyPrompt(
+        this Hex1bTerminalInputSequenceBuilder builder,
+        SequenceCounter counter,
+        TimeSpan? timeout = null)
+    {
+        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(500);
+
+        return builder.WaitUntil(snapshot =>
+            {
+                var successSearcher = new CellPatternSearcher()
+                    .FindPattern(counter.Value.ToString())
+                    .RightText(" OK] $ ");
+                var errorSearcher = new CellPatternSearcher()
+                    .FindPattern(counter.Value.ToString())
+                    .RightText(" ERR:");
+
+                return successSearcher.Search(snapshot).Count > 0 || errorSearcher.Search(snapshot).Count > 0;
+            }, effectiveTimeout)
+            .IncrementSequence(counter);
+    }
+
     internal static Hex1bTerminalInputSequenceBuilder IncrementSequence(
         this Hex1bTerminalInputSequenceBuilder builder,
         SequenceCounter counter)

--- a/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
@@ -138,14 +138,14 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public async Task StopAllAppHosts()
+    public async Task StopAllAppHostsFromAppHostDirectory()
     {
         var workspace = TemporaryWorkspace.Create(output);
 
         var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
         var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
         var isCI = CliE2ETestHelpers.IsRunningInCI;
-        var recordingPath = CliE2ETestHelpers.GetTestResultsRecordingPath(nameof(StopAllAppHosts));
+        var recordingPath = CliE2ETestHelpers.GetTestResultsRecordingPath(nameof(StopAllAppHostsFromAppHostDirectory));
 
         var builder = Hex1bTerminal.CreateBuilder()
             .WithHeadless()
@@ -164,8 +164,11 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
         var waitingForProjectNamePrompt = new CellPatternSearcher()
             .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
 
-        var waitingForOutputPathPrompt = new CellPatternSearcher()
-            .Find($"Enter the output path: (./TestStopAllApp): ");
+        var waitingForOutputPathPrompt1 = new CellPatternSearcher()
+            .Find($"Enter the output path: (./App1): ");
+
+        var waitingForOutputPathPrompt2 = new CellPatternSearcher()
+            .Find($"Enter the output path: (./App2): ");
 
         var waitingForUrlsPrompt = new CellPatternSearcher()
             .Find($"Use *.dev.localhost URLs");
@@ -183,6 +186,9 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
         var waitForAppHostStoppedSuccessfully = new CellPatternSearcher()
             .Find("AppHost stopped successfully.");
 
+        var waitForNoRunningAppHostsFound = new CellPatternSearcher()
+            .Find("No running AppHosts found");
+
         var counter = new SequenceCounter();
         var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
 
@@ -195,15 +201,15 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
             sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
         }
 
-        // Create a new project using aspire new
+        // Create first project
         sequenceBuilder.Type("aspire new")
             .Enter()
             .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter() // select first template (Starter App)
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("TestStopAllApp")
             .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Type("App1")
+            .Enter()
+            .WaitUntil(s => waitingForOutputPathPrompt1.Search(s).Count > 0, TimeSpan.FromSeconds(10))
             .Enter()
             .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
             .Enter()
@@ -213,25 +219,211 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
             .Enter()
             .WaitForSuccessPrompt(counter);
 
-        // Navigate to the AppHost directory
-        sequenceBuilder.Type("cd TestStopAllApp/TestStopAllApp.AppHost")
+        // Clear screen before second project creation
+        sequenceBuilder.ClearScreen(counter);
+
+        // Create second project
+        sequenceBuilder.Type("aspire new")
+            .Enter()
+            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .Enter()
+            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Type("App2")
+            .Enter()
+            .WaitUntil(s => waitingForOutputPathPrompt2.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
             .Enter()
             .WaitForSuccessPrompt(counter);
 
-        // Start the AppHost in the background using aspire run --detach
-        sequenceBuilder.Type("aspire run --detach")
+        // Start first AppHost in background
+        sequenceBuilder.Type("cd App1/App1.AppHost && aspire run --detach")
             .Enter()
             .WaitUntil(s => waitForAppHostStartedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(3))
             .WaitForSuccessPrompt(counter);
 
-        // Clear screen to avoid matching old patterns
+        // Clear screen before starting second apphost
         sequenceBuilder.ClearScreen(counter);
 
-        // Stop all AppHosts using aspire stop --all
-        sequenceBuilder.Type("aspire stop --all")
+        // Navigate back and start second AppHost in background
+        sequenceBuilder.Type("cd ../../App2/App2.AppHost && aspire run --detach")
+            .Enter()
+            .WaitUntil(s => waitForAppHostStartedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(3))
+            .WaitForSuccessPrompt(counter);
+
+        // Clear screen
+        sequenceBuilder.ClearScreen(counter);
+
+        // Stop all AppHosts from within an AppHost directory using --non-interactive --all
+        sequenceBuilder.Type("aspire stop --non-interactive --all")
             .Enter()
             .WaitUntil(s => waitForAppHostStoppedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(1))
             .WaitForSuccessPrompt(counter);
+
+        // Clear screen
+        sequenceBuilder.ClearScreen(counter);
+
+        // Verify no AppHosts are running
+        sequenceBuilder.Type("aspire stop --non-interactive")
+            .Enter()
+            .WaitUntil(s => waitForNoRunningAppHostsFound.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .WaitForAnyPrompt(counter, TimeSpan.FromSeconds(30));
+
+        // Exit the shell
+        sequenceBuilder.Type("exit")
+            .Enter();
+
+        var sequence = sequenceBuilder.Build();
+
+        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+        await pendingRun;
+    }
+
+    [Fact]
+    public async Task StopAllAppHostsFromUnrelatedDirectory()
+    {
+        var workspace = TemporaryWorkspace.Create(output);
+
+        var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
+        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
+        var isCI = CliE2ETestHelpers.IsRunningInCI;
+        var recordingPath = CliE2ETestHelpers.GetTestResultsRecordingPath(nameof(StopAllAppHostsFromUnrelatedDirectory));
+
+        var builder = Hex1bTerminal.CreateBuilder()
+            .WithHeadless()
+            .WithDimensions(160, 48)
+            .WithAsciinemaRecording(recordingPath)
+            .WithPtyProcess("/bin/bash", ["--norc"]);
+
+        using var terminal = builder.Build();
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        // Pattern searchers for aspire new prompts
+        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
+            .FindPattern("> Starter App");
+
+        var waitingForProjectNamePrompt = new CellPatternSearcher()
+            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
+
+        var waitingForOutputPathPrompt1 = new CellPatternSearcher()
+            .Find($"Enter the output path: (./App1): ");
+
+        var waitingForOutputPathPrompt2 = new CellPatternSearcher()
+            .Find($"Enter the output path: (./App2): ");
+
+        var waitingForUrlsPrompt = new CellPatternSearcher()
+            .Find($"Use *.dev.localhost URLs");
+
+        var waitingForRedisPrompt = new CellPatternSearcher()
+            .Find($"Use Redis Cache");
+
+        var waitingForTestPrompt = new CellPatternSearcher()
+            .Find($"Do you want to create a test project?");
+
+        // Pattern searchers for start/stop commands
+        var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
+            .Find("AppHost started successfully.");
+
+        var waitForAppHostStoppedSuccessfully = new CellPatternSearcher()
+            .Find("AppHost stopped successfully.");
+
+        var waitForNoRunningAppHostsFound = new CellPatternSearcher()
+            .Find("No running AppHosts found");
+
+        var counter = new SequenceCounter();
+        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+        sequenceBuilder.PrepareEnvironment(workspace, counter);
+
+        if (isCI)
+        {
+            sequenceBuilder.InstallAspireCliFromPullRequest(prNumber, counter);
+            sequenceBuilder.SourceAspireCliEnvironment(counter);
+            sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
+        }
+
+        // Create first project
+        sequenceBuilder.Type("aspire new")
+            .Enter()
+            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .Enter()
+            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Type("App1")
+            .Enter()
+            .WaitUntil(s => waitingForOutputPathPrompt1.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Clear screen before second project creation
+        sequenceBuilder.ClearScreen(counter);
+
+        // Create second project
+        sequenceBuilder.Type("aspire new")
+            .Enter()
+            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .Enter()
+            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Type("App2")
+            .Enter()
+            .WaitUntil(s => waitingForOutputPathPrompt2.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Start first AppHost in background
+        sequenceBuilder.Type("cd App1/App1.AppHost && aspire run --detach")
+            .Enter()
+            .WaitUntil(s => waitForAppHostStartedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(3))
+            .WaitForSuccessPrompt(counter);
+
+        // Clear screen before starting second apphost
+        sequenceBuilder.ClearScreen(counter);
+
+        // Navigate back and start second AppHost in background
+        sequenceBuilder.Type("cd ../../App2/App2.AppHost && aspire run --detach")
+            .Enter()
+            .WaitUntil(s => waitForAppHostStartedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(3))
+            .WaitForSuccessPrompt(counter);
+
+        // Navigate to workspace root (unrelated to any AppHost directory)
+        sequenceBuilder.Type($"cd {workspace.WorkspaceRoot.FullName}")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Clear screen
+        sequenceBuilder.ClearScreen(counter);
+
+        // Stop all AppHosts from an unrelated directory using --non-interactive --all
+        sequenceBuilder.Type("aspire stop --non-interactive --all")
+            .Enter()
+            .WaitUntil(s => waitForAppHostStoppedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(1))
+            .WaitForSuccessPrompt(counter);
+
+        // Clear screen
+        sequenceBuilder.ClearScreen(counter);
+
+        // Verify no AppHosts are running
+        sequenceBuilder.Type("aspire stop --non-interactive")
+            .Enter()
+            .WaitUntil(s => waitForNoRunningAppHostsFound.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .WaitForAnyPrompt(counter, TimeSpan.FromSeconds(30));
 
         // Exit the shell
         sequenceBuilder.Type("exit")

--- a/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
@@ -1,0 +1,403 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests for aspire stop in non-interactive mode.
+/// Validates fix for https://github.com/dotnet/aspire/issues/14558.
+/// </summary>
+public sealed class StopNonInteractiveTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task StopNonInteractiveSingleAppHost()
+    {
+        var workspace = TemporaryWorkspace.Create(output);
+
+        var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
+        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
+        var isCI = CliE2ETestHelpers.IsRunningInCI;
+        var recordingPath = CliE2ETestHelpers.GetTestResultsRecordingPath(nameof(StopNonInteractiveSingleAppHost));
+
+        var builder = Hex1bTerminal.CreateBuilder()
+            .WithHeadless()
+            .WithDimensions(160, 48)
+            .WithAsciinemaRecording(recordingPath)
+            .WithPtyProcess("/bin/bash", ["--norc"]);
+
+        using var terminal = builder.Build();
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        // Pattern searchers for aspire new prompts
+        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
+            .FindPattern("> Starter App");
+
+        var waitingForProjectNamePrompt = new CellPatternSearcher()
+            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
+
+        var waitingForOutputPathPrompt = new CellPatternSearcher()
+            .Find($"Enter the output path: (./TestStopApp): ");
+
+        var waitingForUrlsPrompt = new CellPatternSearcher()
+            .Find($"Use *.dev.localhost URLs");
+
+        var waitingForRedisPrompt = new CellPatternSearcher()
+            .Find($"Use Redis Cache");
+
+        var waitingForTestPrompt = new CellPatternSearcher()
+            .Find($"Do you want to create a test project?");
+
+        var waitForProjectCreatedSuccessfullyMessage = new CellPatternSearcher()
+            .Find("Project created successfully.");
+
+        // Pattern searchers for start/stop commands
+        var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
+            .Find("AppHost started successfully.");
+
+        var waitForAppHostStoppedSuccessfully = new CellPatternSearcher()
+            .Find("AppHost stopped successfully.");
+
+        var waitForNoRunningAppHostsFound = new CellPatternSearcher()
+            .Find("No running AppHosts found");
+
+        var counter = new SequenceCounter();
+        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+        sequenceBuilder.PrepareEnvironment(workspace, counter);
+
+        if (isCI)
+        {
+            sequenceBuilder.InstallAspireCliFromPullRequest(prNumber, counter);
+            sequenceBuilder.SourceAspireCliEnvironment(counter);
+            sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
+        }
+
+        // Create a new project using aspire new
+        sequenceBuilder.Type("aspire new")
+            .Enter()
+            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .Enter() // select first template (Starter App)
+            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Type("TestStopApp")
+            .Enter()
+            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Navigate to the AppHost directory
+        sequenceBuilder.Type("cd TestStopApp/TestStopApp.AppHost")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Start the AppHost in the background using aspire run --detach
+        sequenceBuilder.Type("aspire run --detach")
+            .Enter()
+            .WaitUntil(s => waitForAppHostStartedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(3))
+            .WaitForSuccessPrompt(counter);
+
+        // Clear screen to avoid matching old patterns
+        sequenceBuilder.ClearScreen(counter);
+
+        // Stop the AppHost using aspire stop --non-interactive (single AppHost should auto-select)
+        sequenceBuilder.Type("aspire stop --non-interactive")
+            .Enter()
+            .WaitUntil(s => waitForAppHostStoppedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(1))
+            .WaitForSuccessPrompt(counter);
+
+        // Clear screen
+        sequenceBuilder.ClearScreen(counter);
+
+        // Verify that stop --non-interactive handles no running AppHosts gracefully
+        sequenceBuilder.Type("aspire stop --non-interactive")
+            .Enter()
+            .WaitUntil(s => waitForNoRunningAppHostsFound.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .WaitForAnyPrompt(counter, TimeSpan.FromSeconds(30));
+
+        // Exit the shell
+        sequenceBuilder.Type("exit")
+            .Enter();
+
+        var sequence = sequenceBuilder.Build();
+
+        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+        await pendingRun;
+    }
+
+    [Fact]
+    public async Task StopAllAppHosts()
+    {
+        var workspace = TemporaryWorkspace.Create(output);
+
+        var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
+        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
+        var isCI = CliE2ETestHelpers.IsRunningInCI;
+        var recordingPath = CliE2ETestHelpers.GetTestResultsRecordingPath(nameof(StopAllAppHosts));
+
+        var builder = Hex1bTerminal.CreateBuilder()
+            .WithHeadless()
+            .WithDimensions(160, 48)
+            .WithAsciinemaRecording(recordingPath)
+            .WithPtyProcess("/bin/bash", ["--norc"]);
+
+        using var terminal = builder.Build();
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        // Pattern searchers for aspire new prompts
+        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
+            .FindPattern("> Starter App");
+
+        var waitingForProjectNamePrompt = new CellPatternSearcher()
+            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
+
+        var waitingForOutputPathPrompt = new CellPatternSearcher()
+            .Find($"Enter the output path: (./TestStopAllApp): ");
+
+        var waitingForUrlsPrompt = new CellPatternSearcher()
+            .Find($"Use *.dev.localhost URLs");
+
+        var waitingForRedisPrompt = new CellPatternSearcher()
+            .Find($"Use Redis Cache");
+
+        var waitingForTestPrompt = new CellPatternSearcher()
+            .Find($"Do you want to create a test project?");
+
+        // Pattern searchers for start/stop commands
+        var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
+            .Find("AppHost started successfully.");
+
+        var waitForAppHostStoppedSuccessfully = new CellPatternSearcher()
+            .Find("AppHost stopped successfully.");
+
+        var counter = new SequenceCounter();
+        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+        sequenceBuilder.PrepareEnvironment(workspace, counter);
+
+        if (isCI)
+        {
+            sequenceBuilder.InstallAspireCliFromPullRequest(prNumber, counter);
+            sequenceBuilder.SourceAspireCliEnvironment(counter);
+            sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
+        }
+
+        // Create a new project using aspire new
+        sequenceBuilder.Type("aspire new")
+            .Enter()
+            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .Enter() // select first template (Starter App)
+            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Type("TestStopAllApp")
+            .Enter()
+            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Navigate to the AppHost directory
+        sequenceBuilder.Type("cd TestStopAllApp/TestStopAllApp.AppHost")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Start the AppHost in the background using aspire run --detach
+        sequenceBuilder.Type("aspire run --detach")
+            .Enter()
+            .WaitUntil(s => waitForAppHostStartedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(3))
+            .WaitForSuccessPrompt(counter);
+
+        // Clear screen to avoid matching old patterns
+        sequenceBuilder.ClearScreen(counter);
+
+        // Stop all AppHosts using aspire stop --all
+        sequenceBuilder.Type("aspire stop --all")
+            .Enter()
+            .WaitUntil(s => waitForAppHostStoppedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(1))
+            .WaitForSuccessPrompt(counter);
+
+        // Exit the shell
+        sequenceBuilder.Type("exit")
+            .Enter();
+
+        var sequence = sequenceBuilder.Build();
+
+        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+        await pendingRun;
+    }
+
+    [Fact]
+    public async Task StopNonInteractiveMultipleAppHostsShowsError()
+    {
+        var workspace = TemporaryWorkspace.Create(output);
+
+        var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
+        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
+        var isCI = CliE2ETestHelpers.IsRunningInCI;
+        var recordingPath = CliE2ETestHelpers.GetTestResultsRecordingPath(nameof(StopNonInteractiveMultipleAppHostsShowsError));
+
+        var builder = Hex1bTerminal.CreateBuilder()
+            .WithHeadless()
+            .WithDimensions(160, 48)
+            .WithAsciinemaRecording(recordingPath)
+            .WithPtyProcess("/bin/bash", ["--norc"]);
+
+        using var terminal = builder.Build();
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        // Pattern searchers for aspire new prompts
+        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
+            .FindPattern("> Starter App");
+
+        // First project prompts
+        var waitingForProjectNamePrompt1 = new CellPatternSearcher()
+            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
+
+        var waitingForOutputPathPrompt1 = new CellPatternSearcher()
+            .Find($"Enter the output path: (./App1): ");
+
+        // Second project prompts
+        var waitingForProjectNamePrompt2 = new CellPatternSearcher()
+            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
+
+        var waitingForOutputPathPrompt2 = new CellPatternSearcher()
+            .Find($"Enter the output path: (./App2): ");
+
+        var waitingForUrlsPrompt = new CellPatternSearcher()
+            .Find($"Use *.dev.localhost URLs");
+
+        var waitingForRedisPrompt = new CellPatternSearcher()
+            .Find($"Use Redis Cache");
+
+        var waitingForTestPrompt = new CellPatternSearcher()
+            .Find($"Do you want to create a test project?");
+
+        // Pattern searchers for start/stop commands
+        var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
+            .Find("AppHost started successfully.");
+
+        var waitForMultipleAppHostsError = new CellPatternSearcher()
+            .Find("Multiple AppHosts are running");
+
+        var waitForAppHostStoppedSuccessfully = new CellPatternSearcher()
+            .Find("AppHost stopped successfully.");
+
+        var counter = new SequenceCounter();
+        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+        sequenceBuilder.PrepareEnvironment(workspace, counter);
+
+        if (isCI)
+        {
+            sequenceBuilder.InstallAspireCliFromPullRequest(prNumber, counter);
+            sequenceBuilder.SourceAspireCliEnvironment(counter);
+            sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
+        }
+
+        // Create first project
+        sequenceBuilder.Type("aspire new")
+            .Enter()
+            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .Enter()
+            .WaitUntil(s => waitingForProjectNamePrompt1.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Type("App1")
+            .Enter()
+            .WaitUntil(s => waitingForOutputPathPrompt1.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Clear screen before second project creation
+        sequenceBuilder.ClearScreen(counter);
+
+        // Create second project
+        sequenceBuilder.Type("aspire new")
+            .Enter()
+            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .Enter()
+            .WaitUntil(s => waitingForProjectNamePrompt2.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Type("App2")
+            .Enter()
+            .WaitUntil(s => waitingForOutputPathPrompt2.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Start first AppHost in background
+        sequenceBuilder.Type("cd App1/App1.AppHost && aspire run --detach")
+            .Enter()
+            .WaitUntil(s => waitForAppHostStartedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(3))
+            .WaitForSuccessPrompt(counter);
+
+        // Clear screen before starting second apphost
+        sequenceBuilder.ClearScreen(counter);
+
+        // Navigate back and start second AppHost in background
+        sequenceBuilder.Type("cd ../../App2/App2.AppHost && aspire run --detach")
+            .Enter()
+            .WaitUntil(s => waitForAppHostStartedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(3))
+            .WaitForSuccessPrompt(counter);
+
+        // Navigate to workspace root
+        sequenceBuilder.Type($"cd {workspace.WorkspaceRoot.FullName}")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Clear screen
+        sequenceBuilder.ClearScreen(counter);
+
+        // Try to stop in non-interactive mode - should get an error about multiple AppHosts
+        sequenceBuilder.Type("aspire stop --non-interactive")
+            .Enter()
+            .WaitUntil(s => waitForMultipleAppHostsError.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .WaitForAnyPrompt(counter, TimeSpan.FromSeconds(30));
+
+        // Clear screen
+        sequenceBuilder.ClearScreen(counter);
+
+        // Now use --all to stop all AppHosts
+        sequenceBuilder.Type("aspire stop --all")
+            .Enter()
+            .WaitUntil(s => waitForAppHostStoppedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(1))
+            .WaitForSuccessPrompt(counter);
+
+        // Exit the shell
+        sequenceBuilder.Type("exit")
+            .Enter();
+
+        var sequence = sequenceBuilder.Build();
+
+        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+        await pendingRun;
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
@@ -111,8 +111,8 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
         // Clear screen to avoid matching old patterns
         sequenceBuilder.ClearScreen(counter);
 
-        // Stop the AppHost using aspire stop --non-interactive (single AppHost should auto-select)
-        sequenceBuilder.Type("aspire stop --non-interactive")
+        // Stop the AppHost using aspire stop --non-interactive --project (targets specific AppHost)
+        sequenceBuilder.Type("aspire stop --non-interactive --project TestStopApp.AppHost.csproj")
             .Enter()
             .WaitUntil(s => waitForAppHostStoppedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(1))
             .WaitForSuccessPrompt(counter);

--- a/tests/Aspire.Cli.Tests/Utils/CliHostEnvironmentTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliHostEnvironmentTests.cs
@@ -285,9 +285,9 @@ public class CliHostEnvironmentTests
     }
 
     [Fact]
-    public void SupportsInteractiveInput_ReturnsTrue_WhenPlaygroundModeSet_ButNonInteractiveIsTrue()
+    public void SupportsInteractiveInput_ReturnsFalse_WhenNonInteractiveIsTrue_EvenWithPlaygroundMode()
     {
-        // Arrange - ASPIRE_PLAYGROUND should take precedence over --non-interactive flag
+        // Arrange - --non-interactive should take precedence over ASPIRE_PLAYGROUND
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -299,14 +299,14 @@ public class CliHostEnvironmentTests
         var env = new CliHostEnvironment(configuration, nonInteractive: true);
         
         // Assert
-        // ASPIRE_PLAYGROUND takes precedence over the --non-interactive flag
-        Assert.True(env.SupportsInteractiveInput);
+        // --non-interactive takes precedence over ASPIRE_PLAYGROUND
+        Assert.False(env.SupportsInteractiveInput);
     }
 
     [Fact]
-    public void SupportsInteractiveOutput_ReturnsTrue_WhenPlaygroundModeSet_ButNonInteractiveIsTrue()
+    public void SupportsInteractiveOutput_ReturnsFalse_WhenNonInteractiveIsTrue_EvenWithPlaygroundMode()
     {
-        // Arrange - ASPIRE_PLAYGROUND should take precedence over --non-interactive flag
+        // Arrange - --non-interactive should take precedence over ASPIRE_PLAYGROUND
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -318,8 +318,8 @@ public class CliHostEnvironmentTests
         var env = new CliHostEnvironment(configuration, nonInteractive: true);
         
         // Assert
-        // ASPIRE_PLAYGROUND takes precedence over the --non-interactive flag
-        Assert.True(env.SupportsInteractiveOutput);
+        // --non-interactive takes precedence over ASPIRE_PLAYGROUND
+        Assert.False(env.SupportsInteractiveOutput);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Fixes #14558

When multiple AppHosts are running and `aspire stop --non-interactive` is used, the CLI crashes because it attempts to prompt the user to select which AppHost to stop, which is not allowed in non-interactive mode.

## Changes

### StopCommand
- In non-interactive mode with a single AppHost: auto-selects and stops it without prompting
- In non-interactive mode with multiple AppHosts: shows clear error message suggesting `--project` or `--all`
- Added `--all` option to stop all running AppHosts at once (works in both interactive and non-interactive modes)

### AppHostConnectionResolver
- Added `ResolveAllConnectionsAsync` method to return all running connections without prompting

### E2E Tests
- `StopNonInteractiveSingleAppHost`: Tests auto-selection of a single AppHost in non-interactive mode
- `StopAllAppHosts`: Tests `--all` flag stops a running AppHost
- `StopNonInteractiveMultipleAppHostsShowsError`: Tests graceful error when multiple AppHosts are running in non-interactive mode, then verifies `--all` resolves it
- Added `WaitForAnyPrompt` helper for tests expecting non-zero exit codes