### PR TITLE
Improve Azure deployment error output

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -373,7 +373,7 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
     /// </summary>
     /// <param name="requestEx">The Azure RequestFailedException containing the error response</param>
     /// <returns>The most specific error message found, or the original exception message if parsing fails</returns>
-    private static string ExtractDetailedErrorMessage(RequestFailedException requestEx)
+    internal static string ExtractDetailedErrorMessage(RequestFailedException requestEx)
     {
         try
         {

--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -401,7 +401,7 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
                                     }
                                 }
 
-                                return $"{code}: {message}";
+                                return $"Error code = {code}, Message = {message}";
                             }
                         }
 
@@ -412,7 +412,7 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
 
                             if (!string.IsNullOrEmpty(code) && !string.IsNullOrEmpty(message))
                             {
-                                return $"{code}: {message}";
+                                return $"Error code = {code}, Message = {message}";
                             }
                         }
                     }
@@ -444,7 +444,7 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
 
                 if (!string.IsNullOrEmpty(detailCode) && !string.IsNullOrEmpty(detailMessage))
                 {
-                    return $"{detailCode}: {detailMessage}";
+                    return $"Error code = {detailCode}, Message = {detailMessage}";
                 }
             }
         }

--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -359,7 +359,7 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
                     $"Failed to provision **{resource.Name}**: {errorMessage}",
                     CompletionState.CompletedWithError,
                     context.CancellationToken).ConfigureAwait(false);
-                throw;
+                throw new ProvisioningFailedException(errorMessage, ex);
             }
         }
     }

--- a/src/Aspire.Hosting.Azure/Exceptions.cs
+++ b/src/Aspire.Hosting.Azure/Exceptions.cs
@@ -26,8 +26,6 @@ internal sealed class FailedToApplyEnvironmentException : DistributedApplication
 
 internal sealed class ProvisioningFailedException : DistributedApplicationException
 {
-    public ProvisioningFailedException() { }
-    public ProvisioningFailedException(string message) : base(message) { }
     public ProvisioningFailedException(string message, Exception inner) : base(message, inner) { }
 }
 

--- a/src/Aspire.Hosting.Azure/Exceptions.cs
+++ b/src/Aspire.Hosting.Azure/Exceptions.cs
@@ -24,3 +24,10 @@ internal sealed class FailedToApplyEnvironmentException : DistributedApplication
     public FailedToApplyEnvironmentException(string message, Exception inner) : base(message, inner) { }
 }
 
+internal sealed class ProvisioningFailedException : DistributedApplicationException
+{
+    public ProvisioningFailedException() { }
+    public ProvisioningFailedException(string message) : base(message) { }
+    public ProvisioningFailedException(string message, Exception inner) : base(message, inner) { }
+}
+

--- a/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
+++ b/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
@@ -841,6 +841,13 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
         {
             await step.Action(stepContext).ConfigureAwait(false);
         }
+        catch (DistributedApplicationException)
+        {
+            // DistributedApplicationException subtypes already have clean, user-friendly messages.
+            // Re-throw without wrapping to avoid verbose error output (e.g. raw HTTP headers
+            // from Azure SDK RequestFailedException leaking into step failure messages).
+            throw;
+        }
         catch (Exception ex)
         {
             var exceptionInfo = ExceptionDispatchInfo.Capture(ex);

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaDeploymentErrorOutputTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaDeploymentErrorOutputTests.cs
@@ -1,0 +1,240 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Tests.Utils;
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Hex1b;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests that verify Azure deployment error output is clean and user-friendly.
+/// Uses an invalid Azure location to deliberately induce a deployment failure, then asserts
+/// that the error output does not contain verbose HTTP details from RequestFailedException.
+/// </summary>
+/// <remarks>
+/// See https://github.com/dotnet/aspire/issues/12303
+/// </remarks>
+public sealed class AcaDeploymentErrorOutputTests(ITestOutputHelper output)
+{
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(40);
+
+    /// <summary>
+    /// Deploys with an invalid Azure location ('invalidlocation') to induce a provisioning failure,
+    /// then verifies the error output is clean without verbose HTTP headers or status details.
+    /// </summary>
+    [Fact]
+    public async Task DeployWithInvalidLocation_ErrorOutputIsClean()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+
+        await DeployWithInvalidLocation_ErrorOutputIsCleanCore(linkedCts.Token);
+    }
+
+    private async Task DeployWithInvalidLocation_ErrorOutputIsCleanCore(CancellationToken cancellationToken)
+    {
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var recordingPath = DeploymentE2ETestHelpers.GetTestResultsRecordingPath(nameof(DeployWithInvalidLocation_ErrorOutputIsClean));
+        var startTime = DateTime.UtcNow;
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("errout");
+        var deployOutputFile = Path.Combine(workspace.WorkspaceRoot.FullName, "deploy-output.txt");
+
+        output.WriteLine($"Test: {nameof(DeployWithInvalidLocation_ErrorOutputIsClean)}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            var builder = Hex1bTerminal.CreateBuilder()
+                .WithHeadless()
+                .WithDimensions(160, 48)
+                .WithAsciinemaRecording(recordingPath)
+                .WithPtyProcess("/bin/bash", ["--norc"]);
+
+            using var terminal = builder.Build();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            var waitingForInitComplete = new CellPatternSearcher()
+                .Find("Aspire initialization complete");
+
+            var waitingForVersionSelectionPrompt = new CellPatternSearcher()
+                .Find("(based on NuGet.config)");
+
+            var waitingForPipelineFailed = new CellPatternSearcher()
+                .Find("PIPELINE FAILED");
+
+            var counter = new SequenceCounter();
+            var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+            // Step 1: Prepare environment
+            output.WriteLine("Step 1: Preparing environment...");
+            sequenceBuilder.PrepareEnvironment(workspace, counter);
+
+            // Step 2: Set up CLI
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                output.WriteLine("Step 2: Using pre-installed Aspire CLI...");
+                sequenceBuilder.SourceAspireCliEnvironment(counter);
+            }
+
+            // Step 3: Create single-file AppHost
+            output.WriteLine("Step 3: Creating single-file AppHost...");
+            sequenceBuilder.Type("aspire init")
+                .Enter()
+                .Wait(TimeSpan.FromSeconds(5))
+                .Enter()
+                .WaitUntil(s => waitingForInitComplete.Search(s).Count > 0, TimeSpan.FromMinutes(2))
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
+
+            // Step 4: Add Azure Container Apps package
+            output.WriteLine("Step 4: Adding Azure Container Apps package...");
+            sequenceBuilder.Type("aspire add Aspire.Hosting.Azure.AppContainers")
+                .Enter();
+
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                sequenceBuilder
+                    .WaitUntil(s => waitingForVersionSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
+                    .Enter();
+            }
+
+            sequenceBuilder.WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(180));
+
+            // Step 5: Modify apphost.cs to add Azure Container App Environment
+            sequenceBuilder.ExecuteCallback(() =>
+            {
+                var appHostFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs");
+                var content = File.ReadAllText(appHostFilePath);
+
+                var buildRunPattern = "builder.Build().Run();";
+                var replacement = """
+builder.AddAzureContainerAppEnvironment("infra");
+
+builder.Build().Run();
+""";
+
+                content = content.Replace(buildRunPattern, replacement);
+                File.WriteAllText(appHostFilePath, content);
+
+                output.WriteLine($"Modified apphost.cs with Azure Container App Environment");
+            });
+
+            // Step 6: Set environment variables with an INVALID Azure location to induce failure.
+            // 'invalidlocation' is not a real Azure region, so provisioning will fail with
+            // LocationNotAvailableForResourceType or similar error.
+            output.WriteLine("Step 6: Setting invalid Azure location to induce failure...");
+            sequenceBuilder.Type($"unset ASPIRE_PLAYGROUND && export AZURE__LOCATION=invalidlocation && export AZURE__RESOURCEGROUP={resourceGroupName}")
+                .Enter()
+                .WaitForSuccessPrompt(counter);
+
+            // Step 7: Deploy (expecting failure) and capture output to a file
+            output.WriteLine("Step 7: Starting deployment with invalid location (expecting failure)...");
+            sequenceBuilder
+                .Type($"aspire deploy --clear-cache 2>&1 | tee {deployOutputFile}")
+                .Enter()
+                .WaitUntil(s => waitingForPipelineFailed.Search(s).Count > 0, TimeSpan.FromMinutes(30))
+                .WaitForAnyPrompt(counter, TimeSpan.FromMinutes(2));
+
+            // Step 8: Exit terminal
+            sequenceBuilder.Type("exit").Enter();
+
+            var sequence = sequenceBuilder.Build();
+            await sequence.ApplyAsync(terminal, cancellationToken);
+            await pendingRun;
+
+            // Step 9: Read captured output and verify error messages are clean
+            output.WriteLine("Step 9: Verifying error output is clean...");
+            Assert.True(File.Exists(deployOutputFile), $"Deploy output file not found at {deployOutputFile}");
+
+            var deployOutput = File.ReadAllText(deployOutputFile);
+            output.WriteLine($"Captured {deployOutput.Length} characters of deploy output");
+            output.WriteLine("--- Deploy output (last 2000 chars) ---");
+            output.WriteLine(deployOutput.Length > 2000 ? deployOutput[^2000..] : deployOutput);
+            output.WriteLine("--- End deploy output ---");
+
+            // Verify the output does NOT contain verbose HTTP details from RequestFailedException
+            Assert.DoesNotContain("Headers:", deployOutput);
+            Assert.DoesNotContain("Cache-Control:", deployOutput);
+            Assert.DoesNotContain("x-ms-failure-cause:", deployOutput);
+            Assert.DoesNotContain("x-ms-request-id:", deployOutput);
+            Assert.DoesNotContain("Content-Type: application/json", deployOutput);
+            Assert.DoesNotContain("Status: 400", deployOutput);
+            Assert.DoesNotContain("Status: 404", deployOutput);
+
+            // Verify the pipeline DID fail (sanity check)
+            Assert.Contains("PIPELINE FAILED", deployOutput);
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"✅ Test completed in {duration} - error output is clean");
+        }
+        catch (Exception ex)
+        {
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"❌ Test failed after {duration}: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployWithInvalidLocation_ErrorOutputIsClean),
+                resourceGroupName,
+                ex.Message,
+                ex.StackTrace);
+
+            throw;
+        }
+        finally
+        {
+            // Cleanup: resource group may not have been created if provisioning failed early,
+            // but attempt cleanup just in case.
+            output.WriteLine($"Cleaning up resource group: {resourceGroupName}");
+            TriggerCleanupResourceGroup(resourceGroupName);
+        }
+    }
+
+    private void TriggerCleanupResourceGroup(string resourceGroupName)
+    {
+        var process = new System.Diagnostics.Process
+        {
+            StartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "az",
+                Arguments = $"group delete --name {resourceGroupName} --yes --no-wait",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        try
+        {
+            process.Start();
+            output.WriteLine($"Cleanup triggered for resource group: {resourceGroupName}");
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Failed to trigger cleanup: {ex.Message}");
+        }
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaDeploymentErrorOutputTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaDeploymentErrorOutputTests.cs
@@ -145,8 +145,11 @@ builder.Build().Run();
             // Step 6: Set environment variables with an INVALID Azure location to induce failure.
             // 'invalidlocation' is not a real Azure region, so provisioning will fail with
             // LocationNotAvailableForResourceType or similar error.
+            // Note: Unset both Azure__Location and AZURE__LOCATION because the CI workflow
+            // sets Azure__Location=westus3 at the job level, and on Linux env vars are
+            // case-sensitive. Then set the invalid location with both casings to be safe.
             output.WriteLine("Step 6: Setting invalid Azure location to induce failure...");
-            sequenceBuilder.Type($"unset ASPIRE_PLAYGROUND && export AZURE__LOCATION=invalidlocation && export AZURE__RESOURCEGROUP={resourceGroupName}")
+            sequenceBuilder.Type($"unset ASPIRE_PLAYGROUND && unset Azure__Location && export AZURE__LOCATION=invalidlocation && export Azure__Location=invalidlocation && export AZURE__RESOURCEGROUP={resourceGroupName}")
                 .Enter()
                 .WaitForSuccessPrompt(counter);
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -1199,6 +1199,57 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         await Verify(logs);
     }
 
+    [Fact]
+    public async Task DeployAsync_WithRequestFailedException_DoesNotIncludeVerboseHttpDetails()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: WellKnownPipelineSteps.Deploy);
+        var mockActivityReporter = new TestPipelineActivityReporter(testOutputHelper);
+
+        ConfigureTestServices(builder, bicepProvisioner: new FailingBicepProvisioner(), activityReporter: mockActivityReporter);
+
+        builder.AddAzureEnvironment();
+        builder.AddAzureSqlServer("sql").AddDatabase("db");
+
+        using var app = builder.Build();
+        await app.RunAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Collect all error-level messages from the pipeline activity reporter
+        var errorLogs = mockActivityReporter.LoggedMessages
+                .Where(m => m.LogLevel >= LogLevel.Error)
+                .Select(s => s.Message)
+                .ToList();
+
+        // Collect all completed step/task messages
+        var completedStepMessages = mockActivityReporter.CompletedSteps
+                .Where(s => s.CompletionState == CompletionState.CompletedWithError)
+                .Select(s => s.CompletionText)
+                .ToList();
+
+        var completedTaskMessages = mockActivityReporter.CompletedTasks
+                .Where(t => t.CompletionState == CompletionState.CompletedWithError)
+                .Select(t => t.CompletionMessage ?? t.TaskStatusText)
+                .ToList();
+
+        var allMessages = errorLogs.Concat(completedStepMessages).Concat(completedTaskMessages).ToList();
+
+        Assert.NotEmpty(allMessages);
+
+        // Verify that NO error message contains verbose HTTP details from RequestFailedException
+        foreach (var message in allMessages)
+        {
+            Assert.DoesNotContain("Headers:", message);
+            Assert.DoesNotContain("Cache-Control:", message);
+            Assert.DoesNotContain("x-ms-failure-cause:", message);
+            Assert.DoesNotContain("x-ms-request-id:", message);
+            Assert.DoesNotContain("Content-Type: application/json", message);
+            Assert.DoesNotContain("Status: 400 (Bad Request)", message);
+        }
+
+        // Verify the clean extracted error message IS present somewhere
+        var hasCleanError = allMessages.Any(m => m.Contains("LocationNotAvailableForResourceType"));
+        Assert.True(hasCleanError, "Expected the clean error code 'LocationNotAvailableForResourceType' to appear in error output");
+    }
+
     private void ConfigureTestServices(IDistributedApplicationTestingBuilder builder,
         IInteractionService? interactionService = null,
         IBicepProvisioner? bicepProvisioner = null,
@@ -1264,6 +1315,54 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
         {
             return Task.CompletedTask;
         }
+    }
+
+    private sealed class FailingBicepProvisioner : IBicepProvisioner
+    {
+        public Task<bool> ConfigureResourceAsync(IConfiguration configuration, AzureBicepResource resource, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(false);
+        }
+
+        public Task GetOrCreateResourceAsync(AzureBicepResource resource, ProvisioningContext context, CancellationToken cancellationToken)
+        {
+            // Build a mock Azure Response with JSON error body, simulating what the ARM
+            // deployment API returns when a deployment fails. This ensures the
+            // ExtractDetailedErrorMessage method can parse the JSON and produce a clean
+            // error message rather than falling back to the verbose Message property.
+            var jsonContent = """{"error":{"code":"LocationNotAvailableForResourceType","message":"The provided location 'asia' is not available for resource type 'Microsoft.ManagedIdentity/userAssignedIdentities'."}}""";
+            var response = new TestAzureResponse(400, "Bad Request", jsonContent);
+
+            throw new global::Azure.RequestFailedException(response);
+        }
+    }
+
+    /// <summary>
+    /// Minimal Azure Response subclass for testing. Provides JSON content that
+    /// ExtractDetailedErrorMessage can parse, simulating a real Azure SDK error.
+    /// </summary>
+    private sealed class TestAzureResponse : global::Azure.Response
+    {
+        private readonly int _status;
+        private readonly string _reasonPhrase;
+
+        public TestAzureResponse(int status, string reasonPhrase, string content)
+        {
+            _status = status;
+            _reasonPhrase = reasonPhrase;
+            ContentStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(content));
+        }
+
+        public override int Status => _status;
+        public override string ReasonPhrase => _reasonPhrase;
+        public override Stream? ContentStream { get; set; }
+        public override string ClientRequestId { get; set; } = string.Empty;
+
+        public override void Dispose() { }
+        protected override bool TryGetHeader(string name, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? value) { value = null; return false; }
+        protected override bool TryGetHeaderValues(string name, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEnumerable<string>? values) { values = null; return false; }
+        protected override bool ContainsHeader(string name) => false;
+        protected override IEnumerable<global::Azure.Core.HttpHeader> EnumerateHeaders() => [];
     }
 
     private sealed class Project : IProjectMetadata

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -1234,20 +1234,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
 
         Assert.NotEmpty(allMessages);
 
-        // Verify that NO error message contains verbose HTTP details from RequestFailedException
-        foreach (var message in allMessages)
-        {
-            Assert.DoesNotContain("Headers:", message);
-            Assert.DoesNotContain("Cache-Control:", message);
-            Assert.DoesNotContain("x-ms-failure-cause:", message);
-            Assert.DoesNotContain("x-ms-request-id:", message);
-            Assert.DoesNotContain("Content-Type: application/json", message);
-            Assert.DoesNotContain("Status: 400 (Bad Request)", message);
-        }
-
-        // Verify the clean extracted error message IS present somewhere
-        var hasCleanError = allMessages.Any(m => m.Contains("LocationNotAvailableForResourceType"));
-        Assert.True(hasCleanError, "Expected the clean error code 'LocationNotAvailableForResourceType' to appear in error output");
+        await Verify(allMessages);
     }
 
     private void ConfigureTestServices(IDistributedApplicationTestingBuilder builder,

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithAzureResourcesAndNoEnvironment_Fails.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithAzureResourcesAndNoEnvironment_Fails.verified.txt
@@ -1,4 +1,4 @@
 ﻿[
   Step 'provision-sql-roles' failed.,
-  Step 'provision-sql-roles' failed: An Azure principal parameter was not supplied a value. Ensure you are using an environment that supports role assignments, for example AddAzureContainerAppEnvironment.
+  Deployment failed: An Azure principal parameter was not supplied a value. Ensure you are using an environment that supports role assignments, for example AddAzureContainerAppEnvironment.
 ]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRequestFailedException_DoesNotIncludeVerboseHttpDetails.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithRequestFailedException_DoesNotIncludeVerboseHttpDetails.verified.txt
@@ -1,0 +1,7 @@
+﻿[
+  Step 'provision-sql' failed.,
+  Deployment failed: Error code = LocationNotAvailableForResourceType, Message = The provided location 'asia' is not available for resource type 'Microsoft.ManagedIdentity/userAssignedIdentities'.,
+  Deployment failed: Error code = LocationNotAvailableForResourceType, Message = The provided location 'asia' is not available for resource type 'Microsoft.ManagedIdentity/userAssignedIdentities'.,
+  Failed,
+  Failed to provision **sql**: Deployment failed: Error code = LocationNotAvailableForResourceType, Message = The provided location 'asia' is not available for resource type 'Microsoft.ManagedIdentity/userAssignedIdentities'.
+]


### PR DESCRIPTION
## Summary

Fixes #12303 — Azure deployment errors are too verbose, duplicated, and include raw HTTP headers/JSON.

## Root Cause

When an Azure deployment fails with a `RequestFailedException`:

1. `AzureBicepResource.ProvisionAzureBicepResourceAsync()` catches it, extracts a clean error via `ExtractDetailedErrorMessage()`, but then does `throw;` — re-throwing the **raw** exception
2. `DistributedApplicationPipeline.ExecuteStepAsync()` catches it and wraps: `throw new InvalidOperationException("Step '{step.Name}' failed: {ex.Message}", ex)` — `ex.Message` is the **verbose** `RequestFailedException.Message` (includes HTTP status, error code, JSON body, response headers)
3. The verbose multi-line message propagates through `FailAsync(ex.Message)` into the step completion text
4. The CLI's `ConsoleActivityLogger` splits and prefixes each line, creating a wall of HTTP header noise

## Changes

1. **New `ProvisioningFailedException`** (`src/Aspire.Hosting.Azure/Exceptions.cs`): Internal exception extending `DistributedApplicationException` that carries the clean, extracted error message instead of the raw `RequestFailedException.Message`.

2. **Throw clean exception** (`src/Aspire.Hosting.Azure/AzureBicepResource.cs`): Changed `throw;` to `throw new ProvisioningFailedException(errorMessage, ex)` so the clean message (already extracted by `ExtractDetailedErrorMessage`) propagates up instead of the verbose SDK message.

3. **Skip redundant wrapping** (`src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs`): Added `catch (DistributedApplicationException) { throw; }` before the generic catch in `ExecuteStepAsync` so that `DistributedApplicationException` subtypes (which already have clean messages) pass through without being wrapped in `"Step '...' failed: {verbose}"`.

4. **Unit test** (`tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs`): `DeployAsync_WithRequestFailedException_DoesNotIncludeVerboseHttpDetails` — uses a `FailingBicepProvisioner` with a mock Azure response to verify no HTTP headers, status lines, or raw JSON leak into error output.

## Before / After

**Before**: Error output includes HTTP status, error code, raw JSON content, and full response headers repeated for each failed resource.

**After**: Error output shows only the clean extracted error message (e.g., `LocationNotAvailableForResourceType: The provided location 'asia' is not available...`).