### PR TITLE
Fix NU1009 error for CPM projects during aspire update

### DIFF
--- a/src/Aspire.Cli/Projects/ProjectUpdater.cs
+++ b/src/Aspire.Cli/Projects/ProjectUpdater.cs
@@ -447,6 +447,13 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
 
         projectDocument.Save(projectFile.FullName);
 
+        // The new SDK format adds an implicit PackageReference for Aspire.Hosting.AppHost with
+        // IsImplicitlyDefined="true". NuGet's Central Package Management (CPM) rejects any
+        // PackageVersion entry that targets an implicitly-defined package (NU1009). If the user
+        // was previously managing this package through CPM, we must also remove the now-orphaned
+        // PackageVersion entry from Directory.Packages.props to prevent the NU1009 error.
+        RemovePackageVersionFromDirectoryPackagesProps(projectFile, "Aspire.Hosting.AppHost");
+
         await Task.CompletedTask;
     }
 
@@ -507,6 +514,54 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
             }
         }
         return true;
+    }
+
+    private static void RemovePackageVersionFromDirectoryPackagesProps(FileInfo projectFile, string packageId)
+    {
+        var cpmInfo = DetectCentralPackageManagement(projectFile);
+        if (!cpmInfo.UsesCentralPackageManagement || cpmInfo.DirectoryPackagesPropsFile is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var propsDocument = new XmlDocument();
+            propsDocument.PreserveWhitespace = true;
+            propsDocument.Load(cpmInfo.DirectoryPackagesPropsFile.FullName);
+
+            var packageVersionNode = propsDocument.SelectSingleNode($"/Project/ItemGroup/PackageVersion[@Include='{packageId}']");
+            if (packageVersionNode?.ParentNode is null)
+            {
+                return;
+            }
+
+            var parentNode = packageVersionNode.ParentNode;
+
+            RemoveNodeWithWhitespace(packageVersionNode);
+
+            if (parentNode.Name == "ItemGroup" && IsEmptyOrWhitespace(parentNode))
+            {
+                RemoveNodeWithWhitespace(parentNode);
+            }
+
+            propsDocument.Save(cpmInfo.DirectoryPackagesPropsFile.FullName);
+        }
+        catch (Exception ex)
+        {
+            // The csproj has already been updated at this point, so we can't roll back.
+            // Inform the user what manual step is needed to complete the migration.
+            throw new ProjectUpdaterException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "The project file was updated successfully, but the PackageVersion entry for '{0}' could not be " +
+                    "removed from '{1}': {2}. Please manually remove the <PackageVersion Include=\"{0}\" ... /> " +
+                    "entry from this file to avoid NU1009 build errors.",
+                    packageId,
+                    cpmInfo.DirectoryPackagesPropsFile.FullName,
+                    ex.Message),
+                ex);
+        }
     }
 
     private static async Task UpdateSdkVersionInSingleFileAppHostAsync(FileInfo projectFile, NuGetPackageCli package)

--- a/tests/Aspire.Cli.EndToEnd.Tests/CentralPackageManagementTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/CentralPackageManagementTests.cs
@@ -1,0 +1,135 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests for Central Package Management (CPM) compatibility.
+/// Validates that aspire update correctly handles CPM projects.
+/// Each test class runs as a separate CI job for parallelization.
+/// </summary>
+public sealed class CentralPackageManagementTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task AspireUpdateRemovesAppHostPackageVersionFromDirectoryPackagesProps()
+    {
+        var workspace = TemporaryWorkspace.Create(output);
+
+        var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
+        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
+        var isCI = CliE2ETestHelpers.IsRunningInCI;
+        var recordingPath = CliE2ETestHelpers.GetTestResultsRecordingPath(nameof(AspireUpdateRemovesAppHostPackageVersionFromDirectoryPackagesProps));
+
+        var builder = Hex1bTerminal.CreateBuilder()
+            .WithHeadless()
+            .WithDimensions(160, 48)
+            .WithAsciinemaRecording(recordingPath)
+            .WithPtyProcess("/bin/bash", ["--norc"]);
+
+        using var terminal = builder.Build();
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        // aspire update prompts
+        var waitingForPerformUpdates = new CellPatternSearcher()
+            .Find("Perform updates?");
+
+        var waitingForUpdateSuccessful = new CellPatternSearcher()
+            .Find("Update successful!");
+
+        var counter = new SequenceCounter();
+        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+        sequenceBuilder.PrepareEnvironment(workspace, counter);
+
+        if (isCI)
+        {
+            sequenceBuilder.InstallAspireCliFromPullRequest(prNumber, counter);
+            sequenceBuilder.SourceAspireCliEnvironment(counter);
+            sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
+        }
+
+        // Disable update notifications to prevent the CLI self-update prompt
+        // from appearing after "Update successful!" and blocking the test.
+        sequenceBuilder
+            .Type("aspire config set features.updateNotificationsEnabled false -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Set up an old-format AppHost project with CPM that has a PackageVersion
+        // for Aspire.Hosting.AppHost. This simulates a pre-migration project where
+        // the user adopted CPM before the SDK started adding the implicit reference.
+        var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, "CpmTest");
+        var appHostDir = Path.Combine(projectDir, "CpmTest.AppHost");
+        var appHostCsprojPath = Path.Combine(appHostDir, "CpmTest.AppHost.csproj");
+        var directoryPackagesPropsPath = Path.Combine(projectDir, "Directory.Packages.props");
+
+        sequenceBuilder
+            .ExecuteCallback(() =>
+            {
+                Directory.CreateDirectory(appHostDir);
+
+                File.WriteAllText(appHostCsprojPath, """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                        <Sdk Name="Aspire.AppHost.Sdk" Version="9.1.0" />
+                        <PropertyGroup>
+                            <OutputType>Exe</OutputType>
+                            <TargetFramework>net9.0</TargetFramework>
+                            <IsAspireHost>true</IsAspireHost>
+                        </PropertyGroup>
+                        <ItemGroup>
+                            <PackageReference Include="Aspire.Hosting.AppHost" />
+                        </ItemGroup>
+                    </Project>
+                    """);
+
+                File.WriteAllText(Path.Combine(appHostDir, "Program.cs"), """
+                    var builder = DistributedApplication.CreateBuilder(args);
+                    builder.Build().Run();
+                    """);
+
+                File.WriteAllText(directoryPackagesPropsPath, """
+                    <Project>
+                        <PropertyGroup>
+                            <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                        </PropertyGroup>
+                        <ItemGroup>
+                            <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.1.0" />
+                        </ItemGroup>
+                    </Project>
+                    """);
+            })
+            // Use --channel stable to skip the channel selection prompt that appears
+            // in CI when PR hive directories are present.
+            .Type($"aspire update --project \"{appHostCsprojPath}\" --channel stable")
+            .Enter()
+            .WaitUntil(s => waitingForPerformUpdates.Search(s).Count > 0, TimeSpan.FromSeconds(60))
+            .Enter() // confirm "Perform updates?" (default: Yes)
+            .WaitUntil(s => waitingForUpdateSuccessful.Search(s).Count > 0, TimeSpan.FromSeconds(60))
+            .WaitForSuccessPrompt(counter)
+            // Verify the PackageVersion for Aspire.Hosting.AppHost was removed
+            .VerifyFileDoesNotContain(directoryPackagesPropsPath, "Aspire.Hosting.AppHost")
+            // Verify dotnet restore succeeds (would fail with NU1009 without the fix)
+            .Type($"dotnet restore \"{appHostCsprojPath}\"")
+            .Enter()
+            .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(120))
+            // Clean up: re-enable update notifications
+            .Type("aspire config delete features.updateNotificationsEnabled -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("exit")
+            .Enter();
+
+        var sequence = sequenceBuilder.Build();
+
+        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+        await pendingRun;
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/CentralPackageManagementTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/CentralPackageManagementTests.cs
@@ -40,6 +40,12 @@ public sealed class CentralPackageManagementTests(ITestOutputHelper output)
         var waitingForPerformUpdates = new CellPatternSearcher()
             .Find("Perform updates?");
 
+        var waitingForNuGetConfigDirectory = new CellPatternSearcher()
+            .Find("Which directory for NuGet.config file?");
+
+        var waitingForApplyNuGetConfig = new CellPatternSearcher()
+            .Find("Apply these changes to NuGet.config?");
+
         var waitingForUpdateSuccessful = new CellPatternSearcher()
             .Find("Update successful!");
 
@@ -111,6 +117,12 @@ public sealed class CentralPackageManagementTests(ITestOutputHelper output)
             .Enter()
             .WaitUntil(s => waitingForPerformUpdates.Search(s).Count > 0, TimeSpan.FromSeconds(60))
             .Enter() // confirm "Perform updates?" (default: Yes)
+            // The updater may prompt for a NuGet.config location and ask to apply changes
+            // when the project doesn't have an existing NuGet.config. Accept defaults for both.
+            .WaitUntil(s => waitingForNuGetConfigDirectory.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .Enter() // accept default directory
+            .WaitUntil(s => waitingForApplyNuGetConfig.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .Enter() // confirm "Apply these changes to NuGet.config?" (default: Yes)
             .WaitUntil(s => waitingForUpdateSuccessful.Search(s).Count > 0, TimeSpan.FromSeconds(60))
             .WaitForSuccessPrompt(counter)
             // Verify the PackageVersion for Aspire.Hosting.AppHost was removed


### PR DESCRIPTION
## Summary

Fixes #14550

When a project uses Central Package Management (CPM) and has a `PackageVersion` entry for `Aspire.Hosting.AppHost` in `Directory.Packages.props`, running `aspire update` leaves the `PackageVersion` orphaned after removing the `PackageReference` from the csproj. The new SDK format adds an implicit `PackageReference` with `IsImplicitlyDefined="true"`, and NuGet rejects `PackageVersion` entries for implicitly-defined packages (NU1009).

## Changes

- **`src/Aspire.Cli/Projects/ProjectUpdater.cs`**: Added `RemovePackageVersionFromDirectoryPackagesProps` method that removes the orphaned `PackageVersion` entry from `Directory.Packages.props` during the SDK migration in `UpdateSdkVersionInCsprojAppHostAsync`. Includes error handling that tells the user what to do manually if the removal fails.
- **`tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs`**: Unit test verifying the `PackageVersion` removal with a real temp workspace.
- **`tests/Aspire.Cli.EndToEnd.Tests/CentralPackageManagementTests.cs`**: E2E test that runs `aspire update` on a CPM project with an old-format AppHost and verifies the `PackageVersion` is removed and `dotnet restore` succeeds.