### PR TITLE
Fix AKS deployment test timeouts and ACR token expiration

### DIFF
--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
@@ -165,11 +165,12 @@ public sealed class AksStarterDeploymentTests(ITestOutputHelper output)
                 .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(20));
 
             // Step 6: Ensure AKS can pull from ACR (update attachment to ensure role propagation)
+            // ReconcilingAddons can take several minutes after role assignment updates
             output.WriteLine("Step 6: Verifying AKS-ACR integration...");
             sequenceBuilder
                 .Type($"az aks update --resource-group {resourceGroupName} --name {clusterName} --attach-acr {acrName}")
                 .Enter()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(3));
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
 
             // Step 7: Configure kubectl credentials
             output.WriteLine("Step 7: Configuring kubectl credentials...");
@@ -283,8 +284,14 @@ builder.Build().Run();
                 .Enter()
                 .WaitForSuccessPrompt(counter);
 
-            // Step 16: ACR login was already done in Step 4b (before AKS creation).
-            // Docker credentials persist in ~/.docker/config.json.
+            // Step 16: Re-login to ACR after AKS creation to refresh Docker credentials.
+            // The initial login (Step 4b) may have expired during the 10-15 min AKS provisioning
+            // because OIDC federated tokens have a short lifetime (~5 min).
+            output.WriteLine("Step 16: Refreshing ACR login...");
+            sequenceBuilder
+                .Type($"az acr login --name {acrName}")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(60));
 
             // Step 17: Build and push container images to ACR
             // The starter template creates webfrontend and apiservice projects
@@ -348,11 +355,12 @@ builder.Build().Run();
                 .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(12));
 
             // Step 22: Wait for pods to be ready
+            // Pods may need time to pull images from ACR and start the application
             output.WriteLine("Step 22: Waiting for pods to be ready...");
             sequenceBuilder
-                .Type("kubectl wait --for=condition=ready pod --all -n default --timeout=120s")
+                .Type("kubectl wait --for=condition=ready pod --all -n default --timeout=300s")
                 .Enter()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(3));
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(6));
 
             // Step 23: Verify pods are running
             output.WriteLine("Step 23: Verifying pods are running...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterWithRedisDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterWithRedisDeploymentTests.cs
@@ -368,7 +368,7 @@ builder.Build().Run();
                       "kubectl wait --for=condition=ready pod -l app.kubernetes.io/component=webfrontend --timeout=300s -n default && " +
                       "kubectl wait --for=condition=ready pod -l app.kubernetes.io/component=cache --timeout=300s -n default")
                 .Enter()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(6));
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(16));
 
             // Step 22b: Verify Redis container is running and stable (no restarts)
             output.WriteLine("Step 22b: Verifying Redis container is stable...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterWithRedisDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterWithRedisDeploymentTests.cs
@@ -165,11 +165,12 @@ public sealed class AksStarterWithRedisDeploymentTests(ITestOutputHelper output)
                 .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(20));
 
             // Step 6: Ensure AKS can pull from ACR
+            // ReconcilingAddons can take several minutes after role assignment updates
             output.WriteLine("Step 6: Verifying AKS-ACR integration...");
             sequenceBuilder
                 .Type($"az aks update --resource-group {resourceGroupName} --name {clusterName} --attach-acr {acrName}")
                 .Enter()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(3));
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
 
             // Step 7: Configure kubectl credentials
             output.WriteLine("Step 7: Configuring kubectl credentials...");
@@ -281,8 +282,14 @@ builder.Build().Run();
                 .Enter()
                 .WaitForSuccessPrompt(counter);
 
-            // Step 16: ACR login was already done in Step 4b (before AKS creation).
-            // Docker credentials persist in ~/.docker/config.json.
+            // Step 16: Re-login to ACR after AKS creation to refresh Docker credentials.
+            // The initial login (Step 4b) may have expired during the 10-15 min AKS provisioning
+            // because OIDC federated tokens have a short lifetime (~5 min).
+            output.WriteLine("Step 16: Refreshing ACR login...");
+            sequenceBuilder
+                .Type($"az acr login --name {acrName}")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(60));
 
             // Step 17: Build and push container images to ACR
             // Only project resources need to be built — Redis uses a public container image
@@ -354,13 +361,14 @@ builder.Build().Run();
                 .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(12));
 
             // Step 22: Wait for all pods to be ready (including Redis cache)
+            // Pods may need time to pull images from ACR and start the application
             output.WriteLine("Step 22: Waiting for all pods to be ready...");
             sequenceBuilder
-                .Type("kubectl wait --for=condition=ready pod -l app.kubernetes.io/component=apiservice --timeout=120s -n default && " +
-                      "kubectl wait --for=condition=ready pod -l app.kubernetes.io/component=webfrontend --timeout=120s -n default && " +
-                      "kubectl wait --for=condition=ready pod -l app.kubernetes.io/component=cache --timeout=120s -n default")
+                .Type("kubectl wait --for=condition=ready pod -l app.kubernetes.io/component=apiservice --timeout=300s -n default && " +
+                      "kubectl wait --for=condition=ready pod -l app.kubernetes.io/component=webfrontend --timeout=300s -n default && " +
+                      "kubectl wait --for=condition=ready pod -l app.kubernetes.io/component=cache --timeout=300s -n default")
                 .Enter()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(3));
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(6));
 
             // Step 22b: Verify Redis container is running and stable (no restarts)
             output.WriteLine("Step 22b: Verifying Redis container is stable...");


### PR DESCRIPTION
## Summary

Fixes intermittent failures in `AksStarterDeploymentTests` and `AksStarterWithRedisDeploymentTests`.

### Root Causes Identified

1. **`az aks update --attach-acr` timeout too short (3 min)**: The ReconcilingAddons phase after updating ACR role assignments can take several minutes. Increased to 5 minutes.

2. **Pod readiness timeout too short (120s)**: After Helm deployment, pods need time to pull images from ACR and start. Increased `kubectl wait` timeout from 120s to 300s.

3. **ACR Docker credentials expire during AKS provisioning**: The initial ACR login (Step 4b) happens before AKS creation which takes 10-15 minutes. OIDC federated tokens expire after ~5 minutes, so Docker credentials in `~/.docker/config.json` may be stale by the time images are pushed. Added a re-login step after AKS provisioning completes.

### Changes

- Both test files: Increased `az aks update` timeout from 3→5 minutes
- Both test files: Increased pod readiness timeout from 120s→300s  
- Both test files: Added ACR re-login step after AKS provisioning

### Evidence

Recent failures from [workflow run #22208855323](https://github.com/dotnet/aspire/actions/runs/22208855323):
- `AksStarterDeploymentTests`: `kubectl wait` timed out - pods not ready within 120s
- `AksStarterWithRedisDeploymentTests`: `WaitUntil timed out after 00:03:00` on `az aks update --attach-acr`