### PR TITLE
Improve aspire config list output formatting

### DIFF
--- a/src/Aspire.Cli/Resources/ConfigCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ConfigCommandStrings.Designer.cs
@@ -382,5 +382,14 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("InfoCommand_SettingsProperties", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use &apos;aspire config set features.&lt;name&gt; true|false&apos; to enable or disable a feature..
+        /// </summary>
+        public static string SetFeatureHint {
+            get {
+                return ResourceManager.GetString("SetFeatureHint", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/ConfigCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/ConfigCommandStrings.resx
@@ -216,4 +216,7 @@
   <data name="InfoCommand_SettingsProperties" xml:space="preserve">
     <value>Settings file properties</value>
   </data>
+  <data name="SetFeatureHint" xml:space="preserve">
+    <value>Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.cs.xlf
@@ -182,6 +182,11 @@
         <target state="translated">Hodnota konfigurace, která se má nastavit</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetFeatureHint">
+        <source>Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</source>
+        <target state="new">Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.de.xlf
@@ -182,6 +182,11 @@
         <target state="translated">Der festzulegende Konfigurationswert.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetFeatureHint">
+        <source>Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</source>
+        <target state="new">Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.es.xlf
@@ -182,6 +182,11 @@
         <target state="translated">Valor de configuración que se va a establecer.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetFeatureHint">
+        <source>Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</source>
+        <target state="new">Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.fr.xlf
@@ -182,6 +182,11 @@
         <target state="translated">La valeur de configuration à définir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetFeatureHint">
+        <source>Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</source>
+        <target state="new">Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.it.xlf
@@ -182,6 +182,11 @@
         <target state="translated">Valore di configurazione da impostare.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetFeatureHint">
+        <source>Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</source>
+        <target state="new">Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ja.xlf
@@ -182,6 +182,11 @@
         <target state="translated">設定する構成値。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetFeatureHint">
+        <source>Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</source>
+        <target state="new">Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ko.xlf
@@ -182,6 +182,11 @@
         <target state="translated">설정할 구성 값입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetFeatureHint">
+        <source>Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</source>
+        <target state="new">Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.pl.xlf
@@ -182,6 +182,11 @@
         <target state="translated">Wartość konfiguracji do ustawienia.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetFeatureHint">
+        <source>Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</source>
+        <target state="new">Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.pt-BR.xlf
@@ -182,6 +182,11 @@
         <target state="translated">O valor de configuração a ser definido.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetFeatureHint">
+        <source>Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</source>
+        <target state="new">Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ru.xlf
@@ -182,6 +182,11 @@
         <target state="translated">Значение конфигурации, которое следует задать.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetFeatureHint">
+        <source>Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</source>
+        <target state="new">Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.tr.xlf
@@ -182,6 +182,11 @@
         <target state="translated">Ayarlanacak yapılandırma değeri.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetFeatureHint">
+        <source>Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</source>
+        <target state="new">Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.zh-Hans.xlf
@@ -182,6 +182,11 @@
         <target state="translated">要设置的配置值。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetFeatureHint">
+        <source>Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</source>
+        <target state="new">Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.zh-Hant.xlf
@@ -182,6 +182,11 @@
         <target state="translated">要設定的設定值。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SetFeatureHint">
+        <source>Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</source>
+        <target state="new">Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
## Summary

Cleans up the `aspire config list` output to make configuration values more visually distinct from the available features section.

### Changes

**Configuration tables**: Local and global configuration sections now render in Spectre.Console tables with rounded borders and titled headers (matching the pattern used by `aspire describe` and `aspire docs`). This gives them clear visual boundaries so they don't blend into the feature list.

**Available features**: Instead of a comma-separated list of feature names, each feature is now displayed on its own line with:
- The feature name in cyan
- Its default value (`true`/`false`)
- A description of what the feature controls

A hint line at the bottom shows users how to set a feature: `aspire config set features.<name> true|false`.

### Before
\\\
Local configuration:
  some.key = some-value

Global configuration:
  No global configuration found.

Available features:
  execCommandEnabled, showDeprecatedPackages, stagingChannelEnabled, ...
\\\

### After
\\\
          Local configuration
╭──────────┬────────────╮
│ Key      │ Value      │
├──────────┼────────────┤
│ some.key │ some-value │
╰──────────┴────────────╯
     Global configuration
╭───────────────────────────────────╮
│ Key                         │     │
├───────────────────────────────────┤
│ No global configuration found.    │
╰───────────────────────────────────╯

Available features:
  execCommandEnabled (default: false)
    Enable or disable the 'aspire exec' command...
  showDeprecatedPackages (default: false)
    Show or hide deprecated packages in 'aspire add' search results

  Use 'aspire config set features.<name> true|false' to enable or disable a feature.
\\\

### Testing
All 1300 Aspire.Cli.Tests pass.