### PR TITLE
fixed unreachable CircularBuffer.Decrement double decrement

### DIFF
--- a/src/Shared/CircularBuffer.cs
+++ b/src/Shared/CircularBuffer.cs
@@ -278,12 +278,7 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
 
     private void Decrement(ref int index)
     {
-        if (index <= 0)
-        {
-            index = Capacity - 1;
-        }
-
-        --index;
+        index = (index <= 0) ? Capacity - 1 : index - 1;
     }
 
     public CircularBuffer<T> Clone()


### PR DESCRIPTION
## Description
This is a slightly stupid fix.   The CircularBuffer.Decrement function logic is flawed, I am working to add this code to SpectreConsole currently and noticed it.   The fix is stupid because I realized it was unreachable when trying to write a test case to expose the problem.


The flawed logic:
```
private void Decrement(ref int index)
    {
        if (index <= 0)
        {
            index = Capacity - 1;
        }

        --index;
    }
```

But it isn't hit as its called from:

From RemoveAt:

```csharp
var internalIndex = InternalIndex(index);
_buffer.RemoveAt(internalIndex);
if (internalIndex < _end)
{
    Decrement(ref _end);
    if (_start > 0)
    {
        _start = _end;
    }
}
```

and InternalIndex is:

```csharp
private int InternalIndex(int index)
{
    return (_start + index) % _buffer.Count;
}
```

So with the current code it can't be hit.  At the same time I feel leaving flawed logic there would be a bad idea in case of a future refactoring.  Funnily VS also uses this same class and has the same bug (`microsoft.visualstudio.utilities.circularbuffer`) granted not sure what team to suggest that fix to give its internal only.

## Checklist

- Is this feature complete?
  - [x ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [ x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x ] No

