### PR TITLE
Fix dashboard notifications HTML escaping

### DIFF
--- a/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
+++ b/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
@@ -388,6 +388,10 @@ public class InteractionsProvider : ComponentBase, IAsyncDisposable
                             {
                                 options.Title = WebUtility.HtmlEncode(item.Title);
                                 options.Body = GetMessageHtml(item);
+                                // Allow for HTML in title and body. This is needed to support Markdown output.
+                                // It's safe to enable because content is always either HTML-encoded or generated from Markdown which is sanitized.
+                                options.UseMarkupString = true;
+
                                 options.Intent = MapMessageIntent(notification.Intent);
                                 options.Section = DashboardUIHelpers.MessageBarSection;
                                 options.AllowDismiss = item.ShowDismiss;


### PR DESCRIPTION
## Description

Fixes regression from https://github.com/dotnet/aspire/pull/14549

Before:
<img width="718" height="142" alt="image" src="https://github.com/user-attachments/assets/628c97b3-375c-49aa-8e18-41f276ad2f41" />

After:
<img width="670" height="116" alt="image" src="https://github.com/user-attachments/assets/9441aef2-d60f-49c2-88e4-fdf64a77a27b" />


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
