### PR TITLE
Fix Aspire CLI ANSI detection

### DIFF
--- a/src/Aspire.Cli/Utils/CliHostEnvironment.cs
+++ b/src/Aspire.Cli/Utils/CliHostEnvironment.cs
@@ -102,7 +102,7 @@ internal sealed class CliHostEnvironment : ICliHostEnvironment
             // Update this to use AnsiCapabilities once it's available in Spectre.Console 0.60+ instead of creating a full AnsiConsole instance.
             var ansiConsole = AnsiConsole.Create(new AnsiConsoleSettings
             {
-                Out = new AspireAnsiConsoleOutput(Console.Out, configuration),
+                Out = new AnsiConsoleOutput(TextWriter.Null),
                 Ansi = AnsiSupport.Detect,
                 ColorSystem = ColorSystemSupport.Detect
             });

--- a/src/Aspire.Cli/Utils/CliHostEnvironment.cs
+++ b/src/Aspire.Cli/Utils/CliHostEnvironment.cs
@@ -95,6 +95,9 @@ internal sealed class CliHostEnvironment : ICliHostEnvironment
     {
         if (!TryDetectAnsiSupportConfiguration(configuration, out var supportsAnsi))
         {
+            // If there is no explicit configuration to enable or disable ANSI support, attempt to detect it.
+            // This is required because some terminals don't support ANSI output, e.g. https://github.com/dotnet/aspire/issues/13737
+
             // TODO: Creating a fake console here is a hack to run ANSI detection logic.
             // Update this to use AnsiCapabilities once it's available in Spectre.Console 0.60+ instead of creating a full AnsiConsole instance.
             var ansiConsole = AnsiConsole.Create(new AnsiConsoleSettings

--- a/src/Aspire.Cli/Utils/CliHostEnvironment.cs
+++ b/src/Aspire.Cli/Utils/CliHostEnvironment.cs
@@ -162,8 +162,8 @@ internal sealed class CliHostEnvironment : ICliHostEnvironment
             return true;
         }
 
-        // ANSI codes are supported even in CI environments for colored output
-        // Only disable if explicitly configured
+        // Check for NO_COLOR to explicitly disable ANSI output.
+        // If neither override is set, return false to let the caller fall back to Spectre detection.
         var noColor = configuration["NO_COLOR"];
         if (!string.IsNullOrEmpty(noColor))
         {

--- a/src/Aspire.Cli/Utils/CliHostEnvironment.cs
+++ b/src/Aspire.Cli/Utils/CliHostEnvironment.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Extensions.Configuration;
 using Spectre.Console;
-using static Microsoft.VisualStudio.Threading.AsyncReaderWriterLock;
 
 namespace Aspire.Cli.Utils;
 

--- a/src/Aspire.Cli/Utils/CliHostEnvironment.cs
+++ b/src/Aspire.Cli/Utils/CliHostEnvironment.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Extensions.Configuration;
 using Spectre.Console;
+using static Microsoft.VisualStudio.Threading.AsyncReaderWriterLock;
 
 namespace Aspire.Cli.Utils;
 
@@ -102,7 +103,7 @@ internal sealed class CliHostEnvironment : ICliHostEnvironment
             // Update this to use AnsiCapabilities once it's available in Spectre.Console 0.60+ instead of creating a full AnsiConsole instance.
             var ansiConsole = AnsiConsole.Create(new AnsiConsoleSettings
             {
-                Out = new AnsiConsoleOutput(new StringWriter()),
+                Out = new AspireAnsiConsoleOutput(Console.Out, configuration),
                 Ansi = AnsiSupport.Detect,
                 ColorSystem = ColorSystemSupport.Detect
             });

--- a/tests/Aspire.Cli.Tests/Utils/CliHostEnvironmentTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliHostEnvironmentTests.cs
@@ -13,10 +13,10 @@ public class CliHostEnvironmentTests
     {
         // Arrange
         var configuration = new ConfigurationBuilder().Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: false);
-        
+
         // Assert
         Assert.True(env.SupportsInteractiveInput);
     }
@@ -26,10 +26,10 @@ public class CliHostEnvironmentTests
     {
         // Arrange
         var configuration = new ConfigurationBuilder().Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: false);
-        
+
         // Assert
         Assert.True(env.SupportsInteractiveOutput);
     }
@@ -46,10 +46,10 @@ public class CliHostEnvironmentTests
                 [key] = value
             })
             .Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: false);
-        
+
         // Assert
         Assert.False(env.SupportsInteractiveInput);
     }
@@ -66,10 +66,10 @@ public class CliHostEnvironmentTests
                 [key] = value
             })
             .Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: false);
-        
+
         // Assert
         Assert.False(env.SupportsInteractiveOutput);
     }
@@ -89,10 +89,10 @@ public class CliHostEnvironmentTests
                 [envVar] = value
             })
             .Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: false);
-        
+
         // Assert
         Assert.False(env.SupportsInteractiveInput);
     }
@@ -111,10 +111,10 @@ public class CliHostEnvironmentTests
                 [envVar] = value
             })
             .Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: false);
-        
+
         // Assert
         Assert.False(env.SupportsInteractiveOutput);
     }
@@ -129,10 +129,10 @@ public class CliHostEnvironmentTests
                 ["NO_COLOR"] = "1"
             })
             .Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: false);
-        
+
         // Assert
         Assert.False(env.SupportsAnsi);
     }
@@ -142,10 +142,10 @@ public class CliHostEnvironmentTests
     {
         // Arrange
         var configuration = new ConfigurationBuilder().Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: true);
-        
+
         // Assert
         Assert.False(env.SupportsInteractiveInput);
     }
@@ -155,10 +155,10 @@ public class CliHostEnvironmentTests
     {
         // Arrange
         var configuration = new ConfigurationBuilder().Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: true);
-        
+
         // Assert
         Assert.False(env.SupportsInteractiveOutput);
     }
@@ -173,10 +173,10 @@ public class CliHostEnvironmentTests
                 ["ASPIRE_PLAYGROUND"] = "true"
             })
             .Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: false);
-        
+
         // Assert
         Assert.True(env.SupportsInteractiveInput);
     }
@@ -191,10 +191,10 @@ public class CliHostEnvironmentTests
                 ["ASPIRE_PLAYGROUND"] = "true"
             })
             .Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: false);
-        
+
         // Assert
         Assert.True(env.SupportsInteractiveOutput);
     }
@@ -210,10 +210,10 @@ public class CliHostEnvironmentTests
                 ["CI"] = "true"
             })
             .Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: false);
-        
+
         // Assert
         Assert.True(env.SupportsInteractiveInput);
     }
@@ -229,10 +229,10 @@ public class CliHostEnvironmentTests
                 ["GITHUB_ACTIONS"] = "true"
             })
             .Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: false);
-        
+
         // Assert
         Assert.True(env.SupportsInteractiveOutput);
     }
@@ -247,10 +247,10 @@ public class CliHostEnvironmentTests
                 ["ASPIRE_PLAYGROUND"] = "true"
             })
             .Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: true);
-        
+
         // Assert
         // --non-interactive takes precedence over ASPIRE_PLAYGROUND
         Assert.False(env.SupportsInteractiveInput);
@@ -266,10 +266,10 @@ public class CliHostEnvironmentTests
                 ["ASPIRE_PLAYGROUND"] = "true"
             })
             .Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: true);
-        
+
         // Assert
         // --non-interactive takes precedence over ASPIRE_PLAYGROUND
         Assert.False(env.SupportsInteractiveOutput);
@@ -286,10 +286,10 @@ public class CliHostEnvironmentTests
                 ["CI"] = "true"
             })
             .Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: false);
-        
+
         // Assert
         Assert.False(env.SupportsInteractiveInput);
     }
@@ -304,10 +304,10 @@ public class CliHostEnvironmentTests
                 ["ASPIRE_PLAYGROUND"] = "true"
             })
             .Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: false);
-        
+
         // Assert
         Assert.True(env.SupportsAnsi);
     }
@@ -323,29 +323,28 @@ public class CliHostEnvironmentTests
                 ["NO_COLOR"] = "1"
             })
             .Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: false);
-        
+
         // Assert
         Assert.True(env.SupportsAnsi);
     }
 
     [Fact]
-    public void SupportsAnsi_ReturnsTrue_WhenPlaygroundModeSet_WithNonInteractive_AndAnsiPassThru()
+    public void SupportsAnsi_ReturnsTrue_WhenAnsiPassThruSet_WithNonInteractive()
     {
         // Arrange - ASPIRE_ANSI_PASS_THRU explicitly enables ANSI even with --non-interactive
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["ASPIRE_PLAYGROUND"] = "true",
                 ["ASPIRE_ANSI_PASS_THRU"] = "true"
             })
             .Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: true);
-        
+
         // Assert
         Assert.True(env.SupportsAnsi);
     }
@@ -362,10 +361,10 @@ public class CliHostEnvironmentTests
                 [key] = value
             })
             .Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: false);
-        
+
         // Assert
         Assert.True(env.SupportsAnsi);
     }
@@ -381,10 +380,10 @@ public class CliHostEnvironmentTests
                 ["NO_COLOR"] = "1"
             })
             .Build();
-        
+
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: false);
-        
+
         // Assert
         Assert.True(env.SupportsAnsi);
     }

--- a/tests/Aspire.Cli.Tests/Utils/CliHostEnvironmentTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliHostEnvironmentTests.cs
@@ -34,19 +34,6 @@ public class CliHostEnvironmentTests
         Assert.True(env.SupportsInteractiveOutput);
     }
 
-    [Fact]
-    public void SupportsAnsi_ReturnsTrue_WhenNoConfigSet()
-    {
-        // Arrange
-        var configuration = new ConfigurationBuilder().Build();
-        
-        // Act
-        var env = new CliHostEnvironment(configuration, nonInteractive: false);
-        
-        // Assert
-        Assert.True(env.SupportsAnsi);
-    }
-
     [Theory]
     [InlineData("ASPIRE_NON_INTERACTIVE", "true")]
     [InlineData("ASPIRE_NON_INTERACTIVE", "1")]
@@ -132,27 +119,6 @@ public class CliHostEnvironmentTests
         Assert.False(env.SupportsInteractiveOutput);
     }
 
-    [Theory]
-    [InlineData("CI", "true")]
-    [InlineData("CI", "1")]
-    [InlineData("GITHUB_ACTIONS", "true")]
-    public void SupportsAnsi_ReturnsTrue_InCIEnvironment(string envVar, string value)
-    {
-        // Arrange - ANSI should still be supported in CI for colored output
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [envVar] = value
-            })
-            .Build();
-        
-        // Act
-        var env = new CliHostEnvironment(configuration, nonInteractive: false);
-        
-        // Assert
-        Assert.True(env.SupportsAnsi);
-    }
-
     [Fact]
     public void SupportsAnsi_ReturnsFalse_WhenNO_COLORSet()
     {
@@ -195,19 +161,6 @@ public class CliHostEnvironmentTests
         
         // Assert
         Assert.False(env.SupportsInteractiveOutput);
-    }
-
-    [Fact]
-    public void SupportsAnsi_ReturnsTrue_WhenNonInteractiveTrue()
-    {
-        // Arrange - ANSI should still be supported even in non-interactive mode
-        var configuration = new ConfigurationBuilder().Build();
-        
-        // Act
-        var env = new CliHostEnvironment(configuration, nonInteractive: true);
-        
-        // Assert
-        Assert.True(env.SupportsAnsi);
     }
 
     [Fact]
@@ -379,13 +332,14 @@ public class CliHostEnvironmentTests
     }
 
     [Fact]
-    public void SupportsAnsi_ReturnsTrue_WhenPlaygroundModeSet_WithNonInteractive()
+    public void SupportsAnsi_ReturnsTrue_WhenPlaygroundModeSet_WithNonInteractive_AndAnsiPassThru()
     {
-        // Arrange - ASPIRE_PLAYGROUND should enable ANSI even with --non-interactive
+        // Arrange - ASPIRE_ANSI_PASS_THRU explicitly enables ANSI even with --non-interactive
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["ASPIRE_PLAYGROUND"] = "true"
+                ["ASPIRE_PLAYGROUND"] = "true",
+                ["ASPIRE_ANSI_PASS_THRU"] = "true"
             })
             .Build();
         


### PR DESCRIPTION
## Description

Fixes https://github.com/dotnet/aspire/issues/13737

The CLI assumes ANSI is always supported unless certain configuration is present. This ignores Spectre's built-in detection.

This PR:
- Changes detection to use configuration as override, and then fallback to Spectre's detection.
- Removes some tests that assert whether ANSI support is enabled/disabled when configuration isn't present

Before:
<img width="1099" height="633" alt="image" src="https://github.com/user-attachments/assets/67e69569-c0e7-44ee-820c-51ba7c9331b6" />

After:
<img width="1097" height="634" alt="image" src="https://github.com/user-attachments/assets/640a7d43-00e3-4bba-b281-92f545d5f731" />


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
