### PR TITLE
Use scheme instead of endpoint name when registering service discovery environment variables

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ReferenceEnvironmentInjectionFlags.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ReferenceEnvironmentInjectionFlags.cs
@@ -25,7 +25,7 @@ public enum ReferenceEnvironmentInjectionFlags
     ConnectionProperties = 1 << 1,
 
     /// <summary>
-    /// Each endpoint defined on the resource will be injected using the format "services__{resourceName}__{endpointName}__{endpointIndex}".
+    /// Each endpoint defined on the resource will be injected using the format "services__{resourceName}__{endpointScheme}__{endpointIndex}".
     /// </summary>
     ServiceDiscovery = 1 << 2,
 

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeWithProjectResources.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeWithProjectResources.verified.yaml
@@ -1,4 +1,4 @@
-services:
+﻿services:
   docker-compose-dashboard:
     image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
     ports:
@@ -33,13 +33,13 @@ services:
       services__project1__http__0: "http://project1:${PROJECT1_PORT}"
       PROJECT1_HTTPS: "https://project1:${PROJECT1_PORT}"
       PROJECT1_CUSTOM1: "http://project1:8000"
-      services__project1__custom1__0: "http://project1:8000"
+      services__project1__http__1: "http://project1:8000"
       PROJECT1_CUSTOM2: "http://project1:8001"
-      services__project1__custom2__0: "http://project1:8001"
+      services__project1__http__2: "http://project1:8001"
       PROJECT1_CUSTOM3: "http://project1:7002"
-      services__project1__custom3__0: "http://project1:7002"
+      services__project1__http__3: "http://project1:7002"
       PROJECT1_CUSTOM4: "http://project1:7004"
-      services__project1__custom4__0: "http://project1:7004"
+      services__project1__http__4: "http://project1:7004"
     networks:
       - "aspire"
 networks:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#01.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#01.verified.yaml
@@ -1,4 +1,4 @@
-parameters:
+﻿parameters:
   project1:
     port_http: 8080
     project1_image: "project1:latest"
@@ -9,10 +9,10 @@ config:
     ASPNETCORE_FORWARDEDHEADERS_ENABLED: "true"
   api:
     PROJECT1_CUSTOM1: "http://project1-service:8000"
-    services__project1__custom1__0: "http://project1-service:8000"
+    services__project1__http__1: "http://project1-service:8000"
     PROJECT1_CUSTOM2: "http://project1-service:8001"
-    services__project1__custom2__0: "http://project1-service:8001"
+    services__project1__http__2: "http://project1-service:8001"
     PROJECT1_CUSTOM3: "http://project1-service:7002"
-    services__project1__custom3__0: "http://project1-service:7002"
+    services__project1__http__3: "http://project1-service:7002"
     PROJECT1_CUSTOM4: "http://project1-service:7004"
-    services__project1__custom4__0: "http://project1-service:7004"
+    services__project1__http__4: "http://project1-service:7004"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#06.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#06.verified.yaml
@@ -1,4 +1,4 @@
----
+﻿---
 apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
@@ -13,10 +13,10 @@ data:
   PROJECT1_HTTPS: "https://project1-service:{{ .Values.parameters.project1.port_http }}"
   services__project1__https__0: "https://project1-service:{{ .Values.parameters.project1.port_http }}"
   PROJECT1_CUSTOM1: "{{ .Values.config.api.PROJECT1_CUSTOM1 }}"
-  services__project1__custom1__0: "{{ .Values.config.api.services__project1__custom1__0 }}"
+  services__project1__http__1: "{{ .Values.config.api.services__project1__http__1 }}"
   PROJECT1_CUSTOM2: "{{ .Values.config.api.PROJECT1_CUSTOM2 }}"
-  services__project1__custom2__0: "{{ .Values.config.api.services__project1__custom2__0 }}"
+  services__project1__http__2: "{{ .Values.config.api.services__project1__http__2 }}"
   PROJECT1_CUSTOM3: "{{ .Values.config.api.PROJECT1_CUSTOM3 }}"
-  services__project1__custom3__0: "{{ .Values.config.api.services__project1__custom3__0 }}"
+  services__project1__http__3: "{{ .Values.config.api.services__project1__http__3 }}"
   PROJECT1_CUSTOM4: "{{ .Values.config.api.PROJECT1_CUSTOM4 }}"
-  services__project1__custom4__0: "{{ .Values.config.api.services__project1__custom4__0 }}"
+  services__project1__http__4: "{{ .Values.config.api.services__project1__http__4 }}"

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -27,7 +27,7 @@ public class WithReferenceTests
         // Call environment variable callbacks.
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectB.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
-        Assert.Equal("https://localhost:2000", config["services__projecta__mybinding__0"]);
+        Assert.Equal("https://localhost:2000", config["services__projecta__https__0"]);
         Assert.Equal("https://localhost:2000", config["PROJECTA_MYBINDING"]);
 
         Assert.True(projectB.Resource.TryGetAnnotationsOfType<ResourceRelationshipAnnotation>(out var relationships));
@@ -50,9 +50,9 @@ public class WithReferenceTests
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectB.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
-        Assert.Equal("https://localhost:2000", config["services__project-a__mybinding__0"]);
+        Assert.Equal("https://localhost:2000", config["services__project-a__https__0"]);
         Assert.Equal("https://localhost:2000", config["PROJECT_A_MYBINDING"]);
-        Assert.DoesNotContain("services__project_a__mybinding__0", config.Keys);
+        Assert.DoesNotContain("services__project_a__https__0", config.Keys);
         Assert.DoesNotContain("PROJECT-A_MYBINDING", config.Keys);
     }
 
@@ -70,9 +70,9 @@ public class WithReferenceTests
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectB.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
-        Assert.Equal("https://localhost:2000", config["services__custom-name__mybinding__0"]);
+        Assert.Equal("https://localhost:2000", config["services__custom-name__https__0"]);
         Assert.Equal("https://localhost:2000", config["custom_name_MYBINDING"]);
-        Assert.DoesNotContain("services__custom_name__mybinding__0", config.Keys);
+        Assert.DoesNotContain("services__custom_name__https__0", config.Keys);
         Assert.DoesNotContain("custom-name_MYBINDING", config.Keys);
     }
 
@@ -103,28 +103,28 @@ public class WithReferenceTests
         switch (flags)
         {
             case ReferenceEnvironmentInjectionFlags.All:
-                Assert.Equal("https://localhost:2000", config["services__custom__mybinding__0"]);
+                Assert.Equal("https://localhost:2000", config["services__custom__https__0"]);
                 Assert.Equal("https://localhost:2000", config["custom_MYBINDING"]);
                 break;
             case ReferenceEnvironmentInjectionFlags.ConnectionProperties:
                 Assert.False(config.ContainsKey("custom_MYBINDING"));
-                Assert.False(config.ContainsKey("services__custom__mybinding__0"));
+                Assert.False(config.ContainsKey("services__custom__https__0"));
                 break;
             case ReferenceEnvironmentInjectionFlags.ConnectionString:
                 Assert.False(config.ContainsKey("custom_MYBINDING"));
-                Assert.False(config.ContainsKey("services__custom__mybinding__0"));
+                Assert.False(config.ContainsKey("services__custom__https__0"));
                 break;
             case ReferenceEnvironmentInjectionFlags.ServiceDiscovery:
                 Assert.False(config.ContainsKey("custom_MYBINDING"));
-                Assert.True(config.ContainsKey("services__custom__mybinding__0"));
+                Assert.True(config.ContainsKey("services__custom__https__0"));
                 break;
             case ReferenceEnvironmentInjectionFlags.Endpoints:
                 Assert.True(config.ContainsKey("custom_MYBINDING"));
-                Assert.False(config.ContainsKey("services__custom__mybinding__0"));
+                Assert.False(config.ContainsKey("services__custom__https__0"));
                 break;
             case ReferenceEnvironmentInjectionFlags.None:
                 Assert.False(config.ContainsKey("custom_MYBINDING"));
-                Assert.False(config.ContainsKey("services__custom__mybinding__0"));
+                Assert.False(config.ContainsKey("services__custom__https__0"));
                 break;
         }
     }
@@ -149,8 +149,8 @@ public class WithReferenceTests
         // Call environment variable callbacks.
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectB.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
-        Assert.Equal("https://localhost:2000", config["services__projecta__mybinding__0"]);
-        Assert.Equal("https://localhost:3000", config["services__projecta__myconflictingbinding__0"]);
+        Assert.Equal("https://localhost:2000", config["services__projecta__https__0"]);
+        Assert.Equal("https://localhost:3000", config["services__projecta__https__1"]);
 
         Assert.Equal("https://localhost:2000", config["PROJECTA_MYBINDING"]);
         Assert.Equal("https://localhost:3000", config["PROJECTA_MYCONFLICTINGBINDING"]);
@@ -177,8 +177,8 @@ public class WithReferenceTests
         // Call environment variable callbacks.
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectB.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
-        Assert.Equal("https://localhost:2000", config["services__projecta__mybinding__0"]);
-        Assert.Equal("http://localhost:3000", config["services__projecta__mynonconflictingbinding__0"]);
+        Assert.Equal("https://localhost:2000", config["services__projecta__https__0"]);
+        Assert.Equal("http://localhost:3000", config["services__projecta__http__0"]);
 
         Assert.Equal("https://localhost:2000", config["PROJECTA_MYBINDING"]);
         Assert.Equal("http://localhost:3000", config["PROJECTA_MYNONCONFLICTINGBINDING"]);
@@ -203,8 +203,8 @@ public class WithReferenceTests
         // Call environment variable callbacks.
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectB.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
-        Assert.Equal("https://localhost:2000", config["services__projecta__mybinding__0"]);
-        Assert.Equal("https://localhost:3000", config["services__projecta__mybinding2__0"]);
+        Assert.Equal("https://localhost:2000", config["services__projecta__https__0"]);
+        Assert.Equal("https://localhost:3000", config["services__projecta__https__1"]);
 
         Assert.Equal("https://localhost:2000", config["PROJECTA_MYBINDING"]);
         Assert.Equal("https://localhost:3000", config["PROJECTA_MYBINDING2"]);
@@ -232,8 +232,8 @@ public class WithReferenceTests
         // Call environment variable callbacks.
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectB.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
 
-        Assert.Equal("https://localhost:2000", config["services__projecta__mybinding__0"]);
-        Assert.Equal("http://localhost:3000", config["services__projecta__mybinding2__0"]);
+        Assert.Equal("https://localhost:2000", config["services__projecta__https__0"]);
+        Assert.Equal("http://localhost:3000", config["services__projecta__http__0"]);
 
         Assert.Equal("https://localhost:2000", config["PROJECTA_MYBINDING"]);
         Assert.Equal("http://localhost:3000", config["PROJECTA_MYBINDING2"]);


### PR DESCRIPTION
## Description

Updates the service discovery environment variable names to use the endpoint scheme rather than the endpoint name when building the environment variable name (i.e. `services__{service name}__{scheme}__0` instead of `services__{service name}__{endpoint name}__0`.

Fixes #14411

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No - this is a bug fix and doesn't invalidate the current service discovery docs at aspire.dev
