### PR TITLE
Fix port mismatch for bait-and-switch resources in Kubernetes publisher (13.2)

### DIFF
--- a/src/Aspire.Hosting.Kubernetes/Aspire.Hosting.Kubernetes.csproj
+++ b/src/Aspire.Hosting.Kubernetes/Aspire.Hosting.Kubernetes.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup>
     <Compile Include="$(SharedDir)PublishingContextUtils.cs" LinkBase="Shared" />
-    <Compile Include="$(SharedDir)ResourceNameComparer.cs" LinkBase="Shared" />
     <Compile Include="$(SharedDir)Yaml\*.cs" LinkBase="Shared\Yaml" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.Kubernetes/Aspire.Hosting.Kubernetes.csproj
+++ b/src/Aspire.Hosting.Kubernetes/Aspire.Hosting.Kubernetes.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedDir)PublishingContextUtils.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedDir)ResourceNameComparer.cs" LinkBase="Shared" />
     <Compile Include="$(SharedDir)Yaml\*.cs" LinkBase="Shared\Yaml" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentContext.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentContext.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.Kubernetes;
 
 internal sealed class KubernetesEnvironmentContext(KubernetesEnvironmentResource environment, ILogger logger)
 {
-    private readonly Dictionary<IResource, KubernetesResource> _kubernetesComponents = [];
+    private readonly Dictionary<IResource, KubernetesResource> _kubernetesComponents = new(new ResourceNameComparer());
 
     public ILogger Logger => logger;
 

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
@@ -424,6 +424,7 @@ public class KubernetesPublisherTests()
         // Assert
         var expectedFiles = new[]
         {
+            "Chart.yaml",
             "values.yaml",
             "templates/api/deployment.yaml",
             "templates/api/service.yaml",

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#00.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#00.verified.yaml
@@ -1,0 +1,10 @@
+parameters:
+  api:
+    api_image: "api:latest"
+secrets: {}
+config:
+  api:
+    PORT: "8000"
+  gateway:
+    API_HTTP: "http://api-service:8000"
+    services__api__http__0: "http://api-service:8000"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#00.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#00.verified.yaml
@@ -1,10 +1,11 @@
-parameters:
-  api:
-    api_image: "api:latest"
-secrets: {}
-config:
-  api:
-    PORT: "8000"
-  gateway:
-    API_HTTP: "http://api-service:8000"
-    services__api__http__0: "http://api-service:8000"
+apiVersion: "v2"
+name: "aspire-hosting-tests"
+version: "0.1.0"
+kubeVersion: ">= 1.18.0-0"
+description: "Aspire Helm Chart"
+type: "application"
+keywords:
+  - "aspire"
+  - "kubernetes"
+appVersion: "0.1.0"
+deprecated: false

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#01.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#01.verified.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  name: "api-deployment"
+  labels:
+    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/component: "api"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/component: "api"
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+    spec:
+      containers:
+        - image: "{{ .Values.parameters.api.api_image }}"
+          name: "api"
+          envFrom:
+            - configMapRef:
+                name: "api-config"
+          ports:
+            - name: "http"
+              protocol: "TCP"
+              containerPort: 8000
+          imagePullPolicy: "IfNotPresent"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/component: "api"
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: "RollingUpdate"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#01.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#01.verified.yaml
@@ -1,40 +1,10 @@
----
-apiVersion: "apps/v1"
-kind: "Deployment"
-metadata:
-  name: "api-deployment"
-  labels:
-    app.kubernetes.io/name: "aspire-hosting-tests"
-    app.kubernetes.io/component: "api"
-    app.kubernetes.io/instance: "{{ .Release.Name }}"
-spec:
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
-        app.kubernetes.io/component: "api"
-        app.kubernetes.io/instance: "{{ .Release.Name }}"
-    spec:
-      containers:
-        - image: "{{ .Values.parameters.api.api_image }}"
-          name: "api"
-          envFrom:
-            - configMapRef:
-                name: "api-config"
-          ports:
-            - name: "http"
-              protocol: "TCP"
-              containerPort: 8000
-          imagePullPolicy: "IfNotPresent"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
-      app.kubernetes.io/component: "api"
-      app.kubernetes.io/instance: "{{ .Release.Name }}"
-  replicas: 1
-  revisionHistoryLimit: 3
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
-    type: "RollingUpdate"
+parameters:
+  api:
+    api_image: "api:latest"
+secrets: {}
+config:
+  api:
+    PORT: "8000"
+  gateway:
+    API_HTTP: "http://api-service:8000"
+    services__api__http__0: "http://api-service:8000"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#02.verified.yaml
@@ -1,20 +1,40 @@
 ---
-apiVersion: "v1"
-kind: "Service"
+apiVersion: "apps/v1"
+kind: "Deployment"
 metadata:
-  name: "api-service"
+  name: "api-deployment"
   labels:
     app.kubernetes.io/name: "aspire-hosting-tests"
     app.kubernetes.io/component: "api"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
-  type: "ClusterIP"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/component: "api"
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+    spec:
+      containers:
+        - image: "{{ .Values.parameters.api.api_image }}"
+          name: "api"
+          envFrom:
+            - configMapRef:
+                name: "api-config"
+          ports:
+            - name: "http"
+              protocol: "TCP"
+              containerPort: 8000
+          imagePullPolicy: "IfNotPresent"
   selector:
-    app.kubernetes.io/name: "aspire-hosting-tests"
-    app.kubernetes.io/component: "api"
-    app.kubernetes.io/instance: "{{ .Release.Name }}"
-  ports:
-    - name: "http"
-      protocol: "TCP"
-      port: 8000
-      targetPort: 8000
+    matchLabels:
+      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/component: "api"
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: "RollingUpdate"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#02.verified.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  name: "api-service"
+  labels:
+    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/component: "api"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+spec:
+  type: "ClusterIP"
+  selector:
+    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/component: "api"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+  ports:
+    - name: "http"
+      protocol: "TCP"
+      port: 8000
+      targetPort: 8000

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#03.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#03.verified.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  name: "api-config"
+  labels:
+    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/component: "api"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+data:
+  PORT: "{{ .Values.config.api.PORT }}"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#03.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#03.verified.yaml
@@ -1,11 +1,20 @@
 ---
 apiVersion: "v1"
-kind: "ConfigMap"
+kind: "Service"
 metadata:
-  name: "api-config"
+  name: "api-service"
   labels:
     app.kubernetes.io/name: "aspire-hosting-tests"
     app.kubernetes.io/component: "api"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
-data:
-  PORT: "{{ .Values.config.api.PORT }}"
+spec:
+  type: "ClusterIP"
+  selector:
+    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/component: "api"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+  ports:
+    - name: "http"
+      protocol: "TCP"
+      port: 8000
+      targetPort: 8000

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#04.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#04.verified.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  name: "gateway-deployment"
+  labels:
+    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/component: "gateway"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/component: "gateway"
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+    spec:
+      containers:
+        - image: "nginx:latest"
+          name: "gateway"
+          envFrom:
+            - configMapRef:
+                name: "gateway-config"
+          ports:
+            - name: "http"
+              protocol: "TCP"
+              containerPort: 8080
+          imagePullPolicy: "IfNotPresent"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/component: "gateway"
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: "RollingUpdate"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#04.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#04.verified.yaml
@@ -1,40 +1,11 @@
 ---
-apiVersion: "apps/v1"
-kind: "Deployment"
+apiVersion: "v1"
+kind: "ConfigMap"
 metadata:
-  name: "gateway-deployment"
+  name: "api-config"
   labels:
     app.kubernetes.io/name: "aspire-hosting-tests"
-    app.kubernetes.io/component: "gateway"
+    app.kubernetes.io/component: "api"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
-spec:
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: "aspire-hosting-tests"
-        app.kubernetes.io/component: "gateway"
-        app.kubernetes.io/instance: "{{ .Release.Name }}"
-    spec:
-      containers:
-        - image: "nginx:latest"
-          name: "gateway"
-          envFrom:
-            - configMapRef:
-                name: "gateway-config"
-          ports:
-            - name: "http"
-              protocol: "TCP"
-              containerPort: 8080
-          imagePullPolicy: "IfNotPresent"
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: "aspire-hosting-tests"
-      app.kubernetes.io/component: "gateway"
-      app.kubernetes.io/instance: "{{ .Release.Name }}"
-  replicas: 1
-  revisionHistoryLimit: 3
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
-    type: "RollingUpdate"
+data:
+  PORT: "{{ .Values.config.api.PORT }}"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#05.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#05.verified.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  name: "gateway-config"
+  labels:
+    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/component: "gateway"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+data:
+  API_HTTP: "{{ .Values.config.gateway.API_HTTP }}"
+  services__api__http__0: "{{ .Values.config.gateway.services__api__http__0 }}"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#05.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#05.verified.yaml
@@ -1,12 +1,40 @@
 ---
-apiVersion: "v1"
-kind: "ConfigMap"
+apiVersion: "apps/v1"
+kind: "Deployment"
 metadata:
-  name: "gateway-config"
+  name: "gateway-deployment"
   labels:
     app.kubernetes.io/name: "aspire-hosting-tests"
     app.kubernetes.io/component: "gateway"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
-data:
-  API_HTTP: "{{ .Values.config.gateway.API_HTTP }}"
-  services__api__http__0: "{{ .Values.config.gateway.services__api__http__0 }}"
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "aspire-hosting-tests"
+        app.kubernetes.io/component: "gateway"
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+    spec:
+      containers:
+        - image: "nginx:latest"
+          name: "gateway"
+          envFrom:
+            - configMapRef:
+                name: "gateway-config"
+          ports:
+            - name: "http"
+              protocol: "TCP"
+              containerPort: 8080
+          imagePullPolicy: "IfNotPresent"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "aspire-hosting-tests"
+      app.kubernetes.io/component: "gateway"
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: "RollingUpdate"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#06.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#06.verified.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  name: "gateway-config"
+  labels:
+    app.kubernetes.io/name: "aspire-hosting-tests"
+    app.kubernetes.io/component: "gateway"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+data:
+  API_HTTP: "{{ .Values.config.gateway.API_HTTP }}"
+  services__api__http__0: "{{ .Values.config.gateway.services__api__http__0 }}"


### PR DESCRIPTION
Cherry-pick of #14590 targeting release/13.2 for deployment testing.

## Description
The Kubernetes publisher uses a `Dictionary` cache in `KubernetesEnvironmentContext` keyed by object identity. When `PublishAsDockerFile()` replaces an `ExecutableResource` with an `ExecutableContainerResource` (the "bait and switch" pattern), other resources still hold `EndpointReference` objects pointing to the original. The cache misses on the original vs replacement, creating two `KubernetesResource` objects for the same logical resource, each allocating a different port from the shared `PortAllocator`. This causes the referencing resource to get a different port than the one in the service/deployment YAML.

The fix applies the same `ResourceNameComparer` pattern already used by the Docker Compose, Azure App Service, and Azure Container Apps publishers.

Fixes https://github.com/dotnet/aspire/issues/9226
Based on community PR #14590 by @bbartels