### PR TITLE
Fix deployment E2E test for WithCompactResourceNaming experimental attribute

### DIFF
--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
@@ -141,6 +141,10 @@ builder.Build().Run();
 """;
 
                 content = content.Replace(buildRunPattern, replacement);
+
+                // Suppress experimental diagnostic for WithCompactResourceNaming
+                content = "#pragma warning disable ASPIREACANAMING001\n" + content;
+
                 File.WriteAllText(appHostFilePath, content);
 
                 output.WriteLine($"Modified apphost.cs with long env name + compact naming + volume");


### PR DESCRIPTION
## Summary

The `[Experimental("ASPIREACANAMING001")]` attribute added in #14583 causes the `AcaCompactNamingDeploymentTests` deployment E2E test to fail because the dynamically generated `apphost.cs` calls `WithCompactResourceNaming()` without suppressing the experimental diagnostic.

## Fix

Adds `#pragma warning disable ASPIREACANAMING001` to the generated `apphost.cs` content in the test, matching the pattern used in the unit tests.

## Validation

- [x] `dotnet build` succeeds for the test project
- [ ] CI passes
- [ ] `/deployment-tests` pass

cc @eerhardt for review