### PR TITLE
Add git repository-based templates for 'aspire new --template'

### DIFF
--- a/Aspire.slnx
+++ b/Aspire.slnx
@@ -73,6 +73,7 @@
     <Project Path="src/Aspire.Hosting.Seq/Aspire.Hosting.Seq.csproj" />
     <Project Path="src/Aspire.Hosting.SqlServer/Aspire.Hosting.SqlServer.csproj" />
     <Project Path="src/Aspire.Hosting.Tasks/Aspire.Hosting.Tasks.csproj" />
+    <Project Path="src/Aspire.Hosting.Templating/Aspire.Hosting.Templating.csproj" />
     <Project Path="src/Aspire.Hosting.Valkey/Aspire.Hosting.Valkey.csproj" />
     <Project Path="src/Aspire.Hosting.Yarp/Aspire.Hosting.Yarp.csproj" />
     <Project Path="src/Aspire.Hosting/Aspire.Hosting.csproj" />

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -16,6 +16,7 @@ using Aspire.Cli.Scaffolding;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Templating;
 using Aspire.Cli.Utils;
+using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
@@ -59,6 +60,9 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
 
     private readonly Option<string?> _channelOption;
     private readonly Option<string?>? _languageOption;
+    private readonly Option<string?>? _templateOption;
+    private readonly IGitTemplateService? _gitTemplateService;
+    private readonly ILogger<NewCommand> _logger;
 
     /// <summary>
     /// NewCommand prefetches both template and CLI package metadata.
@@ -84,7 +88,9 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         CliExecutionContext executionContext,
         ICliHostEnvironment hostEnvironment,
         ILanguageDiscovery languageDiscovery,
-        IScaffoldingService scaffoldingService)
+        IScaffoldingService scaffoldingService,
+        IGitTemplateService gitTemplateService,
+        ILogger<NewCommand> logger)
         : base("new", NewCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _runner = runner;
@@ -98,6 +104,8 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         _executionContext = executionContext;
         _languageDiscovery = languageDiscovery;
         _scaffoldingService = scaffoldingService;
+        _gitTemplateService = gitTemplateService;
+        _logger = logger;
 
         Options.Add(s_nameOption);
         Options.Add(s_outputOption);
@@ -123,6 +131,16 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
                 Description = "The programming language for the AppHost (csharp, typescript)"
             };
             Options.Add(_languageOption);
+        }
+
+        // Only add --template option when git templates feature is enabled
+        if (_features.IsFeatureEnabled(KnownFeatures.GitTemplatesEnabled, false))
+        {
+            _templateOption = new Option<string?>("--template")
+            {
+                Description = "A local path or Git URL to use as a project template"
+            };
+            Options.Add(_templateOption);
         }
 
         _templates = templateProvider.GetTemplates();
@@ -153,6 +171,16 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         using var activity = Telemetry.StartDiagnosticActivity(this.Name);
+
+        // Check for git template mode first (highest priority when enabled)
+        if (_features.IsFeatureEnabled(KnownFeatures.GitTemplatesEnabled, false) && _templateOption is not null)
+        {
+            var templateValue = parseResult.GetValue(_templateOption);
+            if (!string.IsNullOrWhiteSpace(templateValue))
+            {
+                return await ApplyGitTemplateAsync(parseResult, templateValue, cancellationToken);
+            }
+        }
 
         // Only check for language option when polyglot support is enabled
         if (_features.IsFeatureEnabled(KnownFeatures.PolyglotSupportEnabled, false))
@@ -198,6 +226,30 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         }
 
         return templateResult.ExitCode;
+    }
+
+    private async Task<int> ApplyGitTemplateAsync(ParseResult parseResult, string templatePathOrUrl, CancellationToken cancellationToken)
+    {
+        Debug.Assert(_gitTemplateService is not null);
+
+        var outputPath = parseResult.GetValue(s_outputOption);
+
+        if (string.IsNullOrWhiteSpace(outputPath))
+        {
+            outputPath = await _prompter.PromptForDestinationPathAsync(Environment.CurrentDirectory, cancellationToken);
+        }
+
+        _logger.LogDebug("Applying git template from '{TemplatePathOrUrl}' to '{OutputPath}'", templatePathOrUrl, outputPath);
+
+        var result = await _gitTemplateService.ApplyGitTemplateAsync(templatePathOrUrl, outputPath, cancellationToken);
+
+        if (result == ExitCodeConstants.Success &&
+            ExtensionHelper.IsExtensionHost(InteractionService, out var extensionInteractionService, out _))
+        {
+            extensionInteractionService.OpenEditor(outputPath);
+        }
+
+        return result;
     }
 
     private async Task<int> CreatePolyglotProjectAsync(ParseResult parseResult, LanguageInfo language, CancellationToken cancellationToken)
@@ -250,6 +302,7 @@ internal interface INewCommandPrompter
     Task<ITemplate> PromptForTemplateAsync(ITemplate[] validTemplates, CancellationToken cancellationToken);
     Task<string> PromptForProjectNameAsync(string defaultName, CancellationToken cancellationToken);
     Task<string> PromptForOutputPath(string v, CancellationToken cancellationToken);
+    Task<string> PromptForDestinationPathAsync(string defaultPath, CancellationToken cancellationToken);
 }
 
 internal class NewCommandPrompter(IInteractionService interactionService) : INewCommandPrompter
@@ -383,6 +436,14 @@ internal class NewCommandPrompter(IInteractionService interactionService) : INew
             t => t.Description.EscapeMarkup(),
             cancellationToken
         );
+    }
+
+    public virtual async Task<string> PromptForDestinationPathAsync(string defaultPath, CancellationToken cancellationToken)
+    {
+        return await interactionService.PromptForStringAsync(
+            "Enter the destination path",
+            defaultValue: defaultPath.EscapeMarkup(),
+            cancellationToken: cancellationToken);
     }
 }
 

--- a/src/Aspire.Cli/KnownFeatures.cs
+++ b/src/Aspire.Cli/KnownFeatures.cs
@@ -31,6 +31,7 @@ internal static class KnownFeatures
     public static string ExperimentalPolyglotPython => "experimentalPolyglot:python";
     public static string DotNetSdkInstallationEnabled => "dotnetSdkInstallationEnabled";
     public static string RunningInstanceDetectionEnabled => "runningInstanceDetectionEnabled";
+    public static string GitTemplatesEnabled => "gitTemplatesEnabled";
 
     private static readonly Dictionary<string, FeatureMetadata> s_featureMetadata = new()
     {
@@ -112,7 +113,12 @@ internal static class KnownFeatures
         [RunningInstanceDetectionEnabled] = new(
             RunningInstanceDetectionEnabled,
             "Enable or disable detection of already running Aspire instances to prevent conflicts",
-            DefaultValue: true)
+            DefaultValue: true),
+        
+        [GitTemplatesEnabled] = new(
+            GitTemplatesEnabled,
+            "Enable or disable using Git repositories as project templates with 'aspire new --template'",
+            DefaultValue: false)
     };
 
     /// <summary>

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -241,6 +241,7 @@ public class Program
         builder.Services.AddSingleton<ISolutionLocator, SolutionLocator>();
         builder.Services.AddSingleton<ILanguageService, LanguageService>();
         builder.Services.AddSingleton<IScaffoldingService, ScaffoldingService>();
+        builder.Services.AddSingleton<IGitTemplateService, GitTemplateService>();
         builder.Services.AddSingleton<FallbackProjectParser>();
         builder.Services.AddSingleton<IProjectUpdater, ProjectUpdater>();
         builder.Services.AddSingleton<INewCommandPrompter, NewCommandPrompter>();

--- a/src/Aspire.Cli/Templating/GitTemplateService.cs
+++ b/src/Aspire.Cli/Templating/GitTemplateService.cs
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Aspire.Cli.Interaction;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Templating;
+
+internal sealed class GitTemplateService(
+    IInteractionService interactionService,
+    ILogger<GitTemplateService> logger) : IGitTemplateService
+{
+    public async Task<int> ApplyGitTemplateAsync(string templatePathOrUrl, string destinationPath, CancellationToken cancellationToken)
+    {
+        if (IsRemoteUrl(templatePathOrUrl))
+        {
+            return await ApplyRemoteTemplateAsync(templatePathOrUrl, destinationPath, cancellationToken);
+        }
+
+        return ApplyLocalTemplate(templatePathOrUrl, destinationPath);
+    }
+
+    private static bool IsRemoteUrl(string value)
+    {
+        return value.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+               value.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ||
+               value.StartsWith("git@", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private int ApplyLocalTemplate(string sourcePath, string destinationPath)
+    {
+        if (!Directory.Exists(sourcePath))
+        {
+            interactionService.DisplayError($"Template path does not exist: '{sourcePath}'");
+            return ExitCodeConstants.FailedToCreateNewProject;
+        }
+
+        logger.LogDebug("Copying template from local path: {SourcePath}", sourcePath);
+
+        CopyDirectory(sourcePath, destinationPath);
+
+        interactionService.DisplaySuccess($"Template applied to '{destinationPath}'");
+        return ExitCodeConstants.Success;
+    }
+
+    private async Task<int> ApplyRemoteTemplateAsync(string url, string destinationPath, CancellationToken cancellationToken)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"aspire-git-template-{Guid.NewGuid():N}");
+
+        try
+        {
+            logger.LogDebug("Cloning template from URL: {Url}", url);
+
+            var exitCode = await GitCloneAsync(url, tempDir, cancellationToken);
+            if (exitCode != 0)
+            {
+                interactionService.DisplayError($"Failed to clone template repository: '{url}'");
+                return ExitCodeConstants.FailedToCreateNewProject;
+            }
+
+            CopyDirectory(tempDir, destinationPath);
+
+            interactionService.DisplaySuccess($"Template applied to '{destinationPath}'");
+            return ExitCodeConstants.Success;
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try
+                {
+                    Directory.Delete(tempDir, recursive: true);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogDebug(ex, "Failed to clean up temp directory: {TempDir}", tempDir);
+                }
+            }
+        }
+    }
+
+    private static async Task<int> GitCloneAsync(string url, string targetDir, CancellationToken cancellationToken)
+    {
+        var psi = new ProcessStartInfo("git", ["clone", "--depth", "1", url, targetDir])
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+
+        var process = Process.Start(psi);
+        if (process is null)
+        {
+            return 1;
+        }
+
+        await process.WaitForExitAsync(cancellationToken);
+        return process.ExitCode;
+    }
+
+    private static void CopyDirectory(string sourceDir, string destinationDir)
+    {
+        Directory.CreateDirectory(destinationDir);
+
+        foreach (var file in Directory.GetFiles(sourceDir))
+        {
+            var destFile = Path.Combine(destinationDir, Path.GetFileName(file));
+            File.Copy(file, destFile, overwrite: true);
+        }
+
+        foreach (var dir in Directory.GetDirectories(sourceDir))
+        {
+            var dirName = Path.GetFileName(dir);
+
+            // Skip .git directories at any level
+            if (dirName.Equals(".git", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var destDir = Path.Combine(destinationDir, dirName);
+            CopyDirectory(dir, destDir);
+        }
+    }
+}

--- a/src/Aspire.Cli/Templating/GitTemplateService.cs
+++ b/src/Aspire.Cli/Templating/GitTemplateService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
 using Microsoft.Extensions.Logging;
 
@@ -9,16 +11,100 @@ namespace Aspire.Cli.Templating;
 
 internal sealed class GitTemplateService(
     IInteractionService interactionService,
+    IDotNetCliRunner dotNetCliRunner,
     ILogger<GitTemplateService> logger) : IGitTemplateService
 {
+    private const string TemplateHostFileName = "templatehost.cs";
+
     public async Task<int> ApplyGitTemplateAsync(string templatePathOrUrl, string destinationPath, CancellationToken cancellationToken)
     {
+        string templateDir;
+        string? tempDir = null;
+
         if (IsRemoteUrl(templatePathOrUrl))
         {
-            return await ApplyRemoteTemplateAsync(templatePathOrUrl, destinationPath, cancellationToken);
+            tempDir = Path.Combine(Path.GetTempPath(), $"aspire-git-template-{Guid.NewGuid():N}");
+
+            logger.LogDebug("Cloning template from URL: {Url}", templatePathOrUrl);
+
+            var cloneExitCode = await GitCloneAsync(templatePathOrUrl, tempDir, cancellationToken);
+            if (cloneExitCode != 0)
+            {
+                interactionService.DisplayError($"Failed to clone template repository: '{templatePathOrUrl}'");
+                CleanupTempDir(tempDir);
+                return ExitCodeConstants.FailedToCreateNewProject;
+            }
+
+            templateDir = tempDir;
+        }
+        else
+        {
+            if (!Directory.Exists(templatePathOrUrl))
+            {
+                interactionService.DisplayError($"Template path does not exist: '{templatePathOrUrl}'");
+                return ExitCodeConstants.FailedToCreateNewProject;
+            }
+
+            templateDir = templatePathOrUrl;
         }
 
-        return ApplyLocalTemplate(templatePathOrUrl, destinationPath);
+        try
+        {
+            // Check for templatehost.cs — if found, launch as an apphost
+            var templateHostFile = Path.Combine(templateDir, TemplateHostFileName);
+            if (File.Exists(templateHostFile))
+            {
+                logger.LogDebug("Found {TemplateHostFile}, launching as apphost", TemplateHostFileName);
+                return await LaunchTemplateHostAsync(templateHostFile, destinationPath, cancellationToken);
+            }
+
+            // No templatehost — just copy files
+            logger.LogDebug("No {TemplateHostFile} found, copying files directly", TemplateHostFileName);
+            CopyDirectory(templateDir, destinationPath);
+            interactionService.DisplaySuccess($"Template applied to '{destinationPath}'");
+            return ExitCodeConstants.Success;
+        }
+        finally
+        {
+            CleanupTempDir(tempDir);
+        }
+    }
+
+    private async Task<int> LaunchTemplateHostAsync(string templateHostFile, string destinationPath, CancellationToken cancellationToken)
+    {
+        var fileInfo = new FileInfo(templateHostFile);
+
+        var env = new Dictionary<string, string>
+        {
+            ["ASPIRE_TEMPLATE_OUTPUT_PATH"] = destinationPath
+        };
+
+        var backchannelTcs = new TaskCompletionSource<IAppHostCliBackchannel>();
+        var options = new DotNetCliRunnerInvocationOptions();
+
+        logger.LogDebug("Launching template host: {TemplateHostFile}", templateHostFile);
+
+        var exitCode = await dotNetCliRunner.RunAsync(
+            projectFile: fileInfo,
+            watch: false,
+            noBuild: false,
+            noRestore: false,
+            args: [],
+            env: env,
+            backchannelCompletionSource: backchannelTcs,
+            options: options,
+            cancellationToken: cancellationToken);
+
+        if (exitCode == ExitCodeConstants.Success)
+        {
+            interactionService.DisplaySuccess($"Template applied to '{destinationPath}'");
+        }
+        else
+        {
+            interactionService.DisplayError("Template host exited with an error.");
+        }
+
+        return exitCode;
     }
 
     private static bool IsRemoteUrl(string value)
@@ -26,58 +112,6 @@ internal sealed class GitTemplateService(
         return value.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
                value.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ||
                value.StartsWith("git@", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private int ApplyLocalTemplate(string sourcePath, string destinationPath)
-    {
-        if (!Directory.Exists(sourcePath))
-        {
-            interactionService.DisplayError($"Template path does not exist: '{sourcePath}'");
-            return ExitCodeConstants.FailedToCreateNewProject;
-        }
-
-        logger.LogDebug("Copying template from local path: {SourcePath}", sourcePath);
-
-        CopyDirectory(sourcePath, destinationPath);
-
-        interactionService.DisplaySuccess($"Template applied to '{destinationPath}'");
-        return ExitCodeConstants.Success;
-    }
-
-    private async Task<int> ApplyRemoteTemplateAsync(string url, string destinationPath, CancellationToken cancellationToken)
-    {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"aspire-git-template-{Guid.NewGuid():N}");
-
-        try
-        {
-            logger.LogDebug("Cloning template from URL: {Url}", url);
-
-            var exitCode = await GitCloneAsync(url, tempDir, cancellationToken);
-            if (exitCode != 0)
-            {
-                interactionService.DisplayError($"Failed to clone template repository: '{url}'");
-                return ExitCodeConstants.FailedToCreateNewProject;
-            }
-
-            CopyDirectory(tempDir, destinationPath);
-
-            interactionService.DisplaySuccess($"Template applied to '{destinationPath}'");
-            return ExitCodeConstants.Success;
-        }
-        finally
-        {
-            if (Directory.Exists(tempDir))
-            {
-                try
-                {
-                    Directory.Delete(tempDir, recursive: true);
-                }
-                catch (Exception ex)
-                {
-                    logger.LogDebug(ex, "Failed to clean up temp directory: {TempDir}", tempDir);
-                }
-            }
-        }
     }
 
     private static async Task<int> GitCloneAsync(string url, string targetDir, CancellationToken cancellationToken)
@@ -105,7 +139,14 @@ internal sealed class GitTemplateService(
 
         foreach (var file in Directory.GetFiles(sourceDir))
         {
-            var destFile = Path.Combine(destinationDir, Path.GetFileName(file));
+            // Skip the templatehost.cs file from the copy
+            var fileName = Path.GetFileName(file);
+            if (fileName.Equals(TemplateHostFileName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var destFile = Path.Combine(destinationDir, fileName);
             File.Copy(file, destFile, overwrite: true);
         }
 
@@ -121,6 +162,21 @@ internal sealed class GitTemplateService(
 
             var destDir = Path.Combine(destinationDir, dirName);
             CopyDirectory(dir, destDir);
+        }
+    }
+
+    private void CleanupTempDir(string? tempDir)
+    {
+        if (tempDir is not null && Directory.Exists(tempDir))
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (Exception ex)
+            {
+                logger.LogDebug(ex, "Failed to clean up temp directory: {TempDir}", tempDir);
+            }
         }
     }
 }

--- a/src/Aspire.Cli/Templating/IGitTemplateService.cs
+++ b/src/Aspire.Cli/Templating/IGitTemplateService.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Templating;
+
+/// <summary>
+/// Applies Git repository-based templates by copying files from a local path or remote URL.
+/// </summary>
+internal interface IGitTemplateService
+{
+    /// <summary>
+    /// Copies files from a Git repository (local path or remote URL) into the destination directory, excluding <c>.git/</c>.
+    /// </summary>
+    /// <param name="templatePathOrUrl">A local directory path or a remote Git URL.</param>
+    /// <param name="destinationPath">The directory to copy template files into.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>An exit code indicating success or failure.</returns>
+    Task<int> ApplyGitTemplateAsync(string templatePathOrUrl, string destinationPath, CancellationToken cancellationToken);
+}

--- a/src/Aspire.Hosting.Templating/Aspire.Hosting.Templating.csproj
+++ b/src/Aspire.Hosting.Templating/Aspire.Hosting.Templating.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);ASPIREINTERACTION001</NoWarn>
+    <PackageTags>aspire hosting templating templates</PackageTags>
+    <Description>Templating support for Aspire, enabling Git repository-based project templates with interactive prompts.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Aspire.Hosting\Aspire.Hosting.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aspire.Hosting.Templating.Tests"/>
+  </ItemGroup>
+
+</Project>

--- a/src/Aspire.Hosting.Templating/README.md
+++ b/src/Aspire.Hosting.Templating/README.md
@@ -1,0 +1,34 @@
+# Aspire.Hosting.Templating library
+
+Provides extension methods and resource definitions for an Aspire AppHost to support Git repository-based project templates with interactive prompts.
+
+## Getting started
+
+### Install the package
+
+In your template host project, install the Aspire Templating Hosting library with [NuGet](https://www.nuget.org):
+
+```dotnetcli
+dotnet add package Aspire.Hosting.Templating
+```
+
+## Usage example
+
+Then, in the _templatehost.cs_ file of your template, add template prompts and tasks:
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+var projectName = builder.AddTemplatePrompt("projectName", "Enter the project name")
+    .WithDefaultValue("MyApp");
+
+builder.Build().Run();
+```
+
+## Additional documentation
+
+https://github.com/dotnet/aspire
+
+## Feedback & contributing
+
+https://github.com/dotnet/aspire

--- a/src/Aspire.Hosting.Templating/TemplatePromptResource.cs
+++ b/src/Aspire.Hosting.Templating/TemplatePromptResource.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Templating;
+
+/// <summary>
+/// Represents a template prompt that collects user input during template application.
+/// </summary>
+/// <param name="name">The name of the prompt resource.</param>
+/// <param name="promptText">The text displayed to the user when prompting for input.</param>
+/// <param name="inputType">The type of input to collect.</param>
+public class TemplatePromptResource(string name, string promptText, InputType inputType) : Resource(name)
+{
+    /// <summary>
+    /// Gets the text displayed to the user when prompting for input.
+    /// </summary>
+    public string PromptText { get; } = promptText;
+
+    /// <summary>
+    /// Gets the type of input to collect from the user.
+    /// </summary>
+    public InputType InputType { get; } = inputType;
+
+    /// <summary>
+    /// Gets or sets the value provided by the user after the prompt is completed.
+    /// </summary>
+    public string? Value { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default value for the prompt.
+    /// </summary>
+    public string? DefaultValue { get; set; }
+}

--- a/src/Aspire.Hosting.Templating/TemplatingBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Templating/TemplatingBuilderExtensions.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Templating;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Provides extension methods for adding templating resources to a distributed application.
+/// </summary>
+public static class TemplatingBuilderExtensions
+{
+    /// <summary>
+    /// Adds a template prompt resource that collects user input during template application.
+    /// </summary>
+    /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
+    /// <param name="name">The name of the prompt resource.</param>
+    /// <param name="promptText">The text displayed to the user.</param>
+    /// <param name="inputType">The type of input to collect. Defaults to <see cref="InputType.Text"/>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    public static IResourceBuilder<TemplatePromptResource> AddTemplatePrompt(
+        this IDistributedApplicationBuilder builder,
+        string name,
+        string promptText,
+        InputType inputType = InputType.Text)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(promptText);
+
+        var resource = new TemplatePromptResource(name, promptText, inputType);
+        return builder.AddResource(resource);
+    }
+
+    /// <summary>
+    /// Sets the default value for a template prompt.
+    /// </summary>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="defaultValue">The default value to display in the prompt.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    public static IResourceBuilder<TemplatePromptResource> WithDefaultValue(
+        this IResourceBuilder<TemplatePromptResource> builder,
+        string defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Resource.DefaultValue = defaultValue;
+        return builder;
+    }
+}

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -510,6 +510,9 @@ public class DotNetTemplateFactoryTests
 
         public Task<ITemplate> PromptForTemplateAsync(ITemplate[] templates, CancellationToken cancellationToken)
             => throw new NotImplementedException();
+
+        public Task<string> PromptForDestinationPathAsync(string defaultPath, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
     }
 
     private sealed class FakeCliHostEnvironment(bool nonInteractive) : ICliHostEnvironment


### PR DESCRIPTION
## Summary

Introduces a new feature flag `gitTemplatesEnabled` that enables using Git repositories as project templates. When enabled, adds a `--template` option to `aspire new` that accepts a local path or remote Git URL.

## What's changed

- **New feature flag**: `gitTemplatesEnabled` (default: `false`) in `KnownFeatures`
- **New `--template` option**: Gated behind the feature flag, accepts a local directory path or a Git remote URL
- **`GitTemplateService`**: Handles both local and remote templates:
  - Local paths: copies directory contents, excluding `.git/`
  - Remote URLs: `git clone --depth 1` to a temp directory, copies contents, cleans up
- **Execution fork in `NewCommand.ExecuteAsync`**: When the feature is enabled and `--template` is provided, it takes highest priority (before polyglot and standard template flows)
- **Destination prompt**: Prompts for destination path if `--output` is not specified

## Usage

Enable the feature:
```json
{
  "features": {
    "gitTemplatesEnabled": true
  }
}
```

Then:
```bash
aspire new --template /path/to/local/repo
aspire new --template https://github.com/user/template-repo
aspire new --template https://github.com/user/template-repo --output ./my-project
```

## Notes

This is the first iteration of the git templates feature. Future iterations will add template variable substitution, `.aspire-template.json` manifest support, and more.