### PR TITLE
LogsCommand improvements

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -67,6 +67,7 @@
     <Compile Include="$(SharedDir)BundleDiscovery.cs" Link="Layout\BundleDiscovery.cs" />
     <Compile Include="$(SharedDir)EnumerableExtensions.cs" Link="Utils\EnumerableExtensions.cs" />
     <Compile Include="$(SharedDir)KnownConfigNames.cs" Link="Utils\KnownConfigNames.cs" />
+    <Compile Include="$(SharedDir)KnownFormats.cs" Link="Utils\KnownFormats.cs" />
     <Compile Include="$(SharedDir)PathNormalizer.cs" Link="Utils\PathNormalizer.cs" />
     <Compile Include="$(SharedDir)CircularBuffer.cs" Link="Utils\CircularBuffer.cs" />
     <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />

--- a/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/ExtensionBackchannel.cs
@@ -21,7 +21,7 @@ namespace Aspire.Cli.Backchannel;
 internal interface IExtensionBackchannel
 {
     Task ConnectAsync(CancellationToken cancellationToken);
-    Task DisplayMessageAsync(string emoji, string message, CancellationToken cancellationToken);
+    Task DisplayMessageAsync(string emojiName, string message, CancellationToken cancellationToken);
     Task DisplaySuccessAsync(string message, CancellationToken cancellationToken);
     Task DisplaySubtleMessageAsync(string message, CancellationToken cancellationToken);
     Task DisplayErrorAsync(string error, CancellationToken cancellationToken);
@@ -246,7 +246,7 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
         }
     }
 
-    public async Task DisplayMessageAsync(string emoji, string message, CancellationToken cancellationToken)
+    public async Task DisplayMessageAsync(string emojiName, string message, CancellationToken cancellationToken)
     {
         await ConnectAsync(cancellationToken);
 
@@ -258,7 +258,7 @@ internal sealed class ExtensionBackchannel : IExtensionBackchannel
 
         await rpc.InvokeWithCancellationAsync(
             "displayMessage",
-            [_token, emoji, message],
+            [_token, emojiName, message],
             cancellationToken);
     }
 

--- a/src/Aspire.Cli/Commands/ExecCommand.cs
+++ b/src/Aspire.Cli/Commands/ExecCommand.cs
@@ -199,7 +199,7 @@ internal class ExecCommand : BaseCommand
                         // of the apphost so that the user can attach to it.
                         if (waitForDebugger)
                         {
-                            InteractionService.DisplayMessage(emoji: "bug", InteractionServiceStrings.WaitingForDebuggerToAttachToAppHost);
+                            InteractionService.DisplayMessage("bug", InteractionServiceStrings.WaitingForDebuggerToAttachToAppHost);
                         }
 
                         // The wait for the debugger in the apphost is done inside the CreateBuilder(...) method

--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -193,7 +193,7 @@ internal sealed class LogsCommand : BaseCommand
             if (!snapshots.Any(s => string.Equals(s.Name, resourceName, StringComparisons.ResourceName)
                                  || string.Equals(s.DisplayName, resourceName, StringComparisons.ResourceName)))
             {
-                _interactionService.DisplayError(string.Format(CultureInfo.InvariantCulture, LogsCommandStrings.ResourceNotFound, resourceName));
+                _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, LogsCommandStrings.ResourceNotFound, resourceName));
                 return ExitCodeConstants.InvalidCommand;
             }
         }

--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -12,6 +13,7 @@ using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
+using Aspire.Shared.ConsoleLogs;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 
@@ -23,6 +25,7 @@ namespace Aspire.Cli.Commands;
 internal sealed class LogLineJson
 {
     public required string ResourceName { get; init; }
+    public string? Timestamp { get; init; }
     public required string Content { get; init; }
     public required bool IsError { get; init; }
 }
@@ -98,6 +101,10 @@ internal sealed class LogsCommand : BaseCommand
     {
         Description = LogsCommandStrings.TailOptionDescription
     };
+    private static readonly Option<bool> s_timestampsOption = new("--timestamps", "-t")
+    {
+        Description = LogsCommandStrings.TimestampsOptionDescription
+    };
 
     // Colors to cycle through for different resources (similar to docker-compose)
     private static readonly Color[] s_resourceColors =
@@ -137,6 +144,7 @@ internal sealed class LogsCommand : BaseCommand
         Options.Add(s_followOption);
         Options.Add(s_formatOption);
         Options.Add(s_tailOption);
+        Options.Add(s_timestampsOption);
     }
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
@@ -148,6 +156,7 @@ internal sealed class LogsCommand : BaseCommand
         var follow = parseResult.GetValue(s_followOption);
         var format = parseResult.GetValue(s_formatOption);
         var tail = parseResult.GetValue(s_tailOption);
+        var timestamps = parseResult.GetValue(s_timestampsOption);
 
         // Validate --tail value
         if (tail.HasValue && tail.Value < 1)
@@ -173,13 +182,37 @@ internal sealed class LogsCommand : BaseCommand
             return ExitCodeConstants.Success;
         }
 
-        if (follow)
+        var connection = result.Connection!;
+
+        // Fetch snapshots for resource name resolution
+        var snapshots = await connection.GetResourceSnapshotsAsync(cancellationToken).ConfigureAwait(false);
+
+        // Validate resource name exists (match by Name or DisplayName since users may pass either)
+        if (resourceName is not null)
         {
-            return await ExecuteWatchAsync(result.Connection!, resourceName, format, tail, cancellationToken);
+            if (!snapshots.Any(s => string.Equals(s.Name, resourceName, StringComparisons.ResourceName)
+                                 || string.Equals(s.DisplayName, resourceName, StringComparisons.ResourceName)))
+            {
+                _interactionService.DisplayError(string.Format(CultureInfo.InvariantCulture, LogsCommandStrings.ResourceNotFound, resourceName));
+                return ExitCodeConstants.InvalidCommand;
+            }
         }
         else
         {
-            return await ExecuteGetAsync(result.Connection!, resourceName, format, tail, cancellationToken);
+            if (snapshots.Count == 0)
+            {
+                _interactionService.DisplayMessage("information", LogsCommandStrings.NoResourcesFound);
+                return ExitCodeConstants.Success;
+            }
+        }
+
+        if (follow)
+        {
+            return await ExecuteWatchAsync(connection, resourceName, format, tail, timestamps, snapshots, cancellationToken);
+        }
+        else
+        {
+            return await ExecuteGetAsync(connection, resourceName, format, tail, timestamps, snapshots, cancellationToken);
         }
     }
 
@@ -188,18 +221,20 @@ internal sealed class LogsCommand : BaseCommand
         string? resourceName,
         OutputFormat format,
         int? tail,
+        bool timestamps,
+        IReadOnlyList<ResourceSnapshot> snapshots,
         CancellationToken cancellationToken)
     {
         // Collect all logs
         List<ResourceLogLine> logLines;
         if (!tail.HasValue)
         {
-            logLines = await CollectLogsAsync(connection, resourceName, cancellationToken).ConfigureAwait(false);
+            logLines = await CollectLogsAsync(connection, resourceName, snapshots, cancellationToken).ConfigureAwait(false);
         }
         else
         {
             // With tail specified, collect all logs first then take last N
-            logLines = await CollectLogsAsync(connection, resourceName, cancellationToken).ConfigureAwait(false);
+            logLines = await CollectLogsAsync(connection, resourceName, snapshots, cancellationToken).ConfigureAwait(false);
 
             // Apply tail filter (tail.Value is guaranteed >= 1 by earlier validation)
             if (logLines.Count > tail.Value)
@@ -209,16 +244,23 @@ internal sealed class LogsCommand : BaseCommand
         }
 
         // Output the logs
+        var logParser = new LogParser(ConsoleColor.Black);
+
         if (format == OutputFormat.Json)
         {
             // Wrapped JSON for snapshot - single JSON object compatible with jq
             var logsOutput = new LogsOutput
             {
-                Logs = logLines.Select(l => new LogLineJson
+                Logs = logLines.Select(l =>
                 {
-                    ResourceName = l.ResourceName,
-                    Content = l.Content,
-                    IsError = l.IsError
+                    var entry = logParser.CreateLogEntry(l.Content, l.IsError, l.ResourceName);
+                    return new LogLineJson
+                    {
+                        ResourceName = ResolveResourceName(l.ResourceName, snapshots),
+                        Timestamp = timestamps && entry.Timestamp.HasValue ? FormatTimestamp(entry.Timestamp.Value) : null,
+                        Content = entry.Content ?? l.Content,
+                        IsError = l.IsError
+                    };
                 }).ToArray()
             };
             var json = JsonSerializer.Serialize(logsOutput, LogsCommandJsonContext.Snapshot.LogsOutput);
@@ -229,7 +271,7 @@ internal sealed class LogsCommand : BaseCommand
         {
             foreach (var logLine in logLines)
             {
-                OutputLogLine(logLine, format);
+                OutputLogLine(logLine, format, timestamps, logParser, snapshots);
             }
         }
 
@@ -241,12 +283,16 @@ internal sealed class LogsCommand : BaseCommand
         string? resourceName,
         OutputFormat format,
         int? tail,
+        bool timestamps,
+        IReadOnlyList<ResourceSnapshot> snapshots,
         CancellationToken cancellationToken)
     {
+        var logParser = new LogParser(ConsoleColor.Black);
+
         // If tail is specified, show last N lines first before streaming
         if (tail.HasValue)
         {
-            var historicalLogs = await CollectLogsAsync(connection, resourceName, cancellationToken).ConfigureAwait(false);
+            var historicalLogs = await CollectLogsAsync(connection, resourceName, snapshots, cancellationToken).ConfigureAwait(false);
 
             // Output last N lines
             var tailedLogs = historicalLogs.Count > tail.Value
@@ -255,14 +301,14 @@ internal sealed class LogsCommand : BaseCommand
 
             foreach (var logLine in tailedLogs)
             {
-                OutputLogLine(logLine, format);
+                OutputLogLine(logLine, format, timestamps, logParser, snapshots);
             }
         }
 
         // Now stream new logs
         await foreach (var logLine in connection.GetResourceLogsAsync(resourceName, follow: true, cancellationToken).ConfigureAwait(false))
         {
-            OutputLogLine(logLine, format);
+            OutputLogLine(logLine, format, timestamps, logParser, snapshots);
         }
 
         return ExitCodeConstants.Success;
@@ -271,13 +317,14 @@ internal sealed class LogsCommand : BaseCommand
     /// <summary>
     /// Collects all logs for a resource (or all resources if resourceName is null) into a list.
     /// </summary>
-    private async Task<List<ResourceLogLine>> CollectLogsAsync(
+    private static async Task<List<ResourceLogLine>> CollectLogsAsync(
         IAppHostAuxiliaryBackchannel connection,
         string? resourceName,
+        IReadOnlyList<ResourceSnapshot> snapshots,
         CancellationToken cancellationToken)
     {
         var logLines = new List<ResourceLogLine>();
-        await foreach (var logLine in GetLogsAsync(connection, resourceName, cancellationToken).ConfigureAwait(false))
+        await foreach (var logLine in GetLogsAsync(connection, resourceName, snapshots, cancellationToken).ConfigureAwait(false))
         {
             logLines.Add(logLine);
         }
@@ -287,9 +334,10 @@ internal sealed class LogsCommand : BaseCommand
     /// <summary>
     /// Gets logs for a resource (or all resources if resourceName is null) as an async enumerable.
     /// </summary>
-    private async IAsyncEnumerable<ResourceLogLine> GetLogsAsync(
+    private static async IAsyncEnumerable<ResourceLogLine> GetLogsAsync(
         IAppHostAuxiliaryBackchannel connection,
         string? resourceName,
+        IReadOnlyList<ResourceSnapshot> snapshots,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         if (resourceName is not null)
@@ -302,13 +350,6 @@ internal sealed class LogsCommand : BaseCommand
         }
 
         // Get all resources and stream logs for each (like docker compose logs)
-        var snapshots = await connection.GetResourceSnapshotsAsync(cancellationToken).ConfigureAwait(false);
-        if (snapshots.Count == 0)
-        {
-            _interactionService.DisplayMessage("ℹ️", LogsCommandStrings.NoResourcesFound);
-            yield break;
-        }
-
         foreach (var snapshot in snapshots.OrderBy(s => s.Name))
         {
             await foreach (var logLine in connection.GetResourceLogsAsync(snapshot.Name, follow: false, cancellationToken).ConfigureAwait(false))
@@ -318,15 +359,21 @@ internal sealed class LogsCommand : BaseCommand
         }
     }
 
-    private void OutputLogLine(ResourceLogLine logLine, OutputFormat format)
+    private void OutputLogLine(ResourceLogLine logLine, OutputFormat format, bool timestamps, LogParser logParser, IReadOnlyList<ResourceSnapshot> snapshots)
     {
+        var displayName = ResolveResourceName(logLine.ResourceName, snapshots);
+        var entry = logParser.CreateLogEntry(logLine.Content, logLine.IsError, logLine.ResourceName);
+        var content = entry.Content ?? logLine.Content;
+        var timestampPrefix = timestamps && entry.Timestamp.HasValue ? FormatTimestamp(entry.Timestamp.Value) + " " : string.Empty;
+
         if (format == OutputFormat.Json)
         {
             // NDJSON for streaming - compact, one object per line
             var logLineJson = new LogLineJson
             {
-                ResourceName = logLine.ResourceName,
-                Content = logLine.Content,
+                ResourceName = displayName,
+                Timestamp = timestamps && entry.Timestamp.HasValue ? FormatTimestamp(entry.Timestamp.Value) : null,
+                Content = content,
                 IsError = logLine.IsError
             };
             var output = JsonSerializer.Serialize(logLineJson, LogsCommandJsonContext.Ndjson.LogLineJson);
@@ -336,14 +383,14 @@ internal sealed class LogsCommand : BaseCommand
         else if (_hostEnvironment.SupportsAnsi)
         {
             // Colorized output: assign a consistent color to each resource
-            var color = GetResourceColor(logLine.ResourceName);
-            var escapedContent = logLine.Content.EscapeMarkup();
-            AnsiConsole.MarkupLine($"[{color}][[{logLine.ResourceName.EscapeMarkup()}]][/] {escapedContent}");
+            var color = GetResourceColor(displayName);
+            var escapedContent = content.EscapeMarkup();
+            AnsiConsole.MarkupLine($"{timestampPrefix.EscapeMarkup()}[{color}][[{displayName.EscapeMarkup()}]][/] {escapedContent}");
         }
         else
         {
             // Plain text fallback when colors not supported
-            _interactionService.DisplayPlainText($"[{logLine.ResourceName}] {logLine.Content}");
+            _interactionService.DisplayPlainText($"{timestampPrefix}[{displayName}] {content}");
         }
     }
 
@@ -356,5 +403,20 @@ internal sealed class LogsCommand : BaseCommand
             _nextColorIndex++;
         }
         return color;
+    }
+
+    private static string FormatTimestamp(DateTime timestamp)
+    {
+        return timestamp.ToString("yyyy-MM-ddTHH:mm:ss.fffK", CultureInfo.InvariantCulture);
+    }
+
+    private static string ResolveResourceName(string resourceName, IReadOnlyList<ResourceSnapshot> snapshots)
+    {
+        var snapshot = snapshots.FirstOrDefault(s => string.Equals(s.Name, resourceName, StringComparisons.ResourceName));
+        if (snapshot is not null)
+        {
+            return ResourceSnapshotMapper.GetResourceName(snapshot, snapshots);
+        }
+        return resourceName;
     }
 }

--- a/src/Aspire.Cli/Commands/SetupCommand.cs
+++ b/src/Aspire.Cli/Commands/SetupCommand.cs
@@ -81,15 +81,15 @@ internal sealed class SetupCommand : BaseCommand
         switch (result)
         {
             case BundleExtractResult.NoPayload:
-                InteractionService.DisplayMessage(":information:", "This CLI binary does not contain an embedded bundle. No extraction needed.");
+                InteractionService.DisplayMessage("information", "This CLI binary does not contain an embedded bundle. No extraction needed.");
                 break;
 
             case BundleExtractResult.AlreadyUpToDate:
-                InteractionService.DisplayMessage(":white_check_mark:", "Bundle is already extracted and up to date. Use --force to re-extract.");
+                InteractionService.DisplayMessage("white_check_mark", "Bundle is already extracted and up to date. Use --force to re-extract.");
                 break;
 
             case BundleExtractResult.Extracted:
-                InteractionService.DisplayMessage(":white_check_mark:", $"Bundle extracted to {installPath}");
+                InteractionService.DisplayMessage("white_check_mark", $"Bundle extracted to {installPath}");
                 break;
 
             case BundleExtractResult.ExtractionFailed:

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -208,13 +208,13 @@ internal class ConsoleInteractionService : IInteractionService
         DisplayMessage("cross_mark", $"[red bold]{errorMessage.EscapeMarkup()}[/]");
     }
 
-    public void DisplayMessage(string emoji, string message)
+    public void DisplayMessage(string emojiName, string message)
     {
         // This is a hack to deal with emoji of different size. We write the emoji then move the cursor to aboslute column 4
         // on the same line before writing the message. This ensures that the message starts at the same position regardless
         // of the emoji used. I'm not OCD .. you are!
         var console = MessageConsole;
-        console.Markup($":{emoji}:");
+        console.Markup($":{emojiName}:");
         console.Write("\u001b[4G");
         console.MarkupLine(message);
     }

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -233,11 +233,11 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         _consoleInteractionService.DisplayError(errorMessage);
     }
 
-    public void DisplayMessage(string emoji, string message)
+    public void DisplayMessage(string emojiName, string message)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayMessageAsync(emoji, message.RemoveSpectreFormatting(), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayMessageAsync(emojiName, message.RemoveSpectreFormatting(), _cancellationToken));
         Debug.Assert(result);
-        _consoleInteractionService.DisplayMessage(emoji, message);
+        _consoleInteractionService.DisplayMessage(emojiName, message);
     }
 
     public void DisplaySuccess(string message)

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -16,7 +16,7 @@ internal interface IInteractionService
     Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull;
     int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion);
     void DisplayError(string errorMessage);
-    void DisplayMessage(string emoji, string message);
+    void DisplayMessage(string emojiName, string message);
     void DisplayPlainText(string text);
     void DisplayRawText(string text, ConsoleOutput? consoleOverride = null);
     void DisplayMarkdown(string markdown);

--- a/src/Aspire.Cli/Resources/LogsCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/LogsCommandStrings.Designer.cs
@@ -122,5 +122,17 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("TailMustBePositive", resourceCulture);
             }
         }
+
+        public static string ResourceNotFound {
+            get {
+                return ResourceManager.GetString("ResourceNotFound", resourceCulture);
+            }
+        }
+
+        public static string TimestampsOptionDescription {
+            get {
+                return ResourceManager.GetString("TimestampsOptionDescription", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/LogsCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/LogsCommandStrings.resx
@@ -159,4 +159,10 @@
   <data name="TailMustBePositive" xml:space="preserve">
     <value>The --tail value must be a positive number.</value>
   </data>
+  <data name="ResourceNotFound" xml:space="preserve">
+    <value>Resource '{0}' was not found.</value>
+  </data>
+  <data name="TimestampsOptionDescription" xml:space="preserve">
+    <value>Show timestamps for each log line.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.cs.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Název prostředku, pro který se mají načíst protokoly. Pokud se nezadá, zobrazí se protokoly ze všech prostředků.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' was not found.</source>
+        <target state="new">Resource '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceRequiredWithoutFollow">
         <source>A resource name is required when not using --follow. Use --follow to stream logs from all resources.</source>
         <target state="translated">Pokud nepoužíváte --follow, vyžaduje se název prostředku. Pokud chcete streamovat protokoly ze všech prostředků, použijte --follow.</target>
@@ -70,6 +75,11 @@
       <trans-unit id="TailRequiresResource">
         <source>The --tail option requires a resource name to be specified.</source>
         <target state="translated">Možnost --tail vyžaduje zadání názvu prostředku.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampsOptionDescription">
+        <source>Show timestamps for each log line.</source>
+        <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.de.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Name der Ressource, für die Protokolle abgerufen werden sollen. Wenn keine Angabe erfolgt, werden Protokolle von allen Ressourcen angezeigt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' was not found.</source>
+        <target state="new">Resource '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceRequiredWithoutFollow">
         <source>A resource name is required when not using --follow. Use --follow to stream logs from all resources.</source>
         <target state="translated">Ein Ressourcenname ist erforderlich, wenn --follow nicht verwendet wird. Verwenden Sie --follow, um Protokolle aller Ressourcen zu streamen.</target>
@@ -70,6 +75,11 @@
       <trans-unit id="TailRequiresResource">
         <source>The --tail option requires a resource name to be specified.</source>
         <target state="translated">Für die Option --tail muss ein Ressourcenname angegeben werden.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampsOptionDescription">
+        <source>Show timestamps for each log line.</source>
+        <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.es.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Nombre del recurso para el que se van a obtener registros. Si no se especifica, se muestran los registros de todos los recursos.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' was not found.</source>
+        <target state="new">Resource '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceRequiredWithoutFollow">
         <source>A resource name is required when not using --follow. Use --follow to stream logs from all resources.</source>
         <target state="translated">Se requiere un nombre de recurso cuando no se usa --follow. Use --follow para transmitir registros de todos los recursos.</target>
@@ -70,6 +75,11 @@
       <trans-unit id="TailRequiresResource">
         <source>The --tail option requires a resource name to be specified.</source>
         <target state="translated">La opción --tail requiere que se especifique un nombre de recurso.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampsOptionDescription">
+        <source>Show timestamps for each log line.</source>
+        <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.fr.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Le nom de la ressource pour laquelle obtenir les journaux. Si aucun nom n’est spécifié, les journaux d’activité de toutes les ressources sont affichées.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' was not found.</source>
+        <target state="new">Resource '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceRequiredWithoutFollow">
         <source>A resource name is required when not using --follow. Use --follow to stream logs from all resources.</source>
         <target state="translated">Un nom de ressource est requis si vous n’utilisez pas --follow. Utilisez --follow pour diffuser en continu les journaux de toutes les ressources.</target>
@@ -70,6 +75,11 @@
       <trans-unit id="TailRequiresResource">
         <source>The --tail option requires a resource name to be specified.</source>
         <target state="translated">L’option --tail requiert la spécification d’un nom de ressource.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampsOptionDescription">
+        <source>Show timestamps for each log line.</source>
+        <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.it.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Nome della risorsa per cui ottenere i log. Se non specificato, vengono visualizzati i log di tutte le risorse.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' was not found.</source>
+        <target state="new">Resource '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceRequiredWithoutFollow">
         <source>A resource name is required when not using --follow. Use --follow to stream logs from all resources.</source>
         <target state="translated">Quando non si usa --follow, è necessario specificare un nome di risorsa. Usare --follow per trasmettere i log da tutte le risorse.</target>
@@ -70,6 +75,11 @@
       <trans-unit id="TailRequiresResource">
         <source>The --tail option requires a resource name to be specified.</source>
         <target state="translated">L'opzione --tail richiede che venga specificato un nome di risorsa.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampsOptionDescription">
+        <source>Show timestamps for each log line.</source>
+        <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ja.xlf
@@ -42,6 +42,11 @@
         <target state="translated">ログ取得の対象とするリソースの名前。指定しない場合は、すべてのリソースのログが表示されます。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' was not found.</source>
+        <target state="new">Resource '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceRequiredWithoutFollow">
         <source>A resource name is required when not using --follow. Use --follow to stream logs from all resources.</source>
         <target state="translated">--follow を使わない場合はリソース名の指定が必須です。--follow を使う場合、すべてのリソースのログがストリーミングされます。</target>
@@ -70,6 +75,11 @@
       <trans-unit id="TailRequiresResource">
         <source>The --tail option requires a resource name to be specified.</source>
         <target state="translated">--tail オプションにはリソース名の指定が必須です。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampsOptionDescription">
+        <source>Show timestamps for each log line.</source>
+        <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ko.xlf
@@ -42,6 +42,11 @@
         <target state="translated">로그를 가져올 리소스의 이름입니다. 지정하지 않으면 모든 리소스의 로그가 표시됩니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' was not found.</source>
+        <target state="new">Resource '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceRequiredWithoutFollow">
         <source>A resource name is required when not using --follow. Use --follow to stream logs from all resources.</source>
         <target state="translated">--follow를 사용하지 않을 경우 리소스 이름은 필수 항목입니다. --follow를 사용하여 모든 리소스의 로그를 스트리밍합니다.</target>
@@ -70,6 +75,11 @@
       <trans-unit id="TailRequiresResource">
         <source>The --tail option requires a resource name to be specified.</source>
         <target state="translated">--tail 옵션을 사용하려면 리소스 이름을 지정해야 합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampsOptionDescription">
+        <source>Show timestamps for each log line.</source>
+        <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.pl.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Nazwa zasobu, którego dzienniki mają zostać pobrane. Jeśli nie podasz nazwy, pokażą się dzienniki ze wszystkich zasobów.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' was not found.</source>
+        <target state="new">Resource '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceRequiredWithoutFollow">
         <source>A resource name is required when not using --follow. Use --follow to stream logs from all resources.</source>
         <target state="translated">Nazwa zasobu jest wymagana, jeśli nie używasz opcji --follow. Użyj opcji --follow, aby przesyłać strumieniowo dzienniki ze wszystkich zasobów.</target>
@@ -70,6 +75,11 @@
       <trans-unit id="TailRequiresResource">
         <source>The --tail option requires a resource name to be specified.</source>
         <target state="translated">Opcja --tail wymaga podania nazwy zasobu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampsOptionDescription">
+        <source>Show timestamps for each log line.</source>
+        <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.pt-BR.xlf
@@ -42,6 +42,11 @@
         <target state="translated">O nome do recurso para o qual obter logs. Se não for especificado, os logs de todos os recursos serão mostrados.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' was not found.</source>
+        <target state="new">Resource '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceRequiredWithoutFollow">
         <source>A resource name is required when not using --follow. Use --follow to stream logs from all resources.</source>
         <target state="translated">Um nome de recurso é necessário ao não usar --follow. Use --follow para transmitir logs de todos os recursos.</target>
@@ -70,6 +75,11 @@
       <trans-unit id="TailRequiresResource">
         <source>The --tail option requires a resource name to be specified.</source>
         <target state="translated">A opção --tail requer que um nome de recurso seja especificado.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampsOptionDescription">
+        <source>Show timestamps for each log line.</source>
+        <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ru.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Имя ресурса, для которого нужно получить журналы. Если не указано, отображаются журналы из всех ресурсов.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' was not found.</source>
+        <target state="new">Resource '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceRequiredWithoutFollow">
         <source>A resource name is required when not using --follow. Use --follow to stream logs from all resources.</source>
         <target state="translated">При отсутствии параметра --follow необходимо указать имя ресурса. Используйте --follow для потоковой передачи журналов из всех ресурсов.</target>
@@ -70,6 +75,11 @@
       <trans-unit id="TailRequiresResource">
         <source>The --tail option requires a resource name to be specified.</source>
         <target state="translated">Параметр --tail требует указания имени ресурса.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampsOptionDescription">
+        <source>Show timestamps for each log line.</source>
+        <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.tr.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Günlükleri alınacak kaynağın adı. Belirtilmezse tüm kaynakların günlükleri gösterilir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' was not found.</source>
+        <target state="new">Resource '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceRequiredWithoutFollow">
         <source>A resource name is required when not using --follow. Use --follow to stream logs from all resources.</source>
         <target state="translated">--follow kullanılmadığında kaynak adı gereklidir. Tüm kaynaklardan günlük akışı yapmak için --follow kullanın.</target>
@@ -70,6 +75,11 @@
       <trans-unit id="TailRequiresResource">
         <source>The --tail option requires a resource name to be specified.</source>
         <target state="translated">--tail seçeneği için bir kaynak adı belirtilmelidir.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampsOptionDescription">
+        <source>Show timestamps for each log line.</source>
+        <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.zh-Hans.xlf
@@ -42,6 +42,11 @@
         <target state="translated">要获取其日志的资源的名称。如果未指定，则显示所有资源的日志。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' was not found.</source>
+        <target state="new">Resource '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceRequiredWithoutFollow">
         <source>A resource name is required when not using --follow. Use --follow to stream logs from all resources.</source>
         <target state="translated">不使用 --follow 时必须指定资源名称。使用 --follow 流式传输所有资源的日志。</target>
@@ -70,6 +75,11 @@
       <trans-unit id="TailRequiresResource">
         <source>The --tail option requires a resource name to be specified.</source>
         <target state="translated">--tail 选项需要指定资源名称。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampsOptionDescription">
+        <source>Show timestamps for each log line.</source>
+        <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.zh-Hant.xlf
@@ -42,6 +42,11 @@
         <target state="translated">要取得其記錄的資源名稱。如果未指定，則顯示所有資源的記錄。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceNotFound">
+        <source>Resource '{0}' was not found.</source>
+        <target state="new">Resource '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceRequiredWithoutFollow">
         <source>A resource name is required when not using --follow. Use --follow to stream logs from all resources.</source>
         <target state="translated">當未使用 --follow 時，必須指定資源名稱。使用 --follow 從所有資源串流記錄。</target>
@@ -70,6 +75,11 @@
       <trans-unit id="TailRequiresResource">
         <source>The --tail option requires a resource name to be specified.</source>
         <target state="translated">--tail 選項需要指定資源名稱。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampsOptionDescription">
+        <source>Show timestamps for each log line.</source>
+        <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -780,7 +780,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
 
                 var resourcePrefix = ResourceViewModel.GetResourceName(subscription.Resource, _resourceByName);
 
-                var logParser = new LogParser(ConsoleColor.Black);
+                var logParser = new LogParser(ConsoleColor.Black, encodeForHtml: true);
                 await foreach (var batch in logSubscription.ConfigureAwait(false))
                 {
                     subscription.CancellationToken.ThrowIfCancellationRequested();

--- a/src/Aspire.Dashboard/Mcp/AspireResourceMcpTools.cs
+++ b/src/Aspire.Dashboard/Mcp/AspireResourceMcpTools.cs
@@ -91,7 +91,7 @@ internal sealed class AspireResourceMcpTools
             return $"Unable to find a resource named '{resourceName}'.";
         }
 
-        var logParser = new LogParser(ConsoleColor.Black);
+        var logParser = new LogParser(ConsoleColor.Black, encodeForHtml: true);
         var logEntries = new LogEntries(maximumEntryCount: AIHelpers.ConsoleLogsLimit) { BaseLineNumber = 1 };
 
         // Add a timeout for getting all console logs.

--- a/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
+using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.InternalTesting;
@@ -363,5 +365,294 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
         var deserialized = JsonSerializer.Deserialize(json, LogsCommandJsonContext.Ndjson.LogLineJson);
         Assert.NotNull(deserialized);
         Assert.Equal(logLine.Content, deserialized.Content);
+    }
+
+    [Fact]
+    public async Task LogsCommand_JsonOutput_ResolvesResourceNames()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var provider = CreateLogsTestServices(workspace, outputWriter);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("logs --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var jsonOutput = outputWriter.Logs.FirstOrDefault(l => l.Contains("\"logs\""));
+        Assert.NotNull(jsonOutput);
+
+        var logsOutput = JsonSerializer.Deserialize(jsonOutput, LogsCommandJsonContext.Snapshot.LogsOutput);
+        Assert.NotNull(logsOutput);
+        Assert.Equal(3, logsOutput.Logs.Length);
+
+        // Resources are ordered alphabetically by Name in the output.
+        // Replicas share the same DisplayName, so the unique Name should be used instead
+        Assert.Equal("apiservice-abc123", logsOutput.Logs[0].ResourceName);
+        Assert.Equal("apiservice-def456", logsOutput.Logs[1].ResourceName);
+
+        // Unique display name should be used for the redis resource
+        Assert.Equal("redis", logsOutput.Logs[2].ResourceName);
+    }
+
+    [Fact]
+    public async Task LogsCommand_TextOutput_ResolvesResourceNames()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var provider = CreateLogsTestServices(workspace, outputWriter, configureOptions: config =>
+        {
+            config["NO_COLOR"] = "1";
+        });
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("logs");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        // Plain text output uses "[resourceName] content" format
+        // Replicas share the same DisplayName, so the unique Name should be used instead
+        Assert.Contains(outputWriter.Logs, l => l.Contains("[apiservice-abc123]"));
+        Assert.Contains(outputWriter.Logs, l => l.Contains("[apiservice-def456]"));
+
+        // Unique display name should be used for the redis resource
+        Assert.Contains(outputWriter.Logs, l => l.Contains("[redis]"));
+    }
+
+    [Theory]
+    [InlineData("nonexistent", true)]
+    [InlineData("redis", false)]
+    [InlineData("apiservice-abc123", false)]
+    [InlineData("apiservice", false)]
+    public async Task LogsCommand_WithResourceName_ValidatesAgainstNameAndDisplayName(string resourceName, bool expectError)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var provider = CreateLogsTestServices(workspace, outputWriter);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse($"logs {resourceName} --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        if (expectError)
+        {
+            Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+        }
+        else
+        {
+            Assert.Equal(ExitCodeConstants.Success, exitCode);
+        }
+    }
+
+    [Fact]
+    public async Task LogsCommand_JsonOutput_WithTimestamps_IncludesTimestampField()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var provider = CreateLogsTestServices(workspace, outputWriter);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("logs --format json --timestamps");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var jsonOutput = outputWriter.Logs.FirstOrDefault(l => l.Contains("\"logs\""));
+        Assert.NotNull(jsonOutput);
+
+        var logsOutput = JsonSerializer.Deserialize(jsonOutput, LogsCommandJsonContext.Snapshot.LogsOutput);
+        Assert.NotNull(logsOutput);
+        Assert.Equal(3, logsOutput.Logs.Length);
+
+        // Resources are ordered alphabetically by Name
+        Assert.Equal("apiservice-abc123", logsOutput.Logs[0].ResourceName);
+        Assert.Equal("2025-01-15T10:30:01.000Z", logsOutput.Logs[0].Timestamp);
+        Assert.Equal("Hello from replica 1", logsOutput.Logs[0].Content);
+        Assert.False(logsOutput.Logs[0].IsError);
+
+        Assert.Equal("apiservice-def456", logsOutput.Logs[1].ResourceName);
+        Assert.Equal("2025-01-15T10:30:02.000Z", logsOutput.Logs[1].Timestamp);
+        Assert.Equal("Hello from replica 2", logsOutput.Logs[1].Content);
+        Assert.False(logsOutput.Logs[1].IsError);
+
+        Assert.Equal("redis", logsOutput.Logs[2].ResourceName);
+        Assert.Equal("2025-01-15T10:30:00.000Z", logsOutput.Logs[2].Timestamp);
+        Assert.Equal("Ready to accept connections", logsOutput.Logs[2].Content);
+        Assert.False(logsOutput.Logs[2].IsError);
+    }
+
+    [Fact]
+    public async Task LogsCommand_JsonOutput_WithoutTimestamps_OmitsTimestampField()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var provider = CreateLogsTestServices(workspace, outputWriter);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("logs --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var jsonOutput = outputWriter.Logs.FirstOrDefault(l => l.Contains("\"logs\""));
+        Assert.NotNull(jsonOutput);
+
+        var logsOutput = JsonSerializer.Deserialize(jsonOutput, LogsCommandJsonContext.Snapshot.LogsOutput);
+        Assert.NotNull(logsOutput);
+        Assert.Equal(3, logsOutput.Logs.Length);
+
+        // Timestamp should be null when --timestamps is not specified
+        Assert.Equal("apiservice-abc123", logsOutput.Logs[0].ResourceName);
+        Assert.Null(logsOutput.Logs[0].Timestamp);
+        Assert.Equal("Hello from replica 1", logsOutput.Logs[0].Content);
+        Assert.False(logsOutput.Logs[0].IsError);
+
+        Assert.Equal("apiservice-def456", logsOutput.Logs[1].ResourceName);
+        Assert.Null(logsOutput.Logs[1].Timestamp);
+        Assert.Equal("Hello from replica 2", logsOutput.Logs[1].Content);
+        Assert.False(logsOutput.Logs[1].IsError);
+
+        Assert.Equal("redis", logsOutput.Logs[2].ResourceName);
+        Assert.Null(logsOutput.Logs[2].Timestamp);
+        Assert.Equal("Ready to accept connections", logsOutput.Logs[2].Content);
+        Assert.False(logsOutput.Logs[2].IsError);
+    }
+
+    [Fact]
+    public async Task LogsCommand_TextOutput_WithTimestamps_IncludesTimestampPrefix()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var provider = CreateLogsTestServices(workspace, outputWriter, configureOptions: config =>
+        {
+            config["NO_COLOR"] = "1";
+        });
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("logs --timestamps");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        // Resources are ordered alphabetically by Name, timestamp prefix is ISO 8601 round-trip format
+        var logLines = outputWriter.Logs.Where(l => l.StartsWith("2025-", StringComparison.Ordinal)).ToList();
+        Assert.Equal(3, logLines.Count);
+        Assert.Equal("2025-01-15T10:30:01.000Z [apiservice-abc123] Hello from replica 1", logLines[0]);
+        Assert.Equal("2025-01-15T10:30:02.000Z [apiservice-def456] Hello from replica 2", logLines[1]);
+        Assert.Equal("2025-01-15T10:30:00.000Z [redis] Ready to accept connections", logLines[2]);
+    }
+
+    [Fact]
+    public async Task LogsCommand_TextOutput_WithoutTimestamps_NoTimestampPrefix()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var provider = CreateLogsTestServices(workspace, outputWriter, configureOptions: config =>
+        {
+            config["NO_COLOR"] = "1";
+        });
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("logs");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        // Without --timestamps, log lines start with "[resourceName]" with no timestamp prefix
+        var logLines = outputWriter.Logs.Where(l => l.StartsWith("[", StringComparison.Ordinal)).ToList();
+        Assert.Equal(3, logLines.Count);
+        Assert.Equal("[apiservice-abc123] Hello from replica 1", logLines[0]);
+        Assert.Equal("[apiservice-def456] Hello from replica 2", logLines[1]);
+        Assert.Equal("[redis] Ready to accept connections", logLines[2]);
+    }
+
+    private ServiceProvider CreateLogsTestServices(
+        TemporaryWorkspace workspace,
+        TestOutputTextWriter outputWriter,
+        Action<Dictionary<string, string?>>? configureOptions = null)
+    {
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            IsInScope = true,
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "TestAppHost", "TestAppHost.csproj"),
+                ProcessId = 1234
+            },
+            ResourceSnapshots =
+            [
+                // Unique resource - DisplayName is unique across all resources
+                new ResourceSnapshot
+                {
+                    Name = "redis",
+                    DisplayName = "redis",
+                    ResourceType = "Container",
+                    State = "Running"
+                },
+                // Replicas - two resources share the same DisplayName
+                new ResourceSnapshot
+                {
+                    Name = "apiservice-abc123",
+                    DisplayName = "apiservice",
+                    ResourceType = "Project",
+                    State = "Running"
+                },
+                new ResourceSnapshot
+                {
+                    Name = "apiservice-def456",
+                    DisplayName = "apiservice",
+                    ResourceType = "Project",
+                    State = "Running"
+                }
+            ],
+            LogLines =
+            [
+                new ResourceLogLine
+                {
+                    ResourceName = "redis",
+                    LineNumber = 1,
+                    Content = "2025-01-15T10:30:00Z Ready to accept connections",
+                    IsError = false
+                },
+                new ResourceLogLine
+                {
+                    ResourceName = "apiservice-abc123",
+                    LineNumber = 1,
+                    Content = "2025-01-15T10:30:01Z Hello from replica 1",
+                    IsError = false
+                },
+                new ResourceLogLine
+                {
+                    ResourceName = "apiservice-def456",
+                    LineNumber = 1,
+                    Content = "2025-01-15T10:30:02Z Hello from replica 2",
+                    IsError = false
+                }
+            ]
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+            options.OutputTextWriter = outputWriter;
+
+            if (configureOptions is not null)
+            {
+                options.ConfigurationCallback += configureOptions;
+            }
+        });
+
+        return services.BuildServiceProvider();
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -944,7 +944,7 @@ internal sealed class OrderTrackingInteractionService(List<string> operationOrde
 
     public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;
     public void DisplayError(string errorMessage) { }
-    public void DisplayMessage(string emoji, string message) { }
+    public void DisplayMessage(string emojiName, string message) { }
     public void DisplaySuccess(string message) { }
     public void DisplayLines(IEnumerable<(string Stream, string Line)> lines) { }
     public void DisplayCancellationMessage() { }

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -940,7 +940,7 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
     public void ShowStatus(string statusText, Action action) => action();
     public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;
     public void DisplayError(string errorMessage) => DisplayedErrors.Add(errorMessage);
-    public void DisplayMessage(string emoji, string message) { }
+    public void DisplayMessage(string emojiName, string message) { }
     public void DisplaySuccess(string message) { }
     public void DisplaySubtleMessage(string message, bool escapeMarkup = true) { }
     public void DisplayLines(IEnumerable<(string Stream, string Line)> lines) { }

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -966,7 +966,7 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
     public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) 
         => _innerService.DisplayIncompatibleVersionError(ex, appHostHostingVersion);
     public void DisplayError(string errorMessage) => _innerService.DisplayError(errorMessage);
-    public void DisplayMessage(string emoji, string message) => _innerService.DisplayMessage(emoji, message);
+    public void DisplayMessage(string emojiName, string message) => _innerService.DisplayMessage(emojiName, message);
     public void DisplayPlainText(string text) => _innerService.DisplayPlainText(text);
     public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) => _innerService.DisplayRawText(text, consoleOverride);
     public void DisplayMarkdown(string markdown) => _innerService.DisplayMarkdown(markdown);

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -434,7 +434,7 @@ public class DotNetTemplateFactoryTests
 
         public void DisplaySuccess(string message) { }
         public void DisplayError(string message) { }
-        public void DisplayMessage(string emoji, string message) { }
+        public void DisplayMessage(string emojiName, string message) { }
         public void DisplayLines(IEnumerable<(string Stream, string Line)> lines) { }
         public void DisplayCancellationMessage() { }
         public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;

--- a/tests/Aspire.Cli.Tests/TestServices/TestConsoleInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestConsoleInteractionService.cs
@@ -80,7 +80,7 @@ internal sealed class TestConsoleInteractionService : IInteractionService
         DisplayErrorCallback?.Invoke(errorMessage);
     }
 
-    public void DisplayMessage(string emoji, string message)
+    public void DisplayMessage(string emojiName, string message)
     {
     }
 

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionBackchannel.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionBackchannel.cs
@@ -89,10 +89,10 @@ internal sealed class TestExtensionBackchannel : IExtensionBackchannel
         return Task.CompletedTask;
     }
 
-    public Task DisplayMessageAsync(string emoji, string message, CancellationToken cancellationToken)
+    public Task DisplayMessageAsync(string emojiName, string message, CancellationToken cancellationToken)
     {
         DisplayMessageAsyncCalled?.SetResult();
-        return DisplayMessageAsyncCallback?.Invoke(emoji, message) ?? Task.CompletedTask;
+        return DisplayMessageAsyncCallback?.Invoke(emojiName, message) ?? Task.CompletedTask;
     }
 
     public Task DisplaySuccessAsync(string message, CancellationToken cancellationToken)

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -68,7 +68,7 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
         DisplayErrorCallback?.Invoke(errorMessage);
     }
 
-    public void DisplayMessage(string emoji, string message)
+    public void DisplayMessage(string emojiName, string message)
     {
     }
 

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/LogEntriesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/LogEntriesTests.cs
@@ -17,7 +17,7 @@ public class LogEntriesTests
 
     private static void AddLogLine(LogEntries logEntries, string content, bool isError)
     {
-        var logParser = new LogParser(ConsoleColor.Black);
+        var logParser = new LogParser(ConsoleColor.Black, encodeForHtml: true);
         var logEntry = logParser.CreateLogEntry(content, isError, resourcePrefix: null);
         logEntries.InsertSorted(logEntry);
     }
@@ -29,7 +29,7 @@ public class LogEntriesTests
         var logEntries = CreateLogEntries();
 
         // Act
-        var logParser = new LogParser(ConsoleColor.Black);
+        var logParser = new LogParser(ConsoleColor.Black, encodeForHtml: true);
 
         // Insert log with no timestamp.
         var logEntry1 = logParser.CreateLogEntry("Test", isErrorOutput: false, resourcePrefix: null);
@@ -296,7 +296,7 @@ public class LogEntriesTests
     public void CreateLogEntry_AnsiAndUrl_HasUrlAnchor()
     {
         // Arrange
-        var parser = new LogParser(ConsoleColor.Black);
+        var parser = new LogParser(ConsoleColor.Black, encodeForHtml: true);
 
         // Act
         var entry = parser.CreateLogEntry("\x1b[36mhttps://www.example.com\u001b[0m", isErrorOutput: false, resourcePrefix: null);
@@ -311,7 +311,7 @@ public class LogEntriesTests
     public void CreateLogEntry_DefaultBackgroundColor_SkipMatchingColor(ConsoleColor defaultBackgroundColor, string output)
     {
         // Arrange
-        var parser = new LogParser(defaultBackgroundColor);
+        var parser = new LogParser(defaultBackgroundColor, encodeForHtml: true);
 
         // Act
         var entry = parser.CreateLogEntry("\u001b[40m\u001b[32minfo\u001b[39m\u001b[22m\u001b[49m: LoggerName", isErrorOutput: false, resourcePrefix: null);


### PR DESCRIPTION
## Description

PR changes:
- Resolve resource name to use display name when there aren't replicas. Similar to how dashboard formats names in logs
- Rename emoji to emojiName so AI stops adding emoji instead of the name for DisplayMessage
- Return message that resource name can't be found when invalid resource name is specified

Fixes https://github.com/dotnet/aspire/issues/14290
Fixes https://github.com/dotnet/aspire/issues/14291
Fixes https://github.com/dotnet/aspire/issues/14293

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
