### PR TITLE
Update Hex1b.* packages from 0.90.0 to 0.97.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -98,9 +98,9 @@
     <PackageVersion Include="Grpc.AspNetCore" Version="2.76.0" />
     <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.78.0" />
-    <PackageVersion Include="Hex1b" Version="0.90.0" />
-    <PackageVersion Include="Hex1b.McpServer" Version="0.90.0" />
-    <PackageVersion Include="Hex1b.Tool" Version="0.90.0" />
+    <PackageVersion Include="Hex1b" Version="0.97.0" />
+    <PackageVersion Include="Hex1b.McpServer" Version="0.97.0" />
+    <PackageVersion Include="Hex1b.Tool" Version="0.97.0" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="KubernetesClient" Version="18.0.13" />
     <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />


### PR DESCRIPTION
## Summary

Updates all Hex1b NuGet packages from 0.90.0 to 0.97.0:

| Package | Previous | New |
|---------|----------|-----|
| Hex1b | 0.90.0 | 0.97.0 |
| Hex1b.McpServer | 0.90.0 | 0.97.0 |
| Hex1b.Tool | 0.90.0 | 0.97.0 |

All packages have been mirrored to the internal feed via the dotnet-migrate-package pipeline.