### PR TITLE
Add shortcut for aspire run --detached via aspire start

### DIFF
--- a/.github/skills/create-pr/SKILL.md
+++ b/.github/skills/create-pr/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: create-pr
+description: Create a PR using the repository PR template. Use this when asked to push and open a pull request.
+---
+
+You are a specialized pull request creation agent for this repository.
+
+Your goal is to **create a PR** and always **use the repository PR template** at `.github/pull_request_template.md`.
+
+## Required behavior
+
+1. Ensure the current branch is ready to open a PR:
+   - Confirm branch name.
+   - Confirm changes are committed.
+   - Push with upstream if needed.
+
+2. Determine PR metadata:
+   - Head branch: current branch unless user specifies otherwise.
+   - Base branch: user-specified base when provided; otherwise infer from context (or repository default branch).
+   - Title: concise summary of the change.
+
+3. Build PR body from template:
+   - Read `.github/pull_request_template.md`.
+   - Use the template structure as the PR body.
+   - Fill known details in `## Description` (summary, motivation/context, dependencies, validation).
+   - Fill checklist choices by selecting known answers and leaving only unknown choices unchecked.
+   - Keep `Fixes # (issue)` unless a concrete issue number is provided.
+
+4. Create the PR with `gh` using the template-derived body:
+
+```bash
+GH_PAGER=cat gh pr create \
+  --base <base-branch> \
+  --head <head-branch> \
+  --title "<pr-title>" \
+  --body-file <prepared-template-body-file>
+```
+
+5. If a PR already exists for the branch:
+   - Do not create another.
+   - If requested (or if the body is still mostly unfilled template text), update it with:
+
+```bash
+GH_PAGER=cat gh pr edit <pr-number-or-url> \
+  --body-file <prepared-template-body-file>
+```
+
+   - Return the existing PR URL.
+
+## Notes
+
+- Do not bypass the template with ad-hoc bodies.
+- Keep the body aligned with `.github/pull_request_template.md`.
+- If the user asks to preview before creating, show the prepared PR body first, then create after confirmation.
+- For checklist sections with Yes/No alternatives, prefer selecting exactly one option per question when information is known.

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -1,0 +1,373 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.Json;
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Processes;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Resources;
+using Aspire.Cli.Utils;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+
+namespace Aspire.Cli.Commands;
+
+/// <summary>
+/// Encapsulates the logic for launching an AppHost in detached (background) mode.
+/// Used by both RunCommand (--detach) and StartCommand (no resource).
+/// When adding new launch options, add them here and wire them in both commands.
+/// </summary>
+internal sealed class AppHostLauncher(
+    IProjectLocator projectLocator,
+    CliExecutionContext executionContext,
+    IFeatures features,
+    IInteractionService interactionService,
+    IAnsiConsole ansiConsole,
+    IAuxiliaryBackchannelMonitor backchannelMonitor,
+    ILogger<AppHostLauncher> logger,
+    TimeProvider? timeProvider = null)
+{
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
+
+    /// <summary>
+    /// Shared option for output format (JSON or table) in detached AppHost mode.
+    /// </summary>
+    internal static readonly Option<OutputFormat?> s_formatOption = new("--format")
+    {
+        Description = RunCommandStrings.JsonArgumentDescription
+    };
+
+    /// <summary>
+    /// Shared option for isolated AppHost mode.
+    /// </summary>
+    internal static readonly Option<bool> s_isolatedOption = new("--isolated")
+    {
+        Description = RunCommandStrings.IsolatedArgumentDescription
+    };
+
+    /// <summary>
+    /// Adds the detached launch options to a command so they appear in --help.
+    /// Called by both RunCommand and StartCommand to keep options in sync.
+    /// </summary>
+    internal static void AddLaunchOptions(Command command)
+    {
+        command.Options.Add(s_formatOption);
+        command.Options.Add(s_isolatedOption);
+    }
+
+    /// <summary>
+    /// Launches an AppHost in detached mode, waits for the backchannel, and displays the result.
+    /// </summary>
+    /// <param name="passedAppHostProjectFile">The project file passed via --project, or null to auto-discover.</param>
+    /// <param name="format">The output format (JSON or table).</param>
+    /// <param name="isolated">Whether to run in isolated mode.</param>
+    /// <param name="isExtensionHost">Whether running inside VS Code extension.</param>
+    /// <param name="globalArgs">Global CLI args to forward to child process.</param>
+    /// <param name="additionalArgs">Additional unmatched args to forward.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Exit code indicating success or failure.</returns>
+    public async Task<int> LaunchDetachedAsync(
+        FileInfo? passedAppHostProjectFile,
+        OutputFormat? format,
+        bool isolated,
+        bool isExtensionHost,
+        IEnumerable<string> globalArgs,
+        IEnumerable<string> additionalArgs,
+        CancellationToken cancellationToken)
+    {
+        // Route human-readable output to stderr when JSON is requested.
+        if (format == OutputFormat.Json)
+        {
+            interactionService.Console = ConsoleOutput.Error;
+        }
+
+        // Avoid interactive project prompts in JSON mode to keep stdout parseable.
+        var multipleAppHostBehavior = format == OutputFormat.Json
+            ? MultipleAppHostProjectsFoundBehavior.Throw
+            : MultipleAppHostProjectsFoundBehavior.Prompt;
+
+        // Failure mode 1: Project not found
+        var searchResult = await projectLocator.UseOrFindAppHostProjectFileAsync(
+            passedAppHostProjectFile,
+            multipleAppHostBehavior,
+            createSettingsFile: false,
+            cancellationToken);
+
+        var effectiveAppHostFile = searchResult.SelectedProjectFile;
+
+        if (effectiveAppHostFile is null)
+        {
+            return ExitCodeConstants.FailedToFindProject;
+        }
+
+        logger.LogDebug("Starting AppHost in background: {AppHostPath}", effectiveAppHostFile.FullName);
+
+        // Compute the expected auxiliary socket path prefix for this AppHost.
+        // The hash identifies the AppHost (from project path), while the PID makes each instance unique.
+        // Multiple instances of the same AppHost will have the same hash but different PIDs.
+        var expectedSocketPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(
+            effectiveAppHostFile.FullName,
+            executionContext.HomeDirectory.FullName);
+        // We know the format is valid since we just computed it with ComputeAuxiliarySocketPrefix
+        var expectedHash = AppHostHelper.ExtractHashFromSocketPath(expectedSocketPrefix)!;
+
+        logger.LogDebug("Waiting for socket with prefix: {SocketPrefix}, Hash: {Hash}", expectedSocketPrefix, expectedHash);
+
+        // Check for running instance and stop it if found (same behavior as regular run)
+        var runningInstanceDetectionEnabled = features.IsFeatureEnabled(KnownFeatures.RunningInstanceDetectionEnabled, defaultValue: true);
+        var existingSockets = AppHostHelper.FindMatchingSockets(
+            effectiveAppHostFile.FullName,
+            executionContext.HomeDirectory.FullName);
+
+        if (runningInstanceDetectionEnabled && existingSockets.Length > 0)
+        {
+            logger.LogDebug("Found {Count} running instance(s) for this AppHost, stopping them first", existingSockets.Length);
+            var manager = new RunningInstanceManager(logger, interactionService, _timeProvider);
+            // Stop all running instances in parallel - don't block on failures
+            var stopTasks = existingSockets.Select(socket =>
+                manager.StopRunningInstanceAsync(socket, cancellationToken));
+            await Task.WhenAll(stopTasks).ConfigureAwait(false);
+        }
+
+        // Build the arguments for the child CLI process
+        var childLogFile = GenerateChildLogFilePath(executionContext.LogsDirectory.FullName, _timeProvider);
+
+        var args = new List<string>
+        {
+            "run",
+            "--non-interactive",
+            "--project",
+            effectiveAppHostFile.FullName,
+            "--log-file",
+            childLogFile
+        };
+
+        // Pass through global options that should be forwarded to child CLI
+        args.AddRange(globalArgs);
+
+        // Pass through run-specific options
+        if (isolated)
+        {
+            args.Add("--isolated");
+        }
+
+        // Pass through any additional args
+        foreach (var token in additionalArgs)
+        {
+            args.Add(token);
+        }
+
+        // Get the path to the current executable
+        // When running as `dotnet aspire.dll`, Environment.ProcessPath returns dotnet.exe,
+        // so we need to also pass the entry assembly (aspire.dll) as the first argument.
+        // When running native AOT, ProcessPath IS the native executable.
+        var dotnetPath = Environment.ProcessPath ?? "dotnet";
+        var isDotnetHost = dotnetPath.EndsWith("dotnet", StringComparison.OrdinalIgnoreCase) ||
+                           dotnetPath.EndsWith("dotnet.exe", StringComparison.OrdinalIgnoreCase);
+
+        // For single-file apps, Assembly.Location is empty. Use command-line args instead.
+        // args[0] when running `dotnet aspire.dll` is the dll path
+        var entryAssemblyPath = Environment.GetCommandLineArgs().FirstOrDefault();
+
+        // Build the full argument list for the child process, including the entry assembly
+        // path when running via `dotnet aspire.dll`.
+        var childArgs = new List<string>();
+        if (isDotnetHost && !string.IsNullOrEmpty(entryAssemblyPath) && entryAssemblyPath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+        {
+            childArgs.Add(entryAssemblyPath);
+        }
+
+        childArgs.AddRange(args);
+
+        logger.LogDebug("Spawning child CLI: {Executable} (isDotnetHost={IsDotnetHost}) with args: {Args}",
+            dotnetPath, isDotnetHost, string.Join(" ", childArgs));
+        logger.LogDebug("Working directory: {WorkingDirectory}", executionContext.WorkingDirectory.FullName);
+
+        // Start the child process and wait for the backchannel in a single status spinner
+        Process? childProcess = null;
+        var childExitedEarly = false;
+        var childExitCode = 0;
+
+        async Task<IAppHostAuxiliaryBackchannel?> StartAndWaitForBackchannelAsync()
+        {
+            // Failure mode 2: Failed to spawn child process
+            try
+            {
+                childProcess = DetachedProcessLauncher.Start(
+                    dotnetPath,
+                    childArgs,
+                    executionContext.WorkingDirectory.FullName);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to start child CLI process");
+                return null;
+            }
+
+            logger.LogDebug("Child CLI process started with PID: {PID}", childProcess.Id);
+
+            // Failure modes 3 & 4: Wait for the auxiliary backchannel to become available
+            // - Mode 3: Child exits early (build failure, config error, etc.)
+            // - Mode 4: Timeout waiting for backchannel (120 seconds)
+            var startTime = _timeProvider.GetUtcNow();
+            var timeout = TimeSpan.FromSeconds(120);
+
+            while (_timeProvider.GetUtcNow() - startTime < timeout)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // Failure mode 3: Child process exited early
+                if (childProcess.HasExited)
+                {
+                    childExitedEarly = true;
+                    childExitCode = childProcess.ExitCode;
+                    logger.LogWarning("Child CLI process exited with code {ExitCode}", childExitCode);
+                    return null;
+                }
+
+                // Trigger a scan and try to connect
+                await backchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
+
+                // Check if we can find a connection for this AppHost by hash
+                var connection = backchannelMonitor.GetConnectionsByHash(expectedHash).FirstOrDefault();
+                if (connection is not null)
+                {
+                    return connection;
+                }
+
+                // Wait a bit before trying again, but short-circuit if the child process exits
+                try
+                {
+                    await childProcess.WaitForExitAsync(cancellationToken).WaitAsync(TimeSpan.FromMilliseconds(500), cancellationToken).ConfigureAwait(false);
+                    // If we get here, the process exited - we'll catch it at the top of the next iteration
+                }
+                catch (TimeoutException)
+                {
+                    // Expected - the 500ms delay elapsed without the process exiting
+                }
+            }
+
+            // Failure mode 4: Timeout - loop exited without finding connection
+            return null;
+        }
+
+        // For JSON output, skip the status spinner to avoid contaminating stdout
+        IAppHostAuxiliaryBackchannel? backchannel;
+        if (format == OutputFormat.Json)
+        {
+            backchannel = await StartAndWaitForBackchannelAsync();
+        }
+        else
+        {
+            backchannel = await interactionService.ShowStatusAsync(
+                RunCommandStrings.StartingAppHostInBackground,
+                StartAndWaitForBackchannelAsync);
+        }
+
+        // Handle failure cases - show specific error and log file path
+        if (backchannel is null || childProcess is null)
+        {
+            if (childProcess is null)
+            {
+                interactionService.DisplayError(RunCommandStrings.FailedToStartAppHost);
+                return ExitCodeConstants.FailedToDotnetRunAppHost;
+            }
+
+            if (childExitedEarly)
+            {
+                interactionService.DisplayError(GetDetachedFailureMessage(childExitCode));
+            }
+            else
+            {
+                interactionService.DisplayError(RunCommandStrings.TimeoutWaitingForAppHost);
+
+                // Try to kill the child process if it's still running (timeout case)
+                if (!childProcess.HasExited)
+                {
+                    try
+                    {
+                        childProcess.Kill();
+                    }
+                    catch
+                    {
+                        // Ignore errors when killing
+                    }
+                }
+            }
+
+            // Always show log file path for troubleshooting
+            interactionService.DisplayMessage("magnifying_glass_tilted_right", string.Format(
+                CultureInfo.CurrentCulture,
+                RunCommandStrings.CheckLogsForDetails,
+                childLogFile));
+
+            return ExitCodeConstants.FailedToDotnetRunAppHost;
+        }
+
+        var appHostInfo = backchannel.AppHostInfo;
+
+        // Get the dashboard URLs
+        var dashboardUrls = await backchannel.GetDashboardUrlsAsync(cancellationToken).ConfigureAwait(false);
+
+        var pid = appHostInfo?.ProcessId ?? childProcess.Id;
+
+        if (format == OutputFormat.Json)
+        {
+            // Output structured JSON for programmatic consumption
+            var result = new DetachOutputInfo(
+                effectiveAppHostFile.FullName,
+                pid,
+                childProcess.Id,
+                dashboardUrls?.BaseUrlWithLoginToken,
+                childLogFile);
+            var json = JsonSerializer.Serialize(result, RunCommandJsonContext.RelaxedEscaping.DetachOutputInfo);
+            interactionService.DisplayRawText(json, ConsoleOutput.Standard);
+        }
+        else
+        {
+            // Display success UX using shared rendering
+            var appHostRelativePath = Path.GetRelativePath(executionContext.WorkingDirectory.FullName, effectiveAppHostFile.FullName);
+            RunCommand.RenderAppHostSummary(
+                ansiConsole,
+                appHostRelativePath,
+                dashboardUrls?.BaseUrlWithLoginToken,
+                codespacesUrl: null,
+                childLogFile,
+                isExtensionHost,
+                pid);
+            ansiConsole.WriteLine();
+
+            interactionService.DisplaySuccess(RunCommandStrings.AppHostStartedSuccessfully);
+        }
+
+        return ExitCodeConstants.Success;
+    }
+
+    /// <summary>
+    /// Creates a user-facing error message for detached child process failures.
+    /// </summary>
+    internal static string GetDetachedFailureMessage(int childExitCode)
+    {
+        return childExitCode switch
+        {
+            ExitCodeConstants.FailedToBuildArtifacts => RunCommandStrings.AppHostFailedToBuild,
+            _ => string.Format(CultureInfo.CurrentCulture, RunCommandStrings.AppHostExitedWithCode, childExitCode)
+        };
+    }
+
+    /// <summary>
+    /// Generates a unique log file path for a detached child CLI process.
+    /// </summary>
+    internal static string GenerateChildLogFilePath(string logsDirectory, TimeProvider timeProvider)
+    {
+        var timestamp = timeProvider.GetUtcNow().ToString("yyyyMMddTHHmmssfff", CultureInfo.InvariantCulture);
+        var uniqueId = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
+        var fileName = $"cli_{timestamp}_detach-child_{uniqueId}.log";
+        return Path.Combine(logsDirectory, fileName);
+    }
+}

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -70,10 +70,6 @@ internal sealed class RunCommand : BaseCommand
 
     protected override bool UpdateNotificationsEnabled => !_isDetachMode;
 
-    private static readonly Option<FileInfo?> s_projectOption = new("--project")
-    {
-        Description = RunCommandStrings.ProjectArgumentDescription
-    };
     private static readonly Option<bool> s_detachOption = new("--detach")
     {
         Description = RunCommandStrings.DetachArgumentDescription
@@ -115,7 +111,6 @@ internal sealed class RunCommand : BaseCommand
         _appHostLauncher = appHostLauncher;
         _fileLoggerProvider = fileLoggerProvider;
 
-        Options.Add(s_projectOption);
         Options.Add(s_detachOption);
         Options.Add(s_noBuildOption);
         AppHostLauncher.AddLaunchOptions(this);
@@ -134,7 +129,7 @@ internal sealed class RunCommand : BaseCommand
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        var passedAppHostProjectFile = parseResult.GetValue(s_projectOption);
+        var passedAppHostProjectFile = parseResult.GetValue(AppHostLauncher.s_projectOption);
         var detach = parseResult.GetValue(s_detachOption);
         _isDetachMode = detach;
         var noBuild = parseResult.GetValue(s_noBuildOption);

--- a/src/Aspire.Cli/Commands/StartCommand.cs
+++ b/src/Aspire.Cli/Commands/StartCommand.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.CommandLine;
+using System.Globalization;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
@@ -12,15 +14,30 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Commands;
 
-internal sealed class StartCommand : ResourceCommandBase
+internal sealed class StartCommand : BaseCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.ResourceManagement;
 
-    protected override string CommandName => KnownResourceCommands.StartCommand;
-    protected override string ProgressVerb => "Starting";
-    protected override string BaseVerb => "start";
-    protected override string PastTenseVerb => "started";
-    protected override string ResourceArgumentDescription => ResourceCommandStrings.StartResourceArgumentDescription;
+    private readonly IInteractionService _interactionService;
+    private readonly AppHostConnectionResolver _connectionResolver;
+    private readonly AppHostLauncher _appHostLauncher;
+    private readonly ILogger<StartCommand> _logger;
+
+    private static readonly Argument<string?> s_resourceArgument = new("resource")
+    {
+        Description = ResourceCommandStrings.StartResourceArgumentDescription,
+        Arity = ArgumentArity.ZeroOrOne
+    };
+
+    private static readonly Option<FileInfo?> s_projectOption = new("--project")
+    {
+        Description = ResourceCommandStrings.ProjectOptionDescription
+    };
+
+    private static readonly Option<bool> s_noBuildOption = new("--no-build")
+    {
+        Description = RunCommandStrings.NoBuildArgumentDescription
+    };
 
     public StartCommand(
         IInteractionService interactionService,
@@ -29,10 +46,95 @@ internal sealed class StartCommand : ResourceCommandBase
         ICliUpdateNotifier updateNotifier,
         CliExecutionContext executionContext,
         ILogger<StartCommand> logger,
-        AspireCliTelemetry telemetry)
+        AspireCliTelemetry telemetry,
+        AppHostLauncher appHostLauncher)
         : base("start", ResourceCommandStrings.StartDescription,
-               interactionService, backchannelMonitor, features, updateNotifier,
-               executionContext, logger, telemetry)
+               features, updateNotifier, executionContext, interactionService, telemetry)
     {
+        _interactionService = interactionService;
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, executionContext, logger);
+        _appHostLauncher = appHostLauncher;
+        _logger = logger;
+
+        Arguments.Add(s_resourceArgument);
+        Options.Add(s_projectOption);
+        Options.Add(s_noBuildOption);
+        AppHostLauncher.AddLaunchOptions(this);
+
+        TreatUnmatchedTokensAsErrors = false;
+    }
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        var resourceName = parseResult.GetValue(s_resourceArgument);
+        var passedAppHostProjectFile = parseResult.GetValue(s_projectOption);
+        var format = parseResult.GetValue(AppHostLauncher.s_formatOption);
+        var isolated = parseResult.GetValue(AppHostLauncher.s_isolatedOption);
+
+        // If a resource name is provided, start that specific resource
+        if (!string.IsNullOrEmpty(resourceName))
+        {
+            if (format is not null)
+            {
+                _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, ResourceCommandStrings.OptionNotValidWithResource, "--format"));
+                return ExitCodeConstants.InvalidCommand;
+            }
+
+            if (isolated)
+            {
+                _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, ResourceCommandStrings.OptionNotValidWithResource, "--isolated"));
+                return ExitCodeConstants.InvalidCommand;
+            }
+
+            return await StartResourceAsync(passedAppHostProjectFile, resourceName, cancellationToken);
+        }
+
+        // No resource specified — start the AppHost in detached mode
+        var noBuild = parseResult.GetValue(s_noBuildOption);
+        var isExtensionHost = ExtensionHelper.IsExtensionHost(_interactionService, out _, out _);
+        var globalArgs = RootCommand.GetChildProcessArgs(parseResult);
+        var additionalArgs = parseResult.UnmatchedTokens.ToList();
+
+        if (noBuild)
+        {
+            additionalArgs.Add("--no-build");
+        }
+
+        return await _appHostLauncher.LaunchDetachedAsync(
+            passedAppHostProjectFile,
+            format,
+            isolated,
+            isExtensionHost,
+            globalArgs,
+            additionalArgs,
+            cancellationToken);
+    }
+
+    private async Task<int> StartResourceAsync(FileInfo? passedAppHostProjectFile, string resourceName, CancellationToken cancellationToken)
+    {
+        var result = await _connectionResolver.ResolveConnectionAsync(
+            passedAppHostProjectFile,
+            ResourceCommandStrings.ScanningForRunningAppHosts,
+            ResourceCommandStrings.SelectAppHost,
+            ResourceCommandStrings.NoInScopeAppHostsShowingAll,
+            ResourceCommandStrings.NoRunningAppHostsFound,
+            cancellationToken);
+
+        if (!result.Success)
+        {
+            _interactionService.DisplayError(result.ErrorMessage ?? ResourceCommandStrings.NoRunningAppHostsFound);
+            return ExitCodeConstants.FailedToFindProject;
+        }
+
+        return await ResourceCommandHelper.ExecuteResourceCommandAsync(
+            result.Connection!,
+            _interactionService,
+            _logger,
+            resourceName,
+            KnownResourceCommands.StartCommand,
+            "Starting",
+            "start",
+            "started",
+            cancellationToken);
     }
 }

--- a/src/Aspire.Cli/Commands/StartCommand.cs
+++ b/src/Aspire.Cli/Commands/StartCommand.cs
@@ -29,11 +29,6 @@ internal sealed class StartCommand : BaseCommand
         Arity = ArgumentArity.ZeroOrOne
     };
 
-    private static readonly Option<FileInfo?> s_projectOption = new("--project")
-    {
-        Description = ResourceCommandStrings.ProjectOptionDescription
-    };
-
     private static readonly Option<bool> s_noBuildOption = new("--no-build")
     {
         Description = RunCommandStrings.NoBuildArgumentDescription
@@ -57,7 +52,6 @@ internal sealed class StartCommand : BaseCommand
         _logger = logger;
 
         Arguments.Add(s_resourceArgument);
-        Options.Add(s_projectOption);
         Options.Add(s_noBuildOption);
         AppHostLauncher.AddLaunchOptions(this);
 
@@ -67,7 +61,7 @@ internal sealed class StartCommand : BaseCommand
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var resourceName = parseResult.GetValue(s_resourceArgument);
-        var passedAppHostProjectFile = parseResult.GetValue(s_projectOption);
+        var passedAppHostProjectFile = parseResult.GetValue(AppHostLauncher.s_projectOption);
         var format = parseResult.GetValue(AppHostLauncher.s_formatOption);
         var isolated = parseResult.GetValue(AppHostLauncher.s_isolatedOption);
 
@@ -114,15 +108,15 @@ internal sealed class StartCommand : BaseCommand
     {
         var result = await _connectionResolver.ResolveConnectionAsync(
             passedAppHostProjectFile,
-            ResourceCommandStrings.ScanningForRunningAppHosts,
-            ResourceCommandStrings.SelectAppHost,
-            ResourceCommandStrings.NoInScopeAppHostsShowingAll,
-            ResourceCommandStrings.NoRunningAppHostsFound,
+            SharedCommandStrings.ScanningForRunningAppHosts,
+            string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.SelectAppHost, ResourceCommandStrings.SelectAppHostAction),
+            SharedCommandStrings.NoInScopeAppHostsShowingAll,
+            SharedCommandStrings.AppHostNotRunning,
             cancellationToken);
 
         if (!result.Success)
         {
-            _interactionService.DisplayError(result.ErrorMessage ?? ResourceCommandStrings.NoRunningAppHostsFound);
+            _interactionService.DisplayError(result.ErrorMessage);
             return ExitCodeConstants.FailedToFindProject;
         }
 

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -354,6 +354,7 @@ public class Program
         builder.Services.AddSingleton<IMcpTransportFactory, StdioMcpTransportFactory>();
 
         // Commands.
+        builder.Services.AddTransient<AppHostLauncher>();
         builder.Services.AddTransient<NewCommand>();
         builder.Services.AddTransient<InitCommand>();
         builder.Services.AddTransient<RunCommand>();

--- a/src/Aspire.Cli/Resources/ResourceCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ResourceCommandStrings.Designer.cs
@@ -92,5 +92,11 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("CommandNameArgumentDescription", resourceCulture);
             }
         }
+
+        internal static string OptionNotValidWithResource {
+            get {
+                return ResourceManager.GetString("OptionNotValidWithResource", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/ResourceCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/ResourceCommandStrings.resx
@@ -62,10 +62,10 @@
     <value>connect to</value>
   </data>
   <data name="StartDescription" xml:space="preserve">
-    <value>Start a stopped resource.</value>
+    <value>Start an apphost in the background, or start a stopped resource.</value>
   </data>
   <data name="StartResourceArgumentDescription" xml:space="preserve">
-    <value>The name of the resource to start.</value>
+    <value>The name of the resource to start. If not specified, starts the AppHost in the background.</value>
   </data>
   <data name="RestartDescription" xml:space="preserve">
     <value>Restart a running resource.</value>
@@ -81,5 +81,8 @@
   </data>
   <data name="CommandNameArgumentDescription" xml:space="preserve">
     <value>The name of the command to execute.</value>
+  </data>
+  <data name="OptionNotValidWithResource" xml:space="preserve">
+    <value>The '{0}' option is not valid when starting a resource.</value>
   </data>
 </root>

--- a/src/Aspire.Cli/Resources/RunCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/RunCommandStrings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description" xml:space="preserve">
-    <value>Run an apphost in development mode.</value>
+    <value>Run an Aspire AppHost interactively for development.</value>
   </data>
   <data name="ForceArgumentDescription" xml:space="preserve">
     <value>Stop any running instance of the AppHost without prompting.</value>
@@ -130,7 +130,7 @@
     <value>Run the AppHost in the background and exit after it starts.</value>
   </data>
   <data name="JsonArgumentDescription" xml:space="preserve">
-    <value>Output format (Table or Json). Only valid with --detach.</value>
+    <value>Output format for detached AppHost results.</value>
   </data>
   <data name="WatchArgumentDescription" xml:space="preserve">
     <value>Start project resources in watch mode.</value>

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.Designer.cs
@@ -74,5 +74,17 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("ProjectOptionDescription", resourceCulture);
             }
         }
+
+        internal static string FormatOptionDescription {
+            get {
+                return ResourceManager.GetString("FormatOptionDescription", resourceCulture);
+            }
+        }
+
+        internal static string IsolatedOptionDescription {
+            get {
+                return ResourceManager.GetString("IsolatedOptionDescription", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.resx
@@ -132,4 +132,10 @@
   <data name="ProjectOptionDescription" xml:space="preserve">
     <value>The path to the Aspire AppHost project file.</value>
   </data>
+  <data name="FormatOptionDescription" xml:space="preserve">
+    <value>Output format for detached AppHost results.</value>
+  </data>
+  <data name="IsolatedOptionDescription" xml:space="preserve">
+    <value>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.cs.xlf
@@ -17,24 +17,9 @@
         <target state="translated">Název prostředku, na kterém se má příkaz provést</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
-        <target state="translated">Nebyli nalezeni žádní hostitelé aplikací v daném oboru. Zobrazují se všichni spuštění hostitelé aplikací.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoRunningAppHostsFound">
-        <source>No running AppHosts found.</source>
-        <target state="translated">Nebyl nalezen žádný spuštěný hostitel aplikací.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OptionNotValidWithResource">
         <source>The '{0}' option is not valid when starting a resource.</source>
         <target state="new">The '{0}' option is not valid when starting a resource.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file.</source>
-        <target state="translated">Cesta k souboru projektu Aspire AppHost.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestartDescription">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.cs.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../ResourceCommandStrings.resx">
     <body>
@@ -17,6 +17,26 @@
         <target state="translated">Název prostředku, na kterém se má příkaz provést</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoInScopeAppHostsShowingAll">
+        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
+        <target state="translated">Nebyli nalezeni žádní hostitelé aplikací v daném oboru. Zobrazují se všichni spuštění hostitelé aplikací.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRunningAppHostsFound">
+        <source>No running AppHosts found.</source>
+        <target state="translated">Nebyl nalezen žádný spuštěný hostitel aplikací.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionNotValidWithResource">
+        <source>The '{0}' option is not valid when starting a resource.</source>
+        <target state="new">The '{0}' option is not valid when starting a resource.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file.</source>
+        <target state="translated">Cesta k souboru projektu Aspire AppHost.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart a running resource.</source>
         <target state="translated">Restartujte spuštěný prostředek.</target>
@@ -33,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">
-        <source>Start a stopped resource.</source>
+        <source>Start an apphost in the background, or start a stopped resource.</source>
         <target state="translated">Spusťte zastavený prostředek.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartResourceArgumentDescription">
-        <source>The name of the resource to start.</source>
+        <source>The name of the resource to start. If not specified, starts the AppHost in the background.</source>
         <target state="translated">Název prostředku, který se má spustit</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.de.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../ResourceCommandStrings.resx">
     <body>
@@ -17,6 +17,26 @@
         <target state="translated">Der Name der Ressource, für die der Befehl ausgeführt werden soll.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoInScopeAppHostsShowingAll">
+        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
+        <target state="translated">Es wurden keine AppHosts im Geltungsbereich gefunden. Es werden alle aktiven AppHosts angezeigt.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRunningAppHostsFound">
+        <source>No running AppHosts found.</source>
+        <target state="translated">Es wurden keine ausgeführten AppHosts gefunden.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionNotValidWithResource">
+        <source>The '{0}' option is not valid when starting a resource.</source>
+        <target state="new">The '{0}' option is not valid when starting a resource.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file.</source>
+        <target state="translated">Der Pfad zur Aspire AppHost-Projektdatei.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart a running resource.</source>
         <target state="translated">Starten Sie eine laufende Ressource neu.</target>
@@ -33,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">
-        <source>Start a stopped resource.</source>
+        <source>Start an apphost in the background, or start a stopped resource.</source>
         <target state="translated">Starten Sie eine gestoppte Ressource.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartResourceArgumentDescription">
-        <source>The name of the resource to start.</source>
+        <source>The name of the resource to start. If not specified, starts the AppHost in the background.</source>
         <target state="translated">Der Name der Ressource, die gestartet werden soll.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.de.xlf
@@ -17,24 +17,9 @@
         <target state="translated">Der Name der Ressource, für die der Befehl ausgeführt werden soll.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
-        <target state="translated">Es wurden keine AppHosts im Geltungsbereich gefunden. Es werden alle aktiven AppHosts angezeigt.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoRunningAppHostsFound">
-        <source>No running AppHosts found.</source>
-        <target state="translated">Es wurden keine ausgeführten AppHosts gefunden.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OptionNotValidWithResource">
         <source>The '{0}' option is not valid when starting a resource.</source>
         <target state="new">The '{0}' option is not valid when starting a resource.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file.</source>
-        <target state="translated">Der Pfad zur Aspire AppHost-Projektdatei.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestartDescription">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.es.xlf
@@ -17,24 +17,9 @@
         <target state="translated">El nombre del recurso de destino en el que se ejecutará el comando.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
-        <target state="translated">No se encontraron AppHosts dentro del ámbito. Mostrando todos los AppHosts en ejecución.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoRunningAppHostsFound">
-        <source>No running AppHosts found.</source>
-        <target state="translated">No se encontraron AppHosts en ejecución.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OptionNotValidWithResource">
         <source>The '{0}' option is not valid when starting a resource.</source>
         <target state="new">The '{0}' option is not valid when starting a resource.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file.</source>
-        <target state="translated">La ruta de acceso al archivo del proyecto host de la AppHost Aspire.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestartDescription">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.es.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../ResourceCommandStrings.resx">
     <body>
@@ -17,6 +17,26 @@
         <target state="translated">El nombre del recurso de destino en el que se ejecutará el comando.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoInScopeAppHostsShowingAll">
+        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
+        <target state="translated">No se encontraron AppHosts dentro del ámbito. Mostrando todos los AppHosts en ejecución.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRunningAppHostsFound">
+        <source>No running AppHosts found.</source>
+        <target state="translated">No se encontraron AppHosts en ejecución.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionNotValidWithResource">
+        <source>The '{0}' option is not valid when starting a resource.</source>
+        <target state="new">The '{0}' option is not valid when starting a resource.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file.</source>
+        <target state="translated">La ruta de acceso al archivo del proyecto host de la AppHost Aspire.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart a running resource.</source>
         <target state="translated">Reinicie un recurso en ejecución.</target>
@@ -33,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">
-        <source>Start a stopped resource.</source>
+        <source>Start an apphost in the background, or start a stopped resource.</source>
         <target state="translated">Inicie un recurso detenido.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartResourceArgumentDescription">
-        <source>The name of the resource to start.</source>
+        <source>The name of the resource to start. If not specified, starts the AppHost in the background.</source>
         <target state="translated">Nombre del recurso que se va a iniciar.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.fr.xlf
@@ -17,24 +17,9 @@
         <target state="translated">Nom de la ressource sur laquelle exécuter la commande.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
-        <target state="translated">Aucun AppHost dans le périmètre n’a été trouvé. Affichage de tous les AppHosts en cours d’exécution.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoRunningAppHostsFound">
-        <source>No running AppHosts found.</source>
-        <target state="translated">Désolé, aucun AppHost en cours d’exécution n’a été trouvé.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OptionNotValidWithResource">
         <source>The '{0}' option is not valid when starting a resource.</source>
         <target state="new">The '{0}' option is not valid when starting a resource.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file.</source>
-        <target state="translated">Chemin d’accès au fichier projet AppHost Aspire.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestartDescription">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.fr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../ResourceCommandStrings.resx">
     <body>
@@ -17,6 +17,26 @@
         <target state="translated">Nom de la ressource sur laquelle exécuter la commande.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoInScopeAppHostsShowingAll">
+        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
+        <target state="translated">Aucun AppHost dans le périmètre n’a été trouvé. Affichage de tous les AppHosts en cours d’exécution.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRunningAppHostsFound">
+        <source>No running AppHosts found.</source>
+        <target state="translated">Désolé, aucun AppHost en cours d’exécution n’a été trouvé.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionNotValidWithResource">
+        <source>The '{0}' option is not valid when starting a resource.</source>
+        <target state="new">The '{0}' option is not valid when starting a resource.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file.</source>
+        <target state="translated">Chemin d’accès au fichier projet AppHost Aspire.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart a running resource.</source>
         <target state="translated">Redémarrer une ressource en cours d’exécution.</target>
@@ -33,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">
-        <source>Start a stopped resource.</source>
+        <source>Start an apphost in the background, or start a stopped resource.</source>
         <target state="translated">Démarrer une ressource arrêtée.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartResourceArgumentDescription">
-        <source>The name of the resource to start.</source>
+        <source>The name of the resource to start. If not specified, starts the AppHost in the background.</source>
         <target state="translated">Le nom de la ressource à commencer.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.it.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../ResourceCommandStrings.resx">
     <body>
@@ -17,6 +17,26 @@
         <target state="translated">Nome della risorsa di destinazione rispetto al quale eseguire il comando.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoInScopeAppHostsShowingAll">
+        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
+        <target state="translated">Nessun AppHost in ambito trovato. Visualizzazione di tutti gli AppHost in esecuzione.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRunningAppHostsFound">
+        <source>No running AppHosts found.</source>
+        <target state="translated">Non sono stati trovati AppHost in esecuzione.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionNotValidWithResource">
+        <source>The '{0}' option is not valid when starting a resource.</source>
+        <target state="new">The '{0}' option is not valid when starting a resource.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file.</source>
+        <target state="translated">Percorso del file di un progetto AppHost di Aspire.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart a running resource.</source>
         <target state="translated">Riavviare una risorsa in esecuzione.</target>
@@ -33,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">
-        <source>Start a stopped resource.</source>
+        <source>Start an apphost in the background, or start a stopped resource.</source>
         <target state="translated">Avviare una risorsa arrestata.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartResourceArgumentDescription">
-        <source>The name of the resource to start.</source>
+        <source>The name of the resource to start. If not specified, starts the AppHost in the background.</source>
         <target state="translated">Nome della risorsa da avviare.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.it.xlf
@@ -17,24 +17,9 @@
         <target state="translated">Nome della risorsa di destinazione rispetto al quale eseguire il comando.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
-        <target state="translated">Nessun AppHost in ambito trovato. Visualizzazione di tutti gli AppHost in esecuzione.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoRunningAppHostsFound">
-        <source>No running AppHosts found.</source>
-        <target state="translated">Non sono stati trovati AppHost in esecuzione.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OptionNotValidWithResource">
         <source>The '{0}' option is not valid when starting a resource.</source>
         <target state="new">The '{0}' option is not valid when starting a resource.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file.</source>
-        <target state="translated">Percorso del file di un progetto AppHost di Aspire.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestartDescription">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ja.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../ResourceCommandStrings.resx">
     <body>
@@ -17,6 +17,26 @@
         <target state="translated">コマンドを実行する対象のリソースの名前。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoInScopeAppHostsShowingAll">
+        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
+        <target state="translated">スコープ内の AppHost が見つかりません。実行中のすべての AppHost を表示しています。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRunningAppHostsFound">
+        <source>No running AppHosts found.</source>
+        <target state="translated">実行中の AppHost が見つかりません。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionNotValidWithResource">
+        <source>The '{0}' option is not valid when starting a resource.</source>
+        <target state="new">The '{0}' option is not valid when starting a resource.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file.</source>
+        <target state="translated">Aspire AppHost プロジェクト ファイルへのパス。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart a running resource.</source>
         <target state="translated">実行中のリソースを再起動します。</target>
@@ -33,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">
-        <source>Start a stopped resource.</source>
+        <source>Start an apphost in the background, or start a stopped resource.</source>
         <target state="translated">停止しているリソースを開始します。</target>
         <note />
       </trans-unit>
       <trans-unit id="StartResourceArgumentDescription">
-        <source>The name of the resource to start.</source>
+        <source>The name of the resource to start. If not specified, starts the AppHost in the background.</source>
         <target state="translated">開始するリソースの名前。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ja.xlf
@@ -17,24 +17,9 @@
         <target state="translated">コマンドを実行する対象のリソースの名前。</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
-        <target state="translated">スコープ内の AppHost が見つかりません。実行中のすべての AppHost を表示しています。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoRunningAppHostsFound">
-        <source>No running AppHosts found.</source>
-        <target state="translated">実行中の AppHost が見つかりません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OptionNotValidWithResource">
         <source>The '{0}' option is not valid when starting a resource.</source>
         <target state="new">The '{0}' option is not valid when starting a resource.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file.</source>
-        <target state="translated">Aspire AppHost プロジェクト ファイルへのパス。</target>
         <note />
       </trans-unit>
       <trans-unit id="RestartDescription">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ko.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../ResourceCommandStrings.resx">
     <body>
@@ -17,6 +17,26 @@
         <target state="translated">명령을 실행할 대상 리소스의 이름입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoInScopeAppHostsShowingAll">
+        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
+        <target state="translated">범위 내 AppHost를 찾을 수 없습니다. 실행 중인 모든 AppHost를 표시하는 중입니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRunningAppHostsFound">
+        <source>No running AppHosts found.</source>
+        <target state="translated">실행 중인 AppHost를 찾을 수 없습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionNotValidWithResource">
+        <source>The '{0}' option is not valid when starting a resource.</source>
+        <target state="new">The '{0}' option is not valid when starting a resource.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file.</source>
+        <target state="translated">Aspire AppHost 프로젝트 파일의 경로입니다.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart a running resource.</source>
         <target state="translated">실행 중인 리소스를 다시 시작합니다.</target>
@@ -33,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">
-        <source>Start a stopped resource.</source>
+        <source>Start an apphost in the background, or start a stopped resource.</source>
         <target state="translated">중지된 리소스를 시작합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartResourceArgumentDescription">
-        <source>The name of the resource to start.</source>
+        <source>The name of the resource to start. If not specified, starts the AppHost in the background.</source>
         <target state="translated">시작할 리소스의 이름입니다.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ko.xlf
@@ -17,24 +17,9 @@
         <target state="translated">명령을 실행할 대상 리소스의 이름입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
-        <target state="translated">범위 내 AppHost를 찾을 수 없습니다. 실행 중인 모든 AppHost를 표시하는 중입니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoRunningAppHostsFound">
-        <source>No running AppHosts found.</source>
-        <target state="translated">실행 중인 AppHost를 찾을 수 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OptionNotValidWithResource">
         <source>The '{0}' option is not valid when starting a resource.</source>
         <target state="new">The '{0}' option is not valid when starting a resource.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file.</source>
-        <target state="translated">Aspire AppHost 프로젝트 파일의 경로입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestartDescription">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pl.xlf
@@ -17,24 +17,9 @@
         <target state="translated">Nazwa zasobu, na którym ma zostać wykonane polecenie.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
-        <target state="translated">Nie znaleziono hostów aplikacji w zakresie. Wyświetlanie wszystkich uruchomionych hostów aplikacji.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoRunningAppHostsFound">
-        <source>No running AppHosts found.</source>
-        <target state="translated">Nie znaleziono uruchomionych hostów aplikacji.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OptionNotValidWithResource">
         <source>The '{0}' option is not valid when starting a resource.</source>
         <target state="new">The '{0}' option is not valid when starting a resource.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file.</source>
-        <target state="translated">Ścieżka do pliku projektu hosta AppHost platformy Aspire.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestartDescription">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pl.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../ResourceCommandStrings.resx">
     <body>
@@ -17,6 +17,26 @@
         <target state="translated">Nazwa zasobu, na którym ma zostać wykonane polecenie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoInScopeAppHostsShowingAll">
+        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
+        <target state="translated">Nie znaleziono hostów aplikacji w zakresie. Wyświetlanie wszystkich uruchomionych hostów aplikacji.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRunningAppHostsFound">
+        <source>No running AppHosts found.</source>
+        <target state="translated">Nie znaleziono uruchomionych hostów aplikacji.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionNotValidWithResource">
+        <source>The '{0}' option is not valid when starting a resource.</source>
+        <target state="new">The '{0}' option is not valid when starting a resource.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file.</source>
+        <target state="translated">Ścieżka do pliku projektu hosta AppHost platformy Aspire.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart a running resource.</source>
         <target state="translated">Uruchom ponownie uruchomiony zasób.</target>
@@ -33,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">
-        <source>Start a stopped resource.</source>
+        <source>Start an apphost in the background, or start a stopped resource.</source>
         <target state="translated">Uruchom zatrzymany zasób.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartResourceArgumentDescription">
-        <source>The name of the resource to start.</source>
+        <source>The name of the resource to start. If not specified, starts the AppHost in the background.</source>
         <target state="translated">Nazwa zasobu do uruchomienia.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pt-BR.xlf
@@ -17,24 +17,9 @@
         <target state="translated">O nome do recurso no qual executar o comando.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
-        <target state="translated">Nenhum AppHosts no escopo encontrado. Mostrando todos os AppHosts em execução.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoRunningAppHostsFound">
-        <source>No running AppHosts found.</source>
-        <target state="translated">Nenhum AppHosts em execução encontrado.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OptionNotValidWithResource">
         <source>The '{0}' option is not valid when starting a resource.</source>
         <target state="new">The '{0}' option is not valid when starting a resource.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file.</source>
-        <target state="translated">O caminho para o arquivo de projeto do Aspire AppHost.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestartDescription">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.pt-BR.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ResourceCommandStrings.resx">
     <body>
@@ -17,6 +17,26 @@
         <target state="translated">O nome do recurso no qual executar o comando.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoInScopeAppHostsShowingAll">
+        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
+        <target state="translated">Nenhum AppHosts no escopo encontrado. Mostrando todos os AppHosts em execução.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRunningAppHostsFound">
+        <source>No running AppHosts found.</source>
+        <target state="translated">Nenhum AppHosts em execução encontrado.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionNotValidWithResource">
+        <source>The '{0}' option is not valid when starting a resource.</source>
+        <target state="new">The '{0}' option is not valid when starting a resource.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file.</source>
+        <target state="translated">O caminho para o arquivo de projeto do Aspire AppHost.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart a running resource.</source>
         <target state="translated">Reinicie um recurso em execução.</target>
@@ -33,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">
-        <source>Start a stopped resource.</source>
+        <source>Start an apphost in the background, or start a stopped resource.</source>
         <target state="translated">Inicie um recurso parado.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartResourceArgumentDescription">
-        <source>The name of the resource to start.</source>
+        <source>The name of the resource to start. If not specified, starts the AppHost in the background.</source>
         <target state="translated">O nome do recurso a ser iniciado.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ru.xlf
@@ -17,24 +17,9 @@
         <target state="translated">Имя целевого ресурса, на котором будет выполняться команда.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
-        <target state="translated">Не найдено ни одного AppHost в области действия. Показаны все выполняющиеся AppHost.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoRunningAppHostsFound">
-        <source>No running AppHosts found.</source>
-        <target state="translated">Запущенные appHosts не найдены.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OptionNotValidWithResource">
         <source>The '{0}' option is not valid when starting a resource.</source>
         <target state="new">The '{0}' option is not valid when starting a resource.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file.</source>
-        <target state="translated">Путь к файлу проекта Aspire AppHost.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestartDescription">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.ru.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../ResourceCommandStrings.resx">
     <body>
@@ -17,6 +17,26 @@
         <target state="translated">Имя целевого ресурса, на котором будет выполняться команда.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoInScopeAppHostsShowingAll">
+        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
+        <target state="translated">Не найдено ни одного AppHost в области действия. Показаны все выполняющиеся AppHost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRunningAppHostsFound">
+        <source>No running AppHosts found.</source>
+        <target state="translated">Запущенные appHosts не найдены.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionNotValidWithResource">
+        <source>The '{0}' option is not valid when starting a resource.</source>
+        <target state="new">The '{0}' option is not valid when starting a resource.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file.</source>
+        <target state="translated">Путь к файлу проекта Aspire AppHost.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart a running resource.</source>
         <target state="translated">Перезапустить уже запущенный ресурс.</target>
@@ -33,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">
-        <source>Start a stopped resource.</source>
+        <source>Start an apphost in the background, or start a stopped resource.</source>
         <target state="translated">Запустить остановленный ресурс.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartResourceArgumentDescription">
-        <source>The name of the resource to start.</source>
+        <source>The name of the resource to start. If not specified, starts the AppHost in the background.</source>
         <target state="translated">Имя ресурса, который нужно запустить.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.tr.xlf
@@ -17,24 +17,9 @@
         <target state="translated">Komutu yürütecek kaynağın adı.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
-        <target state="translated">Kapsam dahilinde AppHost bulunamadı. Tüm çalışan AppHost'lar gösteriliyor.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoRunningAppHostsFound">
-        <source>No running AppHosts found.</source>
-        <target state="translated">Çalışan AppHost bulunamadı.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OptionNotValidWithResource">
         <source>The '{0}' option is not valid when starting a resource.</source>
         <target state="new">The '{0}' option is not valid when starting a resource.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file.</source>
-        <target state="translated">Aspire AppHost proje dosyasının yolu.</target>
         <note />
       </trans-unit>
       <trans-unit id="RestartDescription">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.tr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../ResourceCommandStrings.resx">
     <body>
@@ -17,6 +17,26 @@
         <target state="translated">Komutu yürütecek kaynağın adı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoInScopeAppHostsShowingAll">
+        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
+        <target state="translated">Kapsam dahilinde AppHost bulunamadı. Tüm çalışan AppHost'lar gösteriliyor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRunningAppHostsFound">
+        <source>No running AppHosts found.</source>
+        <target state="translated">Çalışan AppHost bulunamadı.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionNotValidWithResource">
+        <source>The '{0}' option is not valid when starting a resource.</source>
+        <target state="new">The '{0}' option is not valid when starting a resource.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file.</source>
+        <target state="translated">Aspire AppHost proje dosyasının yolu.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart a running resource.</source>
         <target state="translated">Çalışan bir kaynağı yeniden başlatın.</target>
@@ -33,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">
-        <source>Start a stopped resource.</source>
+        <source>Start an apphost in the background, or start a stopped resource.</source>
         <target state="translated">Durdurulmuş bir kaynağı başlatın.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartResourceArgumentDescription">
-        <source>The name of the resource to start.</source>
+        <source>The name of the resource to start. If not specified, starts the AppHost in the background.</source>
         <target state="translated">Başlatılacak kaynağın adı.</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hans.xlf
@@ -17,24 +17,9 @@
         <target state="translated">要在其上执行命令的资源的名称。</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
-        <target state="translated">未找到范围内的 AppHost。显示所有正在运行的 AppHost。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoRunningAppHostsFound">
-        <source>No running AppHosts found.</source>
-        <target state="translated">未找到正在运行的 AppHost。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OptionNotValidWithResource">
         <source>The '{0}' option is not valid when starting a resource.</source>
         <target state="new">The '{0}' option is not valid when starting a resource.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file.</source>
-        <target state="translated">Aspire AppHost 项目文件的路径。</target>
         <note />
       </trans-unit>
       <trans-unit id="RestartDescription">

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hans.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ResourceCommandStrings.resx">
     <body>
@@ -17,6 +17,26 @@
         <target state="translated">要在其上执行命令的资源的名称。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoInScopeAppHostsShowingAll">
+        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
+        <target state="translated">未找到范围内的 AppHost。显示所有正在运行的 AppHost。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRunningAppHostsFound">
+        <source>No running AppHosts found.</source>
+        <target state="translated">未找到正在运行的 AppHost。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionNotValidWithResource">
+        <source>The '{0}' option is not valid when starting a resource.</source>
+        <target state="new">The '{0}' option is not valid when starting a resource.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file.</source>
+        <target state="translated">Aspire AppHost 项目文件的路径。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart a running resource.</source>
         <target state="translated">重启正在运行的资源。</target>
@@ -33,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">
-        <source>Start a stopped resource.</source>
+        <source>Start an apphost in the background, or start a stopped resource.</source>
         <target state="translated">启动已停止的资源。</target>
         <note />
       </trans-unit>
       <trans-unit id="StartResourceArgumentDescription">
-        <source>The name of the resource to start.</source>
+        <source>The name of the resource to start. If not specified, starts the AppHost in the background.</source>
         <target state="translated">要启动的资源的名称。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hant.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ResourceCommandStrings.resx">
     <body>
@@ -17,6 +17,26 @@
         <target state="translated">要執行命令的資源名稱。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoInScopeAppHostsShowingAll">
+        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
+        <target state="translated">未找到符合範圍的 AppHost。顯示所有正在執行的 AppHost。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRunningAppHostsFound">
+        <source>No running AppHosts found.</source>
+        <target state="translated">找不到正在執行的 AppHost。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionNotValidWithResource">
+        <source>The '{0}' option is not valid when starting a resource.</source>
+        <target state="new">The '{0}' option is not valid when starting a resource.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectOptionDescription">
+        <source>The path to the Aspire AppHost project file.</source>
+        <target state="translated">Aspire AppHost 專案檔案的路徑。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartDescription">
         <source>Restart a running resource.</source>
         <target state="translated">重新啟動正在執行的資源。</target>
@@ -33,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="StartDescription">
-        <source>Start a stopped resource.</source>
+        <source>Start an apphost in the background, or start a stopped resource.</source>
         <target state="translated">啟動已停止的資源。</target>
         <note />
       </trans-unit>
       <trans-unit id="StartResourceArgumentDescription">
-        <source>The name of the resource to start.</source>
+        <source>The name of the resource to start. If not specified, starts the AppHost in the background.</source>
         <target state="translated">要啟動的資源名稱。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ResourceCommandStrings.zh-Hant.xlf
@@ -17,24 +17,9 @@
         <target state="translated">要執行命令的資源名稱。</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No in-scope AppHosts found. Showing all running AppHosts.</source>
-        <target state="translated">未找到符合範圍的 AppHost。顯示所有正在執行的 AppHost。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoRunningAppHostsFound">
-        <source>No running AppHosts found.</source>
-        <target state="translated">找不到正在執行的 AppHost。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OptionNotValidWithResource">
         <source>The '{0}' option is not valid when starting a resource.</source>
         <target state="new">The '{0}' option is not valid when starting a resource.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectOptionDescription">
-        <source>The path to the Aspire AppHost project file.</source>
-        <target state="translated">Aspire AppHost 專案檔案的路徑。</target>
         <note />
       </trans-unit>
       <trans-unit id="RestartDescription">

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.cs.xlf
@@ -78,7 +78,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Run an apphost in development mode.</source>
+        <source>Run an Aspire AppHost interactively for development.</source>
         <target state="needs-review-translation">Spusťte hostitele aplikací Aspire ve vývojovém režimu.</target>
         <note />
       </trans-unit>
@@ -118,7 +118,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonArgumentDescription">
-        <source>Output format (Table or Json). Only valid with --detach.</source>
+        <source>Output format for detached AppHost results.</source>
         <target state="needs-review-translation">Výsledek výstupu ve formátu JSON (platný jenom s parametrem --detach).</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.de.xlf
@@ -78,7 +78,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Run an apphost in development mode.</source>
+        <source>Run an Aspire AppHost interactively for development.</source>
         <target state="needs-review-translation">Führen Sie einen Aspire-App-Host im Entwicklungsmodus aus.</target>
         <note />
       </trans-unit>
@@ -118,7 +118,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonArgumentDescription">
-        <source>Output format (Table or Json). Only valid with --detach.</source>
+        <source>Output format for detached AppHost results.</source>
         <target state="needs-review-translation">Ausgabeergebnis als JSON (nur gültig mit --detach).</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.es.xlf
@@ -78,7 +78,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Run an apphost in development mode.</source>
+        <source>Run an Aspire AppHost interactively for development.</source>
         <target state="needs-review-translation">Ejecutar un apphost de Aspire en modo de desarrollo.</target>
         <note />
       </trans-unit>
@@ -118,7 +118,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonArgumentDescription">
-        <source>Output format (Table or Json). Only valid with --detach.</source>
+        <source>Output format for detached AppHost results.</source>
         <target state="needs-review-translation">Resultado de salida como JSON (solo válido con --detach).</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.fr.xlf
@@ -78,7 +78,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Run an apphost in development mode.</source>
+        <source>Run an Aspire AppHost interactively for development.</source>
         <target state="needs-review-translation">Exécutez un hôte d’application Aspire en mode développement.</target>
         <note />
       </trans-unit>
@@ -118,7 +118,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonArgumentDescription">
-        <source>Output format (Table or Json). Only valid with --detach.</source>
+        <source>Output format for detached AppHost results.</source>
         <target state="needs-review-translation">Afficher le résultat au format JSON (valide uniquement avec --detach).</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.it.xlf
@@ -78,7 +78,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Run an apphost in development mode.</source>
+        <source>Run an Aspire AppHost interactively for development.</source>
         <target state="needs-review-translation">Esegui un AppHost Aspire in modalità di sviluppo.</target>
         <note />
       </trans-unit>
@@ -118,7 +118,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonArgumentDescription">
-        <source>Output format (Table or Json). Only valid with --detach.</source>
+        <source>Output format for detached AppHost results.</source>
         <target state="needs-review-translation">Restituisce il risultato in formato JSON (valido solo con --detach).</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ja.xlf
@@ -78,7 +78,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Run an apphost in development mode.</source>
+        <source>Run an Aspire AppHost interactively for development.</source>
         <target state="needs-review-translation">開発モードで Aspire AppHost を実行します。</target>
         <note />
       </trans-unit>
@@ -118,7 +118,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonArgumentDescription">
-        <source>Output format (Table or Json). Only valid with --detach.</source>
+        <source>Output format for detached AppHost results.</source>
         <target state="needs-review-translation">結果を JSON 形式で出力します (--detach オプション指定時のみ有効)。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ko.xlf
@@ -78,7 +78,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Run an apphost in development mode.</source>
+        <source>Run an Aspire AppHost interactively for development.</source>
         <target state="needs-review-translation">개발 모드에서 Aspire 앱호스트를 실행합니다.</target>
         <note />
       </trans-unit>
@@ -118,7 +118,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonArgumentDescription">
-        <source>Output format (Table or Json). Only valid with --detach.</source>
+        <source>Output format for detached AppHost results.</source>
         <target state="needs-review-translation">JSON으로 결과를 출력합니다(--detach와 함께 사용 시에만 유효).</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pl.xlf
@@ -78,7 +78,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Run an apphost in development mode.</source>
+        <source>Run an Aspire AppHost interactively for development.</source>
         <target state="needs-review-translation">Uruchamianie hosta AppHost platformy Aspire w trybie programowania.</target>
         <note />
       </trans-unit>
@@ -118,7 +118,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonArgumentDescription">
-        <source>Output format (Table or Json). Only valid with --detach.</source>
+        <source>Output format for detached AppHost results.</source>
         <target state="needs-review-translation">Wyświetl wynik jako JSON (działa tylko z parametrem --detach).</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pt-BR.xlf
@@ -78,7 +78,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Run an apphost in development mode.</source>
+        <source>Run an Aspire AppHost interactively for development.</source>
         <target state="needs-review-translation">Execute um apphost do Aspire no modo de desenvolvimento.</target>
         <note />
       </trans-unit>
@@ -118,7 +118,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonArgumentDescription">
-        <source>Output format (Table or Json). Only valid with --detach.</source>
+        <source>Output format for detached AppHost results.</source>
         <target state="needs-review-translation">Resultado de saída como JSON (válido somente com --detach).</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ru.xlf
@@ -78,7 +78,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Run an apphost in development mode.</source>
+        <source>Run an Aspire AppHost interactively for development.</source>
         <target state="needs-review-translation">Запустите хост приложений Aspire в режиме разработки.</target>
         <note />
       </trans-unit>
@@ -118,7 +118,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonArgumentDescription">
-        <source>Output format (Table or Json). Only valid with --detach.</source>
+        <source>Output format for detached AppHost results.</source>
         <target state="needs-review-translation">Вывод результата в формате JSON (допустимо только с параметром --detach).</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.tr.xlf
@@ -78,7 +78,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Run an apphost in development mode.</source>
+        <source>Run an Aspire AppHost interactively for development.</source>
         <target state="needs-review-translation">Geliştirme modunda bir Aspire uygulama ana işlemini çalıştırın.</target>
         <note />
       </trans-unit>
@@ -118,7 +118,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonArgumentDescription">
-        <source>Output format (Table or Json). Only valid with --detach.</source>
+        <source>Output format for detached AppHost results.</source>
         <target state="needs-review-translation">Sonucu JSON olarak çıkar (yalnızca --detach ile geçerlidir).</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hans.xlf
@@ -78,7 +78,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Run an apphost in development mode.</source>
+        <source>Run an Aspire AppHost interactively for development.</source>
         <target state="needs-review-translation">在开发模式下运行 Aspire 应用主机。</target>
         <note />
       </trans-unit>
@@ -118,7 +118,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonArgumentDescription">
-        <source>Output format (Table or Json). Only valid with --detach.</source>
+        <source>Output format for detached AppHost results.</source>
         <target state="needs-review-translation">以 JSON 格式输出结果(仅在使用 --detach 时有效)。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hant.xlf
@@ -78,7 +78,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Run an apphost in development mode.</source>
+        <source>Run an Aspire AppHost interactively for development.</source>
         <target state="needs-review-translation">在開發模式中執行 Aspire AppHost。</target>
         <note />
       </trans-unit>
@@ -118,7 +118,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonArgumentDescription">
-        <source>Output format (Table or Json). Only valid with --detach.</source>
+        <source>Output format for detached AppHost results.</source>
         <target state="needs-review-translation">輸出結果為 JSON (僅於使用 --detach 時有效)。</target>
         <note />
       </trans-unit>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
@@ -1,10 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../SharedCommandStrings.resx">
     <body>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format for detached AppHost results.</source>
+        <target state="new">Output format for detached AppHost results.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsolatedOptionDescription">
+        <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</source>
+        <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
@@ -1,10 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../SharedCommandStrings.resx">
     <body>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format for detached AppHost results.</source>
+        <target state="new">Output format for detached AppHost results.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsolatedOptionDescription">
+        <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</source>
+        <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
@@ -1,10 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../SharedCommandStrings.resx">
     <body>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format for detached AppHost results.</source>
+        <target state="new">Output format for detached AppHost results.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsolatedOptionDescription">
+        <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</source>
+        <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
@@ -1,10 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../SharedCommandStrings.resx">
     <body>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format for detached AppHost results.</source>
+        <target state="new">Output format for detached AppHost results.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsolatedOptionDescription">
+        <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</source>
+        <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
@@ -1,10 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../SharedCommandStrings.resx">
     <body>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format for detached AppHost results.</source>
+        <target state="new">Output format for detached AppHost results.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsolatedOptionDescription">
+        <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</source>
+        <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
@@ -1,10 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../SharedCommandStrings.resx">
     <body>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format for detached AppHost results.</source>
+        <target state="new">Output format for detached AppHost results.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsolatedOptionDescription">
+        <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</source>
+        <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
@@ -1,10 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../SharedCommandStrings.resx">
     <body>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format for detached AppHost results.</source>
+        <target state="new">Output format for detached AppHost results.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsolatedOptionDescription">
+        <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</source>
+        <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
@@ -1,10 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../SharedCommandStrings.resx">
     <body>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format for detached AppHost results.</source>
+        <target state="new">Output format for detached AppHost results.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsolatedOptionDescription">
+        <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</source>
+        <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
@@ -1,10 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../SharedCommandStrings.resx">
     <body>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format for detached AppHost results.</source>
+        <target state="new">Output format for detached AppHost results.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsolatedOptionDescription">
+        <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</source>
+        <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
@@ -1,10 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../SharedCommandStrings.resx">
     <body>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format for detached AppHost results.</source>
+        <target state="new">Output format for detached AppHost results.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsolatedOptionDescription">
+        <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</source>
+        <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
@@ -1,10 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../SharedCommandStrings.resx">
     <body>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format for detached AppHost results.</source>
+        <target state="new">Output format for detached AppHost results.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsolatedOptionDescription">
+        <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</source>
+        <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
@@ -1,10 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../SharedCommandStrings.resx">
     <body>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format for detached AppHost results.</source>
+        <target state="new">Output format for detached AppHost results.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsolatedOptionDescription">
+        <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</source>
+        <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
@@ -1,10 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../SharedCommandStrings.resx">
     <body>
       <trans-unit id="AppHostNotRunning">
         <source>No running AppHost found. Use 'aspire run' to start one first.</source>
         <target state="new">No running AppHost found. Use 'aspire run' to start one first.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FormatOptionDescription">
+        <source>Output format for detached AppHost results.</source>
+        <target state="new">Output format for detached AppHost results.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsolatedOptionDescription">
+        <source>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</source>
+        <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -132,7 +132,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public void GetDetachedFailureMessage_ReturnsBuildSpecificMessage_ForBuildFailureExitCode()
     {
-        var message = RunCommand.GetDetachedFailureMessage(ExitCodeConstants.FailedToBuildArtifacts);
+        var message = AppHostLauncher.GetDetachedFailureMessage(ExitCodeConstants.FailedToBuildArtifacts);
 
         Assert.Equal(RunCommandStrings.AppHostFailedToBuild, message);
     }
@@ -140,7 +140,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public void GetDetachedFailureMessage_ReturnsExitCodeMessage_ForUnknownExitCode()
     {
-        var message = RunCommand.GetDetachedFailureMessage(123);
+        var message = AppHostLauncher.GetDetachedFailureMessage(123);
 
         Assert.Contains("123", message, StringComparison.Ordinal);
     }
@@ -152,7 +152,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         var now = new DateTimeOffset(2026, 02, 12, 18, 00, 00, TimeSpan.Zero);
         var timeProvider = new FixedTimeProvider(now);
 
-        var path = RunCommand.GenerateChildLogFilePath(logsDirectory, timeProvider);
+        var path = AppHostLauncher.GenerateChildLogFilePath(logsDirectory, timeProvider);
         var fileName = Path.GetFileName(path);
 
         Assert.StartsWith(logsDirectory, path, StringComparison.OrdinalIgnoreCase);

--- a/tests/Aspire.Cli.Tests/Commands/StartCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/StartCommandTests.cs
@@ -67,4 +67,74 @@ public class StartCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.Success, exitCode);
     }
+
+    [Fact]
+    public async Task StartCommand_AcceptsNoBuildOption()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("start --no-build --help");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+    }
+
+    [Fact]
+    public async Task StartCommand_AcceptsFormatOption()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("start --format json --help");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+    }
+
+    [Fact]
+    public async Task StartCommand_AcceptsIsolatedOption()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("start --isolated --help");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+    }
+
+    [Fact]
+    public async Task StartCommand_FormatOptionNotValidWithResource()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("start myresource --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+    }
+
+    [Fact]
+    public async Task StartCommand_IsolatedOptionNotValidWithResource()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("start myresource --isolated");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -162,6 +162,7 @@ internal static class CliTestHelper
         services.AddTransient<RootCommand>();
         services.AddTransient<NewCommand>();
         services.AddTransient<InitCommand>();
+        services.AddTransient<AppHostLauncher>();
         services.AddTransient<RunCommand>();
         services.AddTransient<StopCommand>();
         services.AddTransient<StartCommand>();


### PR DESCRIPTION
## Description

This PR adds a shortcut to run detached AppHost startup via `aspire start` (no resource argument), equivalent to `aspire run --detach`, and fixes detached-launch forwarding/regression issues.

### Summary of changes
- Add detached AppHost launch path to `aspire start` when no resource name is provided.
- Keep detached launch behavior shared between `start` and `run` through `AppHostLauncher`.
- Restore JSON-safe detached output behavior:
  - route human-readable output to stderr for `--format json`
  - enforce non-interactive AppHost selection in JSON mode
  - write JSON output explicitly to stdout
- Restore detached child diagnostics behavior:
  - generate and pass child `--log-file`
  - surface child log path in errors and JSON output
- Forward `--no-build` from `aspire run --detach` to the detached child process.
- Use `RunCommand.GetDetachedFailureMessage(childExitCode)` for clearer early-exit errors.
- Include the `create-pr` skill update used to standardize template-filled PR creation/editing in this workflow.

### Motivation and context
The detached launch refactor introduced argument/output regressions and less specific failure messaging. These changes restore expected behavior and provide a clear `aspire start` shortcut for the detached AppHost launch flow.

Dependencies: None.

### Validation
- `dotnet test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj -- --filter-class "*.RunCommandTests" --filter-class "*.StartCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Fixes # (issue)
No linked issue.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
