### PR TITLE
Fix LogsCommand to sort results by timestamp

### DIFF
--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -3,7 +3,6 @@
 
 using System.CommandLine;
 using System.Globalization;
-using System.Runtime.CompilerServices;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -225,42 +224,27 @@ internal sealed class LogsCommand : BaseCommand
         IReadOnlyList<ResourceSnapshot> snapshots,
         CancellationToken cancellationToken)
     {
-        // Collect all logs
-        List<ResourceLogLine> logLines;
-        if (!tail.HasValue)
-        {
-            logLines = await CollectLogsAsync(connection, resourceName, snapshots, cancellationToken).ConfigureAwait(false);
-        }
-        else
-        {
-            // With tail specified, collect all logs first then take last N
-            logLines = await CollectLogsAsync(connection, resourceName, snapshots, cancellationToken).ConfigureAwait(false);
+        // Collect all logs, parsing into LogEntry with resolved resource names sorted by timestamp
+        var entries = await CollectLogsAsync(connection, resourceName, snapshots, cancellationToken).ConfigureAwait(false);
 
-            // Apply tail filter (tail.Value is guaranteed >= 1 by earlier validation)
-            if (logLines.Count > tail.Value)
-            {
-                logLines = logLines.Skip(logLines.Count - tail.Value).ToList();
-            }
+        // Apply tail filter (tail.Value is guaranteed >= 1 by earlier validation)
+        if (tail.HasValue && entries.Count > tail.Value)
+        {
+            entries = entries.Skip(entries.Count - tail.Value).ToList();
         }
 
         // Output the logs
-        var logParser = new LogParser(ConsoleColor.Black);
-
         if (format == OutputFormat.Json)
         {
             // Wrapped JSON for snapshot - single JSON object compatible with jq
             var logsOutput = new LogsOutput
             {
-                Logs = logLines.Select(l =>
+                Logs = entries.Select(entry => new LogLineJson
                 {
-                    var entry = logParser.CreateLogEntry(l.Content, l.IsError, l.ResourceName);
-                    return new LogLineJson
-                    {
-                        ResourceName = ResolveResourceName(l.ResourceName, snapshots),
-                        Timestamp = timestamps && entry.Timestamp.HasValue ? FormatTimestamp(entry.Timestamp.Value) : null,
-                        Content = entry.Content ?? l.Content,
-                        IsError = l.IsError
-                    };
+                    ResourceName = entry.ResourcePrefix ?? string.Empty,
+                    Timestamp = timestamps && entry.Timestamp.HasValue ? FormatTimestamp(entry.Timestamp.Value) : null,
+                    Content = entry.Content ?? entry.RawContent ?? string.Empty,
+                    IsError = entry.Type == LogEntryType.Error
                 }).ToArray()
             };
             var json = JsonSerializer.Serialize(logsOutput, LogsCommandJsonContext.Snapshot.LogsOutput);
@@ -269,9 +253,9 @@ internal sealed class LogsCommand : BaseCommand
         }
         else
         {
-            foreach (var logLine in logLines)
+            foreach (var entry in entries)
             {
-                OutputLogLine(logLine, format, timestamps, logParser, snapshots);
+                OutputLogLine(entry, format, timestamps);
             }
         }
 
@@ -292,78 +276,63 @@ internal sealed class LogsCommand : BaseCommand
         // If tail is specified, show last N lines first before streaming
         if (tail.HasValue)
         {
-            var historicalLogs = await CollectLogsAsync(connection, resourceName, snapshots, cancellationToken).ConfigureAwait(false);
+            var entries = await CollectLogsAsync(connection, resourceName, snapshots, cancellationToken).ConfigureAwait(false);
 
             // Output last N lines
-            var tailedLogs = historicalLogs.Count > tail.Value
-                ? historicalLogs.Skip(historicalLogs.Count - tail.Value)
-                : historicalLogs;
+            var tailedEntries = entries.Count > tail.Value
+                ? entries.Skip(entries.Count - tail.Value)
+                : entries;
 
-            foreach (var logLine in tailedLogs)
+            foreach (var entry in tailedEntries)
             {
-                OutputLogLine(logLine, format, timestamps, logParser, snapshots);
+                OutputLogLine(entry, format, timestamps);
             }
         }
 
         // Now stream new logs
         await foreach (var logLine in connection.GetResourceLogsAsync(resourceName, follow: true, cancellationToken).ConfigureAwait(false))
         {
-            OutputLogLine(logLine, format, timestamps, logParser, snapshots);
+            var entry = ParseLogLine(logLine, logParser, snapshots);
+            OutputLogLine(entry, format, timestamps);
         }
 
         return ExitCodeConstants.Success;
     }
 
     /// <summary>
-    /// Collects all logs for a resource (or all resources if resourceName is null) into a list.
+    /// Collects all logs for a resource (or all resources if resourceName is null), parsing each
+    /// into a <see cref="LogEntry"/> with the resolved resource name set on <see cref="LogEntry.ResourcePrefix"/>
+    /// and returning entries sorted by timestamp.
     /// </summary>
-    private static async Task<List<ResourceLogLine>> CollectLogsAsync(
+    private static async Task<IList<LogEntry>> CollectLogsAsync(
         IAppHostAuxiliaryBackchannel connection,
         string? resourceName,
         IReadOnlyList<ResourceSnapshot> snapshots,
         CancellationToken cancellationToken)
     {
-        var logLines = new List<ResourceLogLine>();
-        await foreach (var logLine in GetLogsAsync(connection, resourceName, snapshots, cancellationToken).ConfigureAwait(false))
+        var logParser = new LogParser(ConsoleColor.Black);
+        var logEntries = new LogEntries(int.MaxValue) { BaseLineNumber = 1 };
+        await foreach (var logLine in connection.GetResourceLogsAsync(resourceName, follow: false, cancellationToken).ConfigureAwait(false))
         {
-            logLines.Add(logLine);
+            logEntries.InsertSorted(ParseLogLine(logLine, logParser, snapshots));
         }
-        return logLines;
+        return logEntries.GetEntries();
     }
 
     /// <summary>
-    /// Gets logs for a resource (or all resources if resourceName is null) as an async enumerable.
+    /// Parses a <see cref="ResourceLogLine"/> into a <see cref="LogEntry"/> with the resolved resource name
+    /// set on <see cref="LogEntry.ResourcePrefix"/>.
     /// </summary>
-    private static async IAsyncEnumerable<ResourceLogLine> GetLogsAsync(
-        IAppHostAuxiliaryBackchannel connection,
-        string? resourceName,
-        IReadOnlyList<ResourceSnapshot> snapshots,
-        [EnumeratorCancellation] CancellationToken cancellationToken)
+    private static LogEntry ParseLogLine(ResourceLogLine logLine, LogParser logParser, IReadOnlyList<ResourceSnapshot> snapshots)
     {
-        if (resourceName is not null)
-        {
-            await foreach (var logLine in connection.GetResourceLogsAsync(resourceName, follow: false, cancellationToken).ConfigureAwait(false))
-            {
-                yield return logLine;
-            }
-            yield break;
-        }
-
-        // Get all resources and stream logs for each (like docker compose logs)
-        foreach (var snapshot in snapshots.OrderBy(s => s.Name))
-        {
-            await foreach (var logLine in connection.GetResourceLogsAsync(snapshot.Name, follow: false, cancellationToken).ConfigureAwait(false))
-            {
-                yield return logLine;
-            }
-        }
+        var resolvedName = ResolveResourceName(logLine.ResourceName, snapshots);
+        return logParser.CreateLogEntry(logLine.Content, logLine.IsError, resolvedName);
     }
 
-    private void OutputLogLine(ResourceLogLine logLine, OutputFormat format, bool timestamps, LogParser logParser, IReadOnlyList<ResourceSnapshot> snapshots)
+    private void OutputLogLine(LogEntry entry, OutputFormat format, bool timestamps)
     {
-        var displayName = ResolveResourceName(logLine.ResourceName, snapshots);
-        var entry = logParser.CreateLogEntry(logLine.Content, logLine.IsError, logLine.ResourceName);
-        var content = entry.Content ?? logLine.Content;
+        var displayName = entry.ResourcePrefix ?? string.Empty;
+        var content = entry.Content ?? entry.RawContent ?? string.Empty;
         var timestampPrefix = timestamps && entry.Timestamp.HasValue ? FormatTimestamp(entry.Timestamp.Value) + " " : string.Empty;
 
         if (format == OutputFormat.Json)
@@ -374,7 +343,7 @@ internal sealed class LogsCommand : BaseCommand
                 ResourceName = displayName,
                 Timestamp = timestamps && entry.Timestamp.HasValue ? FormatTimestamp(entry.Timestamp.Value) : null,
                 Content = content,
-                IsError = logLine.IsError
+                IsError = entry.Type == LogEntryType.Error
             };
             var output = JsonSerializer.Serialize(logLineJson, LogsCommandJsonContext.Ndjson.LogLineJson);
             // Structured output always goes to stdout.

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using System.Threading.Channels;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dashboard;
 using Microsoft.Extensions.Configuration;
@@ -653,113 +654,24 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var resourceLoggerService = serviceProvider.GetRequiredService<ResourceLoggerService>();
-        var appModel = serviceProvider.GetService<DistributedApplicationModel>();
+        var appModel = serviceProvider.GetRequiredService<DistributedApplicationModel>();
+
+        // Step 1: Calculate the resource names
+        var resourcesToLog = new List<string>();
 
         if (resourceName is not null)
         {
-            // Look up the resource from the app model to get resolved DCP resource names
-            var resource = appModel?.Resources.FirstOrDefault(r => StringComparers.ResourceName.Equals(r.Name, resourceName));
-
-            // Get the resolved resource names (DCP names for replicas)
-            var resolvedNames = resource?.GetResolvedResourceNames() ?? [resourceName];
-            var hasReplicas = resolvedNames.Length > 1;
-
-            if (hasReplicas && follow)
+            var resource = appModel.Resources.FirstOrDefault(r => StringComparers.ResourceName.Equals(r.Name, resourceName));
+            if (resource is null)
             {
-                // For replicas in follow mode, watch each replica individually to preserve source
-                var channel = System.Threading.Channels.Channel.CreateUnbounded<ResourceLogLine>();
-                var watchTasks = new List<Task>();
-
-                foreach (var dcpName in resolvedNames)
-                {
-                    var name = dcpName;
-                    var task = Task.Run(async () =>
-                    {
-                        try
-                        {
-                            await foreach (var batch in resourceLoggerService.WatchAsync(name).WithCancellation(cancellationToken).ConfigureAwait(false))
-                            {
-                                foreach (var logLine in batch)
-                                {
-                                    await channel.Writer.WriteAsync(new ResourceLogLine
-                                    {
-                                        ResourceName = name,
-                                        LineNumber = logLine.LineNumber,
-                                        Content = logLine.Content,
-                                        IsError = logLine.IsErrorMessage
-                                    }, cancellationToken).ConfigureAwait(false);
-                                }
-                            }
-                        }
-                        catch (OperationCanceledException)
-                        {
-                            // Expected when cancelled
-                        }
-                        catch (Exception ex)
-                        {
-                            logger.LogDebug(ex, "Error watching logs for resource {ResourceName}", name);
-                        }
-                    }, cancellationToken);
-                    watchTasks.Add(task);
-                }
-
-                _ = Task.WhenAll(watchTasks).ContinueWith(_ => channel.Writer.Complete(), CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
-
-                await foreach (var logLine in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
-                {
-                    yield return logLine;
-                }
+                logger.LogWarning("Resource '{ResourceName}' not found. No logs will be returned.", resourceName);
+                yield break;
             }
-            else if (hasReplicas)
-            {
-                // For replicas in snapshot mode, get logs from each replica individually
-                foreach (var dcpName in resolvedNames)
-                {
-                    await foreach (var batch in resourceLoggerService.GetAllAsync(dcpName).WithCancellation(cancellationToken).ConfigureAwait(false))
-                    {
-                        foreach (var logLine in batch)
-                        {
-                            yield return new ResourceLogLine
-                            {
-                                ResourceName = dcpName,
-                                LineNumber = logLine.LineNumber,
-                                Content = logLine.Content,
-                                IsError = logLine.IsErrorMessage
-                            };
-                        }
-                    }
-                }
-            }
-            else
-            {
-                // Single resource (no replicas) - use original behavior
-                var logStream = follow
-                    ? resourceLoggerService.WatchAsync(resolvedNames[0])
-                    : resourceLoggerService.GetAllAsync(resolvedNames[0]);
 
-                await foreach (var batch in logStream.WithCancellation(cancellationToken).ConfigureAwait(false))
-                {
-                    foreach (var logLine in batch)
-                    {
-                        yield return new ResourceLogLine
-                        {
-                            ResourceName = resourceName,  // Use app-model name for single resources
-                            LineNumber = logLine.LineNumber,
-                            Content = logLine.Content,
-                            IsError = logLine.IsErrorMessage
-                        };
-                    }
-                }
-            }
+            resourcesToLog.AddRange(resource.GetResolvedResourceNames());
         }
-        else if (follow && appModel is not null)
+        else
         {
-            // Stream logs from all resources (only valid with follow=true)
-            // Create a merged stream from all resources
-            var channel = System.Threading.Channels.Channel.CreateUnbounded<ResourceLogLine>();
-
-            // Start watching all resources in parallel, using DCP names for replicas
-            var watchTasks = new List<Task>();
             foreach (var resource in appModel.Resources)
             {
                 // Skip the dashboard
@@ -768,53 +680,64 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
                     continue;
                 }
 
-                var resolvedNames = resource.GetResolvedResourceNames();
-                var hasReplicas = resolvedNames.Length > 1;
-
-                foreach (var dcpName in resolvedNames)
-                {
-                    // Use DCP name for replicas, app-model name for single resources
-                    var displayName = hasReplicas ? dcpName : resource.Name;
-                    var name = dcpName;
-                    var task = Task.Run(async () =>
-                    {
-                        try
-                        {
-                            await foreach (var batch in resourceLoggerService.WatchAsync(name).WithCancellation(cancellationToken).ConfigureAwait(false))
-                            {
-                                foreach (var logLine in batch)
-                                {
-                                    await channel.Writer.WriteAsync(new ResourceLogLine
-                                    {
-                                        ResourceName = displayName,
-                                        LineNumber = logLine.LineNumber,
-                                        Content = logLine.Content,
-                                        IsError = logLine.IsErrorMessage
-                                    }, cancellationToken).ConfigureAwait(false);
-                                }
-                            }
-                        }
-                        catch (OperationCanceledException)
-                        {
-                            // Expected when cancelled
-                        }
-                        catch (Exception ex)
-                        {
-                            logger.LogDebug(ex, "Error watching logs for resource {ResourceName}", name);
-                        }
-                    }, cancellationToken);
-                    watchTasks.Add(task);
-                }
+                resourcesToLog.AddRange(resource.GetResolvedResourceNames());
             }
+        }
 
-            // Complete the channel when all watch tasks complete
-            _ = Task.WhenAll(watchTasks).ContinueWith(_ => channel.Writer.Complete(), CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
+        if (resourcesToLog.Count == 0)
+        {
+            yield break;
+        }
 
-            // Yield log lines as they arrive
-            await foreach (var logLine in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+        // Step 2: Stream logs from all resources in parallel via a channel.
+        var channel = Channel.CreateUnbounded<ResourceLogLine>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false
+        });
+        var tasks = new List<Task>();
+
+        foreach (var name in resourcesToLog)
+        {
+            var task = Task.Run(async () =>
             {
-                yield return logLine;
-            }
+                try
+                {
+                    var logStream = follow
+                        ? resourceLoggerService.WatchAsync(name)
+                        : resourceLoggerService.GetAllAsync(name);
+
+                    await foreach (var batch in logStream.WithCancellation(cancellationToken).ConfigureAwait(false))
+                    {
+                        foreach (var logLine in batch)
+                        {
+                            await channel.Writer.WriteAsync(new ResourceLogLine
+                            {
+                                ResourceName = name,
+                                LineNumber = logLine.LineNumber,
+                                Content = logLine.Content,
+                                IsError = logLine.IsErrorMessage
+                            }, cancellationToken).ConfigureAwait(false);
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected when cancelled
+                }
+                catch (Exception ex)
+                {
+                    logger.LogDebug(ex, "Error streaming logs for resource {ResourceName}", name);
+                }
+            }, cancellationToken);
+            tasks.Add(task);
+        }
+
+        _ = Task.WhenAll(tasks).ContinueWith(_ => channel.Writer.Complete(), CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
+
+        await foreach (var logLine in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+        {
+            yield return logLine;
         }
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
@@ -388,13 +388,13 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
         Assert.NotNull(logsOutput);
         Assert.Equal(3, logsOutput.Logs.Length);
 
-        // Resources are ordered alphabetically by Name in the output.
-        // Replicas share the same DisplayName, so the unique Name should be used instead
-        Assert.Equal("apiservice-abc123", logsOutput.Logs[0].ResourceName);
-        Assert.Equal("apiservice-def456", logsOutput.Logs[1].ResourceName);
-
+        // Logs are sorted by timestamp.
         // Unique display name should be used for the redis resource
-        Assert.Equal("redis", logsOutput.Logs[2].ResourceName);
+        Assert.Equal("redis", logsOutput.Logs[0].ResourceName);
+
+        // Replicas share the same DisplayName, so the unique Name should be used instead
+        Assert.Equal("apiservice-abc123", logsOutput.Logs[1].ResourceName);
+        Assert.Equal("apiservice-def456", logsOutput.Logs[2].ResourceName);
     }
 
     [Fact]
@@ -470,20 +470,20 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
         Assert.NotNull(logsOutput);
         Assert.Equal(3, logsOutput.Logs.Length);
 
-        // Resources are ordered alphabetically by Name
-        Assert.Equal("apiservice-abc123", logsOutput.Logs[0].ResourceName);
-        Assert.Equal("2025-01-15T10:30:01.000Z", logsOutput.Logs[0].Timestamp);
-        Assert.Equal("Hello from replica 1", logsOutput.Logs[0].Content);
+        // Logs are sorted by timestamp
+        Assert.Equal("redis", logsOutput.Logs[0].ResourceName);
+        Assert.Equal("2025-01-15T10:30:00.000Z", logsOutput.Logs[0].Timestamp);
+        Assert.Equal("Ready to accept connections", logsOutput.Logs[0].Content);
         Assert.False(logsOutput.Logs[0].IsError);
 
-        Assert.Equal("apiservice-def456", logsOutput.Logs[1].ResourceName);
-        Assert.Equal("2025-01-15T10:30:02.000Z", logsOutput.Logs[1].Timestamp);
-        Assert.Equal("Hello from replica 2", logsOutput.Logs[1].Content);
+        Assert.Equal("apiservice-abc123", logsOutput.Logs[1].ResourceName);
+        Assert.Equal("2025-01-15T10:30:01.000Z", logsOutput.Logs[1].Timestamp);
+        Assert.Equal("Hello from replica 1", logsOutput.Logs[1].Content);
         Assert.False(logsOutput.Logs[1].IsError);
 
-        Assert.Equal("redis", logsOutput.Logs[2].ResourceName);
-        Assert.Equal("2025-01-15T10:30:00.000Z", logsOutput.Logs[2].Timestamp);
-        Assert.Equal("Ready to accept connections", logsOutput.Logs[2].Content);
+        Assert.Equal("apiservice-def456", logsOutput.Logs[2].ResourceName);
+        Assert.Equal("2025-01-15T10:30:02.000Z", logsOutput.Logs[2].Timestamp);
+        Assert.Equal("Hello from replica 2", logsOutput.Logs[2].Content);
         Assert.False(logsOutput.Logs[2].IsError);
     }
 
@@ -509,19 +509,20 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(3, logsOutput.Logs.Length);
 
         // Timestamp should be null when --timestamps is not specified
-        Assert.Equal("apiservice-abc123", logsOutput.Logs[0].ResourceName);
+        // Logs are sorted by timestamp
+        Assert.Equal("redis", logsOutput.Logs[0].ResourceName);
         Assert.Null(logsOutput.Logs[0].Timestamp);
-        Assert.Equal("Hello from replica 1", logsOutput.Logs[0].Content);
+        Assert.Equal("Ready to accept connections", logsOutput.Logs[0].Content);
         Assert.False(logsOutput.Logs[0].IsError);
 
-        Assert.Equal("apiservice-def456", logsOutput.Logs[1].ResourceName);
+        Assert.Equal("apiservice-abc123", logsOutput.Logs[1].ResourceName);
         Assert.Null(logsOutput.Logs[1].Timestamp);
-        Assert.Equal("Hello from replica 2", logsOutput.Logs[1].Content);
+        Assert.Equal("Hello from replica 1", logsOutput.Logs[1].Content);
         Assert.False(logsOutput.Logs[1].IsError);
 
-        Assert.Equal("redis", logsOutput.Logs[2].ResourceName);
+        Assert.Equal("apiservice-def456", logsOutput.Logs[2].ResourceName);
         Assert.Null(logsOutput.Logs[2].Timestamp);
-        Assert.Equal("Ready to accept connections", logsOutput.Logs[2].Content);
+        Assert.Equal("Hello from replica 2", logsOutput.Logs[2].Content);
         Assert.False(logsOutput.Logs[2].IsError);
     }
 
@@ -542,12 +543,12 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
 
-        // Resources are ordered alphabetically by Name, timestamp prefix is ISO 8601 round-trip format
+        // Logs are sorted by timestamp, timestamp prefix is ISO 8601 round-trip format
         var logLines = outputWriter.Logs.Where(l => l.StartsWith("2025-", StringComparison.Ordinal)).ToList();
         Assert.Equal(3, logLines.Count);
-        Assert.Equal("2025-01-15T10:30:01.000Z [apiservice-abc123] Hello from replica 1", logLines[0]);
-        Assert.Equal("2025-01-15T10:30:02.000Z [apiservice-def456] Hello from replica 2", logLines[1]);
-        Assert.Equal("2025-01-15T10:30:00.000Z [redis] Ready to accept connections", logLines[2]);
+        Assert.Equal("2025-01-15T10:30:00.000Z [redis] Ready to accept connections", logLines[0]);
+        Assert.Equal("2025-01-15T10:30:01.000Z [apiservice-abc123] Hello from replica 1", logLines[1]);
+        Assert.Equal("2025-01-15T10:30:02.000Z [apiservice-def456] Hello from replica 2", logLines[2]);
     }
 
     [Fact]
@@ -568,11 +569,12 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(ExitCodeConstants.Success, exitCode);
 
         // Without --timestamps, log lines start with "[resourceName]" with no timestamp prefix
+        // Logs are sorted by timestamp
         var logLines = outputWriter.Logs.Where(l => l.StartsWith("[", StringComparison.Ordinal)).ToList();
         Assert.Equal(3, logLines.Count);
-        Assert.Equal("[apiservice-abc123] Hello from replica 1", logLines[0]);
-        Assert.Equal("[apiservice-def456] Hello from replica 2", logLines[1]);
-        Assert.Equal("[redis] Ready to accept connections", logLines[2]);
+        Assert.Equal("[redis] Ready to accept connections", logLines[0]);
+        Assert.Equal("[apiservice-abc123] Hello from replica 1", logLines[1]);
+        Assert.Equal("[apiservice-def456] Hello from replica 2", logLines[2]);
     }
 
     private ServiceProvider CreateLogsTestServices(
@@ -617,6 +619,14 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
             ],
             LogLines =
             [
+                // Log lines are intentionally out of timestamp order to verify sorting
+                new ResourceLogLine
+                {
+                    ResourceName = "apiservice-def456",
+                    LineNumber = 1,
+                    Content = "2025-01-15T10:30:02Z Hello from replica 2",
+                    IsError = false
+                },
                 new ResourceLogLine
                 {
                     ResourceName = "redis",
@@ -629,13 +639,6 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
                     ResourceName = "apiservice-abc123",
                     LineNumber = 1,
                     Content = "2025-01-15T10:30:01Z Hello from replica 1",
-                    IsError = false
-                },
-                new ResourceLogLine
-                {
-                    ResourceName = "apiservice-def456",
-                    LineNumber = 1,
-                    Content = "2025-01-15T10:30:02Z Hello from replica 2",
                     IsError = false
                 }
             ]


### PR DESCRIPTION
## Description

Fixes https://github.com/dotnet/aspire/issues/14646

Follow up to https://github.com/dotnet/aspire/pull/14632. Logs for multiple resources weren't sorted by timestamp across resources

Changes:
- Get logs for all resources in app host
- Logs are fetched in parallel to improve performance
- Add logs sorting in LogEntries collection in CLI
- Refactored `GetResourceLogsAsync` to not be a mess of branches

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
