### PR TITLE
Remove mention of .NET in Aspire CLI settings schema

### DIFF
--- a/extension/schemas/aspire-global-settings.schema.json
+++ b/extension/schemas/aspire-global-settings.schema.json
@@ -3,7 +3,7 @@
   "$id": "https://json.schemastore.org/aspire-global-settings.json",
   "type": "object",
   "title": "Aspire Global Settings",
-  "description": "Global configuration file for .NET Aspire CLI (~/.aspire/settings.json)",
+  "description": "Aspire CLI global configuration file (~/.aspire/settings.json)",
   "properties": {
     "channel": {
       "description": "The Aspire channel to use for package resolution (e.g., \"stable\", \"preview\", \"staging\"). Used by aspire add to determine which NuGet feed to use.",
@@ -59,6 +59,70 @@
             }
           ],
           "description": "Enable or disable the 'aspire exec' command for executing commands inside running resources",
+          "default": false
+        },
+        "experimentalPolyglot:go": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          ],
+          "description": "Enable or disable experimental Go language support for polyglot Aspire applications (requires polyglotSupportEnabled)",
+          "default": false
+        },
+        "experimentalPolyglot:java": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          ],
+          "description": "Enable or disable experimental Java language support for polyglot Aspire applications (requires polyglotSupportEnabled)",
+          "default": false
+        },
+        "experimentalPolyglot:python": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          ],
+          "description": "Enable or disable experimental Python language support for polyglot Aspire applications (requires polyglotSupportEnabled)",
+          "default": false
+        },
+        "experimentalPolyglot:rust": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          ],
+          "description": "Enable or disable experimental Rust language support for polyglot Aspire applications (requires polyglotSupportEnabled)",
           "default": false
         },
         "minimumSdkCheckEnabled": {
@@ -124,77 +188,6 @@
           ],
           "description": "Enable or disable support for non-.NET (polyglot) languages and runtimes in Aspire applications",
           "default": false
-        },
-        "experimentalPolyglot": {
-          "description": "Per-language feature flags for experimental polyglot languages (requires polyglotSupportEnabled).",
-          "type": "object",
-          "properties": {
-            "go": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "true",
-                    "false"
-                  ]
-                }
-              ],
-              "description": "Enable or disable experimental Go language support for polyglot Aspire applications (requires polyglotSupportEnabled)",
-              "default": false
-            },
-            "java": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "true",
-                    "false"
-                  ]
-                }
-              ],
-              "description": "Enable or disable experimental Java language support for polyglot Aspire applications (requires polyglotSupportEnabled)",
-              "default": false
-            },
-            "python": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "true",
-                    "false"
-                  ]
-                }
-              ],
-              "description": "Enable or disable experimental Python language support for polyglot Aspire applications (requires polyglotSupportEnabled)",
-              "default": false
-            },
-            "rust": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "true",
-                    "false"
-                  ]
-                }
-              ],
-              "description": "Enable or disable experimental Rust language support for polyglot Aspire applications (requires polyglotSupportEnabled)",
-              "default": false
-            }
-          },
-          "additionalProperties": false
         },
         "runningInstanceDetectionEnabled": {
           "anyOf": [
@@ -294,27 +287,6 @@
     "sdkVersion": {
       "description": "The Aspire SDK version used for this polyglot AppHost project. Determines the version of Aspire.Hosting packages to use.",
       "type": "string"
-    },
-    "overrideStagingFeed": {
-      "description": "[Internal] Override the NuGet feed URL used by the staging channel. When set, this URL is used instead of the default SHA-based build-specific feed.",
-      "type": "string"
-    },
-    "overrideStagingQuality": {
-      "description": "[Internal] Override the package quality filter for the staging channel. Set to \"Prerelease\" when staging builds are not yet marked as stable to use the shared daily feed instead of the SHA-based feed. Valid values: \"Stable\", \"Prerelease\", \"Both\".",
-      "type": "string",
-      "enum": [
-        "Stable",
-        "Prerelease",
-        "Both"
-      ]
-    },
-    "stagingPinToCliVersion": {
-      "description": "[Internal] When set to \"true\" and using the staging channel with Prerelease quality on the shared feed, all template and integration packages are pinned to the exact version of the installed CLI. This bypasses NuGet search entirely, ensuring version consistency.",
-      "type": "string",
-      "enum": [
-        "true",
-        "false"
-      ]
     }
   },
   "additionalProperties": false

--- a/extension/schemas/aspire-settings.schema.json
+++ b/extension/schemas/aspire-settings.schema.json
@@ -3,7 +3,7 @@
   "$id": "https://json.schemastore.org/aspire-settings.json",
   "type": "object",
   "title": "Aspire Local Settings",
-  "description": "Configuration file for .NET Aspire application host (.aspire/settings.json)",
+  "description": "Aspire CLI local configuration file (.aspire/settings.json)",
   "properties": {
     "appHostPath": {
       "description": "The path to the AppHost entry point file (e.g., \"Program.cs\", \"app.ts\"). Relative to the directory containing .aspire/settings.json.",
@@ -63,6 +63,70 @@
             }
           ],
           "description": "Enable or disable the 'aspire exec' command for executing commands inside running resources",
+          "default": false
+        },
+        "experimentalPolyglot:go": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          ],
+          "description": "Enable or disable experimental Go language support for polyglot Aspire applications (requires polyglotSupportEnabled)",
+          "default": false
+        },
+        "experimentalPolyglot:java": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          ],
+          "description": "Enable or disable experimental Java language support for polyglot Aspire applications (requires polyglotSupportEnabled)",
+          "default": false
+        },
+        "experimentalPolyglot:python": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          ],
+          "description": "Enable or disable experimental Python language support for polyglot Aspire applications (requires polyglotSupportEnabled)",
+          "default": false
+        },
+        "experimentalPolyglot:rust": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          ],
+          "description": "Enable or disable experimental Rust language support for polyglot Aspire applications (requires polyglotSupportEnabled)",
           "default": false
         },
         "minimumSdkCheckEnabled": {
@@ -128,77 +192,6 @@
           ],
           "description": "Enable or disable support for non-.NET (polyglot) languages and runtimes in Aspire applications",
           "default": false
-        },
-        "experimentalPolyglot": {
-          "description": "Per-language feature flags for experimental polyglot languages (requires polyglotSupportEnabled).",
-          "type": "object",
-          "properties": {
-            "go": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "true",
-                    "false"
-                  ]
-                }
-              ],
-              "description": "Enable or disable experimental Go language support for polyglot Aspire applications (requires polyglotSupportEnabled)",
-              "default": false
-            },
-            "java": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "true",
-                    "false"
-                  ]
-                }
-              ],
-              "description": "Enable or disable experimental Java language support for polyglot Aspire applications (requires polyglotSupportEnabled)",
-              "default": false
-            },
-            "python": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "true",
-                    "false"
-                  ]
-                }
-              ],
-              "description": "Enable or disable experimental Python language support for polyglot Aspire applications (requires polyglotSupportEnabled)",
-              "default": false
-            },
-            "rust": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "true",
-                    "false"
-                  ]
-                }
-              ],
-              "description": "Enable or disable experimental Rust language support for polyglot Aspire applications (requires polyglotSupportEnabled)",
-              "default": false
-            }
-          },
-          "additionalProperties": false
         },
         "runningInstanceDetectionEnabled": {
           "anyOf": [
@@ -298,27 +291,6 @@
     "sdkVersion": {
       "description": "The Aspire SDK version used for this polyglot AppHost project. Determines the version of Aspire.Hosting packages to use.",
       "type": "string"
-    },
-    "overrideStagingFeed": {
-      "description": "[Internal] Override the NuGet feed URL used by the staging channel. When set, this URL is used instead of the default SHA-based build-specific feed.",
-      "type": "string"
-    },
-    "overrideStagingQuality": {
-      "description": "[Internal] Override the package quality filter for the staging channel. Set to \"Prerelease\" when staging builds are not yet marked as stable to use the shared daily feed instead of the SHA-based feed. Valid values: \"Stable\", \"Prerelease\", \"Both\".",
-      "type": "string",
-      "enum": [
-        "Stable",
-        "Prerelease",
-        "Both"
-      ]
-    },
-    "stagingPinToCliVersion": {
-      "description": "[Internal] When set to \"true\" and using the staging channel with Prerelease quality on the shared feed, all template and integration packages are pinned to the exact version of the installed CLI. This bypasses NuGet search entirely, ensuring version consistency.",
-      "type": "string",
-      "enum": [
-        "true",
-        "false"
-      ]
     }
   },
   "additionalProperties": false

--- a/extension/scripts/generate-schema.js
+++ b/extension/scripts/generate-schema.js
@@ -41,7 +41,7 @@ try {
     const localSchema = generateJsonSchema(configInfo, configInfo.LocalSettingsSchema, {
         id: 'https://json.schemastore.org/aspire-settings.json',
         title: 'Aspire Local Settings',
-        description: 'Configuration file for .NET Aspire application host (.aspire/settings.json)'
+        description: 'Aspire CLI local configuration file (.aspire/settings.json)'
     });
     fs.writeFileSync(localSchemaOutputPath, JSON.stringify(localSchema, null, 2), 'utf8');
     console.log(`✓ Local schema generated: ${localSchemaOutputPath}`);
@@ -51,7 +51,7 @@ try {
     const globalSchema = generateJsonSchema(configInfo, configInfo.GlobalSettingsSchema, {
         id: 'https://json.schemastore.org/aspire-global-settings.json',
         title: 'Aspire Global Settings',
-        description: 'Global configuration file for .NET Aspire CLI (~/.aspire/settings.json)'
+        description: 'Aspire CLI global configuration file (~/.aspire/settings.json)'
     });
     fs.writeFileSync(globalSchemaOutputPath, JSON.stringify(globalSchema, null, 2), 'utf8');
     console.log(`✓ Global schema generated: ${globalSchemaOutputPath}`);


### PR DESCRIPTION
## Description

This PR updates the Aspire CLI settings schema files to remove ".NET" from property names and descriptions, replacing ".NET Aspire" with just "Aspire" for consistency.

Changes:
- Renamed schema properties from `.NET Aspire` to `Aspire`
- Rebuilt schema files with the updated naming
- Updated the schema generation script to use consistent naming

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No