### PR TITLE
Fix SecurityRule name generation to include "to" and to add an index on conflicts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,21 @@ dotnet test tests/Aspire.Hosting.Testing.Tests/Aspire.Hosting.Testing.Tests.cspr
 
 **Important**: Avoid passing `--no-build` unless you have just built in the same session and there have been no code changes since. In automation or while iterating on code, omit `--no-build` so changes are compiled and picked up by the test run.
 
+### CRITICAL: Do NOT use VSTest-style `--filter` with `dotnet test`
+
+This repo uses **Microsoft.Testing.Platform (MTP)** as the test runner, not VSTest. The classic `--filter` argument (before `--`) uses VSTest filter syntax and **will hang or behave unexpectedly** with MTP.
+
+```bash
+# WRONG - VSTest-style filter, will hang with MTP
+dotnet test tests/Project.Tests/Project.Tests.csproj --filter "FullyQualifiedName~ClassName"
+
+# CORRECT - MTP-native filters go after the -- separator
+dotnet test tests/Project.Tests/Project.Tests.csproj -- --filter-class "*.ClassName"
+dotnet test tests/Project.Tests/Project.Tests.csproj -- --filter-method "*.MethodName"
+```
+
+All test filtering must use MTP-native switches placed **after `--`**. See the filter switches listed below for the full set of options.
+
 ### CRITICAL: Excluding Quarantined and Outerloop Tests
 
 When running tests in automated environments (including Copilot agent), **always exclude quarantined and outerloop tests** to avoid false negatives and long-running tests:

--- a/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkExtensions.cs
@@ -489,7 +489,7 @@ public static class AzureVirtualNetworkExtensions
         // Auto-generate name
         var accessStr = access == SecurityRuleAccess.Allow ? "allow" : "deny";
         var directionStr = direction == SecurityRuleDirection.Inbound ? "inbound" : "outbound";
-        var resolvedName = name ?? GenerateRuleName(accessStr, directionStr, port, from);
+        var resolvedName = name ?? GenerateUniqueRuleName(nsgResource, accessStr, directionStr, port, from, to);
 
         var rule = new AzureSecurityRule
         {
@@ -516,7 +516,23 @@ public static class AzureVirtualNetworkExtensions
         return builder;
     }
 
-    private static string GenerateRuleName(string access, string direction, string? port, string? from)
+    private static string GenerateUniqueRuleName(AzureNetworkSecurityGroupResource nsgResource, string access, string direction, string? port, string? from, string? to)
+    {
+        var baseName = GenerateRuleName(access, direction, port, from, to);
+
+        // Check for conflicts and append an index if needed
+        var candidateName = baseName;
+        var index = 2;
+        while (nsgResource.SecurityRules.Any(r => r.Name == candidateName))
+        {
+            candidateName = $"{baseName}-{index}";
+            index++;
+        }
+
+        return candidateName;
+    }
+
+    private static string GenerateRuleName(string access, string direction, string? port, string? from, string? to)
     {
         var parts = new List<string> { access, direction };
 
@@ -528,6 +544,11 @@ public static class AzureVirtualNetworkExtensions
         if (from is not null)
         {
             parts.Add(from);
+        }
+
+        if (to is not null)
+        {
+            parts.Add(to);
         }
 
         return string.Join("-", parts);

--- a/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkExtensions.cs
@@ -525,6 +525,10 @@ public static class AzureVirtualNetworkExtensions
         var index = 2;
         while (nsgResource.SecurityRules.Any(r => r.Name == candidateName))
         {
+            if (index == 100)
+            {
+                throw new InvalidOperationException($"Could not generate a unique name for security rule '{baseName}'");
+            }
             candidateName = $"{baseName}-{index}";
             index++;
         }


### PR DESCRIPTION
## Description

Also update the test instructions in AGENTS.md to ensure agents don't use the dotnet test --filter syntax becuase that doesn't work. https://github.com/microsoft/testfx/issues/7160

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
