### PR TITLE
Write empty JSON from aspire ps to stdout

### DIFF
--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -100,7 +100,7 @@ internal sealed class PsCommand : BaseCommand
         {
             if (format == OutputFormat.Json)
             {
-                _interactionService.DisplayPlainText("[]");
+                _interactionService.DisplayRawText("[]", ConsoleOutput.Standard);
             }
             else
             {

--- a/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
@@ -183,6 +183,10 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
-        Assert.Equal("[]", string.Join(string.Empty, textWriter.Logs));
+
+        var json = string.Join(string.Empty, textWriter.Logs);
+        var document = JsonDocument.Parse(json);
+        Assert.Equal(JsonValueKind.Array, document.RootElement.ValueKind);
+        Assert.Equal(0, document.RootElement.GetArrayLength());
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
@@ -1,7 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
+using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
+using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.InternalTesting;
@@ -97,6 +100,77 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var textWriter = new TestOutputTextWriter(outputHelper);
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection1 = new TestAppHostAuxiliaryBackchannel
+        {
+            IsInScope = true,
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj"),
+                ProcessId = 1234,
+                CliProcessId = 5678
+            },
+            DashboardUrlsState = new DashboardUrlsState
+            {
+                BaseUrlWithLoginToken = "http://localhost:18888/login?t=abc123"
+            }
+        };
+        var connection2 = new TestAppHostAuxiliaryBackchannel
+        {
+            Hash = "test-hash-2",
+            SocketPath = "/tmp/test2.sock",
+            IsInScope = true,
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App2", "App2.AppHost.csproj"),
+                ProcessId = 9012
+            }
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection1);
+        monitor.AddConnection("hash2", "socket.hash2", connection2);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = textWriter;
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ps --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var jsonOutput = string.Join(string.Empty, textWriter.Logs);
+
+        var appHosts = JsonSerializer.Deserialize(jsonOutput, PsCommandJsonContext.RelaxedEscaping.ListAppHostDisplayInfo);
+        Assert.NotNull(appHosts);
+
+        Assert.Collection(appHosts.OrderBy(a => a.AppHostPid),
+            first =>
+            {
+                Assert.EndsWith("App1.AppHost.csproj", first.AppHostPath);
+                Assert.Equal(1234, first.AppHostPid);
+                Assert.Equal(5678, first.CliPid);
+                Assert.Equal("http://localhost:18888/login?t=abc123", first.DashboardUrl);
+            },
+            second =>
+            {
+                Assert.EndsWith("App2.AppHost.csproj", second.AppHostPath);
+                Assert.Equal(9012, second.AppHostPid);
+                Assert.Null(second.CliPid);
+                Assert.Null(second.DashboardUrl);
+            });
+    }
+
+    [Fact]
+    public async Task PsCommand_JsonFormat_NoResults_WritesEmptyArrayToStdout()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var textWriter = new TestOutputTextWriter(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
             options.OutputTextWriter = textWriter;
@@ -109,5 +183,6 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Equal("[]", string.Join(string.Empty, textWriter.Logs));
     }
 }


### PR DESCRIPTION
## Description

I noticed `aspire ps` was incorrectly writing an empty result to stderr instead of stdout.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
