### PR TITLE
Enable HTTPS support for vnext cosmosdb emulator

### DIFF
--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
@@ -86,7 +86,14 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
     /// </summary>
     public bool IsEmulator => this.IsContainer();
 
-    internal bool IsPreviewEmulator { get; set; }
+    /// <summary>
+    /// Is this instance running a preview emulator version?
+    /// </summary>
+    internal bool IsPreviewEmulator
+    {
+        get => IsEmulator && field;
+        set => field = value;
+    }
 
     /// <summary>
     /// Gets the account endpoint URI expression for the Cosmos DB account.

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
@@ -86,9 +86,7 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
     /// </summary>
     public bool IsEmulator => this.IsContainer();
 
-    internal bool IsPreviewEmulator =>
-        this.TryGetContainerImageName(out var imageName) &&
-        imageName == $"{CosmosDBEmulatorContainerImageTags.Registry}/{CosmosDBEmulatorContainerImageTags.Image}:{CosmosDBEmulatorContainerImageTags.TagVNextPreview}";
+    internal bool IsPreviewEmulator { get; set; }
 
     /// <summary>
     /// Gets the account endpoint URI expression for the Cosmos DB account.
@@ -98,9 +96,7 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
     /// </remarks>
     public ReferenceExpression UriExpression =>
         IsEmulator ?
-            IsPreviewEmulator ?
-                ReferenceExpression.Create($"{EmulatorEndpoint.Property(EndpointProperty.Url)}") :
-                ReferenceExpression.Create($"https://{EmulatorEndpoint.Property(EndpointProperty.IPV4Host)}:{EmulatorEndpoint.Property(EndpointProperty.Port)}") :
+            ReferenceExpression.Create($"{EmulatorEndpoint.Property(EndpointProperty.Url)}") :
             ReferenceExpression.Create($"{ConnectionStringOutput}");
 
     /// <summary>

--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -631,33 +631,11 @@ public static class JavaScriptHostingExtensions
 
         if (builder.ExecutionContext.IsRunMode)
         {
-            builder.Eventing.Subscribe<BeforeStartEvent>((@event, _) =>
+            // Vite only supports a single endpoint, so we have to modify the existing endpoint to use HTTPS instead of
+            // adding a new one.
+            resourceBuilder.SubscribeHttpsEndpointsUpdate(ctx =>
             {
-                var developerCertificateService = @event.Services.GetRequiredService<IDeveloperCertificateService>();
-
-                bool addHttps = false;
-                if (!resourceBuilder.Resource.TryGetLastAnnotation<HttpsCertificateAnnotation>(out var annotation))
-                {
-                    if (developerCertificateService.UseForHttps)
-                    {
-                        // If no certificate is configured, and the developer certificate service supports container trust,
-                        // configure the resource to use the developer certificate for its key pair.
-                        addHttps = true;
-                    }
-                }
-                else if (annotation.UseDeveloperCertificate.GetValueOrDefault(developerCertificateService.UseForHttps) || annotation.Certificate is not null)
-                {
-                    addHttps = true;
-                }
-
-                if (addHttps)
-                {
-                    // Vite only supports a single endpoint, so we have to modify the existing endpoint to use HTTPS instead of
-                    // adding a new one.
-                    resourceBuilder.WithEndpoint("http", ep => ep.UriScheme = "https");
-                }
-
-                return Task.CompletedTask;
+                resourceBuilder.WithEndpoint("http", ep => ep.UriScheme = "https");
             });
         }
 

--- a/src/Aspire.Hosting/ApplicationModel/HttpsEndpointUpdateCallbackContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/HttpsEndpointUpdateCallbackContext.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Context provided to the callback of <see cref="ResourceBuilderExtensions.SubscribeHttpsEndpointsUpdate{TResource}"/>
+/// when an HTTPS certificate is determined to be available for the resource.
+/// </summary>
+[Experimental("ASPIRECERTIFICATES001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public sealed class HttpsEndpointUpdateCallbackContext
+{
+    /// <summary>
+    /// Gets the <see cref="IServiceProvider"/> instance from the application.
+    /// </summary>
+    public required IServiceProvider Services { get; init; }
+
+    /// <summary>
+    /// Gets the <see cref="IResource"/> that is being configured for HTTPS.
+    /// </summary>
+    public required IResource Resource { get; init; }
+
+    /// <summary>
+    /// Gets the <see cref="DistributedApplicationModel"/> instance.
+    /// </summary>
+    public required DistributedApplicationModel Model { get; init; }
+
+    /// <summary>
+    /// Gets the <see cref="CancellationToken"/> for the operation.
+    /// </summary>
+    public required CancellationToken CancellationToken { get; init; }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBConnectionPropertiesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBConnectionPropertiesTests.cs
@@ -65,7 +65,7 @@ public class AzureCosmosDBConnectionPropertiesTests
             property =>
             {
                 Assert.Equal("Uri", property.Key);
-                Assert.Equal("https://{cosmos.bindings.emulator.host}:{cosmos.bindings.emulator.port}", property.Value.ValueExpression);
+                Assert.Equal("{cosmos.bindings.emulator.url}", property.Value.ValueExpression);
             },
             property =>
             {

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBContainerConnectionPropertiesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBContainerConnectionPropertiesTests.cs
@@ -94,7 +94,7 @@ public class AzureCosmosDBContainerConnectionPropertiesTests
             property =>
             {
                 Assert.Equal("Uri", property.Key);
-                Assert.Equal("https://{cosmosdb.bindings.emulator.host}:{cosmosdb.bindings.emulator.port}", property.Value.ValueExpression);
+                Assert.Equal("{cosmosdb.bindings.emulator.url}", property.Value.ValueExpression);
             },
             property =>
             {

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBDatabaseConnectionPropertiesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBDatabaseConnectionPropertiesTests.cs
@@ -81,7 +81,7 @@ public class AzureCosmosDBDatabaseConnectionPropertiesTests
             property =>
             {
                 Assert.Equal("Uri", property.Key);
-                Assert.Equal("https://{cosmosdb.bindings.emulator.host}:{cosmosdb.bindings.emulator.port}", property.Value.ValueExpression);
+                Assert.Equal("{cosmosdb.bindings.emulator.url}", property.Value.ValueExpression);
             },
             property =>
             {

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIRECOSMOSDB001
+#pragma warning disable ASPIRECERTIFICATES001
+
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography.X509Certificates;
@@ -76,7 +79,6 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
     [Fact]
     public void AddAzureCosmosDBWithDataExplorer()
     {
-#pragma warning disable ASPIRECOSMOSDB001 // RunAsPreviewEmulator is experimental
         using var builder = TestDistributedApplicationBuilder.Create();
 
         var cosmos = builder.AddAzureCosmosDB("cosmos");
@@ -89,7 +91,6 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
         // WithDataExplorer doesn't work against the non-preview emulator
         var cosmos2 = builder.AddAzureCosmosDB("cosmos2");
         Assert.Throws<NotSupportedException>(() => cosmos2.RunAsEmulator(e => e.WithDataExplorer()));
-#pragma warning restore ASPIRECOSMOSDB001 // RunAsPreviewEmulator is experimental
     }
 
     [Fact]
@@ -204,7 +205,6 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
         var manifest = await GetManifestWithBicep(model, cosmos.Resource);
 
         await Verify(manifest.BicepText, extension: "bicep");
-            
 
         var cosmosRoles = Assert.Single(model.Resources.OfType<AzureProvisioningResource>(), r => r.Name == "cosmos-roles");
         var cosmosRolesManifest = await GetManifestWithBicep(cosmosRoles, skipPreparer: true);
@@ -260,7 +260,7 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
 
         await Verify(manifest.BicepText, extension: "bicep");
     }
-    
+
     [Fact]
     public async Task AddAzureCosmosDBEmulator()
     {
@@ -288,10 +288,7 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
         using var builder = TestDistributedApplicationBuilder.Create();
 
         builder.AddAzureCosmosDB("cosmos").WithAccessKeyAuthentication().RunAsEmulator();
-
-#pragma warning disable ASPIRECOSMOSDB001
         builder.AddAzureCosmosDB("cosmos2").WithAccessKeyAuthentication().RunAsPreviewEmulator();
-#pragma warning restore ASPIRECOSMOSDB001
 
         var app = builder.Build();
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
@@ -541,10 +538,8 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
     public void RunAsPreviewEmulatorAppliesEmulatorResourceAnnotation()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
-#pragma warning disable ASPIRECOSMOSDB001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         var cosmos = builder.AddAzureCosmosDB("cosmos")
                            .RunAsPreviewEmulator();
-#pragma warning restore ASPIRECOSMOSDB001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
         // Verify that the EmulatorResourceAnnotation is applied
         Assert.True(cosmos.Resource.IsEmulator());
@@ -623,16 +618,12 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
     [Fact]
     public void RunAsPreviewEmulatorRegistersHttpsCertificateConfigurationCallback()
     {
-#pragma warning disable ASPIRECOSMOSDB001
         using var builder = TestDistributedApplicationBuilder.Create();
         var cosmos = builder.AddAzureCosmosDB("cosmos")
                            .RunAsPreviewEmulator();
-#pragma warning restore ASPIRECOSMOSDB001
 
         // Verify that the HttpsCertificateConfigurationCallbackAnnotation is registered
-#pragma warning disable ASPIRECERTIFICATES001
         Assert.Contains(cosmos.Resource.Annotations, a => a is HttpsCertificateConfigurationCallbackAnnotation);
-#pragma warning restore ASPIRECERTIFICATES001
     }
 
     [Fact]
@@ -643,21 +634,16 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
                            .RunAsEmulator();
 
         // Standard (non-preview) emulator should NOT have HTTPS certificate configuration
-#pragma warning disable ASPIRECERTIFICATES001
         Assert.DoesNotContain(cosmos.Resource.Annotations, a => a is HttpsCertificateConfigurationCallbackAnnotation);
-#pragma warning restore ASPIRECERTIFICATES001
     }
 
     [Fact]
     public async Task RunAsPreviewEmulatorHttpsCertificateCallbackSetsExpectedEnvironmentVariables()
     {
-#pragma warning disable ASPIRECOSMOSDB001
         using var builder = TestDistributedApplicationBuilder.Create();
         var cosmos = builder.AddAzureCosmosDB("cosmos")
                            .RunAsPreviewEmulator();
-#pragma warning restore ASPIRECOSMOSDB001
 
-#pragma warning disable ASPIRECERTIFICATES001
         var certConfigAnnotation = Assert.Single(
             cosmos.Resource.Annotations.OfType<HttpsCertificateConfigurationCallbackAnnotation>());
 
@@ -683,19 +669,15 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
         Assert.Contains("EXPLORER_PROTOCOL", env.Keys);
         Assert.Contains("CERT_PATH", env.Keys);
         Assert.DoesNotContain("CERT_SECRET", env.Keys);
-#pragma warning restore ASPIRECERTIFICATES001
     }
 
     [Fact]
     public async Task RunAsPreviewEmulatorHttpsCertificateCallbackSetsPasswordWhenProvided()
     {
-#pragma warning disable ASPIRECOSMOSDB001
         using var builder = TestDistributedApplicationBuilder.Create();
         var cosmos = builder.AddAzureCosmosDB("cosmos")
                            .RunAsPreviewEmulator();
-#pragma warning restore ASPIRECOSMOSDB001
 
-#pragma warning disable ASPIRECERTIFICATES001
         var certConfigAnnotation = Assert.Single(
             cosmos.Resource.Annotations.OfType<HttpsCertificateConfigurationCallbackAnnotation>());
 
@@ -723,14 +705,11 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
         Assert.Contains("CERT_PATH", env.Keys);
         Assert.Contains("CERT_SECRET", env.Keys);
         Assert.Same(passwordParam, env["CERT_SECRET"]);
-#pragma warning restore ASPIRECERTIFICATES001
     }
 
     [Fact]
     public async Task RunAsPreviewEmulatorSwitchesEndpointToHttpsWhenCertificateAvailable()
     {
-#pragma warning disable ASPIRECOSMOSDB001
-#pragma warning disable ASPIRECERTIFICATES001
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
 
         builder.Services.AddSingleton<IDeveloperCertificateService>(new TestDeveloperCertificateService(
@@ -757,15 +736,11 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
 
         var emulatorEndpoint = Assert.Single(cosmos.Resource.Annotations.OfType<EndpointAnnotation>(), e => e.Name == "emulator");
         Assert.Equal("https", emulatorEndpoint.UriScheme);
-#pragma warning restore ASPIRECERTIFICATES001
-#pragma warning restore ASPIRECOSMOSDB001
     }
 
     [Fact]
     public async Task RunAsPreviewEmulatorKeepsHttpWhenNoCertificateAvailable()
     {
-#pragma warning disable ASPIRECOSMOSDB001
-#pragma warning disable ASPIRECERTIFICATES001
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
 
         builder.Services.AddSingleton<IDeveloperCertificateService>(new TestDeveloperCertificateService(
@@ -793,15 +768,11 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
 
         var emulatorEndpoint = Assert.Single(cosmos.Resource.Annotations.OfType<EndpointAnnotation>(), e => e.Name == "emulator");
         Assert.Equal("http", emulatorEndpoint.UriScheme);
-#pragma warning restore ASPIRECERTIFICATES001
-#pragma warning restore ASPIRECOSMOSDB001
     }
 
     [Fact]
     public async Task WithDataExplorerSwitchesEndpointToHttpsWhenCertificateAvailable()
     {
-#pragma warning disable ASPIRECOSMOSDB001
-#pragma warning disable ASPIRECERTIFICATES001
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
 
         builder.Services.AddSingleton<IDeveloperCertificateService>(new TestDeveloperCertificateService(
@@ -826,15 +797,11 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
 
         var dataExplorerEndpoint = Assert.Single(cosmos.Resource.Annotations.OfType<EndpointAnnotation>(), e => e.Name == "data-explorer");
         Assert.Equal("https", dataExplorerEndpoint.UriScheme);
-#pragma warning restore ASPIRECERTIFICATES001
-#pragma warning restore ASPIRECOSMOSDB001
     }
 
     [Fact]
     public async Task WithDataExplorerKeepsHttpWhenNoCertificateAvailable()
     {
-#pragma warning disable ASPIRECOSMOSDB001
-#pragma warning disable ASPIRECERTIFICATES001
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
 
         builder.Services.AddSingleton<IDeveloperCertificateService>(new TestDeveloperCertificateService(
@@ -860,8 +827,6 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
 
         var dataExplorerEndpoint = Assert.Single(cosmos.Resource.Annotations.OfType<EndpointAnnotation>(), e => e.Name == "data-explorer");
         Assert.Equal("http", dataExplorerEndpoint.UriScheme);
-#pragma warning restore ASPIRECERTIFICATES001
-#pragma warning restore ASPIRECOSMOSDB001
     }
 
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "ExecuteBeforeStartHooksAsync")]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -679,8 +679,9 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
 
         await certConfigAnnotation.Callback(context);
 
+        Assert.Contains("PROTOCOL", env.Keys);
+        Assert.Contains("EXPLORER_PROTOCOL", env.Keys);
         Assert.Contains("CERT_PATH", env.Keys);
-        Assert.Contains("KEY_FILE", env.Keys);
         Assert.DoesNotContain("CERT_SECRET", env.Keys);
 #pragma warning restore ASPIRECERTIFICATES001
     }
@@ -717,8 +718,9 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
 
         await certConfigAnnotation.Callback(context);
 
+        Assert.Contains("PROTOCOL", env.Keys);
+        Assert.Contains("EXPLORER_PROTOCOL", env.Keys);
         Assert.Contains("CERT_PATH", env.Keys);
-        Assert.Contains("KEY_FILE", env.Keys);
         Assert.Contains("CERT_SECRET", env.Keys);
         Assert.Same(passwordParam, env["CERT_SECRET"]);
 #pragma warning restore ASPIRECERTIFICATES001


### PR DESCRIPTION
## Description

This enables HTTPS/TLS termination for the vnext emulator using the new `WithHttpsCertificateConfiguration` API. Also adds TLS termination for the data explorer endpoint if enabled.

Fixes #13893

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [ ] No
