### PR TITLE
Consistently send messages to stderr when format is JSON. And display status message in more situations

### DIFF
--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -116,12 +116,9 @@ internal sealed class DescribeCommand : BaseCommand
         var follow = parseResult.GetValue(s_followOption);
         var format = parseResult.GetValue(s_formatOption);
 
-        // When outputting JSON, suppress status messages to keep output machine-readable
-        var scanningMessage = format == OutputFormat.Json ? string.Empty : SharedCommandStrings.ScanningForRunningAppHosts;
-
         var result = await _connectionResolver.ResolveConnectionAsync(
             passedAppHostProjectFile,
-            scanningMessage,
+            SharedCommandStrings.ScanningForRunningAppHosts,
             string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.SelectAppHost, DescribeCommandStrings.SelectAppHostAction),
             SharedCommandStrings.NoInScopeAppHostsShowingAll,
             SharedCommandStrings.AppHostNotRunning,

--- a/src/Aspire.Cli/Commands/DoctorCommand.cs
+++ b/src/Aspire.Cli/Commands/DoctorCommand.cs
@@ -44,12 +44,9 @@ internal sealed class DoctorCommand : BaseCommand
     {
         var format = parseResult.GetValue(s_formatOption);
 
-        // When outputting JSON, suppress status messages to keep output machine-readable
-        var statusMessage = format == OutputFormat.Json ? string.Empty : DoctorCommandStrings.CheckingPrerequisites;
-
         // Run all prerequisite checks
         var results = await InteractionService.ShowStatusAsync(
-            statusMessage,
+            DoctorCommandStrings.CheckingPrerequisites,
             async () => await _environmentChecker.CheckAllAsync(cancellationToken));
 
         if (format == OutputFormat.Json)

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -79,27 +79,19 @@ internal sealed class PsCommand : BaseCommand
 
         // Scan for running AppHosts (same as ListAppHostsTool)
         // Skip status display for JSON output to avoid contaminating stdout
-        List<IAppHostAuxiliaryBackchannel> connections;
-        if (format == OutputFormat.Json)
-        {
-            await _backchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
-            connections = _backchannelMonitor.Connections.ToList();
-        }
-        else
-        {
-            connections = await _interactionService.ShowStatusAsync(
-                SharedCommandStrings.ScanningForRunningAppHosts,
-                async () =>
-                {
-                    await _backchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
-                    return _backchannelMonitor.Connections.ToList();
-                });
-        }
+        var connections = await _interactionService.ShowStatusAsync(
+            SharedCommandStrings.ScanningForRunningAppHosts,
+            async () =>
+            {
+                await _backchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
+                return _backchannelMonitor.Connections.ToList();
+            });
 
         if (connections.Count == 0)
         {
             if (format == OutputFormat.Json)
             {
+                // Structured output always goes to stdout.
                 _interactionService.DisplayRawText("[]", ConsoleOutput.Standard);
             }
             else

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -147,7 +147,7 @@ internal sealed class RunCommand : BaseCommand
         // var force = runningInstanceDetectionEnabled && parseResult.GetValue<bool>("--force");
 
         // Validate that --format is only used with --detach
-        if (format is not null && !detach)
+        if (format == OutputFormat.Json && !detach)
         {
             InteractionService.DisplayError(RunCommandStrings.FormatRequiresDetach);
             return ExitCodeConstants.InvalidCommand;

--- a/src/Aspire.Cli/Commands/StartCommand.cs
+++ b/src/Aspire.Cli/Commands/StartCommand.cs
@@ -68,7 +68,7 @@ internal sealed class StartCommand : BaseCommand
         // If a resource name is provided, start that specific resource
         if (!string.IsNullOrEmpty(resourceName))
         {
-            if (format is not null)
+            if (format == OutputFormat.Json)
             {
                 _interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, ResourceCommandStrings.OptionNotValidWithResource, "--format"));
                 return ExitCodeConstants.InvalidCommand;

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -106,6 +106,8 @@ internal static class TelemetryCommandHelpers
         FileInfo? projectFile,
         CancellationToken cancellationToken)
     {
+        _ = format; // Will be used to conditionally skip status display in JSON mode.
+
         var result = await connectionResolver.ResolveConnectionAsync(
             projectFile,
             SharedCommandStrings.ScanningForRunningAppHosts,

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -106,8 +106,6 @@ internal static class TelemetryCommandHelpers
         FileInfo? projectFile,
         CancellationToken cancellationToken)
     {
-        _ = format; // Will be used to conditionally skip status display in JSON mode.
-
         var result = await connectionResolver.ResolveConnectionAsync(
             projectFile,
             SharedCommandStrings.ScanningForRunningAppHosts,

--- a/src/Aspire.Cli/Properties/launchSettings.json
+++ b/src/Aspire.Cli/Properties/launchSettings.json
@@ -61,6 +61,11 @@
       "dotnetRunMessages": true,
       "commandLineArgs": "--help"
     },
+    "logs": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "commandLineArgs": "logs"
+    },
     "run-testapphost": {
       "commandName": "Project",
       "dotnetRunMessages": true,

--- a/src/Aspire.Cli/Resources/LogsCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/LogsCommandStrings.Designer.cs
@@ -110,5 +110,11 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("SelectAppHostAction", resourceCulture);
             }
         }
+
+        public static string GettingLogs {
+            get {
+                return ResourceManager.GetString("GettingLogs", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/LogsCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/LogsCommandStrings.resx
@@ -153,4 +153,7 @@
   <data name="SelectAppHostAction" xml:space="preserve">
     <value>stream logs from</value>
   </data>
+  <data name="GettingLogs" xml:space="preserve">
+    <value>Getting logs...</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.cs.xlf
@@ -62,6 +62,11 @@
         <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GettingLogs">
+        <source>Getting logs...</source>
+        <target state="new">Getting logs...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.de.xlf
@@ -62,6 +62,11 @@
         <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GettingLogs">
+        <source>Getting logs...</source>
+        <target state="new">Getting logs...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.es.xlf
@@ -62,6 +62,11 @@
         <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GettingLogs">
+        <source>Getting logs...</source>
+        <target state="new">Getting logs...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.fr.xlf
@@ -62,6 +62,11 @@
         <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GettingLogs">
+        <source>Getting logs...</source>
+        <target state="new">Getting logs...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.it.xlf
@@ -62,6 +62,11 @@
         <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GettingLogs">
+        <source>Getting logs...</source>
+        <target state="new">Getting logs...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ja.xlf
@@ -62,6 +62,11 @@
         <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GettingLogs">
+        <source>Getting logs...</source>
+        <target state="new">Getting logs...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ko.xlf
@@ -62,6 +62,11 @@
         <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GettingLogs">
+        <source>Getting logs...</source>
+        <target state="new">Getting logs...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.pl.xlf
@@ -62,6 +62,11 @@
         <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GettingLogs">
+        <source>Getting logs...</source>
+        <target state="new">Getting logs...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.pt-BR.xlf
@@ -62,6 +62,11 @@
         <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GettingLogs">
+        <source>Getting logs...</source>
+        <target state="new">Getting logs...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.ru.xlf
@@ -62,6 +62,11 @@
         <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GettingLogs">
+        <source>Getting logs...</source>
+        <target state="new">Getting logs...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.tr.xlf
@@ -62,6 +62,11 @@
         <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GettingLogs">
+        <source>Getting logs...</source>
+        <target state="new">Getting logs...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.zh-Hans.xlf
@@ -62,6 +62,11 @@
         <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GettingLogs">
+        <source>Getting logs...</source>
+        <target state="new">Getting logs...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/LogsCommandStrings.zh-Hant.xlf
@@ -62,6 +62,11 @@
         <target state="new">Show timestamps for each log line.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GettingLogs">
+        <source>Getting logs...</source>
+        <target state="new">Getting logs...</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Commands;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Cli.Tests.Commands;
+
+public class BaseCommandTests(ITestOutputHelper outputHelper)
+{
+    [Theory]
+    [InlineData("ps", false)]
+    [InlineData("ps --format json", true)]
+    [InlineData("ps --format table", false)]
+    [InlineData("ps --format invalid", false)]
+    [InlineData("docs --format json", false)]
+    public async Task BaseCommand_FormatOption_SetsConsoleOutputCorrectly(string args, bool expectErrorConsole)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var testInteractionService = new TestConsoleInteractionService();
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = _ => testInteractionService;
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse(args);
+
+        await result.InvokeAsync().DefaultTimeout();
+
+        var expected = expectErrorConsole ? ConsoleOutput.Error : ConsoleOutput.Standard;
+        Assert.Equal(expected, testInteractionService.Console);
+    }
+}


### PR DESCRIPTION
## Description

Consistently output non-JSON content to stderr when format is JSON. Set in BaseCommand to automatically set value.

Also display status message in more commands even when format is JSON because it's sent to stderr.
Also display status message when getting logs because it can take a while. Addresses https://github.com/dotnet/aspire/issues/14646

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
