### PR TITLE
Add WithPurgeTask to Azure Container Registry for scheduled image cleanup

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -117,6 +117,7 @@
     <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.5.0" />
     <PackageVersion Include="MySqlConnector.Logging.Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageVersion Include="NATS.Net" Version="2.7.2" />
+    <PackageVersion Include="NCrontab.Signed" Version="3.4.0" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.1" />
     <PackageVersion Include="OpenAI" Version="2.7.0" />
     <PackageVersion Include="Oracle.ManagedDataAccess.OpenTelemetry" Version="23.26.100" />

--- a/src/Aspire.Hosting.Azure.ContainerRegistry/Aspire.Hosting.Azure.ContainerRegistry.csproj
+++ b/src/Aspire.Hosting.Azure.ContainerRegistry/Aspire.Hosting.Azure.ContainerRegistry.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <PackageReference Include="Azure.Provisioning" />
     <PackageReference Include="Azure.Provisioning.ContainerRegistry" />
+    <PackageReference Include="NCrontab.Signed" />
   </ItemGroup>
 
 

--- a/src/Aspire.Hosting.Azure.ContainerRegistry/AzureContainerRegistryExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ContainerRegistry/AzureContainerRegistryExtensions.cs
@@ -3,10 +3,14 @@
 
 #pragma warning disable ASPIRECOMPUTE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
+using System.Globalization;
+using System.Text;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Azure.Provisioning;
 using Azure.Provisioning.ContainerRegistry;
+using Azure.Provisioning.Expressions;
+using NCrontab;
 
 namespace Aspire.Hosting;
 
@@ -109,6 +113,132 @@ public static class AzureContainerRegistryExtensions
     }
 
     /// <summary>
+    /// Gets the <see cref="AzureContainerRegistryResource"/> associated with the specified Azure compute environment resource.
+    /// </summary>
+    /// <typeparam name="T">The resource type that implements <see cref="IAzureComputeEnvironmentResource"/>.</typeparam>
+    /// <param name="builder">The resource builder for the compute environment resource.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{AzureContainerRegistryResource}"/> for the associated registry.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the resource does not have an associated Azure Container Registry,
+    /// or when the associated container registry is not an <see cref="AzureContainerRegistryResource"/>.</exception>
+    public static IResourceBuilder<AzureContainerRegistryResource> GetAzureContainerRegistry<T>(this IResourceBuilder<T> builder)
+        where T : IResource, IAzureComputeEnvironmentResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        var containerRegistry = builder.Resource.ContainerRegistry ?? throw new InvalidOperationException($"The resource '{builder.Resource.Name}' does not have an associated Azure Container Registry.");
+        var registry = containerRegistry as AzureContainerRegistryResource ?? throw new InvalidOperationException($"The Container Registry associated with resource '{builder.Resource.Name}' is not an Azure Container Registry.");
+
+        return builder.ApplicationBuilder.CreateResourceBuilder(registry);
+    }
+
+    /// <summary>
+    /// Adds a scheduled ACR purge task to remove old or unused container images from the registry.
+    /// </summary>
+    /// <param name="builder">The resource builder for the <see cref="AzureContainerRegistryResource"/>.</param>
+    /// <param name="schedule">The cron schedule for the purge task timer trigger. Must be a five-part cron expression
+    /// (<c>minute hour day-of-month month day-of-week</c>); seconds are not supported.</param>
+    /// <param name="filter">An optional filter for the <c>acr purge --filter</c> parameter. Only repositories matching this
+    /// filter will be purged. Defaults to <c>".*:.*"</c> (all repositories and tags) when <see langword="null"/>.</param>
+    /// <param name="ago">The age threshold for <c>acr purge --ago</c>. Images older than this duration will be considered
+    /// for removal. Uses Go-style duration format (e.g., <c>2d3h6m</c>). Defaults to <c>0d</c> when <see langword="null"/>.</param>
+    /// <param name="keep">The number of most recent images to keep per repository, regardless of age.
+    /// Must be greater than zero. Defaults to 3.</param>
+    /// <param name="taskName">An optional name for the ACR task resource. If not provided, a name is auto-generated
+    /// based on existing purge tasks to avoid conflicts. If a task with the specified name already exists,
+    /// an <see cref="ArgumentException"/> is thrown.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{AzureContainerRegistryResource}"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="schedule"/> is <see langword="null"/>, empty, or whitespace,
+    /// or when <paramref name="taskName"/> conflicts with an existing task.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="keep"/> is less than 1,
+    /// or <paramref name="ago"/> is negative or less than 1 minute (when non-zero).</exception>
+    /// <example>
+    /// This example configures a daily purge task that removes images older than 7 days, keeping the 5 most recent:
+    /// <code>
+    /// var acr = builder.AddAzureContainerRegistry("myregistry")
+    ///     .WithPurgeTask("0 1 * * *", ago: TimeSpan.FromDays(7), keep: 5);
+    /// </code>
+    /// </example>
+    public static IResourceBuilder<AzureContainerRegistryResource> WithPurgeTask(
+        this IResourceBuilder<AzureContainerRegistryResource> builder,
+        string schedule,
+        string? filter = null,
+        TimeSpan? ago = null,
+        int keep = 3,
+        string? taskName = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(schedule);
+        schedule = schedule.Trim();
+        _ = CrontabSchedule.Parse(schedule, new CrontabSchedule.ParseOptions { IncludingSeconds = false });
+
+        if (keep < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(keep), keep, "Keep must be greater than zero.");
+        }
+
+        var purgeAgo = FormatAgo(ago ?? TimeSpan.Zero);
+
+        return builder.ConfigureInfrastructure(infra =>
+        {
+            var prefix = "purgeOldImages";
+
+            var registry = infra.GetProvisionableResources().OfType<ContainerRegistryService>().Single();
+            var allTasks = infra.GetProvisionableResources().OfType<ContainerRegistryTask>()
+                .Where(t => t.Parent == registry)
+                .ToList();
+            var autoNamedTasks = allTasks
+                .Where(t => t.Name.Value?.StartsWith(prefix, StringComparison.Ordinal) == true)
+                .ToList();
+            var taskIndex = autoNamedTasks.Count;
+
+            if (!string.IsNullOrWhiteSpace(taskName))
+            {
+                if (allTasks.Any(t => string.Equals(t.Name.Value, taskName, StringComparison.Ordinal)))
+                {
+                    throw new ArgumentException($"A purge task with the name '{taskName}' already exists.", nameof(taskName));
+                }
+            }
+            else
+            {
+                taskName = taskIndex == 0 ? prefix : $"{prefix}_{taskIndex}";
+            }
+
+            var bicepIdentifier = $"{prefix}_{taskIndex}";
+
+            var purgeTaskCmdVariable = new ProvisioningVariable($"purgeTaskCmd_{taskIndex}", typeof(string))
+            {
+                Value = CreatePurgeTaskContent(filter, purgeAgo, keep)
+            };
+            infra.Add(purgeTaskCmdVariable);
+
+            var purgeTask = new ContainerRegistryTask(bicepIdentifier)
+            {
+                Name = taskName,
+                Parent = registry,
+                Platform = { OS = ContainerRegistryOS.Linux },
+                Step = new ContainerRegistryEncodedTaskStep
+                {
+                    EncodedTaskContent = new FunctionCallExpression(new IdentifierExpression("base64"), [new IdentifierExpression(purgeTaskCmdVariable.BicepIdentifier)])
+                },
+                Trigger =
+                {
+                    TimerTriggers =
+                    [
+                        new ContainerRegistryTimerTrigger
+                        {
+                            Name = $"{taskName}_trigger",
+                            Schedule = schedule
+                        }
+                    ]
+                }
+            };
+            infra.Add(purgeTask);
+        });
+    }
+
+    /// <summary>
     /// Adds role assignments to the specified Azure Container Registry resource.
     /// </summary>
     /// <typeparam name="T">The type of the resource being configured.</typeparam>
@@ -123,5 +253,52 @@ public static class AzureContainerRegistryExtensions
         where T : IResource
     {
         return builder.WithRoleAssignments(target, ContainerRegistryBuiltInRole.GetBuiltInRoleName, roles);
+    }
+
+    private static string CreatePurgeTaskContent(string? filter, string ago, int keep)
+    {
+        return $"""
+            version: v1.1.0
+            steps:
+            - cmd: acr purge --filter '{filter ?? ".*:.*"}' --ago {ago} --keep {keep}
+            """.ReplaceLineEndings("\n");
+    }
+
+    // Formats a TimeSpan into a string representation compatible with the `--ago` parameter of the `az acr purge` command, using the largest appropriate time unit (days, hours, or minutes).
+    // From the docs: https://learn.microsoft.com/azure/container-registry/container-registry-auto-purge#example-scheduled-purge-of-multiple-repositories-in-a-registry
+    //   A Go-style duration string to indicate a duration beyond which images are deleted. The duration consists of a sequence
+    //   of one or more decimal numbers, each with a unit suffix. Valid time units include "d" for days, "h" for hours, and "m"
+    //   for minutes. For example, --ago 2d3h6m selects all filtered images last modified more than two days, 3 hours, and 6 minutes
+    //   ago, and --ago 1.5h selects images last modified more than 1.5 hours ago.
+    private static string FormatAgo(TimeSpan ago)
+    {
+        if (ago.TotalMinutes < 1 && ago != TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(ago), ago, "Ago must be at least 1 minute to be compatible with acr purge.");
+        }
+
+        if (ago == TimeSpan.Zero)
+        {
+            return "0d";
+        }
+
+        var sb = new StringBuilder();
+
+        if (ago.Days > 0)
+        {
+            sb.Append(CultureInfo.InvariantCulture, $"{ago.Days}d");
+        }
+
+        if (ago.Hours > 0)
+        {
+            sb.Append(CultureInfo.InvariantCulture, $"{ago.Hours}h");
+        }
+
+        if (ago.Minutes > 0)
+        {
+            sb.Append(CultureInfo.InvariantCulture, $"{ago.Minutes}m");
+        }
+
+        return sb.ToString();
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerRegistryTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerRegistryTests.cs
@@ -279,7 +279,7 @@ public class AzureContainerRegistryTests
 
         var acr = builder.AddAzureContainerRegistry("acr");
 
-        Assert.ThrowsAny<Exception>(() => acr.WithPurgeTask(schedule));
+        Assert.ThrowsAny<ArgumentException>(() => acr.WithPurgeTask(schedule));
     }
 
     [Fact]
@@ -343,7 +343,7 @@ public class AzureContainerRegistryTests
     }
 
     [Fact]
-    public async Task GetAzureContainerRegistry_ReturnsRegistryFromEnvironment()
+    public void GetAzureContainerRegistry_ReturnsRegistryFromEnvironment()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
@@ -357,7 +357,7 @@ public class AzureContainerRegistryTests
     }
 
     [Fact]
-    public async Task GetAzureContainerRegistry_ReturnsDefaultRegistryWhenNoExplicitRegistry()
+    public void GetAzureContainerRegistry_ReturnsDefaultRegistryWhenNoExplicitRegistry()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
@@ -370,7 +370,7 @@ public class AzureContainerRegistryTests
     }
 
     [Fact]
-    public async Task GetAzureContainerRegistry_ThrowWhenExplicitNoRegistry()
+    public void GetAzureContainerRegistry_ThrowWhenExplicitNoRegistry()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerRegistryTests.WithPurgeTask_CustomTaskName_UsedInBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerRegistryTests.WithPurgeTask_CustomTaskName_UsedInBicep.verified.bicep
@@ -1,0 +1,42 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+resource acr 'Microsoft.ContainerRegistry/registries@2025-04-01' = {
+  name: take('acr${uniqueString(resourceGroup().id)}', 50)
+  location: location
+  sku: {
+    name: 'Basic'
+  }
+  tags: {
+    'aspire-resource-name': 'acr'
+  }
+}
+
+var purgeTaskCmd_0 = 'version: v1.1.0\nsteps:\n- cmd: acr purge --filter \'.*:.*\' --ago 0d --keep 3'
+
+resource purgeOldImages_0 'Microsoft.ContainerRegistry/registries/tasks@2019-04-01' = {
+  name: 'myCustomPurge'
+  location: location
+  properties: {
+    platform: {
+      os: 'Linux'
+    }
+    step: {
+      type: 'EncodedTask'
+      encodedTaskContent: base64(purgeTaskCmd_0)
+    }
+    trigger: {
+      timerTriggers: [
+        {
+          schedule: '0 3 * * *'
+          name: 'myCustomPurge_trigger'
+        }
+      ]
+    }
+  }
+  parent: acr
+}
+
+output name string = acr.name
+
+output loginServer string = acr.properties.loginServer

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerRegistryTests.WithPurgeTask_GeneratesCorrectBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerRegistryTests.WithPurgeTask_GeneratesCorrectBicep.verified.bicep
@@ -1,0 +1,42 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+resource acr 'Microsoft.ContainerRegistry/registries@2025-04-01' = {
+  name: take('acr${uniqueString(resourceGroup().id)}', 50)
+  location: location
+  sku: {
+    name: 'Basic'
+  }
+  tags: {
+    'aspire-resource-name': 'acr'
+  }
+}
+
+var purgeTaskCmd_0 = 'version: v1.1.0\nsteps:\n- cmd: acr purge --filter \'.*:.*\' --ago 7d --keep 5'
+
+resource purgeOldImages_0 'Microsoft.ContainerRegistry/registries/tasks@2019-04-01' = {
+  name: 'purgeOldImages'
+  location: location
+  properties: {
+    platform: {
+      os: 'Linux'
+    }
+    step: {
+      type: 'EncodedTask'
+      encodedTaskContent: base64(purgeTaskCmd_0)
+    }
+    trigger: {
+      timerTriggers: [
+        {
+          schedule: '0 1 * * *'
+          name: 'purgeOldImages_trigger'
+        }
+      ]
+    }
+  }
+  parent: acr
+}
+
+output name string = acr.name
+
+output loginServer string = acr.properties.loginServer

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerRegistryTests.WithPurgeTask_MultipleTasks_GeneratesUniqueNames.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerRegistryTests.WithPurgeTask_MultipleTasks_GeneratesUniqueNames.verified.bicep
@@ -1,0 +1,67 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+resource acr 'Microsoft.ContainerRegistry/registries@2025-04-01' = {
+  name: take('acr${uniqueString(resourceGroup().id)}', 50)
+  location: location
+  sku: {
+    name: 'Basic'
+  }
+  tags: {
+    'aspire-resource-name': 'acr'
+  }
+}
+
+var purgeTaskCmd_0 = 'version: v1.1.0\nsteps:\n- cmd: acr purge --filter \'app1:.*\' --ago 0d --keep 3'
+
+resource purgeOldImages_0 'Microsoft.ContainerRegistry/registries/tasks@2019-04-01' = {
+  name: 'purgeOldImages'
+  location: location
+  properties: {
+    platform: {
+      os: 'Linux'
+    }
+    step: {
+      type: 'EncodedTask'
+      encodedTaskContent: base64(purgeTaskCmd_0)
+    }
+    trigger: {
+      timerTriggers: [
+        {
+          schedule: '0 1 * * *'
+          name: 'purgeOldImages_trigger'
+        }
+      ]
+    }
+  }
+  parent: acr
+}
+
+var purgeTaskCmd_1 = 'version: v1.1.0\nsteps:\n- cmd: acr purge --filter \'app2:.*\' --ago 30d --keep 10'
+
+resource purgeOldImages_1 'Microsoft.ContainerRegistry/registries/tasks@2019-04-01' = {
+  name: 'purgeOldImages_1'
+  location: location
+  properties: {
+    platform: {
+      os: 'Linux'
+    }
+    step: {
+      type: 'EncodedTask'
+      encodedTaskContent: base64(purgeTaskCmd_1)
+    }
+    trigger: {
+      timerTriggers: [
+        {
+          schedule: '0 2 * * 0'
+          name: 'purgeOldImages_1_trigger'
+        }
+      ]
+    }
+  }
+  parent: acr
+}
+
+output name string = acr.name
+
+output loginServer string = acr.properties.loginServer

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerRegistryTests.WithPurgeTask_WithHoursAndMinutesAgo_FormatsCorrectly.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerRegistryTests.WithPurgeTask_WithHoursAndMinutesAgo_FormatsCorrectly.verified.bicep
@@ -1,0 +1,42 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+resource acr 'Microsoft.ContainerRegistry/registries@2025-04-01' = {
+  name: take('acr${uniqueString(resourceGroup().id)}', 50)
+  location: location
+  sku: {
+    name: 'Basic'
+  }
+  tags: {
+    'aspire-resource-name': 'acr'
+  }
+}
+
+var purgeTaskCmd_0 = 'version: v1.1.0\nsteps:\n- cmd: acr purge --filter \'.*:.*\' --ago 2d3h6m --keep 3'
+
+resource purgeOldImages_0 'Microsoft.ContainerRegistry/registries/tasks@2019-04-01' = {
+  name: 'purgeOldImages'
+  location: location
+  properties: {
+    platform: {
+      os: 'Linux'
+    }
+    step: {
+      type: 'EncodedTask'
+      encodedTaskContent: base64(purgeTaskCmd_0)
+    }
+    trigger: {
+      timerTriggers: [
+        {
+          schedule: '0 0 * * *'
+          name: 'purgeOldImages_trigger'
+        }
+      ]
+    }
+  }
+  parent: acr
+}
+
+output name string = acr.name
+
+output loginServer string = acr.properties.loginServer


### PR DESCRIPTION
## Summary

Adds a `WithPurgeTask` extension method on `IResourceBuilder<AzureContainerRegistryResource>` that provisions a `ContainerRegistryTask` with a timer-triggered `acr purge` command to automatically remove old/unused container images on a schedule.

## Usage

```csharp
var acr = builder.AddAzureContainerRegistry("myregistry")
    .WithPurgeTask("0 1 * * *", ago: TimeSpan.FromDays(7), keep: 5);
```

## Features

- **Cron schedule validation** using NCrontab (5-part expressions)
- **Configurable parameters**: filter, age threshold (\--ago\), and keep count
- **Multiple purge tasks** per registry with auto-indexed naming
- **Custom task names** with duplicate detection
- **Go-style duration formatting** for the \--ago\ parameter (e.g., \2d3h6m\)

## Changes

- `Directory.Packages.props` — Added `NCrontab.Signed` v3.4.0
- `Aspire.Hosting.Azure.ContainerRegistry.csproj` — Added `NCrontab.Signed` package reference
- `AzureContainerRegistryExtensions.cs` — Added `WithPurgeTask` method, helper methods, and XML docs for `GetAzureContainerRegistry`
- `AzureContainerRegistryTests.cs` — Added 12 tests covering Bicep generation, multiple tasks, custom names, duration formatting, input validation, and `GetAzureContainerRegistry`

## Generated Bicep

The purge task generates Bicep like:

```bicep
var purgeTaskCmd_0 = 'version: v1.1.0\nsteps:\n- cmd: acr purge --filter \x27.*:.*\x27 --ago 7d --keep 5'

resource purgeOldImages_0 'Microsoft.ContainerRegistry/registries/tasks@2019-04-01' = {
  name: 'purgeOldImages'
  location: location
  properties: {
    platform: { os: 'Linux' }
    step: {
      type: 'EncodedTask'
      encodedTaskContent: base64(purgeTaskCmd_0)
    }
    trigger: {
      timerTriggers: [{ schedule: '0 1 * * *', name: 'purgeOldImages_trigger' }]
    }
  }
  parent: acr
}
```
