### PR TITLE
Fix extension README command table to match actual commands

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -7,16 +7,19 @@ The Aspire VS Code extension provides a set of commands and tools to help you wo
 
 The extension adds the following commands to VS Code:
 
-| Command | Description | Availability |
-|---------|-------------|--------------|
-| Aspire: New Aspire project | Create a new Aspire apphost or starter app from a template. | Available |
-| Aspire: Add an integration | Add a hosting integration (`Aspire.Hosting.*`) to the Aspire apphost. | Available |
-| Aspire: Configure launch.json | Adds the default Aspire debugger launch configuration to your workspace's `launch.json`, which will detect and run the apphost in the workspace. | Available |
-| Aspire: Manage configuration settings | Manage configuration settings including feature flags. | Available |
-| Aspire: Open Aspire terminal | Open an Aspire VS Code terminal for working with Aspire projects. | Available |
-| Aspire: Publish deployment artifacts | Generates deployment artifacts for an Aspire apphost. | Preview |
-| Aspire: Deploy app | Deploy the contents of an Aspire apphost to its defined deployment targets. | Preview |
-| Aspire: Update integrations | Update hosting integrations and Aspire SDK in the apphost. | Preview |
+| Command | Description |
+|---------|-------------|
+| Aspire: New Aspire project | Create a new Aspire apphost or starter app from a template. |
+| Aspire: Initialize Aspire | Initialize Aspire in an existing project. |
+| Aspire: Add an integration | Add a hosting integration (`Aspire.Hosting.*`) to the Aspire apphost. |
+| Aspire: Update integrations | Update hosting integrations and Aspire SDK in the apphost. |
+| Aspire: Publish deployment artifacts | Generate deployment artifacts for an Aspire apphost. |
+| Aspire: Deploy app | Deploy the contents of an Aspire apphost to its defined deployment targets. |
+| Aspire: Configure launch.json file | Add the default Aspire debugger launch configuration to your workspace's `launch.json`. |
+| Aspire: Extension settings | Open Aspire extension settings. |
+| Aspire: Open local Aspire settings | Open the local `.aspire/settings.json` file for the current workspace. |
+| Aspire: Open global Aspire settings | Open the global `~/.aspire/globalsettings.json` file. |
+| Aspire: Open Aspire terminal | Open an Aspire VS Code terminal for working with Aspire projects. |
 
 All commands are available from the Command Palette (`Cmd+Shift+P` or `Ctrl+Shift+P`) and are grouped under the "Aspire" category.
 


### PR DESCRIPTION
## Description

The extension README command table was out of sync with the actual commands registered in `package.nls.json`. This updates it to be consistent.

Changes:
- **Renamed commands** to match their actual titles:
  - "Configure launch.json" → "Configure launch.json file"
  - "Manage configuration settings" → "Extension settings"
- **Added missing commands** that were in `package.nls.json` but not in the README:
  - "Initialize Aspire"
  - "Open local Aspire settings"
  - "Open global Aspire settings"
- **Removed the "Availability" column** — the "Available"/"Preview" distinction was not reflected in the codebase and was outdated.

Fixes #14425

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
