### PR TITLE
Add networkIsolationPolicy to 1ES pipeline templates for SFI-ES4.2.4 compliance

### DIFF
--- a/eng/pipelines/azure-pipelines-unofficial.yml
+++ b/eng/pipelines/azure-pipelines-unofficial.yml
@@ -39,6 +39,8 @@ resources:
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean2
     featureFlags:
       autoEnablePREfastWithNewRuleset: false
       autoEnableRoslynWithNewRuleset: false

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -104,6 +104,8 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean2
     featureFlags:
       autoEnablePREfastWithNewRuleset: false
       autoEnableRoslynWithNewRuleset: false


### PR DESCRIPTION
## Summary

Adds `networkIsolationPolicy: Permissive,CFSClean2` to the 1ES pipeline template parameters to resolve the [SFI-ES4.2.4] "Network Isolation for CFS endpoints" S360 KPI violation (CFSClean violation type).

## Background

The S360 KPI [SFI-ES4.2.4] requires that CI/CD pipelines use Central Feed Service (CFS) package feeds, Azure Artifacts feeds, rather than public package registries, to enforce supply chain security and network isolation.

Our NuGet.config already exclusively uses Azure Artifacts/CFS-compliant feeds (all pointing to pkgs.dev.azure.com/dnceng or dnceng.pkgs.visualstudio.com). No public feeds like nuget.org are referenced. However, the 1ES pipeline template parameters were missing the `networkIsolationPolicy` declaration, which is what the compliance scanner checks for.

## What the setting means

- **Permissive** - Allows broader outbound network access during pipeline runs. This is appropriate for public/OSS repos that need to access multiple Azure Artifacts feeds, npm registries (for the VS Code extension build), and other legitimate external endpoints.
- **CFSClean2** - Declares CFS compliance at the current wave level, confirming that package dependency resolution goes through Azure Artifacts/CFS rather than direct public registries.

## Precedent

This is the same approach used by dotnet/source-indexer (see their azure-pipelines.yml), which previously had the same CFSClean violation and resolved it with this one-line setting.

## Changes

- `eng/pipelines/azure-pipelines.yml` - Added `settings.networkIsolationPolicy: Permissive,CFSClean2` under `extends.parameters`
- `eng/pipelines/azure-pipelines-unofficial.yml` - Same change applied
