### PR TITLE
Fix flaky test: thread-safe test fakes for concurrent pipeline steps

### DIFF
--- a/tests/Aspire.Hosting.Tests/MockImageBuilder.cs
+++ b/tests/Aspire.Hosting.Tests/MockImageBuilder.cs
@@ -12,6 +12,8 @@ namespace Aspire.Hosting.Tests;
 /// </summary>
 public sealed class MockImageBuilder : IResourceContainerImageManager
 {
+    private readonly object _lock = new();
+
     public bool BuildImageCalled { get; private set; }
     public bool BuildImagesCalled { get; private set; }
     public bool PushImageCalled { get; private set; }
@@ -21,22 +23,31 @@ public sealed class MockImageBuilder : IResourceContainerImageManager
 
     public Task BuildImageAsync(IResource resource, CancellationToken cancellationToken = default)
     {
-        BuildImageCalled = true;
-        BuildImageResources.Add(resource);
+        lock (_lock)
+        {
+            BuildImageCalled = true;
+            BuildImageResources.Add(resource);
+        }
         return Task.CompletedTask;
     }
 
     public Task BuildImagesAsync(IEnumerable<IResource> resources, CancellationToken cancellationToken = default)
     {
-        BuildImagesCalled = true;
-        BuildImageResources.AddRange(resources);
+        lock (_lock)
+        {
+            BuildImagesCalled = true;
+            BuildImageResources.AddRange(resources);
+        }
         return Task.CompletedTask;
     }
 
     public Task PushImageAsync(IResource resource, CancellationToken cancellationToken)
     {
-        PushImageCalled = true;
-        PushImageCalls.Add(resource);
+        lock (_lock)
+        {
+            PushImageCalled = true;
+            PushImageCalls.Add(resource);
+        }
         return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
## Fix for flaky test: DeployAsync_WithMultipleComputeEnvironments_Works

Fixes #13287

### Root Cause
`FakeContainerRuntime` and `MockImageBuilder` use `List<T>` for tracking concurrent method calls, but pipeline steps execute concurrently via `Task.WhenAll`. This causes `List<T>.Add()` race conditions where entries are lost, leading to intermittent `Assert.Contains()` failures.

**Windows (34% failure rate)** was most affected because its thread scheduler is more aggressive about interleaving concurrent task continuations.

### Fix
Added `lock` synchronization to all mutation methods in both test fakes. This preserves the `List<T>` types (keeping all existing test assertions including indexing and ordering compatible) while making writes thread-safe.

### Verification
| Run | Config | Result |
|-----|--------|--------|
| Pre-fix (macOS) | 1 iteration | 1 failure (100%) ❌ |
| Post-fix first attempt | 8 iterations | 1 failure at iter 8 (discovered MockImageBuilder also needed fix) |
| Post-fix both fixes | 30 iterations | All passed ✅ |

### Files Changed
- `tests/Aspire.Hosting.Tests/Publishing/FakeContainerRuntime.cs` — Added lock synchronization to all methods
- `tests/Aspire.Hosting.Tests/MockImageBuilder.cs` — Added lock synchronization to all methods