### PR TITLE
Update pipeline images to non-deprecated pools

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -106,7 +106,7 @@ extends:
         justificationForDisabling: 'see https://portal.microsofticm.com/imp/v3/incidents/incident/482258316/summary'
       sourceAnalysisPool:
         name: NetCore1ESPool-Internal
-        image: windows.vs2022preview.amd64
+        image: windows.vs2026preview.scout.amd64
         os: windows
       tsa:
         enabled: true
@@ -200,7 +200,7 @@ extends:
 
             pool:
               name: NetCore1ESPool-Internal
-              image: windows.vs2022preview.amd64
+              image: windows.vs2026preview.scout.amd64
               os: windows
 
             variables:

--- a/eng/pipelines/templates/build_sign_native.yml
+++ b/eng/pipelines/templates/build_sign_native.yml
@@ -39,7 +39,7 @@ jobs:
         pool:
           ${{ if eq(parameters.agentOs, 'windows') }}:
             name: NetCore1ESPool-Internal
-            image: windows.vs2022preview.amd64
+            image: windows.vs2026preview.scout.amd64
             os: windows
           ${{ if eq(parameters.agentOs, 'linux') }}:
             name: NetCore1ESPool-Internal

--- a/eng/pipelines/templates/public-pipeline-template.yml
+++ b/eng/pipelines/templates/public-pipeline-template.yml
@@ -86,7 +86,7 @@ stages:
 
           pool:
             name: $(DncEngPublicBuildPool)
-            demands: ImageOverride -equals windows.vs2022preview.amd64.open
+            demands: ImageOverride -equals windows.vs2026preview.scout.amd64.open
 
           variables:
             - name: _buildScript
@@ -120,7 +120,7 @@ stages:
 
           pool:
             name: $(DncEngPublicBuildPool)
-            demands: ImageOverride -equals build.ubuntu.2204.amd64.open
+            demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
 
           variables:
             - name: _buildScript


### PR DESCRIPTION
Port pipeline image changes from release/13.2 (#14486, #14493, #14492) to release/13.1:

- Replace `windows.vs2022preview.amd64` with `windows.vs2026preview.scout.amd64` in internal pipelines (azure-pipelines.yml, build_sign_native.yml)
- Replace `windows.vs2022preview.amd64.open` with `windows.vs2026preview.scout.amd64.open` in public pipeline template
- Fix ubuntu image casing: `build.ubuntu.2204.amd64.open` → `Build.Ubuntu.2204.Amd64.Open`

These images were deprecated and the builds would fail without this update.