### PR TITLE
[automated] Fix flaky test: thread-unsafe collections in FakeContainerRuntime and MockImageBuilder

### DIFF
--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposeTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposeTests.cs
@@ -645,8 +645,7 @@ public class DockerComposeTests(ITestOutputHelper output)
         Assert.False(fakeRuntime.WasPushImageCalled, "PushImageAsync should NOT have been called for local registry");
 
         // Verify the tag was applied correctly
-        Assert.Single(fakeRuntime.TagImageCalls);
-        var (localName, targetName) = fakeRuntime.TagImageCalls[0];
+        var (localName, targetName) = Assert.Single(fakeRuntime.TagImageCalls);
         Assert.StartsWith("servicea:", localName); // Local name includes a hash suffix
         Assert.StartsWith("servicea:", targetName); // Target name includes the deploy tag
     }

--- a/tests/Aspire.Hosting.Tests/MockImageBuilder.cs
+++ b/tests/Aspire.Hosting.Tests/MockImageBuilder.cs
@@ -3,6 +3,7 @@
 
 #pragma warning disable ASPIREPIPELINES003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
+using System.Collections.Concurrent;
 using Aspire.Hosting.Publishing;
 
 namespace Aspire.Hosting.Tests;
@@ -15,9 +16,9 @@ public sealed class MockImageBuilder : IResourceContainerImageManager
     public bool BuildImageCalled { get; private set; }
     public bool BuildImagesCalled { get; private set; }
     public bool PushImageCalled { get; private set; }
-    public List<IResource> BuildImageResources { get; } = [];
-    public List<ContainerImageBuildOptions?> BuildImageOptions { get; } = [];
-    public List<IResource> PushImageCalls { get; } = [];
+    public ConcurrentBag<IResource> BuildImageResources { get; } = [];
+    public ConcurrentBag<ContainerImageBuildOptions?> BuildImageOptions { get; } = [];
+    public ConcurrentBag<IResource> PushImageCalls { get; } = [];
 
     public Task BuildImageAsync(IResource resource, CancellationToken cancellationToken = default)
     {
@@ -29,7 +30,10 @@ public sealed class MockImageBuilder : IResourceContainerImageManager
     public Task BuildImagesAsync(IEnumerable<IResource> resources, CancellationToken cancellationToken = default)
     {
         BuildImagesCalled = true;
-        BuildImageResources.AddRange(resources);
+        foreach (var resource in resources)
+        {
+            BuildImageResources.Add(resource);
+        }
         return Task.CompletedTask;
     }
 

--- a/tests/Aspire.Hosting.Tests/Publishing/FakeContainerRuntime.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/FakeContainerRuntime.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using Aspire.Hosting.Publishing;
 
 #pragma warning disable ASPIREPIPELINES003
@@ -20,11 +21,11 @@ public sealed class FakeContainerRuntime(bool shouldFail = false, bool isRunning
     public bool WasPushImageCalled { get; private set; }
     public bool WasBuildImageCalled { get; private set; }
     public bool WasLoginToRegistryCalled { get; private set; }
-    public List<(string localImageName, string targetImageName)> TagImageCalls { get; } = [];
-    public List<string> RemoveImageCalls { get; } = [];
-    public List<IResource> PushImageCalls { get; } = [];
-    public List<(string contextPath, string dockerfilePath, ContainerImageBuildOptions? options)> BuildImageCalls { get; } = [];
-    public List<(string registryServer, string username, string password)> LoginToRegistryCalls { get; } = [];
+    public ConcurrentBag<(string localImageName, string targetImageName)> TagImageCalls { get; } = [];
+    public ConcurrentBag<string> RemoveImageCalls { get; } = [];
+    public ConcurrentBag<IResource> PushImageCalls { get; } = [];
+    public ConcurrentBag<(string contextPath, string dockerfilePath, ContainerImageBuildOptions? options)> BuildImageCalls { get; } = [];
+    public ConcurrentBag<(string registryServer, string username, string password)> LoginToRegistryCalls { get; } = [];
     public Dictionary<string, string?>? CapturedBuildArguments { get; private set; }
     public Dictionary<string, BuildImageSecretValue>? CapturedBuildSecrets { get; private set; }
     public string? CapturedStage { get; private set; }

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
@@ -576,9 +576,8 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 
         // Verify that the fake runtime was called to build the image
         Assert.True(fakeContainerRuntime.WasBuildImageCalled);
-        Assert.Single(fakeContainerRuntime.BuildImageCalls);
 
-        var buildCall = fakeContainerRuntime.BuildImageCalls[0];
+        var buildCall = Assert.Single(fakeContainerRuntime.BuildImageCalls);
 
         // The context path should be normalized (no trailing slashes)
         Assert.False(buildCall.contextPath.EndsWith(Path.DirectorySeparatorChar.ToString()));


### PR DESCRIPTION
## Flaky Test Fix Summary

### Test
- **Method**: `Aspire.Hosting.Azure.Tests.AzureDeployerTests.DeployAsync_WithMultipleComputeEnvironments_Works`
- **Issue**: #13287
- **Project**: `tests/Aspire.Hosting.Azure.Tests/`

### Root Cause
`FakeContainerRuntime` and `MockImageBuilder` test fakes used plain `List<T>` collections to track method calls. The deployment pipeline executes steps concurrently via `Task.WhenAll` (each compute environment's ACR login and image push run as independent pipeline steps). Concurrent `List<T>.Add()` calls caused data loss — some entries were silently dropped, leading to `Assert.Contains()` failures where the collection was missing expected entries.

This matches the **Thread-unsafe collections** pattern from the test review guidelines.

### Fix
Converted all `List<T>` tracking collections to `ConcurrentBag<T>` in both test fakes. Also updated two call sites that used indexed access (`[0]`) to use `Assert.Single()` return value instead, since `ConcurrentBag<T>` doesn't support indexing.

### Verification
| Run | Config | Result |
|-----|--------|--------|
| Pre-fix (local) | 1 iteration, macOS | **1/1 failed** ❌ |
| Post-fix (local) | 30 iterations, macOS | **30/30 passed** ✅ |
| Post-fix (CI) | 5 runners × 5 iters × 3 OSes = 75 total | **All passed** ✅ |

CI verification run: https://github.com/dotnet/aspire/actions/runs/22422968260

### Files Changed
- `tests/Aspire.Hosting.Tests/Publishing/FakeContainerRuntime.cs` — `List<T>` → `ConcurrentBag<T>` for all call-tracking collections
- `tests/Aspire.Hosting.Tests/MockImageBuilder.cs` — `List<T>` → `ConcurrentBag<T>` for all call-tracking collections
- `tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs` — Use `Assert.Single()` return value instead of indexing
- `tests/Aspire.Hosting.Docker.Tests/DockerComposeTests.cs` — Use `Assert.Single()` return value instead of indexing

### Next Steps
- Test remains quarantined — will be unquarantined after 21 days of zero failures
- Issue #13287 remains open — will be closed by the unquarantine process