### PR TITLE
Resolve friendly resource names in aspire describe

### DIFF
--- a/src/Aspire.Cli/Backchannel/ResourceSnapshotMapper.cs
+++ b/src/Aspire.Cli/Backchannel/ResourceSnapshotMapper.cs
@@ -139,6 +139,35 @@ internal static class ResourceSnapshotMapper
     }
 
     /// <summary>
+    /// Resolves a user-provided resource name to matching snapshots.
+    /// First tries an exact match on <see cref="ResourceSnapshot.Name"/>, then falls back
+    /// to matching by <see cref="ResourceSnapshot.DisplayName"/> only when the display name is
+    /// unique (i.e., not a replica set).
+    /// </summary>
+    /// <param name="resourceName">The user-provided resource name to resolve.</param>
+    /// <param name="snapshots">All available resource snapshots.</param>
+    /// <returns>The matching snapshots.</returns>
+    public static IReadOnlyList<ResourceSnapshot> ResolveResources(string resourceName, IReadOnlyList<ResourceSnapshot> snapshots)
+    {
+        // First try exact match on the unique resource Name.
+        var exactMatches = snapshots.Where(s => string.Equals(s.Name, resourceName, StringComparison.OrdinalIgnoreCase)).ToList();
+        if (exactMatches.Count > 0)
+        {
+            return exactMatches;
+        }
+
+        // Fall back to matching by DisplayName, but only when there is exactly one match
+        // (no replicas). When there are replicas the user must specify the full suffixed name.
+        var displayNameMatches = snapshots.Where(s => string.Equals(s.DisplayName, resourceName, StringComparison.OrdinalIgnoreCase)).ToList();
+        if (displayNameMatches.Count == 1)
+        {
+            return displayNameMatches;
+        }
+
+        return [];
+    }
+
+    /// <summary>
     /// Gets the display name for a resource, returning the unique name if there are multiple resources
     /// with the same display name (replicas).
     /// </summary>

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -155,7 +155,7 @@ internal sealed class DescribeCommand : BaseCommand
         // Filter by resource name if specified
         if (resourceName is not null)
         {
-            snapshots = snapshots.Where(s => string.Equals(s.Name, resourceName, StringComparison.OrdinalIgnoreCase)).ToList();
+            snapshots = ResourceSnapshotMapper.ResolveResources(resourceName, snapshots).ToList();
         }
 
         // Check if resource was not found
@@ -200,9 +200,13 @@ internal sealed class DescribeCommand : BaseCommand
             allResources[snapshot.Name] = snapshot;
 
             // Filter by resource name if specified
-            if (resourceName is not null && !string.Equals(snapshot.Name, resourceName, StringComparison.OrdinalIgnoreCase))
+            if (resourceName is not null)
             {
-                continue;
+                var resolved = ResourceSnapshotMapper.ResolveResources(resourceName, allResources.Values.ToList());
+                if (!resolved.Any(r => string.Equals(r.Name, snapshot.Name, StringComparison.OrdinalIgnoreCase)))
+                {
+                    continue;
+                }
             }
 
             var resourceJson = ResourceSnapshotMapper.MapToResourceJson(snapshot, allResources.Values.ToList(), dashboardBaseUrl);

--- a/tests/Aspire.Cli.EndToEnd.Tests/DescribeCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DescribeCommandTests.cs
@@ -148,4 +148,180 @@ public sealed class DescribeCommandTests(ITestOutputHelper output)
 
         await pendingRun;
     }
+
+    [Fact]
+    public async Task DescribeCommandResolvesReplicaNames()
+    {
+        var workspace = TemporaryWorkspace.Create(output);
+
+        var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
+        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
+        var isCI = CliE2ETestHelpers.IsRunningInCI;
+        using var terminal = CliE2ETestHelpers.CreateTestTerminal();
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        // Pattern searchers for aspire new prompts
+        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
+            .Find("> Starter App");
+
+        var waitingForProjectNamePrompt = new CellPatternSearcher()
+            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
+
+        var waitingForOutputPathPrompt = new CellPatternSearcher()
+            .Find($"Enter the output path: (./AspireReplicaTestApp): ");
+
+        var waitingForUrlsPrompt = new CellPatternSearcher()
+            .Find($"Use *.dev.localhost URLs");
+
+        var waitingForRedisPrompt = new CellPatternSearcher()
+            .Find($"Use Redis Cache");
+
+        var waitingForTestPrompt = new CellPatternSearcher()
+            .Find($"Do you want to create a test project?");
+
+        // Pattern searchers for start/stop commands
+        var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
+            .Find("AppHost started successfully.");
+
+        var waitForAppHostStoppedSuccessfully = new CellPatternSearcher()
+            .Find("AppHost stopped successfully.");
+
+        // Pattern for describe output with friendly name (non-replicated resource)
+        var waitForCacheResource = new CellPatternSearcher()
+            .Find("cache");
+
+        // Pattern for describe output showing a specific replica
+        var waitForApiserviceReplicaName = new CellPatternSearcher()
+            .FindPattern("apiservice-[a-z0-9]+");
+
+        var counter = new SequenceCounter();
+        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+        sequenceBuilder.PrepareEnvironment(workspace, counter);
+
+        if (isCI)
+        {
+            sequenceBuilder.InstallAspireCliFromPullRequest(prNumber, counter);
+            sequenceBuilder.SourceAspireCliEnvironment(counter);
+            sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
+        }
+
+        // Create a new project using aspire new
+        sequenceBuilder.Type("aspire new")
+            .Enter()
+            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .Enter() // select first template (Starter App)
+            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Type("AspireReplicaTestApp")
+            .Enter()
+            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Navigate to the AppHost directory
+        sequenceBuilder.Type("cd AspireReplicaTestApp/AspireReplicaTestApp.AppHost")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Add .WithReplicas(2) to the apiservice resource in the AppHost
+        sequenceBuilder.ExecuteCallback(() =>
+        {
+            var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, "AspireReplicaTestApp");
+            var appHostDir = Path.Combine(projectDir, "AspireReplicaTestApp.AppHost");
+            var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
+
+            output.WriteLine($"Looking for AppHost.cs at: {appHostFilePath}");
+
+            var content = File.ReadAllText(appHostFilePath);
+
+            // Add .WithReplicas(2) to the first .WithHttpHealthCheck("/health"); occurrence (apiservice)
+            var originalPattern = ".WithHttpHealthCheck(\"/health\");";
+            var replacement = ".WithHttpHealthCheck(\"/health\").WithReplicas(2);";
+
+            // Only replace the first occurrence (apiservice), not the second (webfrontend)
+            var index = content.IndexOf(originalPattern);
+            if (index >= 0)
+            {
+                content = content[..index] + replacement + content[(index + originalPattern.Length)..];
+            }
+
+            File.WriteAllText(appHostFilePath, content);
+
+            output.WriteLine($"Modified AppHost.cs to add .WithReplicas(2) to apiservice");
+        });
+
+        // Start the AppHost in the background using aspire run --detach
+        sequenceBuilder.Type("aspire run --detach")
+            .Enter()
+            .WaitUntil(s => waitForAppHostStartedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(3))
+            .WaitForSuccessPrompt(counter);
+
+        // Wait for resources to stabilize
+        sequenceBuilder.Type("sleep 10")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Test 1: aspire describe with friendly name for a non-replicated resource (cache)
+        // This should resolve via DisplayName since cache has only one instance
+        sequenceBuilder.Type("aspire describe cache --format json > cache-describe.json")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Verify cache resource was found in the output
+        sequenceBuilder.Type("cat cache-describe.json | grep cache")
+            .Enter()
+            .WaitUntil(s => waitForCacheResource.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .WaitForSuccessPrompt(counter);
+
+        // Test 2: Get all resources to find an apiservice replica name
+        sequenceBuilder.Type("aspire describe --format json > all-resources.json")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Extract a replica name from the JSON - apiservice replicas have names like apiservice-<suffix>
+        sequenceBuilder.Type("REPLICA_NAME=$(cat all-resources.json | grep -o '\"name\": *\"apiservice-[a-z0-9]*\"' | head -1 | sed 's/.*\"\\(apiservice-[a-z0-9]*\\)\"/\\1/')")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Verify we captured a replica name
+        sequenceBuilder.Type("echo \"Found replica: $REPLICA_NAME\"")
+            .Enter()
+            .WaitUntil(s => waitForApiserviceReplicaName.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .WaitForSuccessPrompt(counter);
+
+        // Test 3: aspire describe with the replica name
+        // This should resolve via exact Name match
+        sequenceBuilder.Type("aspire describe $REPLICA_NAME --format json > replica-describe.json")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Verify the replica was found and output contains the replica name
+        sequenceBuilder.Type("cat replica-describe.json | grep apiservice")
+            .Enter()
+            .WaitUntil(s => waitForApiserviceReplicaName.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .WaitForSuccessPrompt(counter);
+
+        // Stop the AppHost using aspire stop
+        sequenceBuilder.Type("aspire stop")
+            .Enter()
+            .WaitUntil(s => waitForAppHostStoppedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(1))
+            .WaitForSuccessPrompt(counter);
+
+        // Exit the shell
+        sequenceBuilder.Type("exit")
+            .Enter();
+
+        var sequence = sequenceBuilder.Build();
+
+        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+        await pendingRun;
+    }
 }

--- a/tests/Aspire.Cli.Tests/Backchannel/ResourceSnapshotMapperTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/ResourceSnapshotMapperTests.cs
@@ -56,4 +56,93 @@ public class ResourceSnapshotMapperTests
         Assert.Contains("localhost:18080", result.DashboardUrl);
     }
 
+    [Fact]
+    public void ResolveResources_ByExactName_ReturnsMatch()
+    {
+        var snapshots = new List<ResourceSnapshot>
+        {
+            new() { Name = "cache-zuyppzgw", DisplayName = "cache", ResourceType = "Container", State = "Running" },
+            new() { Name = "frontend", DisplayName = "frontend", ResourceType = "Project", State = "Running" }
+        };
+
+        var result = ResourceSnapshotMapper.ResolveResources("cache-zuyppzgw", snapshots);
+
+        Assert.Single(result);
+        Assert.Equal("cache-zuyppzgw", result[0].Name);
+    }
+
+    [Fact]
+    public void ResolveResources_ByDisplayName_WhenNoReplicas_ReturnsMatch()
+    {
+        var snapshots = new List<ResourceSnapshot>
+        {
+            new() { Name = "cache-zuyppzgw", DisplayName = "cache", ResourceType = "Container", State = "Running" },
+            new() { Name = "frontend", DisplayName = "frontend", ResourceType = "Project", State = "Running" }
+        };
+
+        var result = ResourceSnapshotMapper.ResolveResources("cache", snapshots);
+
+        Assert.Single(result);
+        Assert.Equal("cache-zuyppzgw", result[0].Name);
+    }
+
+    [Fact]
+    public void ResolveResources_ByDisplayName_WhenReplicas_ReturnsEmpty()
+    {
+        var snapshots = new List<ResourceSnapshot>
+        {
+            new() { Name = "cache-abc12345", DisplayName = "cache", ResourceType = "Container", State = "Running" },
+            new() { Name = "cache-def67890", DisplayName = "cache", ResourceType = "Container", State = "Running" },
+            new() { Name = "frontend", DisplayName = "frontend", ResourceType = "Project", State = "Running" }
+        };
+
+        var result = ResourceSnapshotMapper.ResolveResources("cache", snapshots);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ResolveResources_ByExactName_WhenReplicas_ReturnsMatch()
+    {
+        var snapshots = new List<ResourceSnapshot>
+        {
+            new() { Name = "cache-abc12345", DisplayName = "cache", ResourceType = "Container", State = "Running" },
+            new() { Name = "cache-def67890", DisplayName = "cache", ResourceType = "Container", State = "Running" },
+            new() { Name = "frontend", DisplayName = "frontend", ResourceType = "Project", State = "Running" }
+        };
+
+        var result = ResourceSnapshotMapper.ResolveResources("cache-abc12345", snapshots);
+
+        Assert.Single(result);
+        Assert.Equal("cache-abc12345", result[0].Name);
+    }
+
+    [Fact]
+    public void ResolveResources_NoMatch_ReturnsEmpty()
+    {
+        var snapshots = new List<ResourceSnapshot>
+        {
+            new() { Name = "cache-zuyppzgw", DisplayName = "cache", ResourceType = "Container", State = "Running" }
+        };
+
+        var result = ResourceSnapshotMapper.ResolveResources("nonexistent", snapshots);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ResolveResources_IsCaseInsensitive()
+    {
+        var snapshots = new List<ResourceSnapshot>
+        {
+            new() { Name = "Cache-Zuyppzgw", DisplayName = "Cache", ResourceType = "Container", State = "Running" }
+        };
+
+        var resultByName = ResourceSnapshotMapper.ResolveResources("cache-zuyppzgw", snapshots);
+        Assert.Single(resultByName);
+
+        var resultByDisplayName = ResourceSnapshotMapper.ResolveResources("CACHE", snapshots);
+        Assert.Single(resultByDisplayName);
+    }
+
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/dotnet/aspire/issues/14669

This fixes aspire describe specifically. I want to go through commands that accept resource names and make sure there is consistency in how they behave.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
