### PR TITLE
Wrap E2E test recordings in collapsible details sections

### DIFF
--- a/.github/workflows/cli-e2e-recording-comment.yml
+++ b/.github/workflows/cli-e2e-recording-comment.yml
@@ -182,6 +182,9 @@ jobs:
           
           The following terminal recordings are available for commit \`${SHORT_SHA}\`:
           
+          <details>
+          <summary>View recordings</summary>
+          
           | Test | Recording |
           |------|-----------|"
             
@@ -212,6 +215,8 @@ jobs:
             done
             
             COMMENT_BODY="${COMMENT_BODY}
+          
+          </details>
           
           ---
           <sub>📹 Recordings uploaded automatically from [CI run #${RUN_ID}](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID})</sub>"

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -507,13 +507,17 @@ jobs:
           
           [View workflow run](${RUN_URL})"
           
-          # Add passed tests section if any
+          # Add passed tests section if any (collapsible since it's usually long)
           if [ "$PASSED_COUNT" -gt 0 ]; then
             PASSED_LIST=$(echo "$PASSED_TESTS" | jq -r '.[]' | while read test; do echo "- ✅ ${test}"; done)
             COMMENT_BODY="${COMMENT_BODY}
           
-          ### Passed Tests
-          ${PASSED_LIST}"
+          <details>
+          <summary>Passed Tests (${PASSED_COUNT})</summary>
+          
+          ${PASSED_LIST}
+          
+          </details>"
           fi
           
           # Add failed tests section if any

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -543,7 +543,8 @@ jobs:
             
             RECORDING_TABLE="
           
-          ### 🎬 Terminal Recordings
+          <details>
+          <summary>🎬 Terminal Recordings</summary>
           
           | Test | Recording |
           |------|-----------|"
@@ -571,6 +572,10 @@ jobs:
                 fi
               fi
             done
+            
+            RECORDING_TABLE="${RECORDING_TABLE}
+          
+          </details>"
             
             if [ $UPLOAD_COUNT -gt 0 ]; then
               COMMENT_BODY="${COMMENT_BODY}${RECORDING_TABLE}"


### PR DESCRIPTION
## Description

Wrap the recording links posted by the CLI E2E and deployment E2E test workflows inside collapsible `<details>` regions. This keeps the PR comment thread cleaner when there are many recordings, while still making them easily accessible with a single click to expand.

### Changes
- **`cli-e2e-recording-comment.yml`**: Wrap the recordings table in a `<details><summary>View recordings</summary>` block.
- **`deployment-tests.yml`**: Wrap the recordings table in a `<details><summary>🎬 Terminal Recordings</summary>` block.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
