### PR TITLE
Improve CLI tables

### DIFF
--- a/src/Aspire.Cli/Commands/ConfigCommand.cs
+++ b/src/Aspire.Cli/Commands/ConfigCommand.cs
@@ -271,13 +271,13 @@ internal sealed class ConfigCommand : BaseCommand
             return ExitCodeConstants.Success;
         }
 
-        private static void RenderConfigTable(string title, Dictionary<string, string> config, string emptyMessage)
+        private void RenderConfigTable(string title, Dictionary<string, string> config, string emptyMessage)
         {
             var table = new Table();
             table.Title = new TableTitle($"[bold]{title.EscapeMarkup()}[/]");
             table.Border(TableBorder.Rounded);
-            table.AddColumn(new TableColumn("[bold]Key[/]").NoWrap());
-            table.AddColumn(new TableColumn("[bold]Value[/]"));
+            table.AddColumn(new TableColumn($"[bold]{ConfigCommandStrings.HeaderKey.EscapeMarkup()}[/]").NoWrap());
+            table.AddColumn(new TableColumn($"[bold]{ConfigCommandStrings.HeaderValue.EscapeMarkup()}[/]"));
 
             if (config.Count > 0)
             {
@@ -293,7 +293,7 @@ internal sealed class ConfigCommand : BaseCommand
                 table.AddRow($"[dim]{emptyMessage.EscapeMarkup()}[/]", "");
             }
 
-            AnsiConsole.Write(table);
+            InteractionService.DisplayTable(table);
         }
     }
 

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -238,11 +238,11 @@ internal sealed class DescribeCommand : BaseCommand
             .ToList();
 
         var table = new Table();
-        table.AddColumn("Name");
-        table.AddColumn("Type");
-        table.AddColumn("State");
-        table.AddColumn("Health");
-        table.AddColumn("Endpoints");
+        table.AddColumn(DescribeCommandStrings.HeaderName);
+        table.AddColumn(DescribeCommandStrings.HeaderType);
+        table.AddColumn(DescribeCommandStrings.HeaderState);
+        table.AddColumn(DescribeCommandStrings.HeaderHealth);
+        table.AddColumn(DescribeCommandStrings.HeaderEndpoints);
 
         foreach (var (snapshot, displayName) in orderedItems)
         {
@@ -276,7 +276,7 @@ internal sealed class DescribeCommand : BaseCommand
             table.AddRow(displayName, type, stateText, healthText, endpoints);
         }
 
-        AnsiConsole.Write(table);
+        _interactionService.DisplayTable(table);
     }
 
     private void DisplayResourceUpdate(ResourceSnapshot snapshot, IDictionary<string, ResourceSnapshot> allResources)

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -238,11 +238,11 @@ internal sealed class DescribeCommand : BaseCommand
             .ToList();
 
         var table = new Table();
-        table.AddColumn(DescribeCommandStrings.HeaderName);
-        table.AddColumn(DescribeCommandStrings.HeaderType);
-        table.AddColumn(DescribeCommandStrings.HeaderState);
-        table.AddColumn(DescribeCommandStrings.HeaderHealth);
-        table.AddColumn(DescribeCommandStrings.HeaderEndpoints);
+        table.AddBoldColumn(DescribeCommandStrings.HeaderName);
+        table.AddBoldColumn(DescribeCommandStrings.HeaderType);
+        table.AddBoldColumn(DescribeCommandStrings.HeaderState);
+        table.AddBoldColumn(DescribeCommandStrings.HeaderHealth);
+        table.AddBoldColumn(DescribeCommandStrings.HeaderEndpoints);
 
         foreach (var (snapshot, displayName) in orderedItems)
         {
@@ -276,7 +276,7 @@ internal sealed class DescribeCommand : BaseCommand
             table.AddRow(displayName, type, stateText, healthText, endpoints);
         }
 
-        _interactionService.DisplayTable(table);
+        _interactionService.DisplayRenderable(table);
     }
 
     private void DisplayResourceUpdate(ResourceSnapshot snapshot, IDictionary<string, ResourceSnapshot> allResources)

--- a/src/Aspire.Cli/Commands/DocsListCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsListCommand.cs
@@ -76,9 +76,9 @@ internal sealed class DocsListCommand : BaseCommand
             InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, DocsCommandStrings.FoundDocumentationPages, docs.Count));
 
             var table = new Table();
-            table.AddColumn("Title");
-            table.AddColumn("Slug");
-            table.AddColumn("Summary");
+            table.AddColumn(DocsCommandStrings.HeaderTitle);
+            table.AddColumn(DocsCommandStrings.HeaderSlug);
+            table.AddColumn(DocsCommandStrings.HeaderSummary);
 
             foreach (var doc in docs)
             {
@@ -88,7 +88,7 @@ internal sealed class DocsListCommand : BaseCommand
                     Markup.Escape(doc.Summary ?? "-"));
             }
 
-            AnsiConsole.Write(table);
+            InteractionService.DisplayTable(table);
         }
 
         return ExitCodeConstants.Success;

--- a/src/Aspire.Cli/Commands/DocsListCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsListCommand.cs
@@ -76,9 +76,9 @@ internal sealed class DocsListCommand : BaseCommand
             InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, DocsCommandStrings.FoundDocumentationPages, docs.Count));
 
             var table = new Table();
-            table.AddColumn(DocsCommandStrings.HeaderTitle);
-            table.AddColumn(DocsCommandStrings.HeaderSlug);
-            table.AddColumn(DocsCommandStrings.HeaderSummary);
+            table.AddBoldColumn(DocsCommandStrings.HeaderTitle);
+            table.AddBoldColumn(DocsCommandStrings.HeaderSlug);
+            table.AddBoldColumn(DocsCommandStrings.HeaderSummary);
 
             foreach (var doc in docs)
             {
@@ -88,7 +88,7 @@ internal sealed class DocsListCommand : BaseCommand
                     Markup.Escape(doc.Summary ?? "-"));
             }
 
-            InteractionService.DisplayTable(table);
+            InteractionService.DisplayRenderable(table);
         }
 
         return ExitCodeConstants.Success;

--- a/src/Aspire.Cli/Commands/DocsSearchCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsSearchCommand.cs
@@ -91,10 +91,10 @@ internal sealed class DocsSearchCommand : BaseCommand
 
             // Results are already sorted by score (highest first) from the search service
             var table = new Table();
-            table.AddColumn("Title");
-            table.AddColumn("Slug");
-            table.AddColumn("Section");
-            table.AddColumn("Score");
+            table.AddColumn(DocsCommandStrings.HeaderTitle);
+            table.AddColumn(DocsCommandStrings.HeaderSlug);
+            table.AddColumn(DocsCommandStrings.HeaderSection);
+            table.AddColumn(DocsCommandStrings.HeaderScore);
 
             foreach (var result in response.Results)
             {
@@ -105,7 +105,7 @@ internal sealed class DocsSearchCommand : BaseCommand
                     result.Score.ToString("F2", CultureInfo.InvariantCulture)); // Two decimal places
             }
 
-            AnsiConsole.Write(table);
+            InteractionService.DisplayTable(table);
         }
 
         return ExitCodeConstants.Success;

--- a/src/Aspire.Cli/Commands/DocsSearchCommand.cs
+++ b/src/Aspire.Cli/Commands/DocsSearchCommand.cs
@@ -91,10 +91,10 @@ internal sealed class DocsSearchCommand : BaseCommand
 
             // Results are already sorted by score (highest first) from the search service
             var table = new Table();
-            table.AddColumn(DocsCommandStrings.HeaderTitle);
-            table.AddColumn(DocsCommandStrings.HeaderSlug);
-            table.AddColumn(DocsCommandStrings.HeaderSection);
-            table.AddColumn(DocsCommandStrings.HeaderScore);
+            table.AddBoldColumn(DocsCommandStrings.HeaderTitle);
+            table.AddBoldColumn(DocsCommandStrings.HeaderSlug);
+            table.AddBoldColumn(DocsCommandStrings.HeaderSection);
+            table.AddBoldColumn(DocsCommandStrings.HeaderScore);
 
             foreach (var result in response.Results)
             {
@@ -105,7 +105,7 @@ internal sealed class DocsSearchCommand : BaseCommand
                     result.Score.ToString("F2", CultureInfo.InvariantCulture)); // Two decimal places
             }
 
-            InteractionService.DisplayTable(table);
+            InteractionService.DisplayRenderable(table);
         }
 
         return ExitCodeConstants.Success;

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -166,10 +166,10 @@ internal sealed class PsCommand : BaseCommand
         }
 
         var table = new Table();
-        table.AddColumn(PsCommandStrings.HeaderPath);
-        table.AddColumn(PsCommandStrings.HeaderPid);
-        table.AddColumn(PsCommandStrings.HeaderCliPid);
-        table.AddColumn(PsCommandStrings.HeaderDashboard);
+        table.AddBoldColumn(PsCommandStrings.HeaderPath);
+        table.AddBoldColumn(PsCommandStrings.HeaderPid);
+        table.AddBoldColumn(PsCommandStrings.HeaderCliPid);
+        table.AddBoldColumn(PsCommandStrings.HeaderDashboard);
 
         foreach (var appHost in appHosts)
         {
@@ -184,7 +184,7 @@ internal sealed class PsCommand : BaseCommand
                 Markup.Escape(dashboard));
         }
 
-        _interactionService.DisplayTable(table);
+        _interactionService.DisplayRenderable(table);
     }
 
     private static string ShortenPath(string path)

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -230,11 +230,11 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         }
 
         var table = new Table();
-        table.AddColumn(TelemetryCommandStrings.HeaderTraceId);
-        table.AddColumn(TelemetryCommandStrings.HeaderResource);
-        table.AddColumn(TelemetryCommandStrings.HeaderDuration);
-        table.AddColumn(TelemetryCommandStrings.HeaderSpans);
-        table.AddColumn(TelemetryCommandStrings.HeaderStatus);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderTraceId);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderResource);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderDuration);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderSpans);
+        table.AddBoldColumn(TelemetryCommandStrings.HeaderStatus);
 
         // Group by traceId to show trace summary
         var traceInfos = new Dictionary<string, (string Resource, TimeSpan Duration, int SpanCount, bool HasError)>();
@@ -277,7 +277,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
             table.AddRow(traceIdKey, info.Resource, durationStr, info.SpanCount.ToString(CultureInfo.InvariantCulture), statusText);
         }
 
-        interactionService.DisplayTable(table);
+        interactionService.DisplayRenderable(table);
         interactionService.DisplayMarkupLine($"[grey]Showing {traceInfos.Count} of {response?.TotalCount ?? traceInfos.Count} traces[/]");
     }
 

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -205,7 +205,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
             }
             else
             {
-                DisplayTracesTable(json);
+                DisplayTracesTable(json, _interactionService);
             }
 
             return ExitCodeConstants.Success;
@@ -218,7 +218,7 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         }
     }
 
-    private static void DisplayTracesTable(string json)
+    private static void DisplayTracesTable(string json, IInteractionService interactionService)
     {
         var response = JsonSerializer.Deserialize(json, OtlpCliJsonSerializerContext.Default.TelemetryApiResponse);
         var resourceSpans = response?.Data?.ResourceSpans;
@@ -230,11 +230,11 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         }
 
         var table = new Table();
-        table.AddColumn("Trace ID");
-        table.AddColumn("Resource");
-        table.AddColumn("Duration");
-        table.AddColumn("Spans");
-        table.AddColumn("Status");
+        table.AddColumn(TelemetryCommandStrings.HeaderTraceId);
+        table.AddColumn(TelemetryCommandStrings.HeaderResource);
+        table.AddColumn(TelemetryCommandStrings.HeaderDuration);
+        table.AddColumn(TelemetryCommandStrings.HeaderSpans);
+        table.AddColumn(TelemetryCommandStrings.HeaderStatus);
 
         // Group by traceId to show trace summary
         var traceInfos = new Dictionary<string, (string Resource, TimeSpan Duration, int SpanCount, bool HasError)>();
@@ -277,8 +277,8 @@ internal sealed class TelemetryTracesCommand : BaseCommand
             table.AddRow(traceIdKey, info.Resource, durationStr, info.SpanCount.ToString(CultureInfo.InvariantCulture), statusText);
         }
 
-        AnsiConsole.Write(table);
-        AnsiConsole.MarkupLine($"[grey]Showing {traceInfos.Count} of {response?.TotalCount ?? traceInfos.Count} traces[/]");
+        interactionService.DisplayTable(table);
+        interactionService.DisplayMarkupLine($"[grey]Showing {traceInfos.Count} of {response?.TotalCount ?? traceInfos.Count} traces[/]");
     }
 
     private static void DisplayTraceDetails(string json, string traceId)

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -281,6 +281,11 @@ internal class ConsoleInteractionService : IInteractionService
         }
     }
 
+    public void DisplayTable(Table table)
+    {
+        MessageConsole.Write(table);
+    }
+
     public void DisplayCancellationMessage()
     {
         MessageConsole.WriteLine();

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -6,6 +6,7 @@ using Aspire.Cli.Backchannel;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace Aspire.Cli.Interaction;
 
@@ -281,9 +282,9 @@ internal class ConsoleInteractionService : IInteractionService
         }
     }
 
-    public void DisplayTable(Table table)
+    public void DisplayRenderable(IRenderable renderable)
     {
-        MessageConsole.Write(table);
+        MessageConsole.Write(renderable);
     }
 
     public void DisplayCancellationMessage()

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -343,6 +343,11 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         _consoleInteractionService.DisplayVersionUpdateNotification(newerVersion, updateCommand);
     }
 
+    public void DisplayTable(Table table)
+    {
+        _consoleInteractionService.DisplayTable(table);
+    }
+
     public void LogMessage(LogLevel logLevel, string message)
     {
         var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(logLevel, message.RemoveSpectreFormatting(), _cancellationToken));

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -7,6 +7,7 @@ using Aspire.Cli.Backchannel;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace Aspire.Cli.Interaction;
 
@@ -343,9 +344,9 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         _consoleInteractionService.DisplayVersionUpdateNotification(newerVersion, updateCommand);
     }
 
-    public void DisplayTable(Table table)
+    public void DisplayRenderable(IRenderable renderable)
     {
-        _consoleInteractionService.DisplayTable(table);
+        _consoleInteractionService.DisplayRenderable(renderable);
     }
 
     public void LogMessage(LogLevel logLevel, string message)

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -24,6 +24,7 @@ internal interface IInteractionService
     void DisplaySuccess(string message);
     void DisplaySubtleMessage(string message, bool escapeMarkup = true);
     void DisplayLines(IEnumerable<(string Stream, string Line)> lines);
+    void DisplayTable(Table table);
     void DisplayCancellationMessage();
     void DisplayEmptyLine();
 

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.Backchannel;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace Aspire.Cli.Interaction;
 
@@ -24,7 +25,7 @@ internal interface IInteractionService
     void DisplaySuccess(string message);
     void DisplaySubtleMessage(string message, bool escapeMarkup = true);
     void DisplayLines(IEnumerable<(string Stream, string Line)> lines);
-    void DisplayTable(Table table);
+    void DisplayRenderable(IRenderable renderable);
     void DisplayCancellationMessage();
     void DisplayEmptyLine();
 

--- a/src/Aspire.Cli/Resources/ConfigCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ConfigCommandStrings.Designer.cs
@@ -391,5 +391,17 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("SetFeatureHint", resourceCulture);
             }
         }
+
+        public static string HeaderKey {
+            get {
+                return ResourceManager.GetString("HeaderKey", resourceCulture);
+            }
+        }
+
+        public static string HeaderValue {
+            get {
+                return ResourceManager.GetString("HeaderValue", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/ConfigCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/ConfigCommandStrings.resx
@@ -219,4 +219,10 @@
   <data name="SetFeatureHint" xml:space="preserve">
     <value>Use 'aspire config set features.&lt;name&gt; true|false' to enable or disable a feature.</value>
   </data>
+  <data name="HeaderKey" xml:space="preserve">
+    <value>Key</value>
+  </data>
+  <data name="HeaderValue" xml:space="preserve">
+    <value>Value</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/DescribeCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DescribeCommandStrings.Designer.cs
@@ -86,5 +86,35 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("SelectAppHostAction", resourceCulture);
             }
         }
+
+        public static string HeaderName {
+            get {
+                return ResourceManager.GetString("HeaderName", resourceCulture);
+            }
+        }
+
+        public static string HeaderType {
+            get {
+                return ResourceManager.GetString("HeaderType", resourceCulture);
+            }
+        }
+
+        public static string HeaderState {
+            get {
+                return ResourceManager.GetString("HeaderState", resourceCulture);
+            }
+        }
+
+        public static string HeaderHealth {
+            get {
+                return ResourceManager.GetString("HeaderHealth", resourceCulture);
+            }
+        }
+
+        public static string HeaderEndpoints {
+            get {
+                return ResourceManager.GetString("HeaderEndpoints", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/DescribeCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DescribeCommandStrings.resx
@@ -138,4 +138,19 @@
   <data name="SelectAppHostAction" xml:space="preserve">
     <value>describe</value>
   </data>
+  <data name="HeaderName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="HeaderType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="HeaderState" xml:space="preserve">
+    <value>State</value>
+  </data>
+  <data name="HeaderHealth" xml:space="preserve">
+    <value>Health</value>
+  </data>
+  <data name="HeaderEndpoints" xml:space="preserve">
+    <value>Endpoints</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/DocsCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DocsCommandStrings.Designer.cs
@@ -194,5 +194,35 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("FoundSearchResults", resourceCulture);
             }
         }
+
+        internal static string HeaderTitle {
+            get {
+                return ResourceManager.GetString("HeaderTitle", resourceCulture);
+            }
+        }
+
+        internal static string HeaderSlug {
+            get {
+                return ResourceManager.GetString("HeaderSlug", resourceCulture);
+            }
+        }
+
+        internal static string HeaderSummary {
+            get {
+                return ResourceManager.GetString("HeaderSummary", resourceCulture);
+            }
+        }
+
+        internal static string HeaderSection {
+            get {
+                return ResourceManager.GetString("HeaderSection", resourceCulture);
+            }
+        }
+
+        internal static string HeaderScore {
+            get {
+                return ResourceManager.GetString("HeaderScore", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/DocsCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DocsCommandStrings.resx
@@ -162,4 +162,19 @@
   <data name="FoundSearchResults" xml:space="preserve">
     <value>Found {0} results for '{1}'.</value>
   </data>
+  <data name="HeaderTitle" xml:space="preserve">
+    <value>Title</value>
+  </data>
+  <data name="HeaderSlug" xml:space="preserve">
+    <value>Slug</value>
+  </data>
+  <data name="HeaderSummary" xml:space="preserve">
+    <value>Summary</value>
+  </data>
+  <data name="HeaderSection" xml:space="preserve">
+    <value>Section</value>
+  </data>
+  <data name="HeaderScore" xml:space="preserve">
+    <value>Score</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/PsCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/PsCommandStrings.resx
@@ -124,16 +124,16 @@
     <value>Output format (Table or Json).</value>
   </data>
   <data name="HeaderPath" xml:space="preserve">
-    <value>PATH</value>
+    <value>Path</value>
   </data>
   <data name="HeaderPid" xml:space="preserve">
     <value>PID</value>
   </data>
   <data name="HeaderCliPid" xml:space="preserve">
-    <value>CLI_PID</value>
+    <value>CLI PID</value>
   </data>
   <data name="HeaderDashboard" xml:space="preserve">
-    <value>DASHBOARD</value>
+    <value>Dashboard</value>
   </data>
   <data name="UnknownPath" xml:space="preserve">
     <value>Unknown</value>

--- a/src/Aspire.Cli/Resources/TelemetryCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/TelemetryCommandStrings.Designer.cs
@@ -218,5 +218,35 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("SelectAppHostAction", resourceCulture);
             }
         }
+
+        internal static string HeaderTraceId {
+            get {
+                return ResourceManager.GetString("HeaderTraceId", resourceCulture);
+            }
+        }
+
+        internal static string HeaderResource {
+            get {
+                return ResourceManager.GetString("HeaderResource", resourceCulture);
+            }
+        }
+
+        internal static string HeaderDuration {
+            get {
+                return ResourceManager.GetString("HeaderDuration", resourceCulture);
+            }
+        }
+
+        internal static string HeaderSpans {
+            get {
+                return ResourceManager.GetString("HeaderSpans", resourceCulture);
+            }
+        }
+
+        internal static string HeaderStatus {
+            get {
+                return ResourceManager.GetString("HeaderStatus", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/TelemetryCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/TelemetryCommandStrings.resx
@@ -171,4 +171,19 @@
   <data name="SelectAppHostAction" xml:space="preserve">
     <value>view telemetry for</value>
   </data>
+  <data name="HeaderTraceId" xml:space="preserve">
+    <value>Trace Id</value>
+  </data>
+  <data name="HeaderResource" xml:space="preserve">
+    <value>Resource</value>
+  </data>
+  <data name="HeaderDuration" xml:space="preserve">
+    <value>Duration</value>
+  </data>
+  <data name="HeaderSpans" xml:space="preserve">
+    <value>Spans</value>
+  </data>
+  <data name="HeaderStatus" xml:space="preserve">
+    <value>Status</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.cs.xlf
@@ -82,6 +82,16 @@
         <target state="translated">Globální konfigurace</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderKey">
+        <source>Key</source>
+        <target state="new">Key</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoCommand_AvailableFeatures">
         <source>Available features</source>
         <target state="translated">Dostupné funkce</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.de.xlf
@@ -82,6 +82,16 @@
         <target state="translated">Globale Konfiguration</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderKey">
+        <source>Key</source>
+        <target state="new">Key</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoCommand_AvailableFeatures">
         <source>Available features</source>
         <target state="translated">Verfügbare Features</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.es.xlf
@@ -82,6 +82,16 @@
         <target state="translated">Configuración global</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderKey">
+        <source>Key</source>
+        <target state="new">Key</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoCommand_AvailableFeatures">
         <source>Available features</source>
         <target state="translated">Características disponibles</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.fr.xlf
@@ -82,6 +82,16 @@
         <target state="translated">Configuration globale</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderKey">
+        <source>Key</source>
+        <target state="new">Key</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoCommand_AvailableFeatures">
         <source>Available features</source>
         <target state="translated">Fonctionnalités disponibles</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.it.xlf
@@ -82,6 +82,16 @@
         <target state="translated">Configurazione globale</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderKey">
+        <source>Key</source>
+        <target state="new">Key</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoCommand_AvailableFeatures">
         <source>Available features</source>
         <target state="translated">Funzionalità disponibili</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ja.xlf
@@ -82,6 +82,16 @@
         <target state="translated">グローバル構成</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderKey">
+        <source>Key</source>
+        <target state="new">Key</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoCommand_AvailableFeatures">
         <source>Available features</source>
         <target state="translated">使用可能な機能</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ko.xlf
@@ -82,6 +82,16 @@
         <target state="translated">전역 구성</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderKey">
+        <source>Key</source>
+        <target state="new">Key</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoCommand_AvailableFeatures">
         <source>Available features</source>
         <target state="translated">사용 가능한 기능</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.pl.xlf
@@ -82,6 +82,16 @@
         <target state="translated">Konfiguracja globalna</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderKey">
+        <source>Key</source>
+        <target state="new">Key</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoCommand_AvailableFeatures">
         <source>Available features</source>
         <target state="translated">Dostępne funkcje</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.pt-BR.xlf
@@ -82,6 +82,16 @@
         <target state="translated">Configuração global</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderKey">
+        <source>Key</source>
+        <target state="new">Key</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoCommand_AvailableFeatures">
         <source>Available features</source>
         <target state="translated">Recursos disponíveis</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ru.xlf
@@ -82,6 +82,16 @@
         <target state="translated">Глобальная конфигурация</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderKey">
+        <source>Key</source>
+        <target state="new">Key</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoCommand_AvailableFeatures">
         <source>Available features</source>
         <target state="translated">Доступные функции</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.tr.xlf
@@ -82,6 +82,16 @@
         <target state="translated">Genel yapılandırma</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderKey">
+        <source>Key</source>
+        <target state="new">Key</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoCommand_AvailableFeatures">
         <source>Available features</source>
         <target state="translated">Kullanılabilir özellikler</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.zh-Hans.xlf
@@ -82,6 +82,16 @@
         <target state="translated">全局配置</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderKey">
+        <source>Key</source>
+        <target state="new">Key</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoCommand_AvailableFeatures">
         <source>Available features</source>
         <target state="translated">可用的功能</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.zh-Hant.xlf
@@ -82,6 +82,16 @@
         <target state="translated">全域設定</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderKey">
+        <source>Key</source>
+        <target state="new">Key</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderValue">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InfoCommand_AvailableFeatures">
         <source>Available features</source>
         <target state="translated">可用功能</target>

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.cs.xlf
@@ -12,6 +12,31 @@
         <target state="new">Continuously stream resource state changes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderEndpoints">
+        <source>Endpoints</source>
+        <target state="new">Endpoints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderHealth">
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderState">
+        <source>State</source>
+        <target state="new">State</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderType">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json).</source>
         <target state="needs-review-translation">Výstup ve formátu JSON pro spotřebu počítače.</target>

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.de.xlf
@@ -12,6 +12,31 @@
         <target state="new">Continuously stream resource state changes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderEndpoints">
+        <source>Endpoints</source>
+        <target state="new">Endpoints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderHealth">
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderState">
+        <source>State</source>
+        <target state="new">State</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderType">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json).</source>
         <target state="needs-review-translation">Ausgabe im JSON-Format zur maschinellen Verarbeitung.</target>

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.es.xlf
@@ -12,6 +12,31 @@
         <target state="new">Continuously stream resource state changes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderEndpoints">
+        <source>Endpoints</source>
+        <target state="new">Endpoints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderHealth">
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderState">
+        <source>State</source>
+        <target state="new">State</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderType">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json).</source>
         <target state="needs-review-translation">Salida en formato JSON para el consumo de la máquina.</target>

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.fr.xlf
@@ -12,6 +12,31 @@
         <target state="new">Continuously stream resource state changes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderEndpoints">
+        <source>Endpoints</source>
+        <target state="new">Endpoints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderHealth">
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderState">
+        <source>State</source>
+        <target state="new">State</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderType">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json).</source>
         <target state="needs-review-translation">Générer la sortie au format JSON pour traitement automatique.</target>

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.it.xlf
@@ -12,6 +12,31 @@
         <target state="new">Continuously stream resource state changes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderEndpoints">
+        <source>Endpoints</source>
+        <target state="new">Endpoints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderHealth">
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderState">
+        <source>State</source>
+        <target state="new">State</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderType">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json).</source>
         <target state="needs-review-translation">Output in formato JSON per l'utilizzo da parte del computer.</target>

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.ja.xlf
@@ -12,6 +12,31 @@
         <target state="new">Continuously stream resource state changes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderEndpoints">
+        <source>Endpoints</source>
+        <target state="new">Endpoints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderHealth">
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderState">
+        <source>State</source>
+        <target state="new">State</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderType">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json).</source>
         <target state="needs-review-translation">機械処理用の JSON 形式で出力します。</target>

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.ko.xlf
@@ -12,6 +12,31 @@
         <target state="new">Continuously stream resource state changes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderEndpoints">
+        <source>Endpoints</source>
+        <target state="new">Endpoints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderHealth">
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderState">
+        <source>State</source>
+        <target state="new">State</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderType">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json).</source>
         <target state="needs-review-translation">컴퓨터 사용량에 대한 JSON형식의 출력입니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.pl.xlf
@@ -12,6 +12,31 @@
         <target state="new">Continuously stream resource state changes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderEndpoints">
+        <source>Endpoints</source>
+        <target state="new">Endpoints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderHealth">
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderState">
+        <source>State</source>
+        <target state="new">State</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderType">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json).</source>
         <target state="needs-review-translation">Wynik w formacie JSON do przetwarzania przez maszynę.</target>

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.pt-BR.xlf
@@ -12,6 +12,31 @@
         <target state="new">Continuously stream resource state changes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderEndpoints">
+        <source>Endpoints</source>
+        <target state="new">Endpoints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderHealth">
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderState">
+        <source>State</source>
+        <target state="new">State</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderType">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json).</source>
         <target state="needs-review-translation">Saída no formato JSON para consumo do computador.</target>

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.ru.xlf
@@ -12,6 +12,31 @@
         <target state="new">Continuously stream resource state changes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderEndpoints">
+        <source>Endpoints</source>
+        <target state="new">Endpoints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderHealth">
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderState">
+        <source>State</source>
+        <target state="new">State</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderType">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json).</source>
         <target state="needs-review-translation">Вывод в формате JSON для потребления компьютером.</target>

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.tr.xlf
@@ -12,6 +12,31 @@
         <target state="new">Continuously stream resource state changes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderEndpoints">
+        <source>Endpoints</source>
+        <target state="new">Endpoints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderHealth">
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderState">
+        <source>State</source>
+        <target state="new">State</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderType">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json).</source>
         <target state="needs-review-translation">Makine tarafından kullanılmak üzere JSON biçiminde çıktı ver.</target>

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.zh-Hans.xlf
@@ -12,6 +12,31 @@
         <target state="new">Continuously stream resource state changes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderEndpoints">
+        <source>Endpoints</source>
+        <target state="new">Endpoints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderHealth">
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderState">
+        <source>State</source>
+        <target state="new">State</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderType">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json).</source>
         <target state="needs-review-translation">以 JSON 格式输出，供计算机使用。</target>

--- a/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DescribeCommandStrings.zh-Hant.xlf
@@ -12,6 +12,31 @@
         <target state="new">Continuously stream resource state changes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderEndpoints">
+        <source>Endpoints</source>
+        <target state="new">Endpoints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderHealth">
+        <source>Health</source>
+        <target state="new">Health</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderState">
+        <source>State</source>
+        <target state="new">State</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderType">
+        <source>Type</source>
+        <target state="new">Type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json).</source>
         <target state="needs-review-translation">輸出為 JSON 格式供機器使用。</target>

--- a/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.cs.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Získejte úplný obsah stránky dokumentace podle jejího slugu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderScore">
+        <source>Score</source>
+        <target state="new">Score</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSection">
+        <source>Section</source>
+        <target state="new">Section</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSlug">
+        <source>Slug</source>
+        <target state="new">Slug</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSummary">
+        <source>Summary</source>
+        <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTitle">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitOptionDescription">
         <source>Maximum number of search results to return (default: 5, max: 10).</source>
         <target state="translated">Maximální počet výsledků hledání, které se mají vrátit (výchozí: 5, max.: 10)</target>

--- a/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.de.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Den vollständigen Inhalt einer Dokumentationsseite anhand ihres Slugs abrufen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderScore">
+        <source>Score</source>
+        <target state="new">Score</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSection">
+        <source>Section</source>
+        <target state="new">Section</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSlug">
+        <source>Slug</source>
+        <target state="new">Slug</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSummary">
+        <source>Summary</source>
+        <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTitle">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitOptionDescription">
         <source>Maximum number of search results to return (default: 5, max: 10).</source>
         <target state="translated">Die maximale Anzahl der Suchergebnisse, die zurückgegeben werden sollen (Standard: 5, max: 10).</target>

--- a/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.es.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Obtenga el contenido completo de una página de documentación por su identificador.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderScore">
+        <source>Score</source>
+        <target state="new">Score</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSection">
+        <source>Section</source>
+        <target state="new">Section</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSlug">
+        <source>Slug</source>
+        <target state="new">Slug</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSummary">
+        <source>Summary</source>
+        <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTitle">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitOptionDescription">
         <source>Maximum number of search results to return (default: 5, max: 10).</source>
         <target state="translated">Número máximo de resultados de búsqueda que se devolverán (predeterminado: 5, máximo: 10).</target>

--- a/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.fr.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Obtenez le contenu complet d’une page de documentation grâce à son identifiant.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderScore">
+        <source>Score</source>
+        <target state="new">Score</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSection">
+        <source>Section</source>
+        <target state="new">Section</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSlug">
+        <source>Slug</source>
+        <target state="new">Slug</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSummary">
+        <source>Summary</source>
+        <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTitle">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitOptionDescription">
         <source>Maximum number of search results to return (default: 5, max: 10).</source>
         <target state="translated">Nombre maximal de résultats de recherche à retourner (par défaut : 5, max : 10).</target>

--- a/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.it.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Ottieni il contenuto completo di una pagina della documentazione tramite il suo campo dati dinamico.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderScore">
+        <source>Score</source>
+        <target state="new">Score</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSection">
+        <source>Section</source>
+        <target state="new">Section</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSlug">
+        <source>Slug</source>
+        <target state="new">Slug</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSummary">
+        <source>Summary</source>
+        <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTitle">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitOptionDescription">
         <source>Maximum number of search results to return (default: 5, max: 10).</source>
         <target state="translated">Numero massimo di risultati della ricerca da restituire (predefinito: 5, massimo: 10).</target>

--- a/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.ja.xlf
@@ -32,6 +32,31 @@
         <target state="translated">スラッグを指定してドキュメント ページのすべてのコンテンツを取得します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderScore">
+        <source>Score</source>
+        <target state="new">Score</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSection">
+        <source>Section</source>
+        <target state="new">Section</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSlug">
+        <source>Slug</source>
+        <target state="new">Slug</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSummary">
+        <source>Summary</source>
+        <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTitle">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitOptionDescription">
         <source>Maximum number of search results to return (default: 5, max: 10).</source>
         <target state="translated">返される検索結果の最大数 (既定値: 5、最大値: 10)。</target>

--- a/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.ko.xlf
@@ -32,6 +32,31 @@
         <target state="translated">슬러그로 설명서 페이지의 전체 내용을 가져옵니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderScore">
+        <source>Score</source>
+        <target state="new">Score</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSection">
+        <source>Section</source>
+        <target state="new">Section</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSlug">
+        <source>Slug</source>
+        <target state="new">Slug</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSummary">
+        <source>Summary</source>
+        <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTitle">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitOptionDescription">
         <source>Maximum number of search results to return (default: 5, max: 10).</source>
         <target state="translated">반환할 최대 검색 결과 수입니다(기본값: 5, 최대: 10).</target>

--- a/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.pl.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Pobierz pełną zawartość strony dokumentacji przy użyciu jej fragmentu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderScore">
+        <source>Score</source>
+        <target state="new">Score</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSection">
+        <source>Section</source>
+        <target state="new">Section</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSlug">
+        <source>Slug</source>
+        <target state="new">Slug</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSummary">
+        <source>Summary</source>
+        <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTitle">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitOptionDescription">
         <source>Maximum number of search results to return (default: 5, max: 10).</source>
         <target state="translated">Maksymalna liczba wyników wyszukiwania do zwrócenia (wartość domyślna: 5, maksimum: 10).</target>

--- a/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.pt-BR.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Obtenha o conteúdo completo de uma página de documentação pelo seu slug.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderScore">
+        <source>Score</source>
+        <target state="new">Score</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSection">
+        <source>Section</source>
+        <target state="new">Section</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSlug">
+        <source>Slug</source>
+        <target state="new">Slug</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSummary">
+        <source>Summary</source>
+        <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTitle">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitOptionDescription">
         <source>Maximum number of search results to return (default: 5, max: 10).</source>
         <target state="translated">Número máximo de resultados de pesquisa a serem retornados (padrão: 5, máx. 10).</target>

--- a/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.ru.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Получить полное содержимое страницы документации по её динамическому идентификатору.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderScore">
+        <source>Score</source>
+        <target state="new">Score</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSection">
+        <source>Section</source>
+        <target state="new">Section</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSlug">
+        <source>Slug</source>
+        <target state="new">Slug</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSummary">
+        <source>Summary</source>
+        <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTitle">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitOptionDescription">
         <source>Maximum number of search results to return (default: 5, max: 10).</source>
         <target state="translated">Максимальное количество результатов поиска, которые следует вернуть (по умолчанию: 5, максимум: 10).</target>

--- a/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.tr.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Bir belge sayfasının tüm içeriğini özel bilgi alanı ile alın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderScore">
+        <source>Score</source>
+        <target state="new">Score</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSection">
+        <source>Section</source>
+        <target state="new">Section</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSlug">
+        <source>Slug</source>
+        <target state="new">Slug</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSummary">
+        <source>Summary</source>
+        <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTitle">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitOptionDescription">
         <source>Maximum number of search results to return (default: 5, max: 10).</source>
         <target state="translated">Döndürülecek maksimum arama sonucu sayısı (varsayılan: 5, maksimum: 10).</target>

--- a/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.zh-Hans.xlf
@@ -32,6 +32,31 @@
         <target state="translated">通过短标识获取文档页面的完整内容。</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderScore">
+        <source>Score</source>
+        <target state="new">Score</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSection">
+        <source>Section</source>
+        <target state="new">Section</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSlug">
+        <source>Slug</source>
+        <target state="new">Slug</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSummary">
+        <source>Summary</source>
+        <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTitle">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitOptionDescription">
         <source>Maximum number of search results to return (default: 5, max: 10).</source>
         <target state="translated">要返回的最大搜索结果数(默认: 5，上限: 10)。</target>

--- a/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DocsCommandStrings.zh-Hant.xlf
@@ -32,6 +32,31 @@
         <target state="translated">依據識別字串取得文件頁面的完整內容。</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderScore">
+        <source>Score</source>
+        <target state="new">Score</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSection">
+        <source>Section</source>
+        <target state="new">Section</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSlug">
+        <source>Slug</source>
+        <target state="new">Slug</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSummary">
+        <source>Summary</source>
+        <target state="new">Summary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTitle">
+        <source>Title</source>
+        <target state="new">Title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitOptionDescription">
         <source>Maximum number of search results to return (default: 5, max: 10).</source>
         <target state="translated">最多回傳的搜尋結果數量 (預設: 5，最大值: 10)。</target>

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.cs.xlf
@@ -8,23 +8,23 @@
         <note />
       </trans-unit>
       <trans-unit id="HeaderCliPid">
-        <source>CLI_PID</source>
-        <target state="translated">CLI_PID</target>
+        <source>CLI PID</source>
+        <target state="needs-review-translation">CLI_PID</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDashboard">
-        <source>DASHBOARD</source>
-        <target state="translated">ŘÍDICÍ PANEL</target>
+        <source>Dashboard</source>
+        <target state="needs-review-translation">ŘÍDICÍ PANEL</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPath">
-        <source>PATH</source>
-        <target state="translated">CESTA</target>
+        <source>Path</source>
+        <target state="needs-review-translation">CESTA</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPid">
         <source>PID</source>
-        <target state="translated">PID</target>
+        <target state="needs-review-translation">PID</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.de.xlf
@@ -8,23 +8,23 @@
         <note />
       </trans-unit>
       <trans-unit id="HeaderCliPid">
-        <source>CLI_PID</source>
-        <target state="translated">CLI_PID</target>
+        <source>CLI PID</source>
+        <target state="needs-review-translation">CLI_PID</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDashboard">
-        <source>DASHBOARD</source>
-        <target state="translated">Dashboard</target>
+        <source>Dashboard</source>
+        <target state="needs-review-translation">Dashboard</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPath">
-        <source>PATH</source>
-        <target state="translated">PATH</target>
+        <source>Path</source>
+        <target state="needs-review-translation">PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPid">
         <source>PID</source>
-        <target state="translated">PID</target>
+        <target state="needs-review-translation">PID</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.es.xlf
@@ -8,23 +8,23 @@
         <note />
       </trans-unit>
       <trans-unit id="HeaderCliPid">
-        <source>CLI_PID</source>
-        <target state="translated">CLI_PID</target>
+        <source>CLI PID</source>
+        <target state="needs-review-translation">CLI_PID</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDashboard">
-        <source>DASHBOARD</source>
-        <target state="translated">PANEL</target>
+        <source>Dashboard</source>
+        <target state="needs-review-translation">PANEL</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPath">
-        <source>PATH</source>
-        <target state="translated">PATH</target>
+        <source>Path</source>
+        <target state="needs-review-translation">PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPid">
         <source>PID</source>
-        <target state="translated">PID</target>
+        <target state="needs-review-translation">PID</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.fr.xlf
@@ -8,23 +8,23 @@
         <note />
       </trans-unit>
       <trans-unit id="HeaderCliPid">
-        <source>CLI_PID</source>
-        <target state="translated">CLI_PID</target>
+        <source>CLI PID</source>
+        <target state="needs-review-translation">CLI_PID</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDashboard">
-        <source>DASHBOARD</source>
-        <target state="translated">TABLEAU DE BORD</target>
+        <source>Dashboard</source>
+        <target state="needs-review-translation">TABLEAU DE BORD</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPath">
-        <source>PATH</source>
-        <target state="translated">CHEMIN</target>
+        <source>Path</source>
+        <target state="needs-review-translation">CHEMIN</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPid">
         <source>PID</source>
-        <target state="translated">PID</target>
+        <target state="needs-review-translation">PID</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.it.xlf
@@ -8,23 +8,23 @@
         <note />
       </trans-unit>
       <trans-unit id="HeaderCliPid">
-        <source>CLI_PID</source>
-        <target state="translated">CLI_PID</target>
+        <source>CLI PID</source>
+        <target state="needs-review-translation">CLI_PID</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDashboard">
-        <source>DASHBOARD</source>
-        <target state="translated">DASHBOARD</target>
+        <source>Dashboard</source>
+        <target state="needs-review-translation">DASHBOARD</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPath">
-        <source>PATH</source>
-        <target state="translated">PATH</target>
+        <source>Path</source>
+        <target state="needs-review-translation">PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPid">
         <source>PID</source>
-        <target state="translated">PID</target>
+        <target state="needs-review-translation">PID</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.ja.xlf
@@ -8,23 +8,23 @@
         <note />
       </trans-unit>
       <trans-unit id="HeaderCliPid">
-        <source>CLI_PID</source>
-        <target state="translated">CLI_PID</target>
+        <source>CLI PID</source>
+        <target state="needs-review-translation">CLI_PID</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDashboard">
-        <source>DASHBOARD</source>
-        <target state="translated">ダッシュボード</target>
+        <source>Dashboard</source>
+        <target state="needs-review-translation">ダッシュボード</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPath">
-        <source>PATH</source>
-        <target state="translated">PATH</target>
+        <source>Path</source>
+        <target state="needs-review-translation">PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPid">
         <source>PID</source>
-        <target state="translated">PID</target>
+        <target state="needs-review-translation">PID</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.ko.xlf
@@ -8,23 +8,23 @@
         <note />
       </trans-unit>
       <trans-unit id="HeaderCliPid">
-        <source>CLI_PID</source>
-        <target state="translated">CLI_PID</target>
+        <source>CLI PID</source>
+        <target state="needs-review-translation">CLI_PID</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDashboard">
-        <source>DASHBOARD</source>
-        <target state="translated">대시보드</target>
+        <source>Dashboard</source>
+        <target state="needs-review-translation">대시보드</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPath">
-        <source>PATH</source>
-        <target state="translated">PATH</target>
+        <source>Path</source>
+        <target state="needs-review-translation">PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPid">
         <source>PID</source>
-        <target state="translated">PID</target>
+        <target state="needs-review-translation">PID</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.pl.xlf
@@ -8,23 +8,23 @@
         <note />
       </trans-unit>
       <trans-unit id="HeaderCliPid">
-        <source>CLI_PID</source>
-        <target state="translated">CLI_PID</target>
+        <source>CLI PID</source>
+        <target state="needs-review-translation">CLI_PID</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDashboard">
-        <source>DASHBOARD</source>
-        <target state="translated">PULPIT NAWIGACYJNY</target>
+        <source>Dashboard</source>
+        <target state="needs-review-translation">PULPIT NAWIGACYJNY</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPath">
-        <source>PATH</source>
-        <target state="translated">ŚCIEŻKA</target>
+        <source>Path</source>
+        <target state="needs-review-translation">ŚCIEŻKA</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPid">
         <source>PID</source>
-        <target state="translated">Identyfikator PID</target>
+        <target state="needs-review-translation">Identyfikator PID</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.pt-BR.xlf
@@ -8,23 +8,23 @@
         <note />
       </trans-unit>
       <trans-unit id="HeaderCliPid">
-        <source>CLI_PID</source>
-        <target state="translated">CLI_PID</target>
+        <source>CLI PID</source>
+        <target state="needs-review-translation">CLI_PID</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDashboard">
-        <source>DASHBOARD</source>
-        <target state="translated">PAINEL</target>
+        <source>Dashboard</source>
+        <target state="needs-review-translation">PAINEL</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPath">
-        <source>PATH</source>
-        <target state="translated">CAMINHO</target>
+        <source>Path</source>
+        <target state="needs-review-translation">CAMINHO</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPid">
         <source>PID</source>
-        <target state="translated">PID</target>
+        <target state="needs-review-translation">PID</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.ru.xlf
@@ -8,23 +8,23 @@
         <note />
       </trans-unit>
       <trans-unit id="HeaderCliPid">
-        <source>CLI_PID</source>
-        <target state="translated">CLI_PID</target>
+        <source>CLI PID</source>
+        <target state="needs-review-translation">CLI_PID</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDashboard">
-        <source>DASHBOARD</source>
-        <target state="translated">ПАНЕЛЬ МОНИТОРИНГА</target>
+        <source>Dashboard</source>
+        <target state="needs-review-translation">ПАНЕЛЬ МОНИТОРИНГА</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPath">
-        <source>PATH</source>
-        <target state="translated">PATH</target>
+        <source>Path</source>
+        <target state="needs-review-translation">PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPid">
         <source>PID</source>
-        <target state="translated">PID</target>
+        <target state="needs-review-translation">PID</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.tr.xlf
@@ -8,23 +8,23 @@
         <note />
       </trans-unit>
       <trans-unit id="HeaderCliPid">
-        <source>CLI_PID</source>
-        <target state="translated">CLI_PID</target>
+        <source>CLI PID</source>
+        <target state="needs-review-translation">CLI_PID</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDashboard">
-        <source>DASHBOARD</source>
-        <target state="translated">PANO</target>
+        <source>Dashboard</source>
+        <target state="needs-review-translation">PANO</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPath">
-        <source>PATH</source>
-        <target state="translated">YOL</target>
+        <source>Path</source>
+        <target state="needs-review-translation">YOL</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPid">
         <source>PID</source>
-        <target state="translated">PID</target>
+        <target state="needs-review-translation">PID</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.zh-Hans.xlf
@@ -8,23 +8,23 @@
         <note />
       </trans-unit>
       <trans-unit id="HeaderCliPid">
-        <source>CLI_PID</source>
-        <target state="translated">CLI_PID</target>
+        <source>CLI PID</source>
+        <target state="needs-review-translation">CLI_PID</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDashboard">
-        <source>DASHBOARD</source>
-        <target state="translated">仪表板</target>
+        <source>Dashboard</source>
+        <target state="needs-review-translation">仪表板</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPath">
-        <source>PATH</source>
-        <target state="translated">PATH</target>
+        <source>Path</source>
+        <target state="needs-review-translation">PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPid">
         <source>PID</source>
-        <target state="translated">PID</target>
+        <target state="needs-review-translation">PID</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/PsCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/PsCommandStrings.zh-Hant.xlf
@@ -8,23 +8,23 @@
         <note />
       </trans-unit>
       <trans-unit id="HeaderCliPid">
-        <source>CLI_PID</source>
-        <target state="translated">CLI_PID</target>
+        <source>CLI PID</source>
+        <target state="needs-review-translation">CLI_PID</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderDashboard">
-        <source>DASHBOARD</source>
-        <target state="translated">儀表板</target>
+        <source>Dashboard</source>
+        <target state="needs-review-translation">儀表板</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPath">
-        <source>PATH</source>
-        <target state="translated">路徑</target>
+        <source>Path</source>
+        <target state="needs-review-translation">路徑</target>
         <note />
       </trans-unit>
       <trans-unit id="HeaderPid">
         <source>PID</source>
-        <target state="translated">PID</target>
+        <target state="needs-review-translation">PID</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.cs.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Umožňuje filtrovat podle chybového stavu (true pro zobrazení pouze chyb, false pro vyloučení chyb).</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderDuration">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderStatus">
+        <source>Status</source>
+        <target state="new">Status</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace Id</source>
+        <target state="new">Trace Id</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">Hodnota --tail musí být kladné číslo.</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.de.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Filtern Sie nach Fehlerstatus (true, um nur Fehler anzuzeigen; false, um Fehler auszuschließen).</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderDuration">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderStatus">
+        <source>Status</source>
+        <target state="new">Status</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace Id</source>
+        <target state="new">Trace Id</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">Der Wert für --limit muss eine positive Zahl sein.</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.es.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Filtrar por estado de error (true para mostrar solo los errores, false para excluir errores).</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderDuration">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderStatus">
+        <source>Status</source>
+        <target state="new">Status</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace Id</source>
+        <target state="new">Trace Id</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">El valor --limit debe ser un número positivo.</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.fr.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Filtrer selon le statut d’erreur (true pour afficher uniquement les erreurs, false pour exclure les erreurs).</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderDuration">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderStatus">
+        <source>Status</source>
+        <target state="new">Status</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace Id</source>
+        <target state="new">Trace Id</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">La valeur --limit doit être un nombre positif.</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.it.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Filtra per stato di errore (true per mostrare solo gli errori, false per escluderli).</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderDuration">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderStatus">
+        <source>Status</source>
+        <target state="new">Status</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace Id</source>
+        <target state="new">Trace Id</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">Il valore --limit deve essere un numero positivo.</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ja.xlf
@@ -32,6 +32,31 @@
         <target state="translated">エラーの状態でフィルター処理します (エラーのみを表示する場合は true、エラーを除外するには false)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderDuration">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderStatus">
+        <source>Status</source>
+        <target state="new">Status</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace Id</source>
+        <target state="new">Trace Id</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">--limit の値は正の数値である必要があります。</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ko.xlf
@@ -32,6 +32,31 @@
         <target state="translated">오류 상태로 필터링합니다(true면 오류만, false면 오류 제외).</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderDuration">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderStatus">
+        <source>Status</source>
+        <target state="new">Status</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace Id</source>
+        <target state="new">Trace Id</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">--limit 값은 양수여야 합니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pl.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Filtruj według statusu błędu (wartość true, aby pokazać tylko błędy, false, aby je wykluczyć).</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderDuration">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderStatus">
+        <source>Status</source>
+        <target state="new">Status</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace Id</source>
+        <target state="new">Trace Id</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">Wartość --limit musi być liczbą dodatnią.</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.pt-BR.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Filtrar por status de erro (true para mostrar apenas erros, false para excluir erros).</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderDuration">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderStatus">
+        <source>Status</source>
+        <target state="new">Status</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace Id</source>
+        <target state="new">Trace Id</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">O valor --limit deve ser um número positivo.</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.ru.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Фильтрация по состоянию ошибки (true — показывать только ошибки, false — исключать ошибки).</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderDuration">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderStatus">
+        <source>Status</source>
+        <target state="new">Status</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace Id</source>
+        <target state="new">Trace Id</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">Значение --limit должно быть положительным числом.</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.tr.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Hata durumuna göre filtreleyin (yalnızca hataları göstermek için true, hataları hariç tutmak için false).</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderDuration">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderStatus">
+        <source>Status</source>
+        <target state="new">Status</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace Id</source>
+        <target state="new">Trace Id</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">--limit değeri, pozitif bir sayı olmalıdır.</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hans.xlf
@@ -32,6 +32,31 @@
         <target state="translated">按错误状态筛选(true 表示仅显示错误，false 表示排除错误)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderDuration">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderStatus">
+        <source>Status</source>
+        <target state="new">Status</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace Id</source>
+        <target state="new">Trace Id</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">--limit 值必须是正数。</target>

--- a/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TelemetryCommandStrings.zh-Hant.xlf
@@ -32,6 +32,31 @@
         <target state="translated">依錯誤狀態篩選 (true 以僅顯示錯誤，false 以排除錯誤)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="HeaderDuration">
+        <source>Duration</source>
+        <target state="new">Duration</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderResource">
+        <source>Resource</source>
+        <target state="new">Resource</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderSpans">
+        <source>Spans</source>
+        <target state="new">Spans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderStatus">
+        <source>Status</source>
+        <target state="new">Status</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HeaderTraceId">
+        <source>Trace Id</source>
+        <target state="new">Trace Id</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LimitMustBePositive">
         <source>The --limit value must be a positive number.</source>
         <target state="translated">--limit 值必須是正數。</target>

--- a/src/Aspire.Cli/Utils/TableExtensions.cs
+++ b/src/Aspire.Cli/Utils/TableExtensions.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Spectre.Console;
+
+namespace Aspire.Cli.Utils;
+
+/// <summary>
+/// Extension methods for Spectre.Console <see cref="Table"/>.
+/// </summary>
+internal static class TableExtensions
+{
+    /// <summary>
+    /// Adds a column with a bold header to the table.
+    /// </summary>
+    public static Table AddBoldColumn(this Table table, string header)
+    {
+        table.AddColumn($"[bold]{header.EscapeMarkup()}[/]");
+        return table;
+    }
+
+    /// <summary>
+    /// Adds a column with a bold, non-wrapping header to the table.
+    /// </summary>
+    public static Table AddBoldColumn(this Table table, string header, bool noWrap)
+    {
+        var column = new TableColumn($"[bold]{header.EscapeMarkup()}[/]");
+
+        if (noWrap)
+        {
+            column.NoWrap();
+        }
+
+        table.AddColumn(column);
+        return table;
+    }
+
+    /// <summary>
+    /// Adds a column with a bold header and a fixed width to the table.
+    /// </summary>
+    public static Table AddBoldColumn(this Table table, string header, int width)
+    {
+        var column = new TableColumn($"[bold]{header.EscapeMarkup()}[/]");
+        column.Width = width;
+        table.AddColumn(column);
+        return table;
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -15,6 +15,7 @@ using Aspire.Cli.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Tests.Commands;
@@ -957,7 +958,7 @@ internal sealed class OrderTrackingInteractionService(List<string> operationOrde
     public void DisplayMarkupLine(string markup) { }
     public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false) { }
     public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null) { }
-    public void DisplayTable(Table table) { }
+    public void DisplayRenderable(IRenderable renderable) { }
 }
 
 internal sealed class NewCommandTestPackagingService : IPackagingService

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -957,6 +957,7 @@ internal sealed class OrderTrackingInteractionService(List<string> operationOrde
     public void DisplayMarkupLine(string markup) { }
     public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false) { }
     public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null) { }
+    public void DisplayTable(Table table) { }
 }
 
 internal sealed class NewCommandTestPackagingService : IPackagingService

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -953,6 +953,8 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
 
     public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null) { }
 
+    public void DisplayTable(Table table) { }
+
     public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false)
     {
         var messageType = isErrorMessage ? "error" : "info";

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -11,6 +11,7 @@ using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.InternalTesting;
@@ -953,7 +954,7 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
 
     public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null) { }
 
-    public void DisplayTable(Table table) { }
+    public void DisplayRenderable(IRenderable renderable) { }
 
     public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false)
     {

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -12,6 +12,7 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 using Microsoft.AspNetCore.InternalTesting;
 
 namespace Aspire.Cli.Tests.Commands;
@@ -984,7 +985,7 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
         => _innerService.DisplayVersionUpdateNotification(newerVersion, updateCommand);
     public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false) 
         => _innerService.WriteConsoleLog(message, lineNumber, type, isErrorMessage);
-    public void DisplayTable(Table table) => _innerService.DisplayTable(table);
+    public void DisplayRenderable(IRenderable renderable) => _innerService.DisplayRenderable(renderable);
 }
 
 // Test implementation of IProjectUpdater

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -984,6 +984,7 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
         => _innerService.DisplayVersionUpdateNotification(newerVersion, updateCommand);
     public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false) 
         => _innerService.WriteConsoleLog(message, lineNumber, type, isErrorMessage);
+    public void DisplayTable(Table table) => _innerService.DisplayTable(table);
 }
 
 // Test implementation of IProjectUpdater

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -446,6 +446,7 @@ public class DotNetTemplateFactoryTests
         public void DisplayEmptyLine() { }
         public void DisplayVersionUpdateNotification(string message, string? updateCommand = null) { }
         public void WriteConsoleLog(string message, int? resourceHashCode, string? resourceName, bool isError) { }
+        public void DisplayTable(Table table) { }
     }
 
     private sealed class TestDotNetCliRunner : IDotNetCliRunner

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -16,6 +16,7 @@ using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Aspire.Shared;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace Aspire.Cli.Tests.Templating;
 
@@ -446,7 +447,7 @@ public class DotNetTemplateFactoryTests
         public void DisplayEmptyLine() { }
         public void DisplayVersionUpdateNotification(string message, string? updateCommand = null) { }
         public void WriteConsoleLog(string message, int? resourceHashCode, string? resourceName, bool isError) { }
-        public void DisplayTable(Table table) { }
+        public void DisplayRenderable(IRenderable renderable) { }
     }
 
     private sealed class TestDotNetCliRunner : IDotNetCliRunner

--- a/tests/Aspire.Cli.Tests/TestServices/TestConsoleInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestConsoleInteractionService.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace Aspire.Cli.Tests.TestServices;
 
@@ -139,7 +140,7 @@ internal sealed class TestConsoleInteractionService : IInteractionService
         DisplayVersionUpdateNotificationCallback?.Invoke(newerVersion);
     }
 
-    public void DisplayTable(Table table)
+    public void DisplayRenderable(IRenderable renderable)
     {
     }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestConsoleInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestConsoleInteractionService.cs
@@ -138,4 +138,8 @@ internal sealed class TestConsoleInteractionService : IInteractionService
     {
         DisplayVersionUpdateNotificationCallback?.Invoke(newerVersion);
     }
+
+    public void DisplayTable(Table table)
+    {
+    }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -152,6 +152,10 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
         DisplayVersionUpdateNotificationCallback?.Invoke(newerVersion);
     }
 
+    public void DisplayTable(Table table)
+    {
+    }
+
     public Action<string>? OpenEditorCallback { get; set; }
 
     public void OpenEditor(string projectPath)

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -6,6 +6,7 @@ using Aspire.Cli.Interaction;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace Aspire.Cli.Tests.TestServices;
 
@@ -152,7 +153,7 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
         DisplayVersionUpdateNotificationCallback?.Invoke(newerVersion);
     }
 
-    public void DisplayTable(Table table)
+    public void DisplayRenderable(IRenderable renderable)
     {
     }
 


### PR DESCRIPTION
## Description

Improve CLI tables:

- Tables now rendered via IInteractionService
- Table headers always bold (white text)
- Table headers text always comes from resource files
- Change `aspire config list` global and local tables have consistent widths
- Change `aspire ps` to use Spectre.Console table

aspire ps before:
<img width="1284" height="76" alt="image" src="https://github.com/user-attachments/assets/60366fa6-4d1e-4d2e-b0f0-ffbfc4e5f806" />

aspire ps after:
<img width="1361" height="168" alt="image" src="https://github.com/user-attachments/assets/69fbc67a-d178-497f-9d9c-f685363cea2c" />

aspire config after:
<img width="958" height="422" alt="image" src="https://github.com/user-attachments/assets/ecf5e2c4-0cca-4ad5-a664-29699bb9c72e" />

Fixes https://github.com/dotnet/aspire/issues/14728

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
