### PR TITLE
Move DOTNET_ENVIRONMENT/ASPNETCORE_ENVIRONMENT to code for polyglot apphosts

### DIFF
--- a/playground/TypeScriptAppHost/apphost.run.json
+++ b/playground/TypeScriptAppHost/apphost.run.json
@@ -7,8 +7,6 @@
       "launchBrowser": true,
       "applicationUrl": "https://localhost:17000;http://localhost:15000",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21000",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22000",
         "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
@@ -20,8 +18,6 @@
       "launchBrowser": true,
       "applicationUrl": "http://localhost:15000",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19000",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20000",
         "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",

--- a/playground/polyglot/TypeScript/Aspire.Hosting.Azure.CognitiveServices/ValidationAppHost/apphost.run.json
+++ b/playground/polyglot/TypeScript/Aspire.Hosting.Azure.CognitiveServices/ValidationAppHost/apphost.run.json
@@ -3,8 +3,6 @@
     "https": {
       "applicationUrl": "https://localhost:55134;http://localhost:18351",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:34251",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:60108"
       }

--- a/playground/polyglot/TypeScript/Aspire.Hosting.Azure.Functions/ValidationAppHost/apphost.run.json
+++ b/playground/polyglot/TypeScript/Aspire.Hosting.Azure.Functions/ValidationAppHost/apphost.run.json
@@ -3,8 +3,6 @@
     "https": {
       "applicationUrl": "https://localhost:43912;http://localhost:19322",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:30254",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:15931"
       }

--- a/playground/polyglot/TypeScript/Aspire.Hosting.Azure.KeyVault/ValidationAppHost/apphost.run.json
+++ b/playground/polyglot/TypeScript/Aspire.Hosting.Azure.KeyVault/ValidationAppHost/apphost.run.json
@@ -3,8 +3,6 @@
     "https": {
       "applicationUrl": "https://localhost:52800;http://localhost:51322",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:10120",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:11479"
       }

--- a/playground/polyglot/TypeScript/Aspire.Hosting.Azure.OperationalInsights/ValidationAppHost/apphost.run.json
+++ b/playground/polyglot/TypeScript/Aspire.Hosting.Azure.OperationalInsights/ValidationAppHost/apphost.run.json
@@ -3,8 +3,6 @@
     "https": {
       "applicationUrl": "https://localhost:52066;http://localhost:47700",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:62976",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:34207"
       }

--- a/playground/polyglot/TypeScript/Aspire.Hosting.Azure.ServiceBus/ValidationAppHost/apphost.run.json
+++ b/playground/polyglot/TypeScript/Aspire.Hosting.Azure.ServiceBus/ValidationAppHost/apphost.run.json
@@ -3,8 +3,6 @@
     "https": {
       "applicationUrl": "https://localhost:24190;http://localhost:42530",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:60807",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:16724"
       }

--- a/playground/polyglot/TypeScript/Aspire.Hosting.Azure.Storage/ValidationAppHost/apphost.run.json
+++ b/playground/polyglot/TypeScript/Aspire.Hosting.Azure.Storage/ValidationAppHost/apphost.run.json
@@ -3,8 +3,6 @@
     "https": {
       "applicationUrl": "https://localhost:52066;http://localhost:47700",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:62976",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:34207"
       }

--- a/playground/polyglot/TypeScript/Aspire.Hosting.RabbitMQ/ValidationAppHost/apphost.run.json
+++ b/playground/polyglot/TypeScript/Aspire.Hosting.RabbitMQ/ValidationAppHost/apphost.run.json
@@ -3,8 +3,6 @@
     "https": {
       "applicationUrl": "https://localhost:18076;http://localhost:48822",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:56384",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:64883"
       }

--- a/playground/polyglot/TypeScript/Aspire.Hosting.SqlServer/apphost.run.json
+++ b/playground/polyglot/TypeScript/Aspire.Hosting.SqlServer/apphost.run.json
@@ -3,8 +3,6 @@
     "https": {
       "applicationUrl": "https://localhost:55686;http://localhost:57768",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:51980",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:28684"
       }

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -487,8 +487,9 @@ internal sealed class GuestAppHostProject : IAppHostProject
     {
         var envVars = ReadLaunchSettingsEnvironmentVariables(directory) ?? new Dictionary<string, string>();
 
-        // Support ASPIRE_ENVIRONMENT as a single env var that sets both DOTNET_ENVIRONMENT and ASPNETCORE_ENVIRONMENT
-        var environment = Environment.GetEnvironmentVariable("ASPIRE_ENVIRONMENT") ?? "Development";
+        // Support ASPIRE_ENVIRONMENT from the launch profile to set both DOTNET_ENVIRONMENT and ASPNETCORE_ENVIRONMENT
+        envVars.TryGetValue("ASPIRE_ENVIRONMENT", out var environment);
+        environment ??= "Development";
 
         // Set the environment for the AppHost server process
         envVars["DOTNET_ENVIRONMENT"] = environment;

--- a/src/Aspire.Hosting.CodeGeneration.Go/GoLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Go/GoLanguageSupport.cs
@@ -92,8 +92,6 @@ public sealed class GoLanguageSupport : ILanguageSupport
                 "https": {
                   "applicationUrl": "https://localhost:{{httpsPort}};http://localhost:{{httpPort}}",
                   "environmentVariables": {
-                    "ASPNETCORE_ENVIRONMENT": "Development",
-                    "DOTNET_ENVIRONMENT": "Development",
                     "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:{{otlpPort}}",
                     "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:{{resourceServicePort}}"
                   }

--- a/src/Aspire.Hosting.CodeGeneration.Java/JavaLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Java/JavaLanguageSupport.cs
@@ -76,8 +76,6 @@ public sealed class JavaLanguageSupport : ILanguageSupport
                 "https": {
                   "applicationUrl": "https://localhost:{{httpsPort}};http://localhost:{{httpPort}}",
                   "environmentVariables": {
-                    "ASPNETCORE_ENVIRONMENT": "Development",
-                    "DOTNET_ENVIRONMENT": "Development",
                     "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:{{otlpPort}}",
                     "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:{{resourceServicePort}}"
                   }

--- a/src/Aspire.Hosting.CodeGeneration.Python/PythonLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Python/PythonLanguageSupport.cs
@@ -104,8 +104,6 @@ public sealed class PythonLanguageSupport : ILanguageSupport
                 "https": {
                   "applicationUrl": "https://localhost:{{httpsPort}};http://localhost:{{httpPort}}",
                   "environmentVariables": {
-                    "ASPNETCORE_ENVIRONMENT": "Development",
-                    "DOTNET_ENVIRONMENT": "Development",
                     "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:{{otlpPort}}",
                     "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:{{resourceServicePort}}"
                   }

--- a/src/Aspire.Hosting.CodeGeneration.Rust/RustLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Rust/RustLanguageSupport.cs
@@ -91,8 +91,6 @@ public sealed class RustLanguageSupport : ILanguageSupport
                 "https": {
                   "applicationUrl": "https://localhost:{{httpsPort}};http://localhost:{{httpPort}}",
                   "environmentVariables": {
-                    "ASPNETCORE_ENVIRONMENT": "Development",
-                    "DOTNET_ENVIRONMENT": "Development",
                     "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:{{otlpPort}}",
                     "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:{{resourceServicePort}}"
                   }

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
@@ -109,8 +109,6 @@ public sealed class TypeScriptLanguageSupport : ILanguageSupport
                 "https": {
                   "applicationUrl": "https://localhost:{{httpsPort}};http://localhost:{{httpPort}}",
                   "environmentVariables": {
-                    "ASPNETCORE_ENVIRONMENT": "Development",
-                    "DOTNET_ENVIRONMENT": "Development",
                     "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:{{otlpPort}}",
                     "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:{{resourceServicePort}}"
                   }


### PR DESCRIPTION
## Description

Move `DOTNET_ENVIRONMENT` and `ASPNETCORE_ENVIRONMENT` out of generated `apphost.run.json` files and into code for polyglot apphosts.

**Motivation:** These environment variables were being hardcoded into every generated `apphost.run.json` for polyglot languages (TypeScript, Python, Java, Go, Rust) and in playground samples. This is unnecessary file-level configuration that should be set programmatically by the CLI when launching the AppHost server process.

**Changes:**
- Removed `DOTNET_ENVIRONMENT` and `ASPNETCORE_ENVIRONMENT` from generated `apphost.run.json` in all 5 polyglot `*LanguageSupport.cs` scaffold methods
- Removed these variables from all 9 TypeScript playground `apphost.run.json` files
- Added `GetServerEnvironmentVariables()` helper in `GuestAppHostProject` that sets these env vars in code, used by both run and publish paths
- Added `ASPIRE_ENVIRONMENT` support: a single env var that controls both `DOTNET_ENVIRONMENT` and `ASPNETCORE_ENVIRONMENT`, defaulting to `Development`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
