### PR TITLE
Follow-up: aspire secret table pattern and Development-only polyglot secrets

### DIFF
--- a/src/Aspire.Cli/Commands/SecretListCommand.cs
+++ b/src/Aspire.Cli/Commands/SecretListCommand.cs
@@ -75,9 +75,8 @@ internal sealed class SecretListCommand : BaseCommand
             else
             {
                 var table = new Table();
-                table.Border(TableBorder.Rounded);
-                table.AddColumn(new TableColumn($"[bold]{SecretCommandStrings.KeyColumnHeader}[/]").NoWrap());
-                table.AddColumn(new TableColumn($"[bold]{SecretCommandStrings.ValueColumnHeader}[/]"));
+                table.AddBoldColumn(SecretCommandStrings.KeyColumnHeader, noWrap: true);
+                table.AddBoldColumn(SecretCommandStrings.ValueColumnHeader);
 
                 foreach (var (key, value) in secrets.OrderBy(s => s.Key, StringComparer.OrdinalIgnoreCase))
                 {
@@ -86,7 +85,7 @@ internal sealed class SecretListCommand : BaseCommand
                         $"[yellow]{value.EscapeMarkup()}[/]");
                 }
 
-                AnsiConsole.Write(table);
+                InteractionService.DisplayRenderable(table);
             }
         }
 

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -193,8 +193,10 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
         // For polyglot AppHosts (no assembly attribute), add user secrets early so they have the
         // same precedence as the default AddUserSecrets called by HostApplicationBuilder for .NET projects.
+        // Only add in Development environment, matching the behavior of the default AddUserSecrets.
         if (!string.IsNullOrEmpty(userSecretsId) &&
-            AppHostAssembly?.GetCustomAttribute<UserSecretsIdAttribute>() is null)
+            AppHostAssembly?.GetCustomAttribute<UserSecretsIdAttribute>() is null &&
+            _innerBuilder.Environment.IsDevelopment())
         {
             _innerBuilder.Configuration.AddUserSecrets(userSecretsId);
         }


### PR DESCRIPTION
## Description

Follow-up fixes for `aspire secret` after merging #14673:

1. **Update table output** to match the new CLI table pattern from #14730 — use `AddBoldColumn` extension and `InteractionService.DisplayRenderable` instead of `AnsiConsole.Write` with manual `TableBorder.Rounded`.

2. **Only add polyglot user secrets in Development environment** — `HostApplicationBuilder`'s default `AddUserSecrets` only loads secrets when `IsDevelopment()` is true. The polyglot `ASPIRE_USER_SECRETS_ID` fallback in `DistributedApplicationBuilder` now matches this behavior.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
