### PR TITLE
Fix and consolidate markup escaping in CLI

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -162,7 +162,7 @@ internal sealed class AppHostConnectionResolver(
         else if (outOfScopeConnections.Count > 0)
         {
             // No in-scope AppHosts, but there are out-of-scope ones - let user pick
-            interactionService.DisplayMessage("information", noInScopeMessage);
+            interactionService.DisplayMessage(KnownEmojis.Information, noInScopeMessage);
 
             // Order by most recently started first
             var choices = outOfScopeConnections

--- a/src/Aspire.Cli/Certificates/CertificateService.cs
+++ b/src/Aspire.Cli/Certificates/CertificateService.cs
@@ -81,8 +81,9 @@ internal sealed partial class CertificateService(
         };
 
         var (_, result) = await interactionService.ShowStatusAsync(
-            $":locked_with_key: {InteractionServiceStrings.CheckingCertificates}",
-            async () => await certificateToolRunner.CheckHttpCertificateMachineReadableAsync(options, cancellationToken));
+            InteractionServiceStrings.CheckingCertificates,
+            async () => await certificateToolRunner.CheckHttpCertificateMachineReadableAsync(options, cancellationToken),
+            emoji: KnownEmojis.LockedWithKey);
 
         // Return the result or a default "no certificates" result
         return result ?? new CertificateTrustResult
@@ -115,13 +116,14 @@ internal sealed partial class CertificateService(
             };
 
             var trustExitCode = await interactionService.ShowStatusAsync(
-                $":locked_with_key: {InteractionServiceStrings.TrustingCertificates}",
-                () => certificateToolRunner.TrustHttpCertificateAsync(options, cancellationToken));
+                InteractionServiceStrings.TrustingCertificates,
+                () => certificateToolRunner.TrustHttpCertificateAsync(options, cancellationToken),
+                emoji: KnownEmojis.LockedWithKey);
 
             if (trustExitCode != 0)
             {
                 interactionService.DisplayLines(collector.GetLines());
-                interactionService.DisplayMessage("warning", string.Format(CultureInfo.CurrentCulture, ErrorStrings.CertificatesMayNotBeFullyTrusted, trustExitCode));
+                interactionService.DisplayMessage(KnownEmojis.Warning, string.Format(CultureInfo.CurrentCulture, ErrorStrings.CertificatesMayNotBeFullyTrusted, trustExitCode));
             }
 
             // Re-check trust status after trust operation

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -219,7 +219,7 @@ internal sealed class AddCommand : BaseCommand
 
                 if (runningInstanceResult == RunningInstanceResult.InstanceStopped)
                 {
-                    InteractionService.DisplayMessage("information_source", AddCommandStrings.StoppedRunningInstance);
+                    InteractionService.DisplayMessage(KnownEmojis.Information, AddCommandStrings.StoppedRunningInstance);
                 }
                 else if (runningInstanceResult == RunningInstanceResult.StopFailed)
                 {

--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -161,7 +161,7 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
 
         if (hasErrors)
         {
-            _interactionService.DisplayMessage("warning", AgentCommandStrings.ConfigurationCompletedWithErrors);
+            _interactionService.DisplayMessage(KnownEmojis.Warning, AgentCommandStrings.ConfigurationCompletedWithErrors);
         }
         else
         {

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -304,7 +304,7 @@ internal sealed class AppHostLauncher(
             }
         }
 
-        interactionService.DisplayMessage("magnifying_glass_tilted_right", string.Format(
+        interactionService.DisplayMessage(KnownEmojis.MagnifyingGlassTiltedRight, string.Format(
             CultureInfo.CurrentCulture,
             RunCommandStrings.CheckLogsForDetails,
             childLogFile));

--- a/src/Aspire.Cli/Commands/CacheCommand.cs
+++ b/src/Aspire.Cli/Commands/CacheCommand.cs
@@ -150,7 +150,7 @@ internal sealed class CacheCommand : BaseCommand
 
                 if (filesDeleted == 0)
                 {
-                    InteractionService.DisplayMessage("information", CacheCommandStrings.CacheAlreadyEmpty);
+                    InteractionService.DisplayMessage(KnownEmojis.Information, CacheCommandStrings.CacheAlreadyEmpty);
                 }
                 else
                 {

--- a/src/Aspire.Cli/Commands/ConfigCommand.cs
+++ b/src/Aspire.Cli/Commands/ConfigCommand.cs
@@ -226,7 +226,7 @@ internal sealed class ConfigCommand : BaseCommand
             // Check if we have any configuration at all
             if (localConfig.Count == 0 && globalConfig.Count == 0)
             {
-                InteractionService.DisplayMessage("information", ConfigCommandStrings.NoConfigurationValuesFound);
+                InteractionService.DisplayMessage(KnownEmojis.Information, ConfigCommandStrings.NoConfigurationValuesFound);
                 return ExitCodeConstants.Success;
             }
 
@@ -477,7 +477,7 @@ internal sealed class ConfigCommand : BaseCommand
                 foreach (var property in localSchema.Properties)
                 {
                     var requiredText = property.Required ? "[red]*[/]" : "";
-                    InteractionService.DisplayMarkupLine($"  {requiredText}[cyan]{property.Name.EscapeMarkup()}[/] ([yellow]{property.Type}[/]) - {property.Description.EscapeMarkup()}");
+                    InteractionService.DisplayMarkupLine($"  {requiredText}[cyan]{property.Name.EscapeMarkup()}[/] ([yellow]{property.Type.EscapeMarkup()}[/]) - {property.Description.EscapeMarkup()}");
                 }
             }
 

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -127,7 +127,7 @@ internal sealed class DescribeCommand : BaseCommand
         if (!result.Success)
         {
             // No running AppHosts is not an error - similar to Unix 'ps' returning empty
-            _interactionService.DisplayMessage("information", result.ErrorMessage);
+            _interactionService.DisplayMessage(KnownEmojis.Information, result.ErrorMessage);
             return ExitCodeConstants.Success;
         }
 

--- a/src/Aspire.Cli/Commands/ExecCommand.cs
+++ b/src/Aspire.Cli/Commands/ExecCommand.cs
@@ -189,14 +189,14 @@ internal class ExecCommand : BaseCommand
                 // We wait for the back channel to be created to signal that
                 // the AppHost is ready to accept requests.
                 backchannel = await InteractionService.ShowStatusAsync(
-                    $":linked_paperclips:  {RunCommandStrings.StartingAppHost}",
+                    RunCommandStrings.StartingAppHost,
                     async () =>
                     {
                         // If we use the --wait-for-debugger option we print out the process ID
                         // of the apphost so that the user can attach to it.
                         if (waitForDebugger)
                         {
-                            InteractionService.DisplayMessage("bug", InteractionServiceStrings.WaitingForDebuggerToAttachToAppHost);
+                            InteractionService.DisplayMessage(KnownEmojis.Bug, InteractionServiceStrings.WaitingForDebuggerToAttachToAppHost);
                         }
 
                         // The wait for the debugger in the apphost is done inside the CreateBuilder(...) method
@@ -204,10 +204,10 @@ internal class ExecCommand : BaseCommand
                         // good signal that the debugger was attached (or timed out).
                         var backchannel = await backchannelCompletionSource.Task.WaitAsync(cancellationToken);
                         return backchannel;
-                    });
+                    }, emoji: KnownEmojis.LinkedPaperclips);
 
                 commandExitCode = await InteractionService.ShowStatusAsync<int?>(
-                    $":running_shoe: {ExecCommandStrings.Running}",
+                    ExecCommandStrings.Running,
                     async () =>
                     {
                         // execute tool and stream the output
@@ -223,19 +223,19 @@ internal class ExecCommand : BaseCommand
                         }
 
                         return exitCode;
-                    });
+                    }, emoji: KnownEmojis.RunningShoe);
             }
             finally
             {
                 if (backchannel is not null)
                 {
                     _ = await InteractionService.ShowStatusAsync<int>(
-                    $":linked_paperclips: {ExecCommandStrings.StoppingAppHost}",
+                    ExecCommandStrings.StoppingAppHost,
                     async () =>
                     {
                         await backchannel.RequestStopAsync(cancellationToken);
                         return ExitCodeConstants.Success;
-                    });
+                    }, emoji: KnownEmojis.LinkedPaperclips);
                 }
             }
 

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -143,7 +143,7 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
             }
 
             InteractionService.DisplayEmptyLine();
-            InteractionService.DisplayMessage("information", $"Creating {languageInfo.DisplayName} AppHost...");
+            InteractionService.DisplayMessage(KnownEmojis.Information, $"Creating {languageInfo.DisplayName} AppHost...");
             InteractionService.DisplayEmptyLine();
             return await CreatePolyglotAppHostAsync(languageInfo, cancellationToken);
         }
@@ -163,14 +163,14 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
         if (initContext.SelectedSolutionFile is not null)
         {
             InteractionService.DisplayEmptyLine();
-            InteractionService.DisplayMessage("information", string.Format(CultureInfo.CurrentCulture, InitCommandStrings.SolutionDetected, initContext.SelectedSolutionFile.Name));
+            InteractionService.DisplayMessage(KnownEmojis.Information, string.Format(CultureInfo.CurrentCulture, InitCommandStrings.SolutionDetected, initContext.SelectedSolutionFile.Name));
             InteractionService.DisplayEmptyLine();
             return await InitializeExistingSolutionAsync(initContext, parseResult, cancellationToken);
         }
         else
         {
             InteractionService.DisplayEmptyLine();
-            InteractionService.DisplayMessage("information", InitCommandStrings.NoSolutionFoundCreatingSingleFileAppHost);
+            InteractionService.DisplayMessage(KnownEmojis.Information, InitCommandStrings.NoSolutionFoundCreatingSingleFileAppHost);
             InteractionService.DisplayEmptyLine();
             return await CreateEmptyAppHostAsync(parseResult, cancellationToken);
         }
@@ -214,7 +214,7 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
 
         if (initContext.AlreadyHasAppHost)
         {
-            InteractionService.DisplayMessage("check_mark", InitCommandStrings.SolutionAlreadyInitialized);
+            InteractionService.DisplayMessage(KnownEmojis.CheckMark, InitCommandStrings.SolutionAlreadyInitialized);
             return ExitCodeConstants.Success;
         }
 
@@ -246,12 +246,12 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
             if (initContext.ExecutableProjectsToAddToAppHost.Count > 0)
             {
                 InteractionService.DisplayEmptyLine();
-                InteractionService.DisplayMessage("information", "The following projects will be added to the AppHost:");
+                InteractionService.DisplayMessage(KnownEmojis.Information, "The following projects will be added to the AppHost:");
                 InteractionService.DisplayEmptyLine();
 
                 foreach (var project in initContext.ExecutableProjectsToAddToAppHost)
                 {
-                    InteractionService.DisplayMessage("check_box_with_check", project.ProjectFile.Name);
+                    InteractionService.DisplayMessage(KnownEmojis.CheckBoxWithCheck, project.ProjectFile.Name);
                 }
 
                 var addServiceDefaultsMessage = """
@@ -550,7 +550,7 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
             var appHostPath = Path.Combine(workingDirectory.FullName, appHostFileName);
             if (File.Exists(appHostPath))
             {
-                InteractionService.DisplayMessage("check_mark", $"{appHostFileName} already exists in this directory.");
+                InteractionService.DisplayMessage(KnownEmojis.CheckMark, $"{appHostFileName} already exists in this directory.");
                 return ExitCodeConstants.Success;
             }
         }
@@ -560,7 +560,7 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
         await _scaffoldingService.ScaffoldAsync(context, cancellationToken);
 
         InteractionService.DisplaySuccess($"Created {appHostFileName}");
-        InteractionService.DisplayMessage("information", $"Run 'aspire run' to start your AppHost.");
+        InteractionService.DisplayMessage(KnownEmojis.Information, $"Run 'aspire run' to start your AppHost.");
         return ExitCodeConstants.Success;
     }
 

--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -172,7 +172,7 @@ internal sealed class LogsCommand : BaseCommand
         if (!result.Success)
         {
             // No running AppHosts is not an error - similar to Unix 'ps' returning empty
-            _interactionService.DisplayMessage("information", result.ErrorMessage);
+            _interactionService.DisplayMessage(KnownEmojis.Information, result.ErrorMessage);
             return ExitCodeConstants.Success;
         }
 
@@ -195,7 +195,7 @@ internal sealed class LogsCommand : BaseCommand
         {
             if (snapshots.Count == 0)
             {
-                _interactionService.DisplayMessage("information", LogsCommandStrings.NoResourcesFound);
+                _interactionService.DisplayMessage(KnownEmojis.Information, LogsCommandStrings.NoResourcesFound);
                 return ExitCodeConstants.Success;
             }
         }

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -170,10 +170,10 @@ internal abstract class PipelineCommandBase : BaseCommand
             // of the apphost so that the user can attach to it.
             if (waitForDebugger)
             {
-                InteractionService.DisplayMessage("bug", InteractionServiceStrings.WaitingForDebuggerToAttachToAppHost);
+                InteractionService.DisplayMessage(KnownEmojis.Bug, InteractionServiceStrings.WaitingForDebuggerToAttachToAppHost);
             }
 
-            var backchannel = await InteractionService.ShowStatusAsync($":hammer_and_wrench:  {GetProgressMessage(parseResult)}", async () =>
+            var backchannel = await InteractionService.ShowStatusAsync(GetProgressMessage(parseResult), async () =>
             {
                 var completedTask = await Task.WhenAny(backchannelCompletionSource.Task, pendingRun);
                 if (completedTask == backchannelCompletionSource.Task)
@@ -191,7 +191,7 @@ internal abstract class PipelineCommandBase : BaseCommand
                 // Include possible error if the run task faulted.
                 var innerException = completedTask.IsFaulted ? completedTask.Exception : null;
                 throw new InvalidOperationException("Run completed without returning a backchannel.", innerException);
-            });
+            }, emoji: KnownEmojis.HammerAndWrench);
 
             var publishingActivities = backchannel.GetPublishingActivitiesAsync(cancellationToken);
 
@@ -335,7 +335,7 @@ internal abstract class PipelineCommandBase : BaseCommand
                 {
                     // New step - log it
                     var statusText = ConvertTextWithMarkdownFlag(activity.Data.StatusText, activity.Data);
-                    InteractionService.DisplaySubtleMessage($"[[DEBUG]] Step {stepCounter++}: {statusText}", escapeMarkup: false);
+                    InteractionService.DisplaySubtleMessage($"[[DEBUG]] Step {stepCounter++}: {statusText}", allowMarkup: true);
                     steps[activity.Data.Id] = activity.Data.CompletionState;
                 }
                 else if (IsCompletionStateComplete(activity.Data.CompletionState))
@@ -344,7 +344,7 @@ internal abstract class PipelineCommandBase : BaseCommand
                     var status = IsCompletionStateError(activity.Data.CompletionState) ? "FAILED" :
                         IsCompletionStateWarning(activity.Data.CompletionState) ? "WARNING" : "COMPLETED";
                     var statusText = ConvertTextWithMarkdownFlag(activity.Data.StatusText, activity.Data);
-                    InteractionService.DisplaySubtleMessage($"[[DEBUG]] Step {activity.Data.Id}: {status} - {statusText}", escapeMarkup: false);
+                    InteractionService.DisplaySubtleMessage($"[[DEBUG]] Step {activity.Data.Id}: {status} - {statusText}", allowMarkup: true);
                     steps[activity.Data.Id] = activity.Data.CompletionState;
                 }
             }
@@ -379,7 +379,7 @@ internal abstract class PipelineCommandBase : BaseCommand
                     _ => $"[[{timestamp}]] [[{logPrefix}]] {message}"
                 };
                 
-                InteractionService.DisplaySubtleMessage(formattedMessage, escapeMarkup: false);
+                InteractionService.DisplaySubtleMessage(formattedMessage, allowMarkup: true);
             }
             else
             {
@@ -390,17 +390,17 @@ internal abstract class PipelineCommandBase : BaseCommand
                     var status = IsCompletionStateError(activity.Data.CompletionState) ? "FAILED" :
                         IsCompletionStateWarning(activity.Data.CompletionState) ? "WARNING" : "COMPLETED";
                     var statusText = ConvertTextWithMarkdownFlag(activity.Data.StatusText, activity.Data);
-                    InteractionService.DisplaySubtleMessage($"[[DEBUG]] Task {activity.Data.Id} ({stepId}): {status} - {statusText}", escapeMarkup: false);
+                    InteractionService.DisplaySubtleMessage($"[[DEBUG]] Task {activity.Data.Id} ({stepId}): {status} - {statusText}", allowMarkup: true);
                     if (!string.IsNullOrEmpty(activity.Data.CompletionMessage))
                     {
                         var completionMessage = ConvertTextWithMarkdownFlag(activity.Data.CompletionMessage, activity.Data);
-                        InteractionService.DisplaySubtleMessage($"[[DEBUG]]   {completionMessage}", escapeMarkup: false);
+                        InteractionService.DisplaySubtleMessage($"[[DEBUG]]   {completionMessage}", allowMarkup: true);
                     }
                 }
                 else
                 {
                     var statusText = ConvertTextWithMarkdownFlag(activity.Data.StatusText, activity.Data);
-                    InteractionService.DisplaySubtleMessage($"[[DEBUG]] Task {activity.Data.Id} ({stepId}): {statusText}", escapeMarkup: false);
+                    InteractionService.DisplaySubtleMessage($"[[DEBUG]] Task {activity.Data.Id} ({stepId}): {statusText}", allowMarkup: true);
                 }
             }
         }
@@ -412,7 +412,7 @@ internal abstract class PipelineCommandBase : BaseCommand
         {
             var status = hasErrors ? "FAILED" : hasWarnings ? "WARNING" : "COMPLETED";
             var statusText = ConvertTextWithMarkdownFlag(publishingActivity.Data.StatusText, publishingActivity.Data);
-            InteractionService.DisplaySubtleMessage($"[[DEBUG]] {OperationCompletedPrefix}: {status} - {statusText}", escapeMarkup: false);
+            InteractionService.DisplaySubtleMessage($"[[DEBUG]] {OperationCompletedPrefix}: {status} - {statusText}", allowMarkup: true);
 
             // Send visual bell notification when operation is complete
             Console.Write("\a");

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -97,7 +97,7 @@ internal sealed class PsCommand : BaseCommand
             }
             else
             {
-                _interactionService.DisplayMessage("information", SharedCommandStrings.AppHostNotRunning);
+                _interactionService.DisplayMessage(KnownEmojis.Information, SharedCommandStrings.AppHostNotRunning);
             }
             return ExitCodeConstants.Success;
         }

--- a/src/Aspire.Cli/Commands/RenderCommand.cs
+++ b/src/Aspire.Cli/Commands/RenderCommand.cs
@@ -1,0 +1,199 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if DEBUG
+
+using System.CommandLine;
+using System.Reflection;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Telemetry;
+using Aspire.Cli.Utils;
+
+namespace Aspire.Cli.Commands;
+
+/// <summary>
+/// Debug-only command for smoke testing CLI rendering (emoji alignment, status spinners, etc.).
+/// </summary>
+internal sealed class RenderCommand : BaseCommand
+{
+    /// <summary>
+    /// All emojis defined in <see cref="KnownEmojis"/>, discovered via reflection.
+    /// </summary>
+    private static readonly KnownEmoji[] s_allEmojis = typeof(KnownEmojis)
+        .GetFields(BindingFlags.Public | BindingFlags.Static)
+        .Where(f => f.FieldType == typeof(KnownEmoji))
+        .Select(f => (KnownEmoji)f.GetValue(null)!)
+        .ToArray();
+
+    private static readonly Dictionary<string, string> s_choices = new()
+    {
+        ["displaymessage"] = "Display message (all emojis)",
+        ["showstatus"] = "Show status spinner (first 5 emojis)",
+        ["showstatus-markup"] = "Show status with markup rendered",
+        ["showstatus-escaped"] = "Show status with markup escaped",
+        ["mixed"] = "Mixed interaction service methods",
+        ["exit"] = "Exit",
+    };
+
+    public RenderCommand(
+        IFeatures features,
+        ICliUpdateNotifier updateNotifier,
+        CliExecutionContext executionContext,
+        IInteractionService interactionService,
+        AspireCliTelemetry telemetry)
+        : base("render", "Smoke test CLI rendering.", features, updateNotifier, executionContext, interactionService, telemetry)
+    {
+        Hidden = true;
+    }
+
+    protected override bool UpdateNotificationsEnabled => false;
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            var choice = await InteractionService.PromptForSelectionAsync(
+                "What do you want to test?",
+                s_choices.Keys,
+                key => s_choices[key],
+                cancellationToken);
+
+            switch (choice)
+            {
+                case "displaymessage":
+                    TestDisplayMessage();
+                    break;
+                case "showstatus":
+                    await TestShowStatusAsync(cancellationToken);
+                    break;
+                case "showstatus-markup":
+                    await TestShowStatusWithMarkupAsync(cancellationToken);
+                    break;
+                case "showstatus-escaped":
+                    await TestShowStatusEscapedAsync(cancellationToken);
+                    break;
+                case "mixed":
+                    await TestMixedMethodsAsync(cancellationToken);
+                    break;
+                case "exit":
+                    return ExitCodeConstants.Success;
+                default:
+                    return ExitCodeConstants.InvalidCommand;
+            }
+        }
+    }
+
+    private int TestDisplayMessage()
+    {
+        foreach (var emoji in s_allEmojis)
+        {
+            InteractionService.DisplayMessage(emoji, $"DisplayMessage with {emoji.Name}");
+        }
+
+        return ExitCodeConstants.Success;
+    }
+
+    private async Task<int> TestShowStatusAsync(CancellationToken cancellationToken)
+    {
+        foreach (var emoji in s_allEmojis.Take(5))
+        {
+            await InteractionService.ShowStatusAsync(
+                $"ShowStatus with {emoji.Name} for 2 seconds...",
+                async () =>
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
+                    return ExitCodeConstants.Success;
+                },
+                emoji: emoji);
+        }
+
+        return ExitCodeConstants.Success;
+    }
+
+    private async Task<int> TestShowStatusWithMarkupAsync(CancellationToken cancellationToken)
+    {
+        await InteractionService.ShowStatusAsync(
+            "[bold]Installing[/] packages with [green]markup[/]...",
+            async () =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
+                return ExitCodeConstants.Success;
+            },
+            emoji: KnownEmojis.Package,
+            allowMarkup: true);
+
+        return ExitCodeConstants.Success;
+    }
+
+    private async Task<int> TestShowStatusEscapedAsync(CancellationToken cancellationToken)
+    {
+        await InteractionService.ShowStatusAsync(
+            "[bold]Installing[/] packages with [green]markup[/] escaped...",
+            async () =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
+                return ExitCodeConstants.Success;
+            },
+            emoji: KnownEmojis.Package);
+
+        return ExitCodeConstants.Success;
+    }
+
+    private async Task TestMixedMethodsAsync(CancellationToken cancellationToken)
+    {
+        InteractionService.DisplayMessage(KnownEmojis.Rocket, "Starting mixed methods test...");
+        InteractionService.DisplayEmptyLine();
+
+        InteractionService.DisplaySuccess("Step 1 complete!");
+        InteractionService.DisplaySubtleMessage("This is a subtle hint.");
+        InteractionService.DisplayMessage(KnownEmojis.MagnifyingGlassTiltedLeft, "Searching for [packages]...");
+        InteractionService.DisplayEmptyLine();
+
+        InteractionService.DisplayMarkupLine("[bold green]Bold green markup[/] and [dim]dim text[/]");
+        InteractionService.DisplayPlainText("Plain text with [brackets] that should appear literally.");
+        InteractionService.DisplayEmptyLine();
+
+        await InteractionService.ShowStatusAsync(
+            "Running a quick task...",
+            async () =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
+                return 42;
+            },
+            emoji: KnownEmojis.Gear);
+
+        InteractionService.ShowStatus(
+            "Synchronous status spinner...",
+            () => Thread.Sleep(TimeSpan.FromSeconds(1)),
+            emoji: KnownEmojis.Hammer);
+
+        InteractionService.DisplayEmptyLine();
+
+        var name = await InteractionService.PromptForStringAsync(
+            "Enter a test value",
+            defaultValue: "hello",
+            cancellationToken: cancellationToken);
+
+        InteractionService.DisplayMessage(KnownEmojis.CheckMark, $"You entered: {name}");
+
+        var confirmed = await InteractionService.ConfirmAsync(
+            "Do you want to continue?",
+            defaultValue: true,
+            cancellationToken: cancellationToken);
+
+        if (confirmed)
+        {
+            InteractionService.DisplaySuccess("Confirmed!");
+        }
+        else
+        {
+            InteractionService.DisplayError("Cancelled.");
+        }
+
+        InteractionService.DisplayEmptyLine();
+        InteractionService.DisplayMessage(KnownEmojis.StopSign, "Mixed methods test complete.");
+    }
+}
+
+#endif

--- a/src/Aspire.Cli/Commands/ResourceCommandHelper.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommandHelper.cs
@@ -70,7 +70,7 @@ internal static class ResourceCommandHelper
         }
         else if (response.Canceled)
         {
-            interactionService.DisplayMessage("warning", $"Command '{commandName}' on '{resourceName}' was canceled.");
+            interactionService.DisplayMessage(KnownEmojis.Warning, $"Command '{commandName}' on '{resourceName}' was canceled.");
             return ExitCodeConstants.FailedToExecuteResourceCommand;
         }
         else
@@ -96,7 +96,7 @@ internal static class ResourceCommandHelper
         }
         else if (response.Canceled)
         {
-            interactionService.DisplayMessage("warning", $"{progressVerb} command for '{resourceName}' was canceled.");
+            interactionService.DisplayMessage(KnownEmojis.Warning, $"{progressVerb} command for '{resourceName}' was canceled.");
             return ExitCodeConstants.FailedToExecuteResourceCommand;
         }
         else

--- a/src/Aspire.Cli/Commands/RootCommand.cs
+++ b/src/Aspire.Cli/Commands/RootCommand.cs
@@ -134,6 +134,9 @@ internal sealed class RootCommand : BaseRootCommand
         SecretCommand secretCommand,
         SdkCommand sdkCommand,
         SetupCommand setupCommand,
+#if DEBUG
+        RenderCommand renderCommand,
+#endif
         ExtensionInternalCommand extensionInternalCommand,
         IBundleService bundleService,
         IFeatures featureFlags,
@@ -153,7 +156,7 @@ internal sealed class RootCommand : BaseRootCommand
             if (waitForDebugger)
             {
                 _interactionService.ShowStatus(
-                    $":bug:  {string.Format(CultureInfo.CurrentCulture, RootCommandStrings.WaitingForDebugger, Environment.ProcessId)}",
+                    string.Format(CultureInfo.CurrentCulture, RootCommandStrings.WaitingForDebugger, Environment.ProcessId),
                     () =>
                     {
                         while (!Debugger.IsAttached)
@@ -162,7 +165,7 @@ internal sealed class RootCommand : BaseRootCommand
                         }
 
                         Debugger.Break();
-                    });
+                    }, emoji: KnownEmojis.Bug);
             }
         });
 #endif
@@ -217,6 +220,10 @@ internal sealed class RootCommand : BaseRootCommand
         Subcommands.Add(telemetryCommand);
         Subcommands.Add(docsCommand);
         Subcommands.Add(secretCommand);
+
+#if DEBUG
+        Subcommands.Add(renderCommand);
+#endif
 
         if (bundleService.IsBundle)
         {

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -211,7 +211,7 @@ internal sealed class RunCommand : BaseCommand
                 // If in isolated mode and a running instance was stopped, warn the user
                 if (isolated && runningInstanceResult == RunningInstanceResult.InstanceStopped)
                 {
-                    InteractionService.DisplayMessage("warning", RunCommandStrings.IsolatedModeRunningInstanceWarning);
+                    InteractionService.DisplayMessage(KnownEmojis.Warning, RunCommandStrings.IsolatedModeRunningInstanceWarning);
                 }
             }
 
@@ -368,7 +368,7 @@ internal sealed class RunCommand : BaseCommand
             Telemetry.RecordError(errorMessage, ex);
             InteractionService.DisplayError(errorMessage);
             // Don't display raw output - it's already in the log file
-            InteractionService.DisplayMessage("page_facing_up", string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, ExecutionContext.LogFilePath.EscapeMarkup()));
+            InteractionService.DisplayMessage(KnownEmojis.PageFacingUp, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, ExecutionContext.LogFilePath));
             return ExitCodeConstants.FailedToDotnetRunAppHost;
         }
         catch (Exception ex)
@@ -377,7 +377,7 @@ internal sealed class RunCommand : BaseCommand
             Telemetry.RecordError(errorMessage, ex);
             InteractionService.DisplayError(errorMessage);
             // Don't display raw output - it's already in the log file
-            InteractionService.DisplayMessage("page_facing_up", string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, ExecutionContext.LogFilePath.EscapeMarkup()));
+            InteractionService.DisplayMessage(KnownEmojis.PageFacingUp, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, ExecutionContext.LogFilePath));
             return ExitCodeConstants.FailedToDotnetRunAppHost;
         }
     }

--- a/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
+++ b/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
@@ -105,8 +105,9 @@ internal sealed class SdkDumpCommand : BaseCommand
         }
 
         return await InteractionService.ShowStatusAsync(
-            ":magnifying_glass_tilted_right: Scanning capabilities...",
-            async () => await DumpCapabilitiesAsync(integrationProject, outputFile, format, cancellationToken));
+            "Scanning capabilities...",
+            async () => await DumpCapabilitiesAsync(integrationProject, outputFile, format, cancellationToken),
+            emoji: KnownEmojis.MagnifyingGlassTiltedRight);
     }
 
     private async Task<int> DumpCapabilitiesAsync(
@@ -153,7 +154,7 @@ internal sealed class SdkDumpCommand : BaseCommand
                 InteractionService.DisplayError("Failed to build capability scanner.");
                 foreach (var (_, line) in buildOutput.GetLines())
                 {
-                    InteractionService.DisplayMessage("wrench", line.EscapeMarkup());
+                    InteractionService.DisplayMessage(KnownEmojis.Wrench, line);
                 }
                 return ExitCodeConstants.FailedToBuildArtifacts;
             }

--- a/src/Aspire.Cli/Commands/Sdk/SdkGenerateCommand.cs
+++ b/src/Aspire.Cli/Commands/Sdk/SdkGenerateCommand.cs
@@ -8,7 +8,6 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging;
-using Spectre.Console;
 
 namespace Aspire.Cli.Commands.Sdk;
 
@@ -94,8 +93,9 @@ internal sealed class SdkGenerateCommand : BaseCommand
         }
 
         return await InteractionService.ShowStatusAsync(
-            $":hammer: Generating {languageInfo.DisplayName} SDK from {integrationProject.Name}...",
-            async () => await GenerateSdkAsync(integrationProject, languageInfo, outputDir, cancellationToken));
+            $"Generating {languageInfo.DisplayName} SDK from {integrationProject.Name}...",
+            async () => await GenerateSdkAsync(integrationProject, languageInfo, outputDir, cancellationToken),
+            emoji: KnownEmojis.Hammer);
     }
 
     private async Task<LanguageInfo?> GetLanguageInfoAsync(string language, CancellationToken cancellationToken)
@@ -155,7 +155,7 @@ internal sealed class SdkGenerateCommand : BaseCommand
                 InteractionService.DisplayError("Failed to build SDK generation server.");
                 foreach (var (_, line) in buildOutput.GetLines())
                 {
-                    InteractionService.DisplayMessage("wrench", line.EscapeMarkup());
+                    InteractionService.DisplayMessage(KnownEmojis.Wrench, line);
                 }
                 return ExitCodeConstants.FailedToBuildArtifacts;
             }

--- a/src/Aspire.Cli/Commands/SecretDeleteCommand.cs
+++ b/src/Aspire.Cli/Commands/SecretDeleteCommand.cs
@@ -60,7 +60,7 @@ internal sealed class SecretDeleteCommand : BaseCommand
         }
 
         result.Store.Save();
-        InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, SecretCommandStrings.SecretDeleteSuccess, key.EscapeMarkup()));
+        InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, SecretCommandStrings.SecretDeleteSuccess, key));
         return ExitCodeConstants.Success;
     }
 }

--- a/src/Aspire.Cli/Commands/SecretListCommand.cs
+++ b/src/Aspire.Cli/Commands/SecretListCommand.cs
@@ -70,7 +70,7 @@ internal sealed class SecretListCommand : BaseCommand
         {
             if (secrets.Count == 0)
             {
-                InteractionService.DisplayMessage("information", SecretCommandStrings.NoSecretsConfigured);
+                InteractionService.DisplayMessage(KnownEmojis.Information, SecretCommandStrings.NoSecretsConfigured);
             }
             else
             {

--- a/src/Aspire.Cli/Commands/SecretSetCommand.cs
+++ b/src/Aspire.Cli/Commands/SecretSetCommand.cs
@@ -9,7 +9,6 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Secrets;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
-using Spectre.Console;
 
 namespace Aspire.Cli.Commands;
 
@@ -65,7 +64,7 @@ internal sealed class SecretSetCommand : BaseCommand
         result.Store.Set(key, value);
         result.Store.Save();
 
-        InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, SecretCommandStrings.SecretSetSuccess, key.EscapeMarkup()));
+        InteractionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, SecretCommandStrings.SecretSetSuccess, key));
         return ExitCodeConstants.Success;
     }
 }

--- a/src/Aspire.Cli/Commands/SetupCommand.cs
+++ b/src/Aspire.Cli/Commands/SetupCommand.cs
@@ -71,25 +71,25 @@ internal sealed class SetupCommand : BaseCommand
         // Extract with spinner
         BundleExtractResult result = BundleExtractResult.NoPayload;
         var exitCode = await InteractionService.ShowStatusAsync(
-            ":package:  Extracting Aspire bundle...",
+            "Extracting Aspire bundle...",
             async () =>
             {
                 result = await _bundleService.ExtractAsync(installPath, force, cancellationToken);
                 return ExitCodeConstants.Success;
-            });
+            }, emoji: KnownEmojis.Package);
 
         switch (result)
         {
             case BundleExtractResult.NoPayload:
-                InteractionService.DisplayMessage("information", "This CLI binary does not contain an embedded bundle. No extraction needed.");
+                InteractionService.DisplayMessage(KnownEmojis.Information, "This CLI binary does not contain an embedded bundle. No extraction needed.");
                 break;
 
             case BundleExtractResult.AlreadyUpToDate:
-                InteractionService.DisplayMessage("white_check_mark", "Bundle is already extracted and up to date. Use --force to re-extract.");
+                InteractionService.DisplayMessage(KnownEmojis.CheckMark, "Bundle is already extracted and up to date. Use --force to re-extract.");
                 break;
 
             case BundleExtractResult.Extracted:
-                InteractionService.DisplayMessage("white_check_mark", $"Bundle extracted to {installPath}");
+                InteractionService.DisplayMessage(KnownEmojis.CheckMark, $"Bundle extracted to {installPath}");
                 break;
 
             case BundleExtractResult.ExtractionFailed:

--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -155,7 +155,7 @@ internal sealed class StopCommand : BaseCommand
 
         if (!result.Success)
         {
-            _interactionService.DisplayMessage("information", result.ErrorMessage);
+            _interactionService.DisplayMessage(KnownEmojis.Information, result.ErrorMessage);
             return ExitCodeConstants.Success;
         }
 
@@ -214,12 +214,12 @@ internal sealed class StopCommand : BaseCommand
         var displayPath = connection.IsInScope
             ? Path.GetRelativePath(ExecutionContext.WorkingDirectory.FullName, appHostPath)
             : appHostPath;
-        _interactionService.DisplayMessage("package", $"Found running AppHost: {displayPath}");
+        _interactionService.DisplayMessage(KnownEmojis.Package, $"Found running AppHost: {displayPath}");
         _logger.LogDebug("Stopping AppHost: {AppHostPath}", appHostPath);
 
         var appHostInfo = connection.AppHostInfo;
 
-        _interactionService.DisplayMessage("stop_sign", "Sending stop signal...");
+        _interactionService.DisplayMessage(KnownEmojis.StopSign, "Sending stop signal...");
 
         // Get the CLI process ID - this is the process we need to kill
         // Killing the CLI process will tear down everything including the AppHost

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -116,7 +116,7 @@ internal static class TelemetryCommandHelpers
 
         if (!result.Success)
         {
-            interactionService.DisplayMessage("information", result.ErrorMessage);
+            interactionService.DisplayMessage(KnownEmojis.Information, result.ErrorMessage);
             return (false, null, null, null, ExitCodeConstants.Success);
         }
 

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -113,7 +113,7 @@ internal sealed class UpdateCommand : BaseCommand
             // When running as a dotnet tool, print the update command instead of executing
             if (IsRunningAsDotNetTool())
             {
-                InteractionService.DisplayMessage("information", UpdateCommandStrings.DotNetToolSelfUpdateMessage);
+                InteractionService.DisplayMessage(KnownEmojis.Information, UpdateCommandStrings.DotNetToolSelfUpdateMessage);
                 InteractionService.DisplayPlainText("  dotnet tool update -g Aspire.Cli");
                 return 0;
             }
@@ -286,8 +286,8 @@ internal sealed class UpdateCommand : BaseCommand
                 return ExitCodeConstants.InvalidCommand;
             }
 
-            InteractionService.DisplayMessage("package", $"Current CLI location: {currentExePath}");
-            InteractionService.DisplayMessage("up_arrow", $"Updating to channel: {channel}");
+            InteractionService.DisplayMessage(KnownEmojis.Package, $"Current CLI location: {currentExePath}");
+            InteractionService.DisplayMessage(KnownEmojis.UpButton, $"Updating to channel: {channel}");
 
             // Download the latest CLI
             var archivePath = await _cliDownloader!.DownloadLatestCliAsync(channel, cancellationToken);
@@ -347,7 +347,7 @@ internal sealed class UpdateCommand : BaseCommand
         try
         {
             // Extract archive
-            InteractionService.DisplayMessage("package", "Extracting new CLI...");
+            InteractionService.DisplayMessage(KnownEmojis.Package, "Extracting new CLI...");
             await ArchiveHelper.ExtractAsync(archivePath, tempExtractDir, cancellationToken);
 
             // Find the aspire executable in the extracted files
@@ -362,7 +362,7 @@ internal sealed class UpdateCommand : BaseCommand
             var backupPath = $"{targetExePath}.old.{unixTimestamp}";
             if (File.Exists(targetExePath))
             {
-                InteractionService.DisplayMessage("floppy_disk", "Backing up current CLI...");
+                InteractionService.DisplayMessage(KnownEmojis.FloppyDisk, "Backing up current CLI...");
                 _logger.LogDebug("Creating backup: {BackupPath}", backupPath);
 
                 // Clean up old backup files
@@ -375,7 +375,7 @@ internal sealed class UpdateCommand : BaseCommand
             try
             {
                 // Copy new executable to install location
-                InteractionService.DisplayMessage("wrench", $"Installing new CLI to {installDir}...");
+                InteractionService.DisplayMessage(KnownEmojis.Wrench, $"Installing new CLI to {installDir}...");
                 File.Copy(newExePath, targetExePath, overwrite: true);
 
                 // On Unix systems, ensure the executable bit is set
@@ -402,7 +402,7 @@ internal sealed class UpdateCommand : BaseCommand
                 // Display helpful message about PATH
                 if (!IsInPath(installDir))
                 {
-                    InteractionService.DisplayMessage("information", $"Note: {installDir} is not in your PATH. Add it to use the updated CLI globally.");
+                    InteractionService.DisplayMessage(KnownEmojis.Information, $"Note: {installDir} is not in your PATH. Add it to use the updated CLI globally.");
                 }
             }
             catch

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -22,7 +22,7 @@ internal interface IExtensionInteractionService : IInteractionService
     void DisplayConsolePlainText(string message);
     Task StartDebugSessionAsync(string workingDirectory, string? projectFile, bool debug);
     void WriteDebugSessionMessage(string message, bool stdout, string? textStyle);
-    void ConsoleDisplaySubtleMessage(string message, bool escapeMarkup = true);
+    void ConsoleDisplaySubtleMessage(string message, bool allowMarkup = false);
 }
 
 internal class ExtensionInteractionService : IExtensionInteractionService
@@ -64,22 +64,22 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         });
     }
 
-    public async Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action)
+    public async Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
         var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(statusText.RemoveSpectreFormatting(), _cancellationToken));
         Debug.Assert(result);
 
-        var value = await _consoleInteractionService.ShowStatusAsync(statusText, action).ConfigureAwait(false);
+        var value = await _consoleInteractionService.ShowStatusAsync(statusText, action, emoji, allowMarkup).ConfigureAwait(false);
         result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(null, _cancellationToken));
         Debug.Assert(result);
         return value;
     }
 
-    public void ShowStatus(string statusText, Action action)
+    public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
         var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(statusText.RemoveSpectreFormatting(), _cancellationToken));
         Debug.Assert(result);
-        _consoleInteractionService.ShowStatus(statusText, action);
+        _consoleInteractionService.ShowStatus(statusText, action, emoji, allowMarkup);
 
         result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.ShowStatusAsync(null, _cancellationToken));
         Debug.Assert(result);
@@ -243,30 +243,30 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         _consoleInteractionService.DisplayError(errorMessage);
     }
 
-    public void DisplayMessage(string emojiName, string message)
+    public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayMessageAsync(emojiName, message.RemoveSpectreFormatting(), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayMessageAsync(emoji.Name, message.RemoveSpectreFormatting(), _cancellationToken));
         Debug.Assert(result);
-        _consoleInteractionService.DisplayMessage(emojiName, message);
+        _consoleInteractionService.DisplayMessage(emoji, message, allowMarkup);
     }
 
-    public void DisplaySuccess(string message)
+    public void DisplaySuccess(string message, bool allowMarkup = false)
     {
         var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplaySuccessAsync(message.RemoveSpectreFormatting(), _cancellationToken));
         Debug.Assert(result);
-        _consoleInteractionService.DisplaySuccess(message);
+        _consoleInteractionService.DisplaySuccess(message, allowMarkup);
     }
 
-    public void DisplaySubtleMessage(string message, bool escapeMarkup = true)
+    public void DisplaySubtleMessage(string message, bool allowMarkup = false)
     {
         var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplaySubtleMessageAsync(message.RemoveSpectreFormatting(), _cancellationToken));
         Debug.Assert(result);
-        _consoleInteractionService.DisplaySubtleMessage(message, escapeMarkup);
+        _consoleInteractionService.DisplaySubtleMessage(message, allowMarkup);
     }
 
-    public void ConsoleDisplaySubtleMessage(string message, bool escapeMarkup = true)
+    public void ConsoleDisplaySubtleMessage(string message, bool allowMarkup = false)
     {
-        _consoleInteractionService.DisplaySubtleMessage(message, escapeMarkup);
+        _consoleInteractionService.DisplaySubtleMessage(message, allowMarkup);
     }
 
     public void DisplayDashboardUrls(DashboardUrlsState dashboardUrls)

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -9,21 +9,21 @@ namespace Aspire.Cli.Interaction;
 
 internal interface IInteractionService
 {
-    Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action);
-    void ShowStatus(string statusText, Action action);
+    Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false);
+    void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false);
     Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default);
     public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default);
     Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull;
     Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull;
     int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion);
     void DisplayError(string errorMessage);
-    void DisplayMessage(string emojiName, string message);
+    void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false);
     void DisplayPlainText(string text);
     void DisplayRawText(string text, ConsoleOutput? consoleOverride = null);
     void DisplayMarkdown(string markdown);
     void DisplayMarkupLine(string markup);
-    void DisplaySuccess(string message);
-    void DisplaySubtleMessage(string message, bool escapeMarkup = true);
+    void DisplaySuccess(string message, bool allowMarkup = false);
+    void DisplaySubtleMessage(string message, bool allowMarkup = false);
     void DisplayLines(IEnumerable<(string Stream, string Line)> lines);
     void DisplayRenderable(IRenderable renderable);
     void DisplayCancellationMessage();

--- a/src/Aspire.Cli/Interaction/KnownEmojis.cs
+++ b/src/Aspire.Cli/Interaction/KnownEmojis.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Interaction;
+
+/// <summary>
+/// Represents an emoji by its Spectre.Console name.
+/// </summary>
+internal readonly struct KnownEmoji(string name)
+{
+    /// <summary>
+    /// Gets the Spectre.Console emoji name (e.g. "rocket", "check_mark").
+    /// </summary>
+    public string Name { get; } = name;
+}
+
+/// <summary>
+/// Defines all emoji values used by the Aspire CLI. Prefer using existing known emojis when possible, but add new ones here as needed.
+/// This allows the CLI to have consistent UI for common operations while adding new emojis relevant to new tasks when required.
+/// </summary>
+internal static class KnownEmojis
+{
+    public static readonly KnownEmoji Bug = new("bug");
+    public static readonly KnownEmoji CheckBoxWithCheck = new("check_box_with_check");
+    public static readonly KnownEmoji CheckMark = new("check_mark");
+    public static readonly KnownEmoji CrossMark = new("cross_mark");
+    public static readonly KnownEmoji FileCabinet = new("file_cabinet");
+    public static readonly KnownEmoji FileFolder = new("file_folder");
+    public static readonly KnownEmoji FloppyDisk = new("floppy_disk");
+    public static readonly KnownEmoji Gear = new("gear");
+    public static readonly KnownEmoji Hammer = new("hammer");
+    public static readonly KnownEmoji HammerAndWrench = new("hammer_and_wrench");
+    public static readonly KnownEmoji Information = new("information");
+    public static readonly KnownEmoji Key = new("key");
+    public static readonly KnownEmoji LinkedPaperclips = new("linked_paperclips");
+    public static readonly KnownEmoji LockedWithKey = new("locked_with_key");
+    public static readonly KnownEmoji MagnifyingGlassTiltedLeft = new("magnifying_glass_tilted_left");
+    public static readonly KnownEmoji MagnifyingGlassTiltedRight = new("magnifying_glass_tilted_right");
+    public static readonly KnownEmoji Microscope = new("microscope");
+    public static readonly KnownEmoji Package = new("package");
+    public static readonly KnownEmoji PageFacingUp = new("page_facing_up");
+    public static readonly KnownEmoji Rocket = new("rocket");
+    public static readonly KnownEmoji RunningShoe = new("running_shoe");
+    public static readonly KnownEmoji StopSign = new("stop_sign");
+    public static readonly KnownEmoji UpButton = new("up_button");
+    public static readonly KnownEmoji Warning = new("warning");
+    public static readonly KnownEmoji Wrench = new("wrench");
+}

--- a/src/Aspire.Cli/Packaging/NuGetConfigPrompter.cs
+++ b/src/Aspire.Cli/Packaging/NuGetConfigPrompter.cs
@@ -57,7 +57,7 @@ internal class NuGetConfigPrompter
             if (string.Equals(choice, TemplatingStrings.Yes, StringComparisons.CliInputOrOutput))
             {
                 await NuGetConfigMerger.CreateOrUpdateAsync(targetDirectory, channel, cancellationToken: cancellationToken);
-                _interactionService.DisplayMessage("package", TemplatingStrings.NuGetConfigCreatedConfirmationMessage);
+                _interactionService.DisplayMessage(KnownEmojis.Package, TemplatingStrings.NuGetConfigCreatedConfirmationMessage);
             }
         }
         else if (hasMissingSources)
@@ -71,7 +71,7 @@ internal class NuGetConfigPrompter
             if (string.Equals(updateChoice, TemplatingStrings.Yes, StringComparisons.CliInputOrOutput))
             {
                 await NuGetConfigMerger.CreateOrUpdateAsync(targetDirectory, channel, cancellationToken: cancellationToken);
-                _interactionService.DisplayMessage("package", "Updated NuGet.config with required package sources.");
+                _interactionService.DisplayMessage(KnownEmojis.Package, "Updated NuGet.config with required package sources.");
             }
         }
     }
@@ -100,6 +100,6 @@ internal class NuGetConfigPrompter
         }
 
         await NuGetConfigMerger.CreateOrUpdateAsync(targetDirectory, channel, cancellationToken: cancellationToken);
-        _interactionService.DisplayMessage("package", "Created or updated NuGet.config in the project directory with required package sources.");
+        _interactionService.DisplayMessage(KnownEmojis.Package, "Created or updated NuGet.config in the project directory with required package sources.");
     }
 }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -403,6 +403,9 @@ public class Program
         builder.Services.AddTransient<SdkGenerateCommand>();
         builder.Services.AddTransient<SdkDumpCommand>();
         builder.Services.AddTransient<SetupCommand>();
+#if DEBUG
+        builder.Services.AddTransient<RenderCommand>();
+#endif
         builder.Services.AddTransient<RootCommand>();
         builder.Services.AddTransient<ExtensionInternalCommand>();
 

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -523,7 +523,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         }
 
         _logger.LogInformation("No UserSecretsId found. Initializing user secrets for {Project}...", projectFile.Name);
-        _interactionService.DisplayMessage("key", $"Initializing user secrets for {projectFile.Name}...");
+        _interactionService.DisplayMessage(KnownEmojis.Key, $"Initializing user secrets for {projectFile.Name}...");
 
         await _runner.InitUserSecretsAsync(
             projectFile,
@@ -586,7 +586,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         var userSecretsId = await QueryUserSecretsIdAsync(appHostFile, cancellationToken);
         if (!string.IsNullOrEmpty(userSecretsId))
         {
-            _interactionService.DisplayMessage("key", RunCommandStrings.CopyingUserSecrets);
+            _interactionService.DisplayMessage(KnownEmojis.Key, RunCommandStrings.CopyingUserSecrets);
             var isolatedUserSecretsId = IsolatedUserSecretsHelper.CreateIsolatedUserSecrets(userSecretsId);
             if (!string.IsNullOrEmpty(isolatedUserSecretsId))
             {

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -17,6 +17,7 @@ using Aspire.Shared.UserSecrets;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Semver;
+using Spectre.Console;
 
 namespace Aspire.Cli.Projects;
 
@@ -297,7 +298,7 @@ internal sealed class GuestAppHostProject : IAppHostProject
             var sdkVersion = GetPrepareSdkVersion(config);
 
             var buildResult = await _interactionService.ShowStatusAsync(
-                ":gear:  Preparing Aspire server...",
+                "Preparing Aspire server...",
                 async () =>
                 {
                     // Prepare the AppHost server (build for dev mode, restore for prebuilt)
@@ -308,7 +309,7 @@ internal sealed class GuestAppHostProject : IAppHostProject
                     }
 
                     return (Success: true, Output: prepareOutput, Error: (string?)null, ChannelName: channelName, NeedsCodeGen: needsCodeGen);
-                });
+                }, emoji: KnownEmojis.Gear);
 
             // Save the channel to settings.json if available (config already has SdkVersion)
             if (buildResult.ChannelName is not null)
@@ -923,7 +924,7 @@ internal sealed class GuestAppHostProject : IAppHostProject
 
         if (updates.Count == 0 && newSdkVersion is null)
         {
-            _interactionService.DisplayMessage("check_mark", UpdateCommandStrings.ProjectUpToDateMessage);
+            _interactionService.DisplayMessage(KnownEmojis.CheckMark, UpdateCommandStrings.ProjectUpToDateMessage);
             return new UpdatePackagesResult { UpdatesApplied = false };
         }
 
@@ -931,11 +932,11 @@ internal sealed class GuestAppHostProject : IAppHostProject
         _interactionService.DisplayEmptyLine();
         if (newSdkVersion is not null)
         {
-            _interactionService.DisplayMessage("package", $"[bold yellow]Aspire SDK[/] [bold green]{config.SdkVersion}[/] to [bold green]{newSdkVersion}[/]");
+            _interactionService.DisplayMessage(KnownEmojis.Package, $"[bold yellow]Aspire SDK[/] [bold green]{config.SdkVersion.EscapeMarkup()}[/] to [bold green]{newSdkVersion.EscapeMarkup()}[/]", allowMarkup: true);
         }
         foreach (var (packageId, currentVersion, newVersion) in updates)
         {
-            _interactionService.DisplayMessage("package", $"[bold yellow]{packageId}[/] [bold green]{currentVersion}[/] to [bold green]{newVersion}[/]");
+            _interactionService.DisplayMessage(KnownEmojis.Package, $"[bold yellow]{packageId.EscapeMarkup()}[/] [bold green]{currentVersion.EscapeMarkup()}[/] to [bold green]{newVersion.EscapeMarkup()}[/]", allowMarkup: true);
         }
         _interactionService.DisplayEmptyLine();
 

--- a/src/Aspire.Cli/Projects/LanguageService.cs
+++ b/src/Aspire.Cli/Projects/LanguageService.cs
@@ -131,7 +131,7 @@ internal sealed class LanguageService : ILanguageService
         if (saveSelection)
         {
             await SetLanguageAsync(selectedLanguage.LanguageId, isGlobal: false, cancellationToken);
-            _interactionService.DisplayMessage("check_mark", $"Language preference saved to local settings: {selectedProject.DisplayName}");
+            _interactionService.DisplayMessage(KnownEmojis.CheckMark, $"Language preference saved to local settings: {selectedProject.DisplayName}");
         }
 
         return selectedProject;

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -52,7 +52,7 @@ internal sealed class ProjectLocator(
                 IgnoreInaccessible = true
             };
 
-            interactionService.DisplayMessage("magnifying_glass_tilted_left", InteractionServiceStrings.FindingAppHosts);
+            interactionService.DisplayMessage(KnownEmojis.MagnifyingGlassTiltedLeft, InteractionServiceStrings.FindingAppHosts);
 
             var parallelOptions = new ParallelOptions
             {
@@ -100,7 +100,7 @@ internal sealed class ProjectLocator(
                     else if (validationResult.IsPossiblyUnbuildable)
                     {
                         var relativePath = Path.GetRelativePath(executionContext.WorkingDirectory.FullName, candidateFile.FullName);
-                        interactionService.DisplayMessage("warning", string.Format(CultureInfo.CurrentCulture, ErrorStrings.ProjectFileMayBeUnbuildableAppHost, relativePath));
+                        interactionService.DisplayMessage(KnownEmojis.Warning, string.Format(CultureInfo.CurrentCulture, ErrorStrings.ProjectFileMayBeUnbuildableAppHost, relativePath));
                         lock (lockObject)
                         {
                             unbuildableSuspectedAppHostProjects.Add(candidateFile);
@@ -147,7 +147,7 @@ internal sealed class ProjectLocator(
                     else
                     {
                         // AppHost file was specified but doesn't exist, return null to trigger fallback logic
-                        interactionService.DisplayMessage("warning", string.Format(CultureInfo.CurrentCulture, ErrorStrings.AppHostWasSpecifiedButDoesntExist, settingsFile.FullName, qualifiedAppHostPath));
+                        interactionService.DisplayMessage(KnownEmojis.Warning, string.Format(CultureInfo.CurrentCulture, ErrorStrings.AppHostWasSpecifiedButDoesntExist, settingsFile.FullName, qualifiedAppHostPath));
                         return null;
                     }
                 }
@@ -326,7 +326,7 @@ internal sealed class ProjectLocator(
         }
 
         var relativeSettingsFilePath = Path.GetRelativePath(executionContext.WorkingDirectory.FullName, settingsFile.FullName).Replace(Path.DirectorySeparatorChar, '/');
-        interactionService.DisplayMessage("file_cabinet", string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.CreatedSettingsFile, $"[bold]'{relativeSettingsFilePath}'[/]"));
+        interactionService.DisplayMessage(KnownEmojis.FileCabinet, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.CreatedSettingsFile, $"[bold]'{relativeSettingsFilePath.EscapeMarkup()}'[/]"), allowMarkup: true);
     }
 
 }

--- a/src/Aspire.Cli/Projects/ProjectUpdater.cs
+++ b/src/Aspire.Cli/Projects/ProjectUpdater.cs
@@ -34,7 +34,7 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
         if (!updateSteps.Any())
         {
             logger.LogInformation("No updates required for project: {ProjectFile}", projectFile.FullName);
-            interactionService.DisplayMessage("check_mark", UpdateCommandStrings.ProjectUpToDateMessage);
+            interactionService.DisplayMessage(KnownEmojis.CheckMark, UpdateCommandStrings.ProjectUpToDateMessage);
             return new ProjectUpdateResult { UpdatedApplied = false };
         }
 
@@ -52,12 +52,12 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
             var projectName = new FileInfo(projectGroup.Key).Name;
             if (updateStepsByProject.Count > 1)
             {
-                interactionService.DisplayMessage("file_folder", $"[bold cyan]{projectName}[/]:");
+                interactionService.DisplayMessage(KnownEmojis.FileFolder, $"[bold cyan]{projectName.EscapeMarkup()}[/]:", allowMarkup: true);
             }
 
             foreach (var packageStep in projectGroup)
             {
-                interactionService.DisplayMessage("package", packageStep.GetFormattedDisplayText());
+                interactionService.DisplayMessage(KnownEmojis.Package, packageStep.GetFormattedDisplayText(), allowMarkup: true);
             }
 
             interactionService.DisplayEmptyLine();
@@ -66,7 +66,7 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
         // Display warning if fallback parsing was used
         if (fallbackUsed)
         {
-            interactionService.DisplayMessage("warning", $"[yellow]{UpdateCommandStrings.FallbackParsingWarning}[/]");
+            interactionService.DisplayMessage(KnownEmojis.Warning, $"[yellow]{UpdateCommandStrings.FallbackParsingWarning}[/]", allowMarkup: true);
             interactionService.DisplayEmptyLine();
         }
 
@@ -1147,7 +1147,7 @@ internal record PackageUpdateStep(
 {
     public override string GetFormattedDisplayText()
     {
-        return $"[bold yellow]{PackageId}[/] [bold green]{CurrentVersion.EscapeMarkup()}[/] to [bold green]{NewVersion.EscapeMarkup()}[/]";
+        return $"[bold yellow]{PackageId.EscapeMarkup()}[/] [bold green]{CurrentVersion.EscapeMarkup()}[/] to [bold green]{NewVersion.EscapeMarkup()}[/]";
     }
 }
 

--- a/src/Aspire.Cli/Projects/RunningInstanceManager.cs
+++ b/src/Aspire.Cli/Projects/RunningInstanceManager.cs
@@ -58,7 +58,7 @@ internal sealed class RunningInstanceManager
 
             // Display message that we're stopping the previous instance
             var cliPidText = appHostInfo.CliProcessId.HasValue ? appHostInfo.CliProcessId.Value.ToString(CultureInfo.InvariantCulture) : "N/A";
-            _interactionService.DisplayMessage("stop_sign", $"Stopping previous instance (AppHost PID: {appHostInfo.ProcessId.ToString(CultureInfo.InvariantCulture)}, CLI PID: {cliPidText})");
+            _interactionService.DisplayMessage(KnownEmojis.StopSign, $"Stopping previous instance (AppHost PID: {appHostInfo.ProcessId.ToString(CultureInfo.InvariantCulture)}, CLI PID: {cliPidText})");
 
             // Call StopAppHostAsync on the auxiliary backchannel
             await backchannel.StopAppHostAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Cli/Properties/launchSettings.json
+++ b/src/Aspire.Cli/Properties/launchSettings.json
@@ -66,6 +66,11 @@
       "dotnetRunMessages": true,
       "commandLineArgs": "logs"
     },
+    "render": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "commandLineArgs": "render"
+    },
     "run-testapphost": {
       "commandName": "Project",
       "dotnetRunMessages": true,

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -72,8 +72,9 @@ internal sealed class ScaffoldingService : IScaffoldingService
         var prepareSdkVersion = config.GetEffectiveSdkVersion(sdkVersion);
 
         var prepareResult = await _interactionService.ShowStatusAsync(
-            ":gear:  Preparing Aspire server...",
-            () => appHostServerProject.PrepareAsync(prepareSdkVersion, packages, cancellationToken));
+            "Preparing Aspire server...",
+            () => appHostServerProject.PrepareAsync(prepareSdkVersion, packages, cancellationToken),
+            emoji: KnownEmojis.Gear);
         if (!prepareResult.Success)
         {
             if (prepareResult.Output is not null)
@@ -115,8 +116,9 @@ internal sealed class ScaffoldingService : IScaffoldingService
 
             // Step 5: Install dependencies using GuestRuntime
             var installResult = await _interactionService.ShowStatusAsync(
-                $":package:  Installing {language.DisplayName} dependencies...",
-                () => InstallDependenciesAsync(directory, language, rpcClient, cancellationToken));
+                $"Installing {language.DisplayName} dependencies...",
+                () => InstallDependenciesAsync(directory, language, rpcClient, cancellationToken),
+                emoji: KnownEmojis.Package);
             if (installResult != 0)
             {
                 return;

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Scaffolding;
 using Aspire.Cli.Utils;
@@ -81,7 +82,7 @@ internal sealed partial class CliTemplateFactory
         }
 
         _interactionService.DisplaySuccess($"Created {language.DisplayName.EscapeMarkup()} project at {outputPath.EscapeMarkup()}");
-        _interactionService.DisplayMessage("information", "Run 'aspire run' to start your AppHost.");
+        _interactionService.DisplayMessage(KnownEmojis.Information, "Run 'aspire run' to start your AppHost.");
 
         return new TemplateResult(ExitCodeConstants.Success, outputPath);
     }
@@ -112,7 +113,7 @@ internal sealed partial class CliTemplateFactory
 
         if (useLocalhostTld ?? false)
         {
-            _interactionService.DisplayMessage("check_mark", TemplatingStrings.UseLocalhostTld_UsingLocalhostTld);
+            _interactionService.DisplayMessage(KnownEmojis.CheckMark, TemplatingStrings.UseLocalhostTld_UsingLocalhostTld);
         }
 
         return useLocalhostTld ?? false;

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Cli.Interaction;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 
@@ -78,7 +79,7 @@ internal sealed partial class CliTemplateFactory
         }
 
         _interactionService.DisplaySuccess($"Created TypeScript starter project at {outputPath.EscapeMarkup()}");
-        _interactionService.DisplayMessage("information", "Run 'aspire run' to start your AppHost.");
+        _interactionService.DisplayMessage(KnownEmojis.Information, "Run 'aspire run' to start your AppHost.");
 
         return new TemplateResult(ExitCodeConstants.Success, outputPath);
     }

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -276,7 +276,7 @@ internal class DotNetTemplateFactory(
 
         if (useLocalhostTld ?? false)
         {
-            interactionService.DisplayMessage("check_mark", TemplatingStrings.UseLocalhostTld_UsingLocalhostTld);
+            interactionService.DisplayMessage(KnownEmojis.CheckMark, TemplatingStrings.UseLocalhostTld_UsingLocalhostTld);
             extraArgs.Add("--localhost-tld");
         }
     }
@@ -296,7 +296,7 @@ internal class DotNetTemplateFactory(
 
         if (useRedisCache ?? false)
         {
-            interactionService.DisplayMessage("check_mark", TemplatingStrings.UseRedisCache_UsingRedisCache);
+            interactionService.DisplayMessage(KnownEmojis.CheckMark, TemplatingStrings.UseRedisCache_UsingRedisCache);
             extraArgs.Add("--use-redis-cache");
         }
     }
@@ -335,7 +335,7 @@ internal class DotNetTemplateFactory(
                 await PromptForXUnitVersionOptionsAsync(result, extraArgs, cancellationToken);
             }
 
-            interactionService.DisplayMessage("check_mark", string.Format(CultureInfo.CurrentCulture, TemplatingStrings.PromptForTFM_UsingForTesting, testFramework));
+            interactionService.DisplayMessage(KnownEmojis.CheckMark, string.Format(CultureInfo.CurrentCulture, TemplatingStrings.PromptForTFM_UsingForTesting, testFramework));
 
             extraArgs.Add("--test-framework");
             extraArgs.Add(testFramework);
@@ -489,11 +489,11 @@ internal class DotNetTemplateFactory(
                 return new TemplateResult(ExitCodeConstants.FailedToInstallTemplates);
             }
 
-            interactionService.DisplayMessage($"package", string.Format(CultureInfo.CurrentCulture, TemplatingStrings.UsingProjectTemplatesVersion, templateInstallResult.TemplateVersion));
+            interactionService.DisplayMessage(KnownEmojis.Package, string.Format(CultureInfo.CurrentCulture, TemplatingStrings.UsingProjectTemplatesVersion, templateInstallResult.TemplateVersion));
 
             var newProjectCollector = new OutputCollector();
             var newProjectExitCode = await interactionService.ShowStatusAsync(
-                $":rocket:  {TemplatingStrings.CreatingNewProject}",
+                TemplatingStrings.CreatingNewProject,
                 async () =>
                 {
                     var options = new DotNetCliRunnerInvocationOptions()
@@ -511,7 +511,7 @@ internal class DotNetTemplateFactory(
                                 cancellationToken);
 
                     return result;
-                });
+                }, emoji: KnownEmojis.Rocket);
 
             if (newProjectExitCode != 0)
             {
@@ -535,7 +535,7 @@ internal class DotNetTemplateFactory(
             // working directory, create one in the newly created project's output directory.
             await templateNuGetConfigService.PromptToCreateOrUpdateNuGetConfigAsync(selectedTemplateDetails.Channel, outputPath, cancellationToken);
 
-            interactionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.ProjectCreatedSuccessfully, outputPath.EscapeMarkup()));
+            interactionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, TemplatingStrings.ProjectCreatedSuccessfully, outputPath));
 
             return new TemplateResult(ExitCodeConstants.Success, outputPath);
         }

--- a/src/Aspire.Cli/Utils/AppHostHelper.cs
+++ b/src/Aspire.Cli/Utils/AppHostHelper.cs
@@ -56,11 +56,12 @@ internal static class AppHostHelper
 
         var relativePath = Path.GetRelativePath(workingDirectory.FullName, projectFile.FullName);
         var appHostInformationResult = await interactionService.ShowStatusAsync(
-            $":microscope: {InteractionServiceStrings.CheckingProjectType}: {relativePath}",
+            $"{InteractionServiceStrings.CheckingProjectType}: {relativePath}",
             () => runner.GetAppHostInformationAsync(
                 projectFile,
                 new DotNetCliRunnerInvocationOptions(),
-                cancellationToken));
+                cancellationToken),
+            emoji: KnownEmojis.Microscope);
 
         return appHostInformationResult;
     }
@@ -69,12 +70,13 @@ internal static class AppHostHelper
     {
         var relativePath = Path.GetRelativePath(workingDirectory.FullName, projectFile.FullName);
         return await interactionService.ShowStatusAsync(
-            $":hammer_and_wrench:  {InteractionServiceStrings.BuildingAppHost} {relativePath}",
+            $"{InteractionServiceStrings.BuildingAppHost} {relativePath}",
             () => runner.BuildAsync(
                 projectFile,
                 noRestore,
                 options,
-                cancellationToken));
+                cancellationToken),
+            emoji: KnownEmojis.HammerAndWrench);
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Utils/CliDownloader.cs
+++ b/src/Aspire.Cli/Utils/CliDownloader.cs
@@ -76,7 +76,7 @@ internal class CliDownloader(
             });
 
             // Validate checksum
-            interactionService.DisplayMessage("check_mark", "Validating downloaded file...");
+            interactionService.DisplayMessage(KnownEmojis.CheckMark, "Validating downloaded file...");
             await ValidateChecksumAsync(archivePath, checksumPath, cancellationToken);
 
             interactionService.DisplaySuccess("Download completed successfully");

--- a/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
+++ b/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
@@ -257,7 +257,7 @@ internal sealed class ConsoleActivityLogger
                     };
                     var name = rec.DisplayName.EscapeMarkup();
                     var reason = rec.State == ActivityState.Failure && !string.IsNullOrEmpty(rec.FailureReason)
-                        ? ( _enableColor ? $" [red]— {HighlightMessage(rec.FailureReason!)}[/]" : $" — {rec.FailureReason}" )
+                        ? ( _enableColor ? $" [red]— {HighlightMessage(rec.FailureReason!.EscapeMarkup())}[/]" : $" — {rec.FailureReason!.EscapeMarkup()}" )
                         : string.Empty;
                     var lineSb = new StringBuilder();
                     lineSb.Append("  ")
@@ -317,8 +317,9 @@ internal sealed class ConsoleActivityLogger
         }
         else
         {
-            var plainValue = MarkdownToSpectreConverter.ConvertLinksToPlainText(value);
-            return $"  {key}: {plainValue}";
+            var plainKey = key.EscapeMarkup();
+            var plainValue = MarkdownToSpectreConverter.ConvertLinksToPlainText(value).EscapeMarkup();
+            return $"  {plainKey}: {plainValue}";
         }
     }
 

--- a/src/Aspire.Cli/Utils/EmojiWidth.cs
+++ b/src/Aspire.Cli/Utils/EmojiWidth.cs
@@ -1,0 +1,155 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace Aspire.Cli.Utils;
+
+/// <summary>
+/// Provides utilities for measuring and formatting emoji display widths in terminal output.
+/// Accounts for Spectre.Console stripping Variation Selector-16 (U+FE0F) from emoji resolution,
+/// which causes text-presentation-default emoji to render as a single cell in terminals.
+/// </summary>
+internal static class EmojiWidth
+{
+    private static readonly ConcurrentDictionary<string, int> s_cellLengthCache = new();
+
+    /// <summary>
+    /// Returns the cached cell width for <paramref name="emojiName"/>, computing it on first access.
+    /// </summary>
+    internal static int GetCachedCellWidth(string emojiName, IAnsiConsole console)
+    {
+        return s_cellLengthCache.GetOrAdd(emojiName, static (name, c) => GetCellWidth(name, c), console);
+    }
+
+    /// <summary>
+    /// Computes the terminal cell width of the emoji identified by <paramref name="emojiName"/>.
+    /// Detects text-presentation-default emoji (those with <c>Emoji_Presentation=No</c> in
+    /// Unicode) and returns 1 for them, since Spectre.Console strips the Variation Selector-16
+    /// (U+FE0F) during resolution and terminals render these as a single cell without it.
+    /// </summary>
+    internal static int GetCellWidth(string emojiName, IAnsiConsole console)
+    {
+        var resolved = Emoji.Replace($":{emojiName}:");
+
+        // Emoji with Emoji_Presentation=No require FE0F for wide (2-cell) rendering.
+        // Spectre strips FE0F during resolution, so terminals render them as 1 cell,
+        // but Spectre's Measure may still report 2. Detect these and return 1.
+        var enumerator = resolved.EnumerateRunes();
+        if (enumerator.MoveNext())
+        {
+            var rune = enumerator.Current;
+            if (!enumerator.MoveNext() && !HasDefaultEmojiPresentation(rune.Value))
+            {
+                return 1;
+            }
+        }
+
+        var renderable = new Markup($":{emojiName}:");
+        var options = RenderOptions.Create(console, console.Profile.Capabilities);
+        return ((IRenderable)renderable).Measure(options, int.MaxValue).Max;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the Unicode code point has the
+    /// <c>Emoji_Presentation=Yes</c> property, meaning it defaults to wide emoji
+    /// rendering without a Variation Selector-16 suffix.
+    /// </summary>
+    /// <remarks>
+    /// Based on Unicode 16.0 emoji-data.txt. Code points not listed here that
+    /// are still emoji have <c>Emoji_Presentation=No</c> and render as narrow
+    /// text characters (1 cell) when FE0F is absent.
+    /// </remarks>
+    private static bool HasDefaultEmojiPresentation(int codePoint)
+    {
+        return codePoint switch
+        {
+            // BMP: Miscellaneous Technical
+            0x231A or 0x231B => true,
+            >= 0x23E9 and <= 0x23EC => true,
+            0x23F0 or 0x23F3 => true,
+            // BMP: Geometric Shapes
+            0x25FD or 0x25FE => true,
+            // BMP: Miscellaneous Symbols
+            0x2614 or 0x2615 => true,
+            >= 0x2648 and <= 0x2653 => true,
+            0x267F or 0x2693 or 0x26A1 => true,
+            0x26AA or 0x26AB => true,
+            0x26BD or 0x26BE => true,
+            0x26C4 or 0x26C5 or 0x26CE or 0x26D4 or 0x26EA => true,
+            0x26F2 or 0x26F3 or 0x26F5 or 0x26FA or 0x26FD => true,
+            // BMP: Dingbats
+            0x2702 or 0x2705 => true,
+            >= 0x2708 and <= 0x270D => true,
+            0x270F or 0x2712 or 0x2714 or 0x2716 => true,
+            0x271D or 0x2721 or 0x2728 => true,
+            0x2733 or 0x2734 or 0x2744 or 0x2747 => true,
+            0x274C or 0x274E => true,
+            >= 0x2753 and <= 0x2755 => true,
+            0x2757 => true,
+            0x2763 or 0x2764 => true,
+            >= 0x2795 and <= 0x2797 => true,
+            0x27A1 or 0x27B0 or 0x27BF => true,
+            // BMP: Supplemental Arrows / Misc Symbols
+            0x2934 or 0x2935 => true,
+            >= 0x2B05 and <= 0x2B07 => true,
+            0x2B1B or 0x2B1C or 0x2B50 or 0x2B55 => true,
+            // BMP: CJK Symbols
+            0x3030 or 0x303D or 0x3297 or 0x3299 => true,
+            // SMP: Mahjong, Playing Cards, Enclosed Ideographic
+            0x1F004 or 0x1F0CF or 0x1F18E => true,
+            >= 0x1F191 and <= 0x1F19A => true,
+            >= 0x1F1E6 and <= 0x1F1FF => true,
+            0x1F201 or 0x1F21A or 0x1F22F => true,
+            >= 0x1F232 and <= 0x1F236 => true,
+            >= 0x1F238 and <= 0x1F23A => true,
+            0x1F250 or 0x1F251 => true,
+            // SMP: Miscellaneous Symbols and Pictographs
+            >= 0x1F300 and <= 0x1F320 => true,
+            >= 0x1F32D and <= 0x1F335 => true,
+            >= 0x1F337 and <= 0x1F37C => true,
+            >= 0x1F37E and <= 0x1F393 => true,
+            >= 0x1F3A0 and <= 0x1F3CA => true,
+            >= 0x1F3CF and <= 0x1F3D3 => true,
+            >= 0x1F3E0 and <= 0x1F3F0 => true,
+            0x1F3F4 => true,
+            >= 0x1F3F8 and <= 0x1F43E => true,
+            0x1F440 => true,
+            >= 0x1F442 and <= 0x1F4FC => true,
+            >= 0x1F4FF and <= 0x1F53D => true,
+            >= 0x1F54B and <= 0x1F54E => true,
+            >= 0x1F550 and <= 0x1F567 => true,
+            0x1F57A => true,
+            0x1F595 or 0x1F596 => true,
+            0x1F5A4 => true,
+            >= 0x1F5FB and <= 0x1F64F => true,
+            // SMP: Transport and Map Symbols
+            >= 0x1F680 and <= 0x1F6C5 => true,
+            0x1F6CC => true,
+            >= 0x1F6D0 and <= 0x1F6D2 => true,
+            >= 0x1F6D5 and <= 0x1F6D7 => true,
+            >= 0x1F6DC and <= 0x1F6DF => true,
+            0x1F6EB or 0x1F6EC => true,
+            >= 0x1F6F4 and <= 0x1F6FC => true,
+            // SMP: Geometric Shapes Extended, Chess Symbols
+            >= 0x1F7E0 and <= 0x1F7EB => true,
+            0x1F7F0 => true,
+            // SMP: Supplemental Symbols and Pictographs
+            >= 0x1F90C and <= 0x1F93A => true,
+            >= 0x1F93C and <= 0x1F945 => true,
+            >= 0x1F947 and <= 0x1F9FF => true,
+            // SMP: Symbols and Pictographs Extended-A
+            >= 0x1FA00 and <= 0x1FA53 => true,
+            >= 0x1FA60 and <= 0x1FA6D => true,
+            >= 0x1FA70 and <= 0x1FA7C => true,
+            >= 0x1FA80 and <= 0x1FA89 => true,
+            >= 0x1FA8F and <= 0x1FAC6 => true,
+            >= 0x1FACE and <= 0x1FADC => true,
+            >= 0x1FADF and <= 0x1FAE9 => true,
+            >= 0x1FAF0 and <= 0x1FAF8 => true,
+            _ => false,
+        };
+    }
+}

--- a/src/Aspire.Cli/Utils/SdkInstallHelper.cs
+++ b/src/Aspire.Cli/Utils/SdkInstallHelper.cs
@@ -88,7 +88,7 @@ internal static class SdkInstallHelper
                 {
                     // When alwaysInstallSdk is true, skip the prompt and install directly
                     shouldInstall = true;
-                    interactionService.DisplayMessage("information",
+                    interactionService.DisplayMessage(KnownEmojis.Information,
                         "alwaysInstallSdk is enabled - forcing SDK installation for testing purposes.");
                 }
                 else

--- a/src/Aspire.Cli/Utils/TableExtensions.cs
+++ b/src/Aspire.Cli/Utils/TableExtensions.cs
@@ -13,16 +13,7 @@ internal static class TableExtensions
     /// <summary>
     /// Adds a column with a bold header to the table.
     /// </summary>
-    public static Table AddBoldColumn(this Table table, string header)
-    {
-        table.AddColumn($"[bold]{header.EscapeMarkup()}[/]");
-        return table;
-    }
-
-    /// <summary>
-    /// Adds a column with a bold, non-wrapping header to the table.
-    /// </summary>
-    public static Table AddBoldColumn(this Table table, string header, bool noWrap)
+    public static Table AddBoldColumn(this Table table, string header, bool noWrap = false, int? width = null)
     {
         var column = new TableColumn($"[bold]{header.EscapeMarkup()}[/]");
 
@@ -31,17 +22,11 @@ internal static class TableExtensions
             column.NoWrap();
         }
 
-        table.AddColumn(column);
-        return table;
-    }
+        if (width is not null)
+        {
+            column.Width = width;
+        }
 
-    /// <summary>
-    /// Adds a column with a bold header and a fixed width to the table.
-    /// </summary>
-    public static Table AddBoldColumn(this Table table, string header, int width)
-    {
-        var column = new TableColumn($"[bold]{header.EscapeMarkup()}[/]");
-        column.Width = width;
         table.AddColumn(column);
         return table;
     }

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1290,12 +1290,12 @@ internal sealed class OrderTrackingInteractionService(List<string> operationOrde
 {
     public ConsoleOutput Console { get; set; }
 
-    public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action)
+    public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
         return action();
     }
 
-    public void ShowStatus(string statusText, Action action)
+    public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
         action();
     }
@@ -1336,12 +1336,12 @@ internal sealed class OrderTrackingInteractionService(List<string> operationOrde
 
     public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;
     public void DisplayError(string errorMessage) { }
-    public void DisplayMessage(string emojiName, string message) { }
-    public void DisplaySuccess(string message) { }
+    public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) { }
+    public void DisplaySuccess(string message, bool allowMarkup = false) { }
     public void DisplayLines(IEnumerable<(string Stream, string Line)> lines) { }
     public void DisplayCancellationMessage() { }
     public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default) => Task.FromResult(true);
-    public void DisplaySubtleMessage(string message, bool escapeMarkup = true) { }
+    public void DisplaySubtleMessage(string message, bool allowMarkup = false) { }
     public void DisplayEmptyLine() { }
     public void DisplayPlainText(string text) { }
     public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) { }

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -937,13 +937,13 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
     }
 
     // Default implementations for other interface methods
-    public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action) => action();
-    public void ShowStatus(string statusText, Action action) => action();
+    public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false) => action();
+    public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false) => action();
     public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;
     public void DisplayError(string errorMessage) => DisplayedErrors.Add(errorMessage);
-    public void DisplayMessage(string emojiName, string message) { }
-    public void DisplaySuccess(string message) { }
-    public void DisplaySubtleMessage(string message, bool escapeMarkup = true) { }
+    public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) { }
+    public void DisplaySuccess(string message, bool allowMarkup = false) { }
+    public void DisplaySubtleMessage(string message, bool allowMarkup = false) { }
     public void DisplayLines(IEnumerable<(string Stream, string Line)> lines) { }
     public void DisplayCancellationMessage() { }
     public void DisplayEmptyLine() { }

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -954,8 +954,8 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
         _innerService = innerService;
     }
 
-    public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action) => _innerService.ShowStatusAsync(statusText, action);
-    public void ShowStatus(string statusText, Action action) => _innerService.ShowStatus(statusText, action);
+    public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false) => _innerService.ShowStatusAsync(statusText, action, emoji, allowMarkup);
+    public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false) => _innerService.ShowStatus(statusText, action, emoji, allowMarkup);
     public Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default) 
         => _innerService.PromptForStringAsync(promptText, defaultValue, validator, isSecret, required, cancellationToken);
     public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default) 
@@ -967,13 +967,13 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
     public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) 
         => _innerService.DisplayIncompatibleVersionError(ex, appHostHostingVersion);
     public void DisplayError(string errorMessage) => _innerService.DisplayError(errorMessage);
-    public void DisplayMessage(string emojiName, string message) => _innerService.DisplayMessage(emojiName, message);
+    public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) => _innerService.DisplayMessage(emoji, message, allowMarkup);
     public void DisplayPlainText(string text) => _innerService.DisplayPlainText(text);
     public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) => _innerService.DisplayRawText(text, consoleOverride);
     public void DisplayMarkdown(string markdown) => _innerService.DisplayMarkdown(markdown);
     public void DisplayMarkupLine(string markup) => _innerService.DisplayMarkupLine(markup);
-    public void DisplaySuccess(string message) => _innerService.DisplaySuccess(message);
-    public void DisplaySubtleMessage(string message, bool escapeMarkup = true) => _innerService.DisplaySubtleMessage(message, escapeMarkup);
+    public void DisplaySuccess(string message, bool allowMarkup = false) => _innerService.DisplaySuccess(message, allowMarkup);
+    public void DisplaySubtleMessage(string message, bool allowMarkup = false) => _innerService.DisplaySubtleMessage(message, allowMarkup);
     public void DisplayLines(IEnumerable<(string Stream, string Line)> lines) => _innerService.DisplayLines(lines);
     public void DisplayCancellationMessage() 
     {

--- a/tests/Aspire.Cli.Tests/Interaction/KnownEmojisTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/KnownEmojisTests.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Aspire.Cli.Interaction;
+using Spectre.Console;
+
+namespace Aspire.Cli.Tests.Interaction;
+
+public class KnownEmojisTests
+{
+    [Fact]
+    public void AllKnownEmojis_MapToValidSpectreConsoleEmojis()
+    {
+        var fields = typeof(KnownEmojis)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(f => f.FieldType == typeof(KnownEmoji))
+            .ToList();
+
+        Assert.NotEmpty(fields);
+
+        foreach (var field in fields)
+        {
+            var knownEmoji = (KnownEmoji)field.GetValue(null)!;
+            var input = $":{knownEmoji.Name}:";
+            var resolved = Emoji.Replace(input);
+
+            Assert.True(resolved != input, $"KnownEmojis.{field.Name} with emoji name \"{knownEmoji.Name}\" is not recognized by Spectre.Console.");
+        }
+    }
+}

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -466,18 +466,18 @@ public class DotNetTemplateFactoryTests
         public Task<bool> ConfirmAsync(string prompt, bool defaultAnswer, CancellationToken cancellationToken)
             => throw new NotImplementedException();
 
-        public Task<TResult> ShowStatusAsync<TResult>(string message, Func<Task<TResult>> work)
+        public Task<TResult> ShowStatusAsync<TResult>(string message, Func<Task<TResult>> work, KnownEmoji? emoji = null, bool allowMarkup = false)
             => throw new NotImplementedException();
 
         public Task ShowStatusAsync(string message, Func<Task> work)
             => throw new NotImplementedException();
 
-        public void ShowStatus(string message, Action work)
+        public void ShowStatus(string message, Action work, KnownEmoji? emoji = null, bool allowMarkup = false)
             => throw new NotImplementedException();
 
-        public void DisplaySuccess(string message) { }
+        public void DisplaySuccess(string message, bool allowMarkup = false) { }
         public void DisplayError(string message) { }
-        public void DisplayMessage(string emojiName, string message) { }
+        public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) { }
         public void DisplayLines(IEnumerable<(string Stream, string Line)> lines) { }
         public void DisplayCancellationMessage() { }
         public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;
@@ -485,7 +485,7 @@ public class DotNetTemplateFactoryTests
         public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) { }
         public void DisplayMarkdown(string markdown) { }
         public void DisplayMarkupLine(string markup) { }
-        public void DisplaySubtleMessage(string message, bool escapeMarkup = true) { }
+        public void DisplaySubtleMessage(string message, bool allowMarkup = false) { }
         public void DisplayEmptyLine() { }
         public void DisplayVersionUpdateNotification(string message, string? updateCommand = null) { }
         public void WriteConsoleLog(string message, int? resourceHashCode, string? resourceName, bool isError) { }

--- a/tests/Aspire.Cli.Tests/TestServices/TestConsoleInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestConsoleInteractionService.cs
@@ -25,13 +25,13 @@ internal sealed class TestConsoleInteractionService : IInteractionService
     /// </summary>
     public Func<string, IEnumerable, Func<object, string>, CancellationToken, object>? PromptForSelectionCallback { get; set; }
 
-    public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action)
+    public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
         ShowStatusCallback?.Invoke(statusText);
         return action();
     }
 
-    public void ShowStatus(string statusText, Action action)
+    public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
         action();
     }
@@ -81,11 +81,11 @@ internal sealed class TestConsoleInteractionService : IInteractionService
         DisplayErrorCallback?.Invoke(errorMessage);
     }
 
-    public void DisplayMessage(string emojiName, string message)
+    public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false)
     {
     }
 
-    public void DisplaySuccess(string message)
+    public void DisplaySuccess(string message, bool allowMarkup = false)
     {
     }
 
@@ -102,7 +102,7 @@ internal sealed class TestConsoleInteractionService : IInteractionService
         return Task.FromResult(ConfirmCallback != null? ConfirmCallback(promptText, defaultValue) : defaultValue);
     }
 
-    public void DisplaySubtleMessage(string message, bool escapeMarkup = true)
+    public void DisplaySubtleMessage(string message, bool allowMarkup = false)
     {
         DisplaySubtleMessageCallback?.Invoke(message);
     }

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -24,12 +24,12 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
 
     public IExtensionBackchannel Backchannel { get; } = serviceProvider.GetRequiredService<IExtensionBackchannel>();
 
-    public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action)
+    public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
         return action();
     }
 
-    public void ShowStatus(string statusText, Action action)
+    public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
         action();
     }
@@ -69,11 +69,11 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
         DisplayErrorCallback?.Invoke(errorMessage);
     }
 
-    public void DisplayMessage(string emojiName, string message)
+    public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false)
     {
     }
 
-    public void DisplaySuccess(string message)
+    public void DisplaySuccess(string message, bool allowMarkup = false)
     {
     }
 
@@ -115,7 +115,7 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
         return Task.FromResult(true);
     }
 
-    public void DisplaySubtleMessage(string message, bool escapeMarkup = true)
+    public void DisplaySubtleMessage(string message, bool allowMarkup = false)
     {
         DisplaySubtleMessageCallback?.Invoke(message);
     }
@@ -185,8 +185,8 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
         return Task.CompletedTask;
     }
 
-    public void ConsoleDisplaySubtleMessage(string message, bool escapeMarkup = true)
+    public void ConsoleDisplaySubtleMessage(string message, bool allowMarkup = false)
     {
-        ConsoleDisplaySubtleMessageCallback?.Invoke(message, escapeMarkup);
+        ConsoleDisplaySubtleMessageCallback?.Invoke(message, allowMarkup);
     }
 }

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -209,6 +209,9 @@ internal static class CliTestHelper
         services.AddTransient<SecretListCommand>();
         services.AddTransient<SecretDeleteCommand>();
         services.AddTransient<SecretStoreResolver>();
+#if DEBUG
+        services.AddTransient<RenderCommand>();
+#endif
         services.AddTransient(options.AppHostBackchannelFactory);
 
         return services;

--- a/tests/Aspire.Cli.Tests/Utils/EmojiWidthTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/EmojiWidthTests.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Utils;
+using Spectre.Console;
+using System.Text;
+
+namespace Aspire.Cli.Tests.Utils;
+
+public class EmojiWidthTests
+{
+    [Theory]
+    [InlineData("file_cabinet")]
+    [InlineData("gear")]
+    [InlineData("hammer_and_wrench")]
+    [InlineData("information")]
+    [InlineData("linked_paperclips")]
+    [InlineData("warning")]
+    public void GetCellWidth_TextPresentationEmojis_ReturnOne(string emojiName)
+    {
+        // Arrange - these emoji have Emoji_Presentation=No in Unicode.
+        // Without FE0F (which Spectre strips), terminals render them as 1 cell.
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter(new StringBuilder()))
+        });
+
+        // Act
+        var width = EmojiWidth.GetCellWidth(emojiName, console);
+
+        // Assert
+        Assert.Equal(1, width);
+    }
+
+    [Theory]
+    [InlineData("bug")]
+    [InlineData("check_mark")]
+    [InlineData("cross_mark")]
+    [InlineData("file_folder")]
+    [InlineData("hammer")]
+    [InlineData("high_voltage")]
+    [InlineData("locked_with_key")]
+    [InlineData("magnifying_glass_tilted_left")]
+    [InlineData("magnifying_glass_tilted_right")]
+    [InlineData("microscope")]
+    [InlineData("package")]
+    [InlineData("rocket")]
+    [InlineData("running_shoe")]
+    [InlineData("stop_sign")]
+    public void GetCellWidth_EmojiPresentationEmojis_ReturnMeasuredWidth(string emojiName)
+    {
+        // Arrange - these emoji have Emoji_Presentation=Yes in Unicode
+        // and use Spectre's measured width (typically 2).
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter(new StringBuilder()))
+        });
+
+        // Act
+        var width = EmojiWidth.GetCellWidth(emojiName, console);
+
+        // Assert - Spectre measurement for EP=Yes emoji is typically 2
+        Assert.InRange(width, 1, 2);
+    }
+}


### PR DESCRIPTION
## Description

The CLI interaction service has methods like `DisplayMessage` and `DisplaySuccess` that are rendered using markup. That means callers must escape external content or get problems when content contains markup characters. This is non-obvious and it's very easy to include external content in these methods.

This PR:
- Add previously missing escaping to all external content with `DisplayMarkup`
- Changes many of the display methods on interaction service to escape by default. Can opt-in to displaying markup using an optional parameter
- Move emoji to a separate argument for `ShowStatusAsync`. Allows message to be escaped by default
- Add emoji measurement to apply consistent spacing. Hopefully fix issues with inconsistent spacing after emojis.
- Add `RenderCommand`. It's a test bed for smoke testing render output. Hidden and excluded from non-debug builds.
- Add `KnownEmojis`. List of emojis used in the CLI. Fix some invalid emojis.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
