### PR TITLE
Fix serialization issue with enum when building capabilities

### DIFF
--- a/src/Aspire.Hosting.RemoteHost/Ats/AtsMarshaller.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/AtsMarshaller.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 
 namespace Aspire.Hosting.RemoteHost.Ats;
 
@@ -49,7 +50,8 @@ internal sealed class AtsMarshaller
     private static readonly JsonSerializerOptions s_jsonOptions = new()
     {
         PropertyNameCaseInsensitive = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() }
     };
 
     /// <summary>

--- a/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
@@ -5,7 +5,6 @@ using System.Collections.Concurrent;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Text.Json.Serialization;
 using Aspire.Hosting.Ats;
 using Microsoft.Extensions.Logging;
 
@@ -534,12 +533,6 @@ internal sealed class CapabilityDispatcher
 /// </summary>
 internal static class CapabilityJsonExtensions
 {
-    private static readonly JsonSerializerOptions s_jsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        Converters = { new JsonStringEnumConverter() }
-    };
 
     /// <summary>
     /// Gets a required string argument.
@@ -617,7 +610,7 @@ internal static class CapabilityJsonExtensions
     {
         if (args.TryGetPropertyValue(name, out var node) && node is JsonObject obj)
         {
-            return JsonSerializer.Deserialize<T>(obj.ToJsonString(), s_jsonOptions);
+            return JsonSerializer.Deserialize<T>(obj.ToJsonString(), AtsMarshaller.JsonOptions);
         }
         return null;
     }

--- a/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using Aspire.Hosting.Ats;
 using Microsoft.Extensions.Logging;
 
@@ -536,7 +537,8 @@ internal static class CapabilityJsonExtensions
     private static readonly JsonSerializerOptions s_jsonOptions = new()
     {
         PropertyNameCaseInsensitive = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() }
     };
 
     /// <summary>

--- a/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
@@ -1153,6 +1153,53 @@ public class CapabilityDispatcherTests
         Assert.Equal("No value", result.GetValue<string>());
     }
 
+    [Fact]
+    public void GetDto_DeserializesEnumPropertyFromString()
+    {
+        var args = new JsonObject
+        {
+            ["dto"] = new JsonObject
+            {
+                ["label"] = "test-item",
+                ["status"] = "ValueB"
+            }
+        };
+
+        var result = args.GetDto<TestDtoWithEnum>("dto");
+
+        Assert.NotNull(result);
+        Assert.Equal("test-item", result.Label);
+        Assert.Equal(TestDispatchEnum.ValueB, result.Status);
+    }
+
+    [Fact]
+    public void GetDto_DeserializesEnumPropertyFromStringCaseInsensitive()
+    {
+        var args = new JsonObject
+        {
+            ["dto"] = new JsonObject
+            {
+                ["label"] = "item",
+                ["status"] = "valuec"
+            }
+        };
+
+        var result = args.GetDto<TestDtoWithEnum>("dto");
+
+        Assert.NotNull(result);
+        Assert.Equal(TestDispatchEnum.ValueC, result.Status);
+    }
+
+    [Fact]
+    public void GetDto_ReturnsNullWhenPropertyMissing()
+    {
+        var args = new JsonObject();
+
+        var result = args.GetDto<TestDtoWithEnum>("dto");
+
+        Assert.Null(result);
+    }
+
     private static CapabilityDispatcher CreateDispatcher(params System.Reflection.Assembly[] assemblies)
     {
         var handles = new HandleRegistry();
@@ -1430,4 +1477,13 @@ internal static class TestEnumCapabilities
     {
         return value.HasValue ? $"Received: {value.Value}" : "No value";
     }
+}
+
+/// <summary>
+/// Test DTO with an enum property for GetDto deserialization tests.
+/// </summary>
+internal sealed class TestDtoWithEnum
+{
+    public string? Label { get; set; }
+    public TestDispatchEnum Status { get; set; }
 }


### PR DESCRIPTION
## Description

Add `JsonStringEnumConverter` to JSON serialization options in `AtsMarshaller` and `CapabilityDispatcher`.

Contributes to #14772

Resolves this following error:

```txt
❌ Uncaught Exception: The JSON value could not be converted to System.Nullable`1[[Aspire.Hosting.ApplicationModel.IconVariant]]. Path: $.iconVariant | LineNumber: 0 |        
BytePositionInLine: 54.
CapabilityError: The JSON value could not be converted to System.Nullable`1[[Aspire.Hosting.ApplicationModel.IconVariant]]. Path: $.iconVariant | LineNumber: 0 |
BytePositionInLine: 54.
    at AspireClient.invokeCapability (D:\GitHub\TsApp\.modules\transport.ts:536:23)
    at async PostgresDatabaseResource._withCommandInternal (D:\GitHub\TsApp\.modules\aspire.ts:4648:24)
    at async <anonymous> (D:\GitHub\TsApp\apphost.ts:26:1)
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
