### PR TITLE
Fix describe duplicate rows and colorize resource name in describe

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
@@ -68,7 +70,6 @@ internal sealed class AppHostConnectionResolver(
     /// <param name="projectFile">Optional project file. If specified, uses fast path to find matching socket.</param>
     /// <param name="scanningMessage">Message to display while scanning for AppHosts.</param>
     /// <param name="selectPrompt">Prompt to display when multiple AppHosts are found.</param>
-    /// <param name="noInScopeMessage">Message to display when no in-scope AppHosts are found but others exist.</param>
     /// <param name="notFoundMessage">Message to display when no AppHosts are found.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The resolved connection, or null with an error message.</returns>
@@ -76,7 +77,6 @@ internal sealed class AppHostConnectionResolver(
         FileInfo? projectFile,
         string scanningMessage,
         string selectPrompt,
-        string noInScopeMessage,
         string notFoundMessage,
         CancellationToken cancellationToken)
     {
@@ -139,48 +139,21 @@ internal sealed class AppHostConnectionResolver(
         }
         else if (inScopeConnections.Count > 1)
         {
-            // Multiple in-scope AppHosts running, prompt for selection
-            // Order by most recently started first
-            var choices = inScopeConnections
-                .OrderByDescending(c => c.AppHostInfo?.StartedAt ?? DateTimeOffset.MinValue)
-                .Select(c =>
-                {
-                    var appHostPath = c.AppHostInfo?.AppHostPath ?? "Unknown";
-                    var relativePath = Path.GetRelativePath(workingDirectory, appHostPath);
-                    return (Display: relativePath, Connection: c);
-                })
-                .ToList();
-
-            var selectedDisplay = await interactionService.PromptForSelectionAsync(
+            selectedConnection = await PromptForAppHostSelectionAsync(
+                inScopeConnections,
+                SharedCommandStrings.MultipleInScopeAppHosts,
                 selectPrompt,
-                choices.Select(c => c.Display).ToArray(),
-                c => c.EscapeMarkup(),
+                path => Path.GetRelativePath(workingDirectory, path),
                 cancellationToken);
-
-            selectedConnection = choices.FirstOrDefault(c => c.Display == selectedDisplay).Connection;
         }
         else if (outOfScopeConnections.Count > 0)
         {
-            // No in-scope AppHosts, but there are out-of-scope ones - let user pick
-            interactionService.DisplayMessage(KnownEmojis.Information, noInScopeMessage);
-
-            // Order by most recently started first
-            var choices = outOfScopeConnections
-                .OrderByDescending(c => c.AppHostInfo?.StartedAt ?? DateTimeOffset.MinValue)
-                .Select(c =>
-                {
-                    var path = c.AppHostInfo?.AppHostPath ?? "Unknown";
-                    return (Display: path, Connection: c);
-                })
-                .ToList();
-
-            var selectedDisplay = await interactionService.PromptForSelectionAsync(
+            selectedConnection = await PromptForAppHostSelectionAsync(
+                outOfScopeConnections,
+                SharedCommandStrings.NoInScopeAppHostsShowingAll,
                 selectPrompt,
-                choices.Select(c => c.Display).ToArray(),
-                c => c.EscapeMarkup(),
+                path => path,
                 cancellationToken);
-
-            selectedConnection = choices.FirstOrDefault(c => c.Display == selectedDisplay).Connection;
         }
 
         if (selectedConnection is null)
@@ -189,5 +162,41 @@ internal sealed class AppHostConnectionResolver(
         }
 
         return new AppHostConnectionResult { Connection = selectedConnection };
+    }
+
+    /// <summary>
+    /// Displays an informational message, prompts the user to select from available AppHost connections,
+    /// and displays the selected AppHost.
+    /// </summary>
+    private async Task<IAppHostAuxiliaryBackchannel?> PromptForAppHostSelectionAsync(
+        List<IAppHostAuxiliaryBackchannel> candidateConnections,
+        string contextMessage,
+        string selectPrompt,
+        Func<string, string> formatPath,
+        CancellationToken cancellationToken)
+    {
+        interactionService.DisplayMessage("information", contextMessage);
+
+        // Order by most recently started first
+        var choices = candidateConnections
+            .OrderByDescending(c => c.AppHostInfo?.StartedAt ?? DateTimeOffset.MinValue)
+            .Select(c =>
+            {
+                var appHostPath = c.AppHostInfo?.AppHostPath ?? "Unknown";
+                return (Display: formatPath(appHostPath), Connection: c);
+            })
+            .ToList();
+
+        var selectedDisplay = await interactionService.PromptForSelectionAsync(
+            selectPrompt,
+            choices.Select(c => c.Display).ToArray(),
+            c => c.EscapeMarkup(),
+            cancellationToken);
+
+        var selectedConnection = choices.FirstOrDefault(c => c.Display == selectedDisplay).Connection;
+
+        interactionService.DisplaySuccess(string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.UsingAppHost, selectedDisplay));
+
+        return selectedConnection;
     }
 }

--- a/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostConnectionResolver.cs
@@ -175,7 +175,7 @@ internal sealed class AppHostConnectionResolver(
         Func<string, string> formatPath,
         CancellationToken cancellationToken)
     {
-        interactionService.DisplayMessage("information", contextMessage);
+        interactionService.DisplayMessage(KnownEmojis.Information, contextMessage);
 
         // Order by most recently started first
         var choices = candidateConnections

--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -77,7 +77,6 @@ internal sealed class LogsCommand : BaseCommand
     private readonly IInteractionService _interactionService;
     private readonly AppHostConnectionResolver _connectionResolver;
     private readonly ILogger<LogsCommand> _logger;
-    private readonly ICliHostEnvironment _hostEnvironment;
 
     private static readonly Argument<string?> s_resourceArgument = new("resource")
     {
@@ -102,22 +101,7 @@ internal sealed class LogsCommand : BaseCommand
         Description = LogsCommandStrings.TimestampsOptionDescription
     };
 
-    // Colors to cycle through for different resources (similar to docker-compose)
-    private static readonly Color[] s_resourceColors =
-    [
-        Color.Cyan1,
-        Color.Green,
-        Color.Yellow,
-        Color.Blue,
-        Color.Magenta1,
-        Color.Orange1,
-        Color.DeepPink1,
-        Color.SpringGreen1,
-        Color.Aqua,
-        Color.Violet
-    ];
-    private readonly Dictionary<string, Color> _resourceColorMap = new(StringComparer.OrdinalIgnoreCase);
-    private int _nextColorIndex;
+    private readonly ResourceColorMap _resourceColorMap = new();
 
     public LogsCommand(
         IInteractionService interactionService,
@@ -125,13 +109,11 @@ internal sealed class LogsCommand : BaseCommand
         IFeatures features,
         ICliUpdateNotifier updateNotifier,
         CliExecutionContext executionContext,
-        ICliHostEnvironment hostEnvironment,
         AspireCliTelemetry telemetry,
         ILogger<LogsCommand> logger)
         : base("logs", LogsCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _interactionService = interactionService;
-        _hostEnvironment = hostEnvironment;
         _logger = logger;
         _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, executionContext, logger);
 
@@ -165,7 +147,6 @@ internal sealed class LogsCommand : BaseCommand
             passedAppHostProjectFile,
             SharedCommandStrings.ScanningForRunningAppHosts,
             string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.SelectAppHost, LogsCommandStrings.SelectAppHostAction),
-            SharedCommandStrings.NoInScopeAppHostsShowingAll,
             SharedCommandStrings.AppHostNotRunning,
             cancellationToken);
 
@@ -348,29 +329,13 @@ internal sealed class LogsCommand : BaseCommand
             // Structured output always goes to stdout.
             _interactionService.DisplayRawText(output, ConsoleOutput.Standard);
         }
-        else if (_hostEnvironment.SupportsAnsi)
-        {
-            // Colorized output: assign a consistent color to each resource
-            var color = GetResourceColor(displayName);
-            var escapedContent = content.EscapeMarkup();
-            AnsiConsole.MarkupLine($"{timestampPrefix.EscapeMarkup()}[{color}][[{displayName.EscapeMarkup()}]][/] {escapedContent}");
-        }
         else
         {
-            // Plain text fallback when colors not supported
-            _interactionService.DisplayPlainText($"{timestampPrefix}[{displayName}] {content}");
+            // Colorized output: assign a consistent color to each resource
+            var color = _resourceColorMap.GetColor(displayName);
+            var escapedContent = content.EscapeMarkup();
+            _interactionService.DisplayMarkupLine($"{timestampPrefix.EscapeMarkup()}[{color}][[{displayName.EscapeMarkup()}]][/] {escapedContent}");
         }
-    }
-
-    private Color GetResourceColor(string resourceName)
-    {
-        if (!_resourceColorMap.TryGetValue(resourceName, out var color))
-        {
-            color = s_resourceColors[_nextColorIndex % s_resourceColors.Length];
-            _resourceColorMap[resourceName] = color;
-            _nextColorIndex++;
-        }
-        return color;
     }
 
     private static string FormatTimestamp(DateTime timestamp)

--- a/src/Aspire.Cli/Commands/ResourceCommand.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommand.cs
@@ -62,7 +62,6 @@ internal sealed class ResourceCommand : BaseCommand
             passedAppHostProjectFile,
             SharedCommandStrings.ScanningForRunningAppHosts,
             string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.SelectAppHost, ResourceCommandStrings.SelectAppHostAction),
-            SharedCommandStrings.NoInScopeAppHostsShowingAll,
             SharedCommandStrings.AppHostNotRunning,
             cancellationToken);
 

--- a/src/Aspire.Cli/Commands/ResourceCommandBase.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommandBase.cs
@@ -83,7 +83,6 @@ internal abstract class ResourceCommandBase : BaseCommand
             passedAppHostProjectFile,
             SharedCommandStrings.ScanningForRunningAppHosts,
             string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.SelectAppHost, ResourceCommandStrings.SelectAppHostAction),
-            SharedCommandStrings.NoInScopeAppHostsShowingAll,
             SharedCommandStrings.AppHostNotRunning,
             cancellationToken);
 

--- a/src/Aspire.Cli/Commands/StartCommand.cs
+++ b/src/Aspire.Cli/Commands/StartCommand.cs
@@ -110,7 +110,6 @@ internal sealed class StartCommand : BaseCommand
             passedAppHostProjectFile,
             SharedCommandStrings.ScanningForRunningAppHosts,
             string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.SelectAppHost, ResourceCommandStrings.SelectAppHostAction),
-            SharedCommandStrings.NoInScopeAppHostsShowingAll,
             SharedCommandStrings.AppHostNotRunning,
             cancellationToken);
 

--- a/src/Aspire.Cli/Commands/StopCommand.cs
+++ b/src/Aspire.Cli/Commands/StopCommand.cs
@@ -149,7 +149,6 @@ internal sealed class StopCommand : BaseCommand
             passedAppHostProjectFile,
             SharedCommandStrings.ScanningForRunningAppHosts,
             string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.SelectAppHost, StopCommandStrings.SelectAppHostAction),
-            SharedCommandStrings.NoInScopeAppHostsShowingAll,
             SharedCommandStrings.AppHostNotRunning,
             cancellationToken);
 

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -110,7 +110,6 @@ internal static class TelemetryCommandHelpers
             projectFile,
             SharedCommandStrings.ScanningForRunningAppHosts,
             string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.SelectAppHost, TelemetryCommandStrings.SelectAppHostAction),
-            SharedCommandStrings.NoInScopeAppHostsShowingAll,
             SharedCommandStrings.AppHostNotRunning,
             cancellationToken);
 

--- a/src/Aspire.Cli/Commands/WaitCommand.cs
+++ b/src/Aspire.Cli/Commands/WaitCommand.cs
@@ -91,7 +91,6 @@ internal sealed class WaitCommand : BaseCommand
             passedAppHostProjectFile,
             SharedCommandStrings.ScanningForRunningAppHosts,
             string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.SelectAppHost, WaitCommandStrings.SelectAppHostAction),
-            SharedCommandStrings.NoInScopeAppHostsShowingAll,
             SharedCommandStrings.AppHostNotRunning,
             cancellationToken);
 

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.Designer.cs
@@ -86,5 +86,17 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("IsolatedOptionDescription", resourceCulture);
             }
         }
+
+        internal static string UsingAppHost {
+            get {
+                return ResourceManager.GetString("UsingAppHost", resourceCulture);
+            }
+        }
+
+        internal static string MultipleInScopeAppHosts {
+            get {
+                return ResourceManager.GetString("MultipleInScopeAppHosts", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.resx
@@ -124,7 +124,7 @@
     <value>Select an AppHost to {0}:</value>
   </data>
   <data name="NoInScopeAppHostsShowingAll" xml:space="preserve">
-    <value>No running AppHosts found in the current directory. Showing all running AppHosts:</value>
+    <value>No running AppHosts found in the current directory. Select from all running AppHosts.</value>
   </data>
   <data name="AppHostNotRunning" xml:space="preserve">
     <value>No running AppHost found. Use 'aspire run' to start one first.</value>
@@ -142,6 +142,6 @@
     <value>Using AppHost: {0}</value>
   </data>
   <data name="MultipleInScopeAppHosts" xml:space="preserve">
-    <value>Multiple running AppHosts found in the current directory:</value>
+    <value>Multiple running AppHosts found in the current directory. Select from running AppHosts.</value>
   </data>
 </root>

--- a/src/Aspire.Cli/Resources/SharedCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/SharedCommandStrings.resx
@@ -138,4 +138,10 @@
   <data name="IsolatedOptionDescription" xml:space="preserve">
     <value>Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</value>
   </data>
+  <data name="UsingAppHost" xml:space="preserve">
+    <value>Using AppHost: {0}</value>
+  </data>
+  <data name="MultipleInScopeAppHosts" xml:space="preserve">
+    <value>Multiple running AppHosts found in the current directory:</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
@@ -17,6 +17,11 @@
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleInScopeAppHosts">
+        <source>Multiple running AppHosts found in the current directory:</source>
+        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
         <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
         <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
@@ -35,6 +40,11 @@
       <trans-unit id="SelectAppHost">
         <source>Select an AppHost to {0}:</source>
         <target state="new">Select an AppHost to {0}:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsingAppHost">
+        <source>Using AppHost: {0}</source>
+        <target state="new">Using AppHost: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.cs.xlf
@@ -18,13 +18,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
-        <source>Multiple running AppHosts found in the current directory:</source>
-        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
+        <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
-        <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
+        <source>No running AppHosts found in the current directory. Select from all running AppHosts.</source>
+        <target state="new">No running AppHosts found in the current directory. Select from all running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
@@ -17,6 +17,11 @@
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleInScopeAppHosts">
+        <source>Multiple running AppHosts found in the current directory:</source>
+        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
         <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
         <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
@@ -35,6 +40,11 @@
       <trans-unit id="SelectAppHost">
         <source>Select an AppHost to {0}:</source>
         <target state="new">Select an AppHost to {0}:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsingAppHost">
+        <source>Using AppHost: {0}</source>
+        <target state="new">Using AppHost: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.de.xlf
@@ -18,13 +18,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
-        <source>Multiple running AppHosts found in the current directory:</source>
-        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
+        <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
-        <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
+        <source>No running AppHosts found in the current directory. Select from all running AppHosts.</source>
+        <target state="new">No running AppHosts found in the current directory. Select from all running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
@@ -17,6 +17,11 @@
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleInScopeAppHosts">
+        <source>Multiple running AppHosts found in the current directory:</source>
+        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
         <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
         <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
@@ -35,6 +40,11 @@
       <trans-unit id="SelectAppHost">
         <source>Select an AppHost to {0}:</source>
         <target state="new">Select an AppHost to {0}:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsingAppHost">
+        <source>Using AppHost: {0}</source>
+        <target state="new">Using AppHost: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.es.xlf
@@ -18,13 +18,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
-        <source>Multiple running AppHosts found in the current directory:</source>
-        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
+        <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
-        <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
+        <source>No running AppHosts found in the current directory. Select from all running AppHosts.</source>
+        <target state="new">No running AppHosts found in the current directory. Select from all running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
@@ -17,6 +17,11 @@
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleInScopeAppHosts">
+        <source>Multiple running AppHosts found in the current directory:</source>
+        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
         <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
         <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
@@ -35,6 +40,11 @@
       <trans-unit id="SelectAppHost">
         <source>Select an AppHost to {0}:</source>
         <target state="new">Select an AppHost to {0}:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsingAppHost">
+        <source>Using AppHost: {0}</source>
+        <target state="new">Using AppHost: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.fr.xlf
@@ -18,13 +18,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
-        <source>Multiple running AppHosts found in the current directory:</source>
-        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
+        <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
-        <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
+        <source>No running AppHosts found in the current directory. Select from all running AppHosts.</source>
+        <target state="new">No running AppHosts found in the current directory. Select from all running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
@@ -17,6 +17,11 @@
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleInScopeAppHosts">
+        <source>Multiple running AppHosts found in the current directory:</source>
+        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
         <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
         <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
@@ -35,6 +40,11 @@
       <trans-unit id="SelectAppHost">
         <source>Select an AppHost to {0}:</source>
         <target state="new">Select an AppHost to {0}:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsingAppHost">
+        <source>Using AppHost: {0}</source>
+        <target state="new">Using AppHost: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.it.xlf
@@ -18,13 +18,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
-        <source>Multiple running AppHosts found in the current directory:</source>
-        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
+        <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
-        <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
+        <source>No running AppHosts found in the current directory. Select from all running AppHosts.</source>
+        <target state="new">No running AppHosts found in the current directory. Select from all running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
@@ -17,6 +17,11 @@
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleInScopeAppHosts">
+        <source>Multiple running AppHosts found in the current directory:</source>
+        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
         <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
         <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
@@ -35,6 +40,11 @@
       <trans-unit id="SelectAppHost">
         <source>Select an AppHost to {0}:</source>
         <target state="new">Select an AppHost to {0}:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsingAppHost">
+        <source>Using AppHost: {0}</source>
+        <target state="new">Using AppHost: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ja.xlf
@@ -18,13 +18,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
-        <source>Multiple running AppHosts found in the current directory:</source>
-        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
+        <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
-        <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
+        <source>No running AppHosts found in the current directory. Select from all running AppHosts.</source>
+        <target state="new">No running AppHosts found in the current directory. Select from all running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
@@ -17,6 +17,11 @@
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleInScopeAppHosts">
+        <source>Multiple running AppHosts found in the current directory:</source>
+        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
         <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
         <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
@@ -35,6 +40,11 @@
       <trans-unit id="SelectAppHost">
         <source>Select an AppHost to {0}:</source>
         <target state="new">Select an AppHost to {0}:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsingAppHost">
+        <source>Using AppHost: {0}</source>
+        <target state="new">Using AppHost: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ko.xlf
@@ -18,13 +18,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
-        <source>Multiple running AppHosts found in the current directory:</source>
-        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
+        <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
-        <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
+        <source>No running AppHosts found in the current directory. Select from all running AppHosts.</source>
+        <target state="new">No running AppHosts found in the current directory. Select from all running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
@@ -17,6 +17,11 @@
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleInScopeAppHosts">
+        <source>Multiple running AppHosts found in the current directory:</source>
+        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
         <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
         <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
@@ -35,6 +40,11 @@
       <trans-unit id="SelectAppHost">
         <source>Select an AppHost to {0}:</source>
         <target state="new">Select an AppHost to {0}:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsingAppHost">
+        <source>Using AppHost: {0}</source>
+        <target state="new">Using AppHost: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pl.xlf
@@ -18,13 +18,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
-        <source>Multiple running AppHosts found in the current directory:</source>
-        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
+        <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
-        <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
+        <source>No running AppHosts found in the current directory. Select from all running AppHosts.</source>
+        <target state="new">No running AppHosts found in the current directory. Select from all running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleInScopeAppHosts">
+        <source>Multiple running AppHosts found in the current directory:</source>
+        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
         <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
         <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
@@ -35,6 +40,11 @@
       <trans-unit id="SelectAppHost">
         <source>Select an AppHost to {0}:</source>
         <target state="new">Select an AppHost to {0}:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsingAppHost">
+        <source>Using AppHost: {0}</source>
+        <target state="new">Using AppHost: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.pt-BR.xlf
@@ -18,13 +18,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
-        <source>Multiple running AppHosts found in the current directory:</source>
-        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
+        <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
-        <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
+        <source>No running AppHosts found in the current directory. Select from all running AppHosts.</source>
+        <target state="new">No running AppHosts found in the current directory. Select from all running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
@@ -17,6 +17,11 @@
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleInScopeAppHosts">
+        <source>Multiple running AppHosts found in the current directory:</source>
+        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
         <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
         <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
@@ -35,6 +40,11 @@
       <trans-unit id="SelectAppHost">
         <source>Select an AppHost to {0}:</source>
         <target state="new">Select an AppHost to {0}:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsingAppHost">
+        <source>Using AppHost: {0}</source>
+        <target state="new">Using AppHost: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.ru.xlf
@@ -18,13 +18,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
-        <source>Multiple running AppHosts found in the current directory:</source>
-        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
+        <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
-        <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
+        <source>No running AppHosts found in the current directory. Select from all running AppHosts.</source>
+        <target state="new">No running AppHosts found in the current directory. Select from all running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
@@ -17,6 +17,11 @@
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleInScopeAppHosts">
+        <source>Multiple running AppHosts found in the current directory:</source>
+        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
         <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
         <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
@@ -35,6 +40,11 @@
       <trans-unit id="SelectAppHost">
         <source>Select an AppHost to {0}:</source>
         <target state="new">Select an AppHost to {0}:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsingAppHost">
+        <source>Using AppHost: {0}</source>
+        <target state="new">Using AppHost: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.tr.xlf
@@ -18,13 +18,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
-        <source>Multiple running AppHosts found in the current directory:</source>
-        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
+        <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
-        <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
+        <source>No running AppHosts found in the current directory. Select from all running AppHosts.</source>
+        <target state="new">No running AppHosts found in the current directory. Select from all running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleInScopeAppHosts">
+        <source>Multiple running AppHosts found in the current directory:</source>
+        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
         <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
         <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
@@ -35,6 +40,11 @@
       <trans-unit id="SelectAppHost">
         <source>Select an AppHost to {0}:</source>
         <target state="new">Select an AppHost to {0}:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsingAppHost">
+        <source>Using AppHost: {0}</source>
+        <target state="new">Using AppHost: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hans.xlf
@@ -18,13 +18,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
-        <source>Multiple running AppHosts found in the current directory:</source>
-        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
+        <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
-        <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
+        <source>No running AppHosts found in the current directory. Select from all running AppHosts.</source>
+        <target state="new">No running AppHosts found in the current directory. Select from all running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="new">Run in isolated mode with randomized ports and isolated user secrets, allowing multiple instances to run simultaneously.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MultipleInScopeAppHosts">
+        <source>Multiple running AppHosts found in the current directory:</source>
+        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
         <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
         <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
@@ -35,6 +40,11 @@
       <trans-unit id="SelectAppHost">
         <source>Select an AppHost to {0}:</source>
         <target state="new">Select an AppHost to {0}:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UsingAppHost">
+        <source>Using AppHost: {0}</source>
+        <target state="new">Using AppHost: {0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SharedCommandStrings.zh-Hant.xlf
@@ -18,13 +18,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MultipleInScopeAppHosts">
-        <source>Multiple running AppHosts found in the current directory:</source>
-        <target state="new">Multiple running AppHosts found in the current directory:</target>
+        <source>Multiple running AppHosts found in the current directory. Select from running AppHosts.</source>
+        <target state="new">Multiple running AppHosts found in the current directory. Select from running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoInScopeAppHostsShowingAll">
-        <source>No running AppHosts found in the current directory. Showing all running AppHosts:</source>
-        <target state="new">No running AppHosts found in the current directory. Showing all running AppHosts:</target>
+        <source>No running AppHosts found in the current directory. Select from all running AppHosts.</source>
+        <target state="new">No running AppHosts found in the current directory. Select from all running AppHosts.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppHostOptionDescription">

--- a/src/Aspire.Cli/Utils/ResourceColorMap.cs
+++ b/src/Aspire.Cli/Utils/ResourceColorMap.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Spectre.Console;
+
+namespace Aspire.Cli.Utils;
+
+/// <summary>
+/// Assigns a consistent color to each resource name for colorized console output.
+/// </summary>
+internal sealed class ResourceColorMap
+{
+    private static readonly Color[] s_resourceColors =
+    [
+        Color.Cyan1,
+        Color.Green,
+        Color.Yellow,
+        Color.Blue,
+        Color.Magenta1,
+        Color.Orange1,
+        Color.DeepPink1,
+        Color.SpringGreen1,
+        Color.Aqua,
+        Color.Violet
+    ];
+
+    private readonly Dictionary<string, Color> _colorMap = new(StringComparers.ResourceName);
+    private int _nextColorIndex;
+
+    /// <summary>
+    /// Gets the color assigned to the specified resource name, assigning a new one if first seen.
+    /// </summary>
+    public Color GetColor(string resourceName)
+    {
+        if (!_colorMap.TryGetValue(resourceName, out var color))
+        {
+            color = s_resourceColors[_nextColorIndex % s_resourceColors.Length];
+            _colorMap[resourceName] = color;
+            _nextColorIndex++;
+        }
+        return color;
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/LogsCommandTests.cs
@@ -402,10 +402,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateLogsTestServices(workspace, outputWriter, configureOptions: config =>
-        {
-            config["NO_COLOR"] = "1";
-        });
+        var provider = CreateLogsTestServices(workspace, outputWriter, disableAnsi: true);
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("logs");
@@ -531,10 +528,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateLogsTestServices(workspace, outputWriter, configureOptions: config =>
-        {
-            config["NO_COLOR"] = "1";
-        });
+        var provider = CreateLogsTestServices(workspace, outputWriter, disableAnsi: true);
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("logs --timestamps");
@@ -556,10 +550,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var outputWriter = new TestOutputTextWriter(outputHelper);
-        var provider = CreateLogsTestServices(workspace, outputWriter, configureOptions: config =>
-        {
-            config["NO_COLOR"] = "1";
-        });
+        var provider = CreateLogsTestServices(workspace, outputWriter, disableAnsi: true);
 
         var command = provider.GetRequiredService<RootCommand>();
         var result = command.Parse("logs");
@@ -580,7 +571,8 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
     private ServiceProvider CreateLogsTestServices(
         TemporaryWorkspace workspace,
         TestOutputTextWriter outputWriter,
-        Action<Dictionary<string, string?>>? configureOptions = null)
+        Action<Dictionary<string, string?>>? configureOptions = null,
+        bool disableAnsi = false)
     {
         var monitor = new TestAuxiliaryBackchannelMonitor();
         var connection = new TestAppHostAuxiliaryBackchannel
@@ -649,6 +641,7 @@ public class LogsCommandTests(ITestOutputHelper outputHelper)
         {
             options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
             options.OutputTextWriter = outputWriter;
+            options.DisableAnsi = disableAnsi;
 
             if (configureOptions is not null)
             {


### PR DESCRIPTION
## Description

Fixes https://github.com/dotnet/aspire/issues/14405

- Track last content written for both JSON and human readable formats. Don't write duplicate entries
- Colorize resource name so it's consistent with `aspire logs`
- Remove special case in `aspire logs` that skips ANSI characters. This feature is built into Spectre.Console

After:
<img width="1256" height="594" alt="image" src="https://github.com/user-attachments/assets/7150a5a8-39a4-4832-bd1a-d282bb319f10" />

Also add colors to table:
<img width="1484" height="471" alt="image" src="https://github.com/user-attachments/assets/3220a805-c237-4bf1-91f7-b70635be1402" />

I think colors need a tweak in how they're displayed, but it's a starting point.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
