### PR TITLE
Fix aspire add in polyglot scenarios without .NET SDK

### DIFF
--- a/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs
+++ b/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Configuration;
-using Aspire.Cli.DotNet;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.Hosting;
@@ -11,22 +10,12 @@ using SystemCommand = System.CommandLine.Command;
 
 namespace Aspire.Cli.NuGet;
 
-internal sealed class NuGetPackagePrefetcher(ILogger<NuGetPackagePrefetcher> logger, CliExecutionContext executionContext, IFeatures features, IPackagingService packagingService, ICliUpdateNotifier cliUpdateNotifier, IDotNetSdkInstaller sdkInstaller) : BackgroundService
+internal sealed class NuGetPackagePrefetcher(ILogger<NuGetPackagePrefetcher> logger, CliExecutionContext executionContext, IFeatures features, IPackagingService packagingService, ICliUpdateNotifier cliUpdateNotifier) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         // Wait for command to be selected
         var command = await WaitForCommandSelectionAsync(stoppingToken);
-
-        // Check if SDK is installed before attempting to prefetch packages
-        // This prevents dirtying the cache when SDK is not available
-        var (sdkAvailable, _, _, _) = await sdkInstaller.CheckAsync(stoppingToken);
-
-        if (!sdkAvailable)
-        {
-            logger.LogDebug("SDK is not installed. Skipping package prefetching to avoid cache pollution.");
-            return;
-        }
 
         var shouldPrefetchTemplates = ShouldPrefetchTemplatePackages(command);
         var shouldPrefetchCli = ShouldPrefetchCliPackages(command);


### PR DESCRIPTION
## Description

`aspire add` fails with "No integration packages were found" in polyglot (TypeScript/Python/etc.) scenarios because the `NuGetPackagePrefetcher` background service skips package fetching when it detects the .NET SDK is not installed.

The prefetcher had an SDK availability gate that was unnecessary — the CLI always uses its bundled NuGet client for package discovery, not `dotnet package search`. Removing the gate allows package prefetching to work regardless of SDK availability.

Fixes #14702

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
