### PR TITLE
Add tsx devDependency to ts-starter template

### DIFF
--- a/src/Aspire.Cli/Templating/Templates/ts-starter/package.json
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/package.json
@@ -8,6 +8,7 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "nodemon": "^3.1.11",
+    "tsx": "^4.19.0",
     "typescript": "^5.3.0"
   }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests for the TypeScript Express/React starter template (aspire-ts-starter).
+/// Validates that aspire new creates a working Express API + React frontend project
+/// and that aspire run starts it successfully.
+/// </summary>
+public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task CreateAndRunTypeScriptStarterProject()
+    {
+        var workspace = TemporaryWorkspace.Create(output);
+
+        var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
+        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
+        var isCI = CliE2ETestHelpers.IsRunningInCI;
+        using var terminal = CliE2ETestHelpers.CreateTestTerminal();
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        // Pattern for template selection - find "Starter App (Express/React)"
+        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
+            .FindPattern("> Starter App");
+
+        // Use Find() for literal string with parentheses/slashes
+        var waitingForExpressReactTemplateSelected = new CellPatternSearcher()
+            .Find("> Starter App (Express/React)");
+
+        var waitingForProjectNamePrompt = new CellPatternSearcher()
+            .Find("Enter the project name (");
+
+        var waitingForOutputPathPrompt = new CellPatternSearcher()
+            .Find("Enter the output path:");
+
+        var waitingForUrlsPrompt = new CellPatternSearcher()
+            .Find("Use *.dev.localhost URLs");
+
+        var waitForDashboardCurlSuccess = new CellPatternSearcher()
+            .Find("dashboard-http-200");
+
+        var counter = new SequenceCounter();
+        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+        sequenceBuilder.PrepareEnvironment(workspace, counter);
+
+        if (isCI)
+        {
+            // TypeScript starter requires the bundle (not just CLI) because the AppHost server
+            // is bundled and cannot be obtained via NuGet packages in SDK-based fallback mode
+            sequenceBuilder.InstallAspireBundleFromPullRequest(prNumber, counter);
+            sequenceBuilder.SourceAspireBundleEnvironment(counter);
+            sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
+        }
+
+        // Step 1: Create project using aspire new, selecting the Express/React template
+        sequenceBuilder.Type("aspire new")
+            .Enter()
+            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            // Navigate down to "Starter App (Express/React)" which is the 4th option
+            .Key(Hex1b.Input.Hex1bKey.DownArrow)
+            .Key(Hex1b.Input.Hex1bKey.DownArrow)
+            .Key(Hex1b.Input.Hex1bKey.DownArrow)
+            .WaitUntil(s => waitingForExpressReactTemplateSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
+            .Enter() // select "Starter App (Express/React)"
+            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Type("TsStarterApp")
+            .Enter()
+            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter() // accept default output path
+            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter() // select "No" for localhost URLs (default)
+            .WaitForSuccessPrompt(counter);
+
+        // Step 2: Navigate into the project and start it in background with JSON output
+        sequenceBuilder
+            .Type("cd TsStarterApp")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("aspire start --format json | tee /tmp/aspire-start.json")
+            .Enter()
+            .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(3))
+            // Extract dashboard URL from JSON and curl it to verify it's reachable
+            .Type("DASHBOARD_URL=$(sed -n 's/.*\"dashboardUrl\"[[:space:]]*:[[:space:]]*\"\\(https:\\/\\/localhost:[0-9]*\\).*/\\1/p' /tmp/aspire-start.json | head -1)")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("curl -ksSL -o /dev/null -w 'dashboard-http-%{http_code}' \"$DASHBOARD_URL\" || echo 'dashboard-http-failed'")
+            .Enter()
+            .WaitUntil(s => waitForDashboardCurlSuccess.Search(s).Count > 0, TimeSpan.FromSeconds(15))
+            .WaitForSuccessPrompt(counter)
+            .Type("aspire stop")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("exit")
+            .Enter();
+
+        var sequence = sequenceBuilder.Build();
+
+        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+        await pendingRun;
+    }
+}


### PR DESCRIPTION
## Description

The TypeScript starter template (`ts-starter`) is missing `tsx` in its `devDependencies`. When `aspire start` runs, it executes `npx tsx apphost.ts` — since `tsx` is not installed locally, `npx` prompts for confirmation to install it. In a non-interactive context this prompt never gets answered, causing the CLI to hang indefinitely.

This adds `tsx` to `devDependencies` in the template's `package.json` and adds an E2E test (`TypeScriptStarterTemplateTests`) that creates and runs a project from the Express/React starter template to catch regressions like this.

Fixes #14815

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
