### PR TITLE
Consistent resource colors, resource colors match dashboard

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -70,6 +70,7 @@
     <Compile Include="$(SharedDir)KnownFormats.cs" Link="Utils\KnownFormats.cs" />
     <Compile Include="$(SharedDir)PathNormalizer.cs" Link="Utils\PathNormalizer.cs" />
     <Compile Include="$(SharedDir)CircularBuffer.cs" Link="Utils\CircularBuffer.cs" />
+    <Compile Include="$(SharedDir)ColorGenerator.cs" Link="Utils\ColorGenerator.cs" />
     <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />
     <Compile Include="$(SharedDir)LocaleHelpers.cs" Link="Utils\LocaleHelpers.cs" />
     <Compile Include="$(SharedDir)DurationFormatter.cs" Link="Utils\DurationFormatter.cs" />

--- a/src/Aspire.Cli/Backchannel/AppHostAuxiliaryBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostAuxiliaryBackchannel.cs
@@ -293,9 +293,12 @@ internal sealed class AppHostAuxiliaryBackchannel : IAppHostAuxiliaryBackchannel
             var snapshots = await rpc.InvokeWithCancellationAsync<List<ResourceSnapshot>>(
                 "GetResourceSnapshotsAsync",
                 [],
-                cancellationToken).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false) ?? [];
 
-            return snapshots ?? [];
+            // Sort resources by name for consistent ordering.
+            snapshots.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+
+            return snapshots;
         }
         catch (RemoteMethodNotFoundException ex)
         {

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -133,31 +133,34 @@ internal sealed class DescribeCommand : BaseCommand
             return ExitCodeConstants.Success;
         }
 
-        if (follow)
-        {
-            return await ExecuteWatchAsync(result.Connection!, resourceName, format, cancellationToken);
-        }
-        else
-        {
-            return await ExecuteSnapshotAsync(result.Connection!, resourceName, format, cancellationToken);
-        }
-    }
+        var connection = result.Connection!;
 
-    private async Task<int> ExecuteSnapshotAsync(IAppHostAuxiliaryBackchannel connection, string? resourceName, OutputFormat format, CancellationToken cancellationToken)
-    {
-        // Get dashboard URL and resource snapshots in parallel
+        // Get dashboard URL and resource snapshots in parallel before
+        // dispatching to the snapshot or watch path.
         var dashboardUrlsTask = connection.GetDashboardUrlsAsync(cancellationToken);
         var snapshotsTask = connection.GetResourceSnapshotsAsync(cancellationToken);
 
         await Task.WhenAll(dashboardUrlsTask, snapshotsTask).ConfigureAwait(false);
 
-        var dashboardUrls = await dashboardUrlsTask.ConfigureAwait(false);
+        var dashboardBaseUrl = (await dashboardUrlsTask.ConfigureAwait(false))?.BaseUrlWithLoginToken;
         var snapshots = await snapshotsTask.ConfigureAwait(false);
 
         // Pre-resolve colors for all resource names so that assignment is
         // deterministic regardless of which resources are displayed.
         _resourceColorMap.ResolveAll(snapshots.Select(s => ResourceSnapshotMapper.GetResourceName(s, snapshots)));
 
+        if (follow)
+        {
+            return await ExecuteWatchAsync(connection, snapshots, dashboardBaseUrl, resourceName, format, cancellationToken);
+        }
+        else
+        {
+            return ExecuteSnapshot(snapshots, dashboardBaseUrl, resourceName, format);
+        }
+    }
+
+    private int ExecuteSnapshot(IReadOnlyList<ResourceSnapshot> snapshots, string? dashboardBaseUrl, string? resourceName, OutputFormat format)
+    {
         // Filter by resource name if specified
         if (resourceName is not null)
         {
@@ -171,8 +174,6 @@ internal sealed class DescribeCommand : BaseCommand
             return ExitCodeConstants.FailedToFindProject;
         }
 
-        // Use the dashboard base URL if available
-        var dashboardBaseUrl = dashboardUrls?.BaseUrlWithLoginToken;
         var resourceList = ResourceSnapshotMapper.MapToResourceJsonList(snapshots, dashboardBaseUrl);
 
         if (format == OutputFormat.Json)
@@ -190,25 +191,16 @@ internal sealed class DescribeCommand : BaseCommand
         return ExitCodeConstants.Success;
     }
 
-    private async Task<int> ExecuteWatchAsync(IAppHostAuxiliaryBackchannel connection, string? resourceName, OutputFormat format, CancellationToken cancellationToken)
+    private async Task<int> ExecuteWatchAsync(IAppHostAuxiliaryBackchannel connection, IReadOnlyList<ResourceSnapshot> initialSnapshots, string? dashboardBaseUrl, string? resourceName, OutputFormat format, CancellationToken cancellationToken)
     {
-        // Get dashboard URL first for generating resource links
-        var dashboardUrls = await connection.GetDashboardUrlsAsync(cancellationToken).ConfigureAwait(false);
-        var dashboardBaseUrl = dashboardUrls?.BaseUrlWithLoginToken;
-
         // Maintain a dictionary of the current state per resource for relationship resolution
         // and display name deduplication. Keyed by snapshot.Name so each resource has exactly
         // one entry representing its latest state.
-        var initialSnapshots = await connection.GetResourceSnapshotsAsync(cancellationToken).ConfigureAwait(false);
         var allResources = new Dictionary<string, ResourceSnapshot>(StringComparers.ResourceName);
         foreach (var snapshot in initialSnapshots)
         {
             allResources[snapshot.Name] = snapshot;
         }
-
-        // Pre-resolve colors for all resource names so that assignment is
-        // deterministic regardless of which resources are displayed.
-        _resourceColorMap.ResolveAll(initialSnapshots.Select(s => ResourceSnapshotMapper.GetResourceName(s, initialSnapshots)));
 
         // Cache the last displayed content per resource to avoid duplicate output.
         // Values are either a string (JSON mode) or a ResourceDisplayState (non-JSON mode).

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -154,6 +154,10 @@ internal sealed class DescribeCommand : BaseCommand
         var dashboardUrls = await dashboardUrlsTask.ConfigureAwait(false);
         var snapshots = await snapshotsTask.ConfigureAwait(false);
 
+        // Pre-resolve colors for all resource names so that assignment is
+        // deterministic regardless of which resources are displayed.
+        _resourceColorMap.ResolveAll(snapshots.Select(s => ResourceSnapshotMapper.GetResourceName(s, snapshots)));
+
         // Filter by resource name if specified
         if (resourceName is not null)
         {
@@ -201,6 +205,10 @@ internal sealed class DescribeCommand : BaseCommand
         {
             allResources[snapshot.Name] = snapshot;
         }
+
+        // Pre-resolve colors for all resource names so that assignment is
+        // deterministic regardless of which resources are displayed.
+        _resourceColorMap.ResolveAll(initialSnapshots.Select(s => ResourceSnapshotMapper.GetResourceName(s, initialSnapshots)));
 
         // Cache the last displayed content per resource to avoid duplicate output.
         // Values are either a string (JSON mode) or a ResourceDisplayState (non-JSON mode).

--- a/src/Aspire.Cli/Commands/LogsCommand.cs
+++ b/src/Aspire.Cli/Commands/LogsCommand.cs
@@ -164,6 +164,10 @@ internal sealed class LogsCommand : BaseCommand
         // Fetch snapshots for resource name resolution
         var snapshots = await connection.GetResourceSnapshotsAsync(cancellationToken).ConfigureAwait(false);
 
+        // Pre-resolve colors for all resource names so that assignment is
+        // deterministic regardless of which resources are displayed.
+        _resourceColorMap.ResolveAll(snapshots.Select(s => ResourceSnapshotMapper.GetResourceName(s, snapshots)));
+
         // Validate resource name exists (match by Name or DisplayName since users may pass either)
         if (resourceName is not null)
         {

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -8,6 +8,7 @@ using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Otlp;
 using Aspire.Cli.Resources;
+using Aspire.Cli.Utils;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Utils;
 using Aspire.Otlp.Serialization;
@@ -209,8 +210,16 @@ internal static class TelemetryCommandHelpers
         var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
-        var resources = await response.Content.ReadFromJsonAsync(OtlpCliJsonSerializerContext.Default.ResourceInfoJsonArray, cancellationToken).ConfigureAwait(false);
-        return resources!;
+        var resources = await response.Content.ReadFromJsonAsync(OtlpCliJsonSerializerContext.Default.ResourceInfoJsonArray, cancellationToken).ConfigureAwait(false) ?? [];
+
+        // Sort resources by name for consistent ordering.
+        Array.Sort(resources, (a, b) =>
+        {
+            var cmp = string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase);
+            return cmp != 0 ? cmp : string.Compare(a.InstanceId, b.InstanceId, StringComparison.OrdinalIgnoreCase);
+        });
+
+        return resources;
     }
 
     /// <summary>
@@ -319,6 +328,15 @@ internal static class TelemetryCommandHelpers
             result[i] = new SimpleOtlpResource(resources[i].Name, resources[i].InstanceId);
         }
         return result;
+    }
+
+    /// <summary>
+    /// Pre-resolves resource colors for all resources in sorted order so that
+    /// color assignment is deterministic regardless of encounter order in telemetry data.
+    /// </summary>
+    public static void ResolveResourceColors(ResourceColorMap colorMap, IReadOnlyList<IOtlpResource> allResources)
+    {
+        colorMap.ResolveAll(allResources.Select(r => OtlpHelpers.GetResourceName(r, allResources)));
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryLogsCommand.cs
@@ -118,6 +118,10 @@ internal sealed class TelemetryLogsCommand : BaseCommand
 
         // Resolve resource name to specific instances (handles replicas)
         var resources = await TelemetryCommandHelpers.GetAllResourcesAsync(client, baseUrl, cancellationToken).ConfigureAwait(false);
+        var allOtlpResources = TelemetryCommandHelpers.ToOtlpResources(resources);
+
+        // Pre-resolve colors so assignment is deterministic regardless of data order
+        TelemetryCommandHelpers.ResolveResourceColors(_resourceColorMap, allOtlpResources);
 
         // If a resource was specified but not found, return error
         if (!TelemetryCommandHelpers.TryResolveResourceNames(resource, resources, out var resolvedResources))
@@ -125,8 +129,6 @@ internal sealed class TelemetryLogsCommand : BaseCommand
             _interactionService.DisplayError($"Resource '{resource}' not found.");
             return ExitCodeConstants.InvalidCommand;
         }
-
-        var allOtlpResources = TelemetryCommandHelpers.ToOtlpResources(resources);
 
         // Build query string with multiple resource parameters
         var additionalParams = new List<(string key, string? value)>

--- a/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetrySpansCommand.cs
@@ -114,6 +114,10 @@ internal sealed class TelemetrySpansCommand : BaseCommand
 
         // Resolve resource name to specific instances (handles replicas)
         var resources = await TelemetryCommandHelpers.GetAllResourcesAsync(client, baseUrl, cancellationToken).ConfigureAwait(false);
+        var allOtlpResources = TelemetryCommandHelpers.ToOtlpResources(resources);
+
+        // Pre-resolve colors so assignment is deterministic regardless of data order
+        TelemetryCommandHelpers.ResolveResourceColors(_resourceColorMap, allOtlpResources);
 
         // If a resource was specified but not found, return error
         if (!TelemetryCommandHelpers.TryResolveResourceNames(resource, resources, out var resolvedResources))
@@ -121,8 +125,6 @@ internal sealed class TelemetrySpansCommand : BaseCommand
             _interactionService.DisplayError($"Resource '{resource}' not found.");
             return ExitCodeConstants.InvalidCommand;
         }
-
-        var allOtlpResources = TelemetryCommandHelpers.ToOtlpResources(resources);
 
         // Build query string with multiple resource parameters
         var additionalParams = new List<(string key, string? value)>

--- a/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
+++ b/src/Aspire.Cli/Commands/TelemetryTracesCommand.cs
@@ -115,6 +115,9 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         var resources = await TelemetryCommandHelpers.GetAllResourcesAsync(client, baseUrl, cancellationToken).ConfigureAwait(false);
         var allOtlpResources = TelemetryCommandHelpers.ToOtlpResources(resources);
 
+        // Pre-resolve colors so assignment is deterministic regardless of data order
+        TelemetryCommandHelpers.ResolveResourceColors(_resourceColorMap, allOtlpResources);
+
         var url = DashboardUrls.TelemetryTraceDetailApiUrl(baseUrl, traceId);
 
         _logger.LogDebug("Fetching trace {TraceId} from {Url}", traceId, url);
@@ -181,6 +184,9 @@ internal sealed class TelemetryTracesCommand : BaseCommand
         }
 
         var allOtlpResources = TelemetryCommandHelpers.ToOtlpResources(resources);
+
+        // Pre-resolve colors so assignment is deterministic regardless of data order
+        TelemetryCommandHelpers.ResolveResourceColors(_resourceColorMap, allOtlpResources);
 
         // Build query string with multiple resource parameters
         var additionalParams = new List<(string key, string? value)>();

--- a/src/Aspire.Cli/Utils/ResourceColorMap.cs
+++ b/src/Aspire.Cli/Utils/ResourceColorMap.cs
@@ -13,33 +13,33 @@ namespace Aspire.Cli.Utils;
 internal sealed class ResourceColorMap
 {
     /// <summary>
-    /// Dark theme hex colors corresponding 1:1 with <see cref="ColorGenerator.s_variableNames"/>.
-    /// The order must match exactly so that the same palette index maps to the same visual color
-    /// in both the CLI and the dashboard.
+    /// Dark theme hex colors keyed by accent variable name from <see cref="ColorGenerator.s_variableNames"/>.
+    /// The keys must match the variable names exactly so that the same palette index maps to the same
+    /// visual color in both the CLI and the dashboard.
     /// </summary>
-    internal static readonly string[] s_hexColors =
-    [
-        "#2CB7BD", // --accent-teal
-        "#F3D58E", // --accent-marigold
-        "#BF8B64", // --accent-brass
-        "#FFC18F", // --accent-peach
-        "#F89170", // --accent-coral
-        "#88A1F0", // --accent-royal-blue
-        "#E19AD4", // --accent-orchid
-        "#1A7ECF", // --accent-brand-blue
-        "#74D6C6", // --accent-seafoam
-        "#B9B2A4", // --accent-mink
-        "#17A0A6", // --accent-cyan
-        "#E3BA7A", // --accent-gold
-        "#8E6038", // --accent-bronze
-        "#FFA44A", // --accent-orange
-        "#EA6A3E", // --accent-rust
-        "#2A4C8A", // --accent-navy
-        "#D150C3", // --accent-berry
-        "#16728F", // --accent-ocean
-        "#51C0A5", // --accent-jade
-        "#847B63", // --accent-olive
-    ];
+    internal static readonly Dictionary<string, string> s_hexColors = new()
+    {
+        ["--accent-teal"] = "#2CB7BD",
+        ["--accent-marigold"] = "#F3D58E",
+        ["--accent-brass"] = "#BF8B64",
+        ["--accent-peach"] = "#FFC18F",
+        ["--accent-coral"] = "#F89170",
+        ["--accent-royal-blue"] = "#88A1F0",
+        ["--accent-orchid"] = "#E19AD4",
+        ["--accent-brand-blue"] = "#1A7ECF",
+        ["--accent-seafoam"] = "#74D6C6",
+        ["--accent-mink"] = "#B9B2A4",
+        ["--accent-cyan"] = "#17A0A6",
+        ["--accent-gold"] = "#E3BA7A",
+        ["--accent-bronze"] = "#8E6038",
+        ["--accent-orange"] = "#FFA44A",
+        ["--accent-rust"] = "#EA6A3E",
+        ["--accent-navy"] = "#2A4C8A",
+        ["--accent-berry"] = "#D150C3",
+        ["--accent-ocean"] = "#16728F",
+        ["--accent-jade"] = "#51C0A5",
+        ["--accent-olive"] = "#847B63",
+    };
 
     private readonly ColorGenerator _palette = new();
 
@@ -50,7 +50,8 @@ internal sealed class ResourceColorMap
     public string GetColor(string resourceName)
     {
         var index = _palette.GetColorIndex(resourceName);
-        return s_hexColors[index];
+        var variableName = ColorGenerator.s_variableNames[index];
+        return s_hexColors[variableName];
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Utils/ResourceColorMap.cs
+++ b/src/Aspire.Cli/Utils/ResourceColorMap.cs
@@ -1,43 +1,65 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Spectre.Console;
-
 namespace Aspire.Cli.Utils;
 
 /// <summary>
 /// Assigns a consistent color to each resource name for colorized console output.
+/// Colors are derived from the Aspire Dashboard's dark theme accent palette to provide
+/// a consistent visual experience across the CLI and dashboard.
+/// Colors are returned as hex strings (e.g. <c>#2CB7BD</c>) suitable for use in
+/// Spectre.Console markup.
 /// </summary>
 internal sealed class ResourceColorMap
 {
-    private static readonly Color[] s_resourceColors =
+    /// <summary>
+    /// Dark theme hex colors corresponding 1:1 with <see cref="ColorGenerator.s_variableNames"/>.
+    /// The order must match exactly so that the same palette index maps to the same visual color
+    /// in both the CLI and the dashboard.
+    /// </summary>
+    internal static readonly string[] s_hexColors =
     [
-        Color.Cyan1,
-        Color.Green,
-        Color.Yellow,
-        Color.Blue,
-        Color.Magenta1,
-        Color.Orange1,
-        Color.DeepPink1,
-        Color.SpringGreen1,
-        Color.Aqua,
-        Color.Violet
+        "#2CB7BD", // --accent-teal
+        "#F3D58E", // --accent-marigold
+        "#BF8B64", // --accent-brass
+        "#FFC18F", // --accent-peach
+        "#F89170", // --accent-coral
+        "#88A1F0", // --accent-royal-blue
+        "#E19AD4", // --accent-orchid
+        "#1A7ECF", // --accent-brand-blue
+        "#74D6C6", // --accent-seafoam
+        "#B9B2A4", // --accent-mink
+        "#17A0A6", // --accent-cyan
+        "#E3BA7A", // --accent-gold
+        "#8E6038", // --accent-bronze
+        "#FFA44A", // --accent-orange
+        "#EA6A3E", // --accent-rust
+        "#2A4C8A", // --accent-navy
+        "#D150C3", // --accent-berry
+        "#16728F", // --accent-ocean
+        "#51C0A5", // --accent-jade
+        "#847B63", // --accent-olive
     ];
 
-    private readonly Dictionary<string, Color> _colorMap = new(StringComparers.ResourceName);
-    private int _nextColorIndex;
+    private readonly ColorGenerator _palette = new();
 
     /// <summary>
-    /// Gets the color assigned to the specified resource name, assigning a new one if first seen.
+    /// Gets the hex color string assigned to the specified resource name, assigning a new one if first seen.
+    /// The returned value is a Spectre.Console markup-compatible hex color (e.g. <c>#2CB7BD</c>).
     /// </summary>
-    public Color GetColor(string resourceName)
+    public string GetColor(string resourceName)
     {
-        if (!_colorMap.TryGetValue(resourceName, out var color))
-        {
-            color = s_resourceColors[_nextColorIndex % s_resourceColors.Length];
-            _colorMap[resourceName] = color;
-            _nextColorIndex++;
-        }
-        return color;
+        var index = _palette.GetColorIndex(resourceName);
+        return s_hexColors[index];
+    }
+
+    /// <summary>
+    /// Pre-resolves colors for all provided resource names in sorted order so that
+    /// color assignment is deterministic regardless of encounter order.
+    /// </summary>
+    public void ResolveAll(IEnumerable<string> resourceNames)
+    {
+        _palette.ResolveAll(resourceNames);
     }
 }
+

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -280,6 +280,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedDir)ChannelExtensions.cs" Link="Extensions\ChannelExtensions.cs" />
+    <Compile Include="$(SharedDir)ColorGenerator.cs" Link="Utils\ColorGenerator.cs" />
     <Compile Include="$(SharedDir)EnumerableExtensions.cs" Link="Utils\EnumerableExtensions.cs" />
     <Compile Include="$(SharedDir)FormatHelpers.cs" Link="Utils\FormatHelpers.cs" />
     <Compile Include="$(SharedDir)TimeProviderExtensions.cs" Link="Extensions\TimeProviderExtensions.cs" />

--- a/src/Aspire.Dashboard/Components/_Imports.razor
+++ b/src/Aspire.Dashboard/Components/_Imports.razor
@@ -13,6 +13,7 @@
 @using Microsoft.FluentUI.AspNetCore.Components
 @using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons
 @using Microsoft.JSInterop
+@using Aspire
 @using Aspire.Dashboard
 @using Aspire.Dashboard.Components
 @using Aspire.Dashboard.Components.Controls

--- a/src/Aspire.Dashboard/Model/Assistant/Markdown/ResourceInlineRenderer.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/Markdown/ResourceInlineRenderer.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Encodings.Web;
-using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Utils;
 using Markdig.Renderers;
 using Markdig.Renderers.Html;

--- a/src/Aspire.Dashboard/Model/ResourceGraph/ResourceGraphMapper.cs
+++ b/src/Aspire.Dashboard/Model/ResourceGraph/ResourceGraphMapper.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Immutable;
 using System.Xml.Linq;
-using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Resources;
 using Microsoft.Extensions.Localization;
 using Microsoft.FluentUI.AspNetCore.Components;

--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -422,6 +422,15 @@ internal sealed class DashboardClient : IDashboardClient
                 {
                     throw new FormatException($"Unexpected {nameof(WatchResourcesUpdate)} kind: {response.KindCase}");
                 }
+
+                // Resolve resource colors for all resources so that color assignment is
+                // deterministic regardless of the order resources arrive.
+                if (changes is not null)
+                {
+                    var resolvedNames = _resourceByName.Values
+                        .Select(r => ResourceViewModel.GetResourceName(r, _resourceByName));
+                    ColorGenerator.Instance.ResolveAll(resolvedNames);
+                }
             }
 
             if (changes is not null)

--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -424,7 +424,7 @@ internal sealed class DashboardClient : IDashboardClient
                 }
 
                 // Resolve resource colors for all resources so that color assignment is
-                // deterministic regardless of the order resources arrive.
+                // deterministic of order returned from the service, not order that the color for a resource is first used.
                 if (changes is not null)
                 {
                     var resolvedNames = _resourceByName.Values

--- a/src/Shared/ColorGenerator.cs
+++ b/src/Shared/ColorGenerator.cs
@@ -3,26 +3,33 @@
 
 using System.Collections.Concurrent;
 
-namespace Aspire.Dashboard.Otlp.Model;
+namespace Aspire;
 
-public sealed class AccentColor
+internal sealed class AccentColor
 {
-    public AccentColor(string variableName)
+    internal AccentColor(string variableName)
     {
         VariableName = variableName;
         ReferencedVariableName = $"var({variableName})";
     }
 
-    public string VariableName { get; }
-    public string ReferencedVariableName { get; }
+    internal string VariableName { get; }
+    internal string ReferencedVariableName { get; }
 }
 
 /// <summary>
-/// Provides a stable color for a named element. When <see cref="GetColorVariableByKey(string)" /> is invoked a new color is returned if the key was not used previously. An instance of this class is thread-safe and multiple threads can query colors concurrently without collisions.
+/// Provides a stable color for a named element. When <see cref="GetColorVariableByKey(string)" />
+/// is invoked a new color is returned if the key was not used previously. An instance of this class
+/// is thread-safe and multiple threads can query colors concurrently without collisions.
+/// The palette of CSS variable names is shared between the dashboard and the CLI so that a given
+/// resource name always receives the same color regardless of where it is displayed.
 /// </summary>
-public class ColorGenerator
+internal class ColorGenerator
 {
-    private static readonly string[] s_variableNames =
+    /// <summary>
+    /// The ordered list of CSS accent variable names used as the color palette.
+    /// </summary>
+    internal static readonly string[] s_variableNames =
     [
         "--accent-teal",
         "--accent-marigold",
@@ -45,13 +52,14 @@ public class ColorGenerator
         "--accent-jade",
         "--accent-olive"
     ];
+
     public static readonly ColorGenerator Instance = new ColorGenerator();
 
     private readonly List<AccentColor> _colors;
     private readonly ConcurrentDictionary<string, Lazy<int>> _colorIndexByKey;
     private int _currentIndex;
 
-    private ColorGenerator()
+    internal ColorGenerator()
     {
         _colors = new List<AccentColor>();
         _colorIndexByKey = new ConcurrentDictionary<string, Lazy<int>>(StringComparer.OrdinalIgnoreCase);
@@ -63,7 +71,7 @@ public class ColorGenerator
         }
     }
 
-    private int GetColorIndex(string key)
+    internal int GetColorIndex(string key)
     {
         return _colorIndexByKey.GetOrAdd(key, k =>
         {
@@ -82,6 +90,18 @@ public class ColorGenerator
     {
         var i = GetColorIndex(key);
         return _colors[i].ReferencedVariableName;
+    }
+
+    /// <summary>
+    /// Pre-resolves colors for all provided keys in sorted order so that
+    /// color assignment is deterministic regardless of encounter order.
+    /// </summary>
+    public void ResolveAll(IEnumerable<string> keys)
+    {
+        foreach (var key in keys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase))
+        {
+            GetColorIndex(key);
+        }
     }
 
     public void Clear()

--- a/tests/Aspire.Cli.Tests/Utils/ResourceColorMapTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/ResourceColorMapTests.cs
@@ -8,17 +8,13 @@ namespace Aspire.Cli.Tests.Utils;
 public class ResourceColorMapTests
 {
     [Fact]
-    public void HexColorsCountMatchesVariableNamesCount()
+    public void HexColorsKeysMatchVariableNames()
     {
-        Assert.Equal(ColorGenerator.s_variableNames.Length, ResourceColorMap.s_hexColors.Length);
-    }
+        Assert.Equal(ColorGenerator.s_variableNames.Length, ResourceColorMap.s_hexColors.Count);
 
-    [Fact]
-    public void AllHexColorsAreValidFormat()
-    {
-        foreach (var hex in ResourceColorMap.s_hexColors)
+        foreach (var variableName in ColorGenerator.s_variableNames)
         {
-            Assert.Matches(@"^#[0-9A-Fa-f]{6}$", hex);
+            Assert.True(ResourceColorMap.s_hexColors.ContainsKey(variableName), $"Missing key: {variableName}");
         }
     }
 

--- a/tests/Aspire.Cli.Tests/Utils/ResourceColorMapTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/ResourceColorMapTests.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Utils;
+
+namespace Aspire.Cli.Tests.Utils;
+
+public class ResourceColorMapTests
+{
+    [Fact]
+    public void HexColorsCountMatchesVariableNamesCount()
+    {
+        Assert.Equal(ColorGenerator.s_variableNames.Length, ResourceColorMap.s_hexColors.Length);
+    }
+
+    [Fact]
+    public void AllHexColorsAreValidFormat()
+    {
+        foreach (var hex in ResourceColorMap.s_hexColors)
+        {
+            Assert.Matches(@"^#[0-9A-Fa-f]{6}$", hex);
+        }
+    }
+
+    [Fact]
+    public void GetColorReturnsDeterministicResult()
+    {
+        var map = new ResourceColorMap();
+        var color1 = map.GetColor("test-resource");
+        var color2 = map.GetColor("test-resource");
+
+        Assert.Equal(color1, color2);
+    }
+
+    [Fact]
+    public void ResolveAllMakesColorAssignmentDeterministic()
+    {
+        var map1 = new ResourceColorMap();
+        map1.ResolveAll(["bravo", "alpha", "charlie"]);
+
+        var map2 = new ResourceColorMap();
+        map2.ResolveAll(["charlie", "alpha", "bravo"]);
+
+        Assert.Equal(map1.GetColor("alpha"), map2.GetColor("alpha"));
+        Assert.Equal(map1.GetColor("bravo"), map2.GetColor("bravo"));
+        Assert.Equal(map1.GetColor("charlie"), map2.GetColor("charlie"));
+    }
+
+    [Fact]
+    public void DifferentNamesGetDifferentColors()
+    {
+        var map = new ResourceColorMap();
+        var color1 = map.GetColor("resource-a");
+        var color2 = map.GetColor("resource-b");
+
+        Assert.NotEqual(color1, color2);
+    }
+}


### PR DESCRIPTION
## Description

Resource color assignment is based on the order resource color is resolved. That can change based on filtered data.

PR changes:
- The dashboard and CLI resolve all known resource names at start up so it doesn't matter how resources are displayed
- The CLI uses the same colors as the dashboard for resources

Fixes https://github.com/dotnet/aspire/issues/14292

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
