### PR TITLE
Add more status indicators while work is in-progress

### DIFF
--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -212,10 +212,12 @@ internal sealed class AddCommand : BaseCommand
             // which prevents 'dotnet add package' from modifying the project.
             if (_features.IsFeatureEnabled(KnownFeatures.RunningInstanceDetectionEnabled, defaultValue: true))
             {
-                var runningInstanceResult = await project.FindAndStopRunningInstanceAsync(
-                    effectiveAppHostProjectFile,
-                    ExecutionContext.HomeDirectory,
-                    cancellationToken);
+                var runningInstanceResult = await InteractionService.ShowStatusAsync(
+                    AddCommandStrings.CheckingForRunningInstances,
+                    async () => await project.FindAndStopRunningInstanceAsync(
+                        effectiveAppHostProjectFile,
+                        ExecutionContext.HomeDirectory,
+                        cancellationToken));
 
                 if (runningInstanceResult == RunningInstanceResult.InstanceStopped)
                 {

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -678,7 +678,9 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
 
     private async Task<(NuGetPackage Package, PackageChannel Channel)> GetProjectTemplatesVersionAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        var allChannels = await _packagingService.GetChannelsAsync(cancellationToken);
+        var allChannels = await InteractionService.ShowStatusAsync(
+            InitCommandStrings.ResolvingTemplateVersion,
+            async () => await _packagingService.GetChannelsAsync(cancellationToken));
 
         // Check if --channel option was provided (highest priority)
         var channelName = parseResult.GetValue(_channelOption);

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
@@ -235,7 +236,16 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         return await _prompter.PromptForTemplateAsync(templatesForPrompt, cancellationToken);
     }
 
-    private record ResolveTemplateVersionResult(string? Version, string? ErrorMessage);
+    private sealed class ResolveTemplateVersionResult
+    {
+        public string? Version { get; init; }
+
+        [MemberNotNullWhen(true, nameof(Version))]
+        [MemberNotNullWhen(false, nameof(ErrorMessage))]
+        public bool Success => Version is not null;
+
+        public string? ErrorMessage { get; init; }
+    }
 
     private async Task<ResolveTemplateVersionResult> ResolveCliTemplateVersionAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
@@ -261,7 +271,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
                         ? "No package channels are available."
                         : $"No channel found matching '{configuredChannelName}'. Valid options are: {string.Join(", ", channels.Select(c => c.Name))}";
 
-                    return new ResolveTemplateVersionResult(null, errorMessage);
+                    return new ResolveTemplateVersionResult { ErrorMessage = errorMessage };
                 }
 
                 var packages = await selectedChannel.GetTemplatePackagesAsync(ExecutionContext.WorkingDirectory, cancellationToken);
@@ -272,10 +282,10 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
 
                 if (package is null)
                 {
-                    return new ResolveTemplateVersionResult(null, $"No template versions found in channel '{selectedChannel.Name}'.");
+                    return new ResolveTemplateVersionResult { ErrorMessage = $"No template versions found in channel '{selectedChannel.Name}'." };
                 }
 
-                return new ResolveTemplateVersionResult(package.Version, null);
+                return new ResolveTemplateVersionResult { Version = package.Version };
             });
     }
 
@@ -302,9 +312,9 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             string.IsNullOrWhiteSpace(version))
         {
             var resolveResult = await ResolveCliTemplateVersionAsync(parseResult, cancellationToken);
-            if (string.IsNullOrWhiteSpace(resolveResult.Version))
+            if (!resolveResult.Success)
             {
-                InteractionService.DisplayError(resolveResult.ErrorMessage!);
+                InteractionService.DisplayError(resolveResult.ErrorMessage);
                 return ExitCodeConstants.InvalidCommand;
             }
 

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -233,7 +233,15 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             return null;
         }
 
-        return await _prompter.PromptForTemplateAsync(templatesForPrompt, cancellationToken);
+        var result = await _prompter.PromptForTemplateAsync(templatesForPrompt, cancellationToken);
+
+        // The prompt is cleared after selection.
+        // Write out the selected template again for context before proceeding.
+        if (result != null)
+        {
+            InteractionService.DisplayPlainText($"{NewCommandStrings.SelectAProjectTemplate} {result.Description}");
+        }
+        return result;
     }
 
     private sealed class ResolveTemplateVersionResult
@@ -298,8 +306,6 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         {
             return ExitCodeConstants.InvalidCommand;
         }
-
-        InteractionService.DisplayPlainText($"{NewCommandStrings.SelectAProjectTemplate} {template.Description}");
 
         var (languageResolutionSuccess, selectedLanguageId) = await ResolveSelectedLanguageAsync(template, parseResult, cancellationToken);
         if (!languageResolutionSuccess)

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -237,45 +237,50 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
 
     private async Task<string?> ResolveCliTemplateVersionAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        var channels = await _packagingService.GetChannelsAsync(cancellationToken);
-
-        var configuredChannelName = parseResult.GetValue(_channelOption);
-        if (string.IsNullOrWhiteSpace(configuredChannelName))
-        {
-            configuredChannelName = await _configurationService.GetConfigurationAsync("channel", cancellationToken);
-        }
-
-        var selectedChannel = string.IsNullOrWhiteSpace(configuredChannelName)
-            ? channels.FirstOrDefault(c => c.Type is PackageChannelType.Implicit) ?? channels.FirstOrDefault()
-            : channels.FirstOrDefault(c => string.Equals(c.Name, configuredChannelName, StringComparison.OrdinalIgnoreCase));
-
-        if (selectedChannel is null)
-        {
-            if (string.IsNullOrWhiteSpace(configuredChannelName))
+        return await InteractionService.ShowStatusAsync(
+            NewCommandStrings.ResolvingTemplateVersion,
+            async () =>
             {
-                InteractionService.DisplayError("No package channels are available.");
-            }
-            else
-            {
-                InteractionService.DisplayError($"No channel found matching '{configuredChannelName}'. Valid options are: {string.Join(", ", channels.Select(c => c.Name))}");
-            }
+                var channels = await _packagingService.GetChannelsAsync(cancellationToken);
 
-            return null;
-        }
+                var configuredChannelName = parseResult.GetValue(_channelOption);
+                if (string.IsNullOrWhiteSpace(configuredChannelName))
+                {
+                    configuredChannelName = await _configurationService.GetConfigurationAsync("channel", cancellationToken);
+                }
 
-        var packages = await selectedChannel.GetTemplatePackagesAsync(ExecutionContext.WorkingDirectory, cancellationToken);
-        var package = packages
-            .Where(p => Semver.SemVersion.TryParse(p.Version, Semver.SemVersionStyles.Strict, out _))
-            .OrderByDescending(p => Semver.SemVersion.Parse(p.Version, Semver.SemVersionStyles.Strict), Semver.SemVersion.PrecedenceComparer)
-            .FirstOrDefault();
+                var selectedChannel = string.IsNullOrWhiteSpace(configuredChannelName)
+                    ? channels.FirstOrDefault(c => c.Type is PackageChannelType.Implicit) ?? channels.FirstOrDefault()
+                    : channels.FirstOrDefault(c => string.Equals(c.Name, configuredChannelName, StringComparison.OrdinalIgnoreCase));
 
-        if (package is null)
-        {
-            InteractionService.DisplayError($"No template versions found in channel '{selectedChannel.Name}'.");
-            return null;
-        }
+                if (selectedChannel is null)
+                {
+                    if (string.IsNullOrWhiteSpace(configuredChannelName))
+                    {
+                        InteractionService.DisplayError("No package channels are available.");
+                    }
+                    else
+                    {
+                        InteractionService.DisplayError($"No channel found matching '{configuredChannelName}'. Valid options are: {string.Join(", ", channels.Select(c => c.Name))}");
+                    }
 
-        return package.Version;
+                    return null;
+                }
+
+                var packages = await selectedChannel.GetTemplatePackagesAsync(ExecutionContext.WorkingDirectory, cancellationToken);
+                var package = packages
+                    .Where(p => Semver.SemVersion.TryParse(p.Version, Semver.SemVersionStyles.Strict, out _))
+                    .OrderByDescending(p => Semver.SemVersion.Parse(p.Version, Semver.SemVersionStyles.Strict), Semver.SemVersion.PrecedenceComparer)
+                    .FirstOrDefault();
+
+                if (package is null)
+                {
+                    InteractionService.DisplayError($"No template versions found in channel '{selectedChannel.Name}'.");
+                    return null;
+                }
+
+                return package.Version;
+            });
     }
 
     protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -235,7 +235,9 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         return await _prompter.PromptForTemplateAsync(templatesForPrompt, cancellationToken);
     }
 
-    private async Task<string?> ResolveCliTemplateVersionAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    private record ResolveTemplateVersionResult(string? Version, string? ErrorMessage);
+
+    private async Task<ResolveTemplateVersionResult> ResolveCliTemplateVersionAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         return await InteractionService.ShowStatusAsync(
             NewCommandStrings.ResolvingTemplateVersion,
@@ -255,16 +257,11 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
 
                 if (selectedChannel is null)
                 {
-                    if (string.IsNullOrWhiteSpace(configuredChannelName))
-                    {
-                        InteractionService.DisplayError("No package channels are available.");
-                    }
-                    else
-                    {
-                        InteractionService.DisplayError($"No channel found matching '{configuredChannelName}'. Valid options are: {string.Join(", ", channels.Select(c => c.Name))}");
-                    }
+                    var errorMessage = string.IsNullOrWhiteSpace(configuredChannelName)
+                        ? "No package channels are available."
+                        : $"No channel found matching '{configuredChannelName}'. Valid options are: {string.Join(", ", channels.Select(c => c.Name))}";
 
-                    return null;
+                    return new ResolveTemplateVersionResult(null, errorMessage);
                 }
 
                 var packages = await selectedChannel.GetTemplatePackagesAsync(ExecutionContext.WorkingDirectory, cancellationToken);
@@ -275,11 +272,10 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
 
                 if (package is null)
                 {
-                    InteractionService.DisplayError($"No template versions found in channel '{selectedChannel.Name}'.");
-                    return null;
+                    return new ResolveTemplateVersionResult(null, $"No template versions found in channel '{selectedChannel.Name}'.");
                 }
 
-                return package.Version;
+                return new ResolveTemplateVersionResult(package.Version, null);
             });
     }
 
@@ -293,6 +289,8 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             return ExitCodeConstants.InvalidCommand;
         }
 
+        InteractionService.DisplayPlainText($"{NewCommandStrings.SelectAProjectTemplate} {template.Description}");
+
         var (languageResolutionSuccess, selectedLanguageId) = await ResolveSelectedLanguageAsync(template, parseResult, cancellationToken);
         if (!languageResolutionSuccess)
         {
@@ -303,11 +301,14 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         if (ShouldResolveCliTemplateVersion(template) &&
             string.IsNullOrWhiteSpace(version))
         {
-            version = await ResolveCliTemplateVersionAsync(parseResult, cancellationToken);
-            if (string.IsNullOrWhiteSpace(version))
+            var resolveResult = await ResolveCliTemplateVersionAsync(parseResult, cancellationToken);
+            if (string.IsNullOrWhiteSpace(resolveResult.Version))
             {
+                InteractionService.DisplayError(resolveResult.ErrorMessage!);
                 return ExitCodeConstants.InvalidCommand;
             }
+
+            version = resolveResult.Version;
         }
 
         var inputs = new TemplateInputs

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -206,7 +206,9 @@ internal sealed class RunCommand : BaseCommand
                 // Even if we fail to stop we won't block the apphost starting
                 // to make sure we don't ever break flow. It should mostly stop
                 // just fine though.
-                var runningInstanceResult = await project.FindAndStopRunningInstanceAsync(effectiveAppHostFile, ExecutionContext.HomeDirectory, cancellationToken);
+                var runningInstanceResult = await InteractionService.ShowStatusAsync(
+                    RunCommandStrings.CheckingForRunningInstances,
+                    async () => await project.FindAndStopRunningInstanceAsync(effectiveAppHostFile, ExecutionContext.HomeDirectory, cancellationToken));
 
                 // If in isolated mode and a running instance was stopped, warn the user
                 if (isolated && runningInstanceResult == RunningInstanceResult.InstanceStopped)

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -152,7 +152,9 @@ internal sealed class UpdateCommand : BaseCommand
             var channelName = parseResult.GetValue(_channelOption) ?? parseResult.GetValue(_qualityOption);
             PackageChannel channel;
 
-            var allChannels = await _packagingService.GetChannelsAsync(cancellationToken);
+            var allChannels = await InteractionService.ShowStatusAsync(
+                UpdateCommandStrings.CheckingForUpdates,
+                async () => await _packagingService.GetChannelsAsync(cancellationToken));
 
             if (!string.IsNullOrEmpty(channelName))
             {
@@ -347,8 +349,14 @@ internal sealed class UpdateCommand : BaseCommand
         try
         {
             // Extract archive
-            InteractionService.DisplayMessage(KnownEmojis.Package, "Extracting new CLI...");
-            await ArchiveHelper.ExtractAsync(archivePath, tempExtractDir, cancellationToken);
+            await InteractionService.ShowStatusAsync(
+                UpdateCommandStrings.ExtractingNewCli,
+                async () =>
+                {
+                    await ArchiveHelper.ExtractAsync(archivePath, tempExtractDir, cancellationToken);
+                    return 0;
+                },
+                KnownEmojis.Package);
 
             // Find the aspire executable in the extracted files
             var newExePath = Path.Combine(tempExtractDir, exeName);

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -358,6 +358,8 @@ internal sealed class UpdateCommand : BaseCommand
                 },
                 KnownEmojis.Package);
 
+            InteractionService.DisplayMessage(KnownEmojis.Package, UpdateCommandStrings.ExtractedNewCli);
+
             // Find the aspire executable in the extracted files
             var newExePath = Path.Combine(tempExtractDir, exeName);
             if (!File.Exists(newExePath))

--- a/src/Aspire.Cli/Interaction/KnownEmojis.cs
+++ b/src/Aspire.Cli/Interaction/KnownEmojis.cs
@@ -29,6 +29,7 @@ internal static class KnownEmojis
     public static readonly KnownEmoji FloppyDisk = new("floppy_disk");
     public static readonly KnownEmoji Gear = new("gear");
     public static readonly KnownEmoji Hammer = new("hammer");
+    public static readonly KnownEmoji Ice = new("ice");
     public static readonly KnownEmoji HammerAndWrench = new("hammer_and_wrench");
     public static readonly KnownEmoji Information = new("information");
     public static readonly KnownEmoji Key = new("key");

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -972,6 +972,8 @@ internal sealed class GuestAppHostProject : IAppHostProject
                 return 0;
             });
 
+        _interactionService.DisplayMessage(KnownEmojis.Package, UpdateCommandStrings.RegeneratedSdkCode);
+
         _interactionService.DisplayEmptyLine();
         _interactionService.DisplaySuccess(UpdateCommandStrings.UpdateSuccessfulMessage);
 

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -964,8 +964,13 @@ internal sealed class GuestAppHostProject : IAppHostProject
 
         // Rebuild and regenerate SDK code with updated packages
         _interactionService.DisplayEmptyLine();
-        _interactionService.DisplaySubtleMessage("Regenerating SDK code with updated packages...");
-        await BuildAndGenerateSdkAsync(directory, cancellationToken);
+        await _interactionService.ShowStatusAsync(
+            UpdateCommandStrings.RegeneratingSdkCode,
+            async () =>
+            {
+                await BuildAndGenerateSdkAsync(directory, cancellationToken);
+                return 0;
+            });
 
         _interactionService.DisplayEmptyLine();
         _interactionService.DisplaySuccess(UpdateCommandStrings.UpdateSuccessfulMessage);

--- a/src/Aspire.Cli/Projects/ProjectUpdater.cs
+++ b/src/Aspire.Cli/Projects/ProjectUpdater.cs
@@ -120,11 +120,18 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
 
         interactionService.DisplayEmptyLine();
 
-        foreach (var updateStep in updateSteps)
-        {
-            interactionService.DisplaySubtleMessage(string.Format(CultureInfo.InvariantCulture, UpdateCommandStrings.ExecutingUpdateStepFormat, updateStep.Description));
-            await updateStep.Callback();
-        }
+        await interactionService.ShowStatusAsync(
+            UpdateCommandStrings.ApplyingUpdates,
+            async () =>
+            {
+                foreach (var updateStep in updateSteps)
+                {
+                    interactionService.DisplaySubtleMessage(string.Format(CultureInfo.InvariantCulture, UpdateCommandStrings.ExecutingUpdateStepFormat, updateStep.Description));
+                    await updateStep.Callback();
+                }
+
+                return 0;
+            });
 
         interactionService.DisplayEmptyLine();
 

--- a/src/Aspire.Cli/Resources/AddCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.Designer.cs
@@ -204,5 +204,13 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("UnableToStopRunningInstances", resourceCulture);
             }
         }
+
+        public static string CheckingForRunningInstances
+        {
+            get
+            {
+                return ResourceManager.GetString("CheckingForRunningInstances", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/AddCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.resx
@@ -178,4 +178,7 @@
   <data name="UnableToStopRunningInstances" xml:space="preserve">
     <value>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</value>
   </data>
+  <data name="CheckingForRunningInstances" xml:space="preserve">
+    <value>Checking for running instances...</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/InitCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/InitCommandStrings.Designer.cs
@@ -110,5 +110,11 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("AddingServiceDefaultsProjectToSolution", resourceCulture);
             }
         }
+
+        internal static string ResolvingTemplateVersion {
+            get {
+                return ResourceManager.GetString("ResolvingTemplateVersion", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/InitCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/InitCommandStrings.resx
@@ -93,4 +93,7 @@
   <data name="AddingServiceDefaultsProjectToSolution" xml:space="preserve">
     <value>Adding ServiceDefaults project to solution...</value>
   </data>
+  <data name="ResolvingTemplateVersion" xml:space="preserve">
+    <value>Resolving template version...</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/NewCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.Designer.cs
@@ -138,5 +138,11 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("PromptToUsePrereleaseTemplates", resourceCulture);
             }
         }
+
+        public static string ResolvingTemplateVersion {
+            get {
+                return ResourceManager.GetString("ResolvingTemplateVersion", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/NewCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.resx
@@ -148,4 +148,7 @@
   <data name="LanguageOptionDescription" xml:space="preserve">
     <value>The programming language for the AppHost.</value>
   </data>
+  <data name="ResolvingTemplateVersion" xml:space="preserve">
+    <value>Resolving template version...</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
@@ -109,5 +109,9 @@ namespace Aspire.Cli.Resources {
     internal static string MigratedToNewSdkFormat => ResourceManager.GetString("MigratedToNewSdkFormat", resourceCulture);
     internal static string RemovedObsoleteAppHostPackage => ResourceManager.GetString("RemovedObsoleteAppHostPackage", resourceCulture);
     internal static string NoWritePermissionToInstallDirectory => ResourceManager.GetString("NoWritePermissionToInstallDirectory", resourceCulture);
+    internal static string CheckingForUpdates => ResourceManager.GetString("CheckingForUpdates", resourceCulture);
+    internal static string ApplyingUpdates => ResourceManager.GetString("ApplyingUpdates", resourceCulture);
+    internal static string ExtractingNewCli => ResourceManager.GetString("ExtractingNewCli", resourceCulture);
+    internal static string RegeneratingSdkCode => ResourceManager.GetString("RegeneratingSdkCode", resourceCulture);
     }
 }

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.Designer.cs
@@ -112,6 +112,8 @@ namespace Aspire.Cli.Resources {
     internal static string CheckingForUpdates => ResourceManager.GetString("CheckingForUpdates", resourceCulture);
     internal static string ApplyingUpdates => ResourceManager.GetString("ApplyingUpdates", resourceCulture);
     internal static string ExtractingNewCli => ResourceManager.GetString("ExtractingNewCli", resourceCulture);
+    internal static string ExtractedNewCli => ResourceManager.GetString("ExtractedNewCli", resourceCulture);
     internal static string RegeneratingSdkCode => ResourceManager.GetString("RegeneratingSdkCode", resourceCulture);
+    internal static string RegeneratedSdkCode => ResourceManager.GetString("RegeneratedSdkCode", resourceCulture);
     }
 }

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
@@ -153,7 +153,13 @@
   <data name="ExtractingNewCli" xml:space="preserve">
     <value>Extracting new CLI...</value>
   </data>
+  <data name="ExtractedNewCli" xml:space="preserve">
+    <value>Extracted new CLI</value>
+  </data>
   <data name="RegeneratingSdkCode" xml:space="preserve">
     <value>Regenerating SDK code with updated packages...</value>
+  </data>
+  <data name="RegeneratedSdkCode" xml:space="preserve">
+    <value>Regenerated SDK code with updated packages</value>
   </data>
 </root>

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
@@ -160,6 +160,6 @@
     <value>Regenerating SDK code with updated packages...</value>
   </data>
   <data name="RegeneratedSdkCode" xml:space="preserve">
-    <value>Regenerated SDK code with updated packages</value>
+    <value>Regenerated SDK code with updated packages.</value>
   </data>
 </root>

--- a/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/UpdateCommandStrings.resx
@@ -144,4 +144,16 @@
   <data name="NoWritePermissionToInstallDirectory" xml:space="preserve">
     <value>Cannot write to installation directory '{0}'. Please run the update with elevated permissions (e.g., using sudo on Linux/macOS).</value>
   </data>
+  <data name="CheckingForUpdates" xml:space="preserve">
+    <value>Checking for updates...</value>
+  </data>
+  <data name="ApplyingUpdates" xml:space="preserve">
+    <value>Applying updates...</value>
+  </data>
+  <data name="ExtractingNewCli" xml:space="preserve">
+    <value>Extracting new CLI...</value>
+  </data>
+  <data name="RegeneratingSdkCode" xml:space="preserve">
+    <value>Regenerating SDK code with updated packages...</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Přidává se integrace hostování Aspire...</target>
         <note />
       </trans-unit>
+      <trans-unit id="CheckingForRunningInstances">
+        <source>Checking for running instances...</source>
+        <target state="new">Checking for running instances...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Přidejte do hostitele aplikací Aspire integraci hostování.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Aspire-Hosting-Integration wird hinzugefügt...</target>
         <note />
       </trans-unit>
+      <trans-unit id="CheckingForRunningInstances">
+        <source>Checking for running instances...</source>
+        <target state="new">Checking for running instances...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Fügen Sie dem Aspire AppHost eine Hosting-Integration hinzu.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Agregando integración de hospedaje de Aspire...</target>
         <note />
       </trans-unit>
+      <trans-unit id="CheckingForRunningInstances">
+        <source>Checking for running instances...</source>
+        <target state="new">Checking for running instances...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Agregue una integración de hospedaje a Aspire AppHost.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Ajout de l’intégration d’hébergement Aspire...</target>
         <note />
       </trans-unit>
+      <trans-unit id="CheckingForRunningInstances">
+        <source>Checking for running instances...</source>
+        <target state="new">Checking for running instances...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Ajoutez une intégration d’hébergement à l’Aspire AppHost.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Aggiunta dell'integrazione di hosting Aspire in corso...</target>
         <note />
       </trans-unit>
+      <trans-unit id="CheckingForRunningInstances">
+        <source>Checking for running instances...</source>
+        <target state="new">Checking for running instances...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Aggiungere un'integrazione di hosting all'AppHost Aspire.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Aspire ホスティング統合を追加しています...</target>
         <note />
       </trans-unit>
+      <trans-unit id="CheckingForRunningInstances">
+        <source>Checking for running instances...</source>
+        <target state="new">Checking for running instances...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Aspire AppHost にホスティング統合を追加します。</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Aspire 호스팅 통합을 추가하는 중...</target>
         <note />
       </trans-unit>
+      <trans-unit id="CheckingForRunningInstances">
+        <source>Checking for running instances...</source>
+        <target state="new">Checking for running instances...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Aspire AppHost에 호스팅 통합을 추가하세요.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Trwa dodawanie integracji hostingu platformy Aspire...</target>
         <note />
       </trans-unit>
+      <trans-unit id="CheckingForRunningInstances">
+        <source>Checking for running instances...</source>
+        <target state="new">Checking for running instances...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Dodaj integrację hostingu do hosta AppHost platformy Aspire.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Adicionando integração de hosting do Aspire...</target>
         <note />
       </trans-unit>
+      <trans-unit id="CheckingForRunningInstances">
+        <source>Checking for running instances...</source>
+        <target state="new">Checking for running instances...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Adicione uma integração de hosting ao Aspire AppHost.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Добавление интеграции размещения Aspire...</target>
         <note />
       </trans-unit>
+      <trans-unit id="CheckingForRunningInstances">
+        <source>Checking for running instances...</source>
+        <target state="new">Checking for running instances...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Добавьте интеграцию размещения в Aspire AppHost.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Aspire barındırma tümleştirmesi ekleniyor...</target>
         <note />
       </trans-unit>
+      <trans-unit id="CheckingForRunningInstances">
+        <source>Checking for running instances...</source>
+        <target state="new">Checking for running instances...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Aspire AppHost'a bir barındırma tümleştirmesi ekleyin.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">正在添加 Aspire 托管集成...</target>
         <note />
       </trans-unit>
+      <trans-unit id="CheckingForRunningInstances">
+        <source>Checking for running instances...</source>
+        <target state="new">Checking for running instances...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">将托管集成添加到 Aspire AppHost。</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">正在新增 Aspire 主機整合...</target>
         <note />
       </trans-unit>
+      <trans-unit id="CheckingForRunningInstances">
+        <source>Checking for running instances...</source>
+        <target state="new">Checking for running instances...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">將主機整合新增到 Aspire AppHost。</target>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.cs.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Nenašel se žádný soubor řešení. Vytváří se AppHost s jedním souborem...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SolutionDetected">
         <source>Solution detected: {0}</source>
         <target state="translated">Zjištěné řešení: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.de.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Keine Lösungsdatei gefunden. AppHost mit einzelner Datei wird erstellt …</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SolutionDetected">
         <source>Solution detected: {0}</source>
         <target state="translated">Lösung erkannt: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.es.xlf
@@ -47,6 +47,11 @@
         <target state="translated">No se encontró ningún archivo de solución. Creando AppHost de un solo archivo...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SolutionDetected">
         <source>Solution detected: {0}</source>
         <target state="translated">Solución detectada: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.fr.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Fichier de solution introuvable. Création d’un AppHost à fichier unique...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SolutionDetected">
         <source>Solution detected: {0}</source>
         <target state="translated">Solution détectée : {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.it.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Nessun file di soluzione trovato. Creazione di AppHost a file singolo in corso...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SolutionDetected">
         <source>Solution detected: {0}</source>
         <target state="translated">Soluzione rilevata: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.ja.xlf
@@ -47,6 +47,11 @@
         <target state="translated">ソリューション ファイルが見つかりません。単一ファイルの AppHost を作成しています...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SolutionDetected">
         <source>Solution detected: {0}</source>
         <target state="translated">ソリューションが検出されました: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.ko.xlf
@@ -47,6 +47,11 @@
         <target state="translated">솔루션 파일을 찾을 수 없습니다. 단일 파일 AppHost를 만드는 중...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SolutionDetected">
         <source>Solution detected: {0}</source>
         <target state="translated">솔루션 검색됨: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.pl.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Nie znaleziono pliku rozwiązania. Trwa tworzenie hosta aplikacji (AppHost) z jednym plikiem...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SolutionDetected">
         <source>Solution detected: {0}</source>
         <target state="translated">Wykryto rozwiązanie: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.pt-BR.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Não há arquivos de solução abertos. Criando o AppHost de arquivo único...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SolutionDetected">
         <source>Solution detected: {0}</source>
         <target state="translated">Solução detectada: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.ru.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Файл решения не найден. Создание однофайлового AppHost...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SolutionDetected">
         <source>Solution detected: {0}</source>
         <target state="translated">Обнаружено решение: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.tr.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Çözüm dosyası bulunamadı. Tek dosyalı AppHost oluşturuluyor...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SolutionDetected">
         <source>Solution detected: {0}</source>
         <target state="translated">Çözüm algılandı: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.zh-Hans.xlf
@@ -47,6 +47,11 @@
         <target state="translated">找不到解决方案文件。正在创建单文件 AppHost...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SolutionDetected">
         <source>Solution detected: {0}</source>
         <target state="translated">检测到解决方案: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.zh-Hant.xlf
@@ -47,6 +47,11 @@
         <target state="translated">找不到解決方案檔案。正在建立單一檔案 AppHost...</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SolutionDetected">
         <source>Solution detected: {0}</source>
         <target state="translated">偵測到的解決方案: {0}</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Výstupní cesta pro projekt</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a template:</source>
         <target state="translated">Vyberte šablonu:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Der Ausgabepfad für das Projekt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a template:</source>
         <target state="translated">Wählen Sie eine Vorlage aus:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
@@ -47,6 +47,11 @@
         <target state="translated">La ruta de salida del proyecto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a template:</source>
         <target state="translated">Seleccione una plantilla:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Le chemin de sortie du projet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a template:</source>
         <target state="translated">Sélectionnez un modèle :</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Percorso di output per il progetto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a template:</source>
         <target state="translated">Selezionare un modello:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
@@ -47,6 +47,11 @@
         <target state="translated">プロジェクトの出力パス。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a template:</source>
         <target state="translated">テンプレートの選択:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
@@ -47,6 +47,11 @@
         <target state="translated">프로젝트의 출력 경로입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a template:</source>
         <target state="translated">템플릿 선택:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Ścieżka wyjściowa projektu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a template:</source>
         <target state="translated">Wybierz szablon:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
@@ -47,6 +47,11 @@
         <target state="translated">O caminho de saída para o projeto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a template:</source>
         <target state="translated">Selecione um modelo:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Выходной путь для проекта.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a template:</source>
         <target state="translated">Выберите шаблон:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Projenin çıkış yolu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a template:</source>
         <target state="translated">Bir şablon seçin:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
@@ -47,6 +47,11 @@
         <target state="translated">项目的输出路径。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a template:</source>
         <target state="translated">选择模板:</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
@@ -47,6 +47,11 @@
         <target state="translated">專案的輸出路徑。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResolvingTemplateVersion">
+        <source>Resolving template version...</source>
+        <target state="new">Resolving template version...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SelectAProjectTemplate">
         <source>Select a template:</source>
         <target state="translated">選取範本:</target>

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Spouští se: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExtractedNewCli">
+        <source>Extracted new CLI</source>
+        <target state="new">Extracted new CLI</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtractingNewCli">
         <source>Extracting new CLI...</source>
         <target state="new">Extracting new CLI...</target>
@@ -190,6 +195,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">Úroveň kvality, na kterou se má aktualizovat (stabilní, příprava, denní)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratedSdkCode">
+        <source>Regenerated SDK code with updated packages</source>
+        <target state="new">Regenerated SDK code with updated packages</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegeneratedSdkCode">
-        <source>Regenerated SDK code with updated packages</source>
-        <target state="new">Regenerated SDK code with updated packages</target>
+        <source>Regenerated SDK code with updated packages.</source>
+        <target state="new">Regenerated SDK code with updated packages.</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.cs.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Chcete tyto změny použít v souboru NuGet.config?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplyingUpdates">
+        <source>Applying updates...</source>
+        <target state="new">Applying updates...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">Centrální správa balíčků není v současné době přes aspire update podporována.</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ChannelOptionDescriptionWithStaging">
         <source>Channel to update to (stable, staging, daily)</source>
         <target state="translated">Kanál, na který se má aktualizovat (stabilní, příprava, denní)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingForUpdates">
+        <source>Checking for updates...</source>
+        <target state="new">Checking for updates...</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -75,6 +85,11 @@
       <trans-unit id="ExecutingUpdateStepFormat">
         <source>Executing: {0}</source>
         <target state="translated">Spouští se: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExtractingNewCli">
+        <source>Extracting new CLI...</source>
+        <target state="new">Extracting new CLI...</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedDiscoverNuGetConfig">
@@ -175,6 +190,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">Úroveň kvality, na kterou se má aktualizovat (stabilní, příprava, denní)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratingSdkCode">
+        <source>Regenerating SDK code with updated packages...</source>
+        <target state="new">Regenerating SDK code with updated packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RemovedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Wird ausgeführt: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExtractedNewCli">
+        <source>Extracted new CLI</source>
+        <target state="new">Extracted new CLI</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtractingNewCli">
         <source>Extracting new CLI...</source>
         <target state="new">Extracting new CLI...</target>
@@ -190,6 +195,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">Qualitätsstufe, auf die aktualisiert werden soll (stable, staging, daily)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratedSdkCode">
+        <source>Regenerated SDK code with updated packages</source>
+        <target state="new">Regenerated SDK code with updated packages</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegeneratedSdkCode">
-        <source>Regenerated SDK code with updated packages</source>
-        <target state="new">Regenerated SDK code with updated packages</target>
+        <source>Regenerated SDK code with updated packages.</source>
+        <target state="new">Regenerated SDK code with updated packages.</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.de.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Diese Änderungen in NuGet.config übernehmen?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplyingUpdates">
+        <source>Applying updates...</source>
+        <target state="new">Applying updates...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">Die zentrale Paketverwaltung wird von „aspire update“ zurzeit nicht unterstützt.</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ChannelOptionDescriptionWithStaging">
         <source>Channel to update to (stable, staging, daily)</source>
         <target state="translated">Kanal, auf den aktualisiert werden soll (stable, staging, daily)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingForUpdates">
+        <source>Checking for updates...</source>
+        <target state="new">Checking for updates...</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -75,6 +85,11 @@
       <trans-unit id="ExecutingUpdateStepFormat">
         <source>Executing: {0}</source>
         <target state="translated">Wird ausgeführt: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExtractingNewCli">
+        <source>Extracting new CLI...</source>
+        <target state="new">Extracting new CLI...</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedDiscoverNuGetConfig">
@@ -175,6 +190,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">Qualitätsstufe, auf die aktualisiert werden soll (stable, staging, daily)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratingSdkCode">
+        <source>Regenerating SDK code with updated packages...</source>
+        <target state="new">Regenerating SDK code with updated packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RemovedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegeneratedSdkCode">
-        <source>Regenerated SDK code with updated packages</source>
-        <target state="new">Regenerated SDK code with updated packages</target>
+        <source>Regenerated SDK code with updated packages.</source>
+        <target state="new">Regenerated SDK code with updated packages.</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Ejecutando: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExtractedNewCli">
+        <source>Extracted new CLI</source>
+        <target state="new">Extracted new CLI</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtractingNewCli">
         <source>Extracting new CLI...</source>
         <target state="new">Extracting new CLI...</target>
@@ -190,6 +195,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">Nivel de calidad al que se va a actualizar (estable, de ensayo, diario)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratedSdkCode">
+        <source>Regenerated SDK code with updated packages</source>
+        <target state="new">Regenerated SDK code with updated packages</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.es.xlf
@@ -32,6 +32,11 @@
         <target state="translated">¿Aplicar estos cambios en NuGet.config?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplyingUpdates">
+        <source>Applying updates...</source>
+        <target state="new">Applying updates...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">La administración central de paquetes no es compatible actualmente con "aspire update".</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ChannelOptionDescriptionWithStaging">
         <source>Channel to update to (stable, staging, daily)</source>
         <target state="translated">Canal al que se va a actualizar (estable, de ensayo, diario)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingForUpdates">
+        <source>Checking for updates...</source>
+        <target state="new">Checking for updates...</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -75,6 +85,11 @@
       <trans-unit id="ExecutingUpdateStepFormat">
         <source>Executing: {0}</source>
         <target state="translated">Ejecutando: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExtractingNewCli">
+        <source>Extracting new CLI...</source>
+        <target state="new">Extracting new CLI...</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedDiscoverNuGetConfig">
@@ -175,6 +190,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">Nivel de calidad al que se va a actualizar (estable, de ensayo, diario)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratingSdkCode">
+        <source>Regenerating SDK code with updated packages...</source>
+        <target state="new">Regenerating SDK code with updated packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RemovedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Voulez-vous appliquer ces modifications à NuGet.config ?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplyingUpdates">
+        <source>Applying updates...</source>
+        <target state="new">Applying updates...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">Actuellement, la gestion centralisée des packages n’est pas prise en charge par « aspire update ».</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ChannelOptionDescriptionWithStaging">
         <source>Channel to update to (stable, staging, daily)</source>
         <target state="translated">Canal vers lequel effectuer une mise à jour (stable, gestion intermédiaire, quotidien)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingForUpdates">
+        <source>Checking for updates...</source>
+        <target state="new">Checking for updates...</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -75,6 +85,11 @@
       <trans-unit id="ExecutingUpdateStepFormat">
         <source>Executing: {0}</source>
         <target state="translated">Exécution : {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExtractingNewCli">
+        <source>Extracting new CLI...</source>
+        <target state="new">Extracting new CLI...</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedDiscoverNuGetConfig">
@@ -175,6 +190,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">Niveau de qualité vers lequel effectuer une mise à jour (stable, gestion intermédiaire, quotidien)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratingSdkCode">
+        <source>Regenerating SDK code with updated packages...</source>
+        <target state="new">Regenerating SDK code with updated packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RemovedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Exécution : {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExtractedNewCli">
+        <source>Extracted new CLI</source>
+        <target state="new">Extracted new CLI</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtractingNewCli">
         <source>Extracting new CLI...</source>
         <target state="new">Extracting new CLI...</target>
@@ -190,6 +195,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">Niveau de qualité vers lequel effectuer une mise à jour (stable, gestion intermédiaire, quotidien)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratedSdkCode">
+        <source>Regenerated SDK code with updated packages</source>
+        <target state="new">Regenerated SDK code with updated packages</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.fr.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegeneratedSdkCode">
-        <source>Regenerated SDK code with updated packages</source>
-        <target state="new">Regenerated SDK code with updated packages</target>
+        <source>Regenerated SDK code with updated packages.</source>
+        <target state="new">Regenerated SDK code with updated packages.</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Esecuzione in corso: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExtractedNewCli">
+        <source>Extracted new CLI</source>
+        <target state="new">Extracted new CLI</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtractingNewCli">
         <source>Extracting new CLI...</source>
         <target state="new">Extracting new CLI...</target>
@@ -190,6 +195,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">Livello di qualità da aggiornare a (stabile, staging, giornaliero)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratedSdkCode">
+        <source>Regenerated SDK code with updated packages</source>
+        <target state="new">Regenerated SDK code with updated packages</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Applicare le modifiche a NuGet.config?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplyingUpdates">
+        <source>Applying updates...</source>
+        <target state="new">Applying updates...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">La gestione centralizzata dei pacchetti non è attualmente supportata da "aspire update".</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ChannelOptionDescriptionWithStaging">
         <source>Channel to update to (stable, staging, daily)</source>
         <target state="translated">Canale da aggiornare a (stabile, staging, giornaliero)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingForUpdates">
+        <source>Checking for updates...</source>
+        <target state="new">Checking for updates...</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -75,6 +85,11 @@
       <trans-unit id="ExecutingUpdateStepFormat">
         <source>Executing: {0}</source>
         <target state="translated">Esecuzione in corso: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExtractingNewCli">
+        <source>Extracting new CLI...</source>
+        <target state="new">Extracting new CLI...</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedDiscoverNuGetConfig">
@@ -175,6 +190,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">Livello di qualità da aggiornare a (stabile, staging, giornaliero)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratingSdkCode">
+        <source>Regenerating SDK code with updated packages...</source>
+        <target state="new">Regenerating SDK code with updated packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RemovedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.it.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegeneratedSdkCode">
-        <source>Regenerated SDK code with updated packages</source>
-        <target state="new">Regenerated SDK code with updated packages</target>
+        <source>Regenerated SDK code with updated packages.</source>
+        <target state="new">Regenerated SDK code with updated packages.</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
@@ -32,6 +32,11 @@
         <target state="translated">これらの変更を NuGet.config に適用しますか?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplyingUpdates">
+        <source>Applying updates...</source>
+        <target state="new">Applying updates...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">現在、中央パッケージ管理では、'aspire update' によるサポートがありません。</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ChannelOptionDescriptionWithStaging">
         <source>Channel to update to (stable, staging, daily)</source>
         <target state="translated">更新先のチャネル (安定、ステージング、毎日)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingForUpdates">
+        <source>Checking for updates...</source>
+        <target state="new">Checking for updates...</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -75,6 +85,11 @@
       <trans-unit id="ExecutingUpdateStepFormat">
         <source>Executing: {0}</source>
         <target state="translated">次を実行しています: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExtractingNewCli">
+        <source>Extracting new CLI...</source>
+        <target state="new">Extracting new CLI...</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedDiscoverNuGetConfig">
@@ -175,6 +190,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">更新先の品質レベル (安定、ステージング、毎日)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratingSdkCode">
+        <source>Regenerating SDK code with updated packages...</source>
+        <target state="new">Regenerating SDK code with updated packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RemovedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
@@ -87,6 +87,11 @@
         <target state="translated">次を実行しています: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExtractedNewCli">
+        <source>Extracted new CLI</source>
+        <target state="new">Extracted new CLI</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtractingNewCli">
         <source>Extracting new CLI...</source>
         <target state="new">Extracting new CLI...</target>
@@ -190,6 +195,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">更新先の品質レベル (安定、ステージング、毎日)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratedSdkCode">
+        <source>Regenerated SDK code with updated packages</source>
+        <target state="new">Regenerated SDK code with updated packages</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ja.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegeneratedSdkCode">
-        <source>Regenerated SDK code with updated packages</source>
-        <target state="new">Regenerated SDK code with updated packages</target>
+        <source>Regenerated SDK code with updated packages.</source>
+        <target state="new">Regenerated SDK code with updated packages.</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
@@ -87,6 +87,11 @@
         <target state="translated">실행 중: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExtractedNewCli">
+        <source>Extracted new CLI</source>
+        <target state="new">Extracted new CLI</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtractingNewCli">
         <source>Extracting new CLI...</source>
         <target state="new">Extracting new CLI...</target>
@@ -190,6 +195,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">업데이트할 품질 수준(안정, 스테이징, 데일리)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratedSdkCode">
+        <source>Regenerated SDK code with updated packages</source>
+        <target state="new">Regenerated SDK code with updated packages</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
@@ -32,6 +32,11 @@
         <target state="translated">NuGet.config에 이러한 변경 내용을 적용하시겠습니까?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplyingUpdates">
+        <source>Applying updates...</source>
+        <target state="new">Applying updates...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">중앙 패키지 관리는 현재 'aspire update'에서 지원되지 않습니다.</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ChannelOptionDescriptionWithStaging">
         <source>Channel to update to (stable, staging, daily)</source>
         <target state="translated">업데이트할 채널(안정, 스테이징, 데일리)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingForUpdates">
+        <source>Checking for updates...</source>
+        <target state="new">Checking for updates...</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -75,6 +85,11 @@
       <trans-unit id="ExecutingUpdateStepFormat">
         <source>Executing: {0}</source>
         <target state="translated">실행 중: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExtractingNewCli">
+        <source>Extracting new CLI...</source>
+        <target state="new">Extracting new CLI...</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedDiscoverNuGetConfig">
@@ -175,6 +190,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">업데이트할 품질 수준(안정, 스테이징, 데일리)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratingSdkCode">
+        <source>Regenerating SDK code with updated packages...</source>
+        <target state="new">Regenerating SDK code with updated packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RemovedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ko.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegeneratedSdkCode">
-        <source>Regenerated SDK code with updated packages</source>
-        <target state="new">Regenerated SDK code with updated packages</target>
+        <source>Regenerated SDK code with updated packages.</source>
+        <target state="new">Regenerated SDK code with updated packages.</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Wykonywanie: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExtractedNewCli">
+        <source>Extracted new CLI</source>
+        <target state="new">Extracted new CLI</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtractingNewCli">
         <source>Extracting new CLI...</source>
         <target state="new">Extracting new CLI...</target>
@@ -190,6 +195,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">Poziom jakości, do którego należy zaktualizować (stabilny, przejściowy, dzienny)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratedSdkCode">
+        <source>Regenerated SDK code with updated packages</source>
+        <target state="new">Regenerated SDK code with updated packages</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Czy zastosować te zmiany do pliku NuGet.config?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplyingUpdates">
+        <source>Applying updates...</source>
+        <target state="new">Applying updates...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">Centralne zarządzanie pakietami nie jest obecnie obsługiwane przez „aktualizację Aspire”.</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ChannelOptionDescriptionWithStaging">
         <source>Channel to update to (stable, staging, daily)</source>
         <target state="translated">Kanał, do którego należy zaktualizować (stabilny, przejściowy, dzienny)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingForUpdates">
+        <source>Checking for updates...</source>
+        <target state="new">Checking for updates...</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -75,6 +85,11 @@
       <trans-unit id="ExecutingUpdateStepFormat">
         <source>Executing: {0}</source>
         <target state="translated">Wykonywanie: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExtractingNewCli">
+        <source>Extracting new CLI...</source>
+        <target state="new">Extracting new CLI...</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedDiscoverNuGetConfig">
@@ -175,6 +190,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">Poziom jakości, do którego należy zaktualizować (stabilny, przejściowy, dzienny)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratingSdkCode">
+        <source>Regenerating SDK code with updated packages...</source>
+        <target state="new">Regenerating SDK code with updated packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RemovedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pl.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegeneratedSdkCode">
-        <source>Regenerated SDK code with updated packages</source>
-        <target state="new">Regenerated SDK code with updated packages</target>
+        <source>Regenerated SDK code with updated packages.</source>
+        <target state="new">Regenerated SDK code with updated packages.</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Aplicar essas alterações ao NuGet.config?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplyingUpdates">
+        <source>Applying updates...</source>
+        <target state="new">Applying updates...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">No momento, o gerenciamento central de pacotes por “atualização de atualização” não ´possui suporte.</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ChannelOptionDescriptionWithStaging">
         <source>Channel to update to (stable, staging, daily)</source>
         <target state="translated">Canal para o qual atualizar (estável, preparo, diariamente)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingForUpdates">
+        <source>Checking for updates...</source>
+        <target state="new">Checking for updates...</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -75,6 +85,11 @@
       <trans-unit id="ExecutingUpdateStepFormat">
         <source>Executing: {0}</source>
         <target state="translated">Executando: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExtractingNewCli">
+        <source>Extracting new CLI...</source>
+        <target state="new">Extracting new CLI...</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedDiscoverNuGetConfig">
@@ -175,6 +190,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">Nível de qualidade para o qual atualizar (estável, preparo, diariamente)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratingSdkCode">
+        <source>Regenerating SDK code with updated packages...</source>
+        <target state="new">Regenerating SDK code with updated packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RemovedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Executando: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExtractedNewCli">
+        <source>Extracted new CLI</source>
+        <target state="new">Extracted new CLI</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtractingNewCli">
         <source>Extracting new CLI...</source>
         <target state="new">Extracting new CLI...</target>
@@ -190,6 +195,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">Nível de qualidade para o qual atualizar (estável, preparo, diariamente)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratedSdkCode">
+        <source>Regenerated SDK code with updated packages</source>
+        <target state="new">Regenerated SDK code with updated packages</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.pt-BR.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegeneratedSdkCode">
-        <source>Regenerated SDK code with updated packages</source>
-        <target state="new">Regenerated SDK code with updated packages</target>
+        <source>Regenerated SDK code with updated packages.</source>
+        <target state="new">Regenerated SDK code with updated packages.</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Применить эти изменения к NuGet.config?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplyingUpdates">
+        <source>Applying updates...</source>
+        <target state="new">Applying updates...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">Централизованное управление пакетами в настоящее время не поддерживается функцией "обновление Aspire".</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ChannelOptionDescriptionWithStaging">
         <source>Channel to update to (stable, staging, daily)</source>
         <target state="translated">Канал для обновления (стабильный, промежуточный, ежедневный)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingForUpdates">
+        <source>Checking for updates...</source>
+        <target state="new">Checking for updates...</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -75,6 +85,11 @@
       <trans-unit id="ExecutingUpdateStepFormat">
         <source>Executing: {0}</source>
         <target state="translated">Выполнение: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExtractingNewCli">
+        <source>Extracting new CLI...</source>
+        <target state="new">Extracting new CLI...</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedDiscoverNuGetConfig">
@@ -175,6 +190,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">Уровень качества для обновления (стабильный, промежуточный, ежедневный)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratingSdkCode">
+        <source>Regenerating SDK code with updated packages...</source>
+        <target state="new">Regenerating SDK code with updated packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RemovedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Выполнение: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExtractedNewCli">
+        <source>Extracted new CLI</source>
+        <target state="new">Extracted new CLI</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtractingNewCli">
         <source>Extracting new CLI...</source>
         <target state="new">Extracting new CLI...</target>
@@ -190,6 +195,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">Уровень качества для обновления (стабильный, промежуточный, ежедневный)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratedSdkCode">
+        <source>Regenerated SDK code with updated packages</source>
+        <target state="new">Regenerated SDK code with updated packages</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.ru.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegeneratedSdkCode">
-        <source>Regenerated SDK code with updated packages</source>
-        <target state="new">Regenerated SDK code with updated packages</target>
+        <source>Regenerated SDK code with updated packages.</source>
+        <target state="new">Regenerated SDK code with updated packages.</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Yürütülüyor: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExtractedNewCli">
+        <source>Extracted new CLI</source>
+        <target state="new">Extracted new CLI</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtractingNewCli">
         <source>Extracting new CLI...</source>
         <target state="new">Extracting new CLI...</target>
@@ -190,6 +195,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">Güncelleştirilecek kalite seviyesi (kararlı, hazırlama, günlük)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratedSdkCode">
+        <source>Regenerated SDK code with updated packages</source>
+        <target state="new">Regenerated SDK code with updated packages</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Bu değişiklikler NuGet.config dosyasına uygulansın mı?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplyingUpdates">
+        <source>Applying updates...</source>
+        <target state="new">Applying updates...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">Merkezi paket yönetimi şu anda 'aspire update' tarafından desteklenmiyor.</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ChannelOptionDescriptionWithStaging">
         <source>Channel to update to (stable, staging, daily)</source>
         <target state="translated">Güncelleştirme yapılacak kanal (kararlı, hazırlama, günlük)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingForUpdates">
+        <source>Checking for updates...</source>
+        <target state="new">Checking for updates...</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -75,6 +85,11 @@
       <trans-unit id="ExecutingUpdateStepFormat">
         <source>Executing: {0}</source>
         <target state="translated">Yürütülüyor: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExtractingNewCli">
+        <source>Extracting new CLI...</source>
+        <target state="new">Extracting new CLI...</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedDiscoverNuGetConfig">
@@ -175,6 +190,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">Güncelleştirilecek kalite seviyesi (kararlı, hazırlama, günlük)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratingSdkCode">
+        <source>Regenerating SDK code with updated packages...</source>
+        <target state="new">Regenerating SDK code with updated packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RemovedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.tr.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegeneratedSdkCode">
-        <source>Regenerated SDK code with updated packages</source>
-        <target state="new">Regenerated SDK code with updated packages</target>
+        <source>Regenerated SDK code with updated packages.</source>
+        <target state="new">Regenerated SDK code with updated packages.</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
@@ -32,6 +32,11 @@
         <target state="translated">是否将这些更改应用到 NuGet.config?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplyingUpdates">
+        <source>Applying updates...</source>
+        <target state="new">Applying updates...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">"aspire update" 当前不支持中央包管理。</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ChannelOptionDescriptionWithStaging">
         <source>Channel to update to (stable, staging, daily)</source>
         <target state="translated">要更新到的频道(稳定、暂存、每日)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingForUpdates">
+        <source>Checking for updates...</source>
+        <target state="new">Checking for updates...</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -75,6 +85,11 @@
       <trans-unit id="ExecutingUpdateStepFormat">
         <source>Executing: {0}</source>
         <target state="translated">正在执行: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExtractingNewCli">
+        <source>Extracting new CLI...</source>
+        <target state="new">Extracting new CLI...</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedDiscoverNuGetConfig">
@@ -175,6 +190,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">要更新到的质量级别(稳定、暂存、每日)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratingSdkCode">
+        <source>Regenerating SDK code with updated packages...</source>
+        <target state="new">Regenerating SDK code with updated packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RemovedFeedFormat">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegeneratedSdkCode">
-        <source>Regenerated SDK code with updated packages</source>
-        <target state="new">Regenerated SDK code with updated packages</target>
+        <source>Regenerated SDK code with updated packages.</source>
+        <target state="new">Regenerated SDK code with updated packages.</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hans.xlf
@@ -87,6 +87,11 @@
         <target state="translated">正在执行: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExtractedNewCli">
+        <source>Extracted new CLI</source>
+        <target state="new">Extracted new CLI</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtractingNewCli">
         <source>Extracting new CLI...</source>
         <target state="new">Extracting new CLI...</target>
@@ -190,6 +195,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">要更新到的质量级别(稳定、暂存、每日)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratedSdkCode">
+        <source>Regenerated SDK code with updated packages</source>
+        <target state="new">Regenerated SDK code with updated packages</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
@@ -87,6 +87,11 @@
         <target state="translated">正在執行: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExtractedNewCli">
+        <source>Extracted new CLI</source>
+        <target state="new">Extracted new CLI</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtractingNewCli">
         <source>Extracting new CLI...</source>
         <target state="new">Extracting new CLI...</target>
@@ -190,6 +195,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">要更新的品質等級 (穩定、暫存、每日)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratedSdkCode">
+        <source>Regenerated SDK code with updated packages</source>
+        <target state="new">Regenerated SDK code with updated packages</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
@@ -198,8 +198,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RegeneratedSdkCode">
-        <source>Regenerated SDK code with updated packages</source>
-        <target state="new">Regenerated SDK code with updated packages</target>
+        <source>Regenerated SDK code with updated packages.</source>
+        <target state="new">Regenerated SDK code with updated packages.</target>
         <note />
       </trans-unit>
       <trans-unit id="RegeneratingSdkCode">

--- a/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/UpdateCommandStrings.zh-Hant.xlf
@@ -32,6 +32,11 @@
         <target state="translated">是否將這些變更套用至 NuGet.config?</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplyingUpdates">
+        <source>Applying updates...</source>
+        <target state="new">Applying updates...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CentralPackageManagementNotSupported">
         <source>Central package management is currently not supported by 'aspire update'.</source>
         <target state="translated">中央套件管理目前不受 'aspire update' 支援。</target>
@@ -45,6 +50,11 @@
       <trans-unit id="ChannelOptionDescriptionWithStaging">
         <source>Channel to update to (stable, staging, daily)</source>
         <target state="translated">要更新的通道 (穩定、暫存、每日)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingForUpdates">
+        <source>Checking for updates...</source>
+        <target state="new">Checking for updates...</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotFindPackageVersionInDirectoryPackagesProps">
@@ -75,6 +85,11 @@
       <trans-unit id="ExecutingUpdateStepFormat">
         <source>Executing: {0}</source>
         <target state="translated">正在執行: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExtractingNewCli">
+        <source>Extracting new CLI...</source>
+        <target state="new">Extracting new CLI...</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedDiscoverNuGetConfig">
@@ -175,6 +190,11 @@
       <trans-unit id="QualityOptionDescriptionWithStaging">
         <source>Quality level to update to (stable, staging, daily)</source>
         <target state="translated">要更新的品質等級 (穩定、暫存、每日)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RegeneratingSdkCode">
+        <source>Regenerating SDK code with updated packages...</source>
+        <target state="new">Regenerating SDK code with updated packages...</target>
         <note />
       </trans-unit>
       <trans-unit id="RemovedFeedFormat">

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
@@ -41,15 +41,13 @@ internal sealed partial class CliTemplateFactory
             var defaultOutputPath = $"./{projectName}";
             outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, cancellationToken);
         }
-        if (!Path.IsPathRooted(outputPath))
-        {
-            outputPath = Path.Combine(_executionContext.WorkingDirectory.FullName, outputPath);
-        }
+        outputPath = Path.GetFullPath(outputPath, _executionContext.WorkingDirectory.FullName);
 
         _logger.LogDebug("Applying empty AppHost template. LanguageId: {LanguageId}, Language: {LanguageDisplayName}, ProjectName: {ProjectName}, OutputPath: {OutputPath}.", languageId, language.DisplayName, projectName, outputPath);
 
         var useLocalhostTld = await ResolveUseLocalhostTldAsync(parseResult, cancellationToken);
 
+        TemplateResult templateResult;
         try
         {
             if (!Directory.Exists(outputPath))
@@ -57,22 +55,40 @@ internal sealed partial class CliTemplateFactory
                 Directory.CreateDirectory(outputPath);
             }
 
-            if (language.LanguageId.Value.Equals(Projects.KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase))
+            var isCsharp = language.LanguageId.Value.Equals(Projects.KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase);
+            if (isCsharp)
             {
-                _logger.LogDebug("Using embedded C# empty AppHost template for '{OutputPath}'.", outputPath);
-                await WriteCSharpEmptyAppHostAsync(inputs.Version, outputPath, projectName, useLocalhostTld, cancellationToken);
+                // Do this first so there is no prompt while status is displayed for creating project.
                 await _templateNuGetConfigService.PromptToCreateOrUpdateNuGetConfigAsync(inputs.Channel, outputPath, cancellationToken);
             }
-            else
-            {
-                _logger.LogDebug("Using scaffolding service for language '{LanguageDisplayName}' in '{OutputPath}'.", language.DisplayName, outputPath);
-                var context = new ScaffoldContext(language, new DirectoryInfo(outputPath), projectName);
-                await _scaffoldingService.ScaffoldAsync(context, cancellationToken);
 
-                if (useLocalhostTld)
+            templateResult = await _interactionService.ShowStatusAsync(
+                TemplatingStrings.CreatingNewProject,
+                async () =>
                 {
-                    await ApplyLocalhostTldToScaffoldedRunProfileAsync(outputPath, projectName, cancellationToken);
-                }
+                    if (isCsharp)
+                    {
+                        _logger.LogDebug("Using embedded C# empty AppHost template for '{OutputPath}'.", outputPath);
+                        await WriteCSharpEmptyAppHostAsync(inputs.Version, outputPath, projectName, useLocalhostTld, cancellationToken);
+                    }
+                    else
+                    {
+                        _logger.LogDebug("Using scaffolding service for language '{LanguageDisplayName}' in '{OutputPath}'.", language.DisplayName, outputPath);
+                        var context = new ScaffoldContext(language, new DirectoryInfo(outputPath), projectName);
+                        await _scaffoldingService.ScaffoldAsync(context, cancellationToken);
+
+                        if (useLocalhostTld)
+                        {
+                            await ApplyLocalhostTldToScaffoldedRunProfileAsync(outputPath, projectName, cancellationToken);
+                        }
+                    }
+
+                    return new TemplateResult(ExitCodeConstants.Success, outputPath);
+                }, emoji: KnownEmojis.Rocket);
+
+            if (templateResult.ExitCode != ExitCodeConstants.Success)
+            {
+                return templateResult;
             }
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
@@ -84,7 +100,7 @@ internal sealed partial class CliTemplateFactory
         _interactionService.DisplaySuccess($"Created {language.DisplayName.EscapeMarkup()} project at {outputPath.EscapeMarkup()}");
         _interactionService.DisplayMessage(KnownEmojis.Information, "Run 'aspire run' to start your AppHost.");
 
-        return new TemplateResult(ExitCodeConstants.Success, outputPath);
+        return templateResult;
     }
 
     private async Task<bool> ResolveUseLocalhostTldAsync(System.CommandLine.ParseResult parseResult, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Resources;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 
@@ -31,15 +32,13 @@ internal sealed partial class CliTemplateFactory
             var defaultOutputPath = $"./{projectName}";
             outputPath = await _prompter.PromptForOutputPath(defaultOutputPath, cancellationToken);
         }
-        if (!Path.IsPathRooted(outputPath))
-        {
-            outputPath = Path.Combine(_executionContext.WorkingDirectory.FullName, outputPath);
-        }
+        outputPath = Path.GetFullPath(outputPath, _executionContext.WorkingDirectory.FullName);
 
         _logger.LogDebug("Applying TypeScript starter template. ProjectName: {ProjectName}, OutputPath: {OutputPath}, AspireVersion: {AspireVersion}.", projectName, outputPath, aspireVersion);
 
         var useLocalhostTld = await ResolveUseLocalhostTldAsync(parseResult, cancellationToken);
 
+        TemplateResult templateResult;
         try
         {
             if (!Directory.Exists(outputPath))
@@ -47,14 +46,42 @@ internal sealed partial class CliTemplateFactory
                 Directory.CreateDirectory(outputPath);
             }
 
-            var projectNameLower = projectName.ToLowerInvariant();
+            templateResult = await _interactionService.ShowStatusAsync(
+                TemplatingStrings.CreatingNewProject,
+                async () =>
+                {
+                    var projectNameLower = projectName.ToLowerInvariant();
 
-            // Generate random ports (matching .NET template port ranges)
-            var ports = GenerateRandomPorts();
-            var hostName = useLocalhostTld ? $"{projectNameLower}.dev.localhost" : "localhost";
-            string ApplyAllTokens(string content) => ApplyTokens(content, projectName, projectNameLower, aspireVersion, ports, hostName);
-            _logger.LogDebug("Copying embedded TypeScript starter template files to '{OutputPath}'.", outputPath);
-            await CopyTemplateTreeToDiskAsync("ts-starter", outputPath, ApplyAllTokens, cancellationToken);
+                    // Generate random ports (matching .NET template port ranges)
+                    var ports = GenerateRandomPorts();
+                    var hostName = useLocalhostTld ? $"{projectNameLower}.dev.localhost" : "localhost";
+                    string ApplyAllTokens(string content) => ApplyTokens(content, projectName, projectNameLower, aspireVersion, ports, hostName);
+                    _logger.LogDebug("Copying embedded TypeScript starter template files to '{OutputPath}'.", outputPath);
+                    await CopyTemplateTreeToDiskAsync("ts-starter", outputPath, ApplyAllTokens, cancellationToken);
+
+                    var npmPath = PathLookupHelper.FindFullPathFromPath("npm") ?? PathLookupHelper.FindFullPathFromPath("npm.cmd");
+                    if (npmPath is null)
+                    {
+                        _interactionService.DisplayError("npm is not installed or not found in PATH. Please install Node.js and try again.");
+                        return new TemplateResult(ExitCodeConstants.InvalidCommand);
+                    }
+
+                    // Run npm install in the output directory (non-fatal — package may not be published yet)
+                    _logger.LogDebug("Running npm install for TypeScript starter in '{OutputPath}'.", outputPath);
+                    var npmInstallResult = await RunProcessAsync(npmPath, "install", outputPath, cancellationToken);
+                    if (npmInstallResult.ExitCode != 0)
+                    {
+                        _interactionService.DisplaySubtleMessage("npm install had warnings or errors. You may need to run 'npm install' manually after dependencies are available.");
+                        DisplayProcessOutput(npmInstallResult, treatStandardErrorAsError: false);
+                    }
+
+                    return new TemplateResult(ExitCodeConstants.Success, outputPath);
+                }, emoji: KnownEmojis.Rocket);
+
+            if (templateResult.ExitCode != ExitCodeConstants.Success)
+            {
+                return templateResult;
+            }
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
@@ -62,25 +89,9 @@ internal sealed partial class CliTemplateFactory
             return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
         }
 
-        var npmPath = PathLookupHelper.FindFullPathFromPath("npm") ?? PathLookupHelper.FindFullPathFromPath("npm.cmd");
-        if (npmPath is null)
-        {
-            _interactionService.DisplayError("npm is not installed or not found in PATH. Please install Node.js and try again.");
-            return new TemplateResult(ExitCodeConstants.InvalidCommand);
-        }
-
-        // Run npm install in the output directory (non-fatal — package may not be published yet)
-        _logger.LogDebug("Running npm install for TypeScript starter in '{OutputPath}'.", outputPath);
-        var npmInstallResult = await RunProcessAsync(npmPath, "install", outputPath, cancellationToken);
-        if (npmInstallResult.ExitCode != 0)
-        {
-            _interactionService.DisplaySubtleMessage("npm install had warnings or errors. You may need to run 'npm install' manually after dependencies are available.");
-            DisplayProcessOutput(npmInstallResult, treatStandardErrorAsError: false);
-        }
-
         _interactionService.DisplaySuccess($"Created TypeScript starter project at {outputPath.EscapeMarkup()}");
         _interactionService.DisplayMessage(KnownEmojis.Information, "Run 'aspire run' to start your AppHost.");
 
-        return new TemplateResult(ExitCodeConstants.Success, outputPath);
+        return templateResult;
     }
 }

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -456,7 +456,7 @@ internal class DotNetTemplateFactory(
 
             var templateInstallCollector = new OutputCollector();
             var templateInstallResult = await interactionService.ShowStatusAsync<(int ExitCode, string? TemplateVersion)>(
-                $":ice:  {TemplatingStrings.GettingTemplates}",
+                TemplatingStrings.GettingTemplates,
                 async () =>
                 {
                     var options = new DotNetCliRunnerInvocationOptions()
@@ -480,7 +480,7 @@ internal class DotNetTemplateFactory(
                         options: options,
                         cancellationToken: cancellationToken);
                     return result;
-                });
+                }, emoji: KnownEmojis.Ice);
 
             if (templateInstallResult.ExitCode != 0)
             {

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1108,6 +1108,70 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task NewCommandWithEmptyTemplateNormalizesDefaultOutputPath()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        string? capturedTargetDirectory = null;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.NewCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestNewCommandPrompter(interactionService);
+
+                // Accept the default "./TestApp" path from the prompt
+                prompter.PromptForOutputPathCallback = (path) => path;
+
+                return prompter;
+            };
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
+                {
+                    var package = new NuGetPackage()
+                    {
+                        Id = "Aspire.ProjectTemplates",
+                        Source = "nuget",
+                        Version = "9.2.0"
+                    };
+
+                    return (0, new NuGetPackage[] { package });
+                };
+
+                return runner;
+            };
+        });
+
+        services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
+        {
+            ScaffoldAsyncCallback = (context, cancellationToken) =>
+            {
+                capturedTargetDirectory = context.TargetDirectory.FullName;
+                return Task.CompletedTask;
+            }
+        });
+
+        var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        // Do not pass --output so the default "./TestApp" path is used via the prompter
+        var result = command.Parse("new --language typescript aspire-empty --name TestApp --localhost-tld false");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(capturedTargetDirectory);
+
+        // The output path should be properly normalized without "./" segments
+        Assert.DoesNotContain("./", capturedTargetDirectory);
+        Assert.DoesNotContain(".\\", capturedTargetDirectory);
+
+        var expectedPath = Path.Combine(workspace.WorkspaceRoot.FullName, "TestApp");
+        Assert.Equal(expectedPath, capturedTargetDirectory);
+    }
+
+    [Fact]
     public async Task NewCommandWithEmptyTemplateAndTypeScriptPromptsForLocalhostTldAndUsesSelection()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);


### PR DESCRIPTION
## Description

PR changes:
- Add more status indicators while work is in-progress in commands
- Add status indicators while projects are created in templates
- Fixed bad path combine on Windows for new project path
- In NewCommand, print a message with the selected template (currently cleared when a value is selected)

Fixes https://github.com/dotnet/aspire/issues/14762

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
