### PR TITLE
Update skill to CLI commands, rework agent init, add aspire mcp tools/call

### DIFF
--- a/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
+++ b/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
@@ -55,7 +55,7 @@ internal static class CommonAgentApplicators
                 context.AddApplicator(new AgentEnvironmentApplicator(
                     $"{description} (update - content has changed)",
                     ct => UpdateSkillFileAsync(skillFilePath, ct),
-                    promptGroup: McpInitPromptGroup.AdditionalOptions,
+                    promptGroup: McpInitPromptGroup.SkillFiles,
                     priority: 0));
                 return true;
             }
@@ -68,7 +68,7 @@ internal static class CommonAgentApplicators
         context.AddApplicator(new AgentEnvironmentApplicator(
             description,
             ct => CreateSkillFileAsync(skillFilePath, ct),
-            promptGroup: McpInitPromptGroup.AdditionalOptions,
+            promptGroup: McpInitPromptGroup.SkillFiles,
             priority: 0));
 
         return true;
@@ -98,9 +98,9 @@ internal static class CommonAgentApplicators
 
         context.PlaywrightApplicatorAdded = true;
         context.AddApplicator(new AgentEnvironmentApplicator(
-            "Install Playwright CLI for browser automation",
+            "Install Playwright CLI (Recommended for browser automation)",
             ct => installer.InstallAsync(context, ct),
-            promptGroup: McpInitPromptGroup.AdditionalOptions,
+            promptGroup: McpInitPromptGroup.Tools,
             priority: 1));
     }
 
@@ -146,136 +146,96 @@ internal static class CommonAgentApplicators
         """
         ---
         name: aspire
-        description: "**WORKFLOW SKILL** - Orchestrates Aspire applications using the Aspire CLI and MCP tools for running, debugging, and managing distributed apps. USE FOR: aspire run, aspire stop, start aspire app, aspire describe, list aspire integrations, debug aspire issues, view aspire logs, add aspire resource, aspire dashboard, update aspire apphost. DO NOT USE FOR: non-Aspire .NET apps (use dotnet CLI), container-only deployments (use docker/podman), Azure deployment after local testing (use azure-deploy skill). INVOKES: Aspire MCP tools (list_resources, list_integrations, list_structured_logs, get_doc, search_docs), bash for CLI commands. FOR SINGLE OPERATIONS: Use Aspire MCP tools directly for quick resource status or doc lookups."
+        description: "Orchestrates Aspire distributed applications using the Aspire CLI for running, debugging, and managing distributed apps. USE FOR: aspire start, aspire stop, start aspire app, aspire describe, list aspire integrations, debug aspire issues, view aspire logs, add aspire resource, aspire dashboard, update aspire apphost. DO NOT USE FOR: non-Aspire .NET apps (use dotnet CLI), container-only deployments (use docker/podman), Azure deployment after local testing (use azure-deploy skill). INVOKES: Aspire CLI commands (aspire start, aspire describe, aspire otel logs, aspire docs search, aspire add), bash. FOR SINGLE OPERATIONS: Use Aspire CLI commands directly for quick resource status or doc lookups."
         ---
 
         # Aspire Skill
 
-        This repository is set up to use Aspire. Aspire is an orchestrator for the entire application and will take care of configuring dependencies, building, and running the application. The resources that make up the application are defined in `apphost.cs` including application code and external dependencies.
+        This repository uses Aspire to orchestrate its distributed application. Resources are defined in the AppHost project (`apphost.cs` or `apphost.ts`).
 
-        ## General recommendations for working with Aspire
+        ## CLI command reference
 
-        1. Before making any changes always run the apphost using `aspire run` and inspect the state of resources to make sure you are building from a known state.
-        2. Changes to the _apphost.cs_ file will require a restart of the application to take effect.
-        3. Make changes incrementally and run the aspire application using the `aspire run` command to validate changes.
-        4. Use the Aspire MCP tools to check the status of resources and debug issues.
+        | Task | Command |
+        |---|---|
+        | Start the app | `aspire start` |
+        | Start isolated (worktrees) | `aspire start --isolated` |
+        | Restart the app | `aspire start` (stops previous automatically) |
+        | Wait for resource healthy | `aspire wait <resource>` |
+        | Stop the app | `aspire stop` |
+        | List resources | `aspire describe` or `aspire resources` |
+        | Run resource command | `aspire resource <resource> <command>` |
+        | Start/stop/restart resource | `aspire resource <resource> start|stop|restart` |
+        | View console logs | `aspire logs [resource]` |
+        | View structured logs | `aspire otel logs [resource]` |
+        | View traces | `aspire otel traces [resource]` |
+        | Logs for a trace | `aspire otel logs --trace-id <id>` |
+        | Add an integration | `aspire add` |
+        | List running AppHosts | `aspire ps` |
+        | Update AppHost packages | `aspire update` |
+        | Search docs | `aspire docs search <query>` |
+        | Get doc page | `aspire docs get <slug>` |
+        | List doc pages | `aspire docs list` |
+        | Environment diagnostics | `aspire doctor` |
+        | List resource MCP tools | `aspire mcp tools` |
+        | Call resource MCP tool | `aspire mcp call <resource> <tool> --input <json>` |
 
-        ## Running Aspire in agent environments
+        Most commands support `--format Json` for machine-readable output. Use `--apphost <path>` to target a specific AppHost.
 
-        Agent environments may terminate foreground processes when a command finishes. Use detached mode:
+        ## Key workflows
 
-        ```bash
-        aspire run --detach
-        ```
+        ### Running in agent environments
 
-        This starts the AppHost in the background and returns immediately. The CLI will:
-        - Automatically stop any existing running instance before starting a new one
-        - Display a summary with the Dashboard URL and resource endpoints
-
-        ### Running with isolation
-
-        The `--isolated` flag starts the AppHost with randomized port numbers and its own copy of user secrets.
-
-        ```bash
-        aspire run --detach --isolated
-        ```
-
-        Isolation should be used when:
-        - When AppHosts are started by background agents
-        - When agents are using source code from a work tree
-        - There are port conflicts when starting the AppHost without isolation
-
-        ### Stopping the application
-
-        To stop a running AppHost:
+        Use `aspire start` to run the AppHost in the background. When working in a git worktree, use `--isolated` to avoid port conflicts and to prevent sharing user secrets or other local state with other running instances:
 
         ```bash
-        aspire stop
+        aspire start --isolated
         ```
 
-        This will scan for running AppHosts and stop them gracefully.
-
-        ### Relaunch rules
-
-        - If AppHost code changes, run `aspire run --detach` again to restart with the new code.
-        - Relaunching is safe: starting a new instance will automatically stop the previous instance.
-        - Do not attempt to keep multiple instances running.
-
-        ## Running the application
-
-        To run the application run the following command:
+        Use `aspire wait <resource>` to block until a resource is healthy before interacting with it:
 
         ```bash
-        aspire run
+        aspire start --isolated
+        aspire wait myapi
         ```
 
-        If there is already an instance of the application running it will prompt to stop the existing instance. You only need to restart the application if code in `apphost.cs` is changed, but if you experience problems it can be useful to reset everything to the starting state.
+        Relaunching is safe — `aspire start` automatically stops any previous instance. Re-run `aspire start` whenever changes are made to the AppHost project.
 
-        ## Checking resources
+        ### Debugging issues
 
-        To check the status of resources defined in the app model use the _list resources_ tool. This will show you the current state of each resource and if there are any issues. If a resource is not running as expected you can use the _execute resource command_ tool to restart it or perform other actions.
+        Before making code changes, inspect the app state:
 
-        ## Listing integrations
+        1. `aspire describe` — check resource status
+        2. `aspire otel logs <resource>` — view structured logs
+        3. `aspire logs <resource>` — view console output
+        4. `aspire otel traces <resource>` — view distributed traces
 
-        IMPORTANT! When a user asks you to add a resource to the app model you should first use the _list integrations_ tool to get a list of the current versions of all the available integrations. You should try to use the version of the integration which aligns with the version of the Aspire.AppHost.Sdk. Some integration versions may have a preview suffix. Once you have identified the correct integration you should always use the _get integration docs_ tool to fetch the latest documentation for the integration and follow the links to get additional guidance.
+        ### Adding integrations
 
-        ## Debugging issues
+        Use `aspire docs search` to find integration documentation, then `aspire docs get` to read the full guide. Use `aspire add` to add the integration package to the AppHost.
 
-        IMPORTANT! Aspire is designed to capture rich logs and telemetry for all resources defined in the app model. Use the following diagnostic tools when debugging issues with the application before making changes to make sure you are focusing on the right things.
+        After adding an integration, restart the app with `aspire start` for the new resource to take effect.
 
-        1. _list structured logs_; use this tool to get details about structured logs.
-        2. _list console logs_; use this tool to get details about console logs.
-        3. _list traces_; use this tool to get details about traces.
-        4. _list trace structured logs_; use this tool to get logs related to a trace
+        ### Using resource MCP tools
 
-        ## Other Aspire MCP tools
+        Some resources expose MCP tools (e.g. `WithPostgresMcp()` adds SQL query tools). Discover and call them via CLI:
 
-        1. _select apphost_; use this tool if working with multiple app hosts within a workspace.
-        2. _list apphosts_; use this tool to get details about active app hosts.
+        ```bash
+        aspire mcp tools                                              # list available tools
+        aspire mcp tools --format Json                                # includes input schemas
+        aspire mcp call <resource> <tool> --input '{"key":"value"}'   # invoke a tool
+        ```
+
+        ## Important rules
+
+        - **Always start the app first** (`aspire start`) before making changes to verify the starting state.
+        - **To restart, just run `aspire start` again** — it automatically stops the previous instance. NEVER use `aspire stop` then `aspire run`. NEVER use `aspire run` at all.
+        - Use `--isolated` when working in a worktree.
+        - **Avoid persistent containers** early in development to prevent state management issues.
+        - **Never install the Aspire workload** — it is obsolete.
+        - Prefer `aspire.dev` and `learn.microsoft.com/dotnet/aspire` for official documentation.
 
         ## Playwright CLI
 
-        The Playwright CLI has been installed in this repository for browser automation. Use it to perform functional investigations of the resources defined in the app model as you work on the codebase. To get endpoints that can be used for navigation use the list resources tool. Run `playwright-cli --help` for available commands.
-
-        ## Updating the app host
-
-        The user may request that you update the Aspire apphost. You can do this using the `aspire update` command. This will update the apphost to the latest version and some of the Aspire specific packages in referenced projects, however you may need to manually update other packages in the solution to ensure compatibility. You can consider using the `dotnet-outdated` with the users consent. To install the `dotnet-outdated` tool use the following command:
-
-        ```bash
-        dotnet tool install --global dotnet-outdated-tool
-        ```
-
-        ## Persistent containers
-
-        IMPORTANT! Consider avoiding persistent containers early during development to avoid creating state management issues when restarting the app.
-
-        ## Aspire workload
-
-        IMPORTANT! The aspire workload is obsolete. You should never attempt to install or use the Aspire workload.
-
-        ## Aspire Documentation Tools
-
-        IMPORTANT! The Aspire MCP server provides tools to search and retrieve official Aspire documentation directly. Use these tools to find accurate, up-to-date information about Aspire features, APIs, and integrations:
-
-        1. **list_docs**: Lists all available documentation pages from aspire.dev. Returns titles, slugs, and summaries. Use this to discover available topics.
-
-        2. **search_docs**: Searches the documentation using keywords. Returns ranked results with titles, slugs, and matched content. Use this when looking for specific features, APIs, or concepts.
-
-        3. **get_doc**: Retrieves the full content of a documentation page by its slug. After using `list_docs` or `search_docs` to find a relevant page, pass the slug to `get_doc` to retrieve the complete documentation.
-
-        ### Recommended workflow for documentation
-
-        1. Use `search_docs` with relevant keywords to find documentation about a topic
-        2. Review the search results - each result includes a **Slug** that identifies the page
-        3. Use `get_doc` with the slug to retrieve the full documentation content
-        4. Optionally use the `section` parameter with `get_doc` to retrieve only a specific section
-
-        ## Official documentation
-
-        IMPORTANT! Always prefer official documentation when available. The following sites contain the official documentation for Aspire and related components
-
-        1. https://aspire.dev
-        2. https://learn.microsoft.com/dotnet/aspire
-        3. https://nuget.org (for specific integration package details)
+        If configured, use Playwright CLI for functional testing of resources. Get endpoints via `aspire describe`. Run `playwright-cli --help` for available commands.
         """;
 }

--- a/src/Aspire.Cli/Agents/McpInitPromptGroup.cs
+++ b/src/Aspire.Cli/Agents/McpInitPromptGroup.cs
@@ -9,19 +9,29 @@ namespace Aspire.Cli.Agents;
 internal sealed class McpInitPromptGroup
 {
     /// <summary>
-    /// Group for updating deprecated agent configurations (highest priority).
+    /// Group for updating deprecated agent configurations (applied silently).
     /// </summary>
     public static readonly McpInitPromptGroup ConfigUpdates = new("ConfigUpdates", priority: -1);
 
     /// <summary>
-    /// Group for agent environment configurations (VS Code, Copilot CLI, etc.).
+    /// Group for agent environment MCP server configurations (VS Code, Copilot CLI, etc.).
     /// </summary>
     public static readonly McpInitPromptGroup AgentEnvironments = new("AgentEnvironments", priority: 0);
 
     /// <summary>
-    /// Group for additional optional configurations (AGENTS.md, Playwright, etc.).
+    /// Group for skill file installations.
     /// </summary>
-    public static readonly McpInitPromptGroup AdditionalOptions = new("AdditionalOptions", priority: 1);
+    public static readonly McpInitPromptGroup SkillFiles = new("SkillFiles", priority: 1);
+
+    /// <summary>
+    /// Group for additional tool installations (Playwright CLI, etc.).
+    /// </summary>
+    public static readonly McpInitPromptGroup Tools = new("Tools", priority: 2);
+
+    /// <summary>
+    /// Group for additional optional configurations.
+    /// </summary>
+    public static readonly McpInitPromptGroup AdditionalOptions = new("AdditionalOptions", priority: 3);
 
     private McpInitPromptGroup(string name, int priority)
     {

--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -150,43 +150,107 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
             return ExitCodeConstants.Success;
         }
 
-        // Group applicators by prompt group and sort by priority
-        var groupedApplicators = applicators
-            .GroupBy(a => a.PromptGroup)
-            .OrderBy(g => g.Key.Priority)
-            .ToList();
+        // Apply deprecated config migrations silently (these are fixes, not choices)
+        var configUpdates = applicators.Where(a => a.PromptGroup == McpInitPromptGroup.ConfigUpdates).ToList();
+        var userChoices = applicators.Where(a => a.PromptGroup != McpInitPromptGroup.ConfigUpdates).ToList();
 
-        var selectedApplicators = new List<AgentEnvironmentApplicator>();
-
-        // Present each group of prompts in priority order
-        foreach (var group in groupedApplicators)
+        foreach (var update in configUpdates)
         {
-            // Get the prompt text for this group
-            var promptText = group.Key.Name switch
+            try
             {
-                "ConfigUpdates" => AgentCommandStrings.ConfigUpdatesSelectPrompt,
-                "AgentEnvironments" => McpCommandStrings.InitCommand_AgentConfigurationSelectPrompt,
-                "AdditionalOptions" => McpCommandStrings.InitCommand_AdditionalOptionsSelectPrompt,
-                _ => $"Select {group.Key.Name}:"
-            };
-
-            // Sort applicators within the group by priority
-            var sortedApplicators = group.OrderBy(a => a.Priority).ToArray();
-
-            // Prompt user for selection from this group
-            var selected = await _interactionService.PromptForSelectionsAsync(
-                promptText,
-                sortedApplicators,
-                applicator => applicator.Description,
-                optional: true,
-                cancellationToken);
-
-            selectedApplicators.AddRange(selected);
+                await update.ApplyAsync(cancellationToken);
+                _interactionService.DisplayMessage(KnownEmojis.Wrench, update.Description);
+            }
+            catch (InvalidOperationException ex)
+            {
+                _interactionService.DisplayError(ex.Message);
+            }
         }
 
-        // Apply all selected applicators
+        if (userChoices.Count == 0)
+        {
+            _interactionService.DisplaySuccess(McpCommandStrings.InitCommand_ConfigurationComplete);
+            return ExitCodeConstants.Success;
+        }
+
+        // Categorize by prompt group (not string matching)
+        var skillApplicators = userChoices
+            .Where(a => a.PromptGroup == McpInitPromptGroup.SkillFiles)
+            .ToList();
+        var mcpApplicators = userChoices
+            .Where(a => a.PromptGroup == McpInitPromptGroup.AgentEnvironments)
+            .ToList();
+        var toolApplicators = userChoices
+            .Where(a => a.PromptGroup == McpInitPromptGroup.Tools)
+            .ToList();
+        var otherApplicators = userChoices
+            .Except(skillApplicators)
+            .Except(mcpApplicators)
+            .Except(toolApplicators)
+            .ToList();
+
+        // Build a flat list: collapsed skill (pre-selected), then others (Playwright CLI, etc.)
+        var promptChoices = new List<AgentEnvironmentApplicator>();
+
+        // Collapse all skill applicators into a single line (pre-selected)
+        AgentEnvironmentApplicator? combinedSkillApplicator = null;
+        if (skillApplicators.Count > 0)
+        {
+            combinedSkillApplicator = new AgentEnvironmentApplicator(
+                AgentCommandStrings.InitCommand_InstallSkillFile,
+                async ct =>
+                {
+                    foreach (var skill in skillApplicators)
+                    {
+                        await skill.ApplyAsync(ct);
+                        _interactionService.DisplayMessage(KnownEmojis.CheckMark, skill.Description);
+                    }
+                },
+                promptGroup: McpInitPromptGroup.AdditionalOptions);
+            promptChoices.Add(combinedSkillApplicator);
+        }
+
+        promptChoices.AddRange(toolApplicators);
+        promptChoices.AddRange(otherApplicators);
+
+        // Add collapsed MCP as last option for compatibility
+        if (mcpApplicators.Count > 0)
+        {
+            var combinedMcpApplicator = new AgentEnvironmentApplicator(
+                AgentCommandStrings.InitCommand_ConfigureMcpServer,
+                async ct =>
+                {
+                    foreach (var mcp in mcpApplicators)
+                    {
+                        await mcp.ApplyAsync(ct);
+                        _interactionService.DisplayMessage(KnownEmojis.CheckMark, mcp.Description);
+                    }
+                },
+                promptGroup: McpInitPromptGroup.AdditionalOptions);
+            promptChoices.Add(combinedMcpApplicator);
+        }
+
+        // Pre-select the skill applicator
+        var preSelected = combinedSkillApplicator is not null ? [combinedSkillApplicator] : Array.Empty<AgentEnvironmentApplicator>();
+
+        // Present a single flat prompt with skill pre-selected
+        var selected = await _interactionService.PromptForSelectionsAsync(
+            AgentCommandStrings.InitCommand_WhatToConfigure,
+            promptChoices,
+            applicator => applicator.Description,
+            preSelected: preSelected,
+            optional: true,
+            cancellationToken);
+
+        if (selected.Count == 0)
+        {
+            _interactionService.DisplaySubtleMessage(AgentCommandStrings.InitCommand_NothingSelected);
+            return ExitCodeConstants.Success;
+        }
+
+        // Apply selected applicators
         var hasErrors = false;
-        foreach (var applicator in selectedApplicators)
+        foreach (var applicator in selected)
         {
             try
             {

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -266,8 +266,7 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
                 initContext.ExecutableProjects,
                 project => Path.GetFileNameWithoutExtension(project.ProjectFile.Name).EscapeMarkup(),
                 optional: true,
-                cancellationToken);
-
+                cancellationToken: cancellationToken);
             initContext.ExecutableProjectsToAddToAppHost = selectedProjects;
 
             // If projects were selected, prompt for which should have ServiceDefaults added
@@ -320,7 +319,7 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
                             initContext.ExecutableProjectsToAddToAppHost,
                             project => Path.GetFileNameWithoutExtension(project.ProjectFile.Name).EscapeMarkup(),
                             optional: true,
-                            cancellationToken);
+                            cancellationToken: cancellationToken);
                         break;
                     case "none":
                         initContext.ProjectsToAddServiceDefaultsTo = Array.Empty<ExecutableProjectInfo>();

--- a/src/Aspire.Cli/Commands/McpCallCommand.cs
+++ b/src/Aspire.Cli/Commands/McpCallCommand.cs
@@ -1,0 +1,151 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.Globalization;
+using System.Text.Json;
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Resources;
+using Aspire.Cli.Telemetry;
+using Aspire.Cli.Utils;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol;
+
+namespace Aspire.Cli.Commands;
+
+/// <summary>
+/// Calls an MCP tool on a running Aspire resource.
+/// </summary>
+internal sealed class McpCallCommand : BaseCommand
+{
+    internal override HelpGroup HelpGroup => HelpGroup.ToolsAndConfiguration;
+
+    private readonly IInteractionService _interactionService;
+    private readonly AppHostConnectionResolver _connectionResolver;
+
+    private static readonly Argument<string> s_resourceArgument = new("resource")
+    {
+        Description = "The name of the resource that exposes the MCP tool."
+    };
+
+    private static readonly Argument<string> s_toolArgument = new("tool")
+    {
+        Description = "The name of the MCP tool to call."
+    };
+
+    private static readonly Option<string?> s_inputOption = new("--input", "-i")
+    {
+        Description = "JSON input to pass to the tool."
+    };
+
+    private static readonly OptionWithLegacy<FileInfo?> s_appHostOption = new("--apphost", "--project", SharedCommandStrings.AppHostOptionDescription);
+
+    public McpCallCommand(
+        IInteractionService interactionService,
+        IAuxiliaryBackchannelMonitor backchannelMonitor,
+        IFeatures features,
+        ICliUpdateNotifier updateNotifier,
+        CliExecutionContext executionContext,
+        AspireCliTelemetry telemetry,
+        ILogger<McpCallCommand> logger)
+        : base("call", "Call an MCP tool on a running resource.", features, updateNotifier, executionContext, interactionService, telemetry)
+    {
+        _interactionService = interactionService;
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, executionContext, logger);
+
+        Arguments.Add(s_resourceArgument);
+        Arguments.Add(s_toolArgument);
+        Options.Add(s_inputOption);
+        Options.Add(s_appHostOption);
+    }
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        var resourceName = parseResult.GetValue(s_resourceArgument)!;
+        var toolName = parseResult.GetValue(s_toolArgument)!;
+        var inputJson = parseResult.GetValue(s_inputOption);
+        var passedAppHostProjectFile = parseResult.GetValue(s_appHostOption);
+
+        var result = await _connectionResolver.ResolveConnectionAsync(
+            passedAppHostProjectFile,
+            SharedCommandStrings.ScanningForRunningAppHosts,
+            string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.SelectAppHost, "call MCP tool on"),
+            SharedCommandStrings.AppHostNotRunning,
+            cancellationToken);
+
+        if (!result.Success)
+        {
+            _interactionService.DisplayError(result.ErrorMessage);
+            return ExitCodeConstants.FailedToDotnetRunAppHost;
+        }
+
+        var connection = result.Connection!;
+
+        // Parse input JSON into arguments dictionary
+        IReadOnlyDictionary<string, JsonElement>? arguments = null;
+        if (!string.IsNullOrEmpty(inputJson))
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(inputJson);
+                var dict = new Dictionary<string, JsonElement>();
+                foreach (var prop in doc.RootElement.EnumerateObject())
+                {
+                    dict[prop.Name] = prop.Value.Clone();
+                }
+                arguments = dict;
+            }
+            catch (JsonException ex)
+            {
+                _interactionService.DisplayError($"Invalid JSON input: {ex.Message}");
+                return ExitCodeConstants.InvalidCommand;
+            }
+        }
+
+        try
+        {
+            var callResult = await connection.CallResourceMcpToolAsync(
+                resourceName,
+                toolName,
+                arguments,
+                cancellationToken);
+
+            // Output the result content
+            if (callResult.Content is { Count: > 0 })
+            {
+                foreach (var content in callResult.Content)
+                {
+                    if (content is TextContentBlock textContent)
+                    {
+                        _interactionService.DisplayRawText(textContent.Text);
+                    }
+                    else
+                    {
+                        using var stream = new MemoryStream();
+                        using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true }))
+                        {
+                            writer.WriteStartObject();
+                            writer.WriteString("type", content.Type);
+                            writer.WriteEndObject();
+                        }
+                        _interactionService.DisplayRawText(System.Text.Encoding.UTF8.GetString(stream.ToArray()));
+                    }
+                }
+            }
+
+            if (callResult.IsError == true)
+            {
+                return ExitCodeConstants.InvalidCommand;
+            }
+
+            return ExitCodeConstants.Success;
+        }
+        catch (Exception ex)
+        {
+            _interactionService.DisplayError($"Failed to call tool '{toolName}' on resource '{resourceName}': {ex.Message}");
+            return ExitCodeConstants.InvalidCommand;
+        }
+    }
+}

--- a/src/Aspire.Cli/Commands/McpCallCommand.cs
+++ b/src/Aspire.Cli/Commands/McpCallCommand.cs
@@ -90,6 +90,11 @@ internal sealed class McpCallCommand : BaseCommand
             try
             {
                 using var doc = JsonDocument.Parse(inputJson);
+                if (doc.RootElement.ValueKind != JsonValueKind.Object)
+                {
+                    _interactionService.DisplayError("Invalid JSON input: expected a JSON object.");
+                    return ExitCodeConstants.InvalidCommand;
+                }
                 var dict = new Dictionary<string, JsonElement>();
                 foreach (var prop in doc.RootElement.EnumerateObject())
                 {

--- a/src/Aspire.Cli/Commands/McpCommand.cs
+++ b/src/Aspire.Cli/Commands/McpCommand.cs
@@ -12,10 +12,13 @@ using Aspire.Cli.Utils;
 namespace Aspire.Cli.Commands;
 
 /// <summary>
-/// Legacy MCP command for backward compatibility. Hidden in favor of 'aspire agent' command.
+/// MCP command for interacting with MCP tools exposed by running resources.
+/// Also provides legacy 'start' and 'init' subcommands for backward compatibility.
 /// </summary>
 internal sealed class McpCommand : BaseCommand
 {
+    internal override HelpGroup HelpGroup => HelpGroup.ToolsAndConfiguration;
+
     public McpCommand(
         IInteractionService interactionService,
         IFeatures features,
@@ -23,12 +26,17 @@ internal sealed class McpCommand : BaseCommand
         CliExecutionContext executionContext,
         McpStartCommand startCommand,
         McpInitCommand initCommand,
+        McpToolsCommand toolsCommand,
+        McpCallCommand callCommand,
         AspireCliTelemetry telemetry)
         : base("mcp", McpCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
-        // Mark as hidden - use 'aspire agent' instead
-        Hidden = true;
+        Subcommands.Add(toolsCommand);
+        Subcommands.Add(callCommand);
 
+        // Legacy subcommands — hidden, use 'aspire agent' instead
+        startCommand.Hidden = true;
+        initCommand.Hidden = true;
         Subcommands.Add(startCommand);
         Subcommands.Add(initCommand);
     }

--- a/src/Aspire.Cli/Commands/McpToolsCommand.cs
+++ b/src/Aspire.Cli/Commands/McpToolsCommand.cs
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.Globalization;
+using System.Text.Json;
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Resources;
+using Aspire.Cli.Telemetry;
+using Aspire.Cli.Utils;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+
+namespace Aspire.Cli.Commands;
+
+/// <summary>
+/// Lists MCP tools exposed by running Aspire resources.
+/// </summary>
+internal sealed class McpToolsCommand : BaseCommand
+{
+    internal override HelpGroup HelpGroup => HelpGroup.ToolsAndConfiguration;
+
+    private readonly IInteractionService _interactionService;
+    private readonly AppHostConnectionResolver _connectionResolver;
+
+    private static readonly OptionWithLegacy<FileInfo?> s_appHostOption = new("--apphost", "--project", SharedCommandStrings.AppHostOptionDescription);
+    private static readonly Option<OutputFormat> s_formatOption = new("--format")
+    {
+        Description = "Output format (Table or Json)."
+    };
+
+    public McpToolsCommand(
+        IInteractionService interactionService,
+        IAuxiliaryBackchannelMonitor backchannelMonitor,
+        IFeatures features,
+        ICliUpdateNotifier updateNotifier,
+        CliExecutionContext executionContext,
+        AspireCliTelemetry telemetry,
+        ILogger<McpToolsCommand> logger)
+        : base("tools", "List MCP tools exposed by running resources.", features, updateNotifier, executionContext, interactionService, telemetry)
+    {
+        _interactionService = interactionService;
+        _connectionResolver = new AppHostConnectionResolver(backchannelMonitor, interactionService, executionContext, logger);
+
+        Options.Add(s_appHostOption);
+        Options.Add(s_formatOption);
+    }
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        var passedAppHostProjectFile = parseResult.GetValue(s_appHostOption);
+        var format = parseResult.GetValue(s_formatOption);
+
+        var result = await _connectionResolver.ResolveConnectionAsync(
+            passedAppHostProjectFile,
+            SharedCommandStrings.ScanningForRunningAppHosts,
+            string.Format(CultureInfo.CurrentCulture, SharedCommandStrings.SelectAppHost, "list MCP tools for"),
+            SharedCommandStrings.AppHostNotRunning,
+            cancellationToken);
+
+        if (!result.Success)
+        {
+            _interactionService.DisplayMessage(KnownEmojis.Information, result.ErrorMessage);
+            return ExitCodeConstants.Success;
+        }
+
+        var connection = result.Connection!;
+        var snapshots = await connection.GetResourceSnapshotsAsync(cancellationToken);
+        var resourcesWithTools = snapshots.Where(r => r.McpServer is not null).ToList();
+
+        if (resourcesWithTools.Count == 0)
+        {
+            _interactionService.DisplayMessage(KnownEmojis.Information, "No resources with MCP tools found.");
+            return ExitCodeConstants.Success;
+        }
+
+        if (format == OutputFormat.Json)
+        {
+            using var stream = new MemoryStream();
+            using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true }))
+            {
+                writer.WriteStartArray();
+                foreach (var r in resourcesWithTools)
+                {
+                    var resourceName = r.DisplayName ?? r.Name;
+                    foreach (var t in r.McpServer!.Tools)
+                    {
+                        writer.WriteStartObject();
+                        writer.WriteString("resource", resourceName);
+                        writer.WriteString("tool", t.Name);
+                        writer.WriteString("description", t.Description ?? "");
+                        writer.WritePropertyName("inputSchema");
+                        t.InputSchema.WriteTo(writer);
+                        writer.WriteEndObject();
+                    }
+                }
+                writer.WriteEndArray();
+            }
+
+            _interactionService.DisplayRawText(System.Text.Encoding.UTF8.GetString(stream.ToArray()));
+        }
+        else
+        {
+            var table = new Table();
+            table.AddColumn("Resource");
+            table.AddColumn("Tool");
+            table.AddColumn("Description");
+
+            foreach (var resource in resourcesWithTools)
+            {
+                var resourceName = resource.DisplayName ?? resource.Name;
+                foreach (var tool in resource.McpServer!.Tools)
+                {
+                    table.AddRow(
+                        resourceName.EscapeMarkup(),
+                        tool.Name.EscapeMarkup(),
+                        (tool.Description ?? "").EscapeMarkup());
+                }
+            }
+
+            _interactionService.DisplayRenderable(table);
+        }
+
+        return ExitCodeConstants.Success;
+    }
+}

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -190,7 +190,7 @@ internal class ConsoleInteractionService : IInteractionService
         return await _outConsole.PromptAsync(prompt, cancellationToken);
     }
 
-    public async Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
+    public async Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
     {
         ArgumentNullException.ThrowIfNull(promptText, nameof(promptText));
         ArgumentNullException.ThrowIfNull(choices, nameof(choices));
@@ -201,21 +201,29 @@ internal class ConsoleInteractionService : IInteractionService
             throw new InvalidOperationException(InteractionServiceStrings.InteractiveInputNotSupported);
         }
 
-        // Check if the choices collection is empty to avoid throwing an InvalidOperationException
-        if (!choices.Any())
+        var choicesList = choices.ToList();
+
+        if (choicesList.Count == 0)
         {
             throw new EmptyChoicesException(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NoItemsAvailableForSelection, promptText));
         }
 
+        var preSelectedSet = preSelected is not null ? new HashSet<T>(preSelected) : null;
+
         var prompt = new MultiSelectionPrompt<T>()
             .Title(promptText)
             .UseConverter(choiceFormatter)
-            .AddChoices(choices)
             .PageSize(10);
 
-        if (optional)
+        prompt.Required = !optional;
+
+        foreach (var choice in choicesList)
         {
-            prompt.NotRequired();
+            var item = prompt.AddChoice(choice);
+            if (preSelectedSet?.Contains(choice) == true)
+            {
+                item.Select();
+            }
         }
 
         var result = await _outConsole.PromptAsync(prompt, cancellationToken);

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -263,7 +263,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
     }
 
     public async Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter,
-        bool optional = false, CancellationToken cancellationToken = default) where T : notnull
+        IEnumerable<T>? preSelected = null, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
     {
         if (_extensionPromptEnabled)
         {
@@ -290,7 +290,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         }
         else
         {
-            return await _consoleInteractionService.PromptForSelectionsAsync(promptText, choices, choiceFormatter, optional, cancellationToken);
+            return await _consoleInteractionService.PromptForSelectionsAsync(promptText, choices, choiceFormatter, preSelected, optional, cancellationToken);
         }
     }
 

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -273,6 +273,8 @@ internal class ExtensionInteractionService : IExtensionInteractionService
             {
                 try
                 {
+                    // Note: The extension backchannel protocol does not yet support preSelected items.
+                    // Pre-selected items are applied only when falling back to the console interaction service.
                     var result = await Backchannel.PromptForSelectionsAsync(promptText.RemoveSpectreFormatting(), choices, choiceFormatter, _cancellationToken).ConfigureAwait(false);
                     tcs.SetResult(result);
                 }

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -15,7 +15,7 @@ internal interface IInteractionService
     Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default);
     public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default);
     Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull;
-    Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool optional = false, CancellationToken cancellationToken = default) where T : notnull;
+    Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, CancellationToken cancellationToken = default) where T : notnull;
     int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion);
     void DisplayError(string errorMessage);
     void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false);

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -389,6 +389,8 @@ public class Program
         builder.Services.AddTransient<McpCommand>();
         builder.Services.AddTransient<McpStartCommand>();
         builder.Services.AddTransient<McpInitCommand>();
+        builder.Services.AddTransient<McpToolsCommand>();
+        builder.Services.AddTransient<McpCallCommand>();
         builder.Services.AddTransient<AgentCommand>();
         builder.Services.AddTransient<AgentMcpCommand>();
         builder.Services.AddTransient<AgentInitCommand>();

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.Designer.cs
@@ -149,5 +149,50 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("ConfigurationCompletedWithErrors", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to None — skip.
+        /// </summary>
+        internal static string SkipNoneDescription {
+            get {
+                return ResourceManager.GetString("SkipNoneDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to What would you like to configure?.
+        /// </summary>
+        internal static string InitCommand_WhatToConfigure {
+            get {
+                return ResourceManager.GetString("InitCommand_WhatToConfigure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No options selected. Nothing to configure..
+        /// </summary>
+        internal static string InitCommand_NothingSelected {
+            get {
+                return ResourceManager.GetString("InitCommand_NothingSelected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Install Aspire MCP server.
+        /// </summary>
+        internal static string InitCommand_ConfigureMcpServer {
+            get {
+                return ResourceManager.GetString("InitCommand_ConfigureMcpServer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Install Aspire skill file (Recommended).
+        /// </summary>
+        internal static string InitCommand_InstallSkillFile {
+            get {
+                return ResourceManager.GetString("InitCommand_InstallSkillFile", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/AgentCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AgentCommandStrings.resx
@@ -90,4 +90,19 @@
   <data name="ConfigurationCompletedWithErrors" xml:space="preserve">
     <value>Configuration completed with errors. Please fix the reported issues and re-run the command.</value>
   </data>
+  <data name="SkipNoneDescription" xml:space="preserve">
+    <value>None — skip</value>
+  </data>
+  <data name="InitCommand_WhatToConfigure" xml:space="preserve">
+    <value>What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</value>
+  </data>
+  <data name="InitCommand_NothingSelected" xml:space="preserve">
+    <value>No options selected. Nothing to configure.</value>
+  </data>
+  <data name="InitCommand_ConfigureMcpServer" xml:space="preserve">
+    <value>Install Aspire MCP server</value>
+  </data>
+  <data name="InitCommand_InstallSkillFile" xml:space="preserve">
+    <value>Install Aspire skill file (Recommended)</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.cs.xlf
@@ -27,9 +27,29 @@
         <target state="needs-review-translation">Spravujte integrace agentů AI.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_ConfigureMcpServer">
+        <source>Install Aspire MCP server</source>
+        <target state="new">Install Aspire MCP server</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_Description">
         <source>Initialize agent environment configuration for detected agents.</source>
         <target state="translated">Inicializujte konfiguraci prostředí agentů pro zjištěné agenty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstallSkillFile">
+        <source>Install Aspire skill file (Recommended)</source>
+        <target state="new">Install Aspire skill file (Recommended)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_NothingSelected">
+        <source>No options selected. Nothing to configure.</source>
+        <target state="new">No options selected. Nothing to configure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WhatToConfigure">
+        <source>What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</source>
+        <target state="new">What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</target>
         <note />
       </trans-unit>
       <trans-unit id="MalformedConfigFileError">
@@ -40,6 +60,11 @@
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">Spusťte server MCP (Model Context Protocol).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SkipNoneDescription">
+        <source>None — skip</source>
+        <target state="new">None — skip</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedMalformedConfigFile">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.de.xlf
@@ -27,9 +27,29 @@
         <target state="needs-review-translation">Verwalten von KI-Agent-Integrationen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_ConfigureMcpServer">
+        <source>Install Aspire MCP server</source>
+        <target state="new">Install Aspire MCP server</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_Description">
         <source>Initialize agent environment configuration for detected agents.</source>
         <target state="translated">Initialisieren Sie die Agent-Umgebungskonfiguration für erkannte Agenten.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstallSkillFile">
+        <source>Install Aspire skill file (Recommended)</source>
+        <target state="new">Install Aspire skill file (Recommended)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_NothingSelected">
+        <source>No options selected. Nothing to configure.</source>
+        <target state="new">No options selected. Nothing to configure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WhatToConfigure">
+        <source>What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</source>
+        <target state="new">What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</target>
         <note />
       </trans-unit>
       <trans-unit id="MalformedConfigFileError">
@@ -40,6 +60,11 @@
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">Starten Sie den MCP-Server (Model Context Protocol).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SkipNoneDescription">
+        <source>None — skip</source>
+        <target state="new">None — skip</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedMalformedConfigFile">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.es.xlf
@@ -27,9 +27,29 @@
         <target state="needs-review-translation">Administrar integraciones de agentes de IA.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_ConfigureMcpServer">
+        <source>Install Aspire MCP server</source>
+        <target state="new">Install Aspire MCP server</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_Description">
         <source>Initialize agent environment configuration for detected agents.</source>
         <target state="translated">Inicialice la configuración del entorno del agente para los agentes detectados.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstallSkillFile">
+        <source>Install Aspire skill file (Recommended)</source>
+        <target state="new">Install Aspire skill file (Recommended)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_NothingSelected">
+        <source>No options selected. Nothing to configure.</source>
+        <target state="new">No options selected. Nothing to configure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WhatToConfigure">
+        <source>What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</source>
+        <target state="new">What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</target>
         <note />
       </trans-unit>
       <trans-unit id="MalformedConfigFileError">
@@ -40,6 +60,11 @@
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">Inicie el servidor MCP (protocolo de contexto de modelo).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SkipNoneDescription">
+        <source>None — skip</source>
+        <target state="new">None — skip</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedMalformedConfigFile">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.fr.xlf
@@ -27,9 +27,29 @@
         <target state="needs-review-translation">Gérer les intégrations des agents IA.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_ConfigureMcpServer">
+        <source>Install Aspire MCP server</source>
+        <target state="new">Install Aspire MCP server</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_Description">
         <source>Initialize agent environment configuration for detected agents.</source>
         <target state="translated">Initialiser la configuration de l’environnement des agents détectés.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstallSkillFile">
+        <source>Install Aspire skill file (Recommended)</source>
+        <target state="new">Install Aspire skill file (Recommended)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_NothingSelected">
+        <source>No options selected. Nothing to configure.</source>
+        <target state="new">No options selected. Nothing to configure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WhatToConfigure">
+        <source>What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</source>
+        <target state="new">What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</target>
         <note />
       </trans-unit>
       <trans-unit id="MalformedConfigFileError">
@@ -40,6 +60,11 @@
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">Démarrez le serveur MCP (Model Context Protocol).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SkipNoneDescription">
+        <source>None — skip</source>
+        <target state="new">None — skip</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedMalformedConfigFile">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.it.xlf
@@ -27,9 +27,29 @@
         <target state="needs-review-translation">Gestire le integrazioni dell'agente AI.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_ConfigureMcpServer">
+        <source>Install Aspire MCP server</source>
+        <target state="new">Install Aspire MCP server</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_Description">
         <source>Initialize agent environment configuration for detected agents.</source>
         <target state="translated">Consente di inizializzare la configurazione dell'ambiente agente per gli agenti rilevati.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstallSkillFile">
+        <source>Install Aspire skill file (Recommended)</source>
+        <target state="new">Install Aspire skill file (Recommended)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_NothingSelected">
+        <source>No options selected. Nothing to configure.</source>
+        <target state="new">No options selected. Nothing to configure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WhatToConfigure">
+        <source>What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</source>
+        <target state="new">What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</target>
         <note />
       </trans-unit>
       <trans-unit id="MalformedConfigFileError">
@@ -40,6 +60,11 @@
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">Avviare il server MCP (Model Context Protocol).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SkipNoneDescription">
+        <source>None — skip</source>
+        <target state="new">None — skip</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedMalformedConfigFile">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ja.xlf
@@ -27,9 +27,29 @@
         <target state="needs-review-translation">AI エージェントの統合を管理します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_ConfigureMcpServer">
+        <source>Install Aspire MCP server</source>
+        <target state="new">Install Aspire MCP server</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_Description">
         <source>Initialize agent environment configuration for detected agents.</source>
         <target state="translated">検出されたエージェントのエージェント環境構成を初期化します。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstallSkillFile">
+        <source>Install Aspire skill file (Recommended)</source>
+        <target state="new">Install Aspire skill file (Recommended)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_NothingSelected">
+        <source>No options selected. Nothing to configure.</source>
+        <target state="new">No options selected. Nothing to configure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WhatToConfigure">
+        <source>What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</source>
+        <target state="new">What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</target>
         <note />
       </trans-unit>
       <trans-unit id="MalformedConfigFileError">
@@ -40,6 +60,11 @@
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">MCP (モデル コンテキスト プロトコル) サーバーを起動します。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SkipNoneDescription">
+        <source>None — skip</source>
+        <target state="new">None — skip</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedMalformedConfigFile">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ko.xlf
@@ -27,9 +27,29 @@
         <target state="needs-review-translation">AI 에이전트 통합을 관리합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_ConfigureMcpServer">
+        <source>Install Aspire MCP server</source>
+        <target state="new">Install Aspire MCP server</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_Description">
         <source>Initialize agent environment configuration for detected agents.</source>
         <target state="translated">감지된 에이전트에 대한 에이전트 환경 구성을 초기화합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstallSkillFile">
+        <source>Install Aspire skill file (Recommended)</source>
+        <target state="new">Install Aspire skill file (Recommended)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_NothingSelected">
+        <source>No options selected. Nothing to configure.</source>
+        <target state="new">No options selected. Nothing to configure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WhatToConfigure">
+        <source>What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</source>
+        <target state="new">What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</target>
         <note />
       </trans-unit>
       <trans-unit id="MalformedConfigFileError">
@@ -40,6 +60,11 @@
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">MCP(모델 컨텍스트 프로토콜) 서버를 시작합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SkipNoneDescription">
+        <source>None — skip</source>
+        <target state="new">None — skip</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedMalformedConfigFile">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pl.xlf
@@ -27,9 +27,29 @@
         <target state="needs-review-translation">Zarządzaj integracjami agentów sztucznej inteligencji.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_ConfigureMcpServer">
+        <source>Install Aspire MCP server</source>
+        <target state="new">Install Aspire MCP server</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_Description">
         <source>Initialize agent environment configuration for detected agents.</source>
         <target state="translated">Zainicjuj konfigurację środowiska agenta dla wykrytych agentów.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstallSkillFile">
+        <source>Install Aspire skill file (Recommended)</source>
+        <target state="new">Install Aspire skill file (Recommended)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_NothingSelected">
+        <source>No options selected. Nothing to configure.</source>
+        <target state="new">No options selected. Nothing to configure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WhatToConfigure">
+        <source>What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</source>
+        <target state="new">What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</target>
         <note />
       </trans-unit>
       <trans-unit id="MalformedConfigFileError">
@@ -40,6 +60,11 @@
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">Uruchom serwer MCP (Model Context Protocol).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SkipNoneDescription">
+        <source>None — skip</source>
+        <target state="new">None — skip</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedMalformedConfigFile">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.pt-BR.xlf
@@ -27,9 +27,29 @@
         <target state="needs-review-translation">Gerencie integrações de agente de IA.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_ConfigureMcpServer">
+        <source>Install Aspire MCP server</source>
+        <target state="new">Install Aspire MCP server</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_Description">
         <source>Initialize agent environment configuration for detected agents.</source>
         <target state="translated">Inicialize a configuração de ambiente do agente para agentes detectados.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstallSkillFile">
+        <source>Install Aspire skill file (Recommended)</source>
+        <target state="new">Install Aspire skill file (Recommended)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_NothingSelected">
+        <source>No options selected. Nothing to configure.</source>
+        <target state="new">No options selected. Nothing to configure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WhatToConfigure">
+        <source>What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</source>
+        <target state="new">What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</target>
         <note />
       </trans-unit>
       <trans-unit id="MalformedConfigFileError">
@@ -40,6 +60,11 @@
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">Inicie o servidor MCP (Protocolo de Contexto de Modelo).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SkipNoneDescription">
+        <source>None — skip</source>
+        <target state="new">None — skip</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedMalformedConfigFile">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.ru.xlf
@@ -27,9 +27,29 @@
         <target state="needs-review-translation">Управляйте интеграциями агентов ИИ.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_ConfigureMcpServer">
+        <source>Install Aspire MCP server</source>
+        <target state="new">Install Aspire MCP server</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_Description">
         <source>Initialize agent environment configuration for detected agents.</source>
         <target state="translated">Инициализировать конфигурацию среды агента для обнаруженных агентов.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstallSkillFile">
+        <source>Install Aspire skill file (Recommended)</source>
+        <target state="new">Install Aspire skill file (Recommended)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_NothingSelected">
+        <source>No options selected. Nothing to configure.</source>
+        <target state="new">No options selected. Nothing to configure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WhatToConfigure">
+        <source>What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</source>
+        <target state="new">What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</target>
         <note />
       </trans-unit>
       <trans-unit id="MalformedConfigFileError">
@@ -40,6 +60,11 @@
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">Запуск сервера MCP (протокол контекста модели).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SkipNoneDescription">
+        <source>None — skip</source>
+        <target state="new">None — skip</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedMalformedConfigFile">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.tr.xlf
@@ -27,9 +27,29 @@
         <target state="needs-review-translation">AI detekli aracı entegrasyonlarınızı yönetin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_ConfigureMcpServer">
+        <source>Install Aspire MCP server</source>
+        <target state="new">Install Aspire MCP server</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_Description">
         <source>Initialize agent environment configuration for detected agents.</source>
         <target state="translated">Tespit edilen aracılar için aracı ortam yapılandırmasını başlatın.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstallSkillFile">
+        <source>Install Aspire skill file (Recommended)</source>
+        <target state="new">Install Aspire skill file (Recommended)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_NothingSelected">
+        <source>No options selected. Nothing to configure.</source>
+        <target state="new">No options selected. Nothing to configure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WhatToConfigure">
+        <source>What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</source>
+        <target state="new">What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</target>
         <note />
       </trans-unit>
       <trans-unit id="MalformedConfigFileError">
@@ -40,6 +60,11 @@
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">MCP (Model Bağlam Protokolü) sunucusunu başlat.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SkipNoneDescription">
+        <source>None — skip</source>
+        <target state="new">None — skip</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedMalformedConfigFile">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hans.xlf
@@ -27,9 +27,29 @@
         <target state="needs-review-translation">管理 AI 智能体集成。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_ConfigureMcpServer">
+        <source>Install Aspire MCP server</source>
+        <target state="new">Install Aspire MCP server</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_Description">
         <source>Initialize agent environment configuration for detected agents.</source>
         <target state="translated">初始化检测到的智能体的智能体环境配置。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstallSkillFile">
+        <source>Install Aspire skill file (Recommended)</source>
+        <target state="new">Install Aspire skill file (Recommended)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_NothingSelected">
+        <source>No options selected. Nothing to configure.</source>
+        <target state="new">No options selected. Nothing to configure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WhatToConfigure">
+        <source>What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</source>
+        <target state="new">What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</target>
         <note />
       </trans-unit>
       <trans-unit id="MalformedConfigFileError">
@@ -40,6 +60,11 @@
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">启动 MCP (模型上下文协议)服务器。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SkipNoneDescription">
+        <source>None — skip</source>
+        <target state="new">None — skip</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedMalformedConfigFile">

--- a/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AgentCommandStrings.zh-Hant.xlf
@@ -27,9 +27,29 @@
         <target state="needs-review-translation">管理 AI Agent 整合。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitCommand_ConfigureMcpServer">
+        <source>Install Aspire MCP server</source>
+        <target state="new">Install Aspire MCP server</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InitCommand_Description">
         <source>Initialize agent environment configuration for detected agents.</source>
         <target state="translated">為偵測到的代理程式初始化代理程式環境設定。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_InstallSkillFile">
+        <source>Install Aspire skill file (Recommended)</source>
+        <target state="new">Install Aspire skill file (Recommended)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_NothingSelected">
+        <source>No options selected. Nothing to configure.</source>
+        <target state="new">No options selected. Nothing to configure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitCommand_WhatToConfigure">
+        <source>What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</source>
+        <target state="new">What would you like to configure? [dim](Enter to skip, Ctrl+C to cancel)[/]</target>
         <note />
       </trans-unit>
       <trans-unit id="MalformedConfigFileError">
@@ -40,6 +60,11 @@
       <trans-unit id="McpCommand_Description">
         <source>Start the MCP (Model Context Protocol) server.</source>
         <target state="translated">啟動 MCP (模型內容通訊協定) 伺服器。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SkipNoneDescription">
+        <source>None — skip</source>
+        <target state="new">None — skip</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedMalformedConfigFile">

--- a/tests/Aspire.Cli.EndToEnd.Tests/AgentCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/AgentCommandTests.cs
@@ -38,10 +38,6 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
         var agentMcpSubcommand = new CellPatternSearcher().Find("mcp");
         var agentInitSubcommand = new CellPatternSearcher().Find("init");
 
-        // Pattern for legacy aspire mcp --help (should still work)
-        var legacyMcpStart = new CellPatternSearcher().Find("start");
-        var legacyMcpInit = new CellPatternSearcher().Find("init");
-
         var counter = new SequenceCounter();
         var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
 
@@ -83,24 +79,26 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
             .WaitUntil(s => initHelpPattern.Search(s).Count > 0, TimeSpan.FromSeconds(30))
             .WaitForSuccessPrompt(counter);
 
-        // Test 4: aspire mcp --help (legacy, should still work)
+        // Test 4: aspire mcp --help (now shows tools and call subcommands)
+        var mcpToolsSubcommand = new CellPatternSearcher().Find("tools");
+        var mcpCallSubcommand = new CellPatternSearcher().Find("call");
         sequenceBuilder
             .Type("aspire mcp --help")
             .Enter()
             .WaitUntil(s =>
             {
-                var hasStart = legacyMcpStart.Search(s).Count > 0;
-                var hasInit = legacyMcpInit.Search(s).Count > 0;
-                return hasStart && hasInit;
+                var hasTools = mcpToolsSubcommand.Search(s).Count > 0;
+                var hasCall = mcpCallSubcommand.Search(s).Count > 0;
+                return hasTools && hasCall;
             }, TimeSpan.FromSeconds(30))
             .WaitForSuccessPrompt(counter);
 
-        // Test 5: aspire mcp start --help (legacy, should still work)
-        var legacyMcpStartPattern = new CellPatternSearcher().Find("aspire mcp start [options]");
+        // Test 5: aspire mcp tools --help
+        var mcpToolsHelpPattern = new CellPatternSearcher().Find("aspire mcp tools [options]");
         sequenceBuilder
-            .Type("aspire mcp start --help")
+            .Type("aspire mcp tools --help")
             .Enter()
-            .WaitUntil(s => legacyMcpStartPattern.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .WaitUntil(s => mcpToolsHelpPattern.Search(s).Count > 0, TimeSpan.FromSeconds(30))
             .WaitForSuccessPrompt(counter);
 
         sequenceBuilder
@@ -138,9 +136,6 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
         // the prompt is ready for input
         var workspacePathPrompt = new CellPatternSearcher().Find("workspace:");
 
-        // Patterns for deprecated config detection in agent init
-        var deprecatedPrompt = new CellPatternSearcher().Find("Update");
-
         // Pattern to detect if no environments are found
         var noEnvironmentsMessage = new CellPatternSearcher().Find("No agent environments");
 
@@ -175,7 +170,11 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
             .WaitUntil(s => fileExistsPattern.Search(s).Count > 0, TimeSpan.FromSeconds(10))
             .WaitForSuccessPrompt(counter);
 
-        // Step 2: Run aspire agent init - should detect deprecated config
+        // Step 2: Run aspire agent init - should detect and auto-migrate deprecated config
+        // In the new flow, deprecated config migrations are applied silently
+        var configurePrompt = new CellPatternSearcher().Find("configure");
+        var configComplete = new CellPatternSearcher().Find("omplete");
+
         sequenceBuilder
             .Type("aspire agent init")
             .Enter()
@@ -184,17 +183,19 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
             .Enter() // Accept default workspace path
             .WaitUntil(s =>
             {
-                // Either we should see the deprecated config prompt, OR the "no environments" message
-                // This helps us diagnose whether the scanner is finding anything
-                var hasDeprecated = deprecatedPrompt.Search(s).Count > 0;
+                // Migration happens silently. We'll see either:
+                // - The configure prompt (if other environments were detected)
+                // - "Configuration complete" (if only deprecated configs were found)
+                // - "No agent environments" (if nothing was found)
+                var hasConfigure = configurePrompt.Search(s).Count > 0;
                 var hasNoEnv = noEnvironmentsMessage.Search(s).Count > 0;
-                return hasDeprecated || hasNoEnv;
+                var hasComplete = configComplete.Search(s).Count > 0;
+                return hasConfigure || hasNoEnv || hasComplete;
             }, TimeSpan.FromSeconds(60));
 
-        // Verify we got the deprecated prompt (not "no environments")
-        // This will show in the terminal capture if the test fails
+        // If we got the configure prompt, just press Enter to accept defaults
+        // If we got complete/no-env, this Enter is harmless
         sequenceBuilder
-            .Type(" ") // Space to select update
             .Enter()
             .WaitForSuccessPrompt(counter);
 
@@ -289,15 +290,12 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
     }
 
     /// <summary>
-    /// Tests that aspire agent init gracefully handles malformed JSON in MCP config files.
-    /// When a .vscode/mcp.json file contains invalid JSON, the command should:
-    /// - Display an error message identifying the malformed file
-    /// - Display a "Skipping" message
-    /// - NOT overwrite the malformed file
-    /// - Exit with a non-zero exit code
+    /// Tests that aspire agent init with a .vscode folder shows the skill pre-selected
+    /// and MCP as an opt-in option, and that accepting the defaults (skill only) completes
+    /// successfully and creates the skill file.
     /// </summary>
     [Fact]
-    public async Task AgentInitCommand_WithMalformedMcpJson_ShowsErrorAndExitsNonZero()
+    public async Task AgentInitCommand_DefaultSelection_InstallsSkillOnly()
     {
         var workspace = TemporaryWorkspace.Create(output);
 
@@ -309,28 +307,14 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Set up paths
+        // Set up .vscode folder so VS Code scanner detects it
         var vscodePath = Path.Combine(workspace.WorkspaceRoot.FullName, ".vscode");
-        var mcpConfigPath = Path.Combine(vscodePath, "mcp.json");
-        var malformedContent = "{ invalid json content";
 
-        // Patterns for agent init prompts
+        // Patterns
         var workspacePathPrompt = new CellPatternSearcher().Find("workspace:");
-
-        // Pattern for the malformed JSON error message
-        var malformedError = new CellPatternSearcher().Find("malformed JSON");
-
-        // Pattern for the skip message
-        var skippingMessage = new CellPatternSearcher().Find("Skipping");
-
-        // Pattern for the partial success warning message
-        var completedWithErrors = new CellPatternSearcher().Find("completed with errors");
-
-        // Pattern for the agent environment selection prompt
-        var agentSelectPrompt = new CellPatternSearcher().Find("agent environments");
-
-        // Pattern for the additional options prompt that appears after agent environment selection
-        var additionalOptionsPrompt = new CellPatternSearcher().Find("additional options");
+        var configurePrompt = new CellPatternSearcher().Find("configure");
+        var skillOption = new CellPatternSearcher().Find("skill");
+        var configComplete = new CellPatternSearcher().Find("complete");
 
         var counter = new SequenceCounter();
         var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
@@ -344,44 +328,26 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
             sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
         }
 
-        // Step 1: Create .vscode folder with malformed mcp.json
+        // Create .vscode folder so the scanner detects VS Code environment
         sequenceBuilder
-            .CreateVsCodeFolder(vscodePath)
-            .CreateMalformedMcpConfig(mcpConfigPath, malformedContent);
+            .CreateVsCodeFolder(vscodePath);
 
-        // Verify the malformed config was created
-        sequenceBuilder
-            .VerifyFileContains(mcpConfigPath, "invalid json");
-
-        // Step 2: Run aspire agent init
+        // Run aspire agent init and accept defaults (skill is pre-selected)
         sequenceBuilder
             .Type("aspire agent init")
             .Enter()
             .WaitUntil(s => workspacePathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
             .Wait(500)
             .Enter() // Accept default workspace path
-            .WaitUntil(s => agentSelectPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
-            .Type(" ") // Select first option (VS Code)
-            .Enter()
-            // Handle the additional options prompt - must select at least one item
-            // (Spectre.Console MultiSelectionPrompt requires at least one selection)
-            // Select the first skill file option which is harmless (doesn't touch mcp.json)
-            .WaitUntil(s => additionalOptionsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Type(" ") // Select first additional option (skill file)
-            .Enter()
-            // After all prompts, wait for the error about malformed JSON and non-zero exit
-            .WaitUntil(s =>
-            {
-                var hasError = malformedError.Search(s).Count > 0;
-                var hasSkip = skippingMessage.Search(s).Count > 0;
-                var hasCompletedWithErrors = completedWithErrors.Search(s).Count > 0;
-                return hasError && hasSkip && hasCompletedWithErrors;
-            }, TimeSpan.FromSeconds(30))
-            .WaitForErrorPrompt(counter);
+            .WaitUntil(s => configurePrompt.Search(s).Count > 0 && skillOption.Search(s).Count > 0, TimeSpan.FromSeconds(60))
+            .Enter() // Accept defaults (skill pre-selected)
+            .WaitUntil(s => configComplete.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+            .WaitForSuccessPrompt(counter);
 
-        // Step 3: Verify the malformed file was NOT overwritten
+        // Verify skill file was created
+        var skillFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, ".github", "skills", "aspire", "SKILL.md");
         sequenceBuilder
-            .VerifyFileContains(mcpConfigPath, "invalid json");
+            .VerifyFileContains(skillFilePath, "aspire start");
 
         sequenceBuilder
             .Type("exit")

--- a/tests/Aspire.Cli.Tests/Agents/CommonAgentApplicatorsTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/CommonAgentApplicatorsTests.cs
@@ -180,7 +180,7 @@ public class CommonAgentApplicatorsTests(ITestOutputHelper outputHelper)
         Assert.True(File.Exists(skillFilePath));
         var content = await File.ReadAllTextAsync(skillFilePath);
         Assert.Contains("# Aspire Skill", content);
-        Assert.Contains("Running Aspire in agent environments", content);
+        Assert.Contains("aspire start --isolated", content);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/McpCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/McpCommandTests.cs
@@ -84,7 +84,7 @@ public class McpCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task McpCommandIsHidden()
+    public async Task McpCommandIsVisible()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
@@ -94,7 +94,7 @@ public class McpCommandTests(ITestOutputHelper outputHelper)
         var mcpCommand = rootCommand.Subcommands.FirstOrDefault(c => c.Name == "mcp");
 
         Assert.NotNull(mcpCommand);
-        Assert.True(mcpCommand.Hidden, "The mcp command should be hidden for backward compatibility");
+        Assert.False(mcpCommand.Hidden, "The mcp command should be visible (contains tools and call subcommands)");
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -16,6 +16,8 @@ using Aspire.Cli.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console;
+using Spectre.Console.Rendering;
+using Aspire.Cli.Backchannel;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Tests.Commands;
@@ -1361,6 +1363,80 @@ internal sealed class TestNewCommandPrompter(IInteractionService interactionServ
             _ => Task.FromResult(candidatePackages.First()) // If no callback is provided just accept the first package.
         };
     }
+}
+
+internal sealed class OrderTrackingInteractionService(List<string> operationOrder) : IInteractionService
+{
+    public ConsoleOutput Console { get; set; }
+
+    public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false)
+    {
+        return action();
+    }
+
+    public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false)
+    {
+        action();
+    }
+
+    public Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(defaultValue ?? string.Empty);
+    }
+
+    public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull
+    {
+        if (!choices.Any())
+        {
+            throw new EmptyChoicesException($"No items available for selection: {promptText}");
+        }
+
+        // Track template option prompts
+        if (promptText?.Contains("Redis") == true ||
+            promptText?.Contains("test framework") == true ||
+            promptText?.Contains("Create a test project") == true ||
+            promptText?.Contains("xUnit") == true)
+        {
+            operationOrder.Add("TemplateOption");
+        }
+
+        return Task.FromResult(choices.First());
+    }
+
+    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
+    {
+        if (!choices.Any())
+        {
+            throw new EmptyChoicesException($"No items available for selection: {promptText}");
+        }
+
+        if (preSelected is not null)
+        {
+            return Task.FromResult<IReadOnlyList<T>>(preSelected.ToList());
+        }
+
+        return Task.FromResult<IReadOnlyList<T>>(choices.ToList());
+    }
+
+    public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;
+    public void DisplayError(string errorMessage) { }
+    public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) { }
+    public void DisplaySuccess(string message, bool allowMarkup = false) { }
+    public void DisplayLines(IEnumerable<(string Stream, string Line)> lines) { }
+    public void DisplayCancellationMessage() { }
+    public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default) => Task.FromResult(true);
+    public Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default)
+        => PromptForStringAsync(promptText, defaultValue, validator, isSecret: false, required, cancellationToken);
+    public void DisplaySubtleMessage(string message, bool escapeMarkup = true) { }
+    public void DisplayEmptyLine() { }
+    public void DisplayPlainText(string text) { }
+    public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) { }
+    public void DisplayMarkdown(string markdown) { }
+    public void DisplayMarkupLine(string markup) { }
+    public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false) { }
+    public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null) { }
+    public void DisplayRenderable(IRenderable renderable) { }
+    public Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback) => callback(_ => { });
 }
 
 internal sealed class NewCommandTestPackagingService : IPackagingService

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -10,6 +10,9 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.InternalTesting;
 
@@ -840,6 +843,135 @@ internal sealed class TestPromptBackchannel : IAppHostCliBackchannel
 internal sealed record PromptInputData(string Name, string Label, string InputType, bool IsRequired, IReadOnlyList<KeyValuePair<string, string>>? Options = null, string? Value = null, IReadOnlyList<string>? ValidationErrors = null);
 internal sealed record PromptData(string PromptId, IReadOnlyList<PromptInputData> Inputs, string Message, string? Title = null);
 internal sealed record PromptCompletion(string PromptId, PublishingPromptInputAnswer[] Answers, bool UpdateResponse);
+
+// Enhanced TestConsoleInteractionService that tracks interaction types
+[SuppressMessage("Usage", "ASPIREINTERACTION001:Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInteractionService
+{
+    private readonly Queue<(string response, ResponseType type)> _responses = new();
+    private bool _shouldCancel;
+
+    public ConsoleOutput Console { get; set; }
+    public List<StringPromptCall> StringPromptCalls { get; } = [];
+    public List<object> SelectionPromptCalls { get; } = []; // Using object to handle generic types
+    public List<BooleanPromptCall> BooleanPromptCalls { get; } = [];
+    public List<string> DisplayedErrors { get; } = [];
+
+    public void SetupStringPromptResponse(string response) => _responses.Enqueue((response, ResponseType.String));
+    public void SetupSelectionResponse(string response) => _responses.Enqueue((response, ResponseType.Selection));
+    public void SetupBooleanResponse(bool response) => _responses.Enqueue((response.ToString().ToLower(), ResponseType.Boolean));
+    public void SetupCancellationResponse() => _shouldCancel = true;
+
+    public void SetupSequentialResponses(params (string response, ResponseType type)[] responses)
+    {
+        foreach (var (response, type) in responses)
+        {
+            _responses.Enqueue((response, type));
+        }
+    }
+
+    public Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default)
+    {
+        StringPromptCalls.Add(new StringPromptCall(promptText, defaultValue, isSecret));
+
+        if (_shouldCancel || cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException();
+        }
+
+        if (_responses.TryDequeue(out var response))
+        {
+            return Task.FromResult(response.response);
+        }
+
+        return Task.FromResult(defaultValue ?? string.Empty);
+    }
+
+    public Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default)
+        => PromptForStringAsync(promptText, defaultValue, validator, isSecret: false, required, cancellationToken);
+
+    public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull
+    {
+        if (_shouldCancel || cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException();
+        }
+
+        if (_responses.TryDequeue(out var response))
+        {
+            // Find the choice that matches the response
+            var matchingChoice = choices.FirstOrDefault(c => choiceFormatter(c) == response.response || c.ToString() == response.response);
+            if (matchingChoice != null)
+            {
+                return Task.FromResult(matchingChoice);
+            }
+        }
+
+        return Task.FromResult(choices.First());
+    }
+
+    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
+    {
+        if (_shouldCancel || cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException();
+        }
+
+        _ = _responses.TryDequeue(out _);
+
+        if (preSelected is not null)
+        {
+            return Task.FromResult<IReadOnlyList<T>>(preSelected.ToList());
+        }
+
+        // For simplicity, return all choices in the test
+        return Task.FromResult<IReadOnlyList<T>>(choices.ToList());
+    }
+
+    public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default)
+    {
+        BooleanPromptCalls.Add(new BooleanPromptCall(promptText, defaultValue));
+
+        if (_shouldCancel || cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException();
+        }
+
+        if (_responses.TryDequeue(out var response))
+        {
+            return Task.FromResult(bool.Parse(response.response));
+        }
+
+        return Task.FromResult(defaultValue);
+    }
+
+    // Default implementations for other interface methods
+    public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false) => action();
+    public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false) => action();
+    public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;
+    public void DisplayError(string errorMessage) => DisplayedErrors.Add(errorMessage);
+    public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) { }
+    public void DisplaySuccess(string message, bool allowMarkup = false) { }
+    public void DisplaySubtleMessage(string message, bool allowMarkup = false) { }
+    public void DisplayLines(IEnumerable<(string Stream, string Line)> lines) { }
+    public void DisplayCancellationMessage() { }
+    public void DisplayEmptyLine() { }
+    public void DisplayPlainText(string text) { }
+    public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) { }
+    public void DisplayMarkdown(string markdown) { }
+    public void DisplayMarkupLine(string markup) { }
+
+    public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null) { }
+
+    public void DisplayRenderable(IRenderable renderable) { }
+    public Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback) => callback(_ => { });
+
+    public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false)
+    {
+        var messageType = isErrorMessage ? "error" : "info";
+        System.Console.WriteLine($"#{lineNumber} [{messageType}] {message}");
+    }
+}
 
 // Input type constants that match the Aspire CLI implementation
 internal static class InputTypes

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -961,8 +961,8 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
         => _innerService.ConfirmAsync(promptText, defaultValue, cancellationToken);
     public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull 
         => _innerService.PromptForSelectionAsync(promptText, choices, choiceFormatter, cancellationToken);
-    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool optional = false, CancellationToken cancellationToken = default) where T : notnull 
-        => _innerService.PromptForSelectionsAsync(promptText, choices, choiceFormatter, optional, cancellationToken);
+    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, CancellationToken cancellationToken = default) where T : notnull 
+        => _innerService.PromptForSelectionsAsync(promptText, choices, choiceFormatter, preSelected, optional, cancellationToken);
     public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) 
         => _innerService.DisplayIncompatibleVersionError(ex, appHostHostingVersion);
     public void DisplayError(string errorMessage) => _innerService.DisplayError(errorMessage);

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -8,6 +8,7 @@ using Aspire.Cli.Certificates;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
+using Aspire.Cli.Interaction;
 using Aspire.Cli.NuGet;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Templating;
@@ -16,6 +17,8 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Aspire.Shared;
+using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace Aspire.Cli.Tests.Templating;
 
@@ -445,6 +448,52 @@ public class DotNetTemplateFactoryTests
                 _ => defaultValue
             };
         }
+    }
+
+    private sealed class TestInteractionService : IInteractionService
+    {
+        public ConsoleOutput Console { get; set; }
+
+        public Task<T> PromptForSelectionAsync<T>(string prompt, IEnumerable<T> choices, Func<T, string> displaySelector, CancellationToken cancellationToken) where T : notnull
+            => throw new NotImplementedException();
+
+        public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
+            => throw new NotImplementedException();
+
+        public Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<bool> ConfirmAsync(string prompt, bool defaultAnswer, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task<TResult> ShowStatusAsync<TResult>(string message, Func<Task<TResult>> work, KnownEmoji? emoji = null, bool allowMarkup = false)
+            => throw new NotImplementedException();
+
+        public Task ShowStatusAsync(string message, Func<Task> work)
+            => throw new NotImplementedException();
+
+        public void ShowStatus(string message, Action work, KnownEmoji? emoji = null, bool allowMarkup = false)
+            => throw new NotImplementedException();
+
+        public void DisplaySuccess(string message, bool allowMarkup = false) { }
+        public void DisplayError(string message) { }
+        public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) { }
+        public void DisplayLines(IEnumerable<(string Stream, string Line)> lines) { }
+        public void DisplayCancellationMessage() { }
+        public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;
+        public void DisplayPlainText(string text) { }
+        public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) { }
+        public void DisplayMarkdown(string markdown) { }
+        public void DisplayMarkupLine(string markup) { }
+        public void DisplaySubtleMessage(string message, bool allowMarkup = false) { }
+        public void DisplayEmptyLine() { }
+        public void DisplayVersionUpdateNotification(string message, string? updateCommand = null) { }
+        public void WriteConsoleLog(string message, int? resourceHashCode, string? resourceName, bool isError) { }
+        public void DisplayRenderable(IRenderable renderable) { }
+        public Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback) => callback(_ => { });
     }
 
     private sealed class TestDotNetCliRunner : IDotNetCliRunner

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -54,11 +54,16 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
         return Task.FromResult(choices.First());
     }
 
-    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
+    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
     {
         if (!choices.Any())
         {
             throw new EmptyChoicesException($"No items available for selection: {promptText}");
+        }
+
+        if (preSelected is not null)
+        {
+            return Task.FromResult<IReadOnlyList<T>>(preSelected.ToList());
         }
 
         return Task.FromResult<IReadOnlyList<T>>(choices.ToList());

--- a/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
@@ -112,7 +112,7 @@ internal sealed class TestInteractionService : IInteractionService
         return Task.FromResult(choices.First());
     }
 
-    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
+    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
     {
         if (_shouldCancel || cancellationToken.IsCancellationRequested)
         {
@@ -124,7 +124,12 @@ internal sealed class TestInteractionService : IInteractionService
             throw new EmptyChoicesException($"No items available for selection: {promptText}");
         }
 
-        _ = _responses.TryDequeue(out _);
+        // In tests, return pre-selected items if provided, otherwise all items
+        if (preSelected is not null)
+        {
+            return Task.FromResult<IReadOnlyList<T>>(preSelected.ToList());
+        }
+
         return Task.FromResult<IReadOnlyList<T>>(choices.ToList());
     }
 

--- a/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
@@ -124,6 +124,8 @@ internal sealed class TestInteractionService : IInteractionService
             throw new EmptyChoicesException($"No items available for selection: {promptText}");
         }
 
+        _ = _responses.TryDequeue(out _);
+
         // In tests, return pre-selected items if provided, otherwise all items
         if (preSelected is not null)
         {

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -186,6 +186,8 @@ internal static class CliTestHelper
         services.AddTransient<McpCommand>();
         services.AddTransient<McpStartCommand>();
         services.AddTransient<McpInitCommand>();
+        services.AddTransient<McpToolsCommand>();
+        services.AddTransient<McpCallCommand>();
         services.AddTransient<AgentCommand>();
         services.AddTransient<AgentMcpCommand>();
         services.AddTransient<AgentInitCommand>();


### PR DESCRIPTION
## Description

Three related changes that shift the Aspire agent story from MCP-server-dependent to CLI-first:

### 1. Skill file: MCP tools → CLI commands

Updates the Aspire skill (`SKILL.md` generated by `aspire agent init`) to use CLI commands instead of MCP server tools. The skill no longer requires the MCP server to be configured — it works in any environment where the `aspire` CLI is installed.

Key changes:
- **`aspire start`** instead of `aspire run` — agents should always use `aspire start` (detached), with `--isolated` in worktrees
- **`aspire wait <resource>`** — block until a resource is healthy before interacting
- **`aspire mcp tools` / `aspire mcp call`** — discover and invoke resource MCP tools via CLI
- **`aspire docs search`** for finding integration docs
- Explicit rules: never use `aspire run`, restart by re-running `aspire start`
- Compact ~650 tokens (within optimal 500–2500 range per [SkillsBench](https://arxiv.org/abs/2602.12670))

### 2. Agent init rework

Replaces the 3-group sequential prompt flow with a single flat prompt:

```
What would you like to configure? (Enter to skip, Ctrl+C to cancel)
  ✅ Install Aspire skill file (Recommended)
  ☐  Install Playwright CLI (Recommended for browser automation)
  ☐  Install Aspire MCP server
```

- Skill file pre-selected, MCP server opt-in (last)
- Deprecated config migrations applied silently
- Categorization via `McpInitPromptGroup` (`SkillFiles`, `Tools`, `AgentEnvironments`) instead of string matching
- Shows which environments were configured after applying
- `preSelected` parameter added to `PromptForSelectionsAsync`

### 3. New CLI commands: `aspire mcp tools` / `aspire mcp call`

CLI-native MCP tool discovery and invocation for resources that expose MCP tools (e.g. `WithPostgresMcp()`):

```bash
aspire mcp tools                                              # list tools (table)
aspire mcp tools --format Json                                # includes input schemas
aspire mcp call <resource> <tool> --input '{"sql":"SELECT 1"}'  # invoke a tool
```

Uses the existing backchannel connection (same as `aspire describe`, `aspire logs`, etc.) — no MCP server needed. Pattern matches prior art ([mcptools](https://github.com/f/mcptools), [mcp-cli](https://github.com/philschmid/mcp-cli)).

Fixes #14619
Fixes #14856

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [ ] No
