### PR TITLE
Add --disableProductStyleUrl to Azurite emulator args

### DIFF
--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -251,11 +251,12 @@ public static class AzureStorageExtensions
 
         // The default arguments list is coming from https://github.com/Azure/Azurite/blob/c3f93445fbd8fd54d380eb265a5665166c460d2b/Dockerfile#L47C6-L47C106
         // They need to be repeated in order to be able to add --skipApiVersionCheck
+        // --disableProductStyleUrl is required to ensure the emulator uses path-style URLs, and not “product-style” URLs which have the account name in the host name of the URL.
 
         var surrogate = new AzureStorageEmulatorResource(builder.Resource);
         var surrogateBuilder = builder.ApplicationBuilder
             .CreateResourceBuilder(surrogate)
-            .WithArgs("azurite", "-l", "/data", "--blobHost", "0.0.0.0", "--queueHost", "0.0.0.0", "--tableHost", "0.0.0.0", SkipApiVersionCheckArgument);
+            .WithArgs("azurite", "-l", "/data", "--blobHost", "0.0.0.0", "--queueHost", "0.0.0.0", "--tableHost", "0.0.0.0", "--disableProductStyleUrl", SkipApiVersionCheckArgument);
 
         configureContainer?.Invoke(surrogateBuilder);
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureStorageExtensionsTests.cs
@@ -146,7 +146,7 @@ public class AzureStorageExtensionsTests(ITestOutputHelper output)
 
         var args = await ArgumentEvaluator.GetArgumentListAsync(storage.Resource);
 
-        Assert.All(["azurite", "-l", "/data", "--blobHost", "0.0.0.0", "--queueHost", "0.0.0.0", "--tableHost", "0.0.0.0"], x => args.Contains(x));
+        Assert.All(["azurite", "-l", "/data", "--blobHost", "0.0.0.0", "--queueHost", "0.0.0.0", "--tableHost", "0.0.0.0", "--disableProductStyleUrl"], x => args.Contains(x));
 
         if (enableApiVersionCheck)
         {
@@ -167,6 +167,7 @@ public class AzureStorageExtensionsTests(ITestOutputHelper output)
         var args = await ArgumentEvaluator.GetArgumentListAsync(storage.Resource);
 
         Assert.Contains("--skipApiVersionCheck", args);
+        Assert.Contains("--disableProductStyleUrl", args);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Include --disableProductStyleUrl in Azurite command line when running Azure Storage as an emulator. This is necessary because when a Container resource references the Storage emulator it gets a URL like storage.dev.internal:10000. Using a URL like this conflicts between the Storage SDK and the emulator because the Storage SDK sees port 10000 and uses path-style URLs. But the emulator rejects them because it expects "product-style" URLs.

Fix #13811
Fix #14044