### PR TITLE
Fix flaky test: ProxylessEndpointWorks

### DIFF
--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -1518,16 +1518,10 @@ public class DistributedApplicationTests
         var result = await client.GetStringAsync("pid").DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
         Assert.NotNull(result);
 
-        // Check that endpoint from launchsettings doesn't work
-        await Assert.ThrowsAnyAsync<Exception>(async () =>
-        {
-            using var client2 = new HttpClient(new SocketsHttpHandler
-            {
-                // Provide a timeout to avoid long timeout while trying to connect.
-                ConnectTimeout = TimeSpan.FromSeconds(2)
-            });
-            await client2.GetStringAsync("http://localhost:5156/pid");
-        }).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        // Verify the service is listening on the dynamically assigned port, not the launch profile port (5156).
+        var urls = await client.GetStringAsync("urls").DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
+        Assert.Contains($":{port}", urls);
+        Assert.DoesNotContain(":5156", urls);
     }
 
     [Fact]


### PR DESCRIPTION
## Flaky Test Fix

### Test
- **Method**: `Aspire.Hosting.Tests.DistributedApplicationTests.ProxylessEndpointWorks`
- **Issue**: #8728

### Root Cause
The test connected to hardcoded port 5156 (from ServiceA's launch profile) and asserted the connection should fail. In CI, other tests or processes may occupy port 5156, causing the connection to succeed and the `Assert.ThrowsAny()` to fail with "No exception was thrown". Failure rate was 65.8% overall (56% on Linux/macOS, 20% on Windows).

### Fix
Replaced the fragile network-based assertion with a check using ServiceA's existing `/urls` endpoint. The test now fetches the service's actual listening URLs and asserts:
- The dynamically assigned port **is** present in the URLs
- Port 5156 (launch profile port) is **NOT** present in the URLs

This is deterministic regardless of what else is running on the machine.

### Verification
| Phase | Run | Config | Result |
|-------|-----|--------|--------|
| Reproduce (no fix) | [22605066609](https://github.com/dotnet/aspire/actions/runs/22605066609) | 3×3×2 OSes, quarantine-project | **4/6 runners failed** — reproduction confirmed |
| Verify (with fix) | [22604240281](https://github.com/dotnet/aspire/actions/runs/22604240281) | 3×3×2 OSes, single-test | **18/18 passed** ✅ |
| Verify (with fix) | [22605355735](https://github.com/dotnet/aspire/actions/runs/22605355735) | 3×3×2 OSes, quarantine-project | **0 ProxylessEndpointWorks failures** ✅ |
| Large verify (with fix) | [22605620674](https://github.com/dotnet/aspire/actions/runs/22605620674) | 5×5×3 OSes, quarantine-project | **0 ProxylessEndpointWorks failures across 14 completed runners** ✅ |

**Details on failures in verification runs**: All failures observed in post-fix quarantine-project runs were from **other quarantined tests** (SlimTestProgramFixture timeouts, Windows infrastructure crashes with exit code -1073741502). Zero ProxylessEndpointWorks failures were observed across all verification runs.

### Verification Rationale
This is a contention-sensitive test — it only fails when other tests run in parallel and occupy port 5156. Single-test CI reproduction could not trigger the failure, so quarantine-project mode (running all quarantined tests together) was used. The pre-fix run reproduced the issue on 4/6 runners, while three post-fix runs totaling 75+ iterations across all 3 OSes showed zero ProxylessEndpointWorks failures — confirming the fix eliminates the port-collision vulnerability.

### Notes
- `[QuarantinedTest]` attribute kept — unquarantining will happen separately after 21 days of zero failures in quarantine CI

---
> **Note:** This PR intentionally does not close #8728. The test will remain quarantined until a separate unquarantine process confirms it has been stable (zero failures) for a sufficient period. Once stability is confirmed, the test will be unquarantined and the issue will be closed.

---
*This fix was generated using the [fix-flaky-test skill](https://github.com/dotnet/aspire/blob/main/.github/skills/fix-flaky-test/SKILL.md).*