### PR TITLE
Fix flaky E2E test: retry MSBuild evaluation on empty output

### DIFF
--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -339,48 +339,76 @@ internal sealed class DotNetCliRunner(
 
         string[] cliArgs = [.. cliArgsList];
 
-        var stdoutBuilder = new StringBuilder();
-        var existingStandardOutputCallback = options.StandardOutputCallback; // Preserve the existing callback if it exists.
-        options.StandardOutputCallback = (line) => {
-            stdoutBuilder.AppendLine(line);
-            existingStandardOutputCallback?.Invoke(line);
-        };
+        var existingStandardOutputCallback = options.StandardOutputCallback;
+        var existingStandardErrorCallback = options.StandardErrorCallback;
 
-        var stderrBuilder = new StringBuilder();
-        var existingStandardErrorCallback = options.StandardErrorCallback; // Preserve the existing callback if it exists.
-        options.StandardErrorCallback = (line) => {
-            stderrBuilder.AppendLine(line);
-            existingStandardErrorCallback?.Invoke(line);
-        };
-
-        var exitCode = await ExecuteAsync(
-            args: cliArgs,
-            env: null,
-            projectFile: projectFile,
-            workingDirectory: projectFile.Directory!,
-            backchannelCompletionSource: null,
-            options: options,
-            cancellationToken: cancellationToken);
-
-        var stdout = stdoutBuilder.ToString();
-        var stderr = stderrBuilder.ToString();
-
-        if (exitCode != 0)
+        // Retry when MSBuild returns success but produces no output, which can happen
+        // due to MSBuild server contention (e.g. when another AppHost build is running).
+        const int maxRetries = 3;
+        for (var attempt = 0; attempt < maxRetries; attempt++)
         {
-            logger.LogError(
-                "Failed to get items and properties from project. Exit code was: {ExitCode}. See debug logs for more details. Stderr: {Stderr}, Stdout: {Stdout}",
-                exitCode,
-                stderr,
-                stdout
-            );
+            var stdoutBuilder = new StringBuilder();
+            options.StandardOutputCallback = (line) => {
+                stdoutBuilder.AppendLine(line);
+                existingStandardOutputCallback?.Invoke(line);
+            };
 
-            return (exitCode, null);
-        }
-        else
-        {
-            var json = JsonDocument.Parse(stdout!);
+            var stderrBuilder = new StringBuilder();
+            options.StandardErrorCallback = (line) => {
+                stderrBuilder.AppendLine(line);
+                existingStandardErrorCallback?.Invoke(line);
+            };
+
+            var exitCode = await ExecuteAsync(
+                args: cliArgs,
+                env: null,
+                projectFile: projectFile,
+                workingDirectory: projectFile.Directory!,
+                backchannelCompletionSource: null,
+                options: options,
+                cancellationToken: cancellationToken);
+
+            var stdout = stdoutBuilder.ToString();
+            var stderr = stderrBuilder.ToString();
+
+            if (exitCode != 0)
+            {
+                logger.LogError(
+                    "Failed to get items and properties from project. Exit code was: {ExitCode}. See debug logs for more details. Stderr: {Stderr}, Stdout: {Stdout}",
+                    exitCode,
+                    stderr,
+                    stdout
+                );
+
+                return (exitCode, null);
+            }
+
+            if (string.IsNullOrWhiteSpace(stdout))
+            {
+                if (attempt < maxRetries - 1)
+                {
+                    logger.LogWarning(
+                        "dotnet msbuild returned exit code 0 but produced no output (attempt {Attempt}/{MaxRetries}). Retrying after delay. Stderr: {Stderr}",
+                        attempt + 1,
+                        maxRetries,
+                        stderr);
+                    await Task.Delay(TimeSpan.FromSeconds(attempt + 1), cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                logger.LogWarning(
+                    "dotnet msbuild returned exit code 0 but produced no output after {MaxRetries} attempts. Stderr: {Stderr}",
+                    maxRetries,
+                    stderr);
+                return (exitCode, null);
+            }
+
+            var json = JsonDocument.Parse(stdout);
             return (exitCode, json);
         }
+
+        // Should not be reached, but return failure as a safety net
+        return (1, null);
     }
 
     public async Task<int> RunAsync(FileInfo projectFile, bool watch, bool noBuild, bool noRestore, string[] args, IDictionary<string, string>? env, TaskCompletionSource<IAppHostCliBackchannel>? backchannelCompletionSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)

--- a/tests/Aspire.Cli.EndToEnd.Tests/MultipleAppHostTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/MultipleAppHostTests.cs
@@ -130,3 +130,4 @@ public sealed class MultipleAppHostTests(ITestOutputHelper output)
         await pendingRun;
     }
 }
+


### PR DESCRIPTION
## Description

Fixes the flaky `DetachFormatJsonProducesValidJson` E2E test in `MultipleAppHostTests`.

### Root Cause

When running `aspire run --detach --format json` while a previous detached AppHost is still running, the CLI calls `dotnet msbuild -getProperty:... -getItem:...` to evaluate project properties during AppHost discovery. Intermittently, this MSBuild evaluation returns exit code 0 but produces **empty stdout output** — likely due to MSBuild server contention with the already-running AppHost's build processes.

The empty output then caused `JsonDocument.Parse("")` to throw:
```
An unexpected error occurred: The input does not contain any JSON tokens.
Expected the input to start with a valid JSON token, when isFinalBlock is true.
LineNumber: 0 | BytePositionInLine: 0.
```

This was confirmed by downloading and analyzing the asciinema recording from the original failing CI run (artifact from [PR #14811 run 22528127115](https://github.com/dotnet/aspire/actions/runs/22528127115)).

### Fix

Added retry logic (up to 3 attempts with increasing delay) in `DotNetCliRunner.GetProjectItemsAndPropertiesAsync` specifically for the case where MSBuild returns success but produces no output. This makes project discovery resilient to transient MSBuild server contention without changing the behavior for normal success or error cases.

Fixes #14819

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
