### PR TITLE
Make template discovery async in aspire new command

### DIFF
--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -23,6 +23,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
     internal override HelpGroup HelpGroup => HelpGroup.AppCommands;
 
     private readonly INewCommandPrompter _prompter;
+    private readonly ITemplateProvider _templateProvider;
     private readonly ITemplate[] _templates;
     private readonly IFeatures _features;
     private readonly IPackagingService _packagingService;
@@ -75,6 +76,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         : base("new", NewCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _prompter = prompter;
+        _templateProvider = templateProvider;
         _features = features;
         _packagingService = packagingService;
         _configurationService = configurationService;
@@ -102,7 +104,11 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         };
         Options.Add(_languageOption);
 
-        _templates = templateProvider.GetTemplatesAsync(CancellationToken.None).GetAwaiter().GetResult().ToArray();
+        // Register template definitions as subcommands synchronously.
+        // This uses GetTemplates() which returns template definitions without
+        // performing any async I/O (e.g. SDK availability checks). Runtime
+        // availability is checked in ExecuteAsync via GetTemplatesAsync().
+        _templates = templateProvider.GetTemplates().ToArray();
 
         foreach (var template in _templates)
         {
@@ -199,10 +205,10 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         return (true, selectedLanguageId);
     }
 
-    private ITemplate[] GetTemplatesForPrompt(ParseResult parseResult)
+    private ITemplate[] GetTemplatesForPrompt(ITemplate[] availableTemplates, ParseResult parseResult)
     {
         var explicitLanguageId = ParseExplicitLanguageId(parseResult);
-        var templatesForPrompt = _templates.ToList();
+        var templatesForPrompt = availableTemplates.ToList();
 
         if (!string.IsNullOrWhiteSpace(explicitLanguageId))
         {
@@ -214,19 +220,24 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         return templatesForPrompt.ToArray();
     }
 
-    private async Task<ITemplate?> GetProjectTemplateAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    private async Task<ITemplate?> GetProjectTemplateAsync(ITemplate[] availableTemplates, ParseResult parseResult, CancellationToken cancellationToken)
     {
         // If a subcommand was matched (e.g., aspire new aspire-starter), find the template by command name
         if (parseResult.CommandResult.Command != this)
         {
-            var subcommandTemplate = _templates.SingleOrDefault(t => t.Name.Equals(parseResult.CommandResult.Command.Name, StringComparison.OrdinalIgnoreCase));
+            var subcommandTemplate = availableTemplates.SingleOrDefault(t => t.Name.Equals(parseResult.CommandResult.Command.Name, StringComparison.OrdinalIgnoreCase));
             if (subcommandTemplate is not null)
             {
                 return subcommandTemplate;
             }
+
+            // The template subcommand was parsed successfully but the template is
+            // not available at runtime (e.g. .NET SDK is not installed).
+            InteractionService.DisplayError($"Template '{parseResult.CommandResult.Command.Name}' is not available. Ensure the required runtime is installed.");
+            return null;
         }
 
-        var templatesForPrompt = GetTemplatesForPrompt(parseResult);
+        var templatesForPrompt = GetTemplatesForPrompt(availableTemplates, parseResult);
         if (templatesForPrompt.Length == 0)
         {
             InteractionService.DisplayError("No templates are available for the current environment.");
@@ -301,7 +312,12 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
     {
         using var activity = Telemetry.StartDiagnosticActivity(this.Name);
 
-        var template = await GetProjectTemplateAsync(parseResult, cancellationToken);
+        // Resolve which templates are actually available at runtime (performs
+        // async checks like SDK availability). This may be a subset of the
+        // templates registered as subcommands.
+        var availableTemplates = (await _templateProvider.GetTemplatesAsync(cancellationToken)).ToArray();
+
+        var template = await GetProjectTemplateAsync(availableTemplates, parseResult, cancellationToken);
         if (template is null)
         {
             return ExitCodeConstants.InvalidCommand;

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.cs
@@ -67,9 +67,24 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
         _logger = logger;
     }
 
+    public IEnumerable<ITemplate> GetTemplates()
+    {
+        return GetTemplateDefinitions();
+    }
+
     public Task<IEnumerable<ITemplate>> GetTemplatesAsync(CancellationToken cancellationToken = default)
     {
-        IEnumerable<ITemplate> templates =
+        return Task.FromResult(GetTemplateDefinitions());
+    }
+
+    public Task<IEnumerable<ITemplate>> GetInitTemplatesAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult<IEnumerable<ITemplate>>([]);
+    }
+
+    private IEnumerable<ITemplate> GetTemplateDefinitions()
+    {
+        return
         [
             new CallbackTemplate(
                 KnownTemplateId.TypeScriptStarter,
@@ -95,13 +110,6 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
                     languageId.Equals(KnownLanguageId.TypeScriptAlias, StringComparison.OrdinalIgnoreCase),
                 selectableAppHostLanguages: [KnownLanguageId.CSharp, KnownLanguageId.TypeScript])
         ];
-
-        return Task.FromResult(templates);
-    }
-
-    public Task<IEnumerable<ITemplate>> GetInitTemplatesAsync(CancellationToken cancellationToken = default)
-    {
-        return Task.FromResult<IEnumerable<ITemplate>>([]);
     }
 
     private static string ApplyTokens(string content, string projectName, string projectNameLower, string aspireVersion, TemplatePorts ports, string hostName = "localhost")

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -54,6 +54,13 @@ internal class DotNetTemplateFactory(
         Description = TemplatingStrings.EnterXUnitVersion_Description
     };
 
+    public IEnumerable<ITemplate> GetTemplates()
+    {
+        var showAllTemplates = features.IsFeatureEnabled(KnownFeatures.ShowAllTemplates, false);
+        var nonInteractive = !hostEnvironment.SupportsInteractiveInput;
+        return GetTemplatesCore(showAllTemplates, nonInteractive);
+    }
+
     public async Task<IEnumerable<ITemplate>> GetTemplatesAsync(CancellationToken cancellationToken = default)
     {
         if (!await IsDotNetSdkAvailableAsync(cancellationToken))

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Configuration;
@@ -56,6 +57,11 @@ internal class DotNetTemplateFactory(
 
     public IEnumerable<ITemplate> GetTemplates()
     {
+        if (!IsDotNetOnPath())
+        {
+            return [];
+        }
+
         var showAllTemplates = features.IsFeatureEnabled(KnownFeatures.ShowAllTemplates, false);
         var nonInteractive = !hostEnvironment.SupportsInteractiveInput;
         return GetTemplatesCore(showAllTemplates, nonInteractive);
@@ -94,6 +100,37 @@ internal class DotNetTemplateFactory(
         {
             return false;
         }
+    }
+
+    private bool IsDotNetOnPath()
+    {
+        // Check the private SDK installation first.
+        var sdkInstallPath = Path.Combine(executionContext.SdksDirectory.FullName, "dotnet", DotNetSdkInstaller.MinimumSdkVersion);
+        if (Directory.Exists(sdkInstallPath))
+        {
+            return true;
+        }
+
+        // Fall back to checking for dotnet on the system PATH.
+        var dotnetFileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
+        var pathVariable = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+
+        foreach (var directory in pathVariable.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            try
+            {
+                if (File.Exists(Path.Combine(directory, dotnetFileName)))
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+                // Skip directories that can't be accessed.
+            }
+        }
+
+        return false;
     }
 
     private IEnumerable<ITemplate> GetTemplatesCore(bool showAllTemplates, bool nonInteractive = false)

--- a/src/Aspire.Cli/Templating/ITemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/ITemplateFactory.cs
@@ -5,6 +5,16 @@ namespace Aspire.Cli.Templating;
 
 internal interface ITemplateFactory
 {
+    /// <summary>
+    /// Gets template definitions synchronously for command registration.
+    /// This must not perform any I/O or async work.
+    /// </summary>
+    IEnumerable<ITemplate> GetTemplates();
+
+    /// <summary>
+    /// Gets templates that are available for use, performing any necessary
+    /// runtime availability checks (e.g. SDK availability).
+    /// </summary>
     Task<IEnumerable<ITemplate>> GetTemplatesAsync(CancellationToken cancellationToken = default);
     Task<IEnumerable<ITemplate>> GetInitTemplatesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Aspire.Cli/Templating/ITemplateProvider.cs
+++ b/src/Aspire.Cli/Templating/ITemplateProvider.cs
@@ -9,7 +9,14 @@ namespace Aspire.Cli.Templating;
 internal interface ITemplateProvider
 {
     /// <summary>
-    /// Gets templates available to the <c>aspire new</c> command.
+    /// Gets template definitions synchronously for command registration (e.g. subcommands).
+    /// This must not perform any I/O or async work.
+    /// </summary>
+    IEnumerable<ITemplate> GetTemplates();
+
+    /// <summary>
+    /// Gets templates available to the <c>aspire new</c> command, performing any
+    /// necessary runtime availability checks.
     /// </summary>
     /// <returns>The templates available for project creation.</returns>
     Task<IEnumerable<ITemplate>> GetTemplatesAsync(CancellationToken cancellationToken = default);

--- a/src/Aspire.Cli/Templating/TemplateProvider.cs
+++ b/src/Aspire.Cli/Templating/TemplateProvider.cs
@@ -20,6 +20,11 @@ internal sealed class TemplateProvider : ITemplateProvider
 
     }
 
+    public IEnumerable<ITemplate> GetTemplates()
+    {
+        return _factories.SelectMany(static f => f.GetTemplates());
+    }
+
     public async Task<IEnumerable<ITemplate>> GetTemplatesAsync(CancellationToken cancellationToken = default)
     {
         var templates = await Task.WhenAll(_factories.Select(f => f.GetTemplatesAsync(cancellationToken)));


### PR DESCRIPTION
## Description

Make template discovery in `aspire new` asynchronous instead of blocking at CLI startup.

**Problem:** `NewCommand`'s constructor called `templateProvider.GetTemplatesAsync(CancellationToken.None).GetAwaiter().GetResult()` which synchronously blocked on async template discovery (including a .NET SDK availability check) every time the command was instantiated.

**Solution:** Separate template *definition* (sync) from template *availability* (async):

- Add a synchronous `GetTemplates()` method to `ITemplateFactory` / `ITemplateProvider` that returns template definitions without performing any I/O or async work
- `NewCommand` constructor uses `GetTemplates()` for subcommand registration — no blocking
- `NewCommand.ExecuteAsync` uses the existing `GetTemplatesAsync()` to resolve which templates are actually available at runtime (e.g. .NET SDK check)
- If a user selects a template subcommand that isn't available at runtime, a clear error is displayed
- Template subcommands and per-template help output are fully preserved

**Validation:** All 1,395 Aspire.Cli.Tests pass (0 failures, 2 skipped).

Fixes #14805

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
