### PR TITLE
Replace ANSI escape codes with Live display, remove IAnsiConsole dependency, and simplify status feedback

### DIFF
--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -212,12 +212,10 @@ internal sealed class AddCommand : BaseCommand
             // which prevents 'dotnet add package' from modifying the project.
             if (_features.IsFeatureEnabled(KnownFeatures.RunningInstanceDetectionEnabled, defaultValue: true))
             {
-                var runningInstanceResult = await InteractionService.ShowStatusAsync(
-                    AddCommandStrings.CheckingForRunningInstances,
-                    async () => await project.FindAndStopRunningInstanceAsync(
-                        effectiveAppHostProjectFile,
-                        ExecutionContext.HomeDirectory,
-                        cancellationToken));
+                var runningInstanceResult = await project.FindAndStopRunningInstanceAsync(
+                    effectiveAppHostProjectFile,
+                    ExecutionContext.HomeDirectory,
+                    cancellationToken);
 
                 if (runningInstanceResult == RunningInstanceResult.InstanceStopped)
                 {

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -13,7 +13,6 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging;
-using Spectre.Console;
 
 namespace Aspire.Cli.Commands;
 
@@ -27,7 +26,6 @@ internal sealed class AppHostLauncher(
     CliExecutionContext executionContext,
     IFeatures features,
     IInteractionService interactionService,
-    IAnsiConsole ansiConsole,
     IAuxiliaryBackchannelMonitor backchannelMonitor,
     ILogger<AppHostLauncher> logger,
     TimeProvider timeProvider)
@@ -122,7 +120,9 @@ internal sealed class AppHostLauncher(
         logger.LogDebug("Waiting for socket with prefix: {SocketPrefix}, Hash: {Hash}", expectedSocketPrefix, expectedHash);
 
         // Start the child process and wait for the backchannel
-        var launchResult = await LaunchAndWaitForBackchannelAsync(executablePath, childArgs, expectedHash, cancellationToken);
+        var launchResult = await interactionService.ShowStatusAsync(
+            RunCommandStrings.StartingAppHostInBackground,
+            () => LaunchAndWaitForBackchannelAsync(executablePath, childArgs, expectedHash, cancellationToken));
 
         // Handle failure cases
         if (launchResult.Backchannel is null || launchResult.ChildProcess is null)
@@ -131,7 +131,7 @@ internal sealed class AppHostLauncher(
         }
 
         // Display results
-        await DisplayLaunchResultAsync(launchResult, effectiveAppHostFile, childLogFile, format, isExtensionHost, cancellationToken);
+        DisplayLaunchResult(launchResult, effectiveAppHostFile, childLogFile, format, isExtensionHost);
 
         return ExitCodeConstants.Success;
     }
@@ -203,7 +203,7 @@ internal sealed class AppHostLauncher(
         return (dotnetPath, childArgs);
     }
 
-    private record LaunchResult(Process? ChildProcess, IAppHostAuxiliaryBackchannel? Backchannel, bool ChildExitedEarly, int ChildExitCode);
+    private record LaunchResult(Process? ChildProcess, IAppHostAuxiliaryBackchannel? Backchannel, DashboardUrlsState? DashboardUrls, bool ChildExitedEarly, int ChildExitCode);
 
     private async Task<LaunchResult> LaunchAndWaitForBackchannelAsync(
         string executablePath,
@@ -211,68 +211,57 @@ internal sealed class AppHostLauncher(
         string expectedHash,
         CancellationToken cancellationToken)
     {
-        Process? childProcess = null;
-        var childExitedEarly = false;
-        var childExitCode = 0;
+        Process childProcess;
 
-        async Task<IAppHostAuxiliaryBackchannel?> WaitForBackchannelAsync()
+        try
         {
-            try
-            {
-                childProcess = DetachedProcessLauncher.Start(
-                    executablePath,
-                    childArgs,
-                    executionContext.WorkingDirectory.FullName);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Failed to start child CLI process");
-                return null;
-            }
-
-            logger.LogDebug("Child CLI process started with PID: {PID}", childProcess.Id);
-
-            var startTime = timeProvider.GetUtcNow();
-            var timeout = TimeSpan.FromSeconds(120);
-
-            while (timeProvider.GetUtcNow() - startTime < timeout)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                if (childProcess.HasExited)
-                {
-                    childExitedEarly = true;
-                    childExitCode = childProcess.ExitCode;
-                    logger.LogWarning("Child CLI process exited with code {ExitCode}", childExitCode);
-                    return null;
-                }
-
-                await backchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
-
-                var connection = backchannelMonitor.GetConnectionsByHash(expectedHash).FirstOrDefault();
-                if (connection is not null)
-                {
-                    return connection;
-                }
-
-                try
-                {
-                    await childProcess.WaitForExitAsync(cancellationToken).WaitAsync(TimeSpan.FromMilliseconds(500), cancellationToken).ConfigureAwait(false);
-                }
-                catch (TimeoutException)
-                {
-                    // Expected - the 500ms delay elapsed without the process exiting
-                }
-            }
-
-            return null;
+            childProcess = DetachedProcessLauncher.Start(
+                executablePath,
+                childArgs,
+                executionContext.WorkingDirectory.FullName);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to start child CLI process");
+            return new LaunchResult(null, null, null, false, 0);
         }
 
-        var backchannel = await interactionService.ShowStatusAsync(
-            RunCommandStrings.StartingAppHostInBackground,
-            WaitForBackchannelAsync);
+        logger.LogDebug("Child CLI process started with PID: {PID}", childProcess.Id);
 
-        return new LaunchResult(childProcess, backchannel, childExitedEarly, childExitCode);
+        var startTime = timeProvider.GetUtcNow();
+        var timeout = TimeSpan.FromSeconds(120);
+
+        while (timeProvider.GetUtcNow() - startTime < timeout)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (childProcess.HasExited)
+            {
+                var exitCode = childProcess.ExitCode;
+                logger.LogWarning("Child CLI process exited with code {ExitCode}", exitCode);
+                return new LaunchResult(childProcess, null, null, true, exitCode);
+            }
+
+            await backchannelMonitor.ScanAsync(cancellationToken).ConfigureAwait(false);
+
+            var connection = backchannelMonitor.GetConnectionsByHash(expectedHash).FirstOrDefault();
+            if (connection is not null)
+            {
+                var dashboardUrls = await connection.GetDashboardUrlsAsync(cancellationToken).ConfigureAwait(false);
+                return new LaunchResult(childProcess, connection, dashboardUrls, false, 0);
+            }
+
+            try
+            {
+                await childProcess.WaitForExitAsync(cancellationToken).WaitAsync(TimeSpan.FromMilliseconds(500), cancellationToken).ConfigureAwait(false);
+            }
+            catch (TimeoutException)
+            {
+                // Expected - the 500ms delay elapsed without the process exiting
+            }
+        }
+
+        return new LaunchResult(childProcess, null, null, false, 0);
     }
 
     private int HandleLaunchFailure(LaunchResult result, string childLogFile)
@@ -312,16 +301,15 @@ internal sealed class AppHostLauncher(
         return ExitCodeConstants.FailedToDotnetRunAppHost;
     }
 
-    private async Task DisplayLaunchResultAsync(
+    private void DisplayLaunchResult(
         LaunchResult result,
         FileInfo effectiveAppHostFile,
         string childLogFile,
         OutputFormat? format,
-        bool isExtensionHost,
-        CancellationToken cancellationToken)
+        bool isExtensionHost)
     {
         var appHostInfo = result.Backchannel!.AppHostInfo;
-        var dashboardUrls = await result.Backchannel.GetDashboardUrlsAsync(cancellationToken).ConfigureAwait(false);
+        var dashboardUrls = result.DashboardUrls;
         var pid = appHostInfo?.ProcessId ?? result.ChildProcess!.Id;
 
         if (format == OutputFormat.Json)
@@ -339,14 +327,14 @@ internal sealed class AppHostLauncher(
         {
             var appHostRelativePath = Path.GetRelativePath(executionContext.WorkingDirectory.FullName, effectiveAppHostFile.FullName);
             RunCommand.RenderAppHostSummary(
-                ansiConsole,
+                interactionService,
                 appHostRelativePath,
                 dashboardUrls?.BaseUrlWithLoginToken,
                 codespacesUrl: null,
                 childLogFile,
                 isExtensionHost,
                 pid);
-            ansiConsole.WriteLine();
+            interactionService.DisplayEmptyLine();
 
             interactionService.DisplaySuccess(RunCommandStrings.AppHostStartedSuccessfully);
         }

--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -247,7 +247,16 @@ internal sealed class AppHostLauncher(
             var connection = backchannelMonitor.GetConnectionsByHash(expectedHash).FirstOrDefault();
             if (connection is not null)
             {
-                var dashboardUrls = await connection.GetDashboardUrlsAsync(cancellationToken).ConfigureAwait(false);
+                DashboardUrlsState? dashboardUrls = null;
+                try
+                {
+                    dashboardUrls = await connection.GetDashboardUrlsAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogDebug(ex, "Failed to retrieve dashboard URLs from backchannel connection. Continuing without dashboard URLs.");
+                }
+
                 return new LaunchResult(childProcess, connection, dashboardUrls, false, 0);
             }
 

--- a/src/Aspire.Cli/Commands/ExecCommand.cs
+++ b/src/Aspire.Cli/Commands/ExecCommand.cs
@@ -13,7 +13,6 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
 using Aspire.Hosting;
-using Spectre.Console;
 
 namespace Aspire.Cli.Commands;
 
@@ -22,7 +21,6 @@ internal class ExecCommand : BaseCommand
     private readonly IDotNetCliRunner _runner;
     private readonly ICertificateService _certificateService;
     private readonly IProjectLocator _projectLocator;
-    private readonly IAnsiConsole _ansiConsole;
     private readonly IDotNetSdkInstaller _sdkInstaller;
 
     private static readonly OptionWithLegacy<FileInfo?> s_appHostOption = new("--apphost", "--project", ExecCommandStrings.ProjectArgumentDescription);
@@ -48,7 +46,6 @@ internal class ExecCommand : BaseCommand
         IInteractionService interactionService,
         ICertificateService certificateService,
         IProjectLocator projectLocator,
-        IAnsiConsole ansiConsole,
         AspireCliTelemetry telemetry,
         IDotNetSdkInstaller sdkInstaller,
         IFeatures features,
@@ -59,7 +56,6 @@ internal class ExecCommand : BaseCommand
         _runner = runner;
         _certificateService = certificateService;
         _projectLocator = projectLocator;
-        _ansiConsole = ansiConsole;
         _sdkInstaller = sdkInstaller;
 
         Options.Add(s_appHostOption);

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -19,6 +19,7 @@ using Aspire.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 using StreamJsonRpc;
 
 namespace Aspire.Cli.Commands;
@@ -58,7 +59,6 @@ internal sealed class RunCommand : BaseCommand
     private readonly IInteractionService _interactionService;
     private readonly ICertificateService _certificateService;
     private readonly IProjectLocator _projectLocator;
-    private readonly IAnsiConsole _ansiConsole;
     private readonly IConfiguration _configuration;
     private readonly IServiceProvider _serviceProvider;
     private readonly IFeatures _features;
@@ -85,7 +85,6 @@ internal sealed class RunCommand : BaseCommand
         IInteractionService interactionService,
         ICertificateService certificateService,
         IProjectLocator projectLocator,
-        IAnsiConsole ansiConsole,
         AspireCliTelemetry telemetry,
         IConfiguration configuration,
         IFeatures features,
@@ -102,7 +101,6 @@ internal sealed class RunCommand : BaseCommand
         _interactionService = interactionService;
         _certificateService = certificateService;
         _projectLocator = projectLocator;
-        _ansiConsole = ansiConsole;
         _configuration = configuration;
         _serviceProvider = serviceProvider;
         _features = features;
@@ -206,9 +204,7 @@ internal sealed class RunCommand : BaseCommand
                 // Even if we fail to stop we won't block the apphost starting
                 // to make sure we don't ever break flow. It should mostly stop
                 // just fine though.
-                var runningInstanceResult = await InteractionService.ShowStatusAsync(
-                    RunCommandStrings.CheckingForRunningInstances,
-                    async () => await project.FindAndStopRunningInstanceAsync(effectiveAppHostFile, ExecutionContext.HomeDirectory, cancellationToken));
+                var runningInstanceResult = await project.FindAndStopRunningInstanceAsync(effectiveAppHostFile, ExecutionContext.HomeDirectory, cancellationToken);
 
                 // If in isolated mode and a running instance was stopped, warn the user
                 if (isolated && runningInstanceResult == RunningInstanceResult.InstanceStopped)
@@ -276,7 +272,7 @@ internal sealed class RunCommand : BaseCommand
             // Display the UX
             var appHostRelativePath = Path.GetRelativePath(ExecutionContext.WorkingDirectory.FullName, effectiveAppHostFile.FullName);
             var longestLocalizedLengthWithColon = RenderAppHostSummary(
-                _ansiConsole,
+                InteractionService,
                 appHostRelativePath,
                 dashboardUrls.BaseUrlWithLoginToken,
                 dashboardUrls.CodespacesUrlWithLoginToken,
@@ -288,45 +284,69 @@ internal sealed class RunCommand : BaseCommand
             var isRemoteContainers = string.Equals(_configuration["REMOTE_CONTAINERS"], "true", StringComparison.OrdinalIgnoreCase);
             var isSshRemote = _configuration["VSCODE_IPC_HOOK_CLI"] is not null
                               && _configuration["SSH_CONNECTION"] is not null;
+            var isRemoteEnvironment = isCodespaces || isRemoteContainers || isSshRemote;
 
-            AppendCtrlCMessage(longestLocalizedLengthWithColon);
-
-            if (isCodespaces || isRemoteContainers || isSshRemote)
+            if (!isRemoteEnvironment)
             {
-                bool firstEndpoint = true;
+                AppendCtrlCMessage(longestLocalizedLengthWithColon);
+            }
+            else
+            {
+                // We want to display resource information in remote environments.
+                // Resources update over time so we'll use a live display.
+                // It is used to show discovered endpoints as they come in over the backchannel.
+                var discoveredEndpoints = new List<(string Resource, string Endpoint)>();
                 var endpointsLocalizedString = RunCommandStrings.Endpoints;
+                var showCtrlC = !ExtensionHelper.IsExtensionHost(_interactionService, out _, out _);
+
+                IRenderable BuildLiveRenderable()
+                {
+                    var rows = new List<IRenderable>();
+
+                    if (discoveredEndpoints.Count > 0)
+                    {
+                        var endpointsGrid = new Grid();
+                        endpointsGrid.AddColumn();
+                        endpointsGrid.AddColumn();
+                        endpointsGrid.Columns[0].Width = longestLocalizedLengthWithColon;
+                        endpointsGrid.AddRow(Text.Empty, Text.Empty);
+
+                        for (var i = 0; i < discoveredEndpoints.Count; i++)
+                        {
+                            var (resource, endpoint) = discoveredEndpoints[i];
+                            endpointsGrid.AddRow(
+                                i == 0
+                                    ? new Align(new Markup($"[bold green]{endpointsLocalizedString}[/]:"), HorizontalAlignment.Right)
+                                    : Text.Empty,
+                                new Markup($"[bold]{resource.EscapeMarkup()}[/] [grey]has endpoint[/] [link={endpoint.EscapeMarkup()}]{endpoint.EscapeMarkup()}[/]")
+                            );
+                        }
+
+                        rows.Add(new Padder(endpointsGrid, new Padding(3, 0)));
+                    }
+
+                    if (showCtrlC)
+                    {
+                        rows.Add(BuildCtrlCRenderable(longestLocalizedLengthWithColon));
+                    }
+
+                    return rows.Count > 0 ? new Rows(rows) : Text.Empty;
+                }
 
                 try
                 {
-                    var resourceStates = backchannel.GetResourceStatesAsync(cancellationToken);
-                    await foreach (var resourceState in resourceStates.WithCancellation(cancellationToken))
+                    await InteractionService.DisplayLiveAsync(BuildLiveRenderable(), async updateTarget =>
                     {
-                        ProcessResourceState(resourceState, (resource, endpoint) =>
+                        var resourceStates = backchannel.GetResourceStatesAsync(cancellationToken);
+                        await foreach (var resourceState in resourceStates.WithCancellation(cancellationToken))
                         {
-                            ClearLines(2);
-
-                            var endpointsGrid = new Grid();
-                            endpointsGrid.AddColumn();
-                            endpointsGrid.AddColumn();
-                            endpointsGrid.Columns[0].Width = longestLocalizedLengthWithColon;
-
-                            if (firstEndpoint)
+                            ProcessResourceState(resourceState, (resource, endpoint) =>
                             {
-                                endpointsGrid.AddRow(Text.Empty, Text.Empty);
-                            }
-
-                            endpointsGrid.AddRow(
-                                firstEndpoint ? new Align(new Markup($"[bold green]{endpointsLocalizedString}[/]:"), HorizontalAlignment.Right) : Text.Empty,
-                                new Markup($"[bold]{resource.EscapeMarkup()}[/] [grey]has endpoint[/] [link={endpoint.EscapeMarkup()}]{endpoint.EscapeMarkup()}[/]")
-                            );
-
-                            var endpointsPadder = new Padder(endpointsGrid, new Padding(3, 0));
-                            _ansiConsole.Write(endpointsPadder);
-                            firstEndpoint = false;
-
-                            AppendCtrlCMessage(longestLocalizedLengthWithColon);
-                        });
-                    }
+                                discoveredEndpoints.Add((resource, endpoint));
+                                updateTarget(BuildLiveRenderable());
+                            });
+                        }
+                    });
                 }
                 catch (ConnectionLostException) when (cancellationToken.IsCancellationRequested)
                 {
@@ -384,18 +404,16 @@ internal sealed class RunCommand : BaseCommand
         }
     }
 
-    private void ClearLines(int lines)
+    private static IRenderable BuildCtrlCRenderable(int longestLocalizedLengthWithColon)
     {
-        if (lines <= 0)
-        {
-            return;
-        }
+        var ctrlCGrid = new Grid();
+        ctrlCGrid.AddColumn();
+        ctrlCGrid.AddColumn();
+        ctrlCGrid.Columns[0].Width = longestLocalizedLengthWithColon;
+        ctrlCGrid.AddRow(Text.Empty, Text.Empty);
+        ctrlCGrid.AddRow(new Text(string.Empty), new Markup(RunCommandStrings.PressCtrlCToStopAppHost) { Overflow = Overflow.Ellipsis });
 
-        for (var i = 0; i < lines; i++)
-        {
-            _ansiConsole.Write("\u001b[1A");
-            _ansiConsole.Write("\u001b[2K"); // Clear the line
-        }
+        return new Padder(ctrlCGrid, new Padding(3, 0));
     }
 
     private void AppendCtrlCMessage(int longestLocalizedLengthWithColon)
@@ -405,15 +423,7 @@ internal sealed class RunCommand : BaseCommand
             return;
         }
 
-        var ctrlCGrid = new Grid();
-        ctrlCGrid.AddColumn();
-        ctrlCGrid.AddColumn();
-        ctrlCGrid.Columns[0].Width = longestLocalizedLengthWithColon;
-        ctrlCGrid.AddRow(Text.Empty, Text.Empty);
-        ctrlCGrid.AddRow(new Text(string.Empty), new Markup(RunCommandStrings.PressCtrlCToStopAppHost) { Overflow = Overflow.Ellipsis });
-
-        var ctrlCPadder = new Padder(ctrlCGrid, new Padding(3, 0));
-        _ansiConsole.Write(ctrlCPadder);
+        InteractionService.DisplayRenderable(BuildCtrlCRenderable(longestLocalizedLengthWithColon));
     }
 
     /// <summary>
@@ -428,7 +438,7 @@ internal sealed class RunCommand : BaseCommand
     /// <param name="isExtensionHost">Whether the AppHost is running in the Aspire extension.</param>
     /// <returns>The column width used, for subsequent grid additions.</returns>
     internal static int RenderAppHostSummary(
-        IAnsiConsole console,
+        IInteractionService console,
         string appHostRelativePath,
         string? dashboardUrl,
         string? codespacesUrl,
@@ -436,7 +446,7 @@ internal sealed class RunCommand : BaseCommand
         bool isExtensionHost,
         int? pid = null)
     {
-        console.WriteLine();
+        console.DisplayEmptyLine();
         var grid = new Grid();
         grid.AddColumn();
         grid.AddColumn();
@@ -501,7 +511,7 @@ internal sealed class RunCommand : BaseCommand
         }
 
         var padder = new Padder(grid, new Padding(3, 0));
-        console.Write(padder);
+        console.DisplayRenderable(padder);
 
         return longestLabelLength;
     }

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -309,6 +309,16 @@ internal class ConsoleInteractionService : IInteractionService
         MessageConsole.Write(renderable);
     }
 
+    public async Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback)
+    {
+        await MessageConsole.Live(initialRenderable)
+            .AutoClear(false)
+            .StartAsync(async ctx =>
+            {
+                await callback(renderable => ctx.UpdateTarget(renderable));
+            });
+    }
+
     public void DisplayCancellationMessage()
     {
         MessageConsole.WriteLine();

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -401,6 +401,11 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         _consoleInteractionService.DisplayRenderable(renderable);
     }
 
+    public Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback)
+    {
+        return _consoleInteractionService.DisplayLiveAsync(initialRenderable, callback);
+    }
+
     public void LogMessage(LogLevel logLevel, string message)
     {
         var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.LogMessageAsync(logLevel, message.RemoveSpectreFormatting(), _cancellationToken));

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -27,6 +27,7 @@ internal interface IInteractionService
     void DisplaySubtleMessage(string message, bool allowMarkup = false);
     void DisplayLines(IEnumerable<(string Stream, string Line)> lines);
     void DisplayRenderable(IRenderable renderable);
+    Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback);
     void DisplayCancellationMessage();
     void DisplayEmptyLine();
 

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -255,7 +255,6 @@ internal sealed class ProjectLocator(
 
         logger.LogDebug("No project file specified, searching for apphost projects in {CurrentDirectory}", executionContext.WorkingDirectory);
         var results = await FindAppHostProjectFilesAsync(executionContext.WorkingDirectory, cancellationToken);
-        interactionService.DisplayEmptyLine();
 
         logger.LogDebug("Found {ProjectFileCount} project files.", results.BuildableAppHost.Count);
 

--- a/src/Aspire.Cli/Resources/AddCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.Designer.cs
@@ -205,12 +205,5 @@ namespace Aspire.Cli.Resources {
             }
         }
 
-        public static string CheckingForRunningInstances
-        {
-            get
-            {
-                return ResourceManager.GetString("CheckingForRunningInstances", resourceCulture);
-            }
-        }
     }
 }

--- a/src/Aspire.Cli/Resources/AddCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/AddCommandStrings.resx
@@ -178,7 +178,4 @@
   <data name="UnableToStopRunningInstances" xml:space="preserve">
     <value>Unable to stop one or more running Aspire AppHost instances. Please stop the application and try again.</value>
   </data>
-  <data name="CheckingForRunningInstances" xml:space="preserve">
-    <value>Checking for running instances...</value>
-  </data>
 </root>

--- a/src/Aspire.Cli/Resources/RunCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/RunCommandStrings.Designer.cs
@@ -207,12 +207,6 @@ namespace Aspire.Cli.Resources {
             }
         }
         
-        public static string CheckingForRunningInstances {
-            get {
-                return ResourceManager.GetString("CheckingForRunningInstances", resourceCulture);
-            }
-        }
-        
         public static string DetachArgumentDescription {
             get {
                 return ResourceManager.GetString("DetachArgumentDescription", resourceCulture);

--- a/src/Aspire.Cli/Resources/RunCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/RunCommandStrings.resx
@@ -208,9 +208,6 @@
   <data name="RunningInstanceStopped" xml:space="preserve">
     <value>Running instance stopped successfully.</value>
   </data>
-  <data name="CheckingForRunningInstances" xml:space="preserve">
-    <value>Checking for running instances...</value>
-  </data>
   <data name="StartingAppHostInBackground" xml:space="preserve">
     <value>Starting Aspire apphost in the background...</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.cs.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Přidává se integrace hostování Aspire...</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="new">Checking for running instances...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Přidejte do hostitele aplikací Aspire integraci hostování.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.de.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Aspire-Hosting-Integration wird hinzugefügt...</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="new">Checking for running instances...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Fügen Sie dem Aspire AppHost eine Hosting-Integration hinzu.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.es.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Agregando integración de hospedaje de Aspire...</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="new">Checking for running instances...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Agregue una integración de hospedaje a Aspire AppHost.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.fr.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Ajout de l’intégration d’hébergement Aspire...</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="new">Checking for running instances...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Ajoutez une intégration d’hébergement à l’Aspire AppHost.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.it.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Aggiunta dell'integrazione di hosting Aspire in corso...</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="new">Checking for running instances...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Aggiungere un'integrazione di hosting all'AppHost Aspire.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ja.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Aspire ホスティング統合を追加しています...</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="new">Checking for running instances...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Aspire AppHost にホスティング統合を追加します。</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ko.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Aspire 호스팅 통합을 추가하는 중...</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="new">Checking for running instances...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Aspire AppHost에 호스팅 통합을 추가하세요.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pl.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Trwa dodawanie integracji hostingu platformy Aspire...</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="new">Checking for running instances...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Dodaj integrację hostingu do hosta AppHost platformy Aspire.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.pt-BR.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Adicionando integração de hosting do Aspire...</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="new">Checking for running instances...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Adicione uma integração de hosting ao Aspire AppHost.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.ru.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Добавление интеграции размещения Aspire...</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="new">Checking for running instances...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Добавьте интеграцию размещения в Aspire AppHost.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.tr.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Aspire barındırma tümleştirmesi ekleniyor...</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="new">Checking for running instances...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">Aspire AppHost'a bir barındırma tümleştirmesi ekleyin.</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hans.xlf
@@ -7,11 +7,6 @@
         <target state="translated">正在添加 Aspire 托管集成...</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="new">Checking for running instances...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">将托管集成添加到 Aspire AppHost。</target>

--- a/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/AddCommandStrings.zh-Hant.xlf
@@ -7,11 +7,6 @@
         <target state="translated">正在新增 Aspire 主機整合...</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="new">Checking for running instances...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Description">
         <source>Add a hosting integration to the apphost.</source>
         <target state="needs-review-translation">將主機整合新增到 Aspire AppHost。</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.cs.xlf
@@ -52,11 +52,6 @@
         <target state="translated">Podrobnosti najdete v protokolech: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="translated">Kontrolují se spuštěné instance...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ConnectingToAppHost">
         <source>Connecting to apphost...</source>
         <target state="translated">Připojování k hostiteli aplikací...</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.de.xlf
@@ -52,11 +52,6 @@
         <target state="translated">Details finden Sie in den Protokollen: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="translated">Es wird nach ausgeführten Instanzen gesucht…</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ConnectingToAppHost">
         <source>Connecting to apphost...</source>
         <target state="translated">Verbindung zum AppHost wird hergestellt...</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.es.xlf
@@ -52,11 +52,6 @@
         <target state="translated">Compruebe los registros para obtener más información: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="translated">Comprobando si hay instancias en ejecución...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ConnectingToAppHost">
         <source>Connecting to apphost...</source>
         <target state="translated">Conectando con apphost...</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.fr.xlf
@@ -52,11 +52,6 @@
         <target state="translated">Pour en savoir plus, consultez les journaux : {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="translated">Vérification des instances en cours d’exécution...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ConnectingToAppHost">
         <source>Connecting to apphost...</source>
         <target state="translated">Connexion à apphost...</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.it.xlf
@@ -52,11 +52,6 @@
         <target state="translated">Controllare i log per i dettagli: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="translated">Verifica delle istanze in esecuzione in corso...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ConnectingToAppHost">
         <source>Connecting to apphost...</source>
         <target state="translated">Connessione all'AppHost Aspire in corso...</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ja.xlf
@@ -52,11 +52,6 @@
         <target state="translated">詳細については、ログを確認してください: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="translated">実行中のインスタンスを確認しています...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ConnectingToAppHost">
         <source>Connecting to apphost...</source>
         <target state="translated">AppHost に接続しています...</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ko.xlf
@@ -52,11 +52,6 @@
         <target state="translated">자세한 내용은 로그를 확인하세요. {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="translated">실행 중인 인스턴스를 확인하는 중...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ConnectingToAppHost">
         <source>Connecting to apphost...</source>
         <target state="translated">apphost에 연결하는 중...</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pl.xlf
@@ -52,11 +52,6 @@
         <target state="translated">Sprawdź dzienniki, aby uzyskać szczegółowe informacje: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="translated">Sprawdzanie uruchomionych wystąpień...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ConnectingToAppHost">
         <source>Connecting to apphost...</source>
         <target state="translated">Trwa łączenie z hostem AppHost...</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.pt-BR.xlf
@@ -52,11 +52,6 @@
         <target state="translated">Verifique os logs para obter detalhes: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="translated">Verificando se há instâncias em execução...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ConnectingToAppHost">
         <source>Connecting to apphost...</source>
         <target state="translated">Conectando ao apphost...</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.ru.xlf
@@ -52,11 +52,6 @@
         <target state="translated">Просмотрите дополнительные сведения в журналах: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="translated">Проверка запущенных экземпляров…</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ConnectingToAppHost">
         <source>Connecting to apphost...</source>
         <target state="translated">Подключение к хосту приложений...</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.tr.xlf
@@ -52,11 +52,6 @@
         <target state="translated">Ayrıntılar için günlükleri kontrol edin: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="translated">Çalışan örnekler kontrol ediliyor...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ConnectingToAppHost">
         <source>Connecting to apphost...</source>
         <target state="translated">Apphost'a bağlanılıyor...</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hans.xlf
@@ -52,11 +52,6 @@
         <target state="translated">请查看日志了解详细信息: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="translated">正在检查正在运行的实例...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ConnectingToAppHost">
         <source>Connecting to apphost...</source>
         <target state="translated">正在连接到应用主机...</target>

--- a/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RunCommandStrings.zh-Hant.xlf
@@ -52,11 +52,6 @@
         <target state="translated">檢查記錄以取得詳細資料: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="CheckingForRunningInstances">
-        <source>Checking for running instances...</source>
-        <target state="translated">正在檢查是否有正在執行的執行個體...</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ConnectingToAppHost">
         <source>Connecting to apphost...</source>
         <target state="translated">正線連線到 AppHost...</target>

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1416,6 +1416,7 @@ internal sealed class OrderTrackingInteractionService(List<string> operationOrde
     public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false) { }
     public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null) { }
     public void DisplayRenderable(IRenderable renderable) { }
+    public Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback) => callback(_ => { });
 }
 
 internal sealed class NewCommandTestPackagingService : IPackagingService

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -958,6 +958,7 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
     public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null) { }
 
     public void DisplayRenderable(IRenderable renderable) { }
+    public Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback) => callback(_ => { });
 
     public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false)
     {

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -988,6 +988,7 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
     public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false) 
         => _innerService.WriteConsoleLog(message, lineNumber, type, isErrorMessage);
     public void DisplayRenderable(IRenderable renderable) => _innerService.DisplayRenderable(renderable);
+    public Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback) => _innerService.DisplayLiveAsync(initialRenderable, callback);
 }
 
 // Test implementation of IProjectUpdater

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -493,6 +493,7 @@ public class DotNetTemplateFactoryTests
         public void DisplayVersionUpdateNotification(string message, string? updateCommand = null) { }
         public void WriteConsoleLog(string message, int? resourceHashCode, string? resourceName, bool isError) { }
         public void DisplayRenderable(IRenderable renderable) { }
+        public Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback) => callback(_ => { });
     }
 
     private sealed class TestDotNetCliRunner : IDotNetCliRunner

--- a/tests/Aspire.Cli.Tests/TestServices/TestConsoleInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestConsoleInteractionService.cs
@@ -148,4 +148,9 @@ internal sealed class TestConsoleInteractionService : IInteractionService
     public void DisplayRenderable(IRenderable renderable)
     {
     }
+
+    public Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback)
+    {
+        return callback(_ => { });
+    }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -162,6 +162,11 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
     {
     }
 
+    public Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback)
+    {
+        return callback(_ => { });
+    }
+
     public Action<string>? OpenEditorCallback { get; set; }
 
     public void OpenEditor(string projectPath)


### PR DESCRIPTION
## Description

- Removed `ShowStatusAsync` spinner wrapper around `FindAndStopRunningInstanceAsync` in `AddCommand` and `RunCommand` — the call is now made directly
- Fetched dashboard URLs inside the backchannel connection loop instead of after launch, storing them in `LaunchResult.DashboardUrls` so `DisplayLaunchResult` is synchronous
- Removed `IAnsiConsole` dependency from `RunCommand`, `ExecCommand`, and `AppHostLauncher`; `RenderAppHostSummary` now takes `IInteractionService` and uses `DisplayEmptyLine()`/`DisplayRenderable()`

@davidfowl Progress now displayed until launch details is ready. Previously there could be a delay while getting the dashboard URL.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
