### PR TITLE
respect central package management when adding aspire integration to AppHost

### DIFF
--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -204,7 +204,7 @@ internal sealed class AddCommand : BaseCommand
                 AppHostFile = effectiveAppHostProjectFile,
                 PackageId = selectedNuGetPackage.Package.Id,
                 PackageVersion = selectedNuGetPackage.Package.Version,
-                Source = source
+                Source = source ?? selectedNuGetPackage.Package.Source
             };
 
             // Stop any running AppHost instance before adding the package.

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -204,7 +204,7 @@ internal sealed class AddCommand : BaseCommand
                 AppHostFile = effectiveAppHostProjectFile,
                 PackageId = selectedNuGetPackage.Package.Id,
                 PackageVersion = selectedNuGetPackage.Package.Version,
-                Source = source ?? selectedNuGetPackage.Package.Source
+                Source = source
             };
 
             // Stop any running AppHost instance before adding the package.

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -298,8 +298,12 @@ internal sealed class AddCommand : BaseCommand
             return preferredVersionPackage;
         }
 
-        // In non-interactive mode, auto-select the latest version.
-        var orderedPackageVersions = packageVersions.OrderByDescending(p => SemVersion.Parse(p.Package.Version), SemVersion.PrecedenceComparer);
+        // In non-interactive mode, prefer the implicit/default channel first to keep
+        // package selection aligned with the project's configured feeds. Then select
+        // the latest version within the chosen channel.
+        var orderedPackageVersions = packageVersions
+            .OrderByDescending(p => p.Channel.Type is PackageChannelType.Implicit)
+            .ThenByDescending(p => SemVersion.Parse(p.Package.Version), SemVersion.PrecedenceComparer);
         if (!_hostEnvironment.SupportsInteractiveInput)
         {
             return orderedPackageVersions.First();

--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -33,7 +33,7 @@ internal interface IDotNetCliRunner
     Task<int> NewProjectAsync(string templateName, string name, string outputPath, string[] extraArgs, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken);
     Task<int> RestoreAsync(FileInfo projectFilePath, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken);
     Task<int> BuildAsync(FileInfo projectFilePath, bool noRestore, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken);
-    Task<int> AddPackageAsync(FileInfo projectFilePath, string packageName, string packageVersion, string? nugetSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken);
+    Task<int> AddPackageAsync(FileInfo projectFilePath, string packageName, string packageVersion, string? nugetSource, bool noRestore, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken);
     Task<int> AddProjectToSolutionAsync(FileInfo solutionFile, FileInfo projectFile, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken);
     Task<(int ExitCode, NuGetPackage[]? Packages)> SearchPackagesAsync(DirectoryInfo workingDirectory, string query, bool prerelease, int take, int skip, FileInfo? nugetConfigFile, bool useCache, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken);
     Task<(int ExitCode, string[] ConfigPaths)> GetNuGetConfigPathsAsync(DirectoryInfo workingDirectory, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken);
@@ -758,7 +758,7 @@ internal sealed class DotNetCliRunner(
             options: options,
             cancellationToken: cancellationToken);
     }
-    public async Task<int> AddPackageAsync(FileInfo projectFilePath, string packageName, string packageVersion, string? nugetSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
+    public async Task<int> AddPackageAsync(FileInfo projectFilePath, string packageName, string packageVersion, string? nugetSource, bool noRestore, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         using var activity = telemetry.StartDiagnosticActivity();
 
@@ -787,11 +787,11 @@ internal sealed class DotNetCliRunner(
             cliArgsList.Add(projectFilePath.FullName);
         }
 
-        if (string.IsNullOrEmpty(nugetSource))
+        if (noRestore)
         {
             cliArgsList.Add("--no-restore");
         }
-        else
+        if (!string.IsNullOrEmpty(nugetSource))
         {
             cliArgsList.Add("--source");
             cliArgsList.Add(nugetSource);

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -476,7 +476,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
             context.PackageId,
             context.PackageVersion,
             context.Source,
-            false,
+            noRestore: false,
             options,
             cancellationToken);
 

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -476,6 +476,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
             context.PackageId,
             context.PackageVersion,
             context.Source,
+            false,
             options,
             cancellationToken);
 

--- a/src/Aspire.Cli/Projects/ProjectUpdater.cs
+++ b/src/Aspire.Cli/Projects/ProjectUpdater.cs
@@ -881,7 +881,8 @@ internal sealed partial class ProjectUpdater(ILogger<ProjectUpdater> logger, IDo
             projectFilePath: projectFile,
             packageName: package.Id,
             packageVersion: package.Version,
-            nugetSource: null, // When source is null we append --no-restore.
+            nugetSource: null,
+            noRestore: false,
             options: new(),
             cancellationToken: cancellationToken);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/CentralPackageManagementTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/CentralPackageManagementTests.cs
@@ -135,4 +135,81 @@ public sealed class CentralPackageManagementTests(ITestOutputHelper output)
 
         await pendingRun;
     }
+
+    [Fact]
+    public async Task AspireAddPackageVersionToDirectoryPackagesProps()
+    {
+        var workspace = TemporaryWorkspace.Create(output);
+
+        var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
+        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
+        var isCI = CliE2ETestHelpers.IsRunningInCI;
+        using var terminal = CliE2ETestHelpers.CreateTestTerminal();
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+        sequenceBuilder.PrepareEnvironment(workspace, counter);
+
+        if (isCI)
+        {
+            sequenceBuilder.InstallAspireCliFromPullRequest(prNumber, counter);
+            sequenceBuilder.SourceAspireCliEnvironment(counter);
+            sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
+        }
+
+        // Set up an AppHost project with CPM, but no installed packages
+        var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, "CpmTest");
+        var appHostDir = Path.Combine(projectDir, "CpmTest.AppHost");
+        var appHostCsprojPath = Path.Combine(appHostDir, "CpmTest.AppHost.csproj");
+        var directoryPackagesPropsPath = Path.Combine(projectDir, "Directory.Packages.props");
+
+        sequenceBuilder
+            .ExecuteCallback(() =>
+            {
+                Directory.CreateDirectory(appHostDir);
+
+                File.WriteAllText(appHostCsprojPath, """
+                    <Project Sdk="Aspire.AppHost.Sdk/13.1.2">
+                        <PropertyGroup>
+                            <OutputType>Exe</OutputType>
+                            <TargetFramework>net9.0</TargetFramework>
+                            <IsAspireHost>true</IsAspireHost>
+                        </PropertyGroup>
+                    </Project>
+                    """);
+
+                File.WriteAllText(Path.Combine(appHostDir, "Program.cs"), """
+                    var builder = DistributedApplication.CreateBuilder(args);
+                    builder.Build().Run();
+                    """);
+
+                File.WriteAllText(directoryPackagesPropsPath, """
+                    <Project>
+                        <PropertyGroup>
+                            <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                        </PropertyGroup>
+                    </Project>
+                    """);
+            })
+            .Type($"aspire add Aspire.Hosting.Redis --version 13.1.2")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            // Verify the PackageVersion for Aspire.Hosting.AppHost was removed
+            .VerifyFileDoesNotContain(appHostCsprojPath, "Version=\"13.1.2\"")
+            // Verify dotnet restore succeeds (would fail with NU1009 if AppHost.csproj contained a version)
+            .Type($"dotnet restore \"{appHostCsprojPath}\"")
+            .Enter()
+            .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(120))
+            .Type("exit")
+            .Enter();
+
+        var sequence = sequenceBuilder.Build();
+
+        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+        await pendingRun;
+    }
 }

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -745,6 +745,73 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(0, exitCode);
         Assert.Equal("Aspire.Hosting.Redis", selectedPackageId);
     }
+
+    [Fact]
+    public async Task AddCommand_WithHives_PrefersImplicitChannelVersionInNonInteractiveMode()
+    {
+        // Arrange
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var hivesDir = new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "hives"));
+        hivesDir.Create();
+        hivesDir.CreateSubdirectory("pr-12345");
+
+        var selectedPackageVersion = string.Empty;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
+
+            options.InteractionServiceFactory = _ => new TestInteractionService()
+            {
+                PromptForSelectionCallback = (message, choices, formatter, ct) => choices.Cast<object>().First()
+            };
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, invocationOptions, cancellationToken) =>
+                {
+                    var implicitPackage = new NuGetPackage
+                    {
+                        Id = "Aspire.Hosting.Redis",
+                        Source = "implicit",
+                        Version = "13.2.0-pr.12345.gabc"
+                    };
+
+                    var explicitPackage = new NuGetPackage
+                    {
+                        Id = "Aspire.Hosting.Redis",
+                        Source = "explicit",
+                        Version = "13.3.0-preview.1.1"
+                    };
+
+                    return nugetSource is null
+                        ? (0, new[] { implicitPackage })
+                        : (0, new[] { explicitPackage });
+                };
+
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, noRestore, invocationOptions, cancellationToken) =>
+                {
+                    selectedPackageVersion = packageVersion;
+                    return 0;
+                };
+
+                return runner;
+            };
+        });
+
+        var provider = services.BuildServiceProvider();
+
+        // Act
+        var command = provider.GetRequiredService<AddCommand>();
+        var result = command.Parse("add redis");
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        Assert.Equal("13.2.0-pr.12345.gabc", selectedPackageVersion);
+    }
 }
 
 internal sealed class TestAddCommandPrompter(IInteractionService interactionService) : AddCommandPrompter(interactionService)

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -76,7 +76,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                         );
                 };
 
-                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, options, cancellationToken) =>
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, noRestore, options, cancellationToken) =>
                 {
                     // Simulate adding the package.
                     return 0; // Success.
@@ -151,7 +151,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                         );
                 };
 
-                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, options, cancellationToken) =>
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, noRestore, options, cancellationToken) =>
                 {
                     // Simulate adding the package.
                     return 0; // Success.
@@ -234,7 +234,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                         );
                 };
 
-                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, options, cancellationToken) =>
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, noRestore, options, cancellationToken) =>
                 {
                     // Simulate adding the package.
                     return 0; // Success.
@@ -314,7 +314,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                         );
                 };
 
-                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, options, cancellationToken) =>
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, noRestore, options, cancellationToken) =>
                 {
                     addedPackageName = packageName;
                     addedPackageVersion = packageVersion;
@@ -381,7 +381,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                         );
                 };
 
-                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, options, cancellationToken) =>
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, noRestore, options, cancellationToken) =>
                 {
                     // Capture the source used for add
                     addUsedSource = nugetSource;
@@ -501,7 +501,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                     return (0, new NuGetPackage[] { dockerPackage, redisPackage });
                 };
 
-                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, options, cancellationToken) =>
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, noRestore, options, cancellationToken) =>
                 {
                     return 0; // Success.
                 };
@@ -723,7 +723,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
                     return (0, new NuGetPackage[] { redisPackage });
                 };
 
-                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, options, cancellationToken) =>
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, noRestore, options, cancellationToken) =>
                 {
                     selectedPackageId = packageName;
                     return 0;
@@ -830,7 +830,7 @@ public class AddCommandFuzzySearchTests(ITestOutputHelper outputHelper)
                     );
                 };
 
-                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, options, cancellationToken) =>
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, noRestore, options, cancellationToken) =>
                 {
                     addedPackage = packageName;
                     return 0; // Success.
@@ -916,7 +916,7 @@ public class AddCommandFuzzySearchTests(ITestOutputHelper outputHelper)
                     );
                 };
 
-                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, options, cancellationToken) =>
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, noRestore, options, cancellationToken) =>
                 {
                     return 0; // Success.
                 };
@@ -985,7 +985,7 @@ public class AddCommandFuzzySearchTests(ITestOutputHelper outputHelper)
                     );
                 };
 
-                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, options, cancellationToken) =>
+                runner.AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, noRestore, options, cancellationToken) =>
                 {
                     addedPackage = packageName;
                     return 0; // Success.

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
@@ -597,7 +597,8 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             appHostFile,
             "Aspire.Hosting.Redis",
             "9.2.0",
-            null, // no source, should use --no-restore
+            null,
+            true, // should use --no-restore
             options,
             CancellationToken.None
             );
@@ -660,6 +661,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             "Aspire.Hosting.Redis",
             "9.2.0",
             "https://api.nuget.org/v3/index.json", // provide source, should use --source
+            false,
             options,
             CancellationToken.None
             );
@@ -724,7 +726,8 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             projectFile,
             "Aspire.Hosting.Redis",
             "9.2.0",
-            null, // no source, should use --no-restore
+            null,
+            true, // should use --no-restore
             options,
             CancellationToken.None
             );

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
@@ -642,6 +642,8 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
                 var packageNameIndex = Array.IndexOf(args, "Aspire.Hosting.Redis");
                 var versionFlagIndex = Array.IndexOf(args, "--version");
                 var versionValueIndex = Array.IndexOf(args, "9.2.0");
+                var sourceFlagIndex = Array.IndexOf(args, "--source");
+                var sourceValueIndex = Array.IndexOf(args, "https://api.nuget.org/v3/index.json");
 
                 Assert.True(packageIndex < addIndex);
                 Assert.True(addIndex < packageNameIndex);
@@ -649,6 +651,8 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
                 Assert.True(versionFlagIndex < versionValueIndex);
                 Assert.True(packageNameIndex < projectFlagIndex);
                 Assert.True(projectFlagIndex < projectValueIndex);
+                Assert.True(packageNameIndex < sourceFlagIndex);
+                Assert.True(sourceFlagIndex < sourceValueIndex);
 
                 // Should NOT contain --file or the @version format
                 Assert.DoesNotContain("--file", args);
@@ -727,7 +731,78 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             "Aspire.Hosting.Redis",
             "9.2.0",
             null,
-            true, // should use --no-restore
+            true,
+            options,
+            CancellationToken.None
+            );
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task AddPackageAsyncWithSourceAndNoRestoreHasArgumentSourceAndNoRestore()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(projectFile.FullName, "<Project></Project>");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        var provider = services.BuildServiceProvider();
+
+        var options = new DotNetCliRunnerInvocationOptions();
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var runner = DotNetCliRunnerTestHelper.Create(
+            provider,
+            executionContext,
+            (args, _, _, _) =>
+            {
+                // Verify arguments are correct for .csproj file with --source and --no-restore
+                Assert.Contains("package", args);
+                Assert.Contains("add", args);
+                Assert.Contains("Aspire.Hosting.Redis", args);
+                Assert.Contains("--version", args);
+                Assert.Contains("9.2.0", args);
+                Assert.Contains("--project", args);
+                Assert.Contains(projectFile.FullName, args);
+                Assert.Contains("--source", args);
+                Assert.Contains("https://api.nuget.org/v3/index.json", args);
+                Assert.Contains("--no-restore", args);
+
+                // Verify the order: package add PackageName --version Version --project ProjectFile --no-restore --source Source
+                var packageIndex = Array.IndexOf(args, "package");
+                var addIndex = Array.IndexOf(args, "add");
+                var packageNameIndex = Array.IndexOf(args, "Aspire.Hosting.Redis");
+                var versionFlagIndex = Array.IndexOf(args, "--version");
+                var versionValueIndex = Array.IndexOf(args, "9.2.0");
+                var projectFlagIndex = Array.IndexOf(args, "--project");
+                var projectValueIndex = Array.IndexOf(args, projectFile.FullName);
+                var sourceFlagIndex = Array.IndexOf(args, "--source");
+                var sourceValueIndex = Array.IndexOf(args, "https://api.nuget.org/v3/index.json");
+                var noRestoreIndex = Array.IndexOf(args, "--no-restore");
+
+                Assert.True(packageIndex < addIndex);
+                Assert.True(addIndex < packageNameIndex);
+                Assert.True(packageNameIndex < versionFlagIndex);
+                Assert.True(versionFlagIndex < versionValueIndex);
+                Assert.True(packageNameIndex < projectFlagIndex);
+                Assert.True(projectFlagIndex < projectValueIndex);
+                Assert.True(packageNameIndex < noRestoreIndex);
+                Assert.True(packageNameIndex < sourceFlagIndex);
+                Assert.True(sourceFlagIndex < sourceValueIndex);
+
+                // Should NOT contain --file or the @version format
+                Assert.DoesNotContain("--file", args);
+                Assert.DoesNotContain("Aspire.Hosting.Redis@9.2.0", args);
+            },
+            0);
+
+        var exitCode = await runner.AddPackageAsync(
+            projectFile,
+            "Aspire.Hosting.Redis",
+            "9.2.0",
+            "https://api.nuget.org/v3/index.json", // provide source, should use --source
+            true,
             options,
             CancellationToken.None
             );

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
@@ -597,8 +597,8 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             appHostFile,
             "Aspire.Hosting.Redis",
             "9.2.0",
-            null,
-            true, // should use --no-restore
+            nugetSource: null,
+            noRestore: true, // should use --no-restore
             options,
             CancellationToken.None
             );
@@ -665,7 +665,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             "Aspire.Hosting.Redis",
             "9.2.0",
             "https://api.nuget.org/v3/index.json", // provide source, should use --source
-            false,
+            noRestore: false,
             options,
             CancellationToken.None
             );
@@ -730,8 +730,8 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             projectFile,
             "Aspire.Hosting.Redis",
             "9.2.0",
-            null,
-            true,
+            nugetSource: null,
+            noRestore: true,
             options,
             CancellationToken.None
             );
@@ -802,7 +802,7 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             "Aspire.Hosting.Redis",
             "9.2.0",
             "https://api.nuget.org/v3/index.json", // provide source, should use --source
-            true,
+            noRestore: true,
             options,
             CancellationToken.None
             );

--- a/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
@@ -153,7 +153,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
             </Project>
             """);
 
-        var packagesAddsExecuted = new List<(FileInfo ProjectFile, string PackageId, string PackageVersion, string? PackageSource)>();
+        var packagesAddsExecuted = new List<(FileInfo ProjectFile, string PackageId, string PackageVersion, string? PackageSource, bool NoRestore)>();
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, config =>
         {
             config.DotNetCliRunnerFactory = (sp) =>
@@ -207,9 +207,9 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                         return (0, document);
                     },
                     // FileInfo, string, string, string?, DotNetCliRunnerInvocationOptions, CancellationToken, int
-                    AddPackageAsyncCallback = (projectFile, packageId, packageVersion, source, _, _) =>
+                    AddPackageAsyncCallback = (projectFile, packageId, packageVersion, source, noRestore, _, _) =>
                     {
-                        packagesAddsExecuted.Add((projectFile, packageId, packageVersion, source!));
+                        packagesAddsExecuted.Add((projectFile, packageId, packageVersion, source!, noRestore));
                         return 0;
                     }
                 };
@@ -284,7 +284,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
             </Project>
             """);
 
-        var packagesAddsExecuted = new List<(FileInfo ProjectFile, string PackageId, string PackageVersion, string? PackageSource)>();
+        var packagesAddsExecuted = new List<(FileInfo ProjectFile, string PackageId, string PackageVersion, string? PackageSource, bool NoRestore)>();
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, config =>
         {
             config.DotNetCliRunnerFactory = (sp) =>
@@ -346,9 +346,9 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                         return (0, document);
                     },
                     // FileInfo, string, string, string?, DotNetCliRunnerInvocationOptions, CancellationToken, int
-                    AddPackageAsyncCallback = (projectFile, packageId, packageVersion, source, _, _) =>
+                    AddPackageAsyncCallback = (projectFile, packageId, packageVersion, source, noRestore, _, _) =>
                     {
-                        packagesAddsExecuted.Add((projectFile, packageId, packageVersion, source!));
+                        packagesAddsExecuted.Add((projectFile, packageId, packageVersion, source!, noRestore));
                         return 0;
                     }
                 };
@@ -437,7 +437,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
             </Project>
             """);
 
-        var packagesAddsExecuted = new List<(FileInfo ProjectFile, string PackageId, string PackageVersion, string? PackageSource)>();
+        var packagesAddsExecuted = new List<(FileInfo ProjectFile, string PackageId, string PackageVersion, string? PackageSource, bool NoRestore)>();
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, config =>
         {
             config.DotNetCliRunnerFactory = (sp) =>
@@ -499,9 +499,9 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                         return (0, document);
                     },
 
-                    AddPackageAsyncCallback = (projectFile, packageId, packageVersion, source, _, _) =>
+                    AddPackageAsyncCallback = (projectFile, packageId, packageVersion, source, noRestore, _, _) =>
                     {
-                        packagesAddsExecuted.Add((projectFile, packageId, packageVersion, source!));
+                        packagesAddsExecuted.Add((projectFile, packageId, packageVersion, source!, noRestore));
                         return 0;
                     }
                 };
@@ -1433,7 +1433,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                         }
                     },
 
-                    AddPackageAsyncCallback = (projectFile, packageName, version, source, options, cancellationToken) =>
+                    AddPackageAsyncCallback = (projectFile, packageName, version, source, noRestore, options, cancellationToken) =>
                     {
                         // Simulate successful package addition
                         return 0;
@@ -1946,7 +1946,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                         var document = JsonDocument.Parse(json);
                         return (0, document);
                     },
-                    AddPackageAsyncCallback = (projectFile, packageName, version, source, options, cancellationToken) =>
+                    AddPackageAsyncCallback = (projectFile, packageName, version, source, noRestore, options, cancellationToken) =>
                     {
                         // Simulate successful package addition
                         return 0;
@@ -2196,7 +2196,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                         var document = JsonDocument.Parse(json);
                         return (0, document);
                     },
-                    AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, options, cancellationToken) =>
+                    AddPackageAsyncCallback = (projectFilePath, packageName, packageVersion, nugetSource, noRestore, options, cancellationToken) =>
                     {
                         // Track which packages are updated
                         packagesUpdated.Add(packageName);
@@ -2289,7 +2289,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
             </Project>
             """);
 
-        var packagesAddsExecuted = new List<(FileInfo ProjectFile, string PackageId, string PackageVersion, string? PackageSource)>();
+        var packagesAddsExecuted = new List<(FileInfo ProjectFile, string PackageId, string PackageVersion, string? PackageSource, bool NoRestore)>();
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, config =>
         {
@@ -2325,9 +2325,9 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
                         var document = JsonDocument.Parse(json);
                         return (0, document);
                     },
-                    AddPackageAsyncCallback = (projectFile, packageId, packageVersion, source, _, _) =>
+                    AddPackageAsyncCallback = (projectFile, packageId, packageVersion, source, noRestore, _, _) =>
                     {
-                        packagesAddsExecuted.Add((projectFile, packageId, packageVersion, source!));
+                        packagesAddsExecuted.Add((projectFile, packageId, packageVersion, source!, noRestore));
                         return 0;
                     }
                 };

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -510,7 +510,7 @@ public class DotNetTemplateFactoryTests
         public Task<int> BuildAsync(FileInfo projectFile, bool noRestore, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
             => throw new NotImplementedException();
 
-        public Task<int> AddPackageAsync(FileInfo projectFile, string packageName, string version, string? packageSourceUrl, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
+        public Task<int> AddPackageAsync(FileInfo projectFile, string packageName, string version, string? packageSourceUrl, bool noRestore, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
             => throw new NotImplementedException();
 
         public Task<int> AddProjectToSolutionAsync(FileInfo solutionFile, FileInfo projectFile, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)

--- a/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestDotNetCliRunner.cs
@@ -11,7 +11,7 @@ namespace Aspire.Cli.Tests.TestServices;
 
 internal sealed class TestDotNetCliRunner : IDotNetCliRunner
 {
-    public Func<FileInfo, string, string, string?, DotNetCliRunnerInvocationOptions, CancellationToken, int>? AddPackageAsyncCallback { get; set; }
+    public Func<FileInfo, string, string, string?, bool, DotNetCliRunnerInvocationOptions, CancellationToken, int>? AddPackageAsyncCallback { get; set; }
     public Func<FileInfo, FileInfo, DotNetCliRunnerInvocationOptions, CancellationToken, int>? AddProjectToSolutionAsyncCallback { get; set; }
     public Func<FileInfo, bool, DotNetCliRunnerInvocationOptions, CancellationToken, int>? BuildAsyncCallback { get; set; }
     public Func<FileInfo, DotNetCliRunnerInvocationOptions, CancellationToken, int>? RestoreAsyncCallback { get; set; }
@@ -25,10 +25,10 @@ internal sealed class TestDotNetCliRunner : IDotNetCliRunner
     public Func<FileInfo, DotNetCliRunnerInvocationOptions, CancellationToken, (int ExitCode, IReadOnlyList<FileInfo> Projects)>? GetSolutionProjectsAsyncCallback { get; set; }
     public Func<FileInfo, FileInfo, DotNetCliRunnerInvocationOptions, CancellationToken, int>? AddProjectReferenceAsyncCallback { get; set; }
 
-    public Task<int> AddPackageAsync(FileInfo projectFilePath, string packageName, string packageVersion, string? nugetSource, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
+    public Task<int> AddPackageAsync(FileInfo projectFilePath, string packageName, string packageVersion, string? nugetSource, bool noRestore, DotNetCliRunnerInvocationOptions options, CancellationToken cancellationToken)
     {
         return AddPackageAsyncCallback != null
-            ? Task.FromResult(AddPackageAsyncCallback(projectFilePath, packageName, packageVersion, nugetSource, options, cancellationToken))
+            ? Task.FromResult(AddPackageAsyncCallback(projectFilePath, packageName, packageVersion, nugetSource, noRestore, options, cancellationToken))
             : throw new NotImplementedException();
     }
 


### PR DESCRIPTION
## Description

Previously when running `aspire add [integration-name]` the `PackageReference` element with a `Version` attribute would be added to the `AppHost.csproj` directly. 
When Central Package Management is in place this will lead to a build error [NU1008](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1008).

The `PackageReference` is added to the `AppHost.csproj` directly because the `--no-restore` flag is passed to the dotnet CLI when no source is explicitly specified for `aspire add`. This effectively tells the dotnet CLI to skip the validation that is required for adding the `PackageVersion` to the `Directory.Packages.props`.

So if no source is explicitly specified to the `aspire add` command pass the one, where the integration NuGet package was found in (for most cases this will be the nuget.org source).

Fixes #13241

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [X] No
