### PR TITLE
Remove temporary nuget.org feed from NuGet.config

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -132,8 +132,8 @@
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <PackageVersion Include="StreamJsonRpc" Version="2.22.23" />
     <PackageVersion Include="Semver" Version="3.0.0" />
-    <PackageVersion Include="Sigstore" Version="0.2.0" />
-    <PackageVersion Include="Tuf" Version="0.2.0" />
+    <PackageVersion Include="Sigstore" Version="0.3.0" />
+    <PackageVersion Include="Tuf" Version="0.3.0" />
     <PackageVersion Include="Microsoft.DevTunnels.Connections" Version="1.3.12" />
     <!-- Open Telemetry -->
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="$(AzureMonitorOpenTelemetryExporterVersion)" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -20,8 +20,6 @@
     <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <add key="dotnet9-transport" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
-    <!-- TEMPORARY: nuget.org for Sigstore/Tuf packages until synced to internal feed -->
-    <add key="nuget-org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="dotnet9-transport">
@@ -44,13 +42,6 @@
     </packageSource>
     <packageSource key="dotnet-eng">
       <package pattern="*" />
-    </packageSource>
-    <!-- TEMPORARY: Sigstore/Tuf packages from nuget.org until synced to internal feed -->
-    <packageSource key="nuget-org">
-      <package pattern="Sigstore" />
-      <package pattern="Tuf" />
-      <package pattern="NSec.Cryptography" />
-      <package pattern="libsodium" />
     </packageSource>
   </packageSourceMapping>
   <disabledPackageSources>


### PR DESCRIPTION
## Description

Remove the temporary `nuget-org` package source and its package source mapping entries (Sigstore, Tuf, NSec.Cryptography, libsodium) from `NuGet.config`. These packages should be resolved from the normal internal feeds (`dotnet-public`, `dotnet-eng`) which already have wildcard `*` pattern mappings.

The package references in `Aspire.Cli.csproj` and `Directory.Packages.props` are unchanged.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
