### PR TITLE
noun-first form for dotnet CLI `package add`

### DIFF
--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -747,24 +747,27 @@ internal sealed class DotNetCliRunner(
 
         var cliArgsList = new List<string>
         {
-            "add"
+            "package"
         };
 
         // For single-file AppHost (apphost.cs), use --file switch instead of positional argument
         var isSingleFileAppHost = projectFilePath.Name.Equals("apphost.cs", StringComparison.OrdinalIgnoreCase);
         if (isSingleFileAppHost)
         {
-            cliArgsList.AddRange(["package", "--file", projectFilePath.FullName]);
+            cliArgsList.Add("add");
+            cliArgsList.AddRange(["--file", projectFilePath.FullName]);
             // For single-file AppHost, use packageName@version format
             cliArgsList.Add($"{packageName}@{packageVersion}");
         }
         else
         {
-            cliArgsList.AddRange([projectFilePath.FullName, "package"]);
+            cliArgsList.Add("add");
             // For non single-file scenarios, use separate --version flag
             cliArgsList.Add(packageName);
             cliArgsList.Add("--version");
             cliArgsList.Add(packageVersion);
+            cliArgsList.Add("--project");
+            cliArgsList.Add(projectFilePath.FullName);
         }
 
         if (string.IsNullOrEmpty(nugetSource))

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetCliRunnerTests.cs
@@ -551,14 +551,14 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
                 Assert.Contains("Aspire.Hosting.Redis@9.2.0", args);
                 Assert.Contains("--no-restore", args);
 
-                // Verify the order: add package PackageName --file FilePath --version Version --no-restore
-                var addIndex = Array.IndexOf(args, "add");
+                // Verify the order: package add PackageName --file FilePath --version Version --no-restore
                 var packageIndex = Array.IndexOf(args, "package");
+                var addIndex = Array.IndexOf(args, "add");
                 var fileIndex = Array.IndexOf(args, "--file");
                 var filePathIndex = Array.IndexOf(args, appHostFile.FullName);
                 var packageNameIndex = Array.IndexOf(args, "Aspire.Hosting.Redis@9.2.0");
 
-                Assert.True(addIndex < packageIndex);
+                Assert.True(packageIndex < addIndex);
                 Assert.True(packageIndex < fileIndex);
                 Assert.True(fileIndex < filePathIndex);
                 Assert.True(filePathIndex < packageNameIndex);
@@ -605,19 +605,21 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
                 Assert.Contains("--source", args);
                 Assert.Contains("https://api.nuget.org/v3/index.json", args);
 
-                // Verify the order: add ProjectFile package PackageName --version Version --source Source
-                var addIndex = Array.IndexOf(args, "add");
-                var projectIndex = Array.IndexOf(args, projectFile.FullName);
+                // Verify the order: package add PackageName --version Version --source Source --project ProjectFile 
                 var packageIndex = Array.IndexOf(args, "package");
+                var addIndex = Array.IndexOf(args, "add");
+                var projectFlagIndex = Array.IndexOf(args, "--project");
+                var projectValueIndex = Array.IndexOf(args, projectFile.FullName);
                 var packageNameIndex = Array.IndexOf(args, "Aspire.Hosting.Redis");
                 var versionFlagIndex = Array.IndexOf(args, "--version");
                 var versionValueIndex = Array.IndexOf(args, "9.2.0");
 
-                Assert.True(addIndex < projectIndex);
-                Assert.True(projectIndex < packageIndex);
-                Assert.True(packageIndex < packageNameIndex);
+                Assert.True(packageIndex < addIndex);
+                Assert.True(addIndex < packageNameIndex);
                 Assert.True(packageNameIndex < versionFlagIndex);
                 Assert.True(versionFlagIndex < versionValueIndex);
+                Assert.True(packageNameIndex < projectFlagIndex);
+                Assert.True(projectFlagIndex < projectValueIndex);
 
                 // Should NOT contain --file or the @version format
                 Assert.DoesNotContain("--file", args);
@@ -656,28 +658,31 @@ public class DotNetCliRunnerTests(ITestOutputHelper outputHelper)
             (args, _, _, _) =>
             {
                 // Verify arguments are correct for .csproj file with --no-restore (no source provided)
-                Assert.Contains("add", args);
                 Assert.Contains("package", args);
-                Assert.Contains(projectFile.FullName, args);
+                Assert.Contains("add", args);
                 Assert.Contains("Aspire.Hosting.Redis", args);
                 Assert.Contains("--version", args);
                 Assert.Contains("9.2.0", args);
+                Assert.Contains("--project", args);
+                Assert.Contains(projectFile.FullName, args);
                 Assert.Contains("--no-restore", args);
 
-                // Verify the order: add ProjectFile package PackageName --version Version --no-restore
-                var addIndex = Array.IndexOf(args, "add");
-                var projectIndex = Array.IndexOf(args, projectFile.FullName);
+                // Verify the order: package add PackageName --version Version --project ProjectFile --no-restore
                 var packageIndex = Array.IndexOf(args, "package");
+                var addIndex = Array.IndexOf(args, "add");
                 var packageNameIndex = Array.IndexOf(args, "Aspire.Hosting.Redis");
                 var versionFlagIndex = Array.IndexOf(args, "--version");
                 var versionValueIndex = Array.IndexOf(args, "9.2.0");
+                var projectFlagIndex = Array.IndexOf(args, "--project");
+                var projectValueIndex = Array.IndexOf(args, projectFile.FullName);
                 var noRestoreIndex = Array.IndexOf(args, "--no-restore");
 
-                Assert.True(addIndex < projectIndex);
-                Assert.True(projectIndex < packageIndex);
-                Assert.True(packageIndex < packageNameIndex);
+                Assert.True(packageIndex < addIndex);
+                Assert.True(addIndex < packageNameIndex);
                 Assert.True(packageNameIndex < versionFlagIndex);
                 Assert.True(versionFlagIndex < versionValueIndex);
+                Assert.True(packageNameIndex < projectFlagIndex);
+                Assert.True(projectFlagIndex < projectValueIndex);
                 Assert.True(versionValueIndex < noRestoreIndex);
 
                 // Should NOT contain --file, --source, or the @version format


### PR DESCRIPTION
## Description

Use the "noun-first" form for adding NuGet packages. It was introduced in .NET SDK 9 for the CLI.
`dotnet package add` vs. `dotnet add package`

This is the form that the dotnet CLI is referencing in the official documentation.
[`dotnet package add` command](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-package-add)

Also use the `--project` flag followed by the path to the project file as suggested by the documentation. But only for apps that are not file-based. 
For file-based apps keep the `--file` flag. (Which doesn't seem to have any official documentation...)

Updated the Aspire.Cli.Tests to expect the "noun-first" form.

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [X] No
