### PR TITLE
Fix flaky YarpFunctionalTests + strengthen fix-flaky-test skill

### DIFF
--- a/tests/Aspire.Hosting.Yarp.Tests/YarpFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Yarp.Tests/YarpFunctionalTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Testing;
 using Aspire.Hosting.Utils;
 using Aspire.Hosting.Yarp.Transforms;
 using Aspire.TestUtilities;
@@ -48,8 +49,7 @@ public class YarpFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.ResourceNotifications.WaitForResourceHealthyAsync(backend.Resource.Name, cts.Token);
         await app.ResourceNotifications.WaitForResourceHealthyAsync(yarp.Resource.Name, cts.Token);
 
-        var endpoint = yarp.Resource.GetEndpoint("http");
-        var httpClient = new HttpClient() { BaseAddress = new Uri(endpoint.Url) };
+        using var httpClient = app.CreateHttpClient(yarp.Resource.Name, "http");
 
         using var response200 = await httpClient.GetAsync("/aspnetapp");
         Assert.Equal(System.Net.HttpStatusCode.OK, response200.StatusCode);


### PR DESCRIPTION
## Two Changes

### 1. Flaky Test Fix

**Test**: `Aspire.Hosting.Yarp.Tests.YarpFunctionalTests.VerifyYarpResourceExtensionsConfig`
**Issue**: #9344

**Root Cause**: The test used a bare `HttpClient` without resilience/retry. When both containers report healthy, the Docker network may not have fully connected them yet (DCP NetworkReconciler shows "Expected: 2, Found: 1"). YARP proxies to the backend → connection refused → 502 BadGateway.

**Fix**: Replace `new HttpClient()` with `app.CreateHttpClient(yarp.Resource.Name, "http")` which uses `IHttpClientFactory` with standard resilience handler that retries transient HTTP errors including 502 BadGateway.

**⚠️ Verification Note**: The CI reproduction was not performed correctly in this session — the fix was applied at the same time as the workflow configuration, so there is no baseline proving the test fails without the fix. The post-fix CI run ([link](https://github.com/dotnet/aspire/actions/runs/22642495474)) showed all 25 Ubuntu iterations passing and all 5 Windows jobs with zero tests (Docker unavailable on standard Windows runners). While the fix is almost certainly correct (it matches a well-known flaky pattern), the verification process did not follow the newly strengthened skill requirements.

### 2. Skill Improvements: `.github/skills/fix-flaky-test/SKILL.md`

The skill document is strengthened to prevent the process failures observed during this investigation:

1. **Two-phase investigation branch**: Phase 1 = workflow-only push (reproduce). Phase 2 = fix push (verify). Prevents skipping reproduction.
2. **CI result validation rules**: Mandatory categorization of all jobs. Zero-test-ran jobs explicitly flagged as NOT passes. Docker-dependent test OS targeting.
3. **PR creation gated on CI completion**: Final PR cannot be opened until verification CI completes and results are validated.
4. **Strengthened checkpoints**: Final checklist requires reproduction baseline, accurate PR body, cross-checked CI claims.

---
> `[QuarantinedTest]` attribute kept. Issue #9344 remains open.
*This fix was generated using the [fix-flaky-test skill](https://github.com/dotnet/aspire/blob/main/.github/skills/fix-flaky-test/SKILL.md).*