### PR TITLE
Add 3rd-party signing entries for Sigstore, Tuf, and NSec.Cryptography

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -51,7 +51,10 @@
     <FileSignInfo Include="OpenTelemetry.Extensions.Hosting.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="OpenTelemetry.PersistentStorage.Abstractions.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="OpenTelemetry.PersistentStorage.FileSystem.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="NSec.Cryptography.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Semver.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Sigstore.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Tuf.dll" CertificateName="3PartySHA2" />
 
     <FileSignInfo Condition="$([System.OperatingSystem]::IsWindows())" Include="aspire.exe" CertificateName="MicrosoftDotNet500" />
     <FileSignInfo Condition="$([System.OperatingSystem]::IsLinux())" Include="aspire" CertificateName="MicrosoftDotNet500" />


### PR DESCRIPTION
## Fix SIGN004 build failures in dotnet-aspire internal pipeline

The [dotnet-aspire internal build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2917477&view=results) is failing with `SIGN004` errors:

```
error SIGN004: Signing 3rd party library 'NSec.Cryptography.dll' with Microsoft certificate 'Microsoft400'.
error SIGN004: Signing 3rd party library 'Sigstore.dll' with Microsoft certificate 'Microsoft400'.
error SIGN004: Signing 3rd party library 'Tuf.dll' with Microsoft certificate 'Microsoft400'.
```

These 3rd-party DLLs were introduced in #14569 when `Sigstore` and `Tuf` NuGet packages were added to `Aspire.Cli`, but the corresponding `FileSignInfo` entries in `eng/Signing.props` were not added. The Arcade SDK's signing validation correctly flags them as 3rd-party libraries (based on copyright metadata) being signed with the wrong certificate.

### Changes

Add `FileSignInfo` entries with `CertificateName="3PartySHA2"` for:
- **NSec.Cryptography.dll** — transitive dependency of Sigstore (© Klaus Hartke)
- **Sigstore.dll** — direct dependency
- **Tuf.dll** — direct dependency

cc @mitchdenny