### PR TITLE
Fix flaky test: use resilient HttpClient in YarpFunctionalTests

### DIFF
--- a/tests/Aspire.Hosting.Yarp.Tests/YarpFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Yarp.Tests/YarpFunctionalTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Testing;
 using Aspire.Hosting.Utils;
 using Aspire.Hosting.Yarp.Transforms;
 using Aspire.TestUtilities;
@@ -48,8 +49,7 @@ public class YarpFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.ResourceNotifications.WaitForResourceHealthyAsync(backend.Resource.Name, cts.Token);
         await app.ResourceNotifications.WaitForResourceHealthyAsync(yarp.Resource.Name, cts.Token);
 
-        var endpoint = yarp.Resource.GetEndpoint("http");
-        var httpClient = new HttpClient() { BaseAddress = new Uri(endpoint.Url) };
+        using var httpClient = app.CreateHttpClient(yarp.Resource.Name);
 
         using var response200 = await httpClient.GetAsync("/aspnetapp");
         Assert.Equal(System.Net.HttpStatusCode.OK, response200.StatusCode);


### PR DESCRIPTION
## Flaky Test Fix

### Test
- **Method**: `Aspire.Hosting.Yarp.Tests.YarpFunctionalTests.VerifyYarpResourceExtensionsConfig`
- **Issue**: #9344

### Root Cause
The test created a bare `new HttpClient()` with no retry logic. After both YARP and backend containers report healthy, Docker inter-container networking may not be fully established — YARP returns 502 BadGateway because it can't yet reach the backend container.

### Fix
Replace `new HttpClient()` with `app.CreateHttpClient()`, which uses the DI container's `IHttpClientFactory` with `AddStandardResilienceHandler()` already configured by `TestDistributedApplicationBuilder`, providing automatic retries for transient failures.

### Verification
| Phase | Run | Config | Result |
|-------|-----|--------|--------|
| Reproduction (pre-fix) | [link](https://github.com/dotnet/aspire/actions/runs/22644656143) | 5 runners × 10 iters × ubuntu-latest | **11/50 failed on ubuntu-latest** ❌ |
| Verification (post-fix) | [link](https://github.com/dotnet/aspire/actions/runs/22644899208) | 5 runners × 10 iters × ubuntu-latest | **All 50 passed on ubuntu-latest** ✅ |

**Local runs:**
- Pre-fix: 10 on macOS — all passed (contention-sensitive, doesn't reproduce locally)
- Post-fix: build verified, no regressions

### Notes
- `[QuarantinedTest]` attribute kept — unquarantining will happen separately after stability is confirmed in quarantine CI

---
> **Note:** This PR intentionally does not close #9344. The test will remain quarantined until a separate unquarantine process confirms it has been stable (zero failures) for a sufficient period. Once stability is confirmed, the test will be unquarantined and the issue will be closed.

---
*This fix was generated using the [fix-flaky-test skill](https://github.com/dotnet/aspire/blob/main/.github/skills/fix-flaky-test/SKILL.md).*