### PR TITLE
Add os.name, os.type, and os.version attributes to CLI telemetry

### DIFF
--- a/src/Aspire.Cli/Telemetry/AspireCliTelemetry.cs
+++ b/src/Aspire.Cli/Telemetry/AspireCliTelemetry.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -201,6 +202,10 @@ internal sealed class AspireCliTelemetry : IHostedService
             _tagsList.Add(new(TelemetryConstants.Tags.CliBuildId, typeof(Program).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version ?? string.Empty));
 
             _tagsList.Add(new(TelemetryConstants.Tags.DeploymentEnvironmentName, _ciEnvironmentDetector.IsCIEnvironment() ? "ci" : "local"));
+
+            _tagsList.Add(new(TelemetryConstants.Tags.OsName, GetOsName()));
+            _tagsList.Add(new(TelemetryConstants.Tags.OsType, GetOsType()));
+            _tagsList.Add(new(TelemetryConstants.Tags.OsVersion, Environment.OSVersion.Version.ToString()));
         }
         catch (Exception ex)
         {
@@ -239,5 +244,51 @@ internal sealed class AspireCliTelemetry : IHostedService
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Gets the human-readable operating system name for the <c>os.name</c> semantic convention.
+    /// </summary>
+    internal static string GetOsName()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return "Windows";
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return "Linux";
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return "macOS";
+        }
+
+        return RuntimeInformation.OSDescription;
+    }
+
+    /// <summary>
+    /// Gets the OpenTelemetry semantic convention value for the <c>os.type</c> attribute.
+    /// </summary>
+    internal static string GetOsType()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return "windows";
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return "linux";
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return "darwin";
+        }
+
+        return "unknown";
     }
 }

--- a/src/Aspire.Cli/Telemetry/TelemetryConstants.cs
+++ b/src/Aspire.Cli/Telemetry/TelemetryConstants.cs
@@ -87,6 +87,21 @@ internal static class TelemetryConstants
         /// Tag indicating the result of the SDK check operation.
         /// </summary>
         public const string SdkCheckResult = "aspire.cli.sdk.check_result";
+
+        /// <summary>
+        /// Tag for the operating system name.
+        /// </summary>
+        public const string OsName = "os.name";
+
+        /// <summary>
+        /// Tag for the operating system type.
+        /// </summary>
+        public const string OsType = "os.type";
+
+        /// <summary>
+        /// Tag for the operating system version.
+        /// </summary>
+        public const string OsVersion = "os.version";
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Telemetry/AspireCliTelemetryTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/AspireCliTelemetryTests.cs
@@ -199,6 +199,20 @@ public class AspireCliTelemetryTests
     }
 
     [Fact]
+    public void InitializeAsync_AddsOsInformationTags()
+    {
+        using var fixture = new TelemetryFixture();
+
+        var tags = fixture.Telemetry.GetDefaultTags();
+
+        var expectedOsName = AspireCliTelemetry.GetOsName();
+        var expectedOsType = AspireCliTelemetry.GetOsType();
+        Assert.Contains(tags, t => t.Key == TelemetryConstants.Tags.OsName && (string?)t.Value == expectedOsName);
+        Assert.Contains(tags, t => t.Key == TelemetryConstants.Tags.OsVersion && t.Value is string s && s == Environment.OSVersion.Version.ToString());
+        Assert.Contains(tags, t => t.Key == TelemetryConstants.Tags.OsType && (string?)t.Value == expectedOsType);
+    }
+
+    [Fact]
     public void StartReportedActivity_IncludesAllDefaultTags()
     {
         var machineInfoProvider = new TelemetryFixture.TestMachineInformationProvider


### PR DESCRIPTION
## Description

Add `os.name`, `os.type`, and `os.version` attributes to telemetry captured in the Aspire CLI. These follow the [OpenTelemetry semantic conventions for OS](https://opentelemetry.io/docs/specs/semconv/resource/os/) and provide visibility into which operating systems CLI users are running on.

**Changes:**
- Added `os.name`, `os.type`, and `os.version` tag constants to `TelemetryConstants.Tags`
- Populated the tags in `AspireCliTelemetry.InitializeAsync()` using `RuntimeInformation.OSDescription`, a `GetOsType()` helper (returns `windows`/`linux`/`darwin`), and `Environment.OSVersion.Version`
- Added a test verifying the OS tags are present after initialization

Background for this change: Telemetry from Azure Monitor Exporter wasn't correctly identifying macOS. The fix is to add our own attributes for identifing OS.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
