### PR TITLE
Log CLI version and build ID at startup

### DIFF
--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -613,6 +613,9 @@ public class Program
 
         try
         {
+            cliLogger.LogInformation("Version: {Version}", AspireCliTelemetry.GetCliVersion());
+            cliLogger.LogInformation("Build ID: {BuildId}", AspireCliTelemetry.GetCliBuildId());
+
             // Log command invocation details for debugging
             var commandLine = args.Length > 0 ? $"aspire {string.Join(" ", args)}" : "aspire";
             var workingDir = Environment.CurrentDirectory;

--- a/src/Aspire.Cli/Telemetry/AspireCliTelemetry.cs
+++ b/src/Aspire.Cli/Telemetry/AspireCliTelemetry.cs
@@ -198,8 +198,8 @@ internal sealed class AspireCliTelemetry : IHostedService
             _tagsList.Add(new(TelemetryConstants.Tags.DeviceId, deviceIdTask.Result));
 
             // This is consistent with dashboard version data.
-            _tagsList.Add(new(TelemetryConstants.Tags.CliVersion, typeof(Program).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty));
-            _tagsList.Add(new(TelemetryConstants.Tags.CliBuildId, typeof(Program).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version ?? string.Empty));
+            _tagsList.Add(new(TelemetryConstants.Tags.CliVersion, GetCliVersion()));
+            _tagsList.Add(new(TelemetryConstants.Tags.CliBuildId, GetCliBuildId()));
 
             _tagsList.Add(new(TelemetryConstants.Tags.DeploymentEnvironmentName, _ciEnvironmentDetector.IsCIEnvironment() ? "ci" : "local"));
 
@@ -290,5 +290,23 @@ internal sealed class AspireCliTelemetry : IHostedService
         }
 
         return "unknown";
+    }
+
+    /// <summary>
+    /// Gets the CLI version from the assembly's informational version attribute.
+    /// </summary>
+    /// <returns>The CLI version string, or an empty string if not available.</returns>
+    internal static string GetCliVersion()
+    {
+        return typeof(Program).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Gets the CLI build ID from the assembly's file version attribute.
+    /// </summary>
+    /// <returns>The CLI build ID string, or an empty string if not available.</returns>
+    internal static string GetCliBuildId()
+    {
+        return typeof(Program).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version ?? string.Empty;
     }
 }


### PR DESCRIPTION
## Description

Log CLI version and build ID at startup for diagnostics.

- Extracted `GetCliVersion()` and `GetCliBuildId()` as `internal static` helper methods on `AspireCliTelemetry`, replacing inline reflection in `InitializeAsync`.
- Added version and build ID logging via `cliLogger` in `Program.Main` using the new helpers.

This makes the version info available in log files for troubleshooting, and reduces duplication of the reflection logic.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
