### PR TITLE
Fix flaky test: Aspire.Hosting.OpenAI.Tests.OpenAIFunctionalTests.DependentResourceWaitsForOpenAIModelResourceWithHealthCheckToBeHealthy

### DIFF
--- a/tests/Aspire.Hosting.OpenAI.Tests/OpenAIFunctionalTests.cs
+++ b/tests/Aspire.Hosting.OpenAI.Tests/OpenAIFunctionalTests.cs
@@ -29,7 +29,14 @@ public class OpenAIFunctionalTests
             return healthCheckTcs.Task;
         });
 
-        var resource = builder.AddOpenAI("resource")
+        var openai = builder.AddOpenAI("resource");
+
+        // Remove the default status page health check from the parent OpenAI resource
+        // to avoid external HTTP calls to status.openai.com during tests.
+        var statusPageHealthCheck = Enumerable.Single(openai.Resource.Annotations, x => x is HealthCheckAnnotation hca && hca.Key == "resource_check");
+        openai.Resource.Annotations.Remove(statusPageHealthCheck);
+
+        var resource = openai
                       .AddModel("chat", "gpt-4o-mini")
                       .WithHealthCheck("blocking_check");
 


### PR DESCRIPTION
## Flaky Test Fix

### Test
- **Method**: `Aspire.Hosting.OpenAI.Tests.OpenAIFunctionalTests.DependentResourceWaitsForOpenAIModelResourceWithHealthCheckToBeHealthy`
- **Issue**: #10977

### Root Cause
The `OpenAIModelResource` implements `IResourceWithParent<OpenAIResource>`, so `ResourceHealthCheckService` discovers health checks from both the model and its parent via `TryGetAnnotationsIncludingAncestorsOfType<HealthCheckAnnotation>()`. The parent's `resource_check` health check makes an external HTTP call to `https://status.openai.com/api/v2/status.json`, which can timeout or fail in CI, preventing the model resource from ever reaching healthy status.

### Fix
Remove the parent's `resource_check` health check annotation in the test before building the app, matching the pattern already used by the non-quarantined sibling test (`DependentResourceWaitsForOpenAIResourceWithHealthCheckToBeHealthy`).

### Verification
| Phase | Run | Config | Result |
|-------|-----|--------|--------|
| Verification (post-fix) | [22652359417](https://github.com/dotnet/aspire/actions/runs/22652359417) | 5 runners × 10 iterations × ubuntu-latest | **All 50 passed** ✅ |

**Local runs:**
- Post-fix: 10/10 passed on macOS (Darwin/arm64)

### Verification Rationale
High confidence — root cause is a clear pattern match (external HTTP calls in health check inherited by child resource). The sibling test already demonstrates the correct fix pattern. CI verification confirms 50/50 pass on Linux, the most affected OS (14% failure rate pre-fix).

### Notes
- `[QuarantinedTest]` attribute kept — unquarantining happens separately after 21 days of zero failures

---
> **Note:** This PR intentionally does not close #10977. The test will remain quarantined until stability is confirmed.

---
*This fix was generated using the [fix-flaky-test skill](https://github.com/dotnet/aspire/blob/main/.github/skills/fix-flaky-test/SKILL.md).*