### PR TITLE
Fail fast when CLI download fails in E2E tests

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
@@ -132,7 +132,7 @@ internal static class CliE2ETestHelpers
         return builder
             .Type(command)
             .Enter()
-            .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(300));
+            .WaitForSuccessPromptFailFast(counter, TimeSpan.FromSeconds(300));
     }
 
     internal static Hex1bTerminalInputSequenceBuilder SourceAspireCliEnvironment(
@@ -323,7 +323,7 @@ internal static class CliE2ETestHelpers
         return builder
             .Type(command)
             .Enter()
-            .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(300));
+            .WaitForSuccessPromptFailFast(counter, TimeSpan.FromSeconds(300));
     }
 
     /// <summary>
@@ -461,7 +461,7 @@ internal static class CliE2ETestHelpers
         return builder
             .Type(command)
             .Enter()
-            .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(300));
+            .WaitForSuccessPromptFailFast(counter, TimeSpan.FromSeconds(300));
     }
 
     /// <summary>

--- a/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentE2ETestHelpers.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentE2ETestHelpers.cs
@@ -143,7 +143,7 @@ internal static class DeploymentE2ETestHelpers
         return builder
             .Type(command)
             .Enter()
-            .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(300));
+            .WaitForSuccessPromptFailFast(counter, TimeSpan.FromSeconds(300));
     }
 
     /// <summary>

--- a/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentE2ETestHelpers.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentE2ETestHelpers.cs
@@ -158,7 +158,7 @@ internal static class DeploymentE2ETestHelpers
         return builder
             .Type(command)
             .Enter()
-            .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(300));
+            .WaitForSuccessPromptFailFast(counter, TimeSpan.FromSeconds(300));
     }
 
     /// <summary>

--- a/tests/Shared/Hex1bTestHelpers.cs
+++ b/tests/Shared/Hex1bTestHelpers.cs
@@ -156,6 +156,56 @@ internal static class Hex1bTestHelpers
     }
 
     /// <summary>
+    /// Waits for a successful command prompt, but fails fast if an error prompt is detected.
+    /// Unlike <see cref="WaitForSuccessPrompt"/>, this method also watches for error prompts
+    /// (ERR:N pattern) and throws immediately instead of waiting for the full timeout.
+    /// Use this for commands that may fail due to transient errors (e.g., CLI downloads).
+    /// </summary>
+    internal static Hex1bTerminalInputSequenceBuilder WaitForSuccessPromptFailFast(
+        this Hex1bTerminalInputSequenceBuilder builder,
+        SequenceCounter counter,
+        TimeSpan? timeout = null)
+    {
+        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(500);
+        var sawError = false;
+
+        return builder.WaitUntil(snapshot =>
+            {
+                var successSearcher = new CellPatternSearcher()
+                    .FindPattern(counter.Value.ToString())
+                    .RightText(" OK] $ ");
+
+                if (successSearcher.Search(snapshot).Count > 0)
+                {
+                    return true;
+                }
+
+                var errorSearcher = new CellPatternSearcher()
+                    .FindPattern(counter.Value.ToString())
+                    .RightText(" ERR:");
+
+                if (errorSearcher.Search(snapshot).Count > 0)
+                {
+                    sawError = true;
+                    return true;
+                }
+
+                return false;
+            }, effectiveTimeout)
+            .WaitUntil(_ =>
+            {
+                if (sawError)
+                {
+                    throw new InvalidOperationException(
+                        $"Command failed with non-zero exit code (detected ERR prompt at sequence {counter.Value}). Check the terminal recording for details.");
+                }
+
+                counter.Increment();
+                return true;
+            }, TimeSpan.FromSeconds(1));
+    }
+
+    /// <summary>
     /// Increments the sequence counter.
     /// </summary>
     internal static Hex1bTerminalInputSequenceBuilder IncrementSequence(


### PR DESCRIPTION
## Description

When CLI artifact download fails during E2E tests (e.g., HTTP 502 from GitHub API), the download script exits with a non-zero exit code and the shell prompt shows `[N ERR:1] $`. However, `InstallAspireCliFromPullRequest` and similar methods use `WaitForSuccessPrompt` which only watches for `[N OK] $`, causing them to wait the full 300-second timeout before throwing `WaitUntilTimeoutException`.

This PR adds `WaitForSuccessPromptFailFast` to the shared `Hex1bTestHelpers` that watches for both OK and ERR prompts. On ERR, it throws `InvalidOperationException` immediately instead of waiting for the full timeout.

Updated methods:
- `InstallAspireCliFromPullRequest` (CliE2ETestHelpers)
- `InstallAspireCliVersion` (CliE2ETestHelpers)
- `InstallAspireBundleFromPullRequest` (CliE2ETestHelpers)
- `InstallAspireCliRelease` (DeploymentE2ETestHelpers)

Fixes #14933

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
