### PR TITLE
Display wait-for-debugger message in CLI

### DIFF
--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -70,6 +70,7 @@ internal sealed class AppHostLauncher(
     /// <param name="format">The output format (JSON or table).</param>
     /// <param name="isolated">Whether to run in isolated mode.</param>
     /// <param name="isExtensionHost">Whether running inside VS Code extension.</param>
+    /// <param name="waitForDebugger">Whether the AppHost is waiting for a debugger to attach.</param>
     /// <param name="globalArgs">Global CLI args to forward to child process.</param>
     /// <param name="additionalArgs">Additional unmatched args to forward.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -79,6 +80,7 @@ internal sealed class AppHostLauncher(
         OutputFormat? format,
         bool isolated,
         bool isExtensionHost,
+        bool waitForDebugger,
         IEnumerable<string> globalArgs,
         IEnumerable<string> additionalArgs,
         CancellationToken cancellationToken)
@@ -118,6 +120,16 @@ internal sealed class AppHostLauncher(
         var expectedHash = AppHostHelper.ExtractHashFromSocketPath(expectedSocketPrefix)!;
 
         logger.LogDebug("Waiting for socket with prefix: {SocketPrefix}, Hash: {Hash}", expectedSocketPrefix, expectedHash);
+
+        // If --wait-for-debugger is active, show a message so the user knows the AppHost
+        // is paused. In detached mode we don't have the AppHost PID (stdout is suppressed),
+        // so we show a generic message without a PID.
+        if (waitForDebugger)
+        {
+            interactionService.DisplayMessage(
+                KnownEmojis.Bug,
+                InteractionServiceStrings.WaitingForDebuggerToAttachToAppHost);
+        }
 
         // Start the child process and wait for the backchannel
         var launchResult = await interactionService.ShowStatusAsync(

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -216,6 +216,7 @@ internal sealed class RunCommand : BaseCommand
             // The completion sources are the contract between RunCommand and IAppHostProject
             var buildCompletionSource = new TaskCompletionSource<bool>();
             var backchannelCompletionSource = new TaskCompletionSource<IAppHostCliBackchannel>();
+            var waitForDebugger = parseResult.GetValue(RootCommand.WaitForDebuggerOption);
 
             context = new AppHostProjectContext
             {
@@ -224,14 +225,14 @@ internal sealed class RunCommand : BaseCommand
                 Debug = parseResult.GetValue(RootCommand.DebugOption),
                 NoBuild = noBuild,
                 NoRestore = noBuild, // --no-build implies --no-restore
-                WaitForDebugger = parseResult.GetValue(RootCommand.WaitForDebuggerOption),
+                WaitForDebugger = waitForDebugger,
                 Isolated = isolated,
                 StartDebugSession = startDebugSession,
                 EnvironmentVariables = new Dictionary<string, string>(),
                 UnmatchedTokens = parseResult.UnmatchedTokens.ToArray(),
                 WorkingDirectory = ExecutionContext.WorkingDirectory,
                 BuildCompletionSource = buildCompletionSource,
-                BackchannelCompletionSource = backchannelCompletionSource
+                BackchannelCompletionSource = backchannelCompletionSource,
             };
 
             // Start the project run as a pending task - we'll handle UX while it runs
@@ -250,7 +251,15 @@ internal sealed class RunCommand : BaseCommand
                 return await pendingRun;
             }
 
-            // Now wait for the backchannel to be established
+            // If --wait-for-debugger, display a message so the user knows the AppHost is paused.
+            if (waitForDebugger)
+            {
+                InteractionService.DisplayMessage(KnownEmojis.Bug, InteractionServiceStrings.WaitingForDebuggerToAttachToAppHost);
+            }
+
+            // Wait for the backchannel. The debugger wait in the AppHost happens inside
+            // CreateBuilder(...) before the backchannel is created, so the backchannel
+            // completing is a good signal that the debugger was attached (or timed out).
             var backchannel = await InteractionService.ShowStatusAsync(
                 isExtensionHost ? InteractionServiceStrings.BuildingAppHost : RunCommandStrings.ConnectingToAppHost,
                 async () => await backchannelCompletionSource.Task.WaitAsync(cancellationToken));
@@ -619,6 +628,7 @@ internal sealed class RunCommand : BaseCommand
         var format = parseResult.GetValue(AppHostLauncher.s_formatOption);
         var isolated = parseResult.GetValue(AppHostLauncher.s_isolatedOption);
         var noBuild = parseResult.GetValue(s_noBuildOption);
+        var waitForDebugger = parseResult.GetValue(RootCommand.WaitForDebuggerOption);
         var globalArgs = RootCommand.GetChildProcessArgs(parseResult);
         var additionalArgs = parseResult.UnmatchedTokens.Where(t => t != "--detach").ToList();
 
@@ -632,6 +642,7 @@ internal sealed class RunCommand : BaseCommand
             format,
             isolated,
             isExtensionHost,
+            waitForDebugger,
             globalArgs,
             additionalArgs,
             cancellationToken);

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -257,9 +257,7 @@ internal sealed class RunCommand : BaseCommand
                 InteractionService.DisplayMessage(KnownEmojis.Bug, InteractionServiceStrings.WaitingForDebuggerToAttachToAppHost);
             }
 
-            // Wait for the backchannel. The debugger wait in the AppHost happens inside
-            // CreateBuilder(...) before the backchannel is created, so the backchannel
-            // completing is a good signal that the debugger was attached (or timed out).
+            // Now wait for the backchannel to be established
             var backchannel = await InteractionService.ShowStatusAsync(
                 isExtensionHost ? InteractionServiceStrings.BuildingAppHost : RunCommandStrings.ConnectingToAppHost,
                 async () => await backchannelCompletionSource.Task.WaitAsync(cancellationToken));

--- a/src/Aspire.Cli/Commands/StartCommand.cs
+++ b/src/Aspire.Cli/Commands/StartCommand.cs
@@ -49,6 +49,7 @@ internal sealed class StartCommand : BaseCommand
 
         var noBuild = parseResult.GetValue(s_noBuildOption);
         var isExtensionHost = ExtensionHelper.IsExtensionHost(_interactionService, out _, out _);
+        var waitForDebugger = parseResult.GetValue(RootCommand.WaitForDebuggerOption);
         var globalArgs = RootCommand.GetChildProcessArgs(parseResult);
         var additionalArgs = parseResult.UnmatchedTokens.ToList();
 
@@ -62,6 +63,7 @@ internal sealed class StartCommand : BaseCommand
             format,
             isolated,
             isExtensionHost,
+            waitForDebugger,
             globalArgs,
             additionalArgs,
             cancellationToken);

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -598,4 +598,5 @@ internal sealed class DotNetAppHostProject : IAppHostProject
 
         return null;
     }
+
 }

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -598,5 +598,4 @@ internal sealed class DotNetAppHostProject : IAppHostProject
 
         return null;
     }
-
 }

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../InteractionServiceStrings.resx">
     <body>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../InteractionServiceStrings.resx">
     <body>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../InteractionServiceStrings.resx">
     <body>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../InteractionServiceStrings.resx">
     <body>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../InteractionServiceStrings.resx">
     <body>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../InteractionServiceStrings.resx">
     <body>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../InteractionServiceStrings.resx">
     <body>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../InteractionServiceStrings.resx">
     <body>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../InteractionServiceStrings.resx">
     <body>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../InteractionServiceStrings.resx">
     <body>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../InteractionServiceStrings.resx">
     <body>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../InteractionServiceStrings.resx">
     <body>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../InteractionServiceStrings.resx">
     <body>

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -249,12 +249,14 @@ public class DistributedApplication : IHost, IAsyncDisposable
         if (Environment.GetEnvironmentVariable(KnownConfigNames.WaitForDebugger) == "true")
         {
             var startedWaiting = DateTimeOffset.UtcNow;
-            TimeSpan timeout = TimeSpan.FromSeconds(30);
+            var timeout = TimeSpan.FromSeconds(30);
 
             if (Environment.GetEnvironmentVariable(KnownConfigNames.WaitForDebuggerTimeout) is string timeoutString && int.TryParse(timeoutString, out var timeoutSeconds))
             {
                 timeout = TimeSpan.FromSeconds(timeoutSeconds);
             }
+
+            Console.WriteLine($"AppHost PID: {Environment.ProcessId}");
 
             while (Debugger.IsAttached == false)
             {


### PR DESCRIPTION
## Description

When `--wait-for-debugger` is passed, the CLI now displays a visible console message so the user knows the AppHost is paused waiting for a debugger to attach.

Previously, `aspire run --wait-for-debugger` showed no feedback in the console — the message was only written to the log file. `ExecCommand` and `PipelineCommandBase` already displayed a message but `RunCommand`, `StartCommand`, and the detached flow did not.

**Changes:**
- **`RunCommand` (non-detached):** Displays "Waiting for debugger to attach to app host process" before the backchannel spinner, matching the existing behavior of `ExecCommand` and `PipelineCommandBase`.
- **`StartCommand` / `RunCommand --detach` (detached):** The `AppHostLauncher` now accepts a `waitForDebugger` parameter and displays the same message before launching the child process. Both `StartCommand` and `RunCommand.ExecuteDetachedAsync` pass the flag through.
- **Shared `KnownConsoleMessages`:** Extracts the debugger wait message prefix into `src/Shared/KnownConsoleMessages.cs`, linked into both `Aspire.Cli` and `Aspire.Hosting` so both sides use the same well-known string for the console output written by `DistributedApplication.WaitForDebugger()`.

All commands that accept `--wait-for-debugger` now consistently display the message: `RunCommand`, `StartCommand`, `ExecCommand`, `PipelineCommandBase` (publish/deploy), and the detached launch flow.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No