### PR TITLE
Refactor DefaultAzureCredential usage

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -179,7 +179,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <!-- Pinned versions for Component Governance - Remove when root dependencies are updated -->
     <PackageVersion Include="Azure.Core" Version="1.51.1" />
-    <PackageVersion Include="Azure.Identity" Version="1.17.1" />
+    <PackageVersion Include="Azure.Identity" Version="1.18.0" />
     <!-- https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3313 -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <!-- tools/scripts dependencies -->

--- a/src/Aspire.Hosting.Azure.CosmosDB/Aspire.Hosting.Azure.CosmosDB.csproj
+++ b/src/Aspire.Hosting.Azure.CosmosDB/Aspire.Hosting.Azure.CosmosDB.csproj
@@ -13,6 +13,7 @@
     <Compile Include="..\Shared\Cosmos\CosmosUtils.cs" Link="Shared\CosmosUtils.cs" />
     <Compile Include="..\Shared\StableConnectionStringBuilder.cs" Link="Shared\StableConnectionStringBuilder.cs" />
     <Compile Include="..\Shared\KnownUrls.cs" Link="KnownUrls.cs" />
+    <Compile Include="..\Shared\AzureCredentialHelper.cs" Link="AzureCredentialHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -10,7 +10,6 @@ using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Azure.CosmosDB;
-using Azure.Identity;
 using Azure.Provisioning;
 using Azure.Provisioning.CosmosDB;
 using Azure.Provisioning.Expressions;
@@ -213,7 +212,7 @@ public static class AzureCosmosExtensions
 
             if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri))
             {
-                return new CosmosClient(uri.OriginalString, new DefaultAzureCredential(), clientOptions);
+                return new CosmosClient(uri.OriginalString, AzureCredentialHelper.CreateDefaultAzureCredential(), clientOptions);
             }
             else
             {

--- a/src/Aspire.Hosting.Azure.Kusto/Aspire.Hosting.Azure.Kusto.csproj
+++ b/src/Aspire.Hosting.Azure.Kusto/Aspire.Hosting.Azure.Kusto.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <Compile Include="$(SharedDir)StringComparers.cs" LinkBase="Utils" />
     <Compile Include="$(SharedDir)AzureRoleAssignmentUtils.cs" LinkBase="Utils" />
+    <Compile Include="$(SharedDir)AzureCredentialHelper.cs" LinkBase="Utils" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
@@ -6,7 +6,6 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
-using Azure.Identity;
 using Azure.Provisioning;
 using Azure.Provisioning.Kusto;
 using Kusto.Data;
@@ -305,7 +304,7 @@ public static class AzureKustoBuilderExtensions
         {
             // When running against Azure, we use the DefaultAzureCredential to authenticate
             // with the Kusto server.
-            builder = builder.WithAadAzureTokenCredentialsAuthentication(new DefaultAzureCredential());
+            builder = builder.WithAadAzureTokenCredentialsAuthentication(AzureCredentialHelper.CreateDefaultAzureCredential());
         }
 
         return builder;

--- a/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
+++ b/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)src\Shared\AzureRoleAssignmentUtils.cs" />
     <Compile Include="$(SharedDir)StringComparers.cs" Link="StringComparers.cs" />
+    <Compile Include="$(SharedDir)AzureCredentialHelper.cs" Link="AzureCredentialHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -6,7 +6,6 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Azure.Storage;
-using Azure.Identity;
 using Azure.Provisioning;
 using Azure.Provisioning.Storage;
 using Azure.Storage.Blobs;
@@ -644,7 +643,7 @@ public static class AzureStorageExtensions
     {
         if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri))
         {
-            return new BlobServiceClient(uri, new DefaultAzureCredential());
+            return new BlobServiceClient(uri, AzureCredentialHelper.CreateDefaultAzureCredential());
         }
         else
         {
@@ -656,7 +655,7 @@ public static class AzureStorageExtensions
     {
         if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri))
         {
-            return new QueueServiceClient(uri, new DefaultAzureCredential());
+            return new QueueServiceClient(uri, AzureCredentialHelper.CreateDefaultAzureCredential());
         }
         else
         {

--- a/src/Components/Aspire.Azure.AI.Inference/Aspire.Azure.AI.Inference.csproj
+++ b/src/Components/Aspire.Azure.AI.Inference/Aspire.Azure.AI.Inference.csproj
@@ -16,6 +16,7 @@
     <Compile Include="..\Common\AzureComponent.cs" Link="AzureComponent.cs" />
     <Compile Include="..\Common\ConfigurationSchemaAttributes.cs" Link="ConfigurationSchemaAttributes.cs" />
     <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
+    <Compile Include="..\..\Shared\AzureCredentialHelper.cs" Link="AzureCredentialHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Azure.AI.Inference/AspireAzureAIInferenceExtensions.cs
+++ b/src/Components/Aspire.Azure.AI.Inference/AspireAzureAIInferenceExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire;
 using Aspire.Azure.AI.Inference;
 using Aspire.Azure.Common;
 using Azure;
@@ -8,7 +9,6 @@ using Azure.AI.Inference;
 using Azure.Core;
 using Azure.Core.Extensions;
 using Azure.Core.Pipeline;
-using Azure.Identity;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
@@ -159,7 +159,7 @@ public static class AspireAzureAIInferenceExtensions
                     }
                     else
                     {
-                        var credential = settings.TokenCredential ?? new DefaultAzureCredential();
+                        var credential = settings.TokenCredential ?? AzureCredentialHelper.CreateDefaultAzureCredential();
 
                         // Defines the scopes used for authorization when connecting to Azure AI Inference services.
                         // Use the default one (ml.azure.com) and add the public one required for Azure Foundry AI.
@@ -412,7 +412,7 @@ public static class AspireAzureAIInferenceExtensions
                     }
                     else
                     {
-                        var credential = settings.TokenCredential ?? new DefaultAzureCredential();
+                        var credential = settings.TokenCredential ?? AzureCredentialHelper.CreateDefaultAzureCredential();
 
                         // Defines the scopes used for authorization when connecting to Azure AI Inference services.
                         // Use the default one (ml.azure.com) and add the public one required for Azure Foundry AI.

--- a/src/Components/Aspire.Azure.AI.Inference/README.md
+++ b/src/Components/Aspire.Azure.AI.Inference/README.md
@@ -54,7 +54,7 @@ And then the connection string will be retrieved from the `ConnectionStrings` co
 
 #### Azure AI Foundry Endpoint
 
-The recommended approach is to use an Endpoint, which works with the `ChatCompletionsClientSettings.Credential` property to establish a connection. If no credential is configured, the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is used.
+The recommended approach is to use an Endpoint, which works with the `ChatCompletionsClientSettings.Credential` property to establish a connection. If no credential is configured, a [default TokenCredential is created based on the current environment](https://aka.ms/aspire/default-azure-credential).
 
 ```json
 {

--- a/src/Components/Aspire.Azure.AI.OpenAI/Aspire.Azure.AI.OpenAI.csproj
+++ b/src/Components/Aspire.Azure.AI.OpenAI/Aspire.Azure.AI.OpenAI.csproj
@@ -17,6 +17,7 @@
     <Compile Include="..\Common\AzureComponent.cs" Link="AzureComponent.cs" />
     <Compile Include="..\Common\ConfigurationSchemaAttributes.cs" Link="ConfigurationSchemaAttributes.cs" />
     <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
+    <Compile Include="..\..\Shared\AzureCredentialHelper.cs" Link="AzureCredentialHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Azure.AI.OpenAI/AspireAzureOpenAIExtensions.cs
+++ b/src/Components/Aspire.Azure.AI.OpenAI/AspireAzureOpenAIExtensions.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ClientModel;
+using Aspire;
 using Aspire.Azure.AI.OpenAI;
 using Aspire.Azure.Common;
 using Azure.AI.OpenAI;
 using Azure.Core;
 using Azure.Core.Extensions;
-using Azure.Identity;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -111,7 +111,7 @@ public static class AspireAzureOpenAIExtensions
                     }
                     else
                     {
-                        return new AzureOpenAIClient(settings.Endpoint, settings.Credential ?? new DefaultAzureCredential(), options);
+                        return new AzureOpenAIClient(settings.Endpoint, settings.Credential ?? AzureCredentialHelper.CreateDefaultAzureCredential(), options);
                     }
                 }
             });

--- a/src/Components/Aspire.Azure.AI.OpenAI/README.md
+++ b/src/Components/Aspire.Azure.AI.OpenAI/README.md
@@ -67,7 +67,7 @@ And then the connection string will be retrieved from the `ConnectionStrings` co
 
 #### Account Endpoint
 
-The recommended approach is to use an Endpoint, which works with the `AzureOpenAISettings.Credential` property to establish a connection. If no credential is configured, the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is used.
+The recommended approach is to use an Endpoint, which works with the `AzureOpenAISettings.Credential` property to establish a connection. If no credential is configured, a [default TokenCredential is created based on the current environment](https://aka.ms/aspire/default-azure-credential).
 
 ```json
 {

--- a/src/Components/Aspire.Azure.Data.Tables/README.md
+++ b/src/Components/Aspire.Azure.Data.Tables/README.md
@@ -54,7 +54,7 @@ And then the connection information will be retrieved from the `ConnectionString
 
 #### Service URI
 
-The recommended approach is to use a ServiceUri, which works with the `AzureDataTablesSettings.Credential` property to establish a connection. If no credential is configured, the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is used.
+The recommended approach is to use a ServiceUri, which works with the `AzureDataTablesSettings.Credential` property to establish a connection. If no credential is configured, a [default TokenCredential is created based on the current environment](https://aka.ms/aspire/default-azure-credential).
 
 ```json
 {

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/Aspire.Azure.Messaging.EventHubs.csproj
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/Aspire.Azure.Messaging.EventHubs.csproj
@@ -14,6 +14,7 @@
     <Compile Include="..\Common\ConfigurationSchemaAttributes.cs" Link="ConfigurationSchemaAttributes.cs" />
     <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
     <Compile Include="..\..\Shared\StableConnectionStringBuilder.cs" Link="StableConnectionStringBuilder.cs" />
+    <Compile Include="..\..\Shared\AzureCredentialHelper.cs" Link="AzureCredentialHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/EventHubsComponent.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/EventHubsComponent.cs
@@ -1,10 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire;
 using Aspire.Azure.Common;
 using Aspire.Azure.Messaging.EventHubs;
 using Azure.Core;
-using Azure.Identity;
 using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Producer;
 using HealthChecks.Azure.Messaging.EventHubs;
@@ -45,7 +45,7 @@ internal abstract class EventHubsComponent<TSettings, TClient, TClientOptions> :
             // If no connection is provided use TokenCredential
             if (string.IsNullOrEmpty(settings.ConnectionString))
             {
-                _healthCheckClient = new EventHubProducerClient(settings.FullyQualifiedNamespace, settings.EventHubName, settings.Credential ?? new DefaultAzureCredential(), producerClientOptions);
+                _healthCheckClient = new EventHubProducerClient(settings.FullyQualifiedNamespace, settings.EventHubName, settings.Credential ?? AzureCredentialHelper.CreateDefaultAzureCredential(), producerClientOptions);
             }
             // If no specific EventHubName is provided, it has to be in the connection string
             else if (string.IsNullOrEmpty(settings.EventHubName))

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/README.md
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/README.md
@@ -74,7 +74,7 @@ And then the connection information will be retrieved from the `ConnectionString
 
 #### Fully Qualified Namespace
 
-The recommended approach is to use a fully qualified namespace, which works with the `AzureMessagingEventHubsSettings.Credential` property to establish a connection. If no credential is configured, the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is used.
+The recommended approach is to use a fully qualified namespace, which works with the `AzureMessagingEventHubsSettings.Credential` property to establish a connection. If no credential is configured, a [default TokenCredential is created based on the current environment](https://aka.ms/aspire/default-azure-credential).
 
 ```json
 {

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/README.md
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/README.md
@@ -54,7 +54,7 @@ And then the connection information will be retrieved from the `ConnectionString
 
 #### Fully Qualified Namespace
 
-The recommended approach is to use a fully qualified namespace, which works with the `AzureMessagingServiceBusSettings.Credential` property to establish a connection. If no credential is configured, the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is used.
+The recommended approach is to use a fully qualified namespace, which works with the `AzureMessagingServiceBusSettings.Credential` property to establish a connection. If no credential is configured, a [default TokenCredential is created based on the current environment](https://aka.ms/aspire/default-azure-credential).
 
 ```json
 {

--- a/src/Components/Aspire.Azure.Messaging.WebPubSub/README.md
+++ b/src/Components/Aspire.Azure.Messaging.WebPubSub/README.md
@@ -54,7 +54,7 @@ And then the connection information will be retrieved from the `ConnectionString
 
 #### Use the service endpoint
 
-The recommended approach is to use the service endpoint, which works with the `AzureMessagingWebPubSubSettings.Credential` property to establish a connection. If no credential is configured, the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is used.
+The recommended approach is to use the service endpoint, which works with the `AzureMessagingWebPubSubSettings.Credential` property to establish a connection. If no credential is configured, a [default TokenCredential is created based on the current environment](https://aka.ms/aspire/default-azure-credential).
 
 ```json
 {

--- a/src/Components/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.csproj
+++ b/src/Components/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <Compile Include="..\Common\ManagedIdentityTokenCredentialHelpers.cs" Link="ManagedIdentityTokenCredentialHelpers.cs" />
+    <Compile Include="..\..\Shared\AzureCredentialHelper.cs" Link="AzureCredentialHelper.cs" />
     <Compile Include="..\Common\EntityFrameworkUtils.cs" Link="EntityFrameworkUtils.cs" />
   </ItemGroup>
   

--- a/src/Components/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL/README.md
+++ b/src/Components/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL/README.md
@@ -108,7 +108,7 @@ or
     builder.EnrichAzureNpgsqlDbContext<MyDbContext>(settings => settings.DisableHealthChecks = true);
 ```
 
-Use the `AzureNpgsqlEntityFrameworkCorePostgreSQLSettings.Credential` property to establish a connection. If no credential is configured, the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is used.
+Use the `AzureNpgsqlEntityFrameworkCorePostgreSQLSettings.Credential` property to establish a connection. If no credential is configured, a [default TokenCredential is created based on the current environment](https://aka.ms/aspire/default-azure-credential).
 
 If the connection string contains a username and a password then the credential will be ignored.
 

--- a/src/Components/Aspire.Azure.Npgsql/Aspire.Azure.Npgsql.csproj
+++ b/src/Components/Aspire.Azure.Npgsql/Aspire.Azure.Npgsql.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <Compile Include="..\Common\ManagedIdentityTokenCredentialHelpers.cs" Link="ManagedIdentityTokenCredentialHelpers.cs" />
+    <Compile Include="..\..\Shared\AzureCredentialHelper.cs" Link="AzureCredentialHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Azure.Npgsql/README.md
+++ b/src/Components/Aspire.Azure.Npgsql/README.md
@@ -90,7 +90,7 @@ Also you can pass the `Action<AzureNpgsqlSettings> configureSettings` delegate t
     builder.AddAzureNpgsqlDataSource("postgresdb", settings => settings.DisableHealthChecks = true);
 ```
 
-Use the `AzureNpgsqlSettings.Credential` property to establish a connection. If no credential is configured, the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is used.
+Use the `AzureNpgsqlSettings.Credential` property to establish a connection. If no credential is configured, a [default TokenCredential is created based on the current environment](https://aka.ms/aspire/default-azure-credential).
 
 If the connection string contains a username and a password then the credential will be ignored.
 

--- a/src/Components/Aspire.Azure.Search.Documents/Aspire.Azure.Search.Documents.csproj
+++ b/src/Components/Aspire.Azure.Search.Documents/Aspire.Azure.Search.Documents.csproj
@@ -13,6 +13,7 @@
     <Compile Include="..\Common\AzureComponent.cs" Link="AzureComponent.cs" />
     <Compile Include="..\Common\ConfigurationSchemaAttributes.cs" Link="ConfigurationSchemaAttributes.cs" />
     <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
+    <Compile Include="..\..\Shared\AzureCredentialHelper.cs" Link="AzureCredentialHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Azure.Search.Documents/AspireAzureSearchExtensions.cs
+++ b/src/Components/Aspire.Azure.Search.Documents/AspireAzureSearchExtensions.cs
@@ -1,12 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire;
 using Aspire.Azure.Common;
 using Aspire.Azure.Search.Documents;
 using Azure;
 using Azure.Core;
 using Azure.Core.Extensions;
-using Azure.Identity;
 using Azure.Search.Documents;
 using Azure.Search.Documents.Indexes;
 using Microsoft.Extensions.Azure;
@@ -87,7 +87,7 @@ public static class AspireAzureSearchExtensions
                 }
                 else
                 {
-                    return new SearchIndexClient(settings.Endpoint, settings.Credential ?? new DefaultAzureCredential(), options);
+                    return new SearchIndexClient(settings.Endpoint, settings.Credential ?? AzureCredentialHelper.CreateDefaultAzureCredential(), options);
                 }
             });
         }

--- a/src/Components/Aspire.Azure.Search.Documents/README.md
+++ b/src/Components/Aspire.Azure.Search.Documents/README.md
@@ -72,7 +72,7 @@ And then the connection string will be retrieved from the `ConnectionStrings` co
 
 #### Account Endpoint
 
-The recommended approach is to use an Endpoint, which works with the `AzureSearchSettings.Credential` property to establish a connection. If no credential is configured, the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is used.
+The recommended approach is to use an Endpoint, which works with the `AzureSearchSettings.Credential` property to establish a connection. If no credential is configured, a [default TokenCredential is created based on the current environment](https://aka.ms/aspire/default-azure-credential).
 
 ```json
 {

--- a/src/Components/Aspire.Azure.Security.KeyVault/Aspire.Azure.Security.KeyVault.csproj
+++ b/src/Components/Aspire.Azure.Security.KeyVault/Aspire.Azure.Security.KeyVault.csproj
@@ -13,6 +13,7 @@
     <Compile Include="..\Common\AzureComponent.cs" Link="AzureComponent.cs" />
     <Compile Include="..\Common\ConfigurationSchemaAttributes.cs" Link="ConfigurationSchemaAttributes.cs" />
     <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
+    <Compile Include="..\..\Shared\AzureCredentialHelper.cs" Link="AzureCredentialHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Azure.Security.KeyVault/AspireKeyVaultExtensions.cs
+++ b/src/Components/Aspire.Azure.Security.KeyVault/AspireKeyVaultExtensions.cs
@@ -1,11 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire;
 using Aspire.Azure.Common;
 using Aspire.Azure.Security.KeyVault;
 using Azure.Core.Extensions;
 using Azure.Extensions.AspNetCore.Configuration.Secrets;
-using Azure.Identity;
 using Azure.Security.KeyVault.Certificates;
 using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Secrets;
@@ -204,6 +204,6 @@ public static class AspireKeyVaultExtensions
             throw new InvalidOperationException($"VaultUri is missing. It should be provided in 'ConnectionStrings:{connectionName}' or under the 'VaultUri' key in the '{DefaultConfigSectionName}' configuration section.");
         }
 
-        return new SecretClient(settings.VaultUri, settings.Credential ?? new DefaultAzureCredential(), clientOptions);
+        return new SecretClient(settings.VaultUri, settings.Credential ?? AzureCredentialHelper.CreateDefaultAzureCredential(), clientOptions);
     }
 }

--- a/src/Components/Aspire.Azure.Security.KeyVault/README.md
+++ b/src/Components/Aspire.Azure.Security.KeyVault/README.md
@@ -104,7 +104,7 @@ When using a connection string from the `ConnectionStrings` configuration sectio
 builder.AddAzureKeyVaultClient("secretConnectionName");
 ```
 
-And then the vault URI will be retrieved from the `ConnectionStrings` configuration section. The vault URI which works with the `AzureSecurityKeyVaultSettings.Credential` property to establish a connection. If no credential is configured, the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is used.
+And then the vault URI will be retrieved from the `ConnectionStrings` configuration section. The vault URI which works with the `AzureSecurityKeyVaultSettings.Credential` property to establish a connection. If no credential is configured, a [default TokenCredential is created based on the current environment](https://aka.ms/aspire/default-azure-credential).
 
 ```json
 {

--- a/src/Components/Aspire.Azure.Storage.Blobs/README.md
+++ b/src/Components/Aspire.Azure.Storage.Blobs/README.md
@@ -54,7 +54,7 @@ And then the connection information will be retrieved from the `ConnectionString
 
 #### Service URI
 
-The recommended approach is to use a ServiceUri, which works with the `AzureStorageBlobsSettings.Credential` property to establish a connection. If no credential is configured, the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is used.
+The recommended approach is to use a ServiceUri, which works with the `AzureStorageBlobsSettings.Credential` property to establish a connection. If no credential is configured, a [default TokenCredential is created based on the current environment](https://aka.ms/aspire/default-azure-credential).
 
 ```json
 {

--- a/src/Components/Aspire.Azure.Storage.Files.DataLake/README.md
+++ b/src/Components/Aspire.Azure.Storage.Files.DataLake/README.md
@@ -57,7 +57,7 @@ And then the connection information will be retrieved from the `ConnectionString
 
 #### Service URI
 
-The recommended approach is to use a ServiceUri, which works with the `AzureDataLakeSettings.Credential` property to establish a connection. If no credential is configured, the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is used.
+The recommended approach is to use a ServiceUri, which works with the `AzureDataLakeSettings.Credential` property to establish a connection. If no credential is configured, a [default TokenCredential is created based on the current environment](https://aka.ms/aspire/default-azure-credential).
 
 ```json
 {

--- a/src/Components/Aspire.Azure.Storage.Queues/README.md
+++ b/src/Components/Aspire.Azure.Storage.Queues/README.md
@@ -54,7 +54,7 @@ And then the connection string will be retrieved from the `ConnectionStrings` co
 
 #### Service URI
 
-The recommended approach is to use a ServiceUri, which works with the `AzureStorageQueuesSettings.Credential` property to establish a connection. If no credential is configured, the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is used.
+The recommended approach is to use a ServiceUri, which works with the `AzureStorageQueuesSettings.Credential` property to establish a connection. If no credential is configured, a [default TokenCredential is created based on the current environment](https://aka.ms/aspire/default-azure-credential).
 
 ```json
 {

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/Aspire.Microsoft.Azure.Cosmos.csproj
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/Aspire.Microsoft.Azure.Cosmos.csproj
@@ -14,6 +14,7 @@
     <Compile Include="..\..\Shared\Cosmos\CosmosConstants.cs" Link="Shared\CosmosConstants.cs" />
     <Compile Include="..\..\Shared\Cosmos\CosmosUtils.cs" Link="Shared\CosmosUtils.cs" />
     <Compile Include="..\..\Shared\StableConnectionStringBuilder.cs" Link="Shared\StableConnectionStringBuilder.cs" />
+    <Compile Include="..\..\Shared\AzureCredentialHelper.cs" Link="AzureCredentialHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosExtensions.cs
@@ -1,9 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire;
 using Aspire.Hosting.Azure.CosmosDB;
 using Aspire.Microsoft.Azure.Cosmos;
-using Azure.Identity;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -272,7 +272,7 @@ public static class AspireMicrosoftAzureCosmosExtensions
         }
         else if (settings.AccountEndpoint is not null)
         {
-            var credential = settings.Credential ?? new DefaultAzureCredential();
+            var credential = settings.Credential ?? AzureCredentialHelper.CreateDefaultAzureCredential();
             return new CosmosClient(settings.AccountEndpoint.OriginalString, credential, clientOptions);
         }
         else

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
@@ -54,7 +54,7 @@ And then the connection string will be retrieved from the `ConnectionStrings` co
 
 #### Account Endpoint
 
-The recommended approach is to use an AccountEndpoint, which works with the `MicrosoftAzureCosmosSettings.Credential` property to establish a connection. If no credential is configured, the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is used.
+The recommended approach is to use an AccountEndpoint, which works with the `MicrosoftAzureCosmosSettings.Credential` property to establish a connection. If no credential is configured, a [default TokenCredential is created based on the current environment](https://aka.ms/aspire/default-azure-credential).
 
 ```json
 {

--- a/src/Components/Aspire.Microsoft.Azure.StackExchangeRedis/Aspire.Microsoft.Azure.StackExchangeRedis.csproj
+++ b/src/Components/Aspire.Microsoft.Azure.StackExchangeRedis/Aspire.Microsoft.Azure.StackExchangeRedis.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\Shared\AzureCredentialHelper.cs" Link="AzureCredentialHelper.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Azure.StackExchangeRedis" />
     <ProjectReference Include="..\Aspire.StackExchange.Redis\Aspire.StackExchange.Redis.csproj" />
   </ItemGroup>

--- a/src/Components/Aspire.Microsoft.Azure.StackExchangeRedis/AspireMicrosoftAzureStackExchangeRedisExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Azure.StackExchangeRedis/AspireMicrosoftAzureStackExchangeRedisExtensions.cs
@@ -1,9 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire;
 using Aspire.StackExchange.Redis;
 using Azure.Core;
-using Azure.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using StackExchange.Redis;
 using StackExchange.Redis.Configuration;
@@ -19,7 +19,7 @@ public static class AspireMicrosoftAzureStackExchangeRedisExtensions
     /// Configures the Redis client to use Azure AD authentication for connecting to Azure Cache for Redis.
     /// </summary>
     /// <param name="builder">The <see cref="AspireRedisClientBuilder"/> to configure.</param>
-    /// <param name="credential">The <see cref="TokenCredential"/> to use for Azure AD authentication. If <see langword="null"/>, <see cref="DefaultAzureCredential"/> will be used.</param>
+    /// <param name="credential">The <see cref="TokenCredential"/> to use for Azure AD authentication. If <see langword="null"/>, a default credential will be used.</param>
     /// <returns>The <see cref="AspireRedisClientBuilder"/> for method chaining.</returns>
     /// <remarks>
     /// This extension method configures the Redis client to authenticate with Azure Cache for Redis using Azure AD (Entra ID) instead of access keys.
@@ -40,7 +40,7 @@ public static class AspireMicrosoftAzureStackExchangeRedisExtensions
                 if (configurationOptions.EndPoints.Any(ep => azureOptionsProvider.IsMatch(ep) || azureManagedOptionsProvider.IsMatch(ep)))
                 {
                     // only set up Azure AD authentication if the endpoint indicates it's an Azure Cache for Redis instance
-                    credential ??= new DefaultAzureCredential();
+                    credential ??= AzureCredentialHelper.CreateDefaultAzureCredential();
 
                     // Configure Microsoft.Azure.StackExchangeRedis for Azure AD authentication
                     // Note: Using GetAwaiter().GetResult() is acceptable here because this is configuration-time setup

--- a/src/Components/Aspire.Microsoft.Azure.StackExchangeRedis/README.md
+++ b/src/Components/Aspire.Microsoft.Azure.StackExchangeRedis/README.md
@@ -73,7 +73,7 @@ builder.AddRedisClientBuilder("cache")
 
 ### Configure Azure AD authentication
 
-Use the `WithAzureAuthentication` method to establish a connection using Azure AD authentication. If no credential is provided, the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is used.
+Use the `WithAzureAuthentication` method to establish a connection using Azure AD authentication. If no credential is provided, a [default TokenCredential is created based on the current environment](https://aka.ms/aspire/default-azure-credential).
 
 ```csharp
 builder.AddRedisClientBuilder("cache")

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/Aspire.Microsoft.EntityFrameworkCore.Cosmos.csproj
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/Aspire.Microsoft.EntityFrameworkCore.Cosmos.csproj
@@ -14,6 +14,7 @@
     <Compile Include="..\..\Shared\Cosmos\CosmosConstants.cs" Link="Shared\CosmosConstants.cs" />
     <Compile Include="..\..\Shared\Cosmos\CosmosUtils.cs" Link="Shared\CosmosUtils.cs" />
     <Compile Include="..\..\Shared\StableConnectionStringBuilder.cs" Link="Shared\StableConnectionStringBuilder.cs" />
+    <Compile Include="..\..\Shared\AzureCredentialHelper.cs" Link="AzureCredentialHelper.cs" />
     <Compile Include="..\Common\EntityFrameworkUtils.cs" Link="EntityFrameworkUtils.cs" />
   </ItemGroup>
   

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/AspireAzureEFCoreCosmosExtensions.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/AspireAzureEFCoreCosmosExtensions.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using Aspire;
 using Aspire.Hosting.Azure.CosmosDB;
 using Aspire.Microsoft.EntityFrameworkCore.Cosmos;
-using Azure.Identity;
 using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Cosmos.Infrastructure.Internal;
@@ -135,7 +134,7 @@ public static class AspireAzureEFCoreCosmosExtensions
             }
             else if (settings.AccountEndpoint is not null)
             {
-                var credential = settings.Credential ?? new DefaultAzureCredential();
+                var credential = settings.Credential ?? AzureCredentialHelper.CreateDefaultAzureCredential();
                 dbContextOptionsBuilder.UseCosmos(settings.AccountEndpoint.OriginalString, credential, settings.DatabaseName, UseCosmosBody);
             }
             else

--- a/src/Components/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
+++ b/src/Components/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj
@@ -13,6 +13,7 @@
     <Compile Include="..\Common\ConfigurationSchemaAttributes.cs" Link="ConfigurationSchemaAttributes.cs" />
     <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
     <Compile Include="..\..\Shared\StableConnectionStringBuilder.cs" Link="StableConnectionStringBuilder.cs" />
+    <Compile Include="..\..\Shared\AzureCredentialHelper.cs" Link="AzureCredentialHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration/AspireAppConfigurationExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration/AspireAppConfigurationExtensions.cs
@@ -1,11 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire;
 using Aspire.Azure.Common;
 using Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Azure.Core.Pipeline;
 using Azure.Core;
-using Azure.Identity;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -75,7 +75,7 @@ public static class AspireAppConfigurationExtensions
             {
                 if (settings.ConnectionString is null)
                 {
-                    options.Connect(settings.Endpoint, settings.Credential ?? new DefaultAzureCredential());
+                    options.Connect(settings.Endpoint, settings.Credential ?? AzureCredentialHelper.CreateDefaultAzureCredential());
                 }
                 else
                 {

--- a/src/Components/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration/README.md
+++ b/src/Components/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration/README.md
@@ -91,7 +91,7 @@ When using a connection string from the `ConnectionStrings` configuration sectio
 builder.AddAzureAppConfiguration("appConfigConnectionName");
 ```
 
-And then the App Configuration endpoint will be retrieved from the `ConnectionStrings` configuration section. The App Configuration store URI works with the `AzureAppConfigurationSettings.Credential` property to establish a connection. If no credential is configured, the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is used.
+And then the App Configuration endpoint will be retrieved from the `ConnectionStrings` configuration section. The App Configuration store URI works with the `AzureAppConfigurationSettings.Credential` property to establish a connection. If no credential is configured, a [default TokenCredential is created based on the current environment](https://aka.ms/aspire/default-azure-credential).
 
 ```json
 {

--- a/src/Components/Common/ManagedIdentityTokenCredentialHelpers.cs
+++ b/src/Components/Common/ManagedIdentityTokenCredentialHelpers.cs
@@ -3,7 +3,6 @@
 
 using System.Text.Json;
 using Azure.Core;
-using Azure.Identity;
 using Npgsql;
 
 namespace Aspire;
@@ -18,7 +17,7 @@ internal static class ManagedIdentityTokenCredentialHelpers
 
     public static bool ConfigureEntraIdAuthentication(this NpgsqlDataSourceBuilder dataSourceBuilder, TokenCredential? credential)
     {
-        credential ??= new DefaultAzureCredential();
+        credential ??= AzureCredentialHelper.CreateDefaultAzureCredential();
         var configuredAuth = false;
 
         // The connection string requires the username to be provided. Since it will depend on the Managed Identity that is used

--- a/src/Shared/AzureCredentialHelper.cs
+++ b/src/Shared/AzureCredentialHelper.cs
@@ -24,7 +24,7 @@ internal static class AzureCredentialHelper
             // we just use ManagedIdentityCredential because that's the only credential type that
             // Aspire Hosting enables by default.
             // If this doesn't work for applications, they can override the TokenCredential in their settings.
-            return new ManagedIdentityCredential();
+            return new ManagedIdentityCredential(new ManagedIdentityCredentialOptions());
         }
 
         // when we can't detect a known Azure environment, fall back to the development credential

--- a/src/Shared/AzureCredentialHelper.cs
+++ b/src/Shared/AzureCredentialHelper.cs
@@ -20,6 +20,10 @@ internal static class AzureCredentialHelper
 
         if (Environment.GetEnvironmentVariable("AZURE_CLIENT_ID") is not null)
         {
+            // When we don't see DefaultEnvironmentVariableName, but we do see AZURE_CLIENT_ID,
+            // we just use ManagedIdentityCredential because that's the only credential type that
+            // Aspire Hosting enables by default.
+            // If this doesn't work for applications, they can override the TokenCredential in their settings.
             return new ManagedIdentityCredential();
         }
 

--- a/src/Shared/AzureCredentialHelper.cs
+++ b/src/Shared/AzureCredentialHelper.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Azure.Core;
+using Azure.Identity;
+
+namespace Aspire;
+
+internal static class AzureCredentialHelper
+{
+    /// <summary>
+    /// Creates a <see cref="TokenCredential"/> for code that can run in local development or deployed to Azure.
+    /// </summary>
+    internal static TokenCredential CreateDefaultAzureCredential()
+    {
+        if (Environment.GetEnvironmentVariable(DefaultAzureCredential.DefaultEnvironmentVariableName) is not null)
+        {
+            return new DefaultAzureCredential(DefaultAzureCredential.DefaultEnvironmentVariableName);
+        }
+
+        if (Environment.GetEnvironmentVariable("AZURE_CLIENT_ID") is not null)
+        {
+            return new ManagedIdentityCredential();
+        }
+
+        // when we can't detect a known Azure environment, fall back to the development credential
+        return CreateDevelopmentAzureCredential();
+    }
+
+    /// <summary>
+    /// Creates a <see cref="DefaultAzureCredential"/> optimized for local development by excluding
+    /// credential types not applicable on developer machines.
+    /// </summary>
+    private static TokenCredential CreateDevelopmentAzureCredential()
+    {
+        return new DefaultAzureCredential(new DefaultAzureCredentialOptions
+        {
+            ExcludeEnvironmentCredential = true,
+            ExcludeWorkloadIdentityCredential = true,
+            ExcludeManagedIdentityCredential = true
+        });
+    }
+}

--- a/tests/Aspire.Azure.Search.Documents.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Search.Documents.Tests/ConformanceTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
+using System.Text;
 using Aspire.Components.ConformanceTests;
 using Azure.Identity;
 using Azure.Search.Documents.Indexes;
@@ -17,10 +19,7 @@ public class ConformanceTests : ConformanceTests<SearchIndexClient, AzureSearchS
 
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Singleton;
 
-    protected override string[] RequiredLogCategories => [
-        "Azure.Core",
-        "Azure.Identity"
-    ];
+    protected override string[] RequiredLogCategories => ["Azure.Identity"];
 
     protected override bool SupportsKeyedRegistrations => true;
 
@@ -104,4 +103,20 @@ public class ConformanceTests : ConformanceTests<SearchIndexClient, AzureSearchS
 
     protected override void TriggerActivity(SearchIndexClient service)
         => service.GetIndex("my-index");
+
+    [Fact]
+    public void DumpEnvironmentVariablesForDiag()
+    {
+        var variableString = new StringBuilder();
+        variableString.AppendLine("ERIC:");
+        foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+        {
+            variableString.AppendLine($"{entry.Key}: {entry.Value}");
+        }
+        var message = variableString.ToString();
+
+        Output?.WriteLine(message);
+
+        Assert.Fail(message);
+    }
 }

--- a/tests/Aspire.Azure.Search.Documents.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Search.Documents.Tests/ConformanceTests.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
-using System.Text;
 using Aspire.Components.ConformanceTests;
 using Azure.Identity;
 using Azure.Search.Documents.Indexes;
@@ -103,20 +101,4 @@ public class ConformanceTests : ConformanceTests<SearchIndexClient, AzureSearchS
 
     protected override void TriggerActivity(SearchIndexClient service)
         => service.GetIndex("my-index");
-
-    [Fact]
-    public void DumpEnvironmentVariablesForDiag()
-    {
-        var variableString = new StringBuilder();
-        variableString.AppendLine("ERIC:");
-        foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
-        {
-            variableString.AppendLine($"{entry.Key}: {entry.Value}");
-        }
-        var message = variableString.ToString();
-
-        Output?.WriteLine(message);
-
-        Assert.Fail(message);
-    }
 }


### PR DESCRIPTION
Using the parameterless ctor of DefaultAzureCredential is not recommended. Instead try to detect when we are running in Azure and use Azure credentials. Fallback to using just development credentials when we can't detect we are in Azure.

Users can always provide their own to override this behavior.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to `aspire.dev` issue:
      https://github.com/microsoft/aspire.dev/issues/516
  - [ ] No
