### PR TITLE
Add Markdown support to pipeline logging and summaries

### DIFF
--- a/src/Aspire.Cli/Backchannel/BackchannelJsonSerializerContext.cs
+++ b/src/Aspire.Cli/Backchannel/BackchannelJsonSerializerContext.cs
@@ -38,7 +38,6 @@ namespace Aspire.Cli.Backchannel;
 [JsonSerializable(typeof(List<EnvVar>))]
 [JsonSerializable(typeof(List<string>))]
 [JsonSerializable(typeof(DebugSessionOptions))]
-[JsonSerializable(typeof(List<KeyValuePair<string, string>>))]
 [JsonSerializable(typeof(bool?))]
 [JsonSerializable(typeof(AppHostProjectSearchResultPoco))]
 [JsonSerializable(typeof(DashboardMcpConnectionInfo))]

--- a/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
+++ b/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
+using Aspire.Cli.Backchannel;
 using Aspire.Shared;
 using Spectre.Console;
 
@@ -40,7 +41,7 @@ internal sealed class ConsoleActivityLogger
 
     private string? _finalStatusHeader;
     private bool _pipelineSucceeded;
-    private IReadOnlyList<KeyValuePair<string, string>>? _pipelineSummary;
+    private IReadOnlyList<BackchannelPipelineSummaryItem>? _pipelineSummary;
 
     // No raw ANSI escape codes; rely on Spectre.Console markup tokens.
 
@@ -281,9 +282,9 @@ internal sealed class ConsoleActivityLogger
                 if (_pipelineSucceeded && pipelineSummary is { Count: > 0 })
                 {
                     _console.WriteLine();
-                    foreach (var kvp in pipelineSummary)
+                    foreach (var item in pipelineSummary)
                     {
-                        var formattedLine = FormatPipelineSummaryKvp(kvp.Key, kvp.Value);
+                        var formattedLine = FormatPipelineSummaryItem(item);
                         _console.MarkupLine(formattedLine);
                     }
                 }
@@ -303,22 +304,26 @@ internal sealed class ConsoleActivityLogger
     }
 
     /// <summary>
-    /// Formats a single key-value pair for the pipeline summary display.
-    /// Values may contain markdown links which are converted to clickable links when supported.
+    /// Formats a pipeline summary item for display.
+    /// Values with Markdown enabled are converted to Spectre markup; plain-text values are escaped.
     /// </summary>
-    private string FormatPipelineSummaryKvp(string key, string value)
+    private string FormatPipelineSummaryItem(BackchannelPipelineSummaryItem item)
     {
         if (_enableColor)
         {
-            var escapedKey = key.EscapeMarkup();
-            var convertedValue = MarkdownToSpectreConverter.ConvertToSpectre(value);
+            var escapedKey = item.Key.EscapeMarkup();
+            var convertedValue = item.EnableMarkdown
+                ? MarkdownToSpectreConverter.ConvertToSpectre(item.Value)
+                : item.Value.EscapeMarkup();
             convertedValue = HighlightMessage(convertedValue);
             return $"  [blue]{escapedKey}[/]: {convertedValue}";
         }
         else
         {
-            var plainKey = key.EscapeMarkup();
-            var plainValue = MarkdownToSpectreConverter.ConvertLinksToPlainText(value).EscapeMarkup();
+            var plainKey = item.Key.EscapeMarkup();
+            var plainValue = item.EnableMarkdown
+                ? MarkdownToSpectreConverter.ConvertLinksToPlainText(item.Value).EscapeMarkup()
+                : item.Value.EscapeMarkup();
             return $"  {plainKey}: {plainValue}";
         }
     }
@@ -329,7 +334,7 @@ internal sealed class ConsoleActivityLogger
     /// </summary>
     /// <param name="succeeded">Whether the pipeline succeeded.</param>
     /// <param name="pipelineSummary">Optional pipeline summary as key-value pairs to display after the result. The list preserves insertion order.</param>
-    public void SetFinalResult(bool succeeded, IReadOnlyList<KeyValuePair<string, string>>? pipelineSummary = null)
+    public void SetFinalResult(bool succeeded, IReadOnlyList<BackchannelPipelineSummaryItem>? pipelineSummary = null)
     {
         _pipelineSucceeded = succeeded;
         _pipelineSummary = pipelineSummary;

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppResource.cs
@@ -53,12 +53,12 @@ public class AzureContainerAppResource : AzureProvisioningResource
                     {
                         var endpoint = $"https://{targetResource.Name.ToLowerInvariant()}.{domainValue}";
 
-                        ctx.ReportingStep.Log(LogLevel.Information, $"Successfully deployed **{targetResource.Name}** to [{endpoint}]({endpoint})", enableMarkdown: true);
+                        ctx.ReportingStep.Log(LogLevel.Information, new MarkdownString($"Successfully deployed **{targetResource.Name}** to [{endpoint}]({endpoint})"));
                         ctx.Summary.Add(targetResource.Name, endpoint);
                     }
                     else
                     {
-                        ctx.ReportingStep.Log(LogLevel.Information, $"Successfully deployed **{targetResource.Name}** to Azure Container Apps environment **{containerAppEnv.Name}**. No public endpoints were configured.", enableMarkdown: true);
+                        ctx.ReportingStep.Log(LogLevel.Information, new MarkdownString($"Successfully deployed **{targetResource.Name}** to Azure Container Apps environment **{containerAppEnv.Name}**. No public endpoints were configured."));
                         ctx.Summary.Add(targetResource.Name, "No public endpoints");
                     }
                 },

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
@@ -199,7 +199,7 @@ public class AzureAppServiceEnvironmentResource :
             // Report each error through the activity reporter for user-friendly display
             foreach (var error in errors)
             {
-                context.ReportingStep.Log(LogLevel.Error, error, enableMarkdown: false);
+                context.ReportingStep.Log(LogLevel.Error, error);
             }
 
             await context.ReportingStep.CompleteAsync(

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
@@ -57,7 +57,7 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
 
                     var hostName = await GetAppServiceWebsiteNameAsync(ctx, deploymentSlot).ConfigureAwait(false);
                     var endpoint = $"https://{hostName}.azurewebsites.net";
-                    ctx.ReportingStep.Log(LogLevel.Information, $"Successfully deployed **{targetResource.Name}** to [{endpoint}]({endpoint})", enableMarkdown: true);
+                    ctx.ReportingStep.Log(LogLevel.Information, new MarkdownString($"Successfully deployed **{targetResource.Name}** to [{endpoint}]({endpoint})"));
                     ctx.Summary.Add(targetResource.Name, endpoint);
                 },
                 Tags = ["print-summary"],

--- a/src/Aspire.Hosting.Azure.ContainerRegistry/AzureContainerRegistryHelpers.cs
+++ b/src/Aspire.Hosting.Azure.ContainerRegistry/AzureContainerRegistryHelpers.cs
@@ -32,7 +32,9 @@ internal static class AzureContainerRegistryHelpers
         var registryEndpoint = await registry.Endpoint.GetValueAsync(context.CancellationToken).ConfigureAwait(false) ??
             throw new InvalidOperationException("Failed to retrieve container registry endpoint.");
 
-        var loginTask = await context.ReportingStep.CreateTaskAsync($"Logging in to **{registryName}**", context.CancellationToken).ConfigureAwait(false);
+        var loginTask = await context.ReportingStep.CreateTaskAsync(
+            new MarkdownString($"Logging in to **{registryName}**"),
+            context.CancellationToken).ConfigureAwait(false);
         await using (loginTask.ConfigureAwait(false))
         {
             try
@@ -49,11 +51,16 @@ internal static class AzureContainerRegistryHelpers
                     tokenCredentialProvider.TokenCredential,
                     context.CancellationToken).ConfigureAwait(false);
 
-                await loginTask.CompleteAsync($"Successfully logged in to **{registryEndpoint}**", CompletionState.Completed, context.CancellationToken).ConfigureAwait(false);
+                await loginTask.CompleteAsync(
+                    new MarkdownString($"Successfully logged in to **{registryEndpoint}**"),
+                    CompletionState.Completed,
+                    context.CancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                await loginTask.FailAsync($"Login to ACR **{registryEndpoint}** failed: {ex.Message}", cancellationToken: context.CancellationToken).ConfigureAwait(false);
+                await loginTask.FailAsync(
+                    new MarkdownString($"Login to ACR **{registryEndpoint}** failed: {ex.Message}"),
+                    context.CancellationToken).ConfigureAwait(false);
                 throw;
             }
         }

--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -318,7 +318,7 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
         var provisioningContext = await azureEnvironment.ProvisioningContextTask.Task.ConfigureAwait(false);
 
         var resourceTask = await context.ReportingStep
-            .CreateTaskAsync($"Deploying **{resource.Name}**", context.CancellationToken)
+            .CreateTaskAsync(new MarkdownString($"Deploying **{resource.Name}**"), context.CancellationToken)
             .ConfigureAwait(false);
 
         await using (resourceTask.ConfigureAwait(false))
@@ -330,7 +330,7 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
                 {
                     resource.ProvisioningTaskCompletionSource?.TrySetResult();
                     await resourceTask.CompleteAsync(
-                        $"Using existing deployment for **{resource.Name}**",
+                        new MarkdownString($"Using existing deployment for **{resource.Name}**"),
                         CompletionState.Completed,
                         context.CancellationToken).ConfigureAwait(false);
                 }
@@ -341,7 +341,7 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
                         .ConfigureAwait(false);
                     resource.ProvisioningTaskCompletionSource?.TrySetResult();
                     await resourceTask.CompleteAsync(
-                        $"Successfully provisioned **{resource.Name}**",
+                        new MarkdownString($"Successfully provisioned **{resource.Name}**"),
                         CompletionState.Completed,
                         context.CancellationToken).ConfigureAwait(false);
                 }
@@ -356,7 +356,7 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
                 };
                 resource.ProvisioningTaskCompletionSource?.TrySetException(ex);
                 await resourceTask.CompleteAsync(
-                    $"Failed to provision **{resource.Name}**: {errorMessage}",
+                    new MarkdownString($"Failed to provision **{resource.Name}**: {errorMessage}"),
                     CompletionState.CompletedWithError,
                     context.CancellationToken).ConfigureAwait(false);
                 throw new ProvisioningFailedException(errorMessage, ex);

--- a/src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs
@@ -143,7 +143,7 @@ public sealed class AzureEnvironmentResource : Resource
         var resourceGroupValue = $"[{resourceGroupName}]({portalUrl})";
 
         ctx.Summary.Add("☁️ Target", "Azure");
-        ctx.Summary.Add("📦 Resource Group", resourceGroupValue);
+        ctx.Summary.Add("📦 Resource Group", new MarkdownString(resourceGroupValue));
         ctx.Summary.Add("🔑 Subscription", subscriptionId);
         ctx.Summary.Add("🌐 Location", location);
     }

--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentResource.cs
@@ -223,7 +223,9 @@ public class DockerComposeEnvironmentResource : Resource, IComputeEnvironmentRes
             throw new InvalidOperationException($"Docker Compose file not found at {dockerComposeFilePath}");
         }
 
-        var deployTask = await context.ReportingStep.CreateTaskAsync($"Running docker compose up for **{Name}**", context.CancellationToken).ConfigureAwait(false);
+        var deployTask = await context.ReportingStep.CreateTaskAsync(
+            new MarkdownString($"Running docker compose up for **{Name}**"),
+            context.CancellationToken).ConfigureAwait(false);
         await using (deployTask.ConfigureAwait(false))
         {
             try
@@ -263,7 +265,10 @@ public class DockerComposeEnvironmentResource : Resource, IComputeEnvironmentRes
                     }
                     else
                     {
-                        await deployTask.CompleteAsync($"Service **{Name}** is now running with Docker Compose locally", CompletionState.Completed, context.CancellationToken).ConfigureAwait(false);
+                        await deployTask.CompleteAsync(
+                            new MarkdownString($"Service **{Name}** is now running with Docker Compose locally"),
+                            CompletionState.Completed,
+                            context.CancellationToken).ConfigureAwait(false);
                     }
                 }
             }
@@ -285,7 +290,9 @@ public class DockerComposeEnvironmentResource : Resource, IComputeEnvironmentRes
             throw new InvalidOperationException($"Docker Compose file not found at {dockerComposeFilePath}");
         }
 
-        var deployTask = await context.ReportingStep.CreateTaskAsync($"Running docker compose down for **{Name}**", context.CancellationToken).ConfigureAwait(false);
+        var deployTask = await context.ReportingStep.CreateTaskAsync(
+            new MarkdownString($"Running docker compose down for **{Name}**"),
+            context.CancellationToken).ConfigureAwait(false);
         await using (deployTask.ConfigureAwait(false))
         {
             try
@@ -317,7 +324,10 @@ public class DockerComposeEnvironmentResource : Resource, IComputeEnvironmentRes
                     }
                     else
                     {
-                        await deployTask.CompleteAsync($"Docker Compose shutdown complete for **{Name}**", CompletionState.Completed, context.CancellationToken).ConfigureAwait(false);
+                        await deployTask.CompleteAsync(
+                            new MarkdownString($"Docker Compose shutdown complete for **{Name}**"),
+                            CompletionState.Completed,
+                            context.CancellationToken).ConfigureAwait(false);
                     }
                 }
             }

--- a/src/Aspire.Hosting.Docker/DockerComposeServiceResource.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeServiceResource.cs
@@ -331,8 +331,7 @@ public class DockerComposeServiceResource : Resource, IResourceWithParent<Docker
         if (externalEndpointMappings.Count == 0)
         {
             context.ReportingStep.Log(LogLevel.Information,
-                $"Successfully deployed **{TargetResource.Name}** to Docker Compose environment **{environment.Name}**. No public endpoints were configured.",
-                enableMarkdown: true);
+                new MarkdownString($"Successfully deployed **{TargetResource.Name}** to Docker Compose environment **{environment.Name}**. No public endpoints were configured."));
             context.Summary.Add(TargetResource.Name, "No public endpoints");
             return;
         }
@@ -346,15 +345,14 @@ public class DockerComposeServiceResource : Resource, IResourceWithParent<Docker
         if (endpoints.Count > 0)
         {
             var endpointList = string.Join(", ", endpoints.Select(e => $"[{e}]({e})"));
-            context.ReportingStep.Log(LogLevel.Information, $"Successfully deployed **{TargetResource.Name}** to {endpointList}.", enableMarkdown: true);
+            context.ReportingStep.Log(LogLevel.Information, new MarkdownString($"Successfully deployed **{TargetResource.Name}** to {endpointList}."));
             context.Summary.Add(TargetResource.Name, string.Join(", ", endpoints));
         }
         else
         {
             // No published ports found in docker compose ps output.
             context.ReportingStep.Log(LogLevel.Information,
-                $"Successfully deployed **{TargetResource.Name}** to Docker Compose environment **{environment.Name}**.",
-                enableMarkdown: true);
+                new MarkdownString($"Successfully deployed **{TargetResource.Name}** to Docker Compose environment **{environment.Name}**."));
             context.Summary.Add(TargetResource.Name, "No public endpoints");
         }
     }

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -472,10 +472,10 @@ internal sealed class PublishingActivityData
 
     /// <summary>
     /// Gets the pipeline summary information to display after pipeline completion.
-    /// This is a list of key-value pairs with deployment targets, resource names, URLs, etc.
+    /// Each item carries its own key, value, and Markdown formatting flag.
     /// The list preserves the order items were added.
     /// </summary>
-    public IReadOnlyList<KeyValuePair<string, string>>? PipelineSummary { get; init; }
+    public IReadOnlyList<BackchannelPipelineSummaryItem>? PipelineSummary { get; init; }
 
     /// <summary>
     /// Gets the input information for prompt activities, if available.
@@ -496,6 +496,27 @@ internal sealed class PublishingActivityData
     /// Gets a value indicating whether markdown formatting is enabled for the publishing activity.
     /// </summary>
     public bool EnableMarkdown { get; init; } = true;
+}
+
+/// <summary>
+/// Represents a single item in a pipeline summary for backchannel transport.
+/// </summary>
+internal sealed class BackchannelPipelineSummaryItem
+{
+    /// <summary>
+    /// Gets the key or label for the summary item.
+    /// </summary>
+    public required string Key { get; init; }
+
+    /// <summary>
+    /// Gets the string value for the summary item.
+    /// </summary>
+    public required string Value { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the value contains Markdown formatting.
+    /// </summary>
+    public bool EnableMarkdown { get; init; }
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/CompatibilitySuppressions.xml
+++ b/src/Aspire.Hosting/CompatibilitySuppressions.xml
@@ -16,6 +16,13 @@
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aspire.Hosting.ResourceBuilderExtensions.WithDebugSupport``2(Aspire.Hosting.ApplicationModel.IResourceBuilder{``0},System.Func{System.String,``1},System.String,System.Action{Aspire.Hosting.ApplicationModel.CommandLineArgsCallbackContext})</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
     <Target>M:Aspire.Hosting.Pipelines.IDeploymentStateManager.DeleteSectionAsync(Aspire.Hosting.Pipelines.DeploymentStateSection,System.Threading.CancellationToken)</Target>
     <Left>lib/net8.0/Aspire.Hosting.dll</Left>
@@ -31,6 +38,34 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aspire.Hosting.Pipelines.IReportingStep.CompleteAsync(Aspire.Hosting.Pipelines.MarkdownString,Aspire.Hosting.Pipelines.CompletionState,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aspire.Hosting.Pipelines.IReportingStep.CreateTaskAsync(Aspire.Hosting.Pipelines.MarkdownString,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aspire.Hosting.Pipelines.IReportingStep.Log(Microsoft.Extensions.Logging.LogLevel,Aspire.Hosting.Pipelines.MarkdownString)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aspire.Hosting.Pipelines.IReportingStep.Log(Microsoft.Extensions.Logging.LogLevel,System.String)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
     <Target>M:Aspire.Hosting.Publishing.IContainerRuntime.BuildImageAsync(System.String,System.String,Aspire.Hosting.Publishing.ContainerImageBuildOptions,System.Collections.Generic.Dictionary{System.String,System.String},System.Collections.Generic.Dictionary{System.String,Aspire.Hosting.Publishing.BuildImageSecretValue},System.String,System.Threading.CancellationToken)</Target>
     <Left>lib/net8.0/Aspire.Hosting.dll</Left>
     <Right>lib/net8.0/Aspire.Hosting.dll</Right>
@@ -39,13 +74,6 @@
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
     <Target>P:Aspire.Hosting.IUserSecretsManager.IsAvailable</Target>
-    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
-    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Aspire.Hosting.ResourceBuilderExtensions.WithDebugSupport``2(Aspire.Hosting.ApplicationModel.IResourceBuilder{``0},System.Func{System.String,``1},System.String,System.Action{Aspire.Hosting.ApplicationModel.CommandLineArgsCallbackContext})</Target>
     <Left>lib/net8.0/Aspire.Hosting.dll</Left>
     <Right>lib/net8.0/Aspire.Hosting.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Aspire.Hosting/CompatibilitySuppressions.xml
+++ b/src/Aspire.Hosting/CompatibilitySuppressions.xml
@@ -66,6 +66,20 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aspire.Hosting.Pipelines.IReportingTask.CompleteAsync(Aspire.Hosting.Pipelines.MarkdownString,Aspire.Hosting.Pipelines.CompletionState,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aspire.Hosting.Pipelines.IReportingTask.UpdateAsync(Aspire.Hosting.Pipelines.MarkdownString,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Aspire.Hosting.dll</Left>
+    <Right>lib/net8.0/Aspire.Hosting.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
     <Target>M:Aspire.Hosting.Publishing.IContainerRuntime.BuildImageAsync(System.String,System.String,Aspire.Hosting.Publishing.ContainerImageBuildOptions,System.Collections.Generic.Dictionary{System.String,System.String},System.Collections.Generic.Dictionary{System.String,Aspire.Hosting.Publishing.BuildImageSecretValue},System.String,System.Threading.CancellationToken)</Target>
     <Left>lib/net8.0/Aspire.Hosting.dll</Left>
     <Right>lib/net8.0/Aspire.Hosting.dll</Right>

--- a/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
+++ b/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
@@ -1056,7 +1056,7 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
             sb.AppendLine();
         }
 
-        context.ReportingStep.Log(LogLevel.Information, sb.ToString(), enableMarkdown: false);
+        context.ReportingStep.Log(LogLevel.Information, sb.ToString());
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Pipelines/IReportingStep.cs
+++ b/src/Aspire.Hosting/Pipelines/IReportingStep.cs
@@ -26,11 +26,7 @@ public interface IReportingStep : IAsyncDisposable
     /// <param name="statusText">The initial Markdown-formatted status text for the task.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The created task.</returns>
-    Task<IReportingTask> CreateTaskAsync(MarkdownString statusText, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(statusText);
-        return CreateTaskAsync(statusText.Value, cancellationToken);
-    }
+    Task<IReportingTask> CreateTaskAsync(MarkdownString statusText, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Logs a message at the specified level within this step.
@@ -46,23 +42,14 @@ public interface IReportingStep : IAsyncDisposable
     /// </summary>
     /// <param name="logLevel">The log level for the message.</param>
     /// <param name="message">The plain-text message to log.</param>
-    void Log(LogLevel logLevel, string message)
-#pragma warning disable CS0618 // Type or member is obsolete
-        => Log(logLevel, message, enableMarkdown: false);
-#pragma warning restore CS0618
+    void Log(LogLevel logLevel, string message);
 
     /// <summary>
     /// Logs a Markdown-formatted message at the specified level within this step.
     /// </summary>
     /// <param name="logLevel">The log level for the message.</param>
     /// <param name="message">The Markdown-formatted message to log.</param>
-    void Log(LogLevel logLevel, MarkdownString message)
-    {
-        ArgumentNullException.ThrowIfNull(message);
-#pragma warning disable CS0618 // Type or member is obsolete
-        Log(logLevel, message.Value, enableMarkdown: true);
-#pragma warning restore CS0618
-    }
+    void Log(LogLevel logLevel, MarkdownString message);
 
     /// <summary>
     /// Completes the step with the specified completion text and state.
@@ -78,9 +65,5 @@ public interface IReportingStep : IAsyncDisposable
     /// <param name="completionText">The Markdown-formatted completion text for the step.</param>
     /// <param name="completionState">The completion state for the step.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    Task CompleteAsync(MarkdownString completionText, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(completionText);
-        return CompleteAsync(completionText.Value, completionState, cancellationToken);
-    }
+    Task CompleteAsync(MarkdownString completionText, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default);
 }

--- a/src/Aspire.Hosting/Pipelines/IReportingStep.cs
+++ b/src/Aspire.Hosting/Pipelines/IReportingStep.cs
@@ -27,7 +27,10 @@ public interface IReportingStep : IAsyncDisposable
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The created task.</returns>
     Task<IReportingTask> CreateTaskAsync(MarkdownString statusText, CancellationToken cancellationToken = default)
-        => CreateTaskAsync(statusText.Value, cancellationToken);
+    {
+        ArgumentNullException.ThrowIfNull(statusText);
+        return CreateTaskAsync(statusText.Value, cancellationToken);
+    }
 
     /// <summary>
     /// Logs a message at the specified level within this step.
@@ -54,9 +57,12 @@ public interface IReportingStep : IAsyncDisposable
     /// <param name="logLevel">The log level for the message.</param>
     /// <param name="message">The Markdown-formatted message to log.</param>
     void Log(LogLevel logLevel, MarkdownString message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
 #pragma warning disable CS0618 // Type or member is obsolete
-        => Log(logLevel, message.Value, enableMarkdown: true);
+        Log(logLevel, message.Value, enableMarkdown: true);
 #pragma warning restore CS0618
+    }
 
     /// <summary>
     /// Completes the step with the specified completion text and state.
@@ -73,5 +79,8 @@ public interface IReportingStep : IAsyncDisposable
     /// <param name="completionState">The completion state for the step.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     Task CompleteAsync(MarkdownString completionText, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
-        => CompleteAsync(completionText.Value, completionState, cancellationToken);
+    {
+        ArgumentNullException.ThrowIfNull(completionText);
+        return CompleteAsync(completionText.Value, completionState, cancellationToken);
+    }
 }

--- a/src/Aspire.Hosting/Pipelines/IReportingStep.cs
+++ b/src/Aspire.Hosting/Pipelines/IReportingStep.cs
@@ -21,12 +21,42 @@ public interface IReportingStep : IAsyncDisposable
     Task<IReportingTask> CreateTaskAsync(string statusText, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Creates a new task within this step with Markdown-formatted status text.
+    /// </summary>
+    /// <param name="statusText">The initial Markdown-formatted status text for the task.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The created task.</returns>
+    Task<IReportingTask> CreateTaskAsync(MarkdownString statusText, CancellationToken cancellationToken = default)
+        => CreateTaskAsync(statusText.Value, cancellationToken);
+
+    /// <summary>
     /// Logs a message at the specified level within this step.
     /// </summary>
     /// <param name="logLevel">The log level for the message.</param>
     /// <param name="message">The message to log.</param>
     /// <param name="enableMarkdown">Whether to enable Markdown formatting for the message.</param>
+    [Obsolete("Use Log(LogLevel, string) or Log(LogLevel, MarkdownString) instead.")]
     void Log(LogLevel logLevel, string message, bool enableMarkdown);
+
+    /// <summary>
+    /// Logs a plain-text message at the specified level within this step.
+    /// </summary>
+    /// <param name="logLevel">The log level for the message.</param>
+    /// <param name="message">The plain-text message to log.</param>
+    void Log(LogLevel logLevel, string message)
+#pragma warning disable CS0618 // Type or member is obsolete
+        => Log(logLevel, message, enableMarkdown: false);
+#pragma warning restore CS0618
+
+    /// <summary>
+    /// Logs a Markdown-formatted message at the specified level within this step.
+    /// </summary>
+    /// <param name="logLevel">The log level for the message.</param>
+    /// <param name="message">The Markdown-formatted message to log.</param>
+    void Log(LogLevel logLevel, MarkdownString message)
+#pragma warning disable CS0618 // Type or member is obsolete
+        => Log(logLevel, message.Value, enableMarkdown: true);
+#pragma warning restore CS0618
 
     /// <summary>
     /// Completes the step with the specified completion text and state.
@@ -35,4 +65,13 @@ public interface IReportingStep : IAsyncDisposable
     /// <param name="completionState">The completion state for the step.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     Task CompleteAsync(string completionText, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Completes the step with Markdown-formatted completion text and the specified state.
+    /// </summary>
+    /// <param name="completionText">The Markdown-formatted completion text for the step.</param>
+    /// <param name="completionState">The completion state for the step.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task CompleteAsync(MarkdownString completionText, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
+        => CompleteAsync(completionText.Value, completionState, cancellationToken);
 }

--- a/src/Aspire.Hosting/Pipelines/IReportingTask.cs
+++ b/src/Aspire.Hosting/Pipelines/IReportingTask.cs
@@ -23,11 +23,7 @@ public interface IReportingTask : IAsyncDisposable
     /// </summary>
     /// <param name="statusText">The new Markdown-formatted status text.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    Task UpdateAsync(MarkdownString statusText, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(statusText);
-        return UpdateAsync(statusText.Value, cancellationToken);
-    }
+    Task UpdateAsync(MarkdownString statusText, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Completes the task with the specified completion message.
@@ -43,9 +39,5 @@ public interface IReportingTask : IAsyncDisposable
     /// <param name="completionMessage">The Markdown-formatted completion message that will appear as a dimmed child message.</param>
     /// <param name="completionState">The completion state of the task.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    Task CompleteAsync(MarkdownString completionMessage, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(completionMessage);
-        return CompleteAsync(completionMessage.Value, completionState, cancellationToken);
-    }
+    Task CompleteAsync(MarkdownString completionMessage, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default);
 }

--- a/src/Aspire.Hosting/Pipelines/IReportingTask.cs
+++ b/src/Aspire.Hosting/Pipelines/IReportingTask.cs
@@ -24,7 +24,10 @@ public interface IReportingTask : IAsyncDisposable
     /// <param name="statusText">The new Markdown-formatted status text.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     Task UpdateAsync(MarkdownString statusText, CancellationToken cancellationToken = default)
-        => UpdateAsync(statusText.Value, cancellationToken);
+    {
+        ArgumentNullException.ThrowIfNull(statusText);
+        return UpdateAsync(statusText.Value, cancellationToken);
+    }
 
     /// <summary>
     /// Completes the task with the specified completion message.
@@ -41,5 +44,8 @@ public interface IReportingTask : IAsyncDisposable
     /// <param name="completionState">The completion state of the task.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     Task CompleteAsync(MarkdownString completionMessage, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
-        => CompleteAsync(completionMessage.Value, completionState, cancellationToken);
+    {
+        ArgumentNullException.ThrowIfNull(completionMessage);
+        return CompleteAsync(completionMessage.Value, completionState, cancellationToken);
+    }
 }

--- a/src/Aspire.Hosting/Pipelines/IReportingTask.cs
+++ b/src/Aspire.Hosting/Pipelines/IReportingTask.cs
@@ -19,10 +19,27 @@ public interface IReportingTask : IAsyncDisposable
     Task UpdateAsync(string statusText, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Updates the status text of this task with Markdown-formatted text.
+    /// </summary>
+    /// <param name="statusText">The new Markdown-formatted status text.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task UpdateAsync(MarkdownString statusText, CancellationToken cancellationToken = default)
+        => UpdateAsync(statusText.Value, cancellationToken);
+
+    /// <summary>
     /// Completes the task with the specified completion message.
     /// </summary>
     /// <param name="completionMessage">Optional completion message that will appear as a dimmed child message.</param>
     /// <param name="completionState">The completion state of the task.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     Task CompleteAsync(string? completionMessage = null, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Completes the task with a Markdown-formatted completion message.
+    /// </summary>
+    /// <param name="completionMessage">The Markdown-formatted completion message that will appear as a dimmed child message.</param>
+    /// <param name="completionState">The completion state of the task.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task CompleteAsync(MarkdownString completionMessage, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
+        => CompleteAsync(completionMessage.Value, completionState, cancellationToken);
 }

--- a/src/Aspire.Hosting/Pipelines/MarkdownString.cs
+++ b/src/Aspire.Hosting/Pipelines/MarkdownString.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aspire.Hosting.Pipelines;
+
+/// <summary>
+/// Represents a string that contains Markdown-formatted content.
+/// </summary>
+/// <remarks>
+/// Use this type to explicitly indicate that a string value should be interpreted as Markdown
+/// when displayed in pipeline output. APIs that accept both <see cref="string"/> and
+/// <see cref="MarkdownString"/> will render Markdown formatting (such as bold, links, and lists)
+/// only when a <see cref="MarkdownString"/> is provided; plain <see cref="string"/> values are
+/// displayed as-is without Markdown processing.
+/// </remarks>
+/// <example>
+/// <code>
+/// // Log a message with Markdown formatting
+/// step.Log(LogLevel.Information, new MarkdownString("Deployed **myapp** to [https://myapp.azurewebsites.net](https://myapp.azurewebsites.net)"));
+///
+/// // Add a Markdown-formatted value to the pipeline summary
+/// summary.Add("📦 Resource Group", new MarkdownString($"[{rgName}]({portalUrl})"));
+/// </code>
+/// </example>
+[Experimental("ASPIREPIPELINES001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public sealed class MarkdownString
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MarkdownString"/> class with the specified Markdown content.
+    /// </summary>
+    /// <param name="value">The Markdown-formatted string value.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="value"/> is <see langword="null"/>.</exception>
+    public MarkdownString(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        Value = value;
+    }
+
+    /// <summary>
+    /// Gets the Markdown-formatted string value.
+    /// </summary>
+    public string Value { get; }
+
+    /// <inheritdoc />
+    public override string ToString() => Value;
+}

--- a/src/Aspire.Hosting/Pipelines/MarkdownString.cs
+++ b/src/Aspire.Hosting/Pipelines/MarkdownString.cs
@@ -18,10 +18,10 @@ namespace Aspire.Hosting.Pipelines;
 /// <example>
 /// <code>
 /// // Log a message with Markdown formatting
-/// step.Log(LogLevel.Information, new MarkdownString("Deployed **myapp** to [https://myapp.azurewebsites.net](https://myapp.azurewebsites.net)"));
+/// step.Log(LogLevel.Information, new MarkdownString("Deployed **myapp** to [endpoint](https://example.com)"));
 ///
 /// // Add a Markdown-formatted value to the pipeline summary
-/// summary.Add("📦 Resource Group", new MarkdownString($"[{rgName}]({portalUrl})"));
+/// summary.Add("Key", new MarkdownString($"[{name}]({url})"));
 /// </code>
 /// </example>
 [Experimental("ASPIREPIPELINES001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]

--- a/src/Aspire.Hosting/Pipelines/NullPipelineActivityReporter.cs
+++ b/src/Aspire.Hosting/Pipelines/NullPipelineActivityReporter.cs
@@ -42,12 +42,34 @@ internal sealed class NullPublishingStep : IReportingStep
         return Task.FromResult<IReportingTask>(new NullPublishingTask());
     }
 
+    public Task<IReportingTask> CreateTaskAsync(MarkdownString statusText, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult<IReportingTask>(new NullPublishingTask());
+    }
+
+#pragma warning disable CS0618 // Type or member is obsolete
     public void Log(LogLevel logLevel, string message, bool enableMarkdown)
+    {
+        // No-op for null implementation
+    }
+#pragma warning restore CS0618
+
+    public void Log(LogLevel logLevel, string message)
+    {
+        // No-op for null implementation
+    }
+
+    public void Log(LogLevel logLevel, MarkdownString message)
     {
         // No-op for null implementation
     }
 
     public Task CompleteAsync(string completionText, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task CompleteAsync(MarkdownString completionText, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
     {
         return Task.CompletedTask;
     }
@@ -66,7 +88,17 @@ internal sealed class NullPublishingTask : IReportingTask
         return Task.CompletedTask;
     }
 
+    public Task UpdateAsync(MarkdownString statusText, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
     public Task CompleteAsync(string? completionMessage = null, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task CompleteAsync(MarkdownString completionMessage, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
     {
         return Task.CompletedTask;
     }

--- a/src/Aspire.Hosting/Pipelines/PipelineActivityReporter.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineActivityReporter.cs
@@ -59,7 +59,7 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
         return step;
     }
 
-    public async Task<ReportingTask> CreateTaskAsync(ReportingStep step, string statusText, CancellationToken cancellationToken, bool enableMarkdown = false)
+    public async Task<ReportingTask> CreateTaskAsync(ReportingStep step, string statusText, bool enableMarkdown, CancellationToken cancellationToken)
     {
         if (!_steps.TryGetValue(step.Id, out var parentStep))
         {
@@ -96,7 +96,7 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
         return task;
     }
 
-    public async Task CompleteStepAsync(ReportingStep step, string completionText, CompletionState completionState, CancellationToken cancellationToken, bool enableMarkdown = false)
+    public async Task CompleteStepAsync(ReportingStep step, string completionText, CompletionState completionState, bool enableMarkdown, CancellationToken cancellationToken)
     {
         lock (step)
         {
@@ -126,7 +126,7 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
         await ActivityItemUpdated.Writer.WriteAsync(state, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task UpdateTaskAsync(ReportingTask task, string statusText, CancellationToken cancellationToken, bool enableMarkdown = false)
+    public async Task UpdateTaskAsync(ReportingTask task, string statusText, bool enableMarkdown, CancellationToken cancellationToken)
     {
         if (!_steps.TryGetValue(task.StepId, out var parentStep))
         {
@@ -192,7 +192,7 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
         ActivityItemUpdated.Writer.TryWrite(state);
     }
 
-    public async Task CompleteTaskAsync(ReportingTask task, CompletionState completionState, string? completionMessage, CancellationToken cancellationToken, bool enableMarkdown = false)
+    public async Task CompleteTaskAsync(ReportingTask task, CompletionState completionState, string? completionMessage, bool enableMarkdown, CancellationToken cancellationToken)
     {
         if (!_steps.TryGetValue(task.StepId, out var parentStep))
         {

--- a/src/Aspire.Hosting/Pipelines/PipelineActivityReporter.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineActivityReporter.cs
@@ -59,7 +59,7 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
         return step;
     }
 
-    public async Task<ReportingTask> CreateTaskAsync(ReportingStep step, string statusText, CancellationToken cancellationToken)
+    public async Task<ReportingTask> CreateTaskAsync(ReportingStep step, string statusText, CancellationToken cancellationToken, bool enableMarkdown = false)
     {
         if (!_steps.TryGetValue(step.Id, out var parentStep))
         {
@@ -87,7 +87,8 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
                 Id = task.Id,
                 StatusText = statusText,
                 CompletionState = ToBackchannelCompletionState(CompletionState.InProgress),
-                StepId = step.Id
+                StepId = step.Id,
+                EnableMarkdown = enableMarkdown
             }
         };
 
@@ -95,7 +96,7 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
         return task;
     }
 
-    public async Task CompleteStepAsync(ReportingStep step, string completionText, CompletionState completionState, CancellationToken cancellationToken)
+    public async Task CompleteStepAsync(ReportingStep step, string completionText, CompletionState completionState, CancellationToken cancellationToken, bool enableMarkdown = false)
     {
         lock (step)
         {
@@ -117,14 +118,15 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
                 Id = step.Id,
                 StatusText = completionText,
                 CompletionState = ToBackchannelCompletionState(completionState),
-                StepId = null
+                StepId = null,
+                EnableMarkdown = enableMarkdown
             }
         };
 
         await ActivityItemUpdated.Writer.WriteAsync(state, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task UpdateTaskAsync(ReportingTask task, string statusText, CancellationToken cancellationToken)
+    public async Task UpdateTaskAsync(ReportingTask task, string statusText, CancellationToken cancellationToken, bool enableMarkdown = false)
     {
         if (!_steps.TryGetValue(task.StepId, out var parentStep))
         {
@@ -149,7 +151,8 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
                 Id = task.Id,
                 StatusText = statusText,
                 CompletionState = ToBackchannelCompletionState(CompletionState.InProgress),
-                StepId = task.StepId
+                StepId = task.StepId,
+                EnableMarkdown = enableMarkdown
             }
         };
 
@@ -189,7 +192,7 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
         ActivityItemUpdated.Writer.TryWrite(state);
     }
 
-    public async Task CompleteTaskAsync(ReportingTask task, CompletionState completionState, string? completionMessage, CancellationToken cancellationToken)
+    public async Task CompleteTaskAsync(ReportingTask task, CompletionState completionState, string? completionMessage, CancellationToken cancellationToken, bool enableMarkdown = false)
     {
         if (!_steps.TryGetValue(task.StepId, out var parentStep))
         {
@@ -222,7 +225,8 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
                 StatusText = task.StatusText,
                 CompletionState = ToBackchannelCompletionState(completionState),
                 StepId = task.StepId,
-                CompletionMessage = completionMessage
+                CompletionMessage = completionMessage,
+                EnableMarkdown = enableMarkdown
             }
         };
 
@@ -248,7 +252,12 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
                     _ => "Pipeline completed"
                 },
                 CompletionState = ToBackchannelCompletionState(finalState),
-                PipelineSummary = options?.PipelineSummary
+                PipelineSummary = options?.PipelineSummary?.Select(item => new BackchannelPipelineSummaryItem
+                {
+                    Key = item.Key,
+                    Value = item.Value,
+                    EnableMarkdown = item.EnableMarkdown
+                }).ToList()
             }
         };
 

--- a/src/Aspire.Hosting/Pipelines/PipelineLoggerProvider.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineLoggerProvider.cs
@@ -94,7 +94,7 @@ internal sealed class PipelineLoggerProvider(IOptions<PipelineLoggingOptions> op
                 message = $"{message} {exception}";
             }
 
-            step.Log(logLevel, message, enableMarkdown: false);
+            step.Log(logLevel, message);
         }
     }
 }

--- a/src/Aspire.Hosting/Pipelines/PipelineStepHelpers.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineStepHelpers.cs
@@ -66,7 +66,7 @@ internal static class PipelineStepHelpers
         var targetTag = await cir.GetValueAsync(new ValueProviderContext { ExecutionContext = context.ExecutionContext }, context.CancellationToken).ConfigureAwait(false);
 
         var tagTask = await context.ReportingStep.CreateTaskAsync(
-            $"Tagging **{resource.Name}** for local use",
+            new MarkdownString($"Tagging **{resource.Name}** for local use"),
             context.CancellationToken).ConfigureAwait(false);
 
         await using (tagTask.ConfigureAwait(false))
@@ -88,14 +88,14 @@ internal static class PipelineStepHelpers
                 await containerRuntime.TagImageAsync(localImageName, targetTag, context.CancellationToken).ConfigureAwait(false);
 
                 await tagTask.CompleteAsync(
-                    $"Successfully tagged **{resource.Name}** as `{targetTag}`",
+                    new MarkdownString($"Successfully tagged **{resource.Name}** as `{targetTag}`"),
                     CompletionState.Completed,
                     context.CancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 await tagTask.CompleteAsync(
-                    $"Failed to tag **{resource.Name}**: {ex.Message}",
+                    new MarkdownString($"Failed to tag **{resource.Name}**: {ex.Message}"),
                     CompletionState.CompletedWithError,
                     context.CancellationToken).ConfigureAwait(false);
                 throw;
@@ -112,7 +112,7 @@ internal static class PipelineStepHelpers
         var targetTag = await cir.GetValueAsync(new ValueProviderContext { ExecutionContext = context.ExecutionContext }, context.CancellationToken).ConfigureAwait(false);
 
         var pushTask = await context.ReportingStep.CreateTaskAsync(
-            $"Pushing **{resource.Name}** to **{registryName}**",
+            new MarkdownString($"Pushing **{resource.Name}** to **{registryName}**"),
             context.CancellationToken).ConfigureAwait(false);
 
         await using (pushTask.ConfigureAwait(false))
@@ -128,14 +128,14 @@ internal static class PipelineStepHelpers
                 await containerImageManager.PushImageAsync(resource, context.CancellationToken).ConfigureAwait(false);
 
                 await pushTask.CompleteAsync(
-                    $"Successfully pushed **{resource.Name}** to `{targetTag}`",
+                    new MarkdownString($"Successfully pushed **{resource.Name}** to `{targetTag}`"),
                     CompletionState.Completed,
                     context.CancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 await pushTask.CompleteAsync(
-                    $"Failed to push **{resource.Name}**: {ex.Message}",
+                    new MarkdownString($"Failed to push **{resource.Name}**: {ex.Message}"),
                     CompletionState.CompletedWithError,
                     context.CancellationToken).ConfigureAwait(false);
                 throw;

--- a/src/Aspire.Hosting/Pipelines/PipelineSummary.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineSummary.cs
@@ -77,7 +77,7 @@ public sealed class PipelineSummary
     /// <summary>
     /// Adds a key-value pair to the pipeline summary with a plain-text value.
     /// </summary>
-    /// <param name="key">The key or label for the item (e.g., "Resource Group", "Namespace", "URL").</param>
+    /// <param name="key">The key or label for the item (e.g., "Namespace", "URL").</param>
     /// <param name="value">The plain-text value for the item.</param>
     public void Add(string key, string value)
     {
@@ -93,7 +93,7 @@ public sealed class PipelineSummary
     /// <summary>
     /// Adds a key-value pair to the pipeline summary with a Markdown-formatted value.
     /// </summary>
-    /// <param name="key">The key or label for the item (e.g., "Resource Group", "Namespace", "URL").</param>
+    /// <param name="key">The key or label for the item (e.g., "Namespace", "URL").</param>
     /// <param name="value">The Markdown-formatted value for the item.</param>
     public void Add(string key, MarkdownString value)
     {

--- a/src/Aspire.Hosting/Pipelines/PipelineSummary.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineSummary.cs
@@ -19,6 +19,7 @@ namespace Aspire.Hosting.Pipelines;
 /// <para>
 /// Pipeline steps can add any relevant information such as resource group names,
 /// subscription IDs, URLs, namespaces, cluster names, or any other details.
+/// Values can be plain text or Markdown-formatted by using <see cref="MarkdownString"/>.
 /// </para>
 /// <para>
 /// The summary is available via the <see cref="Aspire.Hosting.Pipelines.PipelineContext.Summary"/>
@@ -32,49 +33,42 @@ namespace Aspire.Hosting.Pipelines;
 /// {
 ///     // Do work...
 ///
-///     // Add summary items
+///     // Add plain text summary items
 ///     context.PipelineContext.Summary.Add("☁️ Target", "Azure");
-///     context.PipelineContext.Summary.Add("📦 Resource Group", "rg-myapp");
 ///     context.PipelineContext.Summary.Add("🔑 Subscription", "12345678-1234-1234-1234-123456789012");
 ///     context.PipelineContext.Summary.Add("🌐 Location", "eastus");
+///
+///     // Add a Markdown-formatted value (e.g., a clickable link)
+///     context.PipelineContext.Summary.Add("📦 Resource Group", new MarkdownString($"[{rgName}]({portalUrl})"));
 /// }
-///
-/// // Kubernetes example
-/// context.PipelineContext.Summary.Add("☸️ Target", "Kubernetes");
-/// context.PipelineContext.Summary.Add("📦 Namespace", "production");
-/// context.PipelineContext.Summary.Add("🖥️ Cluster", "my-cluster");
-///
-/// // Docker example
-/// context.PipelineContext.Summary.Add("🐳 Target", "Docker");
-/// context.PipelineContext.Summary.Add("🌐 Endpoint", "localhost:8080");
 /// </code>
 /// </example>
 [Experimental("ASPIREPIPELINES001", UrlFormat = "https://aka.ms/aspire/diagnostics#{0}")]
 public sealed class PipelineSummary
 {
     private readonly object _lock = new();
-    private readonly List<KeyValuePair<string, string>> _items = [];
+    private readonly List<PipelineSummaryItem> _items = [];
 
     /// <summary>
     /// Gets the items in the pipeline summary as a read-only collection.
     /// Items are displayed in the order they were added.
     /// </summary>
-    public ReadOnlyCollection<KeyValuePair<string, string>> Items
+    public ReadOnlyCollection<PipelineSummaryItem> Items
     {
         get
         {
             lock (_lock)
             {
-                return new ReadOnlyCollection<KeyValuePair<string, string>>(_items.ToList());
+                return new ReadOnlyCollection<PipelineSummaryItem>(_items.ToList());
             }
         }
     }
 
     /// <summary>
-    /// Adds a key-value pair to the pipeline summary.
+    /// Adds a key-value pair to the pipeline summary with a plain-text value.
     /// </summary>
     /// <param name="key">The key or label for the item (e.g., "Resource Group", "Namespace", "URL").</param>
-    /// <param name="value">The value for the item.</param>
+    /// <param name="value">The plain-text value for the item.</param>
     public void Add(string key, string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
@@ -82,7 +76,23 @@ public sealed class PipelineSummary
 
         lock (_lock)
         {
-            _items.Add(new KeyValuePair<string, string>(key, value));
+            _items.Add(new PipelineSummaryItem(key, value, enableMarkdown: false));
+        }
+    }
+
+    /// <summary>
+    /// Adds a key-value pair to the pipeline summary with a Markdown-formatted value.
+    /// </summary>
+    /// <param name="key">The key or label for the item (e.g., "Resource Group", "Namespace", "URL").</param>
+    /// <param name="value">The Markdown-formatted value for the item.</param>
+    public void Add(string key, MarkdownString value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ArgumentNullException.ThrowIfNull(value);
+
+        lock (_lock)
+        {
+            _items.Add(new PipelineSummaryItem(key, value.Value, enableMarkdown: true));
         }
     }
 

--- a/src/Aspire.Hosting/Pipelines/PipelineSummary.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineSummary.cs
@@ -35,12 +35,22 @@ namespace Aspire.Hosting.Pipelines;
 ///
 ///     // Add plain text summary items
 ///     context.PipelineContext.Summary.Add("☁️ Target", "Azure");
+///     context.PipelineContext.Summary.Add("📦 Resource Group", "rg-myapp");
 ///     context.PipelineContext.Summary.Add("🔑 Subscription", "12345678-1234-1234-1234-123456789012");
 ///     context.PipelineContext.Summary.Add("🌐 Location", "eastus");
+/// }
+///
+///     // Kubernetes example
+///     context.PipelineContext.Summary.Add("☸️ Target", "Kubernetes");
+///     context.PipelineContext.Summary.Add("📦 Namespace", "production");
+///     context.PipelineContext.Summary.Add("🖥️ Cluster", "my-cluster");
+///
+///     // Docker example
+///     context.PipelineContext.Summary.Add("🐳 Target", "Docker");
+///     context.PipelineContext.Summary.Add("🌐 Endpoint", "localhost:8080");
 ///
 ///     // Add a Markdown-formatted value (e.g., a clickable link)
 ///     context.PipelineContext.Summary.Add("📦 Resource Group", new MarkdownString($"[{rgName}]({portalUrl})"));
-/// }
 /// </code>
 /// </example>
 [Experimental("ASPIREPIPELINES001", UrlFormat = "https://aka.ms/aspire/diagnostics#{0}")]

--- a/src/Aspire.Hosting/Pipelines/PipelineSummaryItem.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineSummaryItem.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aspire.Hosting.Pipelines;
+
+/// <summary>
+/// Represents a single item in a <see cref="PipelineSummary"/>, consisting of a key, a value,
+/// and a flag indicating whether the value contains Markdown formatting.
+/// </summary>
+/// <param name="key">The key or label for the summary item.</param>
+/// <param name="value">The string value for the summary item.</param>
+/// <param name="enableMarkdown">Whether the <paramref name="value"/> contains Markdown formatting.</param>
+[Experimental("ASPIREPIPELINES001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public sealed class PipelineSummaryItem(string key, string value, bool enableMarkdown)
+{
+    /// <summary>
+    /// Gets the key or label for the summary item (e.g., "Resource Group", "Namespace", "URL").
+    /// </summary>
+    public string Key { get; } = key;
+
+    /// <summary>
+    /// Gets the string value for the summary item.
+    /// </summary>
+    public string Value { get; } = value;
+
+    /// <summary>
+    /// Gets a value indicating whether <see cref="Value"/> contains Markdown formatting that
+    /// should be rendered by the CLI output.
+    /// </summary>
+    public bool EnableMarkdown { get; } = enableMarkdown;
+}

--- a/src/Aspire.Hosting/Pipelines/PipelineSummaryItem.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineSummaryItem.cs
@@ -16,14 +16,14 @@ namespace Aspire.Hosting.Pipelines;
 public sealed class PipelineSummaryItem(string key, string value, bool enableMarkdown)
 {
     /// <summary>
-    /// Gets the key or label for the summary item (e.g., "Resource Group", "Namespace", "URL").
+    /// Gets the key or label for the summary item (e.g., "Namespace", "URL").
     /// </summary>
-    public string Key { get; } = key;
+    public string Key { get; } = key ?? throw new ArgumentNullException(nameof(key));
 
     /// <summary>
     /// Gets the string value for the summary item.
     /// </summary>
-    public string Value { get; } = value;
+    public string Value { get; } = value ?? throw new ArgumentNullException(nameof(value));
 
     /// <summary>
     /// Gets a value indicating whether <see cref="Value"/> contains Markdown formatting that

--- a/src/Aspire.Hosting/Pipelines/PublishCompletionOptions.cs
+++ b/src/Aspire.Hosting/Pipelines/PublishCompletionOptions.cs
@@ -23,8 +23,8 @@ public sealed class PublishCompletionOptions
     public CompletionState? CompletionState { get; set; }
 
     /// <summary>
-    /// Gets or sets optional pipeline summary information as key-value pairs to display after completion.
-    /// The list preserves insertion order.
+    /// Gets or sets optional pipeline summary information to display after completion.
+    /// The list preserves insertion order. Each item carries its own Markdown formatting flag.
     /// </summary>
-    public IReadOnlyList<KeyValuePair<string, string>>? PipelineSummary { get; set; }
+    public IReadOnlyList<PipelineSummaryItem>? PipelineSummary { get; set; }
 }

--- a/src/Aspire.Hosting/Pipelines/ReportingStep.cs
+++ b/src/Aspire.Hosting/Pipelines/ReportingStep.cs
@@ -98,7 +98,7 @@ internal sealed class ReportingStep : IReportingStep
             throw new InvalidOperationException("Cannot create task: Reporter is not set.");
         }
 
-        return await Reporter.CreateTaskAsync(this, statusText, cancellationToken).ConfigureAwait(false);
+        return await Reporter.CreateTaskAsync(this, statusText, enableMarkdown: false, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -111,7 +111,7 @@ internal sealed class ReportingStep : IReportingStep
             throw new InvalidOperationException("Cannot create task: Reporter is not set.");
         }
 
-        return await Reporter.CreateTaskAsync(this, statusText.Value, cancellationToken, enableMarkdown: true).ConfigureAwait(false);
+        return await Reporter.CreateTaskAsync(this, statusText.Value, enableMarkdown: true, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -159,7 +159,7 @@ internal sealed class ReportingStep : IReportingStep
             throw new InvalidOperationException("Cannot complete step: Reporter is not set.");
         }
 
-        await Reporter.CompleteStepAsync(this, completionText, completionState, cancellationToken).ConfigureAwait(false);
+        await Reporter.CompleteStepAsync(this, completionText, completionState, enableMarkdown: false, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -172,7 +172,7 @@ internal sealed class ReportingStep : IReportingStep
             throw new InvalidOperationException("Cannot complete step: Reporter is not set.");
         }
 
-        await Reporter.CompleteStepAsync(this, completionText.Value, completionState, cancellationToken, enableMarkdown: true).ConfigureAwait(false);
+        await Reporter.CompleteStepAsync(this, completionText.Value, completionState, enableMarkdown: true, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -205,6 +205,6 @@ internal sealed class ReportingStep : IReportingStep
             }
             : CompletionText;
 
-        await Reporter.CompleteStepAsync(this, completionText, finalState, CancellationToken.None).ConfigureAwait(false);
+        await Reporter.CompleteStepAsync(this, completionText, finalState, enableMarkdown: false, cancellationToken: CancellationToken.None).ConfigureAwait(false);
     }
 }

--- a/src/Aspire.Hosting/Pipelines/ReportingStep.cs
+++ b/src/Aspire.Hosting/Pipelines/ReportingStep.cs
@@ -104,6 +104,8 @@ internal sealed class ReportingStep : IReportingStep
     /// <inheritdoc />
     public async Task<IReportingTask> CreateTaskAsync(MarkdownString statusText, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(statusText);
+
         if (Reporter is null)
         {
             throw new InvalidOperationException("Cannot create task: Reporter is not set.");
@@ -139,6 +141,8 @@ internal sealed class ReportingStep : IReportingStep
     /// <inheritdoc />
     public void Log(LogLevel logLevel, MarkdownString message)
     {
+        ArgumentNullException.ThrowIfNull(message);
+
         if (Reporter is null)
         {
             return;
@@ -161,6 +165,8 @@ internal sealed class ReportingStep : IReportingStep
     /// <inheritdoc />
     public async Task CompleteAsync(MarkdownString completionText, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(completionText);
+
         if (Reporter is null)
         {
             throw new InvalidOperationException("Cannot complete step: Reporter is not set.");

--- a/src/Aspire.Hosting/Pipelines/ReportingStep.cs
+++ b/src/Aspire.Hosting/Pipelines/ReportingStep.cs
@@ -90,12 +90,7 @@ internal sealed class ReportingStep : IReportingStep
         return maxState;
     }
 
-    /// <summary>
-    /// Creates a new task within this step.
-    /// </summary>
-    /// <param name="statusText">The initial status text for the task.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The created task.</returns>
+    /// <inheritdoc />
     public async Task<IReportingTask> CreateTaskAsync(string statusText, CancellationToken cancellationToken = default)
     {
         if (Reporter is null)
@@ -106,13 +101,21 @@ internal sealed class ReportingStep : IReportingStep
         return await Reporter.CreateTaskAsync(this, statusText, cancellationToken).ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Logs a message at the specified level within this step.
-    /// </summary>
-    /// <param name="logLevel">The log level for the message.</param>
-    /// <param name="message">The message to log.</param>
-    /// <param name="enableMarkdown">The enableMarkdown</param>
+    /// <inheritdoc />
+    public async Task<IReportingTask> CreateTaskAsync(MarkdownString statusText, CancellationToken cancellationToken = default)
+    {
+        if (Reporter is null)
+        {
+            throw new InvalidOperationException("Cannot create task: Reporter is not set.");
+        }
+
+        return await Reporter.CreateTaskAsync(this, statusText.Value, cancellationToken, enableMarkdown: true).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+#pragma warning disable CS0618 // Type or member is obsolete
     public void Log(LogLevel logLevel, string message, bool enableMarkdown = true)
+#pragma warning restore CS0618
     {
         if (Reporter is null)
         {
@@ -122,12 +125,29 @@ internal sealed class ReportingStep : IReportingStep
         Reporter.Log(this, logLevel, message, enableMarkdown);
     }
 
-    /// <summary>
-    /// Completes the step with the specified completion text and state.
-    /// </summary>
-    /// <param name="completionText">The completion text for the step.</param>
-    /// <param name="completionState">The completion state for the step.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <inheritdoc />
+    public void Log(LogLevel logLevel, string message)
+    {
+        if (Reporter is null)
+        {
+            return;
+        }
+
+        Reporter.Log(this, logLevel, message, enableMarkdown: false);
+    }
+
+    /// <inheritdoc />
+    public void Log(LogLevel logLevel, MarkdownString message)
+    {
+        if (Reporter is null)
+        {
+            return;
+        }
+
+        Reporter.Log(this, logLevel, message.Value, enableMarkdown: true);
+    }
+
+    /// <inheritdoc />
     public async Task CompleteAsync(string completionText, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
     {
         if (Reporter is null)
@@ -136,6 +156,17 @@ internal sealed class ReportingStep : IReportingStep
         }
 
         await Reporter.CompleteStepAsync(this, completionText, completionState, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task CompleteAsync(MarkdownString completionText, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
+    {
+        if (Reporter is null)
+        {
+            throw new InvalidOperationException("Cannot complete step: Reporter is not set.");
+        }
+
+        await Reporter.CompleteStepAsync(this, completionText.Value, completionState, cancellationToken, enableMarkdown: true).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Pipelines/ReportingTask.cs
+++ b/src/Aspire.Hosting/Pipelines/ReportingTask.cs
@@ -51,25 +51,28 @@ internal sealed class ReportingTask : IReportingTask
     /// </summary>
     public string CompletionMessage { get; internal set; } = string.Empty;
 
-    /// <summary>
-    /// Updates the status text of this task.
-    /// </summary>
-    /// <param name="statusText">The new status text.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <inheritdoc />
     public async Task UpdateAsync(string statusText, CancellationToken cancellationToken = default)
     {
         await ParentStep.Reporter.UpdateTaskAsync(this, statusText, cancellationToken).ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Completes the task with the specified completion message.
-    /// </summary>
-    /// <param name="completionMessage">Optional completion message that will appear as a dimmed child message.</param>
-    /// <param name="completionState">The completion state of the task.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <inheritdoc />
+    public async Task UpdateAsync(MarkdownString statusText, CancellationToken cancellationToken = default)
+    {
+        await ParentStep.Reporter.UpdateTaskAsync(this, statusText.Value, cancellationToken, enableMarkdown: true).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
     public async Task CompleteAsync(string? completionMessage = null, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
     {
         await ParentStep.Reporter.CompleteTaskAsync(this, completionState, completionMessage, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task CompleteAsync(MarkdownString completionMessage, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
+    {
+        await ParentStep.Reporter.CompleteTaskAsync(this, completionState, completionMessage.Value, cancellationToken, enableMarkdown: true).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Pipelines/ReportingTask.cs
+++ b/src/Aspire.Hosting/Pipelines/ReportingTask.cs
@@ -60,6 +60,7 @@ internal sealed class ReportingTask : IReportingTask
     /// <inheritdoc />
     public async Task UpdateAsync(MarkdownString statusText, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(statusText);
         await ParentStep.Reporter.UpdateTaskAsync(this, statusText.Value, cancellationToken, enableMarkdown: true).ConfigureAwait(false);
     }
 
@@ -72,6 +73,7 @@ internal sealed class ReportingTask : IReportingTask
     /// <inheritdoc />
     public async Task CompleteAsync(MarkdownString completionMessage, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(completionMessage);
         await ParentStep.Reporter.CompleteTaskAsync(this, completionState, completionMessage.Value, cancellationToken, enableMarkdown: true).ConfigureAwait(false);
     }
 

--- a/src/Aspire.Hosting/Pipelines/ReportingTask.cs
+++ b/src/Aspire.Hosting/Pipelines/ReportingTask.cs
@@ -54,27 +54,27 @@ internal sealed class ReportingTask : IReportingTask
     /// <inheritdoc />
     public async Task UpdateAsync(string statusText, CancellationToken cancellationToken = default)
     {
-        await ParentStep.Reporter.UpdateTaskAsync(this, statusText, cancellationToken).ConfigureAwait(false);
+        await ParentStep.Reporter.UpdateTaskAsync(this, statusText, enableMarkdown: false, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
     public async Task UpdateAsync(MarkdownString statusText, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(statusText);
-        await ParentStep.Reporter.UpdateTaskAsync(this, statusText.Value, cancellationToken, enableMarkdown: true).ConfigureAwait(false);
+        await ParentStep.Reporter.UpdateTaskAsync(this, statusText.Value, enableMarkdown: true, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
     public async Task CompleteAsync(string? completionMessage = null, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
     {
-        await ParentStep.Reporter.CompleteTaskAsync(this, completionState, completionMessage, cancellationToken).ConfigureAwait(false);
+        await ParentStep.Reporter.CompleteTaskAsync(this, completionState, completionMessage, enableMarkdown: false, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
     public async Task CompleteAsync(MarkdownString completionMessage, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(completionMessage);
-        await ParentStep.Reporter.CompleteTaskAsync(this, completionState, completionMessage.Value, cancellationToken, enableMarkdown: true).ConfigureAwait(false);
+        await ParentStep.Reporter.CompleteTaskAsync(this, completionState, completionMessage.Value, enableMarkdown: true, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Publishing/PublishingExtensions.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingExtensions.cs
@@ -31,6 +31,22 @@ public static class PublishingExtensions
     }
 
     /// <summary>
+    /// Completes a publishing step successfully with a Markdown-formatted message.
+    /// </summary>
+    /// <param name="step">The step to complete.</param>
+    /// <param name="message">The Markdown-formatted completion message.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The completed step.</returns>
+    public static async Task<IReportingStep> SucceedAsync(
+        this IReportingStep step,
+        MarkdownString message,
+        CancellationToken cancellationToken = default)
+    {
+        await step.CompleteAsync(message, CompletionState.Completed, cancellationToken).ConfigureAwait(false);
+        return step;
+    }
+
+    /// <summary>
     /// Completes a publishing step with a warning.
     /// </summary>
     /// <param name="step">The step to complete.</param>
@@ -44,6 +60,22 @@ public static class PublishingExtensions
     {
         var completionText = message ?? "Completed with warnings";
         await step.CompleteAsync(completionText, CompletionState.CompletedWithWarning, cancellationToken).ConfigureAwait(false);
+        return step;
+    }
+
+    /// <summary>
+    /// Completes a publishing step with a warning and Markdown-formatted message.
+    /// </summary>
+    /// <param name="step">The step to complete.</param>
+    /// <param name="message">The Markdown-formatted warning message.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The completed step.</returns>
+    public static async Task<IReportingStep> WarnAsync(
+        this IReportingStep step,
+        MarkdownString message,
+        CancellationToken cancellationToken = default)
+    {
+        await step.CompleteAsync(message, CompletionState.CompletedWithWarning, cancellationToken).ConfigureAwait(false);
         return step;
     }
 
@@ -65,6 +97,22 @@ public static class PublishingExtensions
     }
 
     /// <summary>
+    /// Completes a publishing step with an error and Markdown-formatted message.
+    /// </summary>
+    /// <param name="step">The step to complete.</param>
+    /// <param name="errorMessage">The Markdown-formatted error message.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The completed step.</returns>
+    public static async Task<IReportingStep> FailAsync(
+        this IReportingStep step,
+        MarkdownString errorMessage,
+        CancellationToken cancellationToken = default)
+    {
+        await step.CompleteAsync(errorMessage, CompletionState.CompletedWithError, cancellationToken).ConfigureAwait(false);
+        return step;
+    }
+
+    /// <summary>
     /// Updates the status text of a publishing task.
     /// </summary>
     /// <param name="task">The task to update.</param>
@@ -74,6 +122,22 @@ public static class PublishingExtensions
     public static async Task<IReportingTask> UpdateStatusAsync(
         this IReportingTask task,
         string statusText,
+        CancellationToken cancellationToken = default)
+    {
+        await task.UpdateAsync(statusText, cancellationToken).ConfigureAwait(false);
+        return task;
+    }
+
+    /// <summary>
+    /// Updates the status text of a publishing task with Markdown-formatted text.
+    /// </summary>
+    /// <param name="task">The task to update.</param>
+    /// <param name="statusText">The new Markdown-formatted status text.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The updated task.</returns>
+    public static async Task<IReportingTask> UpdateStatusAsync(
+        this IReportingTask task,
+        MarkdownString statusText,
         CancellationToken cancellationToken = default)
     {
         await task.UpdateAsync(statusText, cancellationToken).ConfigureAwait(false);
@@ -97,6 +161,22 @@ public static class PublishingExtensions
     }
 
     /// <summary>
+    /// Completes a publishing task successfully with a Markdown-formatted message.
+    /// </summary>
+    /// <param name="task">The task to complete.</param>
+    /// <param name="message">The Markdown-formatted completion message.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The completed task.</returns>
+    public static async Task<IReportingTask> SucceedAsync(
+        this IReportingTask task,
+        MarkdownString message,
+        CancellationToken cancellationToken = default)
+    {
+        await task.CompleteAsync(message, CompletionState.Completed, cancellationToken).ConfigureAwait(false);
+        return task;
+    }
+
+    /// <summary>
     /// Completes a publishing task with a warning.
     /// </summary>
     /// <param name="task">The task to complete.</param>
@@ -113,6 +193,22 @@ public static class PublishingExtensions
     }
 
     /// <summary>
+    /// Completes a publishing task with a warning and Markdown-formatted message.
+    /// </summary>
+    /// <param name="task">The task to complete.</param>
+    /// <param name="message">The Markdown-formatted warning message.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The completed task.</returns>
+    public static async Task<IReportingTask> WarnAsync(
+        this IReportingTask task,
+        MarkdownString message,
+        CancellationToken cancellationToken = default)
+    {
+        await task.CompleteAsync(message, CompletionState.CompletedWithWarning, cancellationToken).ConfigureAwait(false);
+        return task;
+    }
+
+    /// <summary>
     /// Completes a publishing task with an error.
     /// </summary>
     /// <param name="task">The task to complete.</param>
@@ -122,6 +218,22 @@ public static class PublishingExtensions
     public static async Task<IReportingTask> FailAsync(
         this IReportingTask task,
         string? errorMessage = null,
+        CancellationToken cancellationToken = default)
+    {
+        await task.CompleteAsync(errorMessage, CompletionState.CompletedWithError, cancellationToken).ConfigureAwait(false);
+        return task;
+    }
+
+    /// <summary>
+    /// Completes a publishing task with an error and Markdown-formatted message.
+    /// </summary>
+    /// <param name="task">The task to complete.</param>
+    /// <param name="errorMessage">The Markdown-formatted error message.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The completed task.</returns>
+    public static async Task<IReportingTask> FailAsync(
+        this IReportingTask task,
+        MarkdownString errorMessage,
         CancellationToken cancellationToken = default)
     {
         await task.CompleteAsync(errorMessage, CompletionState.CompletedWithError, cancellationToken).ConfigureAwait(false);

--- a/tests/Aspire.Cli.Tests/Utils/ConsoleActivityLoggerTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/ConsoleActivityLoggerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
+using Aspire.Cli.Backchannel;
 using Aspire.Cli.Utils;
 using Spectre.Console;
 
@@ -31,12 +32,12 @@ public class ConsoleActivityLoggerTests
         var output = new StringBuilder();
         var logger = CreateLogger(output, interactive: true, color: true);
 
-        var summary = new List<KeyValuePair<string, string>>
+        var summary = new List<BackchannelPipelineSummaryItem>
         {
-            new("☁️ Target", "Azure"),
-            new("📦 Resource Group", "VNetTest5 [link](https://portal.azure.com/#/resource/subscriptions/sub-id/resourceGroups/VNetTest5/overview)"),
-            new("🔑 Subscription", "sub-id"),
-            new("🌐 Location", "eastus"),
+            new() { Key = "☁️ Target", Value = "Azure", EnableMarkdown = false },
+            new() { Key = "📦 Resource Group", Value = "VNetTest5 [link](https://portal.azure.com/#/resource/subscriptions/sub-id/resourceGroups/VNetTest5/overview)", EnableMarkdown = true },
+            new() { Key = "🔑 Subscription", Value = "sub-id", EnableMarkdown = false },
+            new() { Key = "🌐 Location", Value = "eastus", EnableMarkdown = false },
         };
 
         logger.SetFinalResult(true, summary);
@@ -61,9 +62,9 @@ public class ConsoleActivityLoggerTests
         var logger = CreateLogger(output, interactive: false, color: false);
 
         var portalUrl = "https://portal.azure.com/";
-        var summary = new List<KeyValuePair<string, string>>
+        var summary = new List<BackchannelPipelineSummaryItem>
         {
-            new("📦 Resource Group", $"VNetTest5 [link]({portalUrl})"),
+            new() { Key = "📦 Resource Group", Value = $"VNetTest5 [link]({portalUrl})", EnableMarkdown = true },
         };
 
         logger.SetFinalResult(true, summary);
@@ -82,9 +83,9 @@ public class ConsoleActivityLoggerTests
         var logger = CreateLogger(output, interactive: false, color: true);
 
         var portalUrl = "https://portal.azure.com/";
-        var summary = new List<KeyValuePair<string, string>>
+        var summary = new List<BackchannelPipelineSummaryItem>
         {
-            new("📦 Resource Group", $"VNetTest5 [link]({portalUrl})"),
+            new() { Key = "📦 Resource Group", Value = $"VNetTest5 [link]({portalUrl})", EnableMarkdown = true },
         };
 
         logger.SetFinalResult(true, summary);
@@ -107,10 +108,10 @@ public class ConsoleActivityLoggerTests
         var output = new StringBuilder();
         var logger = CreateLogger(output, interactive: true, color: true);
 
-        var summary = new List<KeyValuePair<string, string>>
+        var summary = new List<BackchannelPipelineSummaryItem>
         {
-            new("☁️ Target", "Azure"),
-            new("🌐 Location", "eastus"),
+            new() { Key = "☁️ Target", Value = "Azure", EnableMarkdown = false },
+            new() { Key = "🌐 Location", Value = "eastus", EnableMarkdown = false },
         };
 
         logger.SetFinalResult(true, summary);
@@ -129,11 +130,9 @@ public class ConsoleActivityLoggerTests
         var logger = CreateLogger(output, interactive: true, color: true);
 
         // Pipeline summary with markup characters in key
-        // Note: values go through MarkdownToSpectreConverter.ConvertToSpectre which may interpret
-        // bracket patterns, so we test key escaping here (key always uses EscapeMarkup)
-        var summary = new List<KeyValuePair<string, string>>
+        var summary = new List<BackchannelPipelineSummaryItem>
         {
-            new("Key [with] brackets", "plain value"),
+            new() { Key = "Key [with] brackets", Value = "plain value", EnableMarkdown = false },
         };
 
         logger.SetFinalResult(true, summary);
@@ -153,9 +152,9 @@ public class ConsoleActivityLoggerTests
         var output = new StringBuilder();
         var logger = CreateLogger(output, interactive: false, color: false);
 
-        var summary = new List<KeyValuePair<string, string>>
+        var summary = new List<BackchannelPipelineSummaryItem>
         {
-            new("Key [with] brackets", "Value [bold]not bold[/]"),
+            new() { Key = "Key [with] brackets", Value = "Value [bold]not bold[/]", EnableMarkdown = false },
         };
 
         logger.SetFinalResult(true, summary);

--- a/tests/Aspire.Hosting.Tests/Pipelines/PipelineLoggerProviderTests.cs
+++ b/tests/Aspire.Hosting.Tests/Pipelines/PipelineLoggerProviderTests.cs
@@ -133,7 +133,17 @@ public class FakeReportingStep : IReportingStep
         throw new NotImplementedException();
     }
 
+    public Task<IReportingTask> CreateTaskAsync(MarkdownString statusText, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
     public Task CompleteAsync(string statusText, CompletionState completionState, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task CompleteAsync(MarkdownString completionText, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }
@@ -143,8 +153,21 @@ public class FakeReportingStep : IReportingStep
         throw new NotImplementedException();
     }
 
+#pragma warning disable CS0618 // Type or member is obsolete
     public void Log(LogLevel logLevel, string message, bool enableMarkdown = false)
     {
         LoggedMessages.Add((logLevel, message));
+    }
+#pragma warning restore CS0618
+
+    public void Log(LogLevel logLevel, string message)
+    {
+        LoggedMessages.Add((logLevel, message));
+    }
+
+    public void Log(LogLevel logLevel, MarkdownString message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        LoggedMessages.Add((logLevel, message.Value));
     }
 }

--- a/tests/Aspire.Hosting.Tests/Pipelines/PipelineSummaryTests.cs
+++ b/tests/Aspire.Hosting.Tests/Pipelines/PipelineSummaryTests.cs
@@ -23,6 +23,7 @@ public class PipelineSummaryTests
         Assert.Single(summary.Items);
         Assert.Equal("Key1", summary.Items[0].Key);
         Assert.Equal("Value1", summary.Items[0].Value);
+        Assert.False(summary.Items[0].EnableMarkdown);
     }
 
     [Fact]
@@ -96,7 +97,7 @@ public class PipelineSummaryTests
         var items = summary.Items;
 
         // Assert
-        Assert.IsType<System.Collections.ObjectModel.ReadOnlyCollection<KeyValuePair<string, string>>>(items);
+        Assert.IsType<System.Collections.ObjectModel.ReadOnlyCollection<PipelineSummaryItem>>(items);
     }
 
     [Fact]
@@ -119,8 +120,10 @@ public class PipelineSummaryTests
 
         // Act & Assert
         Assert.Equal(2, summary.Items.Count);
-        Assert.Equal(new KeyValuePair<string, string>("Key1", "Value1"), summary.Items[0]);
-        Assert.Equal(new KeyValuePair<string, string>("Key2", "Value2"), summary.Items[1]);
+        Assert.Equal("Key1", summary.Items[0].Key);
+        Assert.Equal("Value1", summary.Items[0].Value);
+        Assert.Equal("Key2", summary.Items[1].Key);
+        Assert.Equal("Value2", summary.Items[1].Value);
     }
 
     [Fact]
@@ -133,8 +136,8 @@ public class PipelineSummaryTests
 
         // Act & Assert
         Assert.Equal(2, summary.Items.Count);
-        Assert.Equal(new KeyValuePair<string, string>("Key", "FirstValue"), summary.Items[0]);
-        Assert.Equal(new KeyValuePair<string, string>("Key", "LastValue"), summary.Items[1]);
+        Assert.Equal("FirstValue", summary.Items[0].Value);
+        Assert.Equal("LastValue", summary.Items[1].Value);
     }
 
     [Fact]
@@ -151,5 +154,53 @@ public class PipelineSummaryTests
         Assert.Equal(2, summary.Items.Count);
         Assert.Equal("☁️ Target", summary.Items[0].Key);
         Assert.Equal("📦 Resource Group", summary.Items[1].Key);
+    }
+
+    [Fact]
+    public void Add_WithMarkdownString_SetsEnableMarkdownTrue()
+    {
+        // Arrange
+        var summary = new PipelineSummary();
+
+        // Act
+        summary.Add("📦 Resource Group", new MarkdownString("[rg-test](https://portal.azure.com)"));
+
+        // Assert
+        Assert.Single(summary.Items);
+        Assert.Equal("📦 Resource Group", summary.Items[0].Key);
+        Assert.Equal("[rg-test](https://portal.azure.com)", summary.Items[0].Value);
+        Assert.True(summary.Items[0].EnableMarkdown);
+    }
+
+    [Fact]
+    public void Add_WithPlainString_SetsEnableMarkdownFalse()
+    {
+        // Arrange
+        var summary = new PipelineSummary();
+
+        // Act
+        summary.Add("☁️ Target", "Azure");
+
+        // Assert
+        Assert.Single(summary.Items);
+        Assert.False(summary.Items[0].EnableMarkdown);
+    }
+
+    [Fact]
+    public void Add_MixedPlainAndMarkdown_PreservesFlags()
+    {
+        // Arrange
+        var summary = new PipelineSummary();
+
+        // Act
+        summary.Add("☁️ Target", "Azure");
+        summary.Add("📦 Resource Group", new MarkdownString("[rg-test](https://portal.azure.com)"));
+        summary.Add("🌐 Location", "eastus");
+
+        // Assert
+        Assert.Equal(3, summary.Items.Count);
+        Assert.False(summary.Items[0].EnableMarkdown);
+        Assert.True(summary.Items[1].EnableMarkdown);
+        Assert.False(summary.Items[2].EnableMarkdown);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Publishing/PipelineActivityReporterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/PipelineActivityReporterTests.cs
@@ -272,7 +272,7 @@ public class PublishingActivityReporterTests
 
         // Act & Assert - Step is completed, so completing tasks should fail
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => task.CompleteAsync(null, cancellationToken: CancellationToken.None));
+            () => task.CompleteAsync((string?)null, cancellationToken: CancellationToken.None));
 
         var taskInternal = Assert.IsType<ReportingTask>(task);
         Assert.Contains($"Cannot complete task '{taskInternal.Id}' because its parent step", exception.Message);
@@ -333,15 +333,15 @@ public class PublishingActivityReporterTests
         var step3 = await reporter.CreateStepAsync("Step 3", CancellationToken.None);
 
         var task1 = await step1.CreateTaskAsync("Task 1", CancellationToken.None);
-        await task1.CompleteAsync(null, cancellationToken: CancellationToken.None);
+        await task1.CompleteAsync((string?)null, cancellationToken: CancellationToken.None);
         await step1.CompleteAsync("Step 1 completed", CompletionState.Completed, CancellationToken.None);
 
         var task2 = await step2.CreateTaskAsync("Task 2", CancellationToken.None);
-        await task2.CompleteAsync(null, cancellationToken: CancellationToken.None);
+        await task2.CompleteAsync((string?)null, cancellationToken: CancellationToken.None);
         await step2.CompleteAsync("Step 2 completed with warning", CompletionState.CompletedWithWarning, CancellationToken.None);
 
         var task3 = await step3.CreateTaskAsync("Task 3", CancellationToken.None);
-        await task3.CompleteAsync(null, cancellationToken: CancellationToken.None);
+        await task3.CompleteAsync((string?)null, cancellationToken: CancellationToken.None);
         await step3.CompleteAsync("Step 3 failed", CompletionState.CompletedWithError, CancellationToken.None);
 
         // Clear previous activities
@@ -369,7 +369,7 @@ public class PublishingActivityReporterTests
         var task = await step.CreateTaskAsync("Test Task", CancellationToken.None);
 
         // Act
-        await task.CompleteAsync(null, cancellationToken: CancellationToken.None);
+        await task.CompleteAsync((string?)null, cancellationToken: CancellationToken.None);
 
         // Assert
         var taskInternal = Assert.IsType<ReportingTask>(task);
@@ -386,13 +386,13 @@ public class PublishingActivityReporterTests
         var task = await step.CreateTaskAsync("Test Task", CancellationToken.None);
 
         // Complete the task first time
-        await task.CompleteAsync(null, cancellationToken: CancellationToken.None);
+        await task.CompleteAsync((string?)null, cancellationToken: CancellationToken.None);
 
         // Clear activities
         ClearActivities(reporter);
 
         // Act - Try to complete the same task again with the same state (should be idempotent, no exception)
-        await task.CompleteAsync(null, cancellationToken: CancellationToken.None);
+        await task.CompleteAsync((string?)null, cancellationToken: CancellationToken.None);
 
         // Assert - No new activity should be emitted (noop)
         AssertNoActivitiesEmitted(reporter);
@@ -411,7 +411,7 @@ public class PublishingActivityReporterTests
         var task = await step.CreateTaskAsync("Test Task", CancellationToken.None);
 
         // Complete the task first time successfully
-        await task.CompleteAsync(null, CompletionState.Completed, cancellationToken: CancellationToken.None);
+        await task.CompleteAsync((string?)null, CompletionState.Completed, cancellationToken: CancellationToken.None);
 
         // Clear activities
         ClearActivities(reporter);
@@ -486,7 +486,7 @@ public class PublishingActivityReporterTests
         var task = await step.CreateTaskAsync("Test Task", CancellationToken.None);
 
         // Complete the task first
-        await task.CompleteAsync(null, cancellationToken: CancellationToken.None);
+        await task.CompleteAsync((string?)null, cancellationToken: CancellationToken.None);
 
         // Act - Complete the step
         await step.CompleteAsync("Step completed", CompletionState.Completed, CancellationToken.None);
@@ -499,7 +499,7 @@ public class PublishingActivityReporterTests
         Assert.Contains($"Cannot update task '{taskInternal.Id}' because its parent step", updateException.Message);
 
         // For CompleteTaskAsync, since task is already completed, attempting to complete with same or different state should be idempotent
-        await task.CompleteAsync(null, cancellationToken: CancellationToken.None); // Should not throw
+        await task.CompleteAsync((string?)null, cancellationToken: CancellationToken.None); // Should not throw
         await task.CompleteAsync("Error", CompletionState.CompletedWithError, cancellationToken: CancellationToken.None); // Should also not throw (noop)
 
         // Creating new tasks for the completed step should also fail because the step is complete
@@ -687,8 +687,8 @@ public class PublishingActivityReporterTests
         var task2 = await step.CreateTaskAsync("Task 2", CancellationToken.None);
 
         // Complete all tasks successfully
-        await task1.SucceedAsync(null, CancellationToken.None);
-        await task2.SucceedAsync(null, CancellationToken.None);
+        await task1.SucceedAsync((string?)null, CancellationToken.None);
+        await task2.SucceedAsync((string?)null, CancellationToken.None);
 
         // Clear previous activities
         ClearActivities(reporter);
@@ -852,12 +852,12 @@ public class PublishingActivityReporterTests
     {
         // Arrange
         var reporter = CreatePublishingReporter();
-        var pipelineSummary = new List<KeyValuePair<string, string>>
+        var pipelineSummary = new List<PipelineSummaryItem>
         {
-            new("Target", "TestTarget"),
-            new("Environment", "test-env"),
-            new("Identifier", "test-123"),
-            new("Region", "test-region")
+            new("Target", "TestTarget", enableMarkdown: false),
+            new("Environment", "test-env", enableMarkdown: false),
+            new("Identifier", "test-123", enableMarkdown: false),
+            new("Region", "test-region", enableMarkdown: false)
         };
 
         // Act
@@ -869,10 +869,14 @@ public class PublishingActivityReporterTests
         Assert.Equal(PublishingActivityTypes.PublishComplete, activity.Type);
         Assert.NotNull(activity.Data.PipelineSummary);
         Assert.Equal(4, activity.Data.PipelineSummary.Count);
-        Assert.Equal(new KeyValuePair<string, string>("Target", "TestTarget"), activity.Data.PipelineSummary[0]);
-        Assert.Equal(new KeyValuePair<string, string>("Environment", "test-env"), activity.Data.PipelineSummary[1]);
-        Assert.Equal(new KeyValuePair<string, string>("Identifier", "test-123"), activity.Data.PipelineSummary[2]);
-        Assert.Equal(new KeyValuePair<string, string>("Region", "test-region"), activity.Data.PipelineSummary[3]);
+        Assert.Equal("Target", activity.Data.PipelineSummary[0].Key);
+        Assert.Equal("TestTarget", activity.Data.PipelineSummary[0].Value);
+        Assert.Equal("Environment", activity.Data.PipelineSummary[1].Key);
+        Assert.Equal("test-env", activity.Data.PipelineSummary[1].Value);
+        Assert.Equal("Identifier", activity.Data.PipelineSummary[2].Key);
+        Assert.Equal("test-123", activity.Data.PipelineSummary[2].Value);
+        Assert.Equal("Region", activity.Data.PipelineSummary[3].Key);
+        Assert.Equal("test-region", activity.Data.PipelineSummary[3].Value);
         Assert.True(activity.Data.IsComplete);
         Assert.False(activity.Data.IsError);
     }
@@ -956,7 +960,7 @@ public class PublishingActivityReporterTests
         reporter.ActivityItemUpdated.Reader.TryRead(out _);
 
         // Act
-        step.Log(logLevel, logMessage, enableMarkdown: true);
+        step.Log(logLevel, new MarkdownString(logMessage));
 
         // Assert
         // Verify activity was emitted
@@ -987,7 +991,7 @@ public class PublishingActivityReporterTests
         ClearActivities(reporter);
 
         // Act - Step is completed, so logging should be a no-op
-        step.Log(LogLevel.Information, "Test log", enableMarkdown: false);
+        step.Log(LogLevel.Information, "Test log");
 
         // Assert - No new activity should be emitted
         AssertNoActivitiesEmitted(reporter);

--- a/tests/Aspire.Hosting.Tests/Publishing/PipelineActivityReporterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/PipelineActivityReporterTests.cs
@@ -1026,6 +1026,85 @@ public class PublishingActivityReporterTests
     }
 
     [Fact]
+    public async Task CreateTaskAsync_WithMarkdownString_SetsEnableMarkdownTrue()
+    {
+        // Arrange
+        var reporter = CreatePublishingReporter();
+        var step = await reporter.CreateStepAsync("Test Step", CancellationToken.None);
+        reporter.ActivityItemUpdated.Reader.TryRead(out _); // Clear step activity
+
+        // Act
+        var task = await step.CreateTaskAsync(new MarkdownString("**Bold** task"), CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(task);
+        var activityReader = reporter.ActivityItemUpdated.Reader;
+        Assert.True(activityReader.TryRead(out var activity));
+        Assert.Equal(PublishingActivityTypes.Task, activity.Type);
+        Assert.Equal("**Bold** task", activity.Data.StatusText);
+        Assert.True(activity.Data.EnableMarkdown);
+    }
+
+    [Fact]
+    public async Task UpdateTaskAsync_WithMarkdownString_SetsEnableMarkdownTrue()
+    {
+        // Arrange
+        var reporter = CreatePublishingReporter();
+        var step = await reporter.CreateStepAsync("Test Step", CancellationToken.None);
+        var task = await step.CreateTaskAsync("Initial status", CancellationToken.None);
+        ClearActivities(reporter);
+
+        // Act
+        await task.UpdateAsync(new MarkdownString("**Updated** status"), CancellationToken.None);
+
+        // Assert
+        var activityReader = reporter.ActivityItemUpdated.Reader;
+        Assert.True(activityReader.TryRead(out var activity));
+        Assert.Equal(PublishingActivityTypes.Task, activity.Type);
+        Assert.Equal("**Updated** status", activity.Data.StatusText);
+        Assert.True(activity.Data.EnableMarkdown);
+    }
+
+    [Fact]
+    public async Task CompleteTaskAsync_WithMarkdownString_SetsEnableMarkdownTrue()
+    {
+        // Arrange
+        var reporter = CreatePublishingReporter();
+        var step = await reporter.CreateStepAsync("Test Step", CancellationToken.None);
+        var task = await step.CreateTaskAsync("Test Task", CancellationToken.None);
+        ClearActivities(reporter);
+
+        // Act
+        await task.CompleteAsync(new MarkdownString("Deployed to **Azure**"), CompletionState.Completed, CancellationToken.None);
+
+        // Assert
+        var activityReader = reporter.ActivityItemUpdated.Reader;
+        Assert.True(activityReader.TryRead(out var activity));
+        Assert.Equal(PublishingActivityTypes.Task, activity.Type);
+        Assert.True(activity.Data.EnableMarkdown);
+        Assert.Equal("Deployed to **Azure**", activity.Data.CompletionMessage);
+    }
+
+    [Fact]
+    public async Task CompleteStepAsync_WithMarkdownString_SetsEnableMarkdownTrue()
+    {
+        // Arrange
+        var reporter = CreatePublishingReporter();
+        var step = await reporter.CreateStepAsync("Test Step", CancellationToken.None);
+        ClearActivities(reporter);
+
+        // Act
+        await step.CompleteAsync(new MarkdownString("Step **completed** successfully"), CompletionState.Completed, CancellationToken.None);
+
+        // Assert
+        var activityReader = reporter.ActivityItemUpdated.Reader;
+        Assert.True(activityReader.TryRead(out var activity));
+        Assert.Equal(PublishingActivityTypes.Step, activity.Type);
+        Assert.True(activity.Data.EnableMarkdown);
+        Assert.Equal("Step **completed** successfully", activity.Data.StatusText);
+    }
+
+    [Fact]
     public async Task CompleteTaskAsync_IdempotentWithWarning()
     {
         // Arrange

--- a/tests/Shared/TestPipelineActivityReporter.cs
+++ b/tests/Shared/TestPipelineActivityReporter.cs
@@ -83,7 +83,7 @@ internal sealed class TestPipelineActivityReporter : IPipelineActivityReporter
     /// <summary>
     /// Gets the pipeline summary passed to <see cref="CompletePublishAsync(PublishCompletionOptions?, CancellationToken)"/>.
     /// </summary>
-    public IReadOnlyList<KeyValuePair<string, string>>? PipelineSummary { get; private set; }
+    public IReadOnlyList<PipelineSummaryItem>? PipelineSummary { get; private set; }
 
     /// <summary>
     /// Clears all captured state to allow reuse between pipeline runs.
@@ -127,7 +127,7 @@ internal sealed class TestPipelineActivityReporter : IPipelineActivityReporter
         CompletionMessage = options?.CompletionMessage;
         ResultCompletionState = options?.CompletionState;
         PipelineSummary = options?.PipelineSummary;
-        var summaryStr = options?.PipelineSummary != null ? string.Join(", ", options.PipelineSummary.Select(kvp => $"{kvp.Key}={kvp.Value}")) : null;
+        var summaryStr = options?.PipelineSummary != null ? string.Join(", ", options.PipelineSummary.Select(item => $"{item.Key}={item.Value}")) : null;
         _testOutputHelper.WriteLine($"[CompletePublish] {options?.CompletionMessage} (State: {options?.CompletionState}) (Summary: {summaryStr})");
 
         return Task.CompletedTask;

--- a/tests/Shared/TestPipelineActivityReporter.cs
+++ b/tests/Shared/TestPipelineActivityReporter.cs
@@ -203,6 +203,37 @@ internal sealed class TestPipelineActivityReporter : IPipelineActivityReporter
                 _testOutputHelper.WriteLine($"    [{logLevel}:{_title}] {message}");
             }
         }
+
+        public void Log(LogLevel logLevel, string message)
+        {
+            lock (_reporter.LoggedMessages)
+            {
+                _reporter.LoggedMessages.Add((_title, logLevel, message));
+                _testOutputHelper.WriteLine($"    [{logLevel}:{_title}] {message}");
+            }
+        }
+
+        public void Log(LogLevel logLevel, MarkdownString message)
+        {
+            ArgumentNullException.ThrowIfNull(message);
+            lock (_reporter.LoggedMessages)
+            {
+                _reporter.LoggedMessages.Add((_title, logLevel, message.Value));
+                _testOutputHelper.WriteLine($"    [{logLevel}:{_title}] {message.Value}");
+            }
+        }
+
+        public Task<IReportingTask> CreateTaskAsync(MarkdownString statusText, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(statusText);
+            return CreateTaskAsync(statusText.Value, cancellationToken);
+        }
+
+        public Task CompleteAsync(MarkdownString completionText, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(completionText);
+            return CompleteAsync(completionText.Value, completionState, cancellationToken);
+        }
     }
 
     private sealed class TestReportingTask : IReportingTask

--- a/tests/Shared/TestPipelineActivityReporter.cs
+++ b/tests/Shared/TestPipelineActivityReporter.cs
@@ -272,5 +272,17 @@ internal sealed class TestPipelineActivityReporter : IPipelineActivityReporter
 
             return Task.CompletedTask;
         }
+
+        public Task UpdateAsync(MarkdownString statusText, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(statusText);
+            return UpdateAsync(statusText.Value, cancellationToken);
+        }
+
+        public Task CompleteAsync(MarkdownString completionMessage, CompletionState completionState = CompletionState.Completed, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(completionMessage);
+            return CompleteAsync(completionMessage.Value, completionState, cancellationToken);
+        }
     }
 }


### PR DESCRIPTION
## Description

Introduce MarkdownString and PipelineSummaryItem types to enable explicit Markdown formatting in pipeline logs and summaries. Update IReportingStep, IReportingTask, and related APIs with overloads and extensions for MarkdownString, allowing richer CLI output (e.g., clickable links, bold text) while preserving plain-text compatibility. Refactor summary storage and backchannel data to track Markdown formatting per item. Update ConsoleActivityLogger and tests to render Markdown appropriately. All changes are backward compatible for existing plain string usage.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
