### PR TITLE
Fix deployment E2E tests: add --language csharp to aspire init

### DIFF
--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
@@ -91,7 +91,7 @@ public sealed class AcaCompactNamingDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost
             output.WriteLine("Step 3: Creating single-file AppHost...");
-            sequenceBuilder.Type("aspire init")
+            sequenceBuilder.Type("aspire init --language csharp")
                 .Enter()
                 .Wait(TimeSpan.FromSeconds(5))
                 .Enter()

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaDeploymentErrorOutputTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaDeploymentErrorOutputTests.cs
@@ -94,7 +94,7 @@ public sealed class AcaDeploymentErrorOutputTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost
             output.WriteLine("Step 3: Creating single-file AppHost...");
-            sequenceBuilder.Type("aspire init")
+            sequenceBuilder.Type("aspire init --language csharp")
                 .Enter()
                 .Wait(TimeSpan.FromSeconds(5))
                 .Enter()

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureAppConfigDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureAppConfigDeploymentTests.cs
@@ -96,7 +96,7 @@ public sealed class AzureAppConfigDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.Type("aspire init")
+            sequenceBuilder.Type("aspire init --language csharp")
                 .Enter()
                 // NuGet.config prompt may or may not appear depending on environment.
                 // Wait a moment then press Enter to dismiss if present, then wait for completion.

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureContainerRegistryDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureContainerRegistryDeploymentTests.cs
@@ -91,7 +91,7 @@ public sealed class AzureContainerRegistryDeploymentTests(ITestOutputHelper outp
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.Type("aspire init")
+            sequenceBuilder.Type("aspire init --language csharp")
                 .Enter()
                 // NuGet.config prompt may or may not appear depending on environment.
                 // Wait a moment then press Enter to dismiss if present, then wait for completion.

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureEventHubsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureEventHubsDeploymentTests.cs
@@ -96,7 +96,7 @@ public sealed class AzureEventHubsDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.Type("aspire init")
+            sequenceBuilder.Type("aspire init --language csharp")
                 .Enter()
                 // NuGet.config prompt may or may not appear depending on environment.
                 // Wait a moment then press Enter to dismiss if present, then wait for completion.

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureKeyVaultDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureKeyVaultDeploymentTests.cs
@@ -96,7 +96,7 @@ public sealed class AzureKeyVaultDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.Type("aspire init")
+            sequenceBuilder.Type("aspire init --language csharp")
                 .Enter()
                 // NuGet.config prompt may or may not appear depending on environment.
                 // Wait a moment then press Enter to dismiss if present, then wait for completion.

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureLogAnalyticsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureLogAnalyticsDeploymentTests.cs
@@ -91,7 +91,7 @@ public sealed class AzureLogAnalyticsDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.Type("aspire init")
+            sequenceBuilder.Type("aspire init --language csharp")
                 .Enter()
                 // NuGet.config prompt may or may not appear depending on environment.
                 // Wait a moment then press Enter to dismiss if present, then wait for completion.

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureServiceBusDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureServiceBusDeploymentTests.cs
@@ -96,7 +96,7 @@ public sealed class AzureServiceBusDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.Type("aspire init")
+            sequenceBuilder.Type("aspire init --language csharp")
                 .Enter()
                 // NuGet.config prompt may or may not appear depending on environment.
                 // Wait a moment then press Enter to dismiss if present, then wait for completion.

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureStorageDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureStorageDeploymentTests.cs
@@ -96,7 +96,7 @@ public sealed class AzureStorageDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.Type("aspire init")
+            sequenceBuilder.Type("aspire init --language csharp")
                 .Enter()
                 // NuGet.config prompt may or may not appear depending on environment.
                 // Wait a moment then press Enter to dismiss if present, then wait for completion.

--- a/tests/Aspire.Deployment.EndToEnd.Tests/VnetKeyVaultInfraDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/VnetKeyVaultInfraDeploymentTests.cs
@@ -85,7 +85,7 @@ public sealed class VnetKeyVaultInfraDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.Type("aspire init")
+            sequenceBuilder.Type("aspire init --language csharp")
                 .Enter()
                 .Wait(TimeSpan.FromSeconds(5))
                 .Enter()

--- a/tests/Aspire.Deployment.EndToEnd.Tests/VnetSqlServerInfraDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/VnetSqlServerInfraDeploymentTests.cs
@@ -85,7 +85,7 @@ public sealed class VnetSqlServerInfraDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.Type("aspire init")
+            sequenceBuilder.Type("aspire init --language csharp")
                 .Enter()
                 .Wait(TimeSpan.FromSeconds(5))
                 .Enter()

--- a/tests/Aspire.Deployment.EndToEnd.Tests/VnetStorageBlobInfraDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/VnetStorageBlobInfraDeploymentTests.cs
@@ -86,7 +86,7 @@ public sealed class VnetStorageBlobInfraDeploymentTests(ITestOutputHelper output
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.Type("aspire init")
+            sequenceBuilder.Type("aspire init --language csharp")
                 .Enter()
                 .Wait(TimeSpan.FromSeconds(5))
                 .Enter()


### PR DESCRIPTION
## Description

Fixes 12 broken deployment E2E tests that were timing out during `aspire init`.

**Root cause:** The `aspire init` command now shows a language selection prompt ("Which language would you like to use?") when multiple languages are available (C#, TypeScript). The failing tests did not handle this new prompt, causing them to timeout waiting for "Aspire initialization complete" after 2 minutes.

**Fix:** Add `--language csharp` to all `aspire init` calls in the 12 affected tests. This explicitly skips the language selection prompt, restoring the expected test flow.

**Affected tests:**
- AcaCompactNamingDeploymentTests
- AcaDeploymentErrorOutputTests
- AzureAppConfigDeploymentTests
- AzureContainerRegistryDeploymentTests
- AzureEventHubsDeploymentTests
- AzureKeyVaultDeploymentTests
- AzureLogAnalyticsDeploymentTests
- AzureServiceBusDeploymentTests
- AzureStorageDeploymentTests
- VnetKeyVaultInfraDeploymentTests
- VnetSqlServerInfraDeploymentTests
- VnetStorageBlobInfraDeploymentTests

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
