### PR TITLE
Add optional parameter to PromptForSelectionsAsync

### DIFF
--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -135,7 +135,7 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
                 promptText,
                 sortedApplicators,
                 applicator => applicator.Description,
-                notRequired: true,
+                optional: true,
                 cancellationToken);
 
             selectedApplicators.AddRange(selected);

--- a/src/Aspire.Cli/Commands/AgentInitCommand.cs
+++ b/src/Aspire.Cli/Commands/AgentInitCommand.cs
@@ -135,6 +135,7 @@ internal sealed class AgentInitCommand : BaseCommand, IPackageMetaPrefetchingCom
                 promptText,
                 sortedApplicators,
                 applicator => applicator.Description,
+                notRequired: true,
                 cancellationToken);
 
             selectedApplicators.AddRange(selected);

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -233,7 +233,7 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
                 "Select projects to add to the AppHost:",
                 initContext.ExecutableProjects,
                 project => Path.GetFileNameWithoutExtension(project.ProjectFile.Name).EscapeMarkup(),
-                notRequired: true,
+                optional: true,
                 cancellationToken);
 
             initContext.ExecutableProjectsToAddToAppHost = selectedProjects;
@@ -287,7 +287,7 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
                             "Select projects to add ServiceDefaults reference to:",
                             initContext.ExecutableProjectsToAddToAppHost,
                             project => Path.GetFileNameWithoutExtension(project.ProjectFile.Name).EscapeMarkup(),
-                            notRequired: true,
+                            optional: true,
                             cancellationToken);
                         break;
                     case "none":

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -233,6 +233,7 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
                 "Select projects to add to the AppHost:",
                 initContext.ExecutableProjects,
                 project => Path.GetFileNameWithoutExtension(project.ProjectFile.Name).EscapeMarkup(),
+                notRequired: true,
                 cancellationToken);
 
             initContext.ExecutableProjectsToAddToAppHost = selectedProjects;
@@ -286,6 +287,7 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
                             "Select projects to add ServiceDefaults reference to:",
                             initContext.ExecutableProjectsToAddToAppHost,
                             project => Path.GetFileNameWithoutExtension(project.ProjectFile.Name).EscapeMarkup(),
+                            notRequired: true,
                             cancellationToken);
                         break;
                     case "none":

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -190,7 +190,7 @@ internal class ConsoleInteractionService : IInteractionService
         return await _outConsole.PromptAsync(prompt, cancellationToken);
     }
 
-    public async Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull
+    public async Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool notRequired = false, CancellationToken cancellationToken = default) where T : notnull
     {
         ArgumentNullException.ThrowIfNull(promptText, nameof(promptText));
         ArgumentNullException.ThrowIfNull(choices, nameof(choices));
@@ -212,6 +212,11 @@ internal class ConsoleInteractionService : IInteractionService
             .UseConverter(choiceFormatter)
             .AddChoices(choices)
             .PageSize(10);
+
+        if (notRequired)
+        {
+            prompt.NotRequired();
+        }
 
         var result = await _outConsole.PromptAsync(prompt, cancellationToken);
         return result;

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -190,7 +190,7 @@ internal class ConsoleInteractionService : IInteractionService
         return await _outConsole.PromptAsync(prompt, cancellationToken);
     }
 
-    public async Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool notRequired = false, CancellationToken cancellationToken = default) where T : notnull
+    public async Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
     {
         ArgumentNullException.ThrowIfNull(promptText, nameof(promptText));
         ArgumentNullException.ThrowIfNull(choices, nameof(choices));
@@ -213,7 +213,7 @@ internal class ConsoleInteractionService : IInteractionService
             .AddChoices(choices)
             .PageSize(10);
 
-        if (notRequired)
+        if (optional)
         {
             prompt.NotRequired();
         }

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -263,7 +263,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
     }
 
     public async Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter,
-        CancellationToken cancellationToken = default) where T : notnull
+        bool notRequired = false, CancellationToken cancellationToken = default) where T : notnull
     {
         if (_extensionPromptEnabled)
         {
@@ -290,7 +290,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         }
         else
         {
-            return await _consoleInteractionService.PromptForSelectionsAsync(promptText, choices, choiceFormatter, cancellationToken);
+            return await _consoleInteractionService.PromptForSelectionsAsync(promptText, choices, choiceFormatter, notRequired, cancellationToken);
         }
     }
 

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -263,7 +263,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
     }
 
     public async Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter,
-        bool notRequired = false, CancellationToken cancellationToken = default) where T : notnull
+        bool optional = false, CancellationToken cancellationToken = default) where T : notnull
     {
         if (_extensionPromptEnabled)
         {
@@ -290,7 +290,7 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         }
         else
         {
-            return await _consoleInteractionService.PromptForSelectionsAsync(promptText, choices, choiceFormatter, notRequired, cancellationToken);
+            return await _consoleInteractionService.PromptForSelectionsAsync(promptText, choices, choiceFormatter, optional, cancellationToken);
         }
     }
 

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -15,7 +15,7 @@ internal interface IInteractionService
     Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default);
     public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default);
     Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull;
-    Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull;
+    Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool notRequired = false, CancellationToken cancellationToken = default) where T : notnull;
     int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion);
     void DisplayError(string errorMessage);
     void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false);

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -15,7 +15,7 @@ internal interface IInteractionService
     Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default);
     public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default);
     Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull;
-    Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool notRequired = false, CancellationToken cancellationToken = default) where T : notnull;
+    Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool optional = false, CancellationToken cancellationToken = default) where T : notnull;
     int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion);
     void DisplayError(string errorMessage);
     void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false);

--- a/tests/Aspire.Cli.Tests/Agents/ClaudeCodeAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/ClaudeCodeAgentEnvironmentScannerTests.cs
@@ -127,7 +127,7 @@ public class ClaudeCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
             new FakeNpmRunner(),
             new FakeNpmProvenanceChecker(),
             new FakePlaywrightCliRunner(),
-            new TestConsoleInteractionService(),
+            new TestInteractionService(),
             new ConfigurationBuilder().Build(),
             NullLogger<PlaywrightCliInstaller>.Instance);
     }

--- a/tests/Aspire.Cli.Tests/Agents/CopilotCliAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/CopilotCliAgentEnvironmentScannerTests.cs
@@ -329,7 +329,7 @@ public class CopilotCliAgentEnvironmentScannerTests(ITestOutputHelper outputHelp
             new FakeNpmRunner(),
             new FakeNpmProvenanceChecker(),
             new FakePlaywrightCliRunner(),
-            new TestConsoleInteractionService(),
+            new TestInteractionService(),
             new ConfigurationBuilder().Build(),
             NullLogger<PlaywrightCliInstaller>.Instance);
     }

--- a/tests/Aspire.Cli.Tests/Agents/OpenCodeAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/OpenCodeAgentEnvironmentScannerTests.cs
@@ -107,7 +107,7 @@ public class OpenCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper
             new FakeNpmRunner(),
             new FakeNpmProvenanceChecker(),
             new FakePlaywrightCliRunner(),
-            new TestConsoleInteractionService(),
+            new TestInteractionService(),
             new ConfigurationBuilder().Build(),
             NullLogger<PlaywrightCliInstaller>.Instance);
     }

--- a/tests/Aspire.Cli.Tests/Agents/PlaywrightCliInstallerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/PlaywrightCliInstallerTests.cs
@@ -33,7 +33,7 @@ public class PlaywrightCliInstallerTests
             ResolveResult = null
         };
         var playwrightRunner = new TestPlaywrightCliRunner();
-        var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestConsoleInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
+        var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
 
         var result = await installer.InstallAsync(CreateTestContext(), CancellationToken.None);
 
@@ -53,7 +53,7 @@ public class PlaywrightCliInstallerTests
             InstalledVersion = version,
             InstallSkillsResult = true
         };
-        var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestConsoleInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
+        var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
 
         var result = await installer.InstallAsync(CreateTestContext(), CancellationToken.None);
 
@@ -77,7 +77,7 @@ public class PlaywrightCliInstallerTests
             InstalledVersion = installedVersion,
             InstallSkillsResult = true
         };
-        var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestConsoleInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
+        var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
 
         var result = await installer.InstallAsync(CreateTestContext(), CancellationToken.None);
 
@@ -96,7 +96,7 @@ public class PlaywrightCliInstallerTests
             PackResult = null
         };
         var playwrightRunner = new TestPlaywrightCliRunner();
-        var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestConsoleInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
+        var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
 
         var result = await installer.InstallAsync(CreateTestContext(), CancellationToken.None);
 
@@ -122,7 +122,7 @@ public class PlaywrightCliInstallerTests
                 PackResult = tarballPath
             };
             var playwrightRunner = new TestPlaywrightCliRunner();
-            var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestConsoleInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
+            var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
 
             var result = await installer.InstallAsync(CreateTestContext(), CancellationToken.None);
 
@@ -161,7 +161,7 @@ public class PlaywrightCliInstallerTests
             {
                 InstallSkillsResult = true
             };
-            var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestConsoleInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
+            var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
 
             var result = await installer.InstallAsync(CreateTestContext(), CancellationToken.None);
 
@@ -197,7 +197,7 @@ public class PlaywrightCliInstallerTests
                 InstallGlobalResult = false
             };
             var playwrightRunner = new TestPlaywrightCliRunner();
-            var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestConsoleInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
+            var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
 
             var result = await installer.InstallAsync(CreateTestContext(), CancellationToken.None);
 
@@ -236,7 +236,7 @@ public class PlaywrightCliInstallerTests
                 InstalledVersion = installedVersion,
                 InstallSkillsResult = true
             };
-            var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestConsoleInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
+            var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
 
             var result = await installer.InstallAsync(CreateTestContext(), CancellationToken.None);
 
@@ -313,7 +313,7 @@ public class PlaywrightCliInstallerTests
         };
         var provenanceChecker = new TestNpmProvenanceChecker { ProvenanceOutcome = ProvenanceVerificationOutcome.SourceRepositoryMismatch };
         var playwrightRunner = new TestPlaywrightCliRunner();
-        var installer = new PlaywrightCliInstaller(npmRunner, provenanceChecker, playwrightRunner, new TestConsoleInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
+        var installer = new PlaywrightCliInstaller(npmRunner, provenanceChecker, playwrightRunner, new TestInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
 
         var result = await installer.InstallAsync(CreateTestContext(), CancellationToken.None);
 
@@ -347,7 +347,7 @@ public class PlaywrightCliInstallerTests
                     [PlaywrightCliInstaller.DisablePackageValidationKey] = "true"
                 })
                 .Build();
-            var installer = new PlaywrightCliInstaller(npmRunner, provenanceChecker, playwrightRunner, new TestConsoleInteractionService(), configuration, NullLogger<PlaywrightCliInstaller>.Instance);
+            var installer = new PlaywrightCliInstaller(npmRunner, provenanceChecker, playwrightRunner, new TestInteractionService(), configuration, NullLogger<PlaywrightCliInstaller>.Instance);
 
             var result = await installer.InstallAsync(CreateTestContext(), CancellationToken.None);
 
@@ -377,7 +377,7 @@ public class PlaywrightCliInstallerTests
                 [PlaywrightCliInstaller.VersionOverrideKey] = "0.2.0"
             })
             .Build();
-        var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestConsoleInteractionService(), configuration, NullLogger<PlaywrightCliInstaller>.Instance);
+        var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestInteractionService(), configuration, NullLogger<PlaywrightCliInstaller>.Instance);
 
         await installer.InstallAsync(CreateTestContext(), CancellationToken.None);
 
@@ -393,7 +393,7 @@ public class PlaywrightCliInstallerTests
             ResolveResult = new NpmPackageInfo { Version = version, Integrity = "sha512-abc123" }
         };
         var playwrightRunner = new TestPlaywrightCliRunner();
-        var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestConsoleInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
+        var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
 
         await installer.InstallAsync(CreateTestContext(), CancellationToken.None);
 
@@ -428,7 +428,7 @@ public class PlaywrightCliInstallerTests
 
             var installer = new PlaywrightCliInstaller(
                 npmRunner, new TestNpmProvenanceChecker(), playwrightRunner,
-                new TestConsoleInteractionService(), new ConfigurationBuilder().Build(),
+                new TestInteractionService(), new ConfigurationBuilder().Build(),
                 NullLogger<PlaywrightCliInstaller>.Instance);
 
             var context = new AgentEnvironmentScanContext

--- a/tests/Aspire.Cli.Tests/Agents/VsCodeAgentEnvironmentScannerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/VsCodeAgentEnvironmentScannerTests.cs
@@ -367,7 +367,7 @@ public class VsCodeAgentEnvironmentScannerTests(ITestOutputHelper outputHelper)
             new FakeNpmRunner(),
             new FakeNpmProvenanceChecker(),
             new FakePlaywrightCliRunner(),
-            new TestConsoleInteractionService(),
+            new TestInteractionService(),
             new ConfigurationBuilder().Build(),
             NullLogger<PlaywrightCliInstaller>.Instance);
     }

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -408,18 +408,14 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public async Task AddCommand_EmptyPackageList_DisplaysErrorMessage()
     {
-        string? displayedErrorMessage = null;
+        TestInteractionService? testInteractionService = null;
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
             options.InteractionServiceFactory = (sp) =>
             {
-                var testInteractionService = new TestInteractionService();
-                testInteractionService.DisplayErrorCallback = (message) =>
-                {
-                    displayedErrorMessage = message;
-                };
+                testInteractionService = new TestInteractionService();
                 return testInteractionService;
             };
 
@@ -443,7 +439,8 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(ExitCodeConstants.FailedToAddPackage, exitCode);
-        Assert.Contains(AddCommandStrings.NoIntegrationPackagesFound, displayedErrorMessage);
+        Assert.NotNull(testInteractionService);
+        Assert.Contains(testInteractionService.DisplayedErrors, e => e.Contains(AddCommandStrings.NoIntegrationPackagesFound));
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AddCommandTests.cs
@@ -415,7 +415,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         {
             options.InteractionServiceFactory = (sp) =>
             {
-                var testInteractionService = new TestConsoleInteractionService();
+                var testInteractionService = new TestInteractionService();
                 testInteractionService.DisplayErrorCallback = (message) =>
                 {
                     displayedErrorMessage = message;
@@ -457,7 +457,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         {
             options.InteractionServiceFactory = (sp) =>
             {
-                var testInteractionService = new TestConsoleInteractionService();
+                var testInteractionService = new TestInteractionService();
                 testInteractionService.DisplaySubtleMessageCallback = (message) =>
                 {
                     displayedSubtleMessage = message;
@@ -551,7 +551,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         {
             options.InteractionServiceFactory = (sp) =>
             {
-                var mockInteraction = new TestConsoleInteractionService();
+                var mockInteraction = new TestInteractionService();
                 mockInteraction.PromptForSelectionCallback = (message, choices, formatter, ct) =>
                 {
                     // Capture what the prompter passes to the interaction service
@@ -599,7 +599,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         {
             options.InteractionServiceFactory = (sp) =>
             {
-                var mockInteraction = new TestConsoleInteractionService();
+                var mockInteraction = new TestInteractionService();
                 mockInteraction.PromptForSelectionCallback = (message, choices, formatter, ct) =>
                 {
                     // Capture what the prompter passes to the interaction service
@@ -647,7 +647,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         {
             options.InteractionServiceFactory = (sp) =>
             {
-                var mockInteraction = new TestConsoleInteractionService();
+                var mockInteraction = new TestInteractionService();
                 mockInteraction.PromptForSelectionCallback = (message, choices, formatter, ct) =>
                 {
                     // Capture what the prompter passes to the interaction service
@@ -700,7 +700,7 @@ public class AddCommandTests(ITestOutputHelper outputHelper)
         {
             options.ProjectLocatorFactory = _ => new TestProjectLocator();
 
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService()
+            options.InteractionServiceFactory = _ => new TestInteractionService()
             {
                 PromptForSelectionCallback = (message, choices, formatter, ct) =>
                 {

--- a/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
@@ -21,7 +21,7 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
     public async Task BaseCommand_FormatOption_SetsConsoleOutputCorrectly(string args, bool expectErrorConsole)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var testInteractionService = new TestConsoleInteractionService();
+        var testInteractionService = new TestInteractionService();
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
             options.InteractionServiceFactory = _ => testInteractionService;

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -170,7 +170,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
 
             options.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 return interactionService;
             };
 

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -539,15 +539,12 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public async Task NewCommand_EmptyPackageList_DisplaysErrorMessage()
     {
-        string? displayedErrorMessage = null;
+        TestInteractionService? testInteractionService = null;
 
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options => {
             options.InteractionServiceFactory = (sp) => {
-                var testInteractionService = new TestInteractionService();
-                testInteractionService.DisplayErrorCallback = (message) => {
-                    displayedErrorMessage = message;
-                };
+                testInteractionService = new TestInteractionService();
                 return testInteractionService;
             };
 
@@ -568,7 +565,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(ExitCodeConstants.FailedToCreateNewProject, exitCode);
-        Assert.Contains(TemplatingStrings.NoTemplateVersionsFound, displayedErrorMessage);
+        Assert.NotNull(testInteractionService);
+        Assert.Contains(testInteractionService.DisplayedErrors, e => e.Contains(TemplatingStrings.NoTemplateVersionsFound));
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Cli.Backchannel;
 using Aspire.Cli.Utils;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Commands;
@@ -17,7 +16,6 @@ using Aspire.Cli.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console;
-using Spectre.Console.Rendering;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
 namespace Aspire.Cli.Tests.Commands;
@@ -546,7 +544,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options => {
             options.InteractionServiceFactory = (sp) => {
-                var testInteractionService = new TestConsoleInteractionService();
+                var testInteractionService = new TestInteractionService();
                 testInteractionService.DisplayErrorCallback = (message) => {
                     displayedErrorMessage = message;
                 };
@@ -711,7 +709,20 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
             options.InteractionServiceFactory = (sp) =>
             {
-                var testInteractionService = new OrderTrackingInteractionService(operationOrder);
+                var testInteractionService = new TestInteractionService();
+                testInteractionService.PromptForSelectionCallback = (promptText, choices, formatter, ct) =>
+                {
+                    // Track template option prompts
+                    if (promptText?.Contains("Redis") == true ||
+                        promptText?.Contains("test framework") == true ||
+                        promptText?.Contains("Create a test project") == true ||
+                        promptText?.Contains("xUnit") == true)
+                    {
+                        operationOrder.Add("TemplateOption");
+                    }
+
+                    return choices.Cast<object>().First();
+                };
                 return testInteractionService;
             };
 
@@ -838,7 +849,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService
+            options.InteractionServiceFactory = _ => new TestInteractionService
             {
                 PromptForSelectionCallback = (promptText, choices, choiceFormatter, cancellationToken) => choices.Cast<object>().First()
             };
@@ -903,7 +914,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService
+            options.InteractionServiceFactory = _ => new TestInteractionService
             {
                 PromptForSelectionCallback = (promptText, choices, choiceFormatter, cancellationToken) => choices.Cast<object>().First()
             };
@@ -1005,7 +1016,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService
+            options.InteractionServiceFactory = _ => new TestInteractionService
             {
                 PromptForSelectionCallback = (promptText, choices, choiceFormatter, cancellationToken) =>
                 {
@@ -1180,7 +1191,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService
+            options.InteractionServiceFactory = _ => new TestInteractionService
             {
                 PromptForSelectionCallback = (promptText, choices, choiceFormatter, cancellationToken) =>
                 {
@@ -1348,75 +1359,6 @@ internal sealed class TestNewCommandPrompter(IInteractionService interactionServ
             _ => Task.FromResult(candidatePackages.First()) // If no callback is provided just accept the first package.
         };
     }
-}
-
-internal sealed class OrderTrackingInteractionService(List<string> operationOrder) : IInteractionService
-{
-    public ConsoleOutput Console { get; set; }
-
-    public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false)
-    {
-        return action();
-    }
-
-    public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false)
-    {
-        action();
-    }
-
-    public Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default)
-    {
-        return Task.FromResult(defaultValue ?? string.Empty);
-    }
-
-    public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull
-    {
-        if (!choices.Any())
-        {
-            throw new EmptyChoicesException($"No items available for selection: {promptText}");
-        }
-
-        // Track template option prompts
-        if (promptText?.Contains("Redis") == true ||
-            promptText?.Contains("test framework") == true ||
-            promptText?.Contains("Create a test project") == true ||
-            promptText?.Contains("xUnit") == true)
-        {
-            operationOrder.Add("TemplateOption");
-        }
-
-        return Task.FromResult(choices.First());
-    }
-
-    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull
-    {
-        if (!choices.Any())
-        {
-            throw new EmptyChoicesException($"No items available for selection: {promptText}");
-        }
-
-        return Task.FromResult<IReadOnlyList<T>>(choices.ToList());
-    }
-
-    public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;
-    public void DisplayError(string errorMessage) { }
-    public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) { }
-    public void DisplaySuccess(string message, bool allowMarkup = false) { }
-    public void DisplayLines(IEnumerable<(string Stream, string Line)> lines) { }
-    public void DisplayCancellationMessage() { }
-    public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default) => Task.FromResult(true);
-    public Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default)
-        => PromptForStringAsync(promptText, defaultValue, validator, isSecret: false, required, cancellationToken);
-    public void DisplaySubtleMessage(string message, bool escapeMarkup = true) { }
-    public void DisplayEmptyLine() { }
-    public void DisplayPlainText(string text) { }
-    public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) { }
-    public void DisplayMarkdown(string markdown) { }
-    public void DisplayMarkupLine(string markup) { }
-    public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false) { }
-    public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null) { }
-    public void DisplayRenderable(IRenderable renderable) { }
-    public Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback) => callback(_ => { });
 }
 
 internal sealed class NewCommandTestPackagingService : IPackagingService

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -10,9 +10,6 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.DependencyInjection;
-using Spectre.Console;
-using Spectre.Console.Rendering;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.InternalTesting;
 
@@ -26,7 +23,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         // Arrange
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var promptBackchannel = new TestPromptBackchannel();
-        var consoleService = new TestConsoleInteractionServiceWithPromptTracking();
+        var consoleService = new TestInteractionService();
 
         // Set up the prompt that will be sent from AppHost
         promptBackchannel.AddPrompt("text-prompt-1", "Environment Name", InputTypes.Text, "Enter environment name:", isRequired: true);
@@ -72,7 +69,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         // Arrange
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var promptBackchannel = new TestPromptBackchannel();
-        var consoleService = new TestConsoleInteractionServiceWithPromptTracking();
+        var consoleService = new TestInteractionService();
 
         // Set up the prompt that will be sent from AppHost
         promptBackchannel.AddPrompt("secret-prompt-1", "Database Password", InputTypes.SecretText, "Enter secure password:", isRequired: true);
@@ -118,7 +115,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         // Arrange
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var promptBackchannel = new TestPromptBackchannel();
-        var consoleService = new TestConsoleInteractionServiceWithPromptTracking();
+        var consoleService = new TestInteractionService();
 
         // Set up the choice prompt with options
         var options = new List<KeyValuePair<string, string>>
@@ -171,7 +168,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         // Arrange
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var promptBackchannel = new TestPromptBackchannel();
-        var consoleService = new TestConsoleInteractionServiceWithPromptTracking();
+        var consoleService = new TestInteractionService();
 
         // Set up the boolean prompt
         promptBackchannel.AddPrompt("bool-prompt-1", "Enable Verbose Logging", InputTypes.Boolean, "Enable verbose logging?", isRequired: false);
@@ -217,7 +214,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         // Arrange
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var promptBackchannel = new TestPromptBackchannel();
-        var consoleService = new TestConsoleInteractionServiceWithPromptTracking();
+        var consoleService = new TestInteractionService();
 
         // Set up the number prompt
         promptBackchannel.AddPrompt("number-prompt-1", "Instance Count", InputTypes.Number, "Enter number of instances:", isRequired: true);
@@ -263,7 +260,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         // Arrange
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var promptBackchannel = new TestPromptBackchannel();
-        var consoleService = new TestConsoleInteractionServiceWithPromptTracking();
+        var consoleService = new TestInteractionService();
 
         // Set up multiple prompts that will be sent in sequence
         promptBackchannel.AddPrompt("text-prompt-1", "Application Name", InputTypes.Text, "Enter app name:", isRequired: true);
@@ -338,7 +335,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         // Arrange
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var promptBackchannel = new TestPromptBackchannel();
-        var consoleService = new TestConsoleInteractionServiceWithPromptTracking();
+        var consoleService = new TestInteractionService();
 
         // Set up a single prompt with multiple inputs
         promptBackchannel.AddMultiInputPrompt("multi-input-prompt-1", "Configuration Setup", "Please provide the following details:",
@@ -422,7 +419,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         // Arrange
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var promptBackchannel = new TestPromptBackchannel();
-        var consoleService = new TestConsoleInteractionServiceWithPromptTracking();
+        var consoleService = new TestInteractionService();
 
         // Set up the prompt with a default value
         promptBackchannel.AddPrompt("text-prompt-1", "Environment Name", InputTypes.Text, "Enter environment name:", isRequired: true, defaultValue: "development");
@@ -474,7 +471,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         // Arrange
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var promptBackchannel = new TestPromptBackchannel();
-        var consoleService = new TestConsoleInteractionServiceWithPromptTracking();
+        var consoleService = new TestInteractionService();
 
         // Set up the prompt with a default value
         promptBackchannel.AddPrompt("text-prompt-1", "Environment Name", InputTypes.Text, "Enter environment name:", isRequired: true, defaultValue: "de", validationErrors: ["Environment name must be at least 3 characters long."]);
@@ -529,7 +526,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         // Arrange
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var promptBackchannel = new TestPromptBackchannel();
-        var consoleService = new TestConsoleInteractionServiceWithPromptTracking();
+        var consoleService = new TestInteractionService();
 
         // Set up the prompt with markdown in the activity status text
         promptBackchannel.AddPrompt("markdown-prompt-1", "Config Value", InputTypes.Text, "**Enter** the `config` value for [Azure Portal](https://portal.azure.com):", isRequired: true);
@@ -600,7 +597,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         // Arrange
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var promptBackchannel = new TestPromptBackchannel();
-        var consoleService = new TestConsoleInteractionServiceWithPromptTracking();
+        var consoleService = new TestInteractionService();
 
         // Set up the prompt that will be sent from AppHost
         promptBackchannel.AddPrompt("debug-prompt-1", "Environment Name", InputTypes.Text, "Enter environment name:", isRequired: true);
@@ -644,7 +641,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         // Arrange
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var promptBackchannel = new TestPromptBackchannel();
-        var consoleService = new TestConsoleInteractionServiceWithPromptTracking();
+        var consoleService = new TestInteractionService();
 
         // Set up a single-input prompt where StatusText and Label are different
         promptBackchannel.AddPrompt("status-label-prompt", "Target Region", InputTypes.Text, "Configure deployment target", isRequired: true);
@@ -687,7 +684,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         // Arrange
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var promptBackchannel = new TestPromptBackchannel();
-        var consoleService = new TestConsoleInteractionServiceWithPromptTracking();
+        var consoleService = new TestInteractionService();
 
         // Set up a single-input prompt where StatusText and Label are the same
         promptBackchannel.AddPrompt("duplicate-prompt", "Environment Name", InputTypes.Text, "Environment Name", isRequired: true);
@@ -844,136 +841,6 @@ internal sealed record PromptInputData(string Name, string Label, string InputTy
 internal sealed record PromptData(string PromptId, IReadOnlyList<PromptInputData> Inputs, string Message, string? Title = null);
 internal sealed record PromptCompletion(string PromptId, PublishingPromptInputAnswer[] Answers, bool UpdateResponse);
 
-// Enhanced TestConsoleInteractionService that tracks interaction types
-[SuppressMessage("Usage", "ASPIREINTERACTION001:Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
-internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInteractionService
-{
-    private readonly Queue<(string response, ResponseType type)> _responses = new();
-    private bool _shouldCancel;
-
-    public ConsoleOutput Console { get; set; }
-    public List<StringPromptCall> StringPromptCalls { get; } = [];
-    public List<object> SelectionPromptCalls { get; } = []; // Using object to handle generic types
-    public List<BooleanPromptCall> BooleanPromptCalls { get; } = [];
-    public List<string> DisplayedErrors { get; } = [];
-
-    public void SetupStringPromptResponse(string response) => _responses.Enqueue((response, ResponseType.String));
-    public void SetupSelectionResponse(string response) => _responses.Enqueue((response, ResponseType.Selection));
-    public void SetupBooleanResponse(bool response) => _responses.Enqueue((response.ToString().ToLower(), ResponseType.Boolean));
-    public void SetupCancellationResponse() => _shouldCancel = true;
-
-    public void SetupSequentialResponses(params (string response, ResponseType type)[] responses)
-    {
-        foreach (var (response, type) in responses)
-        {
-            _responses.Enqueue((response, type));
-        }
-    }
-
-    public Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default)
-    {
-        StringPromptCalls.Add(new StringPromptCall(promptText, defaultValue, isSecret));
-
-        if (_shouldCancel || cancellationToken.IsCancellationRequested)
-        {
-            throw new OperationCanceledException();
-        }
-
-        if (_responses.TryDequeue(out var response))
-        {
-            return Task.FromResult(response.response);
-        }
-
-        return Task.FromResult(defaultValue ?? string.Empty);
-    }
-
-    public Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default)
-        => PromptForStringAsync(promptText, defaultValue, validator, isSecret: false, required, cancellationToken);
-
-    public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull
-    {
-        if (_shouldCancel || cancellationToken.IsCancellationRequested)
-        {
-            throw new OperationCanceledException();
-        }
-
-        if (_responses.TryDequeue(out var response))
-        {
-            // Find the choice that matches the response
-            var matchingChoice = choices.FirstOrDefault(c => choiceFormatter(c) == response.response || c.ToString() == response.response);
-            if (matchingChoice != null)
-            {
-                return Task.FromResult(matchingChoice);
-            }
-        }
-
-        return Task.FromResult(choices.First());
-    }
-
-    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull
-    {
-        if (_shouldCancel || cancellationToken.IsCancellationRequested)
-        {
-            throw new OperationCanceledException();
-        }
-
-        _ = _responses.TryDequeue(out _);
-        // For simplicity, return all choices in the test
-        return Task.FromResult<IReadOnlyList<T>>(choices.ToList());
-    }
-
-    public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default)
-    {
-        BooleanPromptCalls.Add(new BooleanPromptCall(promptText, defaultValue));
-
-        if (_shouldCancel || cancellationToken.IsCancellationRequested)
-        {
-            throw new OperationCanceledException();
-        }
-
-        if (_responses.TryDequeue(out var response))
-        {
-            return Task.FromResult(bool.Parse(response.response));
-        }
-
-        return Task.FromResult(defaultValue);
-    }
-
-    // Default implementations for other interface methods
-    public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false) => action();
-    public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false) => action();
-    public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;
-    public void DisplayError(string errorMessage) => DisplayedErrors.Add(errorMessage);
-    public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) { }
-    public void DisplaySuccess(string message, bool allowMarkup = false) { }
-    public void DisplaySubtleMessage(string message, bool allowMarkup = false) { }
-    public void DisplayLines(IEnumerable<(string Stream, string Line)> lines) { }
-    public void DisplayCancellationMessage() { }
-    public void DisplayEmptyLine() { }
-    public void DisplayPlainText(string text) { }
-    public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) { }
-    public void DisplayMarkdown(string markdown) { }
-    public void DisplayMarkupLine(string markup) { }
-
-    public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null) { }
-
-    public void DisplayRenderable(IRenderable renderable) { }
-    public Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback) => callback(_ => { });
-
-    public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false)
-    {
-        var messageType = isErrorMessage ? "error" : "info";
-        System.Console.WriteLine($"#{lineNumber} [{messageType}] {message}");
-    }
-}
-
-internal enum ResponseType
-{
-    String,
-    Selection,
-    Boolean
-}
-
 // Input type constants that match the Aspire CLI implementation
 internal static class InputTypes
 {
@@ -983,7 +850,3 @@ internal static class InputTypes
     public const string Boolean = "boolean";
     public const string Number = "number";
 }
-
-internal sealed record StringPromptCall(string PromptText, string? DefaultValue, bool IsSecret);
-internal sealed record SelectionPromptCall<T>(string PromptText, IEnumerable<T> Choices, Func<T, string> ChoiceFormatter);
-internal sealed record BooleanPromptCall(string PromptText, bool DefaultValue);

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -386,7 +386,6 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public async Task RunCommand_WhenDashboardFailsToStart_ReturnsNonZeroExitCodeWithClearErrorMessage()
     {
-        var errorMessages = new List<string>();
 
         var backchannelFactory = (IServiceProvider sp) =>
         {
@@ -437,12 +436,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             options.ProjectLocatorFactory = projectLocatorFactory;
             options.AppHostBackchannelFactory = backchannelFactory;
             options.DotNetCliRunnerFactory = runnerFactory;
-            options.InteractionServiceFactory = (sp) =>
-            {
-                var interactionService = new TestInteractionService();
-                interactionService.DisplayErrorCallback = errorMessages.Add;
-                return interactionService;
-            };
+            options.InteractionServiceFactory = (sp) => new TestInteractionService();
         });
 
         var provider = services.BuildServiceProvider();

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
@@ -439,7 +439,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             options.DotNetCliRunnerFactory = runnerFactory;
             options.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.DisplayErrorCallback = errorMessages.Add;
                 return interactionService;
             };
@@ -458,7 +458,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public async Task AppHostHelper_BuildAppHostAsync_IncludesRelativePathInStatusMessage()
     {
-        var testInteractionService = new TestConsoleInteractionService();
+        var testInteractionService = new TestInteractionService();
         testInteractionService.ShowStatusCallback = (statusText) =>
         {
             Assert.Contains(

--- a/tests/Aspire.Cli.Tests/Commands/SdkInstallerTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SdkInstallerTests.cs
@@ -38,7 +38,7 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
             // Use TestDotNetCliRunner to avoid real process execution
             options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner();
 
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService();
+            options.InteractionServiceFactory = _ => new TestInteractionService();
         });
         var provider = services.BuildServiceProvider();
 
@@ -60,7 +60,7 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
                 CheckAsyncCallback = _ => (false, null, "9.0.302") // SDK not installed
             };
 
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService();
+            options.InteractionServiceFactory = _ => new TestInteractionService();
 
             // Need to provide a project locator since AddCommand checks for project first
             options.ProjectLocatorFactory = _ => new TestProjectLocator();
@@ -85,7 +85,7 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
                 CheckAsyncCallback = _ => (false, null, "9.0.302") // SDK not installed
             };
 
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService();
+            options.InteractionServiceFactory = _ => new TestInteractionService();
         });
         var provider = services.BuildServiceProvider();
 
@@ -125,7 +125,7 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
             // Use TestDotNetCliRunner to avoid real process execution
             options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner();
 
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService();
+            options.InteractionServiceFactory = _ => new TestInteractionService();
         });
         var provider = services.BuildServiceProvider();
 
@@ -163,7 +163,7 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
             // Use TestDotNetCliRunner to avoid real process execution
             options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner();
 
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService();
+            options.InteractionServiceFactory = _ => new TestInteractionService();
         });
         var provider = services.BuildServiceProvider();
 
@@ -186,7 +186,7 @@ public class SdkInstallerTests(ITestOutputHelper outputHelper)
                 CheckAsyncCallback = _ => (false, null, "9.0.302") // SDK not installed
             };
 
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService();
+            options.InteractionServiceFactory = _ => new TestInteractionService();
         });
         var provider = services.BuildServiceProvider();
 

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -49,7 +49,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                 }
             };
 
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService();
+            options.InteractionServiceFactory = _ => new TestInteractionService();
 
             options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner();
 
@@ -179,7 +179,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                 }
             };
 
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService()
+            options.InteractionServiceFactory = _ => new TestInteractionService()
             {
                 ConfirmCallback = (prompt, defaultValue) =>
                 {
@@ -222,7 +222,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                 }
             };
 
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService()
+            options.InteractionServiceFactory = _ => new TestInteractionService()
             {
                 ConfirmCallback = (prompt, defaultValue) =>
                 {
@@ -295,7 +295,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                 }
             };
 
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService()
+            options.InteractionServiceFactory = _ => new TestInteractionService()
             {
                 ConfirmCallback = (prompt, defaultValue) =>
                 {
@@ -360,7 +360,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService()
+            options.InteractionServiceFactory = _ => new TestInteractionService()
             {
                 PromptForSelectionCallback = (prompt, choices, formatter, ct) =>
                 {
@@ -407,7 +407,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService()
+            options.InteractionServiceFactory = _ => new TestInteractionService()
             {
                 PromptForSelectionCallback = (prompt, choices, formatter, ct) =>
                 {
@@ -503,7 +503,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                 }
             };
 
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService()
+            options.InteractionServiceFactory = _ => new TestInteractionService()
             {
                 PromptForSelectionCallback = (prompt, choices, formatter, ct) =>
                 {
@@ -570,7 +570,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                 }
             };
 
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService()
+            options.InteractionServiceFactory = _ => new TestInteractionService()
             {
                 PromptForSelectionCallback = (prompt, choices, formatter, ct) =>
                 {
@@ -637,7 +637,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                 }
             };
 
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService()
+            options.InteractionServiceFactory = _ => new TestInteractionService()
             {
                 DisplayErrorCallback = (message) =>
                 {
@@ -697,7 +697,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                 }
             };
 
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService()
+            options.InteractionServiceFactory = _ => new TestInteractionService()
             {
                 PromptForSelectionCallback = (prompt, choices, formatter, ct) =>
                 {
@@ -755,7 +755,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
         var cancellationMessageDisplayed = false;
         
-        var wrappedService = new CancellationTrackingInteractionService(new TestConsoleInteractionService()
+        var wrappedService = new CancellationTrackingInteractionService(new TestInteractionService()
         {
             PromptForSelectionCallback = (prompt, choices, formatter, ct) =>
             {
@@ -820,7 +820,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                 }
             };
 
-            options.InteractionServiceFactory = _ => new TestConsoleInteractionService()
+            options.InteractionServiceFactory = _ => new TestInteractionService()
             {
                 PromptForSelectionCallback = (prompt, choices, formatter, ct) =>
                 {
@@ -876,7 +876,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
 
         var cancellationMessageDisplayed = false;
         
-        var wrappedService = new CancellationTrackingInteractionService(new TestConsoleInteractionService()
+        var wrappedService = new CancellationTrackingInteractionService(new TestInteractionService()
         {
             PromptForSelectionCallback = (prompt, choices, formatter, ct) =>
             {
@@ -964,8 +964,8 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
         => _innerService.ConfirmAsync(promptText, defaultValue, cancellationToken);
     public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull 
         => _innerService.PromptForSelectionAsync(promptText, choices, choiceFormatter, cancellationToken);
-    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull 
-        => _innerService.PromptForSelectionsAsync(promptText, choices, choiceFormatter, cancellationToken);
+    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool notRequired = false, CancellationToken cancellationToken = default) where T : notnull 
+        => _innerService.PromptForSelectionsAsync(promptText, choices, choiceFormatter, notRequired, cancellationToken);
     public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) 
         => _innerService.DisplayIncompatibleVersionError(ex, appHostHostingVersion);
     public void DisplayError(string errorMessage) => _innerService.DisplayError(errorMessage);

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -624,8 +624,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
-        var errorDisplayed = false;
-        string? errorMessage = null;
+        TestInteractionService? testInteractionService = null;
         
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
@@ -637,13 +636,10 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                 }
             };
 
-            options.InteractionServiceFactory = _ => new TestInteractionService()
+            options.InteractionServiceFactory = _ =>
             {
-                DisplayErrorCallback = (message) =>
-                {
-                    errorDisplayed = true;
-                    errorMessage = message;
-                }
+                testInteractionService = new TestInteractionService();
+                return testInteractionService;
             };
 
             options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner();
@@ -671,8 +667,9 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         // Assert
-        Assert.True(errorDisplayed, "Error should be displayed for invalid quality");
-        Assert.NotNull(errorMessage);
+        Assert.NotNull(testInteractionService);
+        Assert.NotEmpty(testInteractionService.DisplayedErrors);
+        var errorMessage = Assert.Single(testInteractionService.DisplayedErrors);
         Assert.Contains("invalid", errorMessage);
         Assert.Contains("stable", errorMessage);
         Assert.Contains("daily", errorMessage);

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -961,8 +961,8 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
         => _innerService.ConfirmAsync(promptText, defaultValue, cancellationToken);
     public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull 
         => _innerService.PromptForSelectionAsync(promptText, choices, choiceFormatter, cancellationToken);
-    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool notRequired = false, CancellationToken cancellationToken = default) where T : notnull 
-        => _innerService.PromptForSelectionsAsync(promptText, choices, choiceFormatter, notRequired, cancellationToken);
+    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool optional = false, CancellationToken cancellationToken = default) where T : notnull 
+        => _innerService.PromptForSelectionsAsync(promptText, choices, choiceFormatter, optional, cancellationToken);
     public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) 
         => _innerService.DisplayIncompatibleVersionError(ex, appHostHostingVersion);
     public void DisplayError(string errorMessage) => _innerService.DisplayError(errorMessage);

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -43,7 +43,7 @@ public class ConsoleInteractionServiceTests
 
         // Act & Assert
         await Assert.ThrowsAsync<EmptyChoicesException>(() =>
-            interactionService.PromptForSelectionsAsync("Select items:", choices, x => x, CancellationToken.None));
+            interactionService.PromptForSelectionsAsync("Select items:", choices, x => x, cancellationToken: CancellationToken.None));
     }
 
     [Fact]
@@ -273,7 +273,7 @@ public class ConsoleInteractionServiceTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            interactionService.PromptForSelectionsAsync("Select items:", choices, x => x, CancellationToken.None));
+            interactionService.PromptForSelectionsAsync("Select items:", choices, x => x, cancellationToken: CancellationToken.None));
         Assert.Contains(InteractionServiceStrings.InteractiveInputNotSupported, exception.Message);
     }
 

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -774,7 +774,7 @@ builder.Build().Run();");
 
         var returnedProjectFile = await projectLocator.UseOrFindAppHostProjectFileAsync(directoryAsFileInfo, createSettingsFile: true).DefaultTimeout();
 
-        // Should return the first project file (TestConsoleInteractionService returns the first choice)
+        // Should return the first project file (TestInteractionService returns the first choice)
         Assert.Equal(projectFile1.FullName, returnedProjectFile!.FullName);
     }
 
@@ -967,7 +967,7 @@ builder.Build().Run();");
         return new ProjectLocator(
             logger,
             executionContext,
-            interactionService ?? new TestConsoleInteractionService(),
+            interactionService ?? new TestInteractionService(),
             configurationService ?? new TestConfigurationService(),
             projectFactory ?? new TestAppHostProjectFactory(),
             languageDiscovery ?? new TestLanguageDiscovery(),

--- a/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectUpdaterTests.cs
@@ -100,7 +100,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.ConfirmCallback = (promptText, defaultValue) =>
                 {
                     throw new InvalidOperationException("Should not prompt when no work required.");
@@ -217,7 +217,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (s) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 return interactionService;
             };
         });
@@ -356,7 +356,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (s) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 return interactionService;
             };
         });
@@ -509,7 +509,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (s) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 return interactionService;
             };
         });
@@ -647,7 +647,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.ConfirmCallback = (promptText, defaultValue) =>
                 {
                     return true;
@@ -752,7 +752,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.ConfirmCallback = (promptText, defaultValue) =>
                 {
                     return true;
@@ -854,7 +854,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.ConfirmCallback = (promptText, defaultValue) =>
                 {
                     // Should not be called since no updates are needed
@@ -998,7 +998,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.ConfirmCallback = (promptText, defaultValue) =>
                 {
                     return true;
@@ -1121,7 +1121,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.ConfirmCallback = (promptText, defaultValue) =>
                 {
                     return true;
@@ -1235,7 +1235,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.ConfirmCallback = (promptText, defaultValue) =>
                 {
                     return true;
@@ -1345,7 +1345,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.ConfirmCallback = (promptText, defaultValue) =>
                 {
                     return true;
@@ -1443,7 +1443,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.ConfirmCallback = (promptText, defaultValue) =>
                 {
                     return true;
@@ -1545,7 +1545,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.ConfirmCallback = (promptText, defaultValue) =>
                 {
                     return true;
@@ -1629,7 +1629,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 return interactionService;
             };
         });
@@ -1711,7 +1711,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 return interactionService;
             };
         });
@@ -1785,7 +1785,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.ConfirmCallback = (promptText, defaultValue) =>
                 {
                     return true;
@@ -1868,7 +1868,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.ConfirmCallback = (promptText, defaultValue) =>
                 {
                     return true;
@@ -1956,7 +1956,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.ConfirmCallback = (promptText, defaultValue) =>
                 {
                     return true;
@@ -2038,7 +2038,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.ConfirmCallback = (promptText, defaultValue) =>
                 {
                     return true;
@@ -2117,7 +2117,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.ConfirmCallback = (promptText, defaultValue) =>
                 {
                     return true;
@@ -2208,7 +2208,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.ConfirmCallback = (promptText, defaultValue) =>
                 {
                     return true;
@@ -2335,7 +2335,7 @@ public class ProjectUpdaterTests(ITestOutputHelper outputHelper)
 
             config.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.ConfirmCallback = (promptText, defaultValue) =>
                 {
                     return true;

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -8,7 +8,6 @@ using Aspire.Cli.Certificates;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
-using Aspire.Cli.Interaction;
 using Aspire.Cli.NuGet;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Templating;
@@ -17,8 +16,6 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Aspire.Shared;
-using Spectre.Console;
-using Spectre.Console.Rendering;
 
 namespace Aspire.Cli.Tests.Templating;
 
@@ -448,52 +445,6 @@ public class DotNetTemplateFactoryTests
                 _ => defaultValue
             };
         }
-    }
-
-    private sealed class TestInteractionService : IInteractionService
-    {
-        public ConsoleOutput Console { get; set; }
-
-        public Task<T> PromptForSelectionAsync<T>(string prompt, IEnumerable<T> choices, Func<T, string> displaySelector, CancellationToken cancellationToken) where T : notnull
-            => throw new NotImplementedException();
-
-        public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull
-            => throw new NotImplementedException();
-
-        public Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default)
-            => throw new NotImplementedException();
-
-        public Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default)
-            => throw new NotImplementedException();
-
-        public Task<bool> ConfirmAsync(string prompt, bool defaultAnswer, CancellationToken cancellationToken)
-            => throw new NotImplementedException();
-
-        public Task<TResult> ShowStatusAsync<TResult>(string message, Func<Task<TResult>> work, KnownEmoji? emoji = null, bool allowMarkup = false)
-            => throw new NotImplementedException();
-
-        public Task ShowStatusAsync(string message, Func<Task> work)
-            => throw new NotImplementedException();
-
-        public void ShowStatus(string message, Action work, KnownEmoji? emoji = null, bool allowMarkup = false)
-            => throw new NotImplementedException();
-
-        public void DisplaySuccess(string message, bool allowMarkup = false) { }
-        public void DisplayError(string message) { }
-        public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) { }
-        public void DisplayLines(IEnumerable<(string Stream, string Line)> lines) { }
-        public void DisplayCancellationMessage() { }
-        public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;
-        public void DisplayPlainText(string text) { }
-        public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) { }
-        public void DisplayMarkdown(string markdown) { }
-        public void DisplayMarkupLine(string markup) { }
-        public void DisplaySubtleMessage(string message, bool allowMarkup = false) { }
-        public void DisplayEmptyLine() { }
-        public void DisplayVersionUpdateNotification(string message, string? updateCommand = null) { }
-        public void WriteConsoleLog(string message, int? resourceHashCode, string? resourceName, bool isError) { }
-        public void DisplayRenderable(IRenderable renderable) { }
-        public Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback) => callback(_ => { });
     }
 
     private sealed class TestDotNetCliRunner : IDotNetCliRunner

--- a/tests/Aspire.Cli.Tests/TestServices/TestConsoleInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestConsoleInteractionService.cs
@@ -66,7 +66,7 @@ internal sealed class TestConsoleInteractionService : IInteractionService
         return Task.FromResult(choices.First());
     }
 
-    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull
+    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool notRequired = false, CancellationToken cancellationToken = default) where T : notnull
     {
         if (!choices.Any())
         {

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -54,7 +54,7 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
         return Task.FromResult(choices.First());
     }
 
-    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull
+    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool notRequired = false, CancellationToken cancellationToken = default) where T : notnull
     {
         if (!choices.Any())
         {

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -54,7 +54,7 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
         return Task.FromResult(choices.First());
     }
 
-    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool notRequired = false, CancellationToken cancellationToken = default) where T : notnull
+    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
     {
         if (!choices.Any())
         {

--- a/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
@@ -17,7 +17,6 @@ internal sealed class TestInteractionService : IInteractionService
     public ConsoleOutput Console { get; set; }
 
     // Callback hooks
-    public Action<string>? DisplayErrorCallback { get; set; }
     public Action<string>? DisplaySubtleMessageCallback { get; set; }
     public Action<string>? DisplayConsoleWriteLineMessage { get; set; }
     public Func<string, bool, bool>? ConfirmCallback { get; set; }
@@ -137,7 +136,6 @@ internal sealed class TestInteractionService : IInteractionService
     public void DisplayError(string errorMessage)
     {
         DisplayedErrors.Add(errorMessage);
-        DisplayErrorCallback?.Invoke(errorMessage);
     }
 
     public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false)

--- a/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
@@ -9,21 +9,46 @@ using Spectre.Console.Rendering;
 
 namespace Aspire.Cli.Tests.TestServices;
 
-internal sealed class TestConsoleInteractionService : IInteractionService
+internal sealed class TestInteractionService : IInteractionService
 {
+    private readonly Queue<(string Response, ResponseType Type)> _responses = new();
+    private bool _shouldCancel;
+
     public ConsoleOutput Console { get; set; }
+
+    // Callback hooks
     public Action<string>? DisplayErrorCallback { get; set; }
     public Action<string>? DisplaySubtleMessageCallback { get; set; }
     public Action<string>? DisplayConsoleWriteLineMessage { get; set; }
     public Func<string, bool, bool>? ConfirmCallback { get; set; }
-    public Action<string>? ShowStatusCallback { get; set;  }
-    
+    public Action<string>? ShowStatusCallback { get; set; }
+    public Action<string>? DisplayVersionUpdateNotificationCallback { get; set; }
+
     /// <summary>
     /// Callback for capturing selection prompts in tests. Uses non-generic IEnumerable and object
     /// to work with the generic PromptForSelectionAsync&lt;T&gt; method regardless of T's type.
     /// This allows tests to inspect what choices are presented without knowing the generic type at compile time.
     /// </summary>
     public Func<string, IEnumerable, Func<object, string>, CancellationToken, object>? PromptForSelectionCallback { get; set; }
+
+    // Call tracking
+    public List<StringPromptCall> StringPromptCalls { get; } = [];
+    public List<BooleanPromptCall> BooleanPromptCalls { get; } = [];
+    public List<string> DisplayedErrors { get; } = [];
+
+    // Response queue setup methods
+    public void SetupStringPromptResponse(string response) => _responses.Enqueue((response, ResponseType.String));
+    public void SetupSelectionResponse(string response) => _responses.Enqueue((response, ResponseType.Selection));
+    public void SetupBooleanResponse(bool response) => _responses.Enqueue((response.ToString().ToLowerInvariant(), ResponseType.Boolean));
+    public void SetupCancellationResponse() => _shouldCancel = true;
+
+    public void SetupSequentialResponses(params (string Response, ResponseType Type)[] responses)
+    {
+        foreach (var (response, type) in responses)
+        {
+            _responses.Enqueue((response, type));
+        }
+    }
 
     public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
@@ -38,6 +63,18 @@ internal sealed class TestConsoleInteractionService : IInteractionService
 
     public Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default)
     {
+        StringPromptCalls.Add(new StringPromptCall(promptText, defaultValue, isSecret));
+
+        if (_shouldCancel || cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException();
+        }
+
+        if (_responses.TryDequeue(out var response))
+        {
+            return Task.FromResult(response.Response);
+        }
+
         return Task.FromResult(defaultValue ?? string.Empty);
     }
 
@@ -48,6 +85,11 @@ internal sealed class TestConsoleInteractionService : IInteractionService
 
     public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull
     {
+        if (_shouldCancel || cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException();
+        }
+
         if (!choices.Any())
         {
             throw new EmptyChoicesException($"No items available for selection: {promptText}");
@@ -55,12 +97,17 @@ internal sealed class TestConsoleInteractionService : IInteractionService
 
         if (PromptForSelectionCallback is not null)
         {
-            // Invoke the callback - casting is safe here because:
-            // 1. 'choices' is IEnumerable<T>, and we cast items to T when calling choiceFormatter
-            // 2. 'result' comes from the callback which receives 'choices', so it must be of type T
-            // 3. These casts are for test infrastructure only, not production code
             var result = PromptForSelectionCallback(promptText, choices, o => choiceFormatter((T)o), cancellationToken);
             return Task.FromResult((T)result);
+        }
+
+        if (_responses.TryDequeue(out var response))
+        {
+            var matchingChoice = choices.FirstOrDefault(c => choiceFormatter(c) == response.Response || c.ToString() == response.Response);
+            if (matchingChoice is not null)
+            {
+                return Task.FromResult(matchingChoice);
+            }
         }
 
         return Task.FromResult(choices.First());
@@ -68,11 +115,17 @@ internal sealed class TestConsoleInteractionService : IInteractionService
 
     public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool notRequired = false, CancellationToken cancellationToken = default) where T : notnull
     {
+        if (_shouldCancel || cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException();
+        }
+
         if (!choices.Any())
         {
             throw new EmptyChoicesException($"No items available for selection: {promptText}");
         }
 
+        _ = _responses.TryDequeue(out _);
         return Task.FromResult<IReadOnlyList<T>>(choices.ToList());
     }
 
@@ -83,6 +136,7 @@ internal sealed class TestConsoleInteractionService : IInteractionService
 
     public void DisplayError(string errorMessage)
     {
+        DisplayedErrors.Add(errorMessage);
         DisplayErrorCallback?.Invoke(errorMessage);
     }
 
@@ -104,7 +158,24 @@ internal sealed class TestConsoleInteractionService : IInteractionService
 
     public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default)
     {
-        return Task.FromResult(ConfirmCallback != null? ConfirmCallback(promptText, defaultValue) : defaultValue);
+        BooleanPromptCalls.Add(new BooleanPromptCall(promptText, defaultValue));
+
+        if (_shouldCancel || cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException();
+        }
+
+        if (ConfirmCallback is not null)
+        {
+            return Task.FromResult(ConfirmCallback(promptText, defaultValue));
+        }
+
+        if (_responses.TryDequeue(out var response))
+        {
+            return Task.FromResult(bool.Parse(response.Response));
+        }
+
+        return Task.FromResult(defaultValue);
     }
 
     public void DisplaySubtleMessage(string message, bool allowMarkup = false)
@@ -138,8 +209,6 @@ internal sealed class TestConsoleInteractionService : IInteractionService
         DisplayConsoleWriteLineMessage?.Invoke(output);
     }
 
-    public Action<string>? DisplayVersionUpdateNotificationCallback { get; set; }
-
     public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null)
     {
         DisplayVersionUpdateNotificationCallback?.Invoke(newerVersion);
@@ -154,3 +223,14 @@ internal sealed class TestConsoleInteractionService : IInteractionService
         return callback(_ => { });
     }
 }
+
+internal enum ResponseType
+{
+    String,
+    Selection,
+    Boolean
+}
+
+internal sealed record StringPromptCall(string PromptText, string? DefaultValue, bool IsSecret);
+internal sealed record SelectionPromptCall<T>(string PromptText, IEnumerable<T> Choices, Func<T, string> ChoiceFormatter);
+internal sealed record BooleanPromptCall(string PromptText, bool DefaultValue);

--- a/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
@@ -112,7 +112,7 @@ internal sealed class TestInteractionService : IInteractionService
         return Task.FromResult(choices.First());
     }
 
-    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool notRequired = false, CancellationToken cancellationToken = default) where T : notnull
+    public Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
     {
         if (_shouldCancel || cancellationToken.IsCancellationRequested)
         {

--- a/tests/Aspire.Cli.Tests/Utils/CliUpdateNotificationServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliUpdateNotificationServiceTests.cs
@@ -43,7 +43,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
 
             configure.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.DisplayVersionUpdateNotificationCallback = (newerVersion) =>
                 {
                     suggestedVersionTcs.SetResult(newerVersion);
@@ -98,7 +98,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
 
             configure.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.DisplayVersionUpdateNotificationCallback = (newerVersion) =>
                 {
                     suggestedVersionTcs.SetResult(newerVersion);
@@ -153,7 +153,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
 
             configure.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.DisplayVersionUpdateNotificationCallback = (newerVersion) =>
                 {
                     suggestedVersionTcs.SetResult(newerVersion);
@@ -204,7 +204,7 @@ public class CliUpdateNotificationServiceTests(ITestOutputHelper outputHelper)
 
             configure.InteractionServiceFactory = (sp) =>
             {
-                var interactionService = new TestConsoleInteractionService();
+                var interactionService = new TestInteractionService();
                 interactionService.DisplayVersionUpdateNotificationCallback = (newerVersion) =>
                 {
                     Assert.Fail("Should not suggest a preview version when current version is stable.");

--- a/tests/Aspire.Cli.Tests/Utils/SdkInstallHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/SdkInstallHelperTests.cs
@@ -20,7 +20,7 @@ public class SdkInstallHelperTests
             CheckAsyncCallback = _ => (true, "9.0.302", "9.0.302")
         };
 
-        var interactionService = new TestConsoleInteractionService();
+        var interactionService = new TestInteractionService();
 
         var result = await SdkInstallHelper.EnsureSdkInstalledAsync(
             sdkInstaller,
@@ -46,7 +46,7 @@ public class SdkInstallHelperTests
             CheckAsyncCallback = _ => (false, null, "9.0.302")
         };
 
-        var interactionService = new TestConsoleInteractionService();
+        var interactionService = new TestInteractionService();
 
         var result = await SdkInstallHelper.EnsureSdkInstalledAsync(
             sdkInstaller,
@@ -72,7 +72,7 @@ public class SdkInstallHelperTests
             CheckAsyncCallback = _ => (false, "8.0.100", "9.0.302")
         };
 
-        var interactionService = new TestConsoleInteractionService();
+        var interactionService = new TestInteractionService();
 
         var result = await SdkInstallHelper.EnsureSdkInstalledAsync(
             sdkInstaller,


### PR DESCRIPTION
## Description

Add a `notRequired` parameter to `PromptForSelectionsAsync` so callers can allow users to submit the multi-selection prompt without choosing any items.

**Changes:**
- Added `bool notRequired = false` parameter to `IInteractionService.PromptForSelectionsAsync`
- Updated `ConsoleInteractionService` to conditionally call `.NotRequired()` on the Spectre.Console `MultiSelectionPrompt` when the parameter is `true`
- Updated `ExtensionInteractionService` to pass through the parameter
- Updated `TestConsoleInteractionService` test implementation
- Enabled `notRequired: true` at all three existing call sites (`InitCommand` x2, `AgentInitCommand` x1) since they all handle empty selections gracefully

Fixes https://github.com/dotnet/aspire/issues/14841
Fixes https://github.com/dotnet/aspire/issues/14460

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
