### PR TITLE
Error in InitCommand when solution and project file are in the same directory

### DIFF
--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -175,6 +175,26 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
     {
         var solutionFile = initContext.SelectedSolutionFile!;
 
+        // Verify that the solution directory does not contain project files.
+        // If the solution and a project file are in the same directory, the AppHost
+        // and ServiceDefaults directories would be created inside that project which
+        // is not supported.
+        var solutionDirectory = solutionFile.Directory!;
+        var projectFilesInSolutionDir = solutionDirectory.EnumerateFiles("*.*proj")
+            .Where(f => DotNetAppHostProject.s_projectExtensions.Contains(f.Extension, StringComparer.OrdinalIgnoreCase))
+            .ToList();
+
+        if (projectFilesInSolutionDir.Count > 0)
+        {
+            InteractionService.DisplayError(
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    InitCommandStrings.SolutionAndProjectInSameDirectory,
+                    solutionFile.Name,
+                    projectFilesInSolutionDir[0].Name));
+            return ExitCodeConstants.FailedToCreateNewProject;
+        }
+
         initContext.GetSolutionProjectsOutputCollector = new OutputCollector();
         var (getSolutionExitCode, solutionProjects) = await InteractionService.ShowStatusAsync("Reading solution...", async () =>
         {

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -180,18 +180,17 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
         // and ServiceDefaults directories would be created inside that project which
         // is not supported.
         var solutionDirectory = solutionFile.Directory!;
-        var projectFilesInSolutionDir = solutionDirectory.EnumerateFiles("*.*proj")
-            .Where(f => DotNetAppHostProject.s_projectExtensions.Contains(f.Extension, StringComparer.OrdinalIgnoreCase))
-            .ToList();
+        var projectFileInSolutionDir = solutionDirectory.EnumerateFiles()
+            .FirstOrDefault(f => DotNetAppHostProject.ProjectExtensions.Contains(f.Extension, StringComparer.OrdinalIgnoreCase));
 
-        if (projectFilesInSolutionDir.Count > 0)
+        if (projectFileInSolutionDir is not null)
         {
             InteractionService.DisplayError(
                 string.Format(
                     CultureInfo.CurrentCulture,
                     InitCommandStrings.SolutionAndProjectInSameDirectory,
                     solutionFile.Name,
-                    projectFilesInSolutionDir[0].Name));
+                    projectFileInSolutionDir.Name));
             return ExitCodeConstants.FailedToCreateNewProject;
         }
 

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -34,7 +34,8 @@ internal sealed class DotNetAppHostProject : IAppHostProject
     private readonly Diagnostics.FileLoggerProvider _fileLoggerProvider;
 
     private static readonly string[] s_detectionPatterns = ["*.csproj", "*.fsproj", "*.vbproj", "apphost.cs"];
-    internal static readonly string[] s_projectExtensions = [".csproj", ".fsproj", ".vbproj"];
+    internal static IReadOnlyCollection<string> ProjectExtensions { get; } =
+        Array.AsReadOnly([".csproj", ".fsproj", ".vbproj"]);
 
     public DotNetAppHostProject(
         IDotNetCliRunner runner,
@@ -85,7 +86,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
         var extension = appHostFile.Extension.ToLowerInvariant();
 
         // Handle project files (.csproj, .fsproj, .vbproj)
-        if (s_projectExtensions.Contains(extension))
+        if (ProjectExtensions.Contains(extension))
         {
             // We can handle any project file - ValidateAsync will do deeper validation
             return true;
@@ -520,7 +521,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
 
         // Auto-initialize user secrets (only for csproj projects - file-based apphosts
         // always have a UserSecretsId provided by the SDK)
-        if (!s_projectExtensions.Contains(projectFile.Extension.ToLowerInvariant()))
+        if (!ProjectExtensions.Contains(projectFile.Extension.ToLowerInvariant()))
         {
             return userSecretsId;
         }

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -34,7 +34,7 @@ internal sealed class DotNetAppHostProject : IAppHostProject
     private readonly Diagnostics.FileLoggerProvider _fileLoggerProvider;
 
     private static readonly string[] s_detectionPatterns = ["*.csproj", "*.fsproj", "*.vbproj", "apphost.cs"];
-    private static readonly string[] s_projectExtensions = [".csproj", ".fsproj", ".vbproj"];
+    internal static readonly string[] s_projectExtensions = [".csproj", ".fsproj", ".vbproj"];
 
     public DotNetAppHostProject(
         IDotNetCliRunner runner,

--- a/src/Aspire.Cli/Resources/InitCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/InitCommandStrings.Designer.cs
@@ -116,5 +116,11 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("ResolvingTemplateVersion", resourceCulture);
             }
         }
+
+        internal static string SolutionAndProjectInSameDirectory {
+            get {
+                return ResourceManager.GetString("SolutionAndProjectInSameDirectory", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/InitCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/InitCommandStrings.resx
@@ -96,4 +96,7 @@
   <data name="ResolvingTemplateVersion" xml:space="preserve">
     <value>Resolving template version...</value>
   </data>
+  <data name="SolutionAndProjectInSameDirectory" xml:space="preserve">
+    <value>The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.cs.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Řešení se už inicializovalo pomocí Aspire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SolutionAndProjectInSameDirectory">
+        <source>The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</source>
+        <target state="new">The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.de.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Die Lösung wurde bereits mit Aspire initialisiert.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SolutionAndProjectInSameDirectory">
+        <source>The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</source>
+        <target state="new">The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.es.xlf
@@ -62,6 +62,11 @@
         <target state="translated">La solución ya está inicializada con Aspire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SolutionAndProjectInSameDirectory">
+        <source>The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</source>
+        <target state="new">The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.fr.xlf
@@ -62,6 +62,11 @@
         <target state="translated">La solution a déjà été initialisée avec Aspire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SolutionAndProjectInSameDirectory">
+        <source>The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</source>
+        <target state="new">The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.it.xlf
@@ -62,6 +62,11 @@
         <target state="translated">La soluzione è già stata inizializzata con Aspire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SolutionAndProjectInSameDirectory">
+        <source>The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</source>
+        <target state="new">The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.ja.xlf
@@ -62,6 +62,11 @@
         <target state="translated">ソリューションは既に Aspire で初期化されています。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SolutionAndProjectInSameDirectory">
+        <source>The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</source>
+        <target state="new">The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.ko.xlf
@@ -62,6 +62,11 @@
         <target state="translated">솔루션이 이미 Aspire로 초기화되었습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SolutionAndProjectInSameDirectory">
+        <source>The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</source>
+        <target state="new">The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.pl.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Rozwiązanie zostało już zainicjowane za pomocą narzędzia Prześlij.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SolutionAndProjectInSameDirectory">
+        <source>The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</source>
+        <target state="new">The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.pt-BR.xlf
@@ -62,6 +62,11 @@
         <target state="translated">A solução já foi inicializada com o Aspire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SolutionAndProjectInSameDirectory">
+        <source>The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</source>
+        <target state="new">The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.ru.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Решение уже инициализировано с помощью Aspire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SolutionAndProjectInSameDirectory">
+        <source>The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</source>
+        <target state="new">The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.tr.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Çözüm zaten Aspire ile başlatıldı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SolutionAndProjectInSameDirectory">
+        <source>The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</source>
+        <target state="new">The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.zh-Hans.xlf
@@ -62,6 +62,11 @@
         <target state="translated">解决方案已使用 Aspire 初始化。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SolutionAndProjectInSameDirectory">
+        <source>The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</source>
+        <target state="new">The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/InitCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InitCommandStrings.zh-Hant.xlf
@@ -62,6 +62,11 @@
         <target state="translated">解決方案已隨著 Aspire 初始化。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SolutionAndProjectInSameDirectory">
+        <source>The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</source>
+        <target state="new">The solution file '{0}' and project file '{1}' are in the same directory. The AppHost and ServiceDefaults projects cannot be created inside an existing project directory. Move the solution file to a parent directory or the project file to a subdirectory.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -14,6 +14,103 @@ namespace Aspire.Cli.Tests.Commands;
 
 public class InitCommandTests(ITestOutputHelper outputHelper)
 {
+    [Theory]
+    [InlineData("Test.csproj")]
+    [InlineData("Test.fsproj")]
+    [InlineData("Test.vbproj")]
+    public async Task InitCommand_WhenSolutionAndProjectInSameDirectory_ReturnsError(string projectFileName)
+    {
+        // Arrange
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Create a solution file and a project file in the same directory
+        var solutionFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Test.sln"));
+        File.WriteAllText(solutionFile.FullName, "Fake solution file");
+
+        var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, projectFileName));
+        File.WriteAllText(projectFile.FullName, "<Project />");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                // GetSolutionProjectsAsync should not be called because the check
+                // happens before reading solution projects
+                runner.GetSolutionProjectsAsyncCallback = (_, _, _) =>
+                {
+                    throw new InvalidOperationException("GetSolutionProjectsAsync should not be called when solution and project are in the same directory.");
+                };
+                return runner;
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        // Act
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        // Assert
+        Assert.Equal(ExitCodeConstants.FailedToCreateNewProject, exitCode);
+    }
+
+    [Fact]
+    public async Task InitCommand_WhenSolutionDirectoryHasNoProjectFiles_Proceeds()
+    {
+        // Arrange
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Create a solution file only (no project files in the same directory)
+        var solutionFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Test.sln"));
+        File.WriteAllText(solutionFile.FullName, "Fake solution file");
+
+        var getSolutionProjectsCalled = false;
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.GetSolutionProjectsAsyncCallback = (_, _, _) =>
+                {
+                    getSolutionProjectsCalled = true;
+                    // Return success with no projects - the test verifies the check passed
+                    return (0, Array.Empty<FileInfo>());
+                };
+                runner.NewProjectAsyncCallback = (_, _, outputPath, _, _) =>
+                {
+                    // Create the expected directories so the code can find them
+                    var appHostDir = Path.Combine(outputPath, "Test.AppHost");
+                    var serviceDefaultsDir = Path.Combine(outputPath, "Test.ServiceDefaults");
+                    Directory.CreateDirectory(appHostDir);
+                    Directory.CreateDirectory(serviceDefaultsDir);
+                    File.WriteAllText(Path.Combine(appHostDir, "Test.AppHost.csproj"), "<Project />");
+                    File.WriteAllText(Path.Combine(serviceDefaultsDir, "Test.ServiceDefaults.csproj"), "<Project />");
+                    return 0;
+                };
+                return runner;
+            };
+            options.PackagingServiceFactory = (sp) =>
+            {
+                return new TestPackagingService();
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        // Act
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        // Assert - the command should have proceeded past the directory check and created projects
+        Assert.True(getSolutionProjectsCalled, "GetSolutionProjectsAsync should have been called when no project files are in the solution directory.");
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "Test.AppHost", "Test.AppHost.csproj")));
+        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "Test.ServiceDefaults", "Test.ServiceDefaults.csproj")));
+    }
+
     [Fact]
     public void InitContext_RequiredAppHostFramework_ReturnsHighestTfm()
     {


### PR DESCRIPTION
## Description

When running `aspire init`, if the solution file and a project file (`.csproj`, `.fsproj`, or `.vbproj`) are in the same directory, the AppHost and ServiceDefaults project directories would be created inside that existing project directory, which is not supported.

This change adds an early validation check in `InitCommand.InitializeExistingSolutionAsync` that detects this situation and exits with a clear error message telling the user to move the solution file to a parent directory or the project file to a subdirectory.

<img width="1456" height="590" alt="image" src="https://github.com/user-attachments/assets/130fec8f-fcdd-4b74-bd40-c3f245ced8a6" />

Fixes https://github.com/dotnet/aspire/issues/14841

### Changes:
- Added validation in `InitCommand` to check for project files in the solution directory before proceeding
- Reused `DotNetAppHostProject.s_projectExtensions` (made `internal`) for consistent extension matching
- Added localized error message `SolutionAndProjectInSameDirectory` to resource files and all xlf translations
- Added tests for both the error case (all three project types) and the success case

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
