### PR TITLE
Add TypeScript Express/React deployment E2E test and template updates

### DIFF
--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -259,6 +259,8 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
     {
         public string? Version { get; init; }
 
+        public string? ChannelName { get; init; }
+
         [MemberNotNullWhen(true, nameof(Version))]
         [MemberNotNullWhen(false, nameof(ErrorMessage))]
         public bool Success => Version is not null;
@@ -304,7 +306,11 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
                     return new ResolveTemplateVersionResult { ErrorMessage = $"No template versions found in channel '{selectedChannel.Name}'." };
                 }
 
-                return new ResolveTemplateVersionResult { Version = package.Version };
+                // Only persist explicit channel names (e.g. local, daily) — implicit channels
+                // (stable/nuget.org) should not be written so aspire add uses its default behavior.
+                var channelName = selectedChannel.Type is PackageChannelType.Explicit ? selectedChannel.Name : null;
+
+                return new ResolveTemplateVersionResult { Version = package.Version, ChannelName = channelName };
             });
     }
 
@@ -330,6 +336,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         }
 
         var version = parseResult.GetValue(s_versionOption);
+        string? resolvedChannelName = null;
         if (ShouldResolveCliTemplateVersion(template) &&
             string.IsNullOrWhiteSpace(version))
         {
@@ -341,6 +348,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             }
 
             version = resolveResult.Version;
+            resolvedChannelName = resolveResult.ChannelName;
         }
 
         var inputs = new TemplateInputs
@@ -349,7 +357,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             Output = parseResult.GetValue(s_outputOption),
             Source = parseResult.GetValue(s_sourceOption),
             Version = version,
-            Channel = parseResult.GetValue(_channelOption),
+            Channel = parseResult.GetValue(_channelOption) ?? resolvedChannelName,
             Language = selectedLanguageId
         };
         var templateResult = await template.ApplyTemplateAsync(inputs, parseResult, cancellationToken);

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Microsoft.Extensions.Logging;
@@ -73,6 +74,18 @@ internal sealed partial class CliTemplateFactory
                     {
                         _interactionService.DisplaySubtleMessage("npm install had warnings or errors. You may need to run 'npm install' manually after dependencies are available.");
                         DisplayProcessOutput(npmInstallResult, treatStandardErrorAsError: false);
+                    }
+
+                    // Write channel to settings.json if available so that aspire add
+                    // knows which channel to use for package resolution
+                    if (!string.IsNullOrEmpty(inputs.Channel))
+                    {
+                        var config = AspireJsonConfiguration.Load(outputPath);
+                        if (config is not null)
+                        {
+                            config.Channel = inputs.Channel;
+                            config.Save(outputPath);
+                        }
                     }
 
                     return new TemplateResult(ExitCodeConstants.Success, outputPath);

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/api/src/index.ts
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/api/src/index.ts
@@ -1,5 +1,9 @@
 import express from "express";
+import { existsSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const app = express();
 const port = process.env.PORT || 5000;
 
@@ -20,6 +24,13 @@ app.get("/api/weatherforecast", (_req, res) => {
 app.get("/health", (_req, res) => {
   res.send("Healthy");
 });
+
+// Serve static files from the "static" directory if it exists (used in publish/deploy mode
+// when the frontend's build output is bundled into this container via publishWithContainerFiles)
+const staticDir = join(__dirname, "..", "static");
+if (existsSync(staticDir)) {
+  app.use(express.static(staticDir));
+}
 
 app.listen(port, () => {
   console.log(`API server listening on port ${port}`);

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/api/src/index.ts
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/api/src/index.ts
@@ -1,9 +1,7 @@
 import express from "express";
 import { existsSync } from "fs";
-import { join, dirname } from "path";
-import { fileURLToPath } from "url";
+import { join } from "path";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
 const app = express();
 const port = process.env.PORT || 5000;
 
@@ -27,7 +25,7 @@ app.get("/health", (_req, res) => {
 
 // Serve static files from the "static" directory if it exists (used in publish/deploy mode
 // when the frontend's build output is bundled into this container via publishWithContainerFiles)
-const staticDir = join(__dirname, "..", "static");
+const staticDir = join(import.meta.dirname, "..", "static");
 if (existsSync(staticDir)) {
   app.use(express.static(staticDir));
 }

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/apphost.ts
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/apphost.ts
@@ -4,7 +4,8 @@ const builder = await createBuilder();
 
 const api = await builder
     .addNodeApp("api", "./api", "src/index.ts")
-    .withHttpEndpoint({ env: "PORT" });
+    .withHttpEndpoint({ env: "PORT" })
+    .withExternalHttpEndpoints();
 
 const frontend = await builder
     .addViteApp("frontend", "./frontend")

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/apphost.ts
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/apphost.ts
@@ -2,16 +2,16 @@ import { createBuilder } from './.modules/aspire.js';
 
 const builder = await createBuilder();
 
-const api = await builder
-    .addNodeApp("api", "./api", "src/index.ts")
+const app = await builder
+    .addNodeApp("app", "./api", "src/index.ts")
     .withHttpEndpoint({ env: "PORT" })
     .withExternalHttpEndpoints();
 
 const frontend = await builder
     .addViteApp("frontend", "./frontend")
-    .withServiceReference(api)
-    .waitFor(api);
+    .withServiceReference(app)
+    .waitFor(app);
 
-api.publishWithContainerFiles(frontend, "./static");
+app.publishWithContainerFiles(frontend, "./static");
 
 await builder.build().run();

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/apphost.ts
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/apphost.ts
@@ -6,9 +6,11 @@ const api = await builder
     .addNodeApp("api", "./api", "src/index.ts")
     .withHttpEndpoint({ env: "PORT" });
 
-await builder
+const frontend = await builder
     .addViteApp("frontend", "./frontend")
     .withServiceReference(api)
     .waitFor(api);
+
+api.publishWithContainerFiles(frontend, "./static");
 
 await builder.build().run();

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/apphost.ts
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/apphost.ts
@@ -12,6 +12,6 @@ const frontend = await builder
     .withServiceReference(app)
     .waitFor(app);
 
-app.publishWithContainerFiles(frontend, "./static");
+await app.publishWithContainerFiles(frontend, "./static");
 
 await builder.build().run();

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/frontend/vite.config.ts
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/frontend/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     proxy: {
       // Proxy API calls to the Express service
       '/api': {
-        target: process.env.API_HTTPS || process.env.API_HTTP,
+        target: process.env.APP_HTTPS || process.env.APP_HTTP,
         changeOrigin: true
       }
     }

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -1403,6 +1403,7 @@ public static class ResourceBuilderExtensions
     /// <param name="builder">The resource builder to which container files will be copied to.</param>
     /// <param name="source">The resource which contains the container files to be copied.</param>
     /// <param name="destinationPath">The destination path within the resource's container where the files will be copied.</param>
+    [AspireExport("publishWithContainerFiles", Description = "Configures the resource to copy container files from the specified source during publishing")]
     public static IResourceBuilder<T> PublishWithContainerFiles<T>(
          this IResourceBuilder<T> builder,
          IResourceBuilder<IResourceWithContainerFiles> source,

--- a/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptExpressDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/TypeScriptExpressDeploymentTests.cs
@@ -1,0 +1,277 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Tests.Utils;
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests for deploying TypeScript Express/React Aspire applications to Azure Container Apps.
+/// </summary>
+public sealed class TypeScriptExpressDeploymentTests(ITestOutputHelper output)
+{
+    // Timeout set to 40 minutes to allow for Azure provisioning and npm install.
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(40);
+
+    [Fact]
+    public async Task DeployTypeScriptExpressTemplateToAzureContainerApps()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+        var cancellationToken = linkedCts.Token;
+
+        await DeployTypeScriptExpressTemplateToAzureContainerAppsCore(cancellationToken);
+    }
+
+    private async Task DeployTypeScriptExpressTemplateToAzureContainerAppsCore(CancellationToken cancellationToken)
+    {
+        // Validate prerequisites
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var startTime = DateTime.UtcNow;
+        var deploymentUrls = new Dictionary<string, string>();
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("ts-express");
+        var projectName = "TsExpressApp";
+
+        output.WriteLine($"Test: {nameof(DeployTypeScriptExpressTemplateToAzureContainerApps)}");
+        output.WriteLine($"Project Name: {projectName}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            // Pattern searchers for aspire new interactive prompts
+            var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
+                .FindPattern("> Starter App");
+
+            // Use Find() for literal string with parentheses/slashes
+            var waitingForExpressReactTemplateSelected = new CellPatternSearcher()
+                .Find("> Starter App (Express/React)");
+
+            var waitingForProjectNamePrompt = new CellPatternSearcher()
+                .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
+
+            var waitingForOutputPathPrompt = new CellPatternSearcher()
+                .Find("Enter the output path:");
+
+            var waitingForUrlsPrompt = new CellPatternSearcher()
+                .Find("Use *.dev.localhost URLs");
+
+            // Pattern searchers for aspire add prompts
+            var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
+                .Find("(based on NuGet.config)");
+
+            // Pattern searcher for deployment success
+            var waitingForPipelineSucceeded = new CellPatternSearcher()
+                .Find("PIPELINE SUCCEEDED");
+
+            var counter = new SequenceCounter();
+            var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+            // Step 1: Prepare environment
+            output.WriteLine("Step 1: Preparing environment...");
+            sequenceBuilder.PrepareEnvironment(workspace, counter);
+
+            // Step 2: Set up CLI environment (in CI)
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                output.WriteLine("Step 2: Using pre-installed Aspire CLI from local build...");
+                sequenceBuilder.SourceAspireCliEnvironment(counter);
+            }
+
+            // Step 3: Create TypeScript Express/React project using aspire new
+            // Navigate down to "Starter App (Express/React)" which is the 4th option
+            output.WriteLine("Step 3: Creating TypeScript Express/React project...");
+            sequenceBuilder.Type("aspire new")
+                .Enter()
+                .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
+                .Key(Hex1b.Input.Hex1bKey.DownArrow)
+                .Key(Hex1b.Input.Hex1bKey.DownArrow)
+                .Key(Hex1b.Input.Hex1bKey.DownArrow)
+                .WaitUntil(s => waitingForExpressReactTemplateSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
+                .Enter() // Select Starter App (Express/React)
+                .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
+                .Type(projectName)
+                .Enter()
+                .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+                .Enter() // Accept default output path
+                .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+                .Enter() // Select "No" for localhost URLs (default)
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+
+            // Step 4: Navigate to project directory
+            output.WriteLine("Step 4: Navigating to project directory...");
+            sequenceBuilder
+                .Type($"cd {projectName}")
+                .Enter()
+                .WaitForSuccessPrompt(counter);
+
+            // Step 5: Add Aspire.Hosting.Azure.AppContainers package
+            output.WriteLine("Step 5: Adding Azure Container Apps hosting package...");
+            sequenceBuilder.Type("aspire add Aspire.Hosting.Azure.AppContainers")
+                .Enter();
+
+            // In CI, aspire add shows a version selection prompt
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                sequenceBuilder
+                    .WaitUntil(s => waitingForAddVersionSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
+                    .Enter(); // select first version (PR build)
+            }
+
+            sequenceBuilder.WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(180));
+
+            // Step 6: Modify apphost.ts to add Azure Container App Environment for deployment
+            sequenceBuilder.ExecuteCallback(() =>
+            {
+                var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+                var appHostFilePath = Path.Combine(projectDir, "apphost.ts");
+
+                output.WriteLine($"Looking for apphost.ts at: {appHostFilePath}");
+
+                var content = File.ReadAllText(appHostFilePath);
+
+                // Add Azure Container App Environment before build().run()
+                // The template already has publishWithContainerFiles for bundling the frontend
+                content = content.Replace(
+                    "await builder.build().run();",
+                    """
+// Add Azure Container App Environment for deployment
+await builder.addAzureContainerAppEnvironment("infra");
+
+await builder.build().run();
+""");
+
+                File.WriteAllText(appHostFilePath, content);
+
+                output.WriteLine($"Modified apphost.ts at: {appHostFilePath}");
+            });
+
+            // Step 7: Set environment for deployment
+            sequenceBuilder.Type($"unset ASPIRE_PLAYGROUND && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}")
+                .Enter()
+                .WaitForSuccessPrompt(counter);
+
+            // Step 8: Deploy to Azure Container Apps using aspire deploy
+            output.WriteLine("Step 8: Starting Azure Container Apps deployment...");
+            sequenceBuilder
+                .Type("aspire deploy --clear-cache")
+                .Enter()
+                .WaitUntil(s => waitingForPipelineSucceeded.Search(s).Count > 0, TimeSpan.FromMinutes(30))
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
+
+            // Step 9: Extract deployment URLs and verify endpoints with retry
+            output.WriteLine("Step 9: Verifying deployed endpoints...");
+            sequenceBuilder
+                .Type($"RG_NAME=\"{resourceGroupName}\" && " +
+                      "echo \"Resource group: $RG_NAME\" && " +
+                      "if ! az group show -n \"$RG_NAME\" &>/dev/null; then echo \"❌ Resource group not found\"; exit 1; fi && " +
+                      "urls=$(az containerapp list -g \"$RG_NAME\" --query \"[].properties.configuration.ingress.fqdn\" -o tsv 2>/dev/null | grep -v '\\.internal\\.') && " +
+                      "if [ -z \"$urls\" ]; then echo \"❌ No external container app endpoints found\"; exit 1; fi && " +
+                      "failed=0 && " +
+                      "for url in $urls; do " +
+                      "echo \"Checking https://$url...\"; " +
+                      "success=0; " +
+                      "for i in $(seq 1 18); do " +
+                      "STATUS=$(curl -s -o /dev/null -w \"%{http_code}\" \"https://$url\" --max-time 10 2>/dev/null); " +
+                      "if [ \"$STATUS\" = \"200\" ] || [ \"$STATUS\" = \"302\" ]; then echo \"  ✅ $STATUS (attempt $i)\"; success=1; break; fi; " +
+                      "echo \"  Attempt $i: $STATUS, retrying in 10s...\"; sleep 10; " +
+                      "done; " +
+                      "if [ \"$success\" -eq 0 ]; then echo \"  ❌ Failed after 18 attempts\"; failed=1; fi; " +
+                      "done && " +
+                      "if [ \"$failed\" -ne 0 ]; then echo \"❌ One or more endpoint checks failed\"; exit 1; fi")
+                .Enter()
+                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+
+            // Step 10: Exit terminal
+            sequenceBuilder
+                .Type("exit")
+                .Enter();
+
+            var sequence = sequenceBuilder.Build();
+            await sequence.ApplyAsync(terminal, cancellationToken);
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"Deployment completed in {duration}");
+
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployTypeScriptExpressTemplateToAzureContainerApps),
+                resourceGroupName,
+                deploymentUrls,
+                duration);
+
+            output.WriteLine("✅ Test passed!");
+        }
+        catch (Exception ex)
+        {
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"❌ Test failed after {duration}: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployTypeScriptExpressTemplateToAzureContainerApps),
+                resourceGroupName,
+                ex.Message,
+                ex.StackTrace);
+
+            throw;
+        }
+        finally
+        {
+            output.WriteLine($"Triggering cleanup of resource group: {resourceGroupName}");
+            TriggerCleanupResourceGroup(resourceGroupName, output);
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Cleanup triggered (fire-and-forget)");
+        }
+    }
+
+    private static void TriggerCleanupResourceGroup(string resourceGroupName, ITestOutputHelper output)
+    {
+        var process = new System.Diagnostics.Process
+        {
+            StartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "az",
+                Arguments = $"group delete --name {resourceGroupName} --yes --no-wait",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        try
+        {
+            process.Start();
+            output.WriteLine($"Cleanup triggered for resource group: {resourceGroupName}");
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Failed to trigger cleanup: {ex.Message}");
+        }
+    }
+}

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -2141,6 +2141,18 @@ func (s *IConfiguration) GetConnectionString(name string) (*string, error) {
 	return result.(*string), nil
 }
 
+// IContainerFilesDestinationResource wraps a handle for Aspire.Hosting/Aspire.Hosting.ApplicationModel.IContainerFilesDestinationResource.
+type IContainerFilesDestinationResource struct {
+	HandleWrapperBase
+}
+
+// NewIContainerFilesDestinationResource creates a new IContainerFilesDestinationResource.
+func NewIContainerFilesDestinationResource(handle *Handle, client *AspireClient) *IContainerFilesDestinationResource {
+	return &IContainerFilesDestinationResource{
+		HandleWrapperBase: NewHandleWrapperBase(handle, client),
+	}
+}
+
 // IDistributedApplicationBuilder wraps a handle for Aspire.Hosting/Aspire.Hosting.IDistributedApplicationBuilder.
 type IDistributedApplicationBuilder struct {
 	HandleWrapperBase
@@ -2415,6 +2427,18 @@ type IResourceWithConnectionString struct {
 // NewIResourceWithConnectionString creates a new IResourceWithConnectionString.
 func NewIResourceWithConnectionString(handle *Handle, client *AspireClient) *IResourceWithConnectionString {
 	return &IResourceWithConnectionString{
+		ResourceBuilderBase: NewResourceBuilderBase(handle, client),
+	}
+}
+
+// IResourceWithContainerFiles wraps a handle for Aspire.Hosting/Aspire.Hosting.IResourceWithContainerFiles.
+type IResourceWithContainerFiles struct {
+	ResourceBuilderBase
+}
+
+// NewIResourceWithContainerFiles creates a new IResourceWithContainerFiles.
+func NewIResourceWithContainerFiles(handle *Handle, client *AspireClient) *IResourceWithContainerFiles {
+	return &IResourceWithContainerFiles{
 		ResourceBuilderBase: NewResourceBuilderBase(handle, client),
 	}
 }
@@ -3208,6 +3232,20 @@ func (s *ProjectResource) WithUrlForEndpointFactory(endpointName string, callbac
 		return nil, err
 	}
 	return result.(*IResourceWithEndpoints), nil
+}
+
+// PublishWithContainerFiles configures the resource to copy container files from the specified source during publishing
+func (s *ProjectResource) PublishWithContainerFiles(source *IResourceWithContainerFiles, destinationPath string) (*IContainerFilesDestinationResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["source"] = SerializeValue(source)
+	reqArgs["destinationPath"] = SerializeValue(destinationPath)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/publishWithContainerFiles", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*IContainerFilesDestinationResource), nil
 }
 
 // WaitFor waits for another resource to be ready
@@ -6594,6 +6632,9 @@ func init() {
 	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.IResourceWithServiceDiscovery", func(h *Handle, c *AspireClient) any {
 		return NewIResourceWithServiceDiscovery(h, c)
 	})
+	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.IResourceWithContainerFiles", func(h *Handle, c *AspireClient) any {
+		return NewIResourceWithContainerFiles(h, c)
+	})
 	RegisterHandleWrapper("Aspire.Hosting.CodeGeneration.Go.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestCallbackContext", func(h *Handle, c *AspireClient) any {
 		return NewTestCallbackContext(h, c)
 	})
@@ -6617,6 +6658,9 @@ func init() {
 	})
 	RegisterHandleWrapper("Aspire.Hosting.CodeGeneration.Go.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.ITestVaultResource", func(h *Handle, c *AspireClient) any {
 		return NewITestVaultResource(h, c)
+	})
+	RegisterHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IContainerFilesDestinationResource", func(h *Handle, c *AspireClient) any {
+		return NewIContainerFilesDestinationResource(h, c)
 	})
 	RegisterHandleWrapper("Aspire.Hosting/Dict<string,any>", func(h *Handle, c *AspireClient) any {
 		return &AspireDict[any, any]{HandleWrapperBase: NewHandleWrapperBase(h, c)}

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -1780,6 +1780,14 @@ class IConfiguration extends HandleWrapperBase {
 
 }
 
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.IContainerFilesDestinationResource. */
+class IContainerFilesDestinationResource extends HandleWrapperBase {
+    IContainerFilesDestinationResource(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+}
+
 /** Wrapper for Aspire.Hosting/Aspire.Hosting.IDistributedApplicationBuilder. */
 class IDistributedApplicationBuilder extends HandleWrapperBase {
     IDistributedApplicationBuilder(Handle handle, AspireClient client) {
@@ -1960,6 +1968,14 @@ class IResourceWithArgs extends ResourceBuilderBase {
 /** Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithConnectionString. */
 class IResourceWithConnectionString extends ResourceBuilderBase {
     IResourceWithConnectionString(Handle handle, AspireClient client) {
+        super(handle, client);
+    }
+
+}
+
+/** Wrapper for Aspire.Hosting/Aspire.Hosting.IResourceWithContainerFiles. */
+class IResourceWithContainerFiles extends ResourceBuilderBase {
+    IResourceWithContainerFiles(Handle handle, AspireClient client) {
         super(handle, client);
     }
 
@@ -2530,6 +2546,15 @@ class ProjectResource extends ResourceBuilderBase {
             reqArgs.put("callback", getClient().registerCallback(callback));
         }
         return (IResourceWithEndpoints) getClient().invokeCapability("Aspire.Hosting/withUrlForEndpointFactory", reqArgs);
+    }
+
+    /** Configures the resource to copy container files from the specified source during publishing */
+    public IContainerFilesDestinationResource publishWithContainerFiles(IResourceWithContainerFiles source, String destinationPath) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("source", AspireClient.serializeValue(source));
+        reqArgs.put("destinationPath", AspireClient.serializeValue(destinationPath));
+        return (IContainerFilesDestinationResource) getClient().invokeCapability("Aspire.Hosting/publishWithContainerFiles", reqArgs);
     }
 
     /** Waits for another resource to be ready */
@@ -4921,6 +4946,7 @@ class AspireRegistrations {
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext", (h, c) -> new ExecuteCommandContext(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceUrlsCallbackContext", (h, c) -> new ResourceUrlsCallbackContext(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.IResourceWithServiceDiscovery", (h, c) -> new IResourceWithServiceDiscovery(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.IResourceWithContainerFiles", (h, c) -> new IResourceWithContainerFiles(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting.CodeGeneration.Java.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestCallbackContext", (h, c) -> new TestCallbackContext(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting.CodeGeneration.Java.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestResourceContext", (h, c) -> new TestResourceContext(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting.CodeGeneration.Java.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestEnvironmentContext", (h, c) -> new TestEnvironmentContext(h, c));
@@ -4929,6 +4955,7 @@ class AspireRegistrations {
         AspireClient.registerHandleWrapper("Aspire.Hosting.CodeGeneration.Java.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestDatabaseResource", (h, c) -> new TestDatabaseResource(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting.CodeGeneration.Java.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestVaultResource", (h, c) -> new TestVaultResource(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting.CodeGeneration.Java.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.ITestVaultResource", (h, c) -> new ITestVaultResource(h, c));
+        AspireClient.registerHandleWrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IContainerFilesDestinationResource", (h, c) -> new IContainerFilesDestinationResource(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Dict<string,any>", (h, c) -> new AspireDict(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/List<any>", (h, c) -> new AspireList(h, c));
         AspireClient.registerHandleWrapper("Aspire.Hosting/Dict<string,string|Aspire.Hosting/Aspire.Hosting.ApplicationModel.ReferenceExpression>", (h, c) -> new AspireDict(h, c));

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -1192,6 +1192,12 @@ class IConfiguration(HandleWrapperBase):
         return self._client.invoke_capability("Aspire.Hosting/getConnectionString", args)
 
 
+class IContainerFilesDestinationResource(HandleWrapperBase):
+    def __init__(self, handle: Handle, client: AspireClient):
+        super().__init__(handle, client)
+
+    pass
+
 class IDistributedApplicationBuilder(HandleWrapperBase):
     def __init__(self, handle: Handle, client: AspireClient):
         super().__init__(handle, client)
@@ -1322,6 +1328,12 @@ class IResourceWithArgs(ResourceBuilderBase):
     pass
 
 class IResourceWithConnectionString(ResourceBuilderBase):
+    def __init__(self, handle: Handle, client: AspireClient):
+        super().__init__(handle, client)
+
+    pass
+
+class IResourceWithContainerFiles(ResourceBuilderBase):
     def __init__(self, handle: Handle, client: AspireClient):
         super().__init__(handle, client)
 
@@ -1743,6 +1755,13 @@ class ProjectResource(ResourceBuilderBase):
         if callback_id is not None:
             args["callback"] = callback_id
         return self._client.invoke_capability("Aspire.Hosting/withUrlForEndpointFactory", args)
+
+    def publish_with_container_files(self, source: IResourceWithContainerFiles, destination_path: str) -> IContainerFilesDestinationResource:
+        """Configures the resource to copy container files from the specified source during publishing"""
+        args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
+        args["source"] = serialize_value(source)
+        args["destinationPath"] = serialize_value(destination_path)
+        return self._client.invoke_capability("Aspire.Hosting/publishWithContainerFiles", args)
 
     def wait_for(self, dependency: IResource) -> IResourceWithWaitSupport:
         """Waits for another resource to be ready"""
@@ -3530,6 +3549,7 @@ register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.UpdateCo
 register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext", lambda handle, client: ExecuteCommandContext(handle, client))
 register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceUrlsCallbackContext", lambda handle, client: ResourceUrlsCallbackContext(handle, client))
 register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.IResourceWithServiceDiscovery", lambda handle, client: IResourceWithServiceDiscovery(handle, client))
+register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.IResourceWithContainerFiles", lambda handle, client: IResourceWithContainerFiles(handle, client))
 register_handle_wrapper("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestCallbackContext", lambda handle, client: TestCallbackContext(handle, client))
 register_handle_wrapper("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestResourceContext", lambda handle, client: TestResourceContext(handle, client))
 register_handle_wrapper("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestEnvironmentContext", lambda handle, client: TestEnvironmentContext(handle, client))
@@ -3538,6 +3558,7 @@ register_handle_wrapper("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosti
 register_handle_wrapper("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestDatabaseResource", lambda handle, client: TestDatabaseResource(handle, client))
 register_handle_wrapper("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestVaultResource", lambda handle, client: TestVaultResource(handle, client))
 register_handle_wrapper("Aspire.Hosting.CodeGeneration.Python.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.ITestVaultResource", lambda handle, client: ITestVaultResource(handle, client))
+register_handle_wrapper("Aspire.Hosting/Aspire.Hosting.ApplicationModel.IContainerFilesDestinationResource", lambda handle, client: IContainerFilesDestinationResource(handle, client))
 register_handle_wrapper("Aspire.Hosting/Dict<string,any>", lambda handle, client: AspireDict(handle, client))
 register_handle_wrapper("Aspire.Hosting/List<any>", lambda handle, client: AspireList(handle, client))
 register_handle_wrapper("Aspire.Hosting/Dict<string,string|Aspire.Hosting/Aspire.Hosting.ApplicationModel.ReferenceExpression>", lambda handle, client: AspireDict(handle, client))

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -2241,6 +2241,32 @@ impl IConfiguration {
     }
 }
 
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.ApplicationModel.IContainerFilesDestinationResource
+pub struct IContainerFilesDestinationResource {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for IContainerFilesDestinationResource {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl IContainerFilesDestinationResource {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+}
+
 /// Wrapper for Aspire.Hosting/Aspire.Hosting.IDistributedApplicationBuilder
 pub struct IDistributedApplicationBuilder {
     handle: Handle,
@@ -2581,6 +2607,32 @@ impl HasHandle for IResourceWithConnectionString {
 }
 
 impl IResourceWithConnectionString {
+    pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
+        Self { handle, client }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn client(&self) -> &Arc<AspireClient> {
+        &self.client
+    }
+}
+
+/// Wrapper for Aspire.Hosting/Aspire.Hosting.IResourceWithContainerFiles
+pub struct IResourceWithContainerFiles {
+    handle: Handle,
+    client: Arc<AspireClient>,
+}
+
+impl HasHandle for IResourceWithContainerFiles {
+    fn handle(&self) -> &Handle {
+        &self.handle
+    }
+}
+
+impl IResourceWithContainerFiles {
     pub fn new(handle: Handle, client: Arc<AspireClient>) -> Self {
         Self { handle, client }
     }
@@ -3400,6 +3452,17 @@ impl ProjectResource {
         let result = self.client.invoke_capability("Aspire.Hosting/withUrlForEndpointFactory", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEndpoints::new(handle, self.client.clone()))
+    }
+
+    /// Configures the resource to copy container files from the specified source during publishing
+    pub fn publish_with_container_files(&self, source: &IResourceWithContainerFiles, destination_path: &str) -> Result<IContainerFilesDestinationResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("source".to_string(), source.handle().to_json());
+        args.insert("destinationPath".to_string(), serde_json::to_value(&destination_path).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/publishWithContainerFiles", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(IContainerFilesDestinationResource::new(handle, self.client.clone()))
     }
 
     /// Waits for another resource to be ready

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -71,6 +71,9 @@ type ExecutableResourceHandle = Handle<'Aspire.Hosting/Aspire.Hosting.Applicatio
 /** Handle to ExecuteCommandContext */
 type ExecuteCommandContextHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecuteCommandContext'>;
 
+/** Handle to IContainerFilesDestinationResource */
+type IContainerFilesDestinationResourceHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.IContainerFilesDestinationResource'>;
+
 /** Handle to IResource */
 type IResourceHandle = Handle<'Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResource'>;
 
@@ -121,6 +124,9 @@ type IDistributedApplicationEventingHandle = Handle<'Aspire.Hosting/Aspire.Hosti
 
 /** Handle to IDistributedApplicationBuilder */
 type IDistributedApplicationBuilderHandle = Handle<'Aspire.Hosting/Aspire.Hosting.IDistributedApplicationBuilder'>;
+
+/** Handle to IResourceWithContainerFiles */
+type IResourceWithContainerFilesHandle = Handle<'Aspire.Hosting/Aspire.Hosting.IResourceWithContainerFiles'>;
 
 /** Handle to IResourceWithServiceDiscovery */
 type IResourceWithServiceDiscoveryHandle = Handle<'Aspire.Hosting/Aspire.Hosting.IResourceWithServiceDiscovery'>;
@@ -4555,6 +4561,21 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
+    private async _publishWithContainerFilesInternal(source: ResourceBuilderBase, destinationPath: string): Promise<ProjectResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, source, destinationPath };
+        const result = await this._client.invokeCapability<ProjectResourceHandle>(
+            'Aspire.Hosting/publishWithContainerFiles',
+            rpcArgs
+        );
+        return new ProjectResource(result, this._client);
+    }
+
+    /** Configures the resource to copy container files from the specified source during publishing */
+    publishWithContainerFiles(source: ResourceBuilderBase, destinationPath: string): ProjectResourcePromise {
+        return new ProjectResourcePromise(this._publishWithContainerFilesInternal(source, destinationPath));
+    }
+
+    /** @internal */
     private async _waitForInternal(dependency: ResourceBuilderBase): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
@@ -5058,6 +5079,11 @@ export class ProjectResourcePromise implements PromiseLike<ProjectResource> {
     /** Adds a URL for a specific endpoint via factory callback */
     withUrlForEndpointFactory(endpointName: string, callback: (arg: EndpointReference) => Promise<ResourceUrlAnnotation>): ProjectResourcePromise {
         return new ProjectResourcePromise(this._promise.then(obj => obj.withUrlForEndpointFactory(endpointName, callback)));
+    }
+
+    /** Configures the resource to copy container files from the specified source during publishing */
+    publishWithContainerFiles(source: ResourceBuilderBase, destinationPath: string): ProjectResourcePromise {
+        return new ProjectResourcePromise(this._promise.then(obj => obj.publishWithContainerFiles(source, destinationPath)));
     }
 
     /** Waits for another resource to be ready */
@@ -9111,6 +9137,54 @@ export class TestVaultResourcePromise implements PromiseLike<TestVaultResource> 
 }
 
 // ============================================================================
+// ContainerFilesDestinationResource
+// ============================================================================
+
+export class ContainerFilesDestinationResource extends ResourceBuilderBase<IContainerFilesDestinationResourceHandle> {
+    constructor(handle: IContainerFilesDestinationResourceHandle, client: AspireClientRpc) {
+        super(handle, client);
+    }
+
+    /** @internal */
+    private async _publishWithContainerFilesInternal(source: ResourceBuilderBase, destinationPath: string): Promise<ContainerFilesDestinationResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, source, destinationPath };
+        const result = await this._client.invokeCapability<IContainerFilesDestinationResourceHandle>(
+            'Aspire.Hosting/publishWithContainerFiles',
+            rpcArgs
+        );
+        return new ContainerFilesDestinationResource(result, this._client);
+    }
+
+    /** Configures the resource to copy container files from the specified source during publishing */
+    publishWithContainerFiles(source: ResourceBuilderBase, destinationPath: string): ContainerFilesDestinationResourcePromise {
+        return new ContainerFilesDestinationResourcePromise(this._publishWithContainerFilesInternal(source, destinationPath));
+    }
+
+}
+
+/**
+ * Thenable wrapper for ContainerFilesDestinationResource that enables fluent chaining.
+ * @example
+ * await builder.addSomething().withX().withY();
+ */
+export class ContainerFilesDestinationResourcePromise implements PromiseLike<ContainerFilesDestinationResource> {
+    constructor(private _promise: Promise<ContainerFilesDestinationResource>) {}
+
+    then<TResult1 = ContainerFilesDestinationResource, TResult2 = never>(
+        onfulfilled?: ((value: ContainerFilesDestinationResource) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    /** Configures the resource to copy container files from the specified source during publishing */
+    publishWithContainerFiles(source: ResourceBuilderBase, destinationPath: string): ContainerFilesDestinationResourcePromise {
+        return new ContainerFilesDestinationResourcePromise(this._promise.then(obj => obj.publishWithContainerFiles(source, destinationPath)));
+    }
+
+}
+
+// ============================================================================
 // Resource
 // ============================================================================
 
@@ -9804,6 +9878,34 @@ export class ResourceWithConnectionStringPromise implements PromiseLike<Resource
 }
 
 // ============================================================================
+// ResourceWithContainerFiles
+// ============================================================================
+
+export class ResourceWithContainerFiles extends ResourceBuilderBase<IResourceWithContainerFilesHandle> {
+    constructor(handle: IResourceWithContainerFilesHandle, client: AspireClientRpc) {
+        super(handle, client);
+    }
+
+}
+
+/**
+ * Thenable wrapper for ResourceWithContainerFiles that enables fluent chaining.
+ * @example
+ * await builder.addSomething().withX().withY();
+ */
+export class ResourceWithContainerFilesPromise implements PromiseLike<ResourceWithContainerFiles> {
+    constructor(private _promise: Promise<ResourceWithContainerFiles>) {}
+
+    then<TResult1 = ResourceWithContainerFiles, TResult2 = never>(
+        onfulfilled?: ((value: ResourceWithContainerFiles) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+}
+
+// ============================================================================
 // ResourceWithEndpoints
 // ============================================================================
 
@@ -10464,9 +10566,11 @@ registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ProjectRes
 registerHandleWrapper('Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestDatabaseResource', (handle, client) => new TestDatabaseResource(handle as TestDatabaseResourceHandle, client));
 registerHandleWrapper('Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestRedisResource', (handle, client) => new TestRedisResource(handle as TestRedisResourceHandle, client));
 registerHandleWrapper('Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestVaultResource', (handle, client) => new TestVaultResource(handle as TestVaultResourceHandle, client));
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IContainerFilesDestinationResource', (handle, client) => new ContainerFilesDestinationResource(handle as IContainerFilesDestinationResourceHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResource', (handle, client) => new Resource(handle as IResourceHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithArgs', (handle, client) => new ResourceWithArgs(handle as IResourceWithArgsHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithConnectionString', (handle, client) => new ResourceWithConnectionString(handle as IResourceWithConnectionStringHandle, client));
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.IResourceWithContainerFiles', (handle, client) => new ResourceWithContainerFiles(handle as IResourceWithContainerFilesHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEndpoints', (handle, client) => new ResourceWithEndpoints(handle as IResourceWithEndpointsHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment', (handle, client) => new ResourceWithEnvironment(handle as IResourceWithEnvironmentHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.IResourceWithServiceDiscovery', (handle, client) => new ResourceWithServiceDiscovery(handle as IResourceWithServiceDiscoveryHandle, client));


### PR DESCRIPTION
## Description

Add a TypeScript Express/React deployment E2E test and update the ts-starter template for deployment readiness.

**Changes:**

1. **TypeScript deployment E2E test** (`TypeScriptExpressDeploymentTests.cs`) — follows the same pattern as `PythonFastApiDeploymentTests`:
   - Creates a project via `aspire new` (Express/React template)
   - Adds `Aspire.Hosting.Azure.AppContainers` via `aspire add`
   - Modifies `apphost.ts` to add `addAzureContainerAppEnvironment`
   - Deploys to Azure Container Apps via `aspire deploy`
   - Verifies deployed endpoints return 200/302

2. **Template updates for deployment support:**
   - `apphost.ts`: Renamed resource from `api` to `app` for consistency with Python template. Capture `frontend` variable and add `await app.publishWithContainerFiles(frontend, "./static")` so the Vite frontend build output is bundled into the Express API container during publish. Added `withExternalHttpEndpoints()` so the API is publicly accessible when deployed.
   - `api/src/index.ts`: Serve static files from `./static` directory when present (deploy mode), using `import.meta.dirname` (Node 22+)

3. **Export `PublishWithContainerFiles` for polyglot apphosts** — Added `[AspireExport]` attribute to `ResourceBuilderExtensions.PublishWithContainerFiles` so TypeScript/Python apphosts can use it via ATS codegen. This exposes the existing public API to the polyglot SDK generation pipeline.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
