### PR TITLE
Consolidate CLI configuration into aspire.config.json

### DIFF
--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -92,9 +92,9 @@ internal sealed class AddCommand : BaseCommand
 
             var source = parseResult.GetValue(s_sourceOption);
 
-            // For non-.NET projects, read the channel from settings.json if available.
-            // Unlike .NET projects which have a nuget.config, polyglot apphosts store
-            // the channel in .aspire/settings.json during the build process.
+            // For non-.NET projects, read the channel from the local Aspire configuration if available.
+            // Unlike .NET projects which have a nuget.config, polyglot apphosts persist the channel
+            // in aspire.config.json (or the legacy settings.json during migration).
             string? configuredChannel = null;
             if (project.LanguageId != KnownLanguageId.CSharp)
             {
@@ -102,8 +102,8 @@ internal sealed class AddCommand : BaseCommand
                 var isProjectReferenceMode = AspireRepositoryDetector.DetectRepositoryRoot(appHostDirectory) is not null;
                 if (!isProjectReferenceMode)
                 {
-                    var settings = AspireJsonConfiguration.Load(appHostDirectory);
-                    configuredChannel = settings?.Channel;
+                    configuredChannel = AspireConfigFile.Load(appHostDirectory)?.Channel
+                        ?? AspireJsonConfiguration.Load(appHostDirectory)?.Channel;
                 }
             }
 

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -102,6 +102,8 @@ internal sealed class AddCommand : BaseCommand
                 var isProjectReferenceMode = AspireRepositoryDetector.DetectRepositoryRoot(appHostDirectory) is not null;
                 if (!isProjectReferenceMode)
                 {
+                    // TODO: Remove legacy AspireJsonConfiguration fallback once confident most users
+                    // have migrated. Tracked by https://github.com/dotnet/aspire/issues/15239
                     configuredChannel = AspireConfigFile.Load(appHostDirectory)?.Channel
                         ?? AspireJsonConfiguration.Load(appHostDirectory)?.Channel;
                 }

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using System.Globalization;
+using System.Text.Json;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
@@ -109,7 +110,7 @@ internal sealed class AddCommand : BaseCommand
                         configuredChannel = AspireConfigFile.Load(appHostDirectory)?.Channel
                             ?? AspireJsonConfiguration.Load(appHostDirectory)?.Channel;
                     }
-                    catch (InvalidOperationException ex)
+                    catch (JsonException ex)
                     {
                         InteractionService.DisplayError(ex.Message);
                         return ExitCodeConstants.FailedToLoadConfiguration;

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -104,8 +104,16 @@ internal sealed class AddCommand : BaseCommand
                 {
                     // TODO: Remove legacy AspireJsonConfiguration fallback once confident most users
                     // have migrated. Tracked by https://github.com/dotnet/aspire/issues/15239
-                    configuredChannel = AspireConfigFile.Load(appHostDirectory)?.Channel
-                        ?? AspireJsonConfiguration.Load(appHostDirectory)?.Channel;
+                    try
+                    {
+                        configuredChannel = AspireConfigFile.Load(appHostDirectory)?.Channel
+                            ?? AspireJsonConfiguration.Load(appHostDirectory)?.Channel;
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        InteractionService.DisplayError(ex.Message);
+                        return ExitCodeConstants.FailedToLoadConfiguration;
+                    }
                 }
             }
 

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -585,7 +585,11 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
 
         // Create the apphost project using the scaffolding service
         var context = new ScaffoldContext(language, workingDirectory, ProjectName: null);
-        await _scaffoldingService.ScaffoldAsync(context, cancellationToken);
+        var scaffolded = await _scaffoldingService.ScaffoldAsync(context, cancellationToken);
+        if (!scaffolded)
+        {
+            return ExitCodeConstants.FailedToCreateNewProject;
+        }
 
         InteractionService.DisplaySuccess($"Created {appHostFileName}");
         InteractionService.DisplayMessage(KnownEmojis.Information, $"Run 'aspire run' to start your AppHost.");

--- a/src/Aspire.Cli/Configuration/AspireConfigFile.cs
+++ b/src/Aspire.Cli/Configuration/AspireConfigFile.cs
@@ -90,6 +90,22 @@ internal sealed class AspireConfigFile
     }
 
     /// <summary>
+    /// Converts this AspireConfigFile back to an AspireJsonConfiguration for compatibility with existing code.
+    /// </summary>
+    public AspireJsonConfiguration ToLegacyConfiguration()
+    {
+        return new AspireJsonConfiguration
+        {
+            AppHostPath = AppHost?.Path,
+            Language = AppHost?.Language,
+            SdkVersion = Sdk?.Version,
+            Channel = Channel,
+            Features = Features,
+            Packages = Packages
+        };
+    }
+
+    /// <summary>
     /// Creates from a legacy AspireJsonConfiguration + apphost.run.json.
     /// </summary>
     public static AspireConfigFile FromLegacy(AspireJsonConfiguration? settings, Dictionary<string, AspireConfigProfile>? profiles)

--- a/src/Aspire.Cli/Configuration/AspireConfigFile.cs
+++ b/src/Aspire.Cli/Configuration/AspireConfigFile.cs
@@ -1,0 +1,169 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Aspire.Cli.Configuration;
+
+/// <summary>
+/// Represents the aspire.config.json configuration file.
+/// Consolidates apphost location, launch settings, and CLI config into one file.
+/// </summary>
+internal sealed class AspireConfigFile
+{
+    public const string FileName = "aspire.config.json";
+
+    /// <summary>
+    /// The JSON Schema URL for this configuration file.
+    /// </summary>
+    [JsonPropertyName("$schema")]
+    public string? Schema { get; set; }
+
+    /// <summary>
+    /// AppHost entry point configuration.
+    /// </summary>
+    [JsonPropertyName("appHost")]
+    public AspireConfigAppHost? AppHost { get; set; }
+
+    /// <summary>
+    /// Aspire SDK version configuration.
+    /// </summary>
+    [JsonPropertyName("sdk")]
+    public AspireConfigSdk? Sdk { get; set; }
+
+    /// <summary>
+    /// Aspire channel for package resolution.
+    /// </summary>
+    [JsonPropertyName("channel")]
+    public string? Channel { get; set; }
+
+    /// <summary>
+    /// Feature flags.
+    /// </summary>
+    [JsonPropertyName("features")]
+    public Dictionary<string, bool>? Features { get; set; }
+
+    /// <summary>
+    /// Launch profiles (ports, env vars). Replaces apphost.run.json.
+    /// </summary>
+    [JsonPropertyName("profiles")]
+    public Dictionary<string, AspireConfigProfile>? Profiles { get; set; }
+
+    /// <summary>
+    /// Package references for non-first-class languages.
+    /// </summary>
+    [JsonPropertyName("packages")]
+    public Dictionary<string, string>? Packages { get; set; }
+
+    /// <summary>
+    /// Loads aspire.config.json from the specified directory.
+    /// </summary>
+    public static AspireConfigFile? Load(string directory)
+    {
+        var filePath = Path.Combine(directory, FileName);
+        if (!File.Exists(filePath))
+        {
+            return null;
+        }
+
+        var json = File.ReadAllText(filePath);
+        return JsonSerializer.Deserialize(json, JsonSourceGenerationContext.Default.AspireConfigFile);
+    }
+
+    /// <summary>
+    /// Saves aspire.config.json to the specified directory.
+    /// </summary>
+    public void Save(string directory)
+    {
+        var filePath = Path.Combine(directory, FileName);
+        var json = JsonSerializer.Serialize(this, JsonSourceGenerationContext.Default.AspireConfigFile);
+        File.WriteAllText(filePath, json);
+    }
+
+    /// <summary>
+    /// Checks if aspire.config.json exists in the specified directory.
+    /// </summary>
+    public static bool Exists(string directory)
+    {
+        return File.Exists(Path.Combine(directory, FileName));
+    }
+
+    /// <summary>
+    /// Creates from a legacy AspireJsonConfiguration + apphost.run.json.
+    /// </summary>
+    public static AspireConfigFile FromLegacy(AspireJsonConfiguration? settings, Dictionary<string, AspireConfigProfile>? profiles)
+    {
+        var config = new AspireConfigFile();
+
+        if (settings is not null)
+        {
+            config.AppHost = new AspireConfigAppHost
+            {
+                Path = settings.AppHostPath,
+                Language = settings.Language
+            };
+
+            if (!string.IsNullOrEmpty(settings.SdkVersion))
+            {
+                config.Sdk = new AspireConfigSdk { Version = settings.SdkVersion };
+            }
+
+            config.Channel = settings.Channel;
+            config.Features = settings.Features;
+            config.Packages = settings.Packages;
+        }
+
+        config.Profiles = profiles;
+
+        return config;
+    }
+}
+
+/// <summary>
+/// AppHost entry point configuration within aspire.config.json.
+/// </summary>
+internal sealed class AspireConfigAppHost
+{
+    /// <summary>
+    /// Relative path to the AppHost entry point file.
+    /// </summary>
+    [JsonPropertyName("path")]
+    public string? Path { get; set; }
+
+    /// <summary>
+    /// Language identifier (e.g., "typescript/nodejs", "python").
+    /// </summary>
+    [JsonPropertyName("language")]
+    public string? Language { get; set; }
+}
+
+/// <summary>
+/// SDK version configuration within aspire.config.json.
+/// </summary>
+internal sealed class AspireConfigSdk
+{
+    /// <summary>
+    /// The Aspire SDK version.
+    /// </summary>
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
+}
+
+/// <summary>
+/// Launch profile within aspire.config.json.
+/// </summary>
+internal sealed class AspireConfigProfile
+{
+    /// <summary>
+    /// Application URLs (e.g., "https://localhost:17000;http://localhost:15000").
+    /// </summary>
+    [JsonPropertyName("applicationUrl")]
+    public string? ApplicationUrl { get; set; }
+
+    /// <summary>
+    /// Environment variables for this profile.
+    /// </summary>
+    [JsonPropertyName("environmentVariables")]
+    public Dictionary<string, string>? EnvironmentVariables { get; set; }
+}

--- a/src/Aspire.Cli/Configuration/AspireConfigFile.cs
+++ b/src/Aspire.Cli/Configuration/AspireConfigFile.cs
@@ -82,6 +82,121 @@ internal sealed class AspireConfigFile
     }
 
     /// <summary>
+    /// Loads aspire.config.json from the specified directory, falling back to legacy
+    /// .aspire/settings.json + apphost.run.json and migrating if needed.
+    /// </summary>
+    public static AspireConfigFile LoadOrCreate(string directory, string? defaultSdkVersion = null)
+    {
+        // Prefer aspire.config.json
+        var config = Load(directory);
+        if (config is not null)
+        {
+            if (defaultSdkVersion is not null)
+            {
+                config.Sdk ??= new AspireConfigSdk();
+                config.Sdk.Version ??= defaultSdkVersion;
+            }
+
+            return config;
+        }
+
+        // Fall back to .aspire/settings.json + apphost.run.json → migrate
+        var legacyConfig = AspireJsonConfiguration.Load(directory);
+        if (legacyConfig is not null)
+        {
+            var profiles = ReadApphostRunProfiles(Path.Combine(directory, "apphost.run.json"));
+            config = FromLegacy(legacyConfig, profiles);
+
+            // Persist the migrated config (legacy files are kept for older CLI versions)
+            config.Save(directory);
+        }
+        else
+        {
+            config = new AspireConfigFile();
+        }
+
+        if (defaultSdkVersion is not null)
+        {
+            config.Sdk ??= new AspireConfigSdk();
+            config.Sdk.Version ??= defaultSdkVersion;
+        }
+
+        return config;
+    }
+
+    /// <summary>
+    /// Saves an <see cref="AspireJsonConfiguration"/> to aspire.config.json, merging with any
+    /// existing aspire.config.json content in the specified directory.
+    /// </summary>
+    public static void SaveFromLegacy(string directory, AspireJsonConfiguration config)
+    {
+        var aspireConfig = Load(directory) ?? new AspireConfigFile();
+        aspireConfig.AppHost ??= new AspireConfigAppHost();
+        aspireConfig.AppHost.Path = config.AppHostPath;
+        aspireConfig.AppHost.Language = config.Language;
+        aspireConfig.Sdk = !string.IsNullOrEmpty(config.SdkVersion) ? new AspireConfigSdk { Version = config.SdkVersion } : aspireConfig.Sdk;
+        aspireConfig.Channel = config.Channel ?? aspireConfig.Channel;
+        aspireConfig.Packages = config.Packages ?? aspireConfig.Packages;
+        aspireConfig.Features = config.Features ?? aspireConfig.Features;
+        aspireConfig.Save(directory);
+    }
+
+    /// <summary>
+    /// Reads launch profiles from an apphost.run.json file.
+    /// </summary>
+    internal static Dictionary<string, AspireConfigProfile>? ReadApphostRunProfiles(string apphostRunPath)
+    {
+        try
+        {
+            if (!File.Exists(apphostRunPath))
+            {
+                return null;
+            }
+
+            var json = File.ReadAllText(apphostRunPath);
+            using var doc = JsonDocument.Parse(json);
+
+            if (!doc.RootElement.TryGetProperty("profiles", out var profilesElement))
+            {
+                return null;
+            }
+
+            var profiles = new Dictionary<string, AspireConfigProfile>();
+            foreach (var prop in profilesElement.EnumerateObject())
+            {
+                var profile = new AspireConfigProfile();
+
+                if (prop.Value.TryGetProperty("applicationUrl", out var appUrl) &&
+                    appUrl.ValueKind == JsonValueKind.String)
+                {
+                    profile.ApplicationUrl = appUrl.GetString();
+                }
+
+                if (prop.Value.TryGetProperty("environmentVariables", out var envVars) &&
+                    envVars.ValueKind == JsonValueKind.Object)
+                {
+                    profile.EnvironmentVariables = new Dictionary<string, string>();
+                    foreach (var envProp in envVars.EnumerateObject())
+                    {
+                        if (envProp.Value.ValueKind == JsonValueKind.String)
+                        {
+                            profile.EnvironmentVariables[envProp.Name] = envProp.Value.GetString()!;
+                        }
+                    }
+                }
+
+                profiles[prop.Name] = profile;
+            }
+
+            return profiles.Count > 0 ? profiles : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Checks if aspire.config.json exists in the specified directory.
     /// </summary>
     public static bool Exists(string directory)

--- a/src/Aspire.Cli/Configuration/AspireConfigFile.cs
+++ b/src/Aspire.Cli/Configuration/AspireConfigFile.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Configuration;
 
@@ -10,6 +11,34 @@ namespace Aspire.Cli.Configuration;
 /// Represents the aspire.config.json configuration file.
 /// Consolidates apphost location, launch settings, and CLI config into one file.
 /// </summary>
+/// <remarks>
+/// <para>The new unified format (<c>aspire.config.json</c>) replaces the legacy split across
+/// <c>.aspire/settings.json</c> (local settings) and <c>apphost.run.json</c> (launch profiles).</para>
+/// <para>Example <c>aspire.config.json</c>:</para>
+/// <code>
+/// {
+///   "appHost": { "path": "app.ts", "language": "typescript/nodejs" },
+///   "sdk": { "version": "9.2.0" },
+///   "channel": "stable",
+///   "features": { "polyglotSupportEnabled": true },
+///   "profiles": {
+///     "default": {
+///       "applicationUrl": "https://localhost:17000;http://localhost:15000",
+///       "environmentVariables": { "ASPNETCORE_ENVIRONMENT": "Development" }
+///     }
+///   },
+///   "packages": { "Aspire.Hosting.Redis": "9.2.0" }
+/// }
+/// </code>
+/// <para>Legacy <c>.aspire/settings.json</c> (flat keys):</para>
+/// <code>
+/// { "appHostPath": "app.ts", "language": "typescript/nodejs", "sdkVersion": "9.2.0" }
+/// </code>
+/// <para>Legacy <c>apphost.run.json</c> (launch profiles):</para>
+/// <code>
+/// { "profiles": { "default": { "applicationUrl": "https://localhost:17000" } } }
+/// </code>
+/// </remarks>
 internal sealed class AspireConfigFile
 {
     public const string FileName = "aspire.config.json";
@@ -59,6 +88,7 @@ internal sealed class AspireConfigFile
     /// <summary>
     /// Loads aspire.config.json from the specified directory.
     /// </summary>
+    /// <returns>The deserialized config, or <c>null</c> if the file does not exist or is malformed.</returns>
     public static AspireConfigFile? Load(string directory)
     {
         var filePath = Path.Combine(directory, FileName);
@@ -67,17 +97,27 @@ internal sealed class AspireConfigFile
             return null;
         }
 
-        var json = File.ReadAllText(filePath);
-        return JsonSerializer.Deserialize(json, JsonSourceGenerationContext.Default.AspireConfigFile);
+        try
+        {
+            var json = File.ReadAllText(filePath);
+            return JsonSerializer.Deserialize(json, JsonSourceGenerationContext.Default.AspireConfigFile);
+        }
+        catch (JsonException)
+        {
+            // The file may have been hand-edited with invalid JSON.
+            return null;
+        }
     }
 
     /// <summary>
     /// Saves aspire.config.json to the specified directory.
+    /// Uses relaxed JSON escaping so non-ASCII characters (CJK, etc.) are preserved as-is.
     /// </summary>
     public void Save(string directory)
     {
+        Directory.CreateDirectory(directory);
         var filePath = Path.Combine(directory, FileName);
-        var json = JsonSerializer.Serialize(this, JsonSourceGenerationContext.Default.AspireConfigFile);
+        var json = JsonSerializer.Serialize(this, JsonSourceGenerationContext.RelaxedEscaping.AspireConfigFile);
         File.WriteAllText(filePath, json);
     }
 
@@ -100,6 +140,8 @@ internal sealed class AspireConfigFile
             return config;
         }
 
+        // TODO: Remove legacy .aspire/settings.json + apphost.run.json fallback once confident
+        // most users have migrated. Tracked by https://github.com/dotnet/aspire/issues/15239
         // Fall back to .aspire/settings.json + apphost.run.json → migrate
         var legacyConfig = AspireJsonConfiguration.Load(directory);
         if (legacyConfig is not null)
@@ -132,8 +174,8 @@ internal sealed class AspireConfigFile
     {
         var aspireConfig = Load(directory) ?? new AspireConfigFile();
         aspireConfig.AppHost ??= new AspireConfigAppHost();
-        aspireConfig.AppHost.Path = config.AppHostPath;
-        aspireConfig.AppHost.Language = config.Language;
+        aspireConfig.AppHost.Path = config.AppHostPath ?? aspireConfig.AppHost.Path;
+        aspireConfig.AppHost.Language = config.Language ?? aspireConfig.AppHost.Language;
         aspireConfig.Sdk = !string.IsNullOrEmpty(config.SdkVersion) ? new AspireConfigSdk { Version = config.SdkVersion } : aspireConfig.Sdk;
         aspireConfig.Channel = config.Channel ?? aspireConfig.Channel;
         aspireConfig.Packages = config.Packages ?? aspireConfig.Packages;
@@ -144,7 +186,12 @@ internal sealed class AspireConfigFile
     /// <summary>
     /// Reads launch profiles from an apphost.run.json file.
     /// </summary>
-    internal static Dictionary<string, AspireConfigProfile>? ReadApphostRunProfiles(string apphostRunPath)
+    /// <remarks>
+    /// This is legacy migration code that reads the old apphost.run.json format and converts
+    /// it to <see cref="AspireConfigProfile"/> entries. Will be removed once legacy files are
+    /// no longer supported. Tracked by https://github.com/dotnet/aspire/issues/15239
+    /// </remarks>
+    internal static Dictionary<string, AspireConfigProfile>? ReadApphostRunProfiles(string apphostRunPath, ILogger? logger = null)
     {
         try
         {
@@ -154,7 +201,11 @@ internal sealed class AspireConfigFile
             }
 
             var json = File.ReadAllText(apphostRunPath);
-            using var doc = JsonDocument.Parse(json);
+            using var doc = JsonDocument.Parse(json, new JsonDocumentOptions
+            {
+                AllowTrailingCommas = true,
+                CommentHandling = JsonCommentHandling.Skip
+            });
 
             if (!doc.RootElement.TryGetProperty("profiles", out var profilesElement))
             {
@@ -190,8 +241,9 @@ internal sealed class AspireConfigFile
 
             return profiles.Count > 0 ? profiles : null;
         }
-        catch
+        catch (Exception ex)
         {
+            logger?.LogDebug(ex, "Failed to read launch profiles from {Path}", apphostRunPath);
             return null;
         }
     }

--- a/src/Aspire.Cli/Configuration/AspireConfigFile.cs
+++ b/src/Aspire.Cli/Configuration/AspireConfigFile.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Aspire.Cli.Resources;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Configuration;
@@ -118,10 +120,9 @@ internal sealed class AspireConfigFile
         }
         catch (JsonException ex)
         {
-            throw new InvalidOperationException(
-                $"The configuration file '{filePath}' contains invalid JSON: {ex.Message}" +
-                Environment.NewLine +
-                "Please fix the JSON syntax error and try again.", ex);
+            throw new JsonException(
+                string.Format(CultureInfo.CurrentCulture, ErrorStrings.InvalidJsonInConfigFile, filePath),
+                ex.Path, ex.LineNumber, ex.BytePositionInLine, ex);
         }
     }
 

--- a/src/Aspire.Cli/Configuration/AspireConfigFile.cs
+++ b/src/Aspire.Cli/Configuration/AspireConfigFile.cs
@@ -62,6 +62,18 @@ internal sealed class AspireConfigFile
     public AspireConfigSdk? Sdk { get; set; }
 
     /// <summary>
+    /// Convenience accessor for the Aspire SDK version.
+    /// Gets or sets <see cref="AspireConfigSdk.Version"/> on the <see cref="Sdk"/> object,
+    /// creating the nested object when setting a value.
+    /// </summary>
+    [JsonIgnore]
+    public string? SdkVersion
+    {
+        get => Sdk?.Version;
+        set => (Sdk ??= new AspireConfigSdk()).Version = value;
+    }
+
+    /// <summary>
     /// Aspire channel for package resolution.
     /// </summary>
     [JsonPropertyName("channel")]
@@ -137,8 +149,7 @@ internal sealed class AspireConfigFile
         {
             if (defaultSdkVersion is not null)
             {
-                config.Sdk ??= new AspireConfigSdk();
-                config.Sdk.Version ??= defaultSdkVersion;
+                config.SdkVersion ??= defaultSdkVersion;
             }
 
             return config;
@@ -163,28 +174,10 @@ internal sealed class AspireConfigFile
 
         if (defaultSdkVersion is not null)
         {
-            config.Sdk ??= new AspireConfigSdk();
-            config.Sdk.Version ??= defaultSdkVersion;
+            config.SdkVersion ??= defaultSdkVersion;
         }
 
         return config;
-    }
-
-    /// <summary>
-    /// Saves an <see cref="AspireJsonConfiguration"/> to aspire.config.json, merging with any
-    /// existing aspire.config.json content in the specified directory.
-    /// </summary>
-    public static void SaveFromLegacy(string directory, AspireJsonConfiguration config)
-    {
-        var aspireConfig = Load(directory) ?? new AspireConfigFile();
-        aspireConfig.AppHost ??= new AspireConfigAppHost();
-        aspireConfig.AppHost.Path = config.AppHostPath ?? aspireConfig.AppHost.Path;
-        aspireConfig.AppHost.Language = config.Language ?? aspireConfig.AppHost.Language;
-        aspireConfig.Sdk = !string.IsNullOrEmpty(config.SdkVersion) ? new AspireConfigSdk { Version = config.SdkVersion } : aspireConfig.Sdk;
-        aspireConfig.Channel = config.Channel ?? aspireConfig.Channel;
-        aspireConfig.Packages = config.Packages ?? aspireConfig.Packages;
-        aspireConfig.Features = config.Features ?? aspireConfig.Features;
-        aspireConfig.Save(directory);
     }
 
     /// <summary>
@@ -276,27 +269,94 @@ internal sealed class AspireConfigFile
     }
 
     /// <summary>
+    /// Gets the effective SDK version for package-based AppHost preparation.
+    /// Falls back to <paramref name="defaultSdkVersion"/> when no SDK version is configured.
+    /// </summary>
+    public string GetEffectiveSdkVersion(string defaultSdkVersion)
+    {
+        return string.IsNullOrWhiteSpace(Sdk?.Version) ? defaultSdkVersion : Sdk.Version;
+    }
+
+    /// <summary>
+    /// Adds a package reference, updating the version if it already exists.
+    /// </summary>
+    public void AddOrUpdatePackage(string packageId, string version)
+    {
+        Packages ??= [];
+        Packages[packageId] = version;
+    }
+
+    /// <summary>
+    /// Removes a package reference.
+    /// </summary>
+    public bool RemovePackage(string packageId)
+    {
+        if (Packages is null)
+        {
+            return false;
+        }
+
+        return Packages.Remove(packageId);
+    }
+
+    /// <summary>
+    /// Gets all integration references (both NuGet packages and project references)
+    /// including the base Aspire.Hosting package.
+    /// A value ending in ".csproj" is treated as a project reference; otherwise as a NuGet version.
+    /// Empty package versions are resolved to the effective SDK version.
+    /// </summary>
+    /// <param name="defaultSdkVersion">Default SDK version to use when not configured.</param>
+    /// <param name="configDirectory">The directory containing aspire.config.json, used to resolve relative project paths.</param>
+    public IEnumerable<IntegrationReference> GetIntegrationReferences(string defaultSdkVersion, string configDirectory)
+    {
+        var sdkVersion = GetEffectiveSdkVersion(defaultSdkVersion);
+
+        // Base package always included
+        yield return IntegrationReference.FromPackage("Aspire.Hosting", sdkVersion);
+
+        if (Packages is null)
+        {
+            yield break;
+        }
+
+        foreach (var (packageName, value) in Packages)
+        {
+            // Skip base packages and SDK-only packages
+            if (string.Equals(packageName, "Aspire.Hosting", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(packageName, "Aspire.Hosting.AppHost", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var trimmedValue = value?.Trim();
+
+            if (string.IsNullOrEmpty(trimmedValue))
+            {
+                // NuGet package reference with no explicit version — fall back to the SDK version
+                yield return IntegrationReference.FromPackage(packageName, sdkVersion);
+                continue;
+            }
+
+            if (trimmedValue.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+            {
+                // Project reference — resolve relative path to absolute
+                var absolutePath = Path.GetFullPath(Path.Combine(configDirectory, trimmedValue));
+                yield return IntegrationReference.FromProject(packageName, absolutePath);
+            }
+            else
+            {
+                // NuGet package reference with explicit version
+                yield return IntegrationReference.FromPackage(packageName, trimmedValue);
+            }
+        }
+    }
+
+    /// <summary>
     /// Checks if aspire.config.json exists in the specified directory.
     /// </summary>
     public static bool Exists(string directory)
     {
         return File.Exists(Path.Combine(directory, FileName));
-    }
-
-    /// <summary>
-    /// Converts this AspireConfigFile back to an AspireJsonConfiguration for compatibility with existing code.
-    /// </summary>
-    public AspireJsonConfiguration ToLegacyConfiguration()
-    {
-        return new AspireJsonConfiguration
-        {
-            AppHostPath = AppHost?.Path,
-            Language = AppHost?.Language,
-            SdkVersion = Sdk?.Version,
-            Channel = Channel,
-            Features = Features,
-            Packages = Packages
-        };
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Configuration/AspireConfigFile.cs
+++ b/src/Aspire.Cli/Configuration/AspireConfigFile.cs
@@ -88,7 +88,8 @@ internal sealed class AspireConfigFile
     /// <summary>
     /// Loads aspire.config.json from the specified directory.
     /// </summary>
-    /// <returns>The deserialized config, or <c>null</c> if the file does not exist or is malformed.</returns>
+    /// <returns>The deserialized config, or <c>null</c> if the file does not exist.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the file exists but contains invalid JSON.</exception>
     public static AspireConfigFile? Load(string directory)
     {
         var filePath = Path.Combine(directory, FileName);
@@ -100,12 +101,15 @@ internal sealed class AspireConfigFile
         try
         {
             var json = File.ReadAllText(filePath);
-            return JsonSerializer.Deserialize(json, JsonSourceGenerationContext.Default.AspireConfigFile);
+            return JsonSerializer.Deserialize(json, JsonSourceGenerationContext.Default.AspireConfigFile)
+                ?? new AspireConfigFile();
         }
-        catch (JsonException)
+        catch (JsonException ex)
         {
-            // The file may have been hand-edited with invalid JSON.
-            return null;
+            throw new InvalidOperationException(
+                $"The configuration file '{filePath}' contains invalid JSON: {ex.Message}" +
+                Environment.NewLine +
+                "Please fix the JSON syntax error and try again.", ex);
         }
     }
 
@@ -229,9 +233,32 @@ internal sealed class AspireConfigFile
                     profile.EnvironmentVariables = new Dictionary<string, string>();
                     foreach (var envProp in envVars.EnumerateObject())
                     {
-                        if (envProp.Value.ValueKind == JsonValueKind.String)
+                        var envValue = envProp.Value.ValueKind switch
                         {
-                            profile.EnvironmentVariables[envProp.Name] = envProp.Value.GetString()!;
+                            JsonValueKind.String => envProp.Value.GetString()!,
+                            JsonValueKind.True => "true",
+                            JsonValueKind.False => "false",
+                            JsonValueKind.Number => envProp.Value.GetRawText(),
+                            JsonValueKind.Null => "",
+                            _ => null
+                        };
+
+                        if (envValue is not null)
+                        {
+                            if (envProp.Value.ValueKind != JsonValueKind.String)
+                            {
+                                logger?.LogWarning(
+                                    "Environment variable '{Name}' has a non-string value ({ValueKind}). Converting to string \"{Value}\".",
+                                    envProp.Name, envProp.Value.ValueKind, envValue);
+                            }
+
+                            profile.EnvironmentVariables[envProp.Name] = envValue;
+                        }
+                        else
+                        {
+                            logger?.LogWarning(
+                                "Environment variable '{Name}' has an unsupported value type ({ValueKind}) and will be ignored.",
+                                envProp.Name, envProp.Value.ValueKind);
                         }
                     }
                 }

--- a/src/Aspire.Cli/Configuration/ConfigurationService.cs
+++ b/src/Aspire.Cli/Configuration/ConfigurationService.cs
@@ -96,18 +96,25 @@ internal sealed class ConfigurationService(IConfiguration configuration, CliExec
         // Walk up the directory tree to find existing settings file
         while (searchDirectory is not null)
         {
-            var settingsFilePath = ConfigurationHelper.BuildPathToSettingsJsonFile(searchDirectory.FullName);
-
-            if (File.Exists(settingsFilePath))
+            // Prefer aspire.config.json (new format)
+            var newSettingsPath = Path.Combine(searchDirectory.FullName, AspireConfigFile.FileName);
+            if (File.Exists(newSettingsPath))
             {
-                return settingsFilePath;
+                return newSettingsPath;
+            }
+
+            // Fall back to .aspire/settings.json (legacy)
+            var legacySettingsPath = ConfigurationHelper.BuildPathToSettingsJsonFile(searchDirectory.FullName);
+            if (File.Exists(legacySettingsPath))
+            {
+                return legacySettingsPath;
             }
 
             searchDirectory = searchDirectory.Parent;
         }
 
-        // If no existing settings file found, create one in current directory
-        return ConfigurationHelper.BuildPathToSettingsJsonFile(executionContext.WorkingDirectory.FullName);
+        // If no existing settings file found, default to aspire.config.json in current directory
+        return Path.Combine(executionContext.WorkingDirectory.FullName, AspireConfigFile.FileName);
     }
 
     public async Task<Dictionary<string, string>> GetAllConfigurationAsync(CancellationToken cancellationToken = default)

--- a/src/Aspire.Cli/Configuration/ConfigurationService.cs
+++ b/src/Aspire.Cli/Configuration/ConfigurationService.cs
@@ -101,7 +101,7 @@ internal sealed class ConfigurationService(IConfiguration configuration, CliExec
             var newSettingsPath = Path.Combine(searchDirectory.FullName, AspireConfigFile.FileName);
             if (File.Exists(newSettingsPath))
             {
-                logger.LogDebug("Found settings file at {Path}", newSettingsPath);
+                logger.LogInformation("Found settings file at {Path}", newSettingsPath);
                 return newSettingsPath;
             }
 
@@ -111,7 +111,7 @@ internal sealed class ConfigurationService(IConfiguration configuration, CliExec
             var legacySettingsPath = ConfigurationHelper.BuildPathToSettingsJsonFile(searchDirectory.FullName);
             if (File.Exists(legacySettingsPath))
             {
-                logger.LogDebug("Found legacy settings file at {Path}", legacySettingsPath);
+                logger.LogInformation("Found legacy settings file at {Path}", legacySettingsPath);
                 return legacySettingsPath;
             }
 

--- a/src/Aspire.Cli/Configuration/ConfigurationService.cs
+++ b/src/Aspire.Cli/Configuration/ConfigurationService.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.Configuration;
@@ -10,6 +11,11 @@ namespace Aspire.Cli.Configuration;
 
 internal sealed class ConfigurationService(IConfiguration configuration, CliExecutionContext executionContext, FileInfo globalSettingsFile, ILogger<ConfigurationService> logger) : IConfigurationService
 {
+    private static readonly JsonDocumentOptions s_jsonDocumentOptions = new()
+    {
+        CommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true
+    };
     public async Task SetConfigurationAsync(string key, string value, bool isGlobal = false, CancellationToken cancellationToken = default)
     {
         var settingsFilePath = GetSettingsFilePath(isGlobal);
@@ -23,7 +29,7 @@ internal sealed class ConfigurationService(IConfiguration configuration, CliExec
             // Handle empty files or whitespace-only content
             settings = string.IsNullOrWhiteSpace(existingContent)
                 ? new JsonObject()
-                : JsonNode.Parse(existingContent)?.AsObject() ?? new JsonObject();
+                : JsonNode.Parse(existingContent, nodeOptions: null, s_jsonDocumentOptions)?.AsObject() ?? new JsonObject();
         }
         else
         {
@@ -55,7 +61,7 @@ internal sealed class ConfigurationService(IConfiguration configuration, CliExec
                 return false;
             }
 
-            var settings = JsonNode.Parse(existingContent)?.AsObject();
+            var settings = JsonNode.Parse(existingContent, nodeOptions: null, s_jsonDocumentOptions)?.AsObject();
 
             if (settings is null)
             {
@@ -162,7 +168,7 @@ internal sealed class ConfigurationService(IConfiguration configuration, CliExec
                 return;
             }
 
-            var settings = JsonNode.Parse(content)?.AsObject();
+            var settings = JsonNode.Parse(content, nodeOptions: null, s_jsonDocumentOptions)?.AsObject();
 
             if (settings is not null)
             {

--- a/src/Aspire.Cli/Configuration/ConfigurationService.cs
+++ b/src/Aspire.Cli/Configuration/ConfigurationService.cs
@@ -4,10 +4,11 @@
 using System.Text.Json.Nodes;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Configuration;
 
-internal sealed class ConfigurationService(IConfiguration configuration, CliExecutionContext executionContext, FileInfo globalSettingsFile) : IConfigurationService
+internal sealed class ConfigurationService(IConfiguration configuration, CliExecutionContext executionContext, FileInfo globalSettingsFile, ILogger<ConfigurationService> logger) : IConfigurationService
 {
     public async Task SetConfigurationAsync(string key, string value, bool isGlobal = false, CancellationToken cancellationToken = default)
     {
@@ -100,13 +101,17 @@ internal sealed class ConfigurationService(IConfiguration configuration, CliExec
             var newSettingsPath = Path.Combine(searchDirectory.FullName, AspireConfigFile.FileName);
             if (File.Exists(newSettingsPath))
             {
+                logger.LogDebug("Found settings file at {Path}", newSettingsPath);
                 return newSettingsPath;
             }
 
+            // TODO: Remove legacy .aspire/settings.json fallback once confident most users have migrated.
+            // Tracked by https://github.com/dotnet/aspire/issues/15239
             // Fall back to .aspire/settings.json (legacy)
             var legacySettingsPath = ConfigurationHelper.BuildPathToSettingsJsonFile(searchDirectory.FullName);
             if (File.Exists(legacySettingsPath))
             {
+                logger.LogDebug("Found legacy settings file at {Path}", legacySettingsPath);
                 return legacySettingsPath;
             }
 
@@ -114,7 +119,9 @@ internal sealed class ConfigurationService(IConfiguration configuration, CliExec
         }
 
         // If no existing settings file found, default to aspire.config.json in current directory
-        return Path.Combine(executionContext.WorkingDirectory.FullName, AspireConfigFile.FileName);
+        var defaultPath = Path.Combine(executionContext.WorkingDirectory.FullName, AspireConfigFile.FileName);
+        logger.LogDebug("No existing settings file found, defaulting to {Path}", defaultPath);
+        return defaultPath;
     }
 
     public async Task<Dictionary<string, string>> GetAllConfigurationAsync(CancellationToken cancellationToken = default)

--- a/src/Aspire.Cli/ExitCodeConstants.cs
+++ b/src/Aspire.Cli/ExitCodeConstants.cs
@@ -24,4 +24,5 @@ internal static class ExitCodeConstants
     public const int FailedToExecuteResourceCommand = 16;
     public const int WaitTimeout = 17;
     public const int WaitResourceFailed = 18;
+    public const int FailedToLoadConfiguration = 19;
 }

--- a/src/Aspire.Cli/JsonSourceGenerationContext.cs
+++ b/src/Aspire.Cli/JsonSourceGenerationContext.cs
@@ -5,6 +5,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Nodes;
+using Aspire.Cli.Certificates;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Mcp.Docs;
@@ -23,6 +24,8 @@ namespace Aspire.Cli;
 [JsonSerializable(typeof(DoctorCheckSummary))]
 [JsonSerializable(typeof(ContainerVersionJson))]
 [JsonSerializable(typeof(AspireJsonConfiguration))]
+[JsonSerializable(typeof(AspireConfigFile))]
+[JsonSerializable(typeof(List<DevCertInfo>))]
 [JsonSerializable(typeof(ConfigInfo))]
 [JsonSerializable(typeof(FeatureInfo))]
 [JsonSerializable(typeof(SettingsSchema))]

--- a/src/Aspire.Cli/JsonSourceGenerationContext.cs
+++ b/src/Aspire.Cli/JsonSourceGenerationContext.cs
@@ -14,7 +14,11 @@ using Aspire.Cli.Utils.EnvironmentChecker;
 
 namespace Aspire.Cli;
 
-[JsonSourceGenerationOptions(WriteIndented = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    AllowTrailingCommas = true,
+    ReadCommentHandling = JsonCommentHandling.Skip)]
 [JsonSerializable(typeof(CliSettings))]
 [JsonSerializable(typeof(JsonObject))]
 [JsonSerializable(typeof(ListIntegrationsResponse))]
@@ -48,6 +52,8 @@ internal partial class JsonSourceGenerationContext : JsonSerializerContext
     {
         WriteIndented = true,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
     });

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -124,8 +124,24 @@ public class Program
     private static string GetGlobalSettingsPath()
     {
         var usersAspirePath = GetUsersAspirePath();
-        var globalSettingsPath = Path.Combine(usersAspirePath, "globalsettings.json");
-        return globalSettingsPath;
+        var newPath = Path.Combine(usersAspirePath, Configuration.AspireConfigFile.FileName);
+
+        // Migrate legacy globalsettings.json → aspire.config.json on first access
+        var legacyPath = Path.Combine(usersAspirePath, "globalsettings.json");
+        if (!File.Exists(newPath) && File.Exists(legacyPath))
+        {
+            try
+            {
+                File.Move(legacyPath, newPath);
+            }
+            catch
+            {
+                // If move fails, fall back to legacy
+                return legacyPath;
+            }
+        }
+
+        return newPath;
     }
 
     internal static async Task<IHost> BuildApplicationAsync(string[] args, Dictionary<string, string?>? configurationValues = null)

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -609,7 +609,20 @@ public class Program
 
         Console.OutputEncoding = Encoding.UTF8;
 
-        using var app = await BuildApplicationAsync(args);
+        IHost app;
+        try
+        {
+            app = await BuildApplicationAsync(args);
+        }
+        catch (InvalidOperationException ex)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.Error.WriteLine(ex.Message);
+            Console.ResetColor();
+            return ExitCodeConstants.FailedToLoadConfiguration;
+        }
+
+        using var _ = app;
 
         await app.StartAsync().ConfigureAwait(false);
 

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -6,6 +6,7 @@ using System.CommandLine.Parsing;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
+using System.Text.Json;
 using Aspire.Cli.Agents;
 using Aspire.Cli.Agents.ClaudeCode;
 using Aspire.Cli.Agents.CopilotCli;
@@ -126,19 +127,22 @@ public class Program
         var usersAspirePath = GetUsersAspirePath();
         var newPath = Path.Combine(usersAspirePath, Configuration.AspireConfigFile.FileName);
 
-        // Copy legacy globalsettings.json → aspire.config.json on first access.
-        // Use Copy (not Move) so older CLI versions that still read globalsettings.json
-        // continue to work without data loss.
+        // Migrate legacy globalsettings.json → aspire.config.json on first access,
+        // transforming flat keys to the new nested schema. Use a copy-based approach
+        // so older CLI versions that still read globalsettings.json continue to work.
         var legacyPath = Path.Combine(usersAspirePath, "globalsettings.json");
         if (!File.Exists(newPath) && File.Exists(legacyPath))
         {
             try
             {
-                File.Copy(legacyPath, newPath);
+                var legacyJson = File.ReadAllText(legacyPath);
+                var legacyConfig = JsonSerializer.Deserialize(legacyJson, JsonSourceGenerationContext.Default.AspireJsonConfiguration);
+                var config = AspireConfigFile.FromLegacy(legacyConfig, profiles: null);
+                config.Save(usersAspirePath);
             }
             catch
             {
-                // If copy fails, newPath will be created on first write.
+                // If migration fails, newPath will be created on first write.
             }
         }
 

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -127,9 +127,9 @@ public class Program
         var usersAspirePath = GetUsersAspirePath();
         var newPath = Path.Combine(usersAspirePath, Configuration.AspireConfigFile.FileName);
 
-        // Migrate legacy globalsettings.json → aspire.config.json on first access,
-        // transforming flat keys to the new nested schema. Use a copy-based approach
-        // so older CLI versions that still read globalsettings.json continue to work.
+        // TODO: Remove globalsettings.json migration once confident most users have migrated.
+        // The old file is intentionally kept so older CLI versions continue to work during
+        // the transition period. Tracked by https://github.com/dotnet/aspire/issues/15239
         var legacyPath = Path.Combine(usersAspirePath, "globalsettings.json");
         if (!File.Exists(newPath) && File.Exists(legacyPath))
         {
@@ -508,7 +508,8 @@ public class Program
         var configuration = serviceProvider.GetRequiredService<IConfiguration>();
         var executionContext = serviceProvider.GetRequiredService<CliExecutionContext>();
         var globalSettingsFile = new FileInfo(GetGlobalSettingsPath());
-        return new ConfigurationService(configuration, executionContext, globalSettingsFile);
+        var logger = serviceProvider.GetRequiredService<ILogger<ConfigurationService>>();
+        return new ConfigurationService(configuration, executionContext, globalSettingsFile, logger);
     }
 
     internal static async Task DisplayFirstTimeUseNoticeIfNeededAsync(IServiceProvider serviceProvider, string[] args, CancellationToken cancellationToken = default)

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -126,18 +126,19 @@ public class Program
         var usersAspirePath = GetUsersAspirePath();
         var newPath = Path.Combine(usersAspirePath, Configuration.AspireConfigFile.FileName);
 
-        // Migrate legacy globalsettings.json → aspire.config.json on first access
+        // Copy legacy globalsettings.json → aspire.config.json on first access.
+        // Use Copy (not Move) so older CLI versions that still read globalsettings.json
+        // continue to work without data loss.
         var legacyPath = Path.Combine(usersAspirePath, "globalsettings.json");
         if (!File.Exists(newPath) && File.Exists(legacyPath))
         {
             try
             {
-                File.Move(legacyPath, newPath);
+                File.Copy(legacyPath, newPath);
             }
             catch
             {
-                // If move fails, fall back to legacy
-                return legacyPath;
+                // If copy fails, newPath will be created on first write.
             }
         }
 

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -614,7 +614,7 @@ public class Program
         {
             app = await BuildApplicationAsync(args);
         }
-        catch (InvalidOperationException ex)
+        catch (JsonException ex)
         {
             Console.ForegroundColor = ConsoleColor.Red;
             Console.Error.WriteLine(ex.Message);

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -36,6 +36,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
     private readonly IDotNetCliRunner _runner;
     private readonly IPackagingService _packagingService;
     private readonly IConfiguration _configuration;
+    private readonly IConfigurationService _configurationService;
     private readonly IFeatures _features;
     private readonly ILanguageDiscovery _languageDiscovery;
     private readonly ILogger<GuestAppHostProject> _logger;
@@ -55,6 +56,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         IDotNetCliRunner runner,
         IPackagingService packagingService,
         IConfiguration configuration,
+        IConfigurationService configurationService,
         IFeatures features,
         ILanguageDiscovery languageDiscovery,
         ILogger<GuestAppHostProject> logger,
@@ -68,6 +70,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         _runner = runner;
         _packagingService = packagingService;
         _configuration = configuration;
+        _configurationService = configurationService;
         _features = features;
         _languageDiscovery = languageDiscovery;
         _logger = logger;
@@ -158,108 +161,43 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         return integrations;
     }
 
+    /// <summary>
+    /// Resolves the directory containing the nearest aspire.config.json (or legacy settings file)
+    /// by using the already-resolved path from <see cref="IConfigurationService"/>.
+    /// Falls back to <paramref name="appHostDirectory"/> when no config file is found.
+    /// </summary>
+    private DirectoryInfo GetConfigDirectory(DirectoryInfo appHostDirectory)
+    {
+        var settingsFilePath = _configurationService.GetSettingsFilePath(isGlobal: false);
+        var settingsFile = new FileInfo(settingsFilePath);
+
+        // If the settings file exists and has a parent directory, use that
+        if (settingsFile.Directory is { Exists: true })
+        {
+            // For legacy .aspire/settings.json, the config directory is the parent of .aspire/
+            if (string.Equals(settingsFile.Directory.Name, AspireJsonConfiguration.SettingsFolder, StringComparison.OrdinalIgnoreCase)
+                && settingsFile.Directory.Parent is not null)
+            {
+                return settingsFile.Directory.Parent;
+            }
+
+            return settingsFile.Directory;
+        }
+
+        return appHostDirectory;
+    }
+
     private AspireJsonConfiguration LoadConfiguration(DirectoryInfo directory)
     {
-        var effectiveSdkVersion = GetEffectiveSdkVersion();
-
-        // If aspire.config.json exists, load from it
-        if (AspireConfigFile.Exists(directory.FullName))
-        {
-            var aspireConfig = AspireConfigFile.Load(directory.FullName);
-            if (aspireConfig is not null)
-            {
-                var config = aspireConfig.ToLegacyConfiguration();
-                config.SdkVersion ??= effectiveSdkVersion;
-                return config;
-            }
-        }
-
-        // If .aspire/settings.json exists but aspire.config.json doesn't, migrate
-        var legacyConfig = AspireJsonConfiguration.Load(directory.FullName);
-        if (legacyConfig is not null)
-        {
-            // Read apphost.run.json profiles if it exists
-            Dictionary<string, AspireConfigProfile>? profiles = null;
-            var apphostRunPath = Path.Combine(directory.FullName, "apphost.run.json");
-            if (File.Exists(apphostRunPath))
-            {
-                profiles = ReadApphostRunProfiles(apphostRunPath);
-            }
-
-            // Merge into AspireConfigFile. Keep legacy files in place so older CLI
-            // versions that still read .aspire/settings.json continue to work.
-            var aspireConfig = AspireConfigFile.FromLegacy(legacyConfig, profiles);
-            aspireConfig.Save(directory.FullName);
-
-            _interactionService.DisplayMessage(KnownEmojis.FileCabinet, "Migrated configuration to aspire.config.json");
-
-            legacyConfig.SdkVersion ??= effectiveSdkVersion;
-            return legacyConfig;
-        }
-
-        // Neither exists — create new
-        var newConfig = new AspireJsonConfiguration();
-        newConfig.SdkVersion ??= effectiveSdkVersion;
-        return newConfig;
+        var configDir = GetConfigDirectory(directory);
+        var aspireConfig = AspireConfigFile.LoadOrCreate(configDir.FullName, GetEffectiveSdkVersion());
+        return aspireConfig.ToLegacyConfiguration();
     }
 
-    private static Dictionary<string, AspireConfigProfile>? ReadApphostRunProfiles(string apphostRunPath)
+    private void SaveConfiguration(AspireJsonConfiguration config, DirectoryInfo directory)
     {
-        try
-        {
-            var json = File.ReadAllText(apphostRunPath);
-            using var doc = JsonDocument.Parse(json);
-
-            if (!doc.RootElement.TryGetProperty("profiles", out var profilesElement))
-            {
-                return null;
-            }
-
-            var profiles = new Dictionary<string, AspireConfigProfile>();
-            foreach (var prop in profilesElement.EnumerateObject())
-            {
-                var profile = new AspireConfigProfile();
-
-                if (prop.Value.TryGetProperty("applicationUrl", out var appUrl) &&
-                    appUrl.ValueKind == JsonValueKind.String)
-                {
-                    profile.ApplicationUrl = appUrl.GetString();
-                }
-
-                if (prop.Value.TryGetProperty("environmentVariables", out var envVars))
-                {
-                    profile.EnvironmentVariables = new Dictionary<string, string>();
-                    foreach (var envProp in envVars.EnumerateObject())
-                    {
-                        if (envProp.Value.ValueKind == JsonValueKind.String)
-                        {
-                            profile.EnvironmentVariables[envProp.Name] = envProp.Value.GetString()!;
-                        }
-                    }
-                }
-
-                profiles[prop.Name] = profile;
-            }
-
-            return profiles.Count > 0 ? profiles : null;
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private static void SaveConfiguration(AspireJsonConfiguration config, DirectoryInfo directory)
-    {
-        var aspireConfig = AspireConfigFile.Load(directory.FullName) ?? new AspireConfigFile();
-        aspireConfig.AppHost ??= new AspireConfigAppHost();
-        aspireConfig.AppHost.Path = config.AppHostPath;
-        aspireConfig.AppHost.Language = config.Language;
-        aspireConfig.Sdk = !string.IsNullOrEmpty(config.SdkVersion) ? new AspireConfigSdk { Version = config.SdkVersion } : aspireConfig.Sdk;
-        aspireConfig.Channel = config.Channel ?? aspireConfig.Channel;
-        aspireConfig.Packages = config.Packages ?? aspireConfig.Packages;
-        aspireConfig.Features = config.Features ?? aspireConfig.Features;
-        aspireConfig.Save(directory.FullName);
+        var configDir = GetConfigDirectory(directory);
+        AspireConfigFile.SaveFromLegacy(configDir.FullName, config);
     }
 
     private string GetPrepareSdkVersion(AspireJsonConfiguration config)
@@ -653,8 +591,9 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
 
     private Dictionary<string, string>? ReadLaunchSettingsEnvironmentVariables(DirectoryInfo directory)
     {
-        // Check aspire.config.json first for launch profiles
-        var aspireConfig = AspireConfigFile.Load(directory.FullName);
+        // Check aspire.config.json first for launch profiles (may be in a parent directory)
+        var configDir = GetConfigDirectory(directory);
+        var aspireConfig = AspireConfigFile.Load(configDir.FullName);
         if (aspireConfig?.Profiles is { Count: > 0 })
         {
             return ReadProfileFromAspireConfig(aspireConfig);

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -186,27 +186,10 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 profiles = ReadApphostRunProfiles(apphostRunPath);
             }
 
-            // Merge into AspireConfigFile
+            // Merge into AspireConfigFile. Keep legacy files in place so older CLI
+            // versions that still read .aspire/settings.json continue to work.
             var aspireConfig = AspireConfigFile.FromLegacy(legacyConfig, profiles);
             aspireConfig.Save(directory.FullName);
-
-            // Delete legacy files
-            var settingsPath = AspireJsonConfiguration.GetFilePath(directory.FullName);
-            if (File.Exists(settingsPath))
-            {
-                File.Delete(settingsPath);
-            }
-            if (File.Exists(apphostRunPath))
-            {
-                File.Delete(apphostRunPath);
-            }
-
-            // Delete .aspire/ directory if empty
-            var aspireFolder = Path.Combine(directory.FullName, AspireJsonConfiguration.SettingsFolder);
-            if (Directory.Exists(aspireFolder) && !Directory.EnumerateFileSystemEntries(aspireFolder).Any())
-            {
-                Directory.Delete(aspireFolder);
-            }
 
             _interactionService.DisplayMessage(KnownEmojis.FileCabinet, "Migrated configuration to aspire.config.json");
 

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -146,7 +146,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
     /// Gets all integration references including the code generation package for the current language.
     /// </summary>
     private async Task<List<IntegrationReference>> GetIntegrationReferencesAsync(
-        AspireJsonConfiguration config,
+        AspireConfigFile config,
         DirectoryInfo directory,
         CancellationToken cancellationToken)
     {
@@ -175,7 +175,9 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         if (settingsFile.Directory is { Exists: true })
         {
             // For legacy .aspire/settings.json, the config directory is the parent of .aspire/
-            if (string.Equals(settingsFile.Directory.Name, AspireJsonConfiguration.SettingsFolder, StringComparison.OrdinalIgnoreCase)
+            // TODO: Remove legacy .aspire/ check once confident most users have migrated.
+            // Tracked by https://github.com/dotnet/aspire/issues/15239
+            if (string.Equals(settingsFile.Directory.Name, ".aspire", StringComparison.OrdinalIgnoreCase)
                 && settingsFile.Directory.Parent is not null)
             {
                 return settingsFile.Directory.Parent;
@@ -187,14 +189,14 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         return appHostDirectory;
     }
 
-    private AspireJsonConfiguration LoadConfiguration(DirectoryInfo directory)
+    private AspireConfigFile LoadConfiguration(DirectoryInfo directory)
     {
         var configDir = GetConfigDirectory(directory);
         try
         {
-            var aspireConfig = AspireConfigFile.LoadOrCreate(configDir.FullName, GetEffectiveSdkVersion());
+            var config = AspireConfigFile.LoadOrCreate(configDir.FullName, GetEffectiveSdkVersion());
             _logger.LogDebug("Loaded config from {Directory} (file exists: {Exists})", configDir.FullName, AspireConfigFile.Exists(configDir.FullName));
-            return aspireConfig.ToLegacyConfiguration();
+            return config;
         }
         catch (InvalidOperationException ex)
         {
@@ -203,13 +205,13 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         }
     }
 
-    private void SaveConfiguration(AspireJsonConfiguration config, DirectoryInfo directory)
+    private void SaveConfiguration(AspireConfigFile config, DirectoryInfo directory)
     {
         var configDir = GetConfigDirectory(directory);
-        AspireConfigFile.SaveFromLegacy(configDir.FullName, config);
+        config.Save(configDir.FullName);
     }
 
-    private string GetPrepareSdkVersion(AspireJsonConfiguration config)
+    private string GetPrepareSdkVersion(AspireConfigFile config)
     {
         return config.GetEffectiveSdkVersion(GetEffectiveSdkVersion());
     }

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -191,6 +191,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
     {
         var configDir = GetConfigDirectory(directory);
         var aspireConfig = AspireConfigFile.LoadOrCreate(configDir.FullName, GetEffectiveSdkVersion());
+        _logger.LogDebug("Loaded config from {Directory} (file exists: {Exists})", configDir.FullName, AspireConfigFile.Exists(configDir.FullName));
         return aspireConfig.ToLegacyConfiguration();
     }
 

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -198,7 +198,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             _logger.LogInformation("Loaded config from {Directory} (file exists: {Exists})", configDir.FullName, AspireConfigFile.Exists(configDir.FullName));
             return config;
         }
-        catch (InvalidOperationException ex)
+        catch (JsonException ex)
         {
             _logger.LogError(ex, "Failed to load configuration from {Directory}", configDir.FullName);
             throw;
@@ -612,7 +612,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 return ReadProfileFromAspireConfig(aspireConfig);
             }
         }
-        catch (InvalidOperationException ex)
+        catch (JsonException ex)
         {
             _logger.LogWarning(ex, "Failed to load config for launch profiles from {Directory}", configDir.FullName);
         }

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -268,24 +268,15 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
 
     private static void SaveConfiguration(AspireJsonConfiguration config, DirectoryInfo directory)
     {
-        if (AspireConfigFile.Exists(directory.FullName))
-        {
-            // Write to aspire.config.json
-            var aspireConfig = AspireConfigFile.Load(directory.FullName) ?? new AspireConfigFile();
-            aspireConfig.AppHost ??= new AspireConfigAppHost();
-            aspireConfig.AppHost.Path = config.AppHostPath;
-            aspireConfig.AppHost.Language = config.Language;
-            aspireConfig.Sdk = !string.IsNullOrEmpty(config.SdkVersion) ? new AspireConfigSdk { Version = config.SdkVersion } : aspireConfig.Sdk;
-            aspireConfig.Channel = config.Channel ?? aspireConfig.Channel;
-            aspireConfig.Packages = config.Packages ?? aspireConfig.Packages;
-            aspireConfig.Features = config.Features ?? aspireConfig.Features;
-            aspireConfig.Save(directory.FullName);
-        }
-        else
-        {
-            // Legacy path
-            config.Save(directory.FullName);
-        }
+        var aspireConfig = AspireConfigFile.Load(directory.FullName) ?? new AspireConfigFile();
+        aspireConfig.AppHost ??= new AspireConfigAppHost();
+        aspireConfig.AppHost.Path = config.AppHostPath;
+        aspireConfig.AppHost.Language = config.Language;
+        aspireConfig.Sdk = !string.IsNullOrEmpty(config.SdkVersion) ? new AspireConfigSdk { Version = config.SdkVersion } : aspireConfig.Sdk;
+        aspireConfig.Channel = config.Channel ?? aspireConfig.Channel;
+        aspireConfig.Packages = config.Packages ?? aspireConfig.Packages;
+        aspireConfig.Features = config.Features ?? aspireConfig.Features;
+        aspireConfig.Save(directory.FullName);
     }
 
     private string GetPrepareSdkVersion(AspireJsonConfiguration config)

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -94,9 +94,9 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
     /// </summary>
     private string GetEffectiveSdkVersion()
     {
-        // IConfiguration merges settings from parent directories and global settings
-        // The key "sdkVersion" is the flattened key from settings.json
-        var configuredVersion = _configuration["sdkVersion"];
+        // IConfiguration merges settings from parent directories and global settings.
+        // Prefer the new nested sdk:version key and fall back to the legacy sdkVersion key.
+        var configuredVersion = _configuration["sdk:version"] ?? _configuration["sdkVersion"];
         if (!string.IsNullOrEmpty(configuredVersion))
         {
             _logger.LogDebug("Using SDK version from configuration: {Version}", configuredVersion);

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -161,7 +161,131 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
     private AspireJsonConfiguration LoadConfiguration(DirectoryInfo directory)
     {
         var effectiveSdkVersion = GetEffectiveSdkVersion();
-        return AspireJsonConfiguration.LoadOrCreate(directory.FullName, effectiveSdkVersion);
+
+        // If aspire.config.json exists, load from it
+        if (AspireConfigFile.Exists(directory.FullName))
+        {
+            var aspireConfig = AspireConfigFile.Load(directory.FullName);
+            if (aspireConfig is not null)
+            {
+                var config = aspireConfig.ToLegacyConfiguration();
+                config.SdkVersion ??= effectiveSdkVersion;
+                return config;
+            }
+        }
+
+        // If .aspire/settings.json exists but aspire.config.json doesn't, migrate
+        var legacyConfig = AspireJsonConfiguration.Load(directory.FullName);
+        if (legacyConfig is not null)
+        {
+            // Read apphost.run.json profiles if it exists
+            Dictionary<string, AspireConfigProfile>? profiles = null;
+            var apphostRunPath = Path.Combine(directory.FullName, "apphost.run.json");
+            if (File.Exists(apphostRunPath))
+            {
+                profiles = ReadApphostRunProfiles(apphostRunPath);
+            }
+
+            // Merge into AspireConfigFile
+            var aspireConfig = AspireConfigFile.FromLegacy(legacyConfig, profiles);
+            aspireConfig.Save(directory.FullName);
+
+            // Delete legacy files
+            var settingsPath = AspireJsonConfiguration.GetFilePath(directory.FullName);
+            if (File.Exists(settingsPath))
+            {
+                File.Delete(settingsPath);
+            }
+            if (File.Exists(apphostRunPath))
+            {
+                File.Delete(apphostRunPath);
+            }
+
+            // Delete .aspire/ directory if empty
+            var aspireFolder = Path.Combine(directory.FullName, AspireJsonConfiguration.SettingsFolder);
+            if (Directory.Exists(aspireFolder) && !Directory.EnumerateFileSystemEntries(aspireFolder).Any())
+            {
+                Directory.Delete(aspireFolder);
+            }
+
+            _interactionService.DisplayMessage(KnownEmojis.FileCabinet, "Migrated configuration to aspire.config.json");
+
+            legacyConfig.SdkVersion ??= effectiveSdkVersion;
+            return legacyConfig;
+        }
+
+        // Neither exists — create new
+        var newConfig = new AspireJsonConfiguration();
+        newConfig.SdkVersion ??= effectiveSdkVersion;
+        return newConfig;
+    }
+
+    private static Dictionary<string, AspireConfigProfile>? ReadApphostRunProfiles(string apphostRunPath)
+    {
+        try
+        {
+            var json = File.ReadAllText(apphostRunPath);
+            using var doc = JsonDocument.Parse(json);
+
+            if (!doc.RootElement.TryGetProperty("profiles", out var profilesElement))
+            {
+                return null;
+            }
+
+            var profiles = new Dictionary<string, AspireConfigProfile>();
+            foreach (var prop in profilesElement.EnumerateObject())
+            {
+                var profile = new AspireConfigProfile();
+
+                if (prop.Value.TryGetProperty("applicationUrl", out var appUrl) &&
+                    appUrl.ValueKind == JsonValueKind.String)
+                {
+                    profile.ApplicationUrl = appUrl.GetString();
+                }
+
+                if (prop.Value.TryGetProperty("environmentVariables", out var envVars))
+                {
+                    profile.EnvironmentVariables = new Dictionary<string, string>();
+                    foreach (var envProp in envVars.EnumerateObject())
+                    {
+                        if (envProp.Value.ValueKind == JsonValueKind.String)
+                        {
+                            profile.EnvironmentVariables[envProp.Name] = envProp.Value.GetString()!;
+                        }
+                    }
+                }
+
+                profiles[prop.Name] = profile;
+            }
+
+            return profiles.Count > 0 ? profiles : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void SaveConfiguration(AspireJsonConfiguration config, DirectoryInfo directory)
+    {
+        if (AspireConfigFile.Exists(directory.FullName))
+        {
+            // Write to aspire.config.json
+            var aspireConfig = AspireConfigFile.Load(directory.FullName) ?? new AspireConfigFile();
+            aspireConfig.AppHost ??= new AspireConfigAppHost();
+            aspireConfig.AppHost.Path = config.AppHostPath;
+            aspireConfig.AppHost.Language = config.Language;
+            aspireConfig.Sdk = !string.IsNullOrEmpty(config.SdkVersion) ? new AspireConfigSdk { Version = config.SdkVersion } : aspireConfig.Sdk;
+            aspireConfig.Channel = config.Channel ?? aspireConfig.Channel;
+            aspireConfig.Packages = config.Packages ?? aspireConfig.Packages;
+            aspireConfig.Features = config.Features ?? aspireConfig.Features;
+            aspireConfig.Save(directory.FullName);
+        }
+        else
+        {
+            // Legacy path
+            config.Save(directory.FullName);
+        }
     }
 
     private string GetPrepareSdkVersion(AspireJsonConfiguration config)
@@ -328,11 +452,11 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                     return (Success: true, Output: prepareOutput, Error: (string?)null, ChannelName: channelName, NeedsCodeGen: needsCodeGen);
                 }, emoji: KnownEmojis.Gear);
 
-            // Save the channel to settings.json if available (config already has SdkVersion)
+            // Save the channel to settings if available (config already has SdkVersion)
             if (buildResult.ChannelName is not null)
             {
                 config.Channel = buildResult.ChannelName;
-                config.Save(directory.FullName);
+                SaveConfiguration(config, directory);
             }
 
             if (!buildResult.Success)
@@ -947,9 +1071,9 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         // Load config - source of truth for SDK version and packages
         var config = LoadConfiguration(directory);
 
-        // Update .aspire/settings.json with the new package
+        // Update configuration with the new package
         config.AddOrUpdatePackage(context.PackageId, context.PackageVersion);
-        config.Save(directory.FullName);
+        SaveConfiguration(config, directory);
 
         // Build and regenerate SDK code with the new package
         return await BuildAndGenerateSdkAsync(directory, cancellationToken);
@@ -1060,7 +1184,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         {
             config.AddOrUpdatePackage(packageId, newVersion);
         }
-        config.Save(directory.FullName);
+        SaveConfiguration(config, directory);
 
         // Rebuild and regenerate SDK code with updated packages
         _interactionService.DisplayEmptyLine();

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -190,9 +190,17 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
     private AspireJsonConfiguration LoadConfiguration(DirectoryInfo directory)
     {
         var configDir = GetConfigDirectory(directory);
-        var aspireConfig = AspireConfigFile.LoadOrCreate(configDir.FullName, GetEffectiveSdkVersion());
-        _logger.LogDebug("Loaded config from {Directory} (file exists: {Exists})", configDir.FullName, AspireConfigFile.Exists(configDir.FullName));
-        return aspireConfig.ToLegacyConfiguration();
+        try
+        {
+            var aspireConfig = AspireConfigFile.LoadOrCreate(configDir.FullName, GetEffectiveSdkVersion());
+            _logger.LogDebug("Loaded config from {Directory} (file exists: {Exists})", configDir.FullName, AspireConfigFile.Exists(configDir.FullName));
+            return aspireConfig.ToLegacyConfiguration();
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogError(ex, "Failed to load configuration from {Directory}", configDir.FullName);
+            throw;
+        }
     }
 
     private void SaveConfiguration(AspireJsonConfiguration config, DirectoryInfo directory)
@@ -594,10 +602,17 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
     {
         // Check aspire.config.json first for launch profiles (may be in a parent directory)
         var configDir = GetConfigDirectory(directory);
-        var aspireConfig = AspireConfigFile.Load(configDir.FullName);
-        if (aspireConfig?.Profiles is { Count: > 0 })
+        try
         {
-            return ReadProfileFromAspireConfig(aspireConfig);
+            var aspireConfig = AspireConfigFile.Load(configDir.FullName);
+            if (aspireConfig?.Profiles is { Count: > 0 })
+            {
+                return ReadProfileFromAspireConfig(aspireConfig);
+            }
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning(ex, "Failed to load config for launch profiles from {Directory}", configDir.FullName);
         }
 
         // Fall back to apphost.run.json / launchSettings.json

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -195,7 +195,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         try
         {
             var config = AspireConfigFile.LoadOrCreate(configDir.FullName, GetEffectiveSdkVersion());
-            _logger.LogDebug("Loaded config from {Directory} (file exists: {Exists})", configDir.FullName, AspireConfigFile.Exists(configDir.FullName));
+            _logger.LogInformation("Loaded config from {Directory} (file exists: {Exists})", configDir.FullName, AspireConfigFile.Exists(configDir.FullName));
             return config;
         }
         catch (InvalidOperationException ex)

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -555,8 +555,14 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
 
     private Dictionary<string, string>? ReadLaunchSettingsEnvironmentVariables(DirectoryInfo directory)
     {
-        // For guest apphosts, look for apphost.run.json
-        // similar to how .NET single-file apphosts use apphost.run.json
+        // Check aspire.config.json first for launch profiles
+        var aspireConfig = AspireConfigFile.Load(directory.FullName);
+        if (aspireConfig?.Profiles is { Count: > 0 })
+        {
+            return ReadProfileFromAspireConfig(aspireConfig);
+        }
+
+        // Fall back to apphost.run.json / launchSettings.json
         var apphostRunPath = Path.Combine(directory.FullName, "apphost.run.json");
         var launchSettingsPath = Path.Combine(directory.FullName, "Properties", "launchSettings.json");
 
@@ -564,7 +570,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
 
         if (!File.Exists(configPath))
         {
-            _logger.LogDebug("No apphost.run.json or launchSettings.json found in {Path}", directory.FullName);
+            _logger.LogDebug("No aspire.config.json, apphost.run.json, or launchSettings.json found in {Path}", directory.FullName);
             return null;
         }
 
@@ -633,6 +639,49 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             _logger.LogWarning(ex, "Failed to read launchSettings.json");
             return null;
         }
+    }
+
+    private Dictionary<string, string>? ReadProfileFromAspireConfig(AspireConfigFile aspireConfig)
+    {
+        AspireConfigProfile? profile;
+
+        // Prefer 'https' profile, then fall back to first
+        if (aspireConfig.Profiles!.TryGetValue("https", out var httpsProfile))
+        {
+            profile = httpsProfile;
+        }
+        else
+        {
+            profile = aspireConfig.Profiles.Values.FirstOrDefault();
+        }
+
+        if (profile is null)
+        {
+            return null;
+        }
+
+        var result = new Dictionary<string, string>();
+
+        if (!string.IsNullOrEmpty(profile.ApplicationUrl))
+        {
+            result["ASPNETCORE_URLS"] = profile.ApplicationUrl;
+        }
+
+        if (profile.EnvironmentVariables is not null)
+        {
+            foreach (var kvp in profile.EnvironmentVariables)
+            {
+                result[kvp.Key] = kvp.Value;
+            }
+        }
+
+        if (result.Count == 0)
+        {
+            return null;
+        }
+
+        _logger.LogDebug("Read {Count} environment variables from aspire.config.json", result.Count);
+        return result;
     }
 
     /// <inheritdoc />

--- a/src/Aspire.Cli/Projects/LanguageService.cs
+++ b/src/Aspire.Cli/Projects/LanguageService.cs
@@ -11,7 +11,7 @@ namespace Aspire.Cli.Projects;
 /// </summary>
 internal sealed class LanguageService : ILanguageService
 {
-    private const string LanguageConfigKey = "language";
+    private const string LanguageConfigKey = "appHost.language";
 
     private readonly IConfigurationService _configurationService;
     private readonly IInteractionService _interactionService;
@@ -131,7 +131,7 @@ internal sealed class LanguageService : ILanguageService
         if (saveSelection)
         {
             await SetLanguageAsync(selectedLanguage.LanguageId, isGlobal: false, cancellationToken);
-            _interactionService.DisplayMessage(KnownEmojis.CheckMark, $"Language preference saved to local settings: {selectedProject.DisplayName}");
+            _interactionService.DisplayMessage(KnownEmojis.CheckMark, $"Language preference saved to local configuration: {selectedProject.DisplayName}");
         }
 
         return selectedProject;

--- a/src/Aspire.Cli/Projects/LanguageService.cs
+++ b/src/Aspire.Cli/Projects/LanguageService.cs
@@ -33,7 +33,11 @@ internal sealed class LanguageService : ILanguageService
     /// <inheritdoc />
     public async Task<IAppHostProject?> GetConfiguredProjectAsync(CancellationToken cancellationToken = default)
     {
-        var languageId = await _configurationService.GetConfigurationAsync(LanguageConfigKey, cancellationToken);
+        // Try new nested key first, then fall back to legacy flat key.
+        // TODO: Remove "language" fallback once legacy .aspire/settings.json is no longer supported.
+        // Tracked by https://github.com/dotnet/aspire/issues/15239
+        var languageId = await _configurationService.GetConfigurationAsync(LanguageConfigKey, cancellationToken)
+            ?? await _configurationService.GetConfigurationAsync("language", cancellationToken);
 
         if (string.IsNullOrWhiteSpace(languageId))
         {

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -402,6 +402,7 @@ internal sealed class ProjectLocator(
     private async Task CreateSettingsFileAsync(FileInfo projectFile, CancellationToken cancellationToken)
     {
         var settingsFile = GetOrCreateLocalAspireConfigFile();
+        var fileExisted = settingsFile.Exists;
 
         logger.LogDebug("Creating settings file at {SettingsFilePath}", settingsFile.FullName);
 
@@ -427,7 +428,8 @@ internal sealed class ProjectLocator(
         }
 
         var relativeSettingsFilePath = Path.GetRelativePath(executionContext.WorkingDirectory.FullName, settingsFile.FullName).Replace(Path.DirectorySeparatorChar, '/');
-        interactionService.DisplayMessage(KnownEmojis.FileCabinet, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.CreatedSettingsFile, $"[bold]'{relativeSettingsFilePath.EscapeMarkup()}'[/]"), allowMarkup: true);
+        var message = fileExisted ? InteractionServiceStrings.UpdatedSettingsFile : InteractionServiceStrings.CreatedSettingsFile;
+        interactionService.DisplayMessage(KnownEmojis.FileCabinet, string.Format(CultureInfo.CurrentCulture, message, $"[bold]'{relativeSettingsFilePath.EscapeMarkup()}'[/]"), allowMarkup: true);
     }
 
     private FileInfo GetOrCreateLocalAspireConfigFile()

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -182,7 +182,7 @@ internal sealed class ProjectLocator(
             {
                 aspireConfig = AspireConfigFile.Load(searchDirectory.FullName);
             }
-            catch (InvalidOperationException ex)
+            catch (JsonException ex)
             {
                 interactionService.DisplayError(ex.Message);
                 return null;

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -188,6 +188,7 @@ internal sealed class ProjectLocator(
 
                 if (appHostFile.Exists)
                 {
+                    logger.LogDebug("Found AppHost path '{AppHostPath}' from config file in {Directory}", configAppHostPath, searchDirectory.FullName);
                     return appHostFile;
                 }
                 else
@@ -198,6 +199,8 @@ internal sealed class ProjectLocator(
                 }
             }
 
+            // TODO: Remove legacy .aspire/settings.json fallback once confident most users have migrated.
+            // Tracked by https://github.com/dotnet/aspire/issues/15239
             // Fall back to .aspire/settings.json
             var settingsFile = new FileInfo(ConfigurationHelper.BuildPathToSettingsJsonFile(searchDirectory.FullName));
 
@@ -389,7 +392,7 @@ internal sealed class ProjectLocator(
 
     private async Task CreateSettingsFileAsync(FileInfo projectFile, CancellationToken cancellationToken)
     {
-        var settingsFile = await GetOrCreateLocalAspireConfigFileAsync(cancellationToken);
+        var settingsFile = GetOrCreateLocalAspireConfigFile();
 
         logger.LogDebug("Creating settings file at {SettingsFilePath}", settingsFile.FullName);
 
@@ -418,41 +421,42 @@ internal sealed class ProjectLocator(
         interactionService.DisplayMessage(KnownEmojis.FileCabinet, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.CreatedSettingsFile, $"[bold]'{relativeSettingsFilePath.EscapeMarkup()}'[/]"), allowMarkup: true);
     }
 
-    private async Task<FileInfo> GetOrCreateLocalAspireConfigFileAsync(CancellationToken cancellationToken)
+    private FileInfo GetOrCreateLocalAspireConfigFile()
     {
         var settingsFile = new FileInfo(configurationService.GetSettingsFilePath(isGlobal: false));
 
         if (string.Equals(settingsFile.Name, AspireConfigFile.FileName, StringComparison.OrdinalIgnoreCase))
         {
+            logger.LogDebug("Using existing config file at {Path}", settingsFile.FullName);
             return settingsFile;
         }
 
         var legacySettingsRootDirectory = GetLegacySettingsRootDirectory(settingsFile);
         if (legacySettingsRootDirectory is null)
         {
-            return new FileInfo(Path.Combine(executionContext.WorkingDirectory.FullName, AspireConfigFile.FileName));
+            var newConfigPath = Path.Combine(executionContext.WorkingDirectory.FullName, AspireConfigFile.FileName);
+            logger.LogDebug("No existing config found, will create new config at {Path}", newConfigPath);
+            return new FileInfo(newConfigPath);
         }
 
         var aspireConfigFile = new FileInfo(Path.Combine(legacySettingsRootDirectory.FullName, AspireConfigFile.FileName));
         if (!aspireConfigFile.Exists)
         {
-            await MigrateLegacySettingsAsync(legacySettingsRootDirectory, cancellationToken);
+            logger.LogDebug("Migrating legacy settings from {LegacyDir} to {ConfigFile}", legacySettingsRootDirectory.FullName, aspireConfigFile.FullName);
+            MigrateLegacySettings(legacySettingsRootDirectory);
         }
 
         return aspireConfigFile;
     }
 
-    private async Task MigrateLegacySettingsAsync(DirectoryInfo settingsRootDirectory, CancellationToken cancellationToken)
+    private void MigrateLegacySettings(DirectoryInfo settingsRootDirectory)
     {
-        logger.LogDebug("Migrating legacy settings to {SettingsFilePath}", Path.Combine(settingsRootDirectory.FullName, AspireConfigFile.FileName));
+        var configFilePath = Path.Combine(settingsRootDirectory.FullName, AspireConfigFile.FileName);
+        logger.LogDebug("Migrating legacy settings to {SettingsFilePath}", configFilePath);
 
-        // LoadOrCreate handles the legacy fallback and migration internally
-        var aspireConfig = AspireConfigFile.LoadOrCreate(settingsRootDirectory.FullName);
-
-        await File.WriteAllTextAsync(
-            Path.Combine(settingsRootDirectory.FullName, AspireConfigFile.FileName),
-            JsonSerializer.Serialize(aspireConfig, JsonSourceGenerationContext.Default.AspireConfigFile),
-            cancellationToken);
+        // LoadOrCreate handles the legacy fallback and migration internally,
+        // including saving the migrated config to disk.
+        _ = AspireConfigFile.LoadOrCreate(settingsRootDirectory.FullName);
     }
 
     private static DirectoryInfo? GetLegacySettingsRootDirectory(FileInfo settingsFile)

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -176,6 +176,29 @@ internal sealed class ProjectLocator(
 
         while (true)
         {
+            // Check aspire.config.json first
+            var aspireConfig = AspireConfigFile.Load(searchDirectory.FullName);
+            if (aspireConfig?.AppHost?.Path is { } configAppHostPath)
+            {
+                var qualifiedPath = Path.IsPathRooted(configAppHostPath)
+                    ? configAppHostPath
+                    : Path.Combine(searchDirectory.FullName, configAppHostPath);
+                qualifiedPath = PathNormalizer.NormalizePathForCurrentPlatform(qualifiedPath);
+                var appHostFile = new FileInfo(qualifiedPath);
+
+                if (appHostFile.Exists)
+                {
+                    return appHostFile;
+                }
+                else
+                {
+                    var configFilePath = Path.Combine(searchDirectory.FullName, AspireConfigFile.FileName);
+                    interactionService.DisplayMessage(KnownEmojis.Warning, string.Format(CultureInfo.CurrentCulture, ErrorStrings.AppHostWasSpecifiedButDoesntExist, configFilePath, qualifiedPath));
+                    return null;
+                }
+            }
+
+            // Fall back to .aspire/settings.json
             var settingsFile = new FileInfo(ConfigurationHelper.BuildPathToSettingsJsonFile(searchDirectory.FullName));
 
             if (settingsFile.Exists)

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -389,33 +389,138 @@ internal sealed class ProjectLocator(
 
     private async Task CreateSettingsFileAsync(FileInfo projectFile, CancellationToken cancellationToken)
     {
-        var settingsFilePath = ConfigurationHelper.BuildPathToSettingsJsonFile(executionContext.WorkingDirectory.FullName);
-        var settingsFile = new FileInfo(settingsFilePath);
+        var settingsFile = await GetOrCreateLocalAspireConfigFileAsync(cancellationToken);
 
         logger.LogDebug("Creating settings file at {SettingsFilePath}", settingsFile.FullName);
 
         var relativePathToProjectFile = Path.GetRelativePath(settingsFile.Directory!.FullName, projectFile.FullName).Replace(Path.DirectorySeparatorChar, '/');
 
-        // Use the configuration writer to set the appHostPath, which will merge with any existing settings
-        await configurationService.SetConfigurationAsync("appHostPath", relativePathToProjectFile, isGlobal: false, cancellationToken);
+        // Use the configuration writer to set the AppHost path, which will merge with any existing settings.
+        await configurationService.SetConfigurationAsync("appHost.path", relativePathToProjectFile, isGlobal: false, cancellationToken);
 
-        // For polyglot projects, also set language and inherit SDK version from parent/global config
+        // For polyglot projects, also set language and inherit SDK version from parent/global config.
         var language = languageDiscovery.GetLanguageByFile(projectFile);
         if (language is not null && !language.LanguageId.Value.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase))
         {
-            await configurationService.SetConfigurationAsync("language", language.LanguageId.Value, isGlobal: false, cancellationToken);
+            await configurationService.SetConfigurationAsync("appHost.language", language.LanguageId.Value, isGlobal: false, cancellationToken);
 
-            // Inherit SDK version from parent/global config if available
-            var inheritedSdkVersion = await configurationService.GetConfigurationAsync("sdkVersion", cancellationToken);
+            // Inherit SDK version from parent/global config if available.
+            var inheritedSdkVersion = await configurationService.GetConfigurationAsync("sdk.version", cancellationToken)
+                ?? await configurationService.GetConfigurationAsync("sdkVersion", cancellationToken);
             if (!string.IsNullOrEmpty(inheritedSdkVersion))
             {
-                await configurationService.SetConfigurationAsync("sdkVersion", inheritedSdkVersion, isGlobal: false, cancellationToken);
+                await configurationService.SetConfigurationAsync("sdk.version", inheritedSdkVersion, isGlobal: false, cancellationToken);
                 logger.LogDebug("Set SDK version {Version} in settings file (inherited from parent config)", inheritedSdkVersion);
             }
         }
 
         var relativeSettingsFilePath = Path.GetRelativePath(executionContext.WorkingDirectory.FullName, settingsFile.FullName).Replace(Path.DirectorySeparatorChar, '/');
         interactionService.DisplayMessage(KnownEmojis.FileCabinet, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.CreatedSettingsFile, $"[bold]'{relativeSettingsFilePath.EscapeMarkup()}'[/]"), allowMarkup: true);
+    }
+
+    private async Task<FileInfo> GetOrCreateLocalAspireConfigFileAsync(CancellationToken cancellationToken)
+    {
+        var settingsFile = new FileInfo(configurationService.GetSettingsFilePath(isGlobal: false));
+
+        if (string.Equals(settingsFile.Name, AspireConfigFile.FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return settingsFile;
+        }
+
+        var legacySettingsRootDirectory = GetLegacySettingsRootDirectory(settingsFile);
+        if (legacySettingsRootDirectory is null)
+        {
+            return new FileInfo(Path.Combine(executionContext.WorkingDirectory.FullName, AspireConfigFile.FileName));
+        }
+
+        var aspireConfigFile = new FileInfo(Path.Combine(legacySettingsRootDirectory.FullName, AspireConfigFile.FileName));
+        if (!aspireConfigFile.Exists)
+        {
+            await MigrateLegacySettingsAsync(legacySettingsRootDirectory, cancellationToken);
+        }
+
+        return aspireConfigFile;
+    }
+
+    private async Task MigrateLegacySettingsAsync(DirectoryInfo settingsRootDirectory, CancellationToken cancellationToken)
+    {
+        logger.LogDebug("Migrating legacy settings to {SettingsFilePath}", Path.Combine(settingsRootDirectory.FullName, AspireConfigFile.FileName));
+
+        var legacyConfig = AspireJsonConfiguration.Load(settingsRootDirectory.FullName);
+        var profiles = ReadApphostRunProfiles(Path.Combine(settingsRootDirectory.FullName, "apphost.run.json"));
+        var aspireConfig = AspireConfigFile.FromLegacy(legacyConfig, profiles);
+
+        await File.WriteAllTextAsync(
+            Path.Combine(settingsRootDirectory.FullName, AspireConfigFile.FileName),
+            JsonSerializer.Serialize(aspireConfig, JsonSourceGenerationContext.Default.AspireConfigFile),
+            cancellationToken);
+    }
+
+    private static DirectoryInfo? GetLegacySettingsRootDirectory(FileInfo settingsFile)
+    {
+        if (!string.Equals(settingsFile.Name, AspireJsonConfiguration.FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var settingsDirectory = settingsFile.Directory;
+        if (settingsDirectory is null || !string.Equals(settingsDirectory.Name, AspireJsonConfiguration.SettingsFolder, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return settingsDirectory.Parent;
+    }
+
+    private static Dictionary<string, AspireConfigProfile>? ReadApphostRunProfiles(string apphostRunPath)
+    {
+        try
+        {
+            if (!File.Exists(apphostRunPath))
+            {
+                return null;
+            }
+
+            var json = File.ReadAllText(apphostRunPath);
+            using var doc = JsonDocument.Parse(json);
+
+            if (!doc.RootElement.TryGetProperty("profiles", out var profilesElement))
+            {
+                return null;
+            }
+
+            var profiles = new Dictionary<string, AspireConfigProfile>();
+            foreach (var prop in profilesElement.EnumerateObject())
+            {
+                var profile = new AspireConfigProfile();
+
+                if (prop.Value.TryGetProperty("applicationUrl", out var appUrl) &&
+                    appUrl.ValueKind == JsonValueKind.String)
+                {
+                    profile.ApplicationUrl = appUrl.GetString();
+                }
+
+                if (prop.Value.TryGetProperty("environmentVariables", out var envVars))
+                {
+                    profile.EnvironmentVariables = new Dictionary<string, string>();
+                    foreach (var envProp in envVars.EnumerateObject())
+                    {
+                        if (envProp.Value.ValueKind == JsonValueKind.String)
+                        {
+                            profile.EnvironmentVariables[envProp.Name] = envProp.Value.GetString()!;
+                        }
+                    }
+                }
+
+                profiles[prop.Name] = profile;
+            }
+
+            return profiles.Count > 0 ? profiles : null;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
 }

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -446,9 +446,8 @@ internal sealed class ProjectLocator(
     {
         logger.LogDebug("Migrating legacy settings to {SettingsFilePath}", Path.Combine(settingsRootDirectory.FullName, AspireConfigFile.FileName));
 
-        var legacyConfig = AspireJsonConfiguration.Load(settingsRootDirectory.FullName);
-        var profiles = ReadApphostRunProfiles(Path.Combine(settingsRootDirectory.FullName, "apphost.run.json"));
-        var aspireConfig = AspireConfigFile.FromLegacy(legacyConfig, profiles);
+        // LoadOrCreate handles the legacy fallback and migration internally
+        var aspireConfig = AspireConfigFile.LoadOrCreate(settingsRootDirectory.FullName);
 
         await File.WriteAllTextAsync(
             Path.Combine(settingsRootDirectory.FullName, AspireConfigFile.FileName),
@@ -470,57 +469,6 @@ internal sealed class ProjectLocator(
         }
 
         return settingsDirectory.Parent;
-    }
-
-    private static Dictionary<string, AspireConfigProfile>? ReadApphostRunProfiles(string apphostRunPath)
-    {
-        try
-        {
-            if (!File.Exists(apphostRunPath))
-            {
-                return null;
-            }
-
-            var json = File.ReadAllText(apphostRunPath);
-            using var doc = JsonDocument.Parse(json);
-
-            if (!doc.RootElement.TryGetProperty("profiles", out var profilesElement))
-            {
-                return null;
-            }
-
-            var profiles = new Dictionary<string, AspireConfigProfile>();
-            foreach (var prop in profilesElement.EnumerateObject())
-            {
-                var profile = new AspireConfigProfile();
-
-                if (prop.Value.TryGetProperty("applicationUrl", out var appUrl) &&
-                    appUrl.ValueKind == JsonValueKind.String)
-                {
-                    profile.ApplicationUrl = appUrl.GetString();
-                }
-
-                if (prop.Value.TryGetProperty("environmentVariables", out var envVars))
-                {
-                    profile.EnvironmentVariables = new Dictionary<string, string>();
-                    foreach (var envProp in envVars.EnumerateObject())
-                    {
-                        if (envProp.Value.ValueKind == JsonValueKind.String)
-                        {
-                            profile.EnvironmentVariables[envProp.Name] = envProp.Value.GetString()!;
-                        }
-                    }
-                }
-
-                profiles[prop.Name] = profile;
-            }
-
-            return profiles.Count > 0 ? profiles : null;
-        }
-        catch
-        {
-            return null;
-        }
     }
 
 }

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -197,7 +197,7 @@ internal sealed class ProjectLocator(
 
                 if (appHostFile.Exists)
                 {
-                    logger.LogDebug("Found AppHost path '{AppHostPath}' from config file in {Directory}", configAppHostPath, searchDirectory.FullName);
+                    logger.LogInformation("Found AppHost path '{AppHostPath}' from config file in {Directory}", configAppHostPath, searchDirectory.FullName);
                     return appHostFile;
                 }
                 else
@@ -453,7 +453,7 @@ internal sealed class ProjectLocator(
         var aspireConfigFile = new FileInfo(Path.Combine(legacySettingsRootDirectory.FullName, AspireConfigFile.FileName));
         if (!aspireConfigFile.Exists)
         {
-            logger.LogDebug("Migrating legacy settings from {LegacyDir} to {ConfigFile}", legacySettingsRootDirectory.FullName, aspireConfigFile.FullName);
+            logger.LogInformation("Migrating legacy settings from {LegacyDir} to {ConfigFile}", legacySettingsRootDirectory.FullName, aspireConfigFile.FullName);
             MigrateLegacySettings(legacySettingsRootDirectory);
         }
 
@@ -463,7 +463,7 @@ internal sealed class ProjectLocator(
     private void MigrateLegacySettings(DirectoryInfo settingsRootDirectory)
     {
         var configFilePath = Path.Combine(settingsRootDirectory.FullName, AspireConfigFile.FileName);
-        logger.LogDebug("Migrating legacy settings to {SettingsFilePath}", configFilePath);
+        logger.LogInformation("Migrating legacy settings to {SettingsFilePath}", configFilePath);
 
         // LoadOrCreate handles the legacy fallback and migration internally,
         // including saving the migrated config to disk.

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -177,7 +177,16 @@ internal sealed class ProjectLocator(
         while (true)
         {
             // Check aspire.config.json first
-            var aspireConfig = AspireConfigFile.Load(searchDirectory.FullName);
+            AspireConfigFile? aspireConfig;
+            try
+            {
+                aspireConfig = AspireConfigFile.Load(searchDirectory.FullName);
+            }
+            catch (InvalidOperationException ex)
+            {
+                interactionService.DisplayError(ex.Message);
+                return null;
+            }
             if (aspireConfig?.AppHost?.Path is { } configAppHostPath)
             {
                 var qualifiedPath = Path.IsPathRooted(configAppHostPath)

--- a/src/Aspire.Cli/Resources/ErrorStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ErrorStrings.Designer.cs
@@ -336,5 +336,14 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("ProjectFileUnsupportedInCurrentEnvironment", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again..
+        /// </summary>
+        public static string InvalidJsonInConfigFile {
+            get {
+                return ResourceManager.GetString("InvalidJsonInConfigFile", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/ErrorStrings.resx
+++ b/src/Aspire.Cli/Resources/ErrorStrings.resx
@@ -229,4 +229,8 @@
   <data name="ProjectFileUnsupportedInCurrentEnvironment" xml:space="preserve">
     <value>Project is not supported in the current environment: {0}</value>
   </data>
+  <data name="InvalidJsonInConfigFile" xml:space="preserve">
+    <value>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</value>
+    <comment>{0} is the file path</comment>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
@@ -133,6 +133,15 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Updated settings file at {0}..
+        /// </summary>
+        public static string UpdatedSettingsFile {
+            get {
+                return ResourceManager.GetString("UpdatedSettingsFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Other (specify next).
         /// </summary>
         public static string CustomChoiceLabel {

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
@@ -172,6 +172,10 @@
     <value>Created settings file at {0}.</value>
     <comment>{0} is a path</comment>
   </data>
+  <data name="UpdatedSettingsFile" xml:space="preserve">
+    <value>Updated settings file at {0}.</value>
+    <comment>{0} is a path</comment>
+  </data>
   <data name="ProjectOptionDoesntExist" xml:space="preserve">
     <value>The --apphost option specified a project that does not exist.</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Nepovedlo se vyhledat balíčky. Ukončovací kód: {0}</target>
         <note>{0} is a number</note>
       </trans-unit>
+      <trans-unit id="InvalidJsonInConfigFile">
+        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
+        <note>{0} is the file path</note>
+      </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>
         <target state="translated">Zadané neplatné národní prostředí {0} se nepoužije.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Fehler beim Suchen nach Paketen. Exitcode: {0}.</target>
         <note>{0} is a number</note>
       </trans-unit>
+      <trans-unit id="InvalidJsonInConfigFile">
+        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
+        <note>{0} is the file path</note>
+      </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>
         <target state="translated">Das angegebene ungültige Gebietsschema „{0}“ wird nicht verwendet.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
@@ -107,6 +107,11 @@
         <target state="translated">No se pudieron buscar paquetes. Código de salida: {0}.</target>
         <note>{0} is a number</note>
       </trans-unit>
+      <trans-unit id="InvalidJsonInConfigFile">
+        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
+        <note>{0} is the file path</note>
+      </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>
         <target state="translated">No se usará la configuración regional no válida {0} proporcionada.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Échec de la recherche des packages. Code de sortie : {0}.</target>
         <note>{0} is a number</note>
       </trans-unit>
+      <trans-unit id="InvalidJsonInConfigFile">
+        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
+        <note>{0} is the file path</note>
+      </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>
         <target state="translated">Les paramètres régionaux non valides {0} fournis ne seront pas utilisés.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Non è possibile cercare i pacchetti. Codice di uscita: {0}.</target>
         <note>{0} is a number</note>
       </trans-unit>
+      <trans-unit id="InvalidJsonInConfigFile">
+        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
+        <note>{0} is the file path</note>
+      </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>
         <target state="translated">Le impostazioni locali {0} specificate non valide non verranno utilizzate.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
@@ -107,6 +107,11 @@
         <target state="translated">パッケージの検索に失敗しました。終了コード: {0}。</target>
         <note>{0} is a number</note>
       </trans-unit>
+      <trans-unit id="InvalidJsonInConfigFile">
+        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
+        <note>{0} is the file path</note>
+      </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>
         <target state="translated">指定された無効なロケール {0} は使用されません。</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
@@ -107,6 +107,11 @@
         <target state="translated">패키지를 검색하지 못했습니다. 종료 코드: {0}.</target>
         <note>{0} is a number</note>
       </trans-unit>
+      <trans-unit id="InvalidJsonInConfigFile">
+        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
+        <note>{0} is the file path</note>
+      </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>
         <target state="translated">제공한 로캘 {0}이(가) 잘못되어 사용되지 않습니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Nie można wyszukać pakietów. Kod zakończenia: {0}.</target>
         <note>{0} is a number</note>
       </trans-unit>
+      <trans-unit id="InvalidJsonInConfigFile">
+        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
+        <note>{0} is the file path</note>
+      </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>
         <target state="translated">Podane nieprawidłowe ustawienia regionalne {0} nie będą używane.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Falha ao pesquisar pacotes. Código de saída: {0}.</target>
         <note>{0} is a number</note>
       </trans-unit>
+      <trans-unit id="InvalidJsonInConfigFile">
+        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
+        <note>{0} is the file path</note>
+      </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>
         <target state="translated">A localidade {0} inválida fornecida não será usada.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Не удалось выполнить поиск пакетов. Код выхода: {0}.</target>
         <note>{0} is a number</note>
       </trans-unit>
+      <trans-unit id="InvalidJsonInConfigFile">
+        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
+        <note>{0} is the file path</note>
+      </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>
         <target state="translated">Указанный недопустимый языковой стандарт {0} не будет использован.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Paketler aranamadı. Çıkış kodu: {0}.</target>
         <note>{0} is a number</note>
       </trans-unit>
+      <trans-unit id="InvalidJsonInConfigFile">
+        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
+        <note>{0} is the file path</note>
+      </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>
         <target state="translated">Sağlanan geçersiz {0} yerel ayarı kullanılmayacaktır.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
@@ -107,6 +107,11 @@
         <target state="translated">未能搜索包。退出代码: {0}。</target>
         <note>{0} is a number</note>
       </trans-unit>
+      <trans-unit id="InvalidJsonInConfigFile">
+        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
+        <note>{0} is the file path</note>
+      </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>
         <target state="translated">将不使用提供的无效区域设置 {0}。</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
@@ -107,6 +107,11 @@
         <target state="translated">無法搜尋套件。結束代碼: {0}。</target>
         <note>{0} is a number</note>
       </trans-unit>
+      <trans-unit id="InvalidJsonInConfigFile">
+        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
+        <note>{0} is the file path</note>
+      </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>
         <target state="translated">提供的無效地區設定 {0} 將不會被使用。</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
@@ -167,6 +167,11 @@
         <target state="translated">Došlo k neočekávané chybě: {0}</target>
         <note>{0} is the exception message</note>
       </trans-unit>
+      <trans-unit id="UpdatedSettingsFile">
+        <source>Updated settings file at {0}.</source>
+        <target state="new">Updated settings file at {0}.</target>
+        <note>{0} is a path</note>
+      </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttachToAppHost">
         <source>Waiting for debugger to attach to app host process</source>
         <target state="translated">Čeká se na připojení ladicího programu k procesu hostitele aplikací.</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
@@ -167,6 +167,11 @@
         <target state="translated">Ein unerwarteter Fehler ist aufgetreten: {0}</target>
         <note>{0} is the exception message</note>
       </trans-unit>
+      <trans-unit id="UpdatedSettingsFile">
+        <source>Updated settings file at {0}.</source>
+        <target state="new">Updated settings file at {0}.</target>
+        <note>{0} is a path</note>
+      </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttachToAppHost">
         <source>Waiting for debugger to attach to app host process</source>
         <target state="translated">Es wird darauf gewartet, dass der Debugger an den App-Hostprozess angefügt wird.</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
@@ -167,6 +167,11 @@
         <target state="translated">Se ha producido un error inesperado: {0}</target>
         <note>{0} is the exception message</note>
       </trans-unit>
+      <trans-unit id="UpdatedSettingsFile">
+        <source>Updated settings file at {0}.</source>
+        <target state="new">Updated settings file at {0}.</target>
+        <note>{0} is a path</note>
+      </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttachToAppHost">
         <source>Waiting for debugger to attach to app host process</source>
         <target state="translated">Esperando a que el depurador se conecte al proceso del host de aplicaciones</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
@@ -167,6 +167,11 @@
         <target state="translated">Une erreur inattendue est survenue : {0}</target>
         <note>{0} is the exception message</note>
       </trans-unit>
+      <trans-unit id="UpdatedSettingsFile">
+        <source>Updated settings file at {0}.</source>
+        <target state="new">Updated settings file at {0}.</target>
+        <note>{0} is a path</note>
+      </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttachToAppHost">
         <source>Waiting for debugger to attach to app host process</source>
         <target state="translated">En attente de l’attachement du débogueur au processus de l’hôte d’application</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
@@ -167,6 +167,11 @@
         <target state="translated">Si è verificato un errore imprevisto: {0}</target>
         <note>{0} is the exception message</note>
       </trans-unit>
+      <trans-unit id="UpdatedSettingsFile">
+        <source>Updated settings file at {0}.</source>
+        <target state="new">Updated settings file at {0}.</target>
+        <note>{0} is a path</note>
+      </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttachToAppHost">
         <source>Waiting for debugger to attach to app host process</source>
         <target state="translated">In attesa del collegamento del debugger al processo dell'host delle app</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
@@ -167,6 +167,11 @@
         <target state="translated">予期しないエラーが発生しました: {0}</target>
         <note>{0} is the exception message</note>
       </trans-unit>
+      <trans-unit id="UpdatedSettingsFile">
+        <source>Updated settings file at {0}.</source>
+        <target state="new">Updated settings file at {0}.</target>
+        <note>{0} is a path</note>
+      </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttachToAppHost">
         <source>Waiting for debugger to attach to app host process</source>
         <target state="translated">デバッガーがアプリ ホスティング プロセスにアタッチされるのを待機しています</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
@@ -167,6 +167,11 @@
         <target state="translated">예기치 않은 오류가 발생했습니다. {0}</target>
         <note>{0} is the exception message</note>
       </trans-unit>
+      <trans-unit id="UpdatedSettingsFile">
+        <source>Updated settings file at {0}.</source>
+        <target state="new">Updated settings file at {0}.</target>
+        <note>{0} is a path</note>
+      </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttachToAppHost">
         <source>Waiting for debugger to attach to app host process</source>
         <target state="translated">디버거가 앱 호스트 프로세스에 연결되기를 기다리는 중</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
@@ -167,6 +167,11 @@
         <target state="translated">Wystąpił nieoczekiwany błąd: {0}</target>
         <note>{0} is the exception message</note>
       </trans-unit>
+      <trans-unit id="UpdatedSettingsFile">
+        <source>Updated settings file at {0}.</source>
+        <target state="new">Updated settings file at {0}.</target>
+        <note>{0} is a path</note>
+      </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttachToAppHost">
         <source>Waiting for debugger to attach to app host process</source>
         <target state="translated">Oczekiwanie na dołączenie debugera do procesu hosta aplikacji</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
@@ -167,6 +167,11 @@
         <target state="translated">Ocorreu um erro inesperado: {0}</target>
         <note>{0} is the exception message</note>
       </trans-unit>
+      <trans-unit id="UpdatedSettingsFile">
+        <source>Updated settings file at {0}.</source>
+        <target state="new">Updated settings file at {0}.</target>
+        <note>{0} is a path</note>
+      </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttachToAppHost">
         <source>Waiting for debugger to attach to app host process</source>
         <target state="translated">Aguardando que o depurador seja anexado ao processo de host do aplicativo</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
@@ -167,6 +167,11 @@
         <target state="translated">Возникла непредвиденная ошибка: {0}</target>
         <note>{0} is the exception message</note>
       </trans-unit>
+      <trans-unit id="UpdatedSettingsFile">
+        <source>Updated settings file at {0}.</source>
+        <target state="new">Updated settings file at {0}.</target>
+        <note>{0} is a path</note>
+      </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttachToAppHost">
         <source>Waiting for debugger to attach to app host process</source>
         <target state="translated">Ожидание подключения отладчика к процессу хоста приложения</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
@@ -167,6 +167,11 @@
         <target state="translated">Beklenmeyen bir hata oluştu: {0}</target>
         <note>{0} is the exception message</note>
       </trans-unit>
+      <trans-unit id="UpdatedSettingsFile">
+        <source>Updated settings file at {0}.</source>
+        <target state="new">Updated settings file at {0}.</target>
+        <note>{0} is a path</note>
+      </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttachToAppHost">
         <source>Waiting for debugger to attach to app host process</source>
         <target state="translated">Hata ayıklayıcının uygulama ana işlemine eklenmesi bekleniyor</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
@@ -167,6 +167,11 @@
         <target state="translated">发生意外错误: {0}</target>
         <note>{0} is the exception message</note>
       </trans-unit>
+      <trans-unit id="UpdatedSettingsFile">
+        <source>Updated settings file at {0}.</source>
+        <target state="new">Updated settings file at {0}.</target>
+        <note>{0} is a path</note>
+      </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttachToAppHost">
         <source>Waiting for debugger to attach to app host process</source>
         <target state="translated">正在等待调试程序附加到应用主机进程</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
@@ -167,6 +167,11 @@
         <target state="translated">發生未預期的錯誤: {0}</target>
         <note>{0} is the exception message</note>
       </trans-unit>
+      <trans-unit id="UpdatedSettingsFile">
+        <source>Updated settings file at {0}.</source>
+        <target state="new">Updated settings file at {0}.</target>
+        <note>{0} is a path</note>
+      </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttachToAppHost">
         <source>Waiting for debugger to attach to app host process</source>
         <target state="translated">正在等候偵錯工具連結到應用程式主機流程</target>

--- a/src/Aspire.Cli/Scaffolding/IScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/IScaffoldingService.cs
@@ -26,5 +26,6 @@ internal interface IScaffoldingService
     /// </summary>
     /// <param name="context">The scaffolding context.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task ScaffoldAsync(ScaffoldContext context, CancellationToken cancellationToken);
+    /// <returns><see langword="true"/> when scaffolding succeeds; otherwise, <see langword="false"/>.</returns>
+    Task<bool> ScaffoldAsync(ScaffoldContext context, CancellationToken cancellationToken);
 }

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -131,7 +131,17 @@ internal sealed class ScaffoldingService : IScaffoldingService
                 language,
                 cancellationToken);
 
-            // Save channel and language to settings.json
+            // Save channel and language to aspire.config.json (new format)
+            var aspireConfigFile = AspireConfigFile.FromLegacy(config, profiles: null);
+            if (prepareResult.ChannelName is not null)
+            {
+                aspireConfigFile.Channel = prepareResult.ChannelName;
+            }
+            aspireConfigFile.AppHost ??= new AspireConfigAppHost();
+            aspireConfigFile.AppHost.Language = language.LanguageId;
+            aspireConfigFile.Save(directory.FullName);
+
+            // Also save legacy settings.json for backward compatibility
             if (prepareResult.ChannelName is not null)
             {
                 config.Channel = prepareResult.ChannelName;

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -133,45 +133,19 @@ internal sealed class ScaffoldingService : IScaffoldingService
 
             // Save channel and language to aspire.config.json (new format)
             // Read profiles from apphost.run.json (created by codegen) and merge into aspire.config.json
-            Dictionary<string, AspireConfigProfile>? profiles = null;
             var appHostRunPath = Path.Combine(directory.FullName, "apphost.run.json");
-            if (File.Exists(appHostRunPath))
+            var profiles = AspireConfigFile.ReadApphostRunProfiles(appHostRunPath);
+
+            if (profiles is not null && File.Exists(appHostRunPath))
             {
                 try
                 {
-                    var runJson = File.ReadAllText(appHostRunPath);
-                    var runDoc = System.Text.Json.JsonDocument.Parse(runJson);
-                    if (runDoc.RootElement.TryGetProperty("profiles", out var profilesElement))
-                    {
-                        profiles = new Dictionary<string, AspireConfigProfile>();
-                        foreach (var profile in profilesElement.EnumerateObject())
-                        {
-                            var configProfile = new AspireConfigProfile();
-                            if (profile.Value.TryGetProperty("applicationUrl", out var appUrl))
-                            {
-                                configProfile.ApplicationUrl = appUrl.GetString();
-                            }
-                            if (profile.Value.TryGetProperty("environmentVariables", out var envVars))
-                            {
-                                configProfile.EnvironmentVariables = new Dictionary<string, string>();
-                                foreach (var envVar in envVars.EnumerateObject())
-                                {
-                                    if (envVar.Value.ValueKind == System.Text.Json.JsonValueKind.String)
-                                    {
-                                        configProfile.EnvironmentVariables[envVar.Name] = envVar.Value.GetString()!;
-                                    }
-                                }
-                            }
-                            profiles[profile.Name] = configProfile;
-                        }
-                    }
-
                     // Delete apphost.run.json since profiles are now in aspire.config.json
                     File.Delete(appHostRunPath);
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogDebug(ex, "Failed to read profiles from apphost.run.json");
+                    _logger.LogDebug(ex, "Failed to delete apphost.run.json after reading profiles");
                 }
             }
 

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -183,15 +183,6 @@ internal sealed class ScaffoldingService : IScaffoldingService
             aspireConfigFile.AppHost ??= new AspireConfigAppHost();
             aspireConfigFile.AppHost.Language = language.LanguageId;
             aspireConfigFile.Save(directory.FullName);
-
-            // Also save legacy settings.json for backward compatibility
-            if (prepareResult.ChannelName is not null)
-            {
-                config.Channel = prepareResult.ChannelName;
-            }
-
-            config.Language = language.LanguageId;
-            config.Save(directory.FullName);
         }
         finally
         {

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -134,7 +134,7 @@ internal sealed class ScaffoldingService : IScaffoldingService
             // Save channel and language to aspire.config.json (new format)
             // Read profiles from apphost.run.json (created by codegen) and merge into aspire.config.json
             var appHostRunPath = Path.Combine(directory.FullName, "apphost.run.json");
-            var profiles = AspireConfigFile.ReadApphostRunProfiles(appHostRunPath);
+            var profiles = AspireConfigFile.ReadApphostRunProfiles(appHostRunPath, _logger);
 
             if (profiles is not null && File.Exists(appHostRunPath))
             {

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -40,17 +40,17 @@ internal sealed class ScaffoldingService : IScaffoldingService
     }
 
     /// <inheritdoc />
-    public async Task ScaffoldAsync(ScaffoldContext context, CancellationToken cancellationToken)
+    public async Task<bool> ScaffoldAsync(ScaffoldContext context, CancellationToken cancellationToken)
     {
         if (context.Language.LanguageId.Value.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase))
         {
             throw new NotSupportedException("C# projects should be created using the template system via NewCommand.");
         }
 
-        await ScaffoldGuestLanguageAsync(context, cancellationToken);
+        return await ScaffoldGuestLanguageAsync(context, cancellationToken);
     }
 
-    private async Task ScaffoldGuestLanguageAsync(ScaffoldContext context, CancellationToken cancellationToken)
+    private async Task<bool> ScaffoldGuestLanguageAsync(ScaffoldContext context, CancellationToken cancellationToken)
     {
         var directory = context.TargetDirectory;
         var language = context.Language;
@@ -82,7 +82,7 @@ internal sealed class ScaffoldingService : IScaffoldingService
                 _interactionService.DisplayLines(prepareResult.Output.GetLines());
             }
             _interactionService.DisplayError("Failed to build AppHost server.");
-            return;
+            return false;
         }
 
         // Step 2: Start the server temporarily for scaffolding and code generation
@@ -121,7 +121,7 @@ internal sealed class ScaffoldingService : IScaffoldingService
                 emoji: KnownEmojis.Package);
             if (installResult != 0)
             {
-                return;
+                return false;
             }
 
             // Step 6: Generate SDK code via RPC
@@ -181,8 +181,10 @@ internal sealed class ScaffoldingService : IScaffoldingService
                 aspireConfigFile.Channel = prepareResult.ChannelName;
             }
             aspireConfigFile.AppHost ??= new AspireConfigAppHost();
+            aspireConfigFile.AppHost.Path ??= language.AppHostFileName;
             aspireConfigFile.AppHost.Language = language.LanguageId;
             aspireConfigFile.Save(directory.FullName);
+            return true;
         }
         finally
         {

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -57,7 +57,7 @@ internal sealed class ScaffoldingService : IScaffoldingService
 
         // Step 1: Resolve SDK and package strategy
         var sdkVersion = await ResolveSdkVersionAsync(cancellationToken);
-        var config = AspireJsonConfiguration.LoadOrCreate(directory.FullName, sdkVersion);
+        var config = AspireConfigFile.LoadOrCreate(directory.FullName, sdkVersion);
 
         // Include the code generation package for scaffolding and code gen
         var codeGenPackage = await _languageDiscovery.GetPackageForLanguageAsync(language.LanguageId, cancellationToken);
@@ -149,15 +149,15 @@ internal sealed class ScaffoldingService : IScaffoldingService
                 }
             }
 
-            var aspireConfigFile = AspireConfigFile.FromLegacy(config, profiles);
+            config.Profiles = profiles;
             if (prepareResult.ChannelName is not null)
             {
-                aspireConfigFile.Channel = prepareResult.ChannelName;
+                config.Channel = prepareResult.ChannelName;
             }
-            aspireConfigFile.AppHost ??= new AspireConfigAppHost();
-            aspireConfigFile.AppHost.Path ??= language.AppHostFileName;
-            aspireConfigFile.AppHost.Language = language.LanguageId;
-            aspireConfigFile.Save(directory.FullName);
+            config.AppHost ??= new AspireConfigAppHost();
+            config.AppHost.Path ??= language.AppHostFileName;
+            config.AppHost.Language = language.LanguageId;
+            config.Save(directory.FullName);
             return true;
         }
         finally

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
@@ -137,20 +137,35 @@ internal sealed partial class CliTemplateFactory
 
     private async Task ApplyLocalhostTldToScaffoldedRunProfileAsync(string outputPath, string projectName, CancellationToken cancellationToken)
     {
-        var appHostRunProfilePath = Path.Combine(outputPath, "apphost.run.json");
-        if (!File.Exists(appHostRunProfilePath))
+        var hostName = $"{projectName.ToLowerInvariant()}.dev.localhost";
+
+        // Check aspire.config.json first
+        var aspireConfigPath = Path.Combine(outputPath, Configuration.AspireConfigFile.FileName);
+        if (File.Exists(aspireConfigPath))
         {
-            _logger.LogDebug("Skipping localhost TLD update because '{RunProfilePath}' was not found.", appHostRunProfilePath);
+            var content = await File.ReadAllTextAsync(aspireConfigPath, cancellationToken);
+            var updatedContent = content.Replace("://localhost", $"://{hostName}", StringComparison.Ordinal);
+            if (!string.Equals(content, updatedContent, StringComparison.Ordinal))
+            {
+                await File.WriteAllTextAsync(aspireConfigPath, updatedContent, cancellationToken);
+            }
             return;
         }
 
-        var hostName = $"{projectName.ToLowerInvariant()}.dev.localhost";
-        var content = await File.ReadAllTextAsync(appHostRunProfilePath, cancellationToken);
-        var updatedContent = content.Replace("://localhost", $"://{hostName}", StringComparison.Ordinal);
-
-        if (!string.Equals(content, updatedContent, StringComparison.Ordinal))
+        // Fall back to apphost.run.json
+        var appHostRunProfilePath = Path.Combine(outputPath, "apphost.run.json");
+        if (!File.Exists(appHostRunProfilePath))
         {
-            await File.WriteAllTextAsync(appHostRunProfilePath, updatedContent, cancellationToken);
+            _logger.LogDebug("Skipping localhost TLD update because neither aspire.config.json nor apphost.run.json was found in '{OutputPath}'.", outputPath);
+            return;
+        }
+
+        var runContent = await File.ReadAllTextAsync(appHostRunProfilePath, cancellationToken);
+        var updatedRunContent = runContent.Replace("://localhost", $"://{hostName}", StringComparison.Ordinal);
+
+        if (!string.Equals(runContent, updatedRunContent, StringComparison.Ordinal))
+        {
+            await File.WriteAllTextAsync(appHostRunProfilePath, updatedRunContent, cancellationToken);
         }
     }
 

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
@@ -139,33 +139,18 @@ internal sealed partial class CliTemplateFactory
     {
         var hostName = $"{projectName.ToLowerInvariant()}.dev.localhost";
 
-        // Check aspire.config.json first
         var aspireConfigPath = Path.Combine(outputPath, Configuration.AspireConfigFile.FileName);
-        if (File.Exists(aspireConfigPath))
+        if (!File.Exists(aspireConfigPath))
         {
-            var content = await File.ReadAllTextAsync(aspireConfigPath, cancellationToken);
-            var updatedContent = content.Replace("://localhost", $"://{hostName}", StringComparison.Ordinal);
-            if (!string.Equals(content, updatedContent, StringComparison.Ordinal))
-            {
-                await File.WriteAllTextAsync(aspireConfigPath, updatedContent, cancellationToken);
-            }
+            _logger.LogDebug("Skipping localhost TLD update because aspire.config.json was not found in '{OutputPath}'.", outputPath);
             return;
         }
 
-        // Fall back to apphost.run.json
-        var appHostRunProfilePath = Path.Combine(outputPath, "apphost.run.json");
-        if (!File.Exists(appHostRunProfilePath))
+        var content = await File.ReadAllTextAsync(aspireConfigPath, cancellationToken);
+        var updatedContent = content.Replace("://localhost", $"://{hostName}", StringComparison.Ordinal);
+        if (!string.Equals(content, updatedContent, StringComparison.Ordinal))
         {
-            _logger.LogDebug("Skipping localhost TLD update because neither aspire.config.json nor apphost.run.json was found in '{OutputPath}'.", outputPath);
-            return;
-        }
-
-        var runContent = await File.ReadAllTextAsync(appHostRunProfilePath, cancellationToken);
-        var updatedRunContent = runContent.Replace("://localhost", $"://{hostName}", StringComparison.Ordinal);
-
-        if (!string.Equals(runContent, updatedRunContent, StringComparison.Ordinal))
-        {
-            await File.WriteAllTextAsync(appHostRunProfilePath, updatedRunContent, cancellationToken);
+            await File.WriteAllTextAsync(aspireConfigPath, updatedContent, cancellationToken);
         }
     }
 

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
@@ -75,7 +75,10 @@ internal sealed partial class CliTemplateFactory
                     {
                         _logger.LogDebug("Using scaffolding service for language '{LanguageDisplayName}' in '{OutputPath}'.", language.DisplayName, outputPath);
                         var context = new ScaffoldContext(language, new DirectoryInfo(outputPath), projectName);
-                        await _scaffoldingService.ScaffoldAsync(context, cancellationToken);
+                        if (!await _scaffoldingService.ScaffoldAsync(context, cancellationToken))
+                        {
+                            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
+                        }
 
                         if (useLocalhostTld)
                         {

--- a/src/Aspire.Cli/Templating/Templates/empty-apphost/aspire.config.json
+++ b/src/Aspire.Cli/Templating/Templates/empty-apphost/aspire.config.json
@@ -1,4 +1,7 @@
 {
+  "appHost": {
+    "path": "apphost.cs"
+  },
   "profiles": {
     "https": {
       "applicationUrl": "https://{{hostName}}:{{httpsPort}};http://{{hostName}}:{{httpPort}}",

--- a/src/Aspire.Cli/Templating/Templates/empty-apphost/aspire.config.json
+++ b/src/Aspire.Cli/Templating/Templates/empty-apphost/aspire.config.json
@@ -1,23 +1,22 @@
 {
-  "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
     "https": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
       "applicationUrl": "https://{{hostName}}:{{httpsPort}};http://{{hostName}}:{{httpPort}}",
       "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://{{hostName}}:{{otlpHttpsPort}}",
+        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "https://{{hostName}}:{{mcpHttpsPort}}",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://{{hostName}}:{{resourceHttpsPort}}"
       }
     },
     "http": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
       "applicationUrl": "http://{{hostName}}:{{httpPort}}",
       "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://{{hostName}}:{{otlpHttpPort}}",
+        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "http://{{hostName}}:{{mcpHttpPort}}",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://{{hostName}}:{{resourceHttpPort}}",
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/.aspire/settings.json
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/.aspire/settings.json
@@ -1,7 +1,0 @@
-{
-  "appHostPath": "../apphost.ts",
-  "language": "typescript/nodejs",
-  "packages": {
-    "Aspire.Hosting.JavaScript": "{{aspireVersion}}"
-  }
-}

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/aspire.config.json
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/aspire.config.json
@@ -1,29 +1,23 @@
 {
-  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "appHost": {
+    "path": "apphost.ts",
+    "language": "typescript/nodejs"
+  },
+  "packages": {
+    "Aspire.Hosting.JavaScript": "{{aspireVersion}}"
+  },
   "profiles": {
     "https": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
       "applicationUrl": "https://{{hostName}}:{{httpsPort}};http://{{hostName}}:{{httpPort}}",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://{{hostName}}:{{otlpHttpsPort}}",
-        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "https://{{hostName}}:{{mcpHttpsPort}}",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://{{hostName}}:{{resourceHttpsPort}}"
       }
     },
     "http": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
       "applicationUrl": "http://{{hostName}}:{{httpPort}}",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://{{hostName}}:{{otlpHttpPort}}",
-        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "http://{{hostName}}:{{mcpHttpPort}}",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://{{hostName}}:{{resourceHttpPort}}",
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }

--- a/src/Aspire.Cli/Utils/ConfigurationHelper.cs
+++ b/src/Aspire.Cli/Utils/ConfigurationHelper.cs
@@ -115,10 +115,12 @@ internal static class ConfigurationHelper
                 return;
             }
         }
-        catch
+        catch (JsonException ex)
         {
-            // If pre-processing fails, fall through to direct file loading.
-            // AddJsonFile will throw a clearer error for the user.
+            throw new InvalidOperationException(
+                $"The configuration file '{filePath}' contains invalid JSON: {ex.Message}" +
+                Environment.NewLine +
+                "Please fix the JSON syntax error and try again.", ex);
         }
 
         configuration.AddJsonFile(filePath, optional: true);

--- a/src/Aspire.Cli/Utils/ConfigurationHelper.cs
+++ b/src/Aspire.Cli/Utils/ConfigurationHelper.cs
@@ -27,6 +27,8 @@ internal static class ConfigurationHelper
                 break;
             }
 
+            // TODO: Remove legacy .aspire/settings.json fallback once confident most users have migrated.
+            // Tracked by https://github.com/dotnet/aspire/issues/15239
             // Fall back to .aspire/settings.json (legacy format)
             var legacySettingsPath = BuildPathToSettingsJsonFile(currentDirectory.FullName);
             if (File.Exists(legacySettingsPath))

--- a/src/Aspire.Cli/Utils/ConfigurationHelper.cs
+++ b/src/Aspire.Cli/Utils/ConfigurationHelper.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Cli.Configuration;
+using Aspire.Cli.Resources;
 using Microsoft.Extensions.Configuration;
 
 namespace Aspire.Cli.Utils;
@@ -117,10 +119,9 @@ internal static class ConfigurationHelper
         }
         catch (JsonException ex)
         {
-            throw new InvalidOperationException(
-                $"The configuration file '{filePath}' contains invalid JSON: {ex.Message}" +
-                Environment.NewLine +
-                "Please fix the JSON syntax error and try again.", ex);
+            throw new JsonException(
+                string.Format(CultureInfo.CurrentCulture, ErrorStrings.InvalidJsonInConfigFile, filePath),
+                ex.Path, ex.LineNumber, ex.BytePositionInLine, ex);
         }
 
         configuration.AddJsonFile(filePath, optional: true);

--- a/src/Aspire.Cli/Utils/ConfigurationHelper.cs
+++ b/src/Aspire.Cli/Utils/ConfigurationHelper.cs
@@ -96,6 +96,31 @@ internal static class ConfigurationHelper
         // (e.g., both "features:key" flat entry and "features" nested object).
         TryNormalizeSettingsFile(filePath);
 
+        // Pre-process the file to handle comments and trailing commas.
+        // Microsoft.Extensions.Configuration.Json doesn't support JSON comments,
+        // so we parse with comment support and load the clean JSON via stream.
+        try
+        {
+            var content = File.ReadAllText(filePath);
+            var node = JsonNode.Parse(content, documentOptions: new JsonDocumentOptions
+            {
+                CommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true
+            });
+            if (node is not null)
+            {
+                var cleanJson = node.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+                var bytes = System.Text.Encoding.UTF8.GetBytes(cleanJson);
+                configuration.AddJsonStream(new MemoryStream(bytes));
+                return;
+            }
+        }
+        catch
+        {
+            // If pre-processing fails, fall through to direct file loading.
+            // AddJsonFile will throw a clearer error for the user.
+        }
+
         configuration.AddJsonFile(filePath, optional: true);
     }
 
@@ -113,7 +138,11 @@ internal static class ConfigurationHelper
                 return false;
             }
 
-            var settings = JsonNode.Parse(content)?.AsObject();
+            var settings = JsonNode.Parse(content, documentOptions: new JsonDocumentOptions
+            {
+                CommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true
+            })?.AsObject();
 
             if (settings is null)
             {

--- a/src/Aspire.Cli/Utils/ConfigurationHelper.cs
+++ b/src/Aspire.Cli/Utils/ConfigurationHelper.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Aspire.Cli.Configuration;
 using Microsoft.Extensions.Configuration;
 
 namespace Aspire.Cli.Utils;
@@ -19,7 +20,7 @@ internal static class ConfigurationHelper
         while (currentDirectory is not null)
         {
             // Check for aspire.config.json first (new format)
-            var newSettingsPath = Path.Combine(currentDirectory.FullName, "aspire.config.json");
+            var newSettingsPath = Path.Combine(currentDirectory.FullName, AspireConfigFile.FileName);
             if (File.Exists(newSettingsPath))
             {
                 localSettingsFile = new FileInfo(newSettingsPath);

--- a/src/Aspire.Cli/Utils/ConfigurationHelper.cs
+++ b/src/Aspire.Cli/Utils/ConfigurationHelper.cs
@@ -13,16 +13,24 @@ internal static class ConfigurationHelper
     {
         var currentDirectory = workingDirectory;
 
-        // Find the nearest local settings file
+        // Find the nearest local settings file (prefer aspire.config.json, fall back to .aspire/settings.json)
         FileInfo? localSettingsFile = null;
 
         while (currentDirectory is not null)
         {
-            var settingsFilePath = BuildPathToSettingsJsonFile(currentDirectory.FullName);
-
-            if (File.Exists(settingsFilePath))
+            // Check for aspire.config.json first (new format)
+            var newSettingsPath = Path.Combine(currentDirectory.FullName, "aspire.config.json");
+            if (File.Exists(newSettingsPath))
             {
-                localSettingsFile = new FileInfo(settingsFilePath);
+                localSettingsFile = new FileInfo(newSettingsPath);
+                break;
+            }
+
+            // Fall back to .aspire/settings.json (legacy format)
+            var legacySettingsPath = BuildPathToSettingsJsonFile(currentDirectory.FullName);
+            if (File.Exists(legacySettingsPath))
+            {
+                localSettingsFile = new FileInfo(legacySettingsPath);
                 break;
             }
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/ConfigHealingTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ConfigHealingTests.cs
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests verifying that the CLI heals a corrupted aspire.config.json
+/// (invalid apphost path, JSON comments) by auto-detecting the correct apphost
+/// and updating the config file.
+/// </summary>
+public sealed class ConfigHealingTests(ITestOutputHelper output)
+{
+    /// <summary>
+    /// Verifies that when aspire.config.json has an invalid apphost path and JSON comments,
+    /// the CLI auto-detects the correct apphost, runs it successfully, and updates ("heals")
+    /// the config file with the correct path.
+    /// </summary>
+    [Fact]
+    public async Task InvalidAppHostPathWithComments_IsHealedOnRun()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(
+            repoRoot, installMode, output,
+            mountDockerSocket: true,
+            workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var waitForCtrlCMessage = new CellPatternSearcher()
+            .Find("Press CTRL+C to stop the apphost and exit.");
+
+        var waitForUpdatedSettingsMessage = new CellPatternSearcher()
+            .Find("Updated settings file at");
+
+        var counter = new SequenceCounter();
+        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+        sequenceBuilder.PrepareDockerEnvironment(counter, workspace);
+        sequenceBuilder.InstallAspireCliInDocker(installMode, counter);
+
+        // 1. Create a starter project
+        sequenceBuilder.AspireNew("HealTest", counter, useRedisCache: false);
+
+        // 2. Overwrite aspire.config.json with an invalid apphost path and a JSON comment
+        var configFilePath = Path.Combine(
+            workspace.WorkspaceRoot.FullName,
+            "HealTest",
+            "aspire.config.json");
+
+        sequenceBuilder.ExecuteCallback(() =>
+        {
+            var malformedConfig = """
+                {
+                  // This comment should be handled gracefully
+                  "appHost": {
+                    "path": "nonexistent/path/to/AppHost.csproj" // this path doesn't exist
+                  },
+                  "channel": "stable"
+                }
+                """;
+            File.WriteAllText(configFilePath, malformedConfig);
+        });
+
+        // 3. Change into the project directory and run aspire run
+        //    The CLI should detect the invalid path, find the real apphost,
+        //    update the config, and start the app successfully
+        sequenceBuilder
+            .Type("cd HealTest")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("aspire run")
+            .Enter()
+            .WaitUntil(s => waitForCtrlCMessage.Search(s).Count > 0, TimeSpan.FromMinutes(3))
+            .Ctrl().Key(Hex1b.Input.Hex1bKey.C)
+            .WaitForSuccessPrompt(counter);
+
+        // 4. Verify the config file was healed (host-side file check)
+        sequenceBuilder.ExecuteCallback(() =>
+        {
+            if (!File.Exists(configFilePath))
+            {
+                throw new InvalidOperationException(
+                    $"Config file does not exist after healing: {configFilePath}");
+            }
+
+            var content = File.ReadAllText(configFilePath);
+
+            // The healed config should contain a valid apphost path
+            // (pointing to the actual AppHost project)
+            if (!content.Contains("HealTest.AppHost"))
+            {
+                throw new InvalidOperationException(
+                    $"Config file was not healed with correct AppHost path. Content:\n{content}");
+            }
+
+            // The invalid path should no longer be present
+            if (content.Contains("nonexistent/path"))
+            {
+                throw new InvalidOperationException(
+                    $"Config file still contains invalid path after healing. Content:\n{content}");
+            }
+        });
+
+        sequenceBuilder
+            .Type("exit")
+            .Enter();
+
+        var sequence = sequenceBuilder.Build();
+
+        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+        await pendingRun;
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/ConfigMigrationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ConfigMigrationTests.cs
@@ -1,0 +1,696 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Aspire.TestUtilities;
+using Hex1b;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests verifying configuration migration from legacy CLI config formats
+/// (globalsettings.json, .aspire/settings.json) to the new unified aspire.config.json format.
+/// These tests simulate the upgrade path users experience when updating from older CLI versions.
+/// </summary>
+/// <remarks>
+/// Each test bind-mounts a host-side directory as <c>/root/.aspire/</c> in the container,
+/// enabling direct host-side file creation and verification via <c>ExecuteCallback</c>.
+/// </remarks>
+public sealed class ConfigMigrationTests(ITestOutputHelper output)
+{
+    /// <summary>
+    /// Pin to the last CLI version before the aspire.config.json consolidation.
+    /// When 13.2 ships with the config change, this version ensures the upgrade
+    /// test exercises the real legacy-to-new migration path.
+    /// </summary>
+    private const string LegacyCliVersion = "13.1.0";
+
+    /// <summary>
+    /// Creates a Docker test terminal with a bind-mounted <c>~/.aspire/</c> directory
+    /// for host-side file creation and verification.
+    /// </summary>
+    /// <returns>
+    /// A tuple containing the host-side path to the mounted .aspire directory
+    /// and the configured terminal.
+    /// </returns>
+    private (string AspireHomeDir, Hex1bTerminal Terminal) CreateMigrationTerminal(
+        string repoRoot,
+        CliE2ETestHelpers.DockerInstallMode installMode,
+        TemporaryWorkspace workspace,
+        [System.Runtime.CompilerServices.CallerMemberName] string testName = "")
+    {
+        // Create a host-side directory that will be bind-mounted as /root/.aspire/ in the container.
+        var aspireHomeDir = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire-home");
+        Directory.CreateDirectory(aspireHomeDir);
+
+        var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(
+            repoRoot, installMode, output,
+            workspace: workspace,
+            additionalVolumes: [$"{aspireHomeDir}:/root/.aspire"],
+            testName: testName);
+
+        return (aspireHomeDir, terminal);
+    }
+
+    /// <summary>
+    /// Throws if the file at <paramref name="filePath"/> does not contain all
+    /// <paramref name="expectedStrings"/>. Used inside <c>ExecuteCallback</c>.
+    /// </summary>
+    private static void AssertFileContains(string filePath, params string[] expectedStrings)
+    {
+        if (!File.Exists(filePath))
+        {
+            throw new InvalidOperationException($"Expected file does not exist: {filePath}");
+        }
+
+        var content = File.ReadAllText(filePath);
+        foreach (var expected in expectedStrings)
+        {
+            if (!content.Contains(expected))
+            {
+                throw new InvalidOperationException(
+                    $"File {filePath} does not contain '{expected}'. Actual content:\n{content}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Throws if the file at <paramref name="filePath"/> contains any of the
+    /// <paramref name="unexpectedStrings"/>. Used inside <c>ExecuteCallback</c>.
+    /// </summary>
+    private static void AssertFileDoesNotContain(string filePath, params string[] unexpectedStrings)
+    {
+        if (!File.Exists(filePath))
+        {
+            return;
+        }
+
+        var content = File.ReadAllText(filePath);
+        foreach (var unexpected in unexpectedStrings)
+        {
+            if (content.Contains(unexpected))
+            {
+                throw new InvalidOperationException(
+                    $"File {filePath} unexpectedly contains '{unexpected}'. Actual content:\n{content}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a legacy ~/.aspire/globalsettings.json is automatically migrated to
+    /// ~/.aspire/aspire.config.json when a CLI command is run, and that the legacy file
+    /// is preserved for backward compatibility with older CLI versions.
+    /// </summary>
+    [Fact]
+    public async Task GlobalSettings_MigratedFromLegacyFormat()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+        var workspace = TemporaryWorkspace.Create(output);
+
+        var (aspireHomeDir, terminal) = CreateMigrationTerminal(repoRoot, installMode, workspace);
+        using var _ = terminal;
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+        sequenceBuilder.PrepareDockerEnvironment(counter, workspace);
+        sequenceBuilder.InstallAspireCliInDocker(installMode, counter);
+
+        // Pre-populate legacy globalsettings.json on the host (visible in container via bind mount).
+        var legacyPath = Path.Combine(aspireHomeDir, "globalsettings.json");
+        var newConfigPath = Path.Combine(aspireHomeDir, "aspire.config.json");
+
+        sequenceBuilder.ExecuteCallback(() =>
+        {
+            File.WriteAllText(legacyPath,
+                """{"channel":"staging","features":{"polyglotSupportEnabled":true},"sdkVersion":"9.1.0"}""");
+
+            // Ensure no aspire.config.json exists yet.
+            if (File.Exists(newConfigPath))
+            {
+                File.Delete(newConfigPath);
+            }
+        });
+
+        // Run any CLI command to trigger global migration in Program.cs.
+        sequenceBuilder
+            .Type("aspire --version")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Verify aspire.config.json was created with migrated values (host-side).
+        sequenceBuilder.ExecuteCallback(() =>
+        {
+            AssertFileContains(newConfigPath, "staging", "polyglotSupportEnabled");
+        });
+
+        // Verify the legacy file was preserved (intentional for backward compat).
+        sequenceBuilder.ExecuteCallback(() =>
+        {
+            AssertFileContains(legacyPath, "channel");
+        });
+
+        // Verify migrated values are accessible via aspire config get.
+        var channelPattern = new CellPatternSearcher().Find("staging");
+
+        sequenceBuilder
+            .ClearScreen(counter)
+            .Type("aspire config get channel")
+            .Enter()
+            .WaitUntil(s => channelPattern.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .WaitForSuccessPrompt(counter);
+
+        // Cleanup.
+        sequenceBuilder
+            .Type("aspire config delete channel -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("aspire config delete features.polyglotSupportEnabled -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("exit")
+            .Enter();
+
+        var sequence = sequenceBuilder.Build();
+        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+        await pendingRun;
+    }
+
+    /// <summary>
+    /// Verifies that global migration does NOT overwrite an existing aspire.config.json.
+    /// If the user already has the new format, legacy globalsettings.json should be ignored.
+    /// </summary>
+    [Fact]
+    public async Task GlobalMigration_SkipsWhenNewConfigExists()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+        var workspace = TemporaryWorkspace.Create(output);
+
+        var (aspireHomeDir, terminal) = CreateMigrationTerminal(repoRoot, installMode, workspace);
+        using var _ = terminal;
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+        sequenceBuilder.PrepareDockerEnvironment(counter, workspace);
+        sequenceBuilder.InstallAspireCliInDocker(installMode, counter);
+
+        // Pre-populate BOTH files on the host: aspire.config.json with "preview",
+        // globalsettings.json with "staging".
+        var newConfigPath = Path.Combine(aspireHomeDir, "aspire.config.json");
+        var legacyPath = Path.Combine(aspireHomeDir, "globalsettings.json");
+
+        sequenceBuilder.ExecuteCallback(() =>
+        {
+            File.WriteAllText(newConfigPath,
+                """{"channel":"preview"}""");
+            File.WriteAllText(legacyPath,
+                """{"channel":"staging","features":{"polyglotSupportEnabled":true}}""");
+        });
+
+        // Run CLI. Migration should be skipped because aspire.config.json already exists.
+        sequenceBuilder
+            .Type("aspire --version")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Verify aspire.config.json still has "preview" (NOT overwritten with "staging").
+        sequenceBuilder.ExecuteCallback(() =>
+        {
+            AssertFileContains(newConfigPath, "preview");
+            AssertFileDoesNotContain(newConfigPath, "staging");
+        });
+
+        // Cleanup.
+        sequenceBuilder
+            .Type("aspire config delete channel -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("exit")
+            .Enter();
+
+        var sequence = sequenceBuilder.Build();
+        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+        await pendingRun;
+    }
+
+    /// <summary>
+    /// Verifies that the CLI gracefully handles malformed JSON in legacy globalsettings.json
+    /// without crashing, and that subsequent config operations still work.
+    /// </summary>
+    [Fact]
+    public async Task GlobalMigration_HandlesMalformedLegacyJson()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+        var workspace = TemporaryWorkspace.Create(output);
+
+        var (aspireHomeDir, terminal) = CreateMigrationTerminal(repoRoot, installMode, workspace);
+        using var _ = terminal;
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+        sequenceBuilder.PrepareDockerEnvironment(counter, workspace);
+        sequenceBuilder.InstallAspireCliInDocker(installMode, counter);
+
+        // Write malformed JSON to the legacy file.
+        var newConfigPath = Path.Combine(aspireHomeDir, "aspire.config.json");
+
+        sequenceBuilder.ExecuteCallback(() =>
+        {
+            File.WriteAllText(
+                Path.Combine(aspireHomeDir, "globalsettings.json"),
+                "this is not valid json {{{");
+
+            if (File.Exists(newConfigPath))
+            {
+                File.Delete(newConfigPath);
+            }
+        });
+
+        // Run CLI. Should not crash despite malformed legacy file.
+        sequenceBuilder
+            .Type("aspire --version")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Verify CLI still works by setting and reading a value.
+        sequenceBuilder
+            .Type("aspire config set channel stable -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        var stablePattern = new CellPatternSearcher().Find("stable");
+
+        sequenceBuilder
+            .ClearScreen(counter)
+            .Type("aspire config get channel")
+            .Enter()
+            .WaitUntil(s => stablePattern.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .WaitForSuccessPrompt(counter);
+
+        // Cleanup.
+        sequenceBuilder
+            .Type("aspire config delete channel -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("exit")
+            .Enter();
+
+        var sequence = sequenceBuilder.Build();
+        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+        await pendingRun;
+    }
+
+    /// <summary>
+    /// Verifies that legacy globalsettings.json containing JSON comments and trailing commas
+    /// (common when hand-edited) is correctly parsed and migrated to aspire.config.json.
+    /// </summary>
+    [Fact]
+    public async Task GlobalMigration_HandlesCommentsAndTrailingCommas()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+        var workspace = TemporaryWorkspace.Create(output);
+
+        var (aspireHomeDir, terminal) = CreateMigrationTerminal(repoRoot, installMode, workspace);
+        using var _ = terminal;
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+        sequenceBuilder.PrepareDockerEnvironment(counter, workspace);
+        sequenceBuilder.InstallAspireCliInDocker(installMode, counter);
+
+        // Write legacy JSON with comments and trailing commas.
+        var newConfigPath = Path.Combine(aspireHomeDir, "aspire.config.json");
+        var legacyPath = Path.Combine(aspireHomeDir, "globalsettings.json");
+
+        sequenceBuilder.ExecuteCallback(() =>
+        {
+            File.WriteAllText(legacyPath,
+                """
+                {
+                  // User-added comment
+                  "channel": "staging",
+                  "features": {
+                    "polyglotSupportEnabled": true,
+                  }
+                }
+                """);
+
+            if (File.Exists(newConfigPath))
+            {
+                File.Delete(newConfigPath);
+            }
+        });
+
+        // Run CLI to trigger migration.
+        sequenceBuilder
+            .Type("aspire --version")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Verify migration succeeded despite comments/trailing commas (host-side).
+        sequenceBuilder.ExecuteCallback(() =>
+        {
+            AssertFileContains(newConfigPath, "staging", "polyglotSupportEnabled");
+        });
+
+        // Verify value accessible via config get.
+        var channelPattern = new CellPatternSearcher().Find("staging");
+
+        sequenceBuilder
+            .ClearScreen(counter)
+            .Type("aspire config get channel")
+            .Enter()
+            .WaitUntil(s => channelPattern.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .WaitForSuccessPrompt(counter);
+
+        // Cleanup.
+        sequenceBuilder
+            .Type("aspire config delete channel -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("aspire config delete features.polyglotSupportEnabled -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("exit")
+            .Enter();
+
+        var sequence = sequenceBuilder.Build();
+        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+        await pendingRun;
+    }
+
+    /// <summary>
+    /// Verifies that aspire config set writes nested JSON to aspire.config.json
+    /// (the new format) and that aspire config get correctly reads from this structure.
+    /// Also confirms globalsettings.json is NOT created when using the new CLI.
+    /// </summary>
+    [Fact]
+    public async Task ConfigSetGet_CreatesNestedJsonFormat()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+        var workspace = TemporaryWorkspace.Create(output);
+
+        var (aspireHomeDir, terminal) = CreateMigrationTerminal(repoRoot, installMode, workspace);
+        using var _ = terminal;
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+        sequenceBuilder.PrepareDockerEnvironment(counter, workspace);
+        sequenceBuilder.InstallAspireCliInDocker(installMode, counter);
+
+        // Ensure clean state.
+        var newConfigPath = Path.Combine(aspireHomeDir, "aspire.config.json");
+        var legacyPath = Path.Combine(aspireHomeDir, "globalsettings.json");
+
+        sequenceBuilder.ExecuteCallback(() =>
+        {
+            foreach (var f in new[] { newConfigPath, legacyPath })
+            {
+                if (File.Exists(f))
+                {
+                    File.Delete(f);
+                }
+            }
+        });
+
+        // Set nested config values.
+        sequenceBuilder
+            .Type("aspire config set channel preview -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("aspire config set features.polyglotSupportEnabled true -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("aspire config set features.stagingChannelEnabled false -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Verify the file has nested JSON structure (host-side).
+        sequenceBuilder.ExecuteCallback(() =>
+        {
+            AssertFileContains(newConfigPath, "features", "polyglotSupportEnabled", "preview");
+        });
+
+        // Verify values are readable via aspire config get.
+        var channelPattern = new CellPatternSearcher().Find("preview");
+
+        sequenceBuilder
+            .ClearScreen(counter)
+            .Type("aspire config get channel")
+            .Enter()
+            .WaitUntil(s => channelPattern.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .WaitForSuccessPrompt(counter);
+
+        var truePattern = new CellPatternSearcher().Find("true");
+
+        sequenceBuilder
+            .ClearScreen(counter)
+            .Type("aspire config get features.polyglotSupportEnabled")
+            .Enter()
+            .WaitUntil(s => truePattern.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .WaitForSuccessPrompt(counter);
+
+        // Verify globalsettings.json was NOT created.
+        sequenceBuilder.ExecuteCallback(() =>
+        {
+            if (File.Exists(legacyPath))
+            {
+                throw new InvalidOperationException(
+                    "globalsettings.json should not be created by the new CLI");
+            }
+        });
+
+        // Cleanup.
+        sequenceBuilder
+            .Type("aspire config delete channel -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("aspire config delete features.polyglotSupportEnabled -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("aspire config delete features.stagingChannelEnabled -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("exit")
+            .Enter();
+
+        var sequence = sequenceBuilder.Build();
+        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+        await pendingRun;
+    }
+
+    /// <summary>
+    /// Verifies that migration from globalsettings.json preserves all supported
+    /// value types: channel (string), features (dictionary of bools), and packages
+    /// (dictionary of strings).
+    /// </summary>
+    [Fact]
+    public async Task GlobalMigration_PreservesAllValueTypes()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+        var workspace = TemporaryWorkspace.Create(output);
+
+        var (aspireHomeDir, terminal) = CreateMigrationTerminal(repoRoot, installMode, workspace);
+        using var _ = terminal;
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+        sequenceBuilder.PrepareDockerEnvironment(counter, workspace);
+        sequenceBuilder.InstallAspireCliInDocker(installMode, counter);
+
+        // Create a comprehensive legacy globalsettings.json with all value types.
+        var newConfigPath = Path.Combine(aspireHomeDir, "aspire.config.json");
+        var legacyPath = Path.Combine(aspireHomeDir, "globalsettings.json");
+
+        sequenceBuilder.ExecuteCallback(() =>
+        {
+            File.WriteAllText(legacyPath,
+                """
+                {
+                    "channel": "preview",
+                    "sdkVersion": "9.1.0",
+                    "features": {
+                        "polyglotSupportEnabled": true,
+                        "stagingChannelEnabled": false
+                    },
+                    "packages": {
+                        "Aspire.Hosting.Redis": "9.1.0"
+                    }
+                }
+                """);
+
+            if (File.Exists(newConfigPath))
+            {
+                File.Delete(newConfigPath);
+            }
+        });
+
+        // Trigger migration.
+        sequenceBuilder
+            .Type("aspire --version")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Verify all value types were migrated (host-side).
+        sequenceBuilder.ExecuteCallback(() =>
+        {
+            AssertFileContains(newConfigPath,
+                "preview",
+                "polyglotSupportEnabled",
+                "stagingChannelEnabled",
+                "Aspire.Hosting.Redis");
+        });
+
+        // Verify individual value via config get.
+        var channelPattern = new CellPatternSearcher().Find("preview");
+
+        sequenceBuilder
+            .ClearScreen(counter)
+            .Type("aspire config get channel")
+            .Enter()
+            .WaitUntil(s => channelPattern.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .WaitForSuccessPrompt(counter);
+
+        // Cleanup.
+        sequenceBuilder
+            .Type("aspire config delete channel -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("aspire config delete features.polyglotSupportEnabled -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("aspire config delete features.stagingChannelEnabled -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("aspire config delete packages -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("exit")
+            .Enter();
+
+        var sequence = sequenceBuilder.Build();
+        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+        await pendingRun;
+    }
+
+    /// <summary>
+    /// Full end-to-end upgrade test: installs a released (legacy) CLI version that
+    /// predates the aspire.config.json consolidation, sets global config values using the
+    /// old format, then upgrades to the new CLI and verifies all settings are migrated.
+    /// </summary>
+    [Fact]
+    [OuterloopTest("Requires downloading two separate CLI versions from GitHub")]
+    public async Task FullUpgrade_LegacyCliToNewCli_MigratesGlobalSettings()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+        var workspace = TemporaryWorkspace.Create(output);
+
+        var (aspireHomeDir, terminal) = CreateMigrationTerminal(repoRoot, installMode, workspace);
+        using var _ = terminal;
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+
+        sequenceBuilder.PrepareDockerEnvironment(counter, workspace);
+
+        // Step 1: Install a released CLI that uses the legacy config format.
+        sequenceBuilder
+            .InstallAspireCliVersion(LegacyCliVersion, counter)
+            .SourceAspireCliEnvironment(counter);
+
+        // Verify the legacy CLI is installed.
+        sequenceBuilder
+            .Type("aspire --version")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Step 2: Set global values using the legacy CLI.
+        // In versions before 13.2, this writes to ~/.aspire/globalsettings.json.
+        sequenceBuilder
+            .Type("aspire config set channel staging -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("aspire config set features.polyglotSupportEnabled true -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Verify values were persisted by the legacy CLI.
+        var channelPattern = new CellPatternSearcher().Find("staging");
+
+        sequenceBuilder
+            .ClearScreen(counter)
+            .Type("aspire config get channel")
+            .Enter()
+            .WaitUntil(s => channelPattern.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .WaitForSuccessPrompt(counter);
+
+        // Snapshot which files exist after using the legacy CLI (for debugging).
+        sequenceBuilder
+            .ClearScreen(counter)
+            .Type("ls -la ~/.aspire/")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Step 3: Install the new CLI (from this PR), overwriting the legacy CLI.
+        sequenceBuilder.InstallAspireCliInDocker(installMode, counter);
+
+        // Step 4: Run the new CLI to trigger global migration.
+        sequenceBuilder
+            .Type("aspire --version")
+            .Enter()
+            .WaitForSuccessPrompt(counter);
+
+        // Step 5: Verify aspire.config.json exists with migrated values (host-side).
+        var newConfigPath = Path.Combine(aspireHomeDir, "aspire.config.json");
+
+        sequenceBuilder.ExecuteCallback(() =>
+        {
+            AssertFileContains(newConfigPath, "staging", "polyglotSupportEnabled");
+        });
+
+        // Step 6: Verify values are still accessible via the new CLI.
+        sequenceBuilder
+            .ClearScreen(counter)
+            .Type("aspire config get channel")
+            .Enter()
+            .WaitUntil(s => channelPattern.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .WaitForSuccessPrompt(counter);
+
+        // Cleanup.
+        sequenceBuilder
+            .Type("aspire config delete channel -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("aspire config delete features.polyglotSupportEnabled -g")
+            .Enter()
+            .WaitForSuccessPrompt(counter)
+            .Type("exit")
+            .Enter();
+
+        var sequence = sequenceBuilder.Build();
+        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+        await pendingRun;
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
@@ -679,7 +679,10 @@ internal static class CliE2ETestHelpers
                     .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30))
                     .Type("export PATH=~/.aspire/bin:$PATH")
                     .Enter()
-                    .WaitForSuccessPrompt(counter);
+                    .WaitForSuccessPrompt(counter)
+                    .Type("aspire config set channel daily --global")
+                    .Enter()
+                    .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
 
             case DockerInstallMode.GaRelease:
                 // Install the latest GA release using the script baked into the container image.

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
@@ -524,6 +524,7 @@ internal static class CliE2ETestHelpers
         DockerfileVariant variant = DockerfileVariant.DotNet,
         bool mountDockerSocket = false,
         TemporaryWorkspace? workspace = null,
+        IEnumerable<string>? additionalVolumes = null,
         int width = 160,
         int height = 48,
         [CallerMemberName] string testName = "")
@@ -567,6 +568,14 @@ internal static class CliE2ETestHelpers
                     // workspace.WorkspaceRoot.Name matches inside the container
                     // (e.g., aspire CLI uses the dir name as the default project name).
                     c.Volumes.Add($"{workspace.WorkspaceRoot.FullName}:/workspace/{workspace.WorkspaceRoot.Name}");
+                }
+
+                if (additionalVolumes is not null)
+                {
+                    foreach (var volume in additionalVolumes)
+                    {
+                        c.Volumes.Add(volume);
+                    }
                 }
 
                 // Always skip the expensive source build inside Docker.

--- a/tests/Aspire.Cli.EndToEnd.Tests/ProjectReferenceTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ProjectReferenceTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Tests.Utils;
 using Hex1b.Automation;
@@ -12,7 +13,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// <summary>
 /// End-to-end test for polyglot project reference support.
 /// Creates a .NET hosting integration project and a TypeScript AppHost that references it
-/// via settings.json, then verifies the integration is discovered, code-generated, and functional.
+/// via <c>aspire.config.json</c>, then verifies the integration is discovered, code-generated, and functional.
 /// </summary>
 public sealed class ProjectReferenceTests(ITestOutputHelper output)
 {
@@ -48,23 +49,23 @@ public sealed class ProjectReferenceTests(ITestOutputHelper output)
 
         sequenceBuilder.InstallAspireCliInDocker(installMode, counter);
 
-        // Step 1: Create a TypeScript AppHost (so we get the sdkVersion in settings.json)
+        // Step 1: Create a TypeScript AppHost (so we get the SDK version in aspire.config.json)
         sequenceBuilder
             .Type("aspire init --language typescript --non-interactive")
             .Enter()
             .WaitUntil(s => waitingForAppHostCreated.Search(s).Count > 0, TimeSpan.FromMinutes(2))
             .WaitForSuccessPrompt(counter);
 
-        // Step 2: Create the integration project, update settings.json, and modify apphost.ts
+        // Step 2: Create the integration project, update aspire.config.json, and modify apphost.ts
         sequenceBuilder.ExecuteCallback(() =>
         {
             var workDir = workspace.WorkspaceRoot.FullName;
 
-            // Read the sdkVersion from the settings.json that aspire init created
-            var settingsPath = Path.Combine(workDir, ".aspire", "settings.json");
-            var settingsJson = File.ReadAllText(settingsPath);
-            using var doc = JsonDocument.Parse(settingsJson);
-            var sdkVersion = doc.RootElement.GetProperty("sdkVersion").GetString()!;
+            // Read the SDK version from the aspire.config.json that aspire init created.
+            var configPath = Path.Combine(workDir, "aspire.config.json");
+            var configJson = File.ReadAllText(configPath);
+            using var doc = JsonDocument.Parse(configJson);
+            var sdkVersion = doc.RootElement.GetProperty("sdk").GetProperty("version").GetString()!;
 
             // Create the .NET hosting integration project
             var integrationDir = Path.Combine(workDir, "MyIntegration");
@@ -129,20 +130,15 @@ public sealed class ProjectReferenceTests(ITestOutputHelper output)
                 }
                 """);
 
-            // Update settings.json to add the project reference
-            using var settingsDoc = JsonDocument.Parse(settingsJson);
-            var settings = new Dictionary<string, object>();
-            foreach (var prop in settingsDoc.RootElement.EnumerateObject())
-            {
-                settings[prop.Name] = prop.Value.Clone();
-            }
-            settings["packages"] = new Dictionary<string, string>
-            {
-                ["MyIntegration"] = "./MyIntegration/MyIntegration.csproj"
-            };
+            // Update aspire.config.json to add the project reference.
+            var config = JsonNode.Parse(configJson)?.AsObject()
+                ?? throw new InvalidOperationException("Expected aspire.config.json to contain a JSON object.");
+            var packages = config["packages"] as JsonObject ?? new JsonObject();
+            packages["MyIntegration"] = "./MyIntegration/MyIntegration.csproj";
+            config["packages"] = packages;
 
-            var updatedJson = JsonSerializer.Serialize(settings, new JsonSerializerOptions { WriteIndented = true });
-            File.WriteAllText(settingsPath, updatedJson);
+            var updatedJson = config.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(configPath, updatedJson);
 
             // Delete the generated .modules folder to force re-codegen with the new integration
             var modulesDir = Path.Combine(workDir, ".modules");

--- a/tests/Aspire.Cli.EndToEnd.Tests/StagingChannelTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StagingChannelTests.cs
@@ -58,13 +58,13 @@ public sealed class StagingChannelTests(ITestOutputHelper output)
             .Enter()
             .WaitForSuccessPrompt(counter);
 
-        // Step 2: Verify the settings were persisted in the global settings file
+        // Step 2: Verify the settings were persisted in the global config file
         var settingsFilePattern = new CellPatternSearcher()
             .Find("stagingPinToCliVersion");
 
         sequenceBuilder
             .ClearScreen(counter)
-            .Type("cat ~/.aspire/globalsettings.json")
+            .Type("cat ~/.aspire/aspire.config.json")
             .Enter()
             .WaitUntil(s => settingsFilePattern.Search(s).Count > 0, TimeSpan.FromSeconds(10))
             .WaitForSuccessPrompt(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
@@ -39,7 +39,7 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
 
         // Pattern for aspire add completion
         var waitingForPackageAdded = new CellPatternSearcher()
-            .Find("The package Aspire.Hosting.JavaScript::");
+            .Find("The package Aspire.Hosting.");
 
         // Pattern for aspire run ready
         var waitForCtrlCMessage = new CellPatternSearcher()

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -891,7 +891,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             {
                 scaffoldedLanguageId = context.Language.LanguageId.Value;
                 File.WriteAllText(Path.Combine(context.TargetDirectory.FullName, "apphost.ts"), "// test apphost");
-                return Task.CompletedTask;
+                return Task.FromResult(true);
             }
         });
 
@@ -1108,7 +1108,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             ScaffoldAsyncCallback = (context, cancellationToken) =>
             {
                 scaffoldingInvoked = true;
-                return Task.CompletedTask;
+                return Task.FromResult(true);
             }
         });
 
@@ -1164,7 +1164,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             ScaffoldAsyncCallback = (context, cancellationToken) =>
             {
                 capturedTargetDirectory = context.TargetDirectory.FullName;
-                return Task.CompletedTask;
+                return Task.FromResult(true);
             }
         });
 
@@ -1260,6 +1260,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                       }
                     }
                     """, cancellationToken);
+                return true;
             }
         });
 
@@ -1636,16 +1637,16 @@ internal sealed class NewCommandTestFakeNuGetPackageCache : INuGetPackageCache
 
 internal sealed class TestScaffoldingService : IScaffoldingService
 {
-    public Func<ScaffoldContext, CancellationToken, Task>? ScaffoldAsyncCallback { get; set; }
+    public Func<ScaffoldContext, CancellationToken, Task<bool>>? ScaffoldAsyncCallback { get; set; }
 
-    public Task ScaffoldAsync(ScaffoldContext context, CancellationToken cancellationToken)
+    public Task<bool> ScaffoldAsync(ScaffoldContext context, CancellationToken cancellationToken)
     {
         if (ScaffoldAsyncCallback is not null)
         {
             return ScaffoldAsyncCallback(context, cancellationToken);
         }
 
-        return Task.CompletedTask;
+        return Task.FromResult(true);
     }
 }
 

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1243,8 +1243,12 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             ScaffoldAsyncCallback = async (context, cancellationToken) =>
             {
                 scaffoldingInvoked = true;
-                await File.WriteAllTextAsync(Path.Combine(context.TargetDirectory.FullName, "apphost.run.json"), """
+                await File.WriteAllTextAsync(Path.Combine(context.TargetDirectory.FullName, "aspire.config.json"), """
                     {
+                      "appHost": {
+                        "path": "apphost.ts",
+                        "language": "typescript/nodejs"
+                      },
                       "profiles": {
                         "https": {
                           "applicationUrl": "https://localhost:1234;http://localhost:5678",
@@ -1268,10 +1272,10 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.True(scaffoldingInvoked);
         Assert.True(localhostPrompted);
 
-        var runProfilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.run.json");
-        var runProfile = await File.ReadAllTextAsync(runProfilePath);
-        Assert.Contains("testapp.dev.localhost", runProfile);
-        Assert.DoesNotContain("://localhost", runProfile);
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json");
+        var configContent = await File.ReadAllTextAsync(configPath);
+        Assert.Contains("testapp.dev.localhost", configContent);
+        Assert.DoesNotContain("://localhost", configContent);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1069,7 +1069,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(0, exitCode);
         Assert.True(localhostPrompted);
 
-        var runProfilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.run.json");
+        var runProfilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json");
         Assert.True(File.Exists(runProfilePath));
         var runProfile = await File.ReadAllTextAsync(runProfilePath);
         Assert.Contains("testapp.dev.localhost", runProfile);

--- a/tests/Aspire.Cli.Tests/Configuration/AspireConfigFileTests.cs
+++ b/tests/Aspire.Cli.Tests/Configuration/AspireConfigFileTests.cs
@@ -1,0 +1,339 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Tests.Utils;
+
+namespace Aspire.Cli.Tests.Configuration;
+
+public class AspireConfigFileTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public void Load_ReturnsNull_WhenFileDoesNotExist()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var result = AspireConfigFile.Load(workspace.WorkspaceRoot.FullName);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Load_ReturnsConfig_WhenFileIsValid()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        File.WriteAllText(configPath, """
+            {
+              "appHost": { "path": "MyApp/MyApp.csproj" },
+              "channel": "daily"
+            }
+            """);
+
+        var result = AspireConfigFile.Load(workspace.WorkspaceRoot.FullName);
+
+        Assert.NotNull(result);
+        Assert.Equal("MyApp/MyApp.csproj", result.AppHost?.Path);
+        Assert.Equal("daily", result.Channel);
+    }
+
+    [Fact]
+    public void Load_ReturnsConfig_WhenFileContainsJsonComments()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        File.WriteAllText(configPath, """
+            {
+              // This is a comment
+              "appHost": {
+                "path": "MyApp/MyApp.csproj" // inline comment
+              },
+              "channel": "stable"
+            }
+            """);
+
+        var result = AspireConfigFile.Load(workspace.WorkspaceRoot.FullName);
+
+        Assert.NotNull(result);
+        Assert.Equal("MyApp/MyApp.csproj", result.AppHost?.Path);
+        Assert.Equal("stable", result.Channel);
+    }
+
+    [Fact]
+    public void Load_ReturnsConfig_WhenFileContainsTrailingCommas()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        File.WriteAllText(configPath, """
+            {
+              "appHost": { "path": "MyApp/MyApp.csproj", },
+              "channel": "daily",
+            }
+            """);
+
+        var result = AspireConfigFile.Load(workspace.WorkspaceRoot.FullName);
+
+        Assert.NotNull(result);
+        Assert.Equal("MyApp/MyApp.csproj", result.AppHost?.Path);
+    }
+
+    [Fact]
+    public void Load_ThrowsJsonException_WhenFileContainsInvalidJson()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        File.WriteAllText(configPath, "{ invalid json content }");
+
+        var ex = Assert.Throws<JsonException>(() => AspireConfigFile.Load(workspace.WorkspaceRoot.FullName));
+
+        Assert.Contains(configPath, ex.Message);
+        Assert.Contains("invalid JSON", ex.Message);
+    }
+
+    [Fact]
+    public void Load_ThrowsJsonException_WithFilePath_WhenJsonIsTruncated()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        File.WriteAllText(configPath, """{ "appHost": { "path": """);
+
+        var ex = Assert.Throws<JsonException>(() => AspireConfigFile.Load(workspace.WorkspaceRoot.FullName));
+
+        Assert.Contains(configPath, ex.Message);
+    }
+
+    [Fact]
+    public void Load_ReturnsEmptyConfig_WhenFileIsEmptyObject()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        File.WriteAllText(configPath, "{}");
+
+        var result = AspireConfigFile.Load(workspace.WorkspaceRoot.FullName);
+
+        Assert.NotNull(result);
+        Assert.Null(result.AppHost);
+        Assert.Null(result.Channel);
+    }
+
+    [Fact]
+    public void Save_CreatesFileWithExpectedContent()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var config = new AspireConfigFile
+        {
+            AppHost = new AspireConfigAppHost { Path = "src/AppHost/AppHost.csproj" },
+            Channel = "daily"
+        };
+
+        config.Save(workspace.WorkspaceRoot.FullName);
+
+        var filePath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        Assert.True(File.Exists(filePath));
+
+        var content = File.ReadAllText(filePath);
+        Assert.Contains("src/AppHost/AppHost.csproj", content);
+        Assert.Contains("daily", content);
+    }
+
+    [Fact]
+    public void Save_CreatesDirectoryIfNeeded()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var subDir = Path.Combine(workspace.WorkspaceRoot.FullName, "nested", "dir");
+        var config = new AspireConfigFile();
+
+        config.Save(subDir);
+
+        Assert.True(File.Exists(Path.Combine(subDir, AspireConfigFile.FileName)));
+    }
+
+    [Fact]
+    public void Exists_ReturnsFalse_WhenFileDoesNotExist()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        Assert.False(AspireConfigFile.Exists(workspace.WorkspaceRoot.FullName));
+    }
+
+    [Fact]
+    public void Exists_ReturnsTrue_WhenFileExists()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        File.WriteAllText(Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName), "{}");
+
+        Assert.True(AspireConfigFile.Exists(workspace.WorkspaceRoot.FullName));
+    }
+
+    [Fact]
+    public void SdkVersion_ReadsFromSdkObject()
+    {
+        var config = new AspireConfigFile
+        {
+            Sdk = new AspireConfigSdk { Version = "13.2.0" }
+        };
+
+        Assert.Equal("13.2.0", config.SdkVersion);
+    }
+
+    [Fact]
+    public void SdkVersion_SetsOnSdkObject()
+    {
+        var config = new AspireConfigFile();
+
+        config.SdkVersion = "13.2.0";
+
+        Assert.NotNull(config.Sdk);
+        Assert.Equal("13.2.0", config.Sdk.Version);
+    }
+
+    [Fact]
+    public void SdkVersion_ReturnsNull_WhenSdkIsNull()
+    {
+        var config = new AspireConfigFile();
+
+        Assert.Null(config.SdkVersion);
+    }
+
+    [Fact]
+    public void GetEffectiveSdkVersion_ReturnsConfigValue_WhenSet()
+    {
+        var config = new AspireConfigFile
+        {
+            Sdk = new AspireConfigSdk { Version = "13.2.0" }
+        };
+
+        Assert.Equal("13.2.0", config.GetEffectiveSdkVersion("13.1.0"));
+    }
+
+    [Fact]
+    public void GetEffectiveSdkVersion_ReturnsFallback_WhenNotSet()
+    {
+        var config = new AspireConfigFile();
+
+        Assert.Equal("13.1.0", config.GetEffectiveSdkVersion("13.1.0"));
+    }
+
+    [Fact]
+    public void AddOrUpdatePackage_AddsNewPackage()
+    {
+        var config = new AspireConfigFile();
+
+        config.AddOrUpdatePackage("Aspire.Hosting.Redis", "13.2.0");
+
+        Assert.NotNull(config.Packages);
+        Assert.Equal("13.2.0", config.Packages["Aspire.Hosting.Redis"]);
+    }
+
+    [Fact]
+    public void AddOrUpdatePackage_UpdatesExistingPackage()
+    {
+        var config = new AspireConfigFile
+        {
+            Packages = new Dictionary<string, string> { ["Aspire.Hosting.Redis"] = "13.1.0" }
+        };
+
+        config.AddOrUpdatePackage("Aspire.Hosting.Redis", "13.2.0");
+
+        Assert.Equal("13.2.0", config.Packages["Aspire.Hosting.Redis"]);
+    }
+
+    [Fact]
+    public void RemovePackage_RemovesExistingPackage()
+    {
+        var config = new AspireConfigFile
+        {
+            Packages = new Dictionary<string, string>
+            {
+                ["Aspire.Hosting.Redis"] = "13.2.0",
+                ["Aspire.Hosting.PostgreSQL"] = "13.2.0"
+            }
+        };
+
+        var removed = config.RemovePackage("Aspire.Hosting.Redis");
+
+        Assert.True(removed);
+        Assert.DoesNotContain("Aspire.Hosting.Redis", config.Packages.Keys);
+        Assert.Contains("Aspire.Hosting.PostgreSQL", config.Packages.Keys);
+    }
+
+    [Fact]
+    public void RemovePackage_ReturnsFalse_WhenPackageDoesNotExist()
+    {
+        var config = new AspireConfigFile();
+
+        var removed = config.RemovePackage("Aspire.Hosting.Redis");
+
+        Assert.False(removed);
+    }
+
+    [Fact]
+    public void GetIntegrationReferences_ReturnsBasePackage_WhenNoPackages()
+    {
+        var config = new AspireConfigFile();
+
+        var refs = config.GetIntegrationReferences("13.2.0", "/tmp").ToList();
+
+        Assert.Single(refs);
+        Assert.Equal("Aspire.Hosting", refs[0].Name);
+    }
+
+    [Fact]
+    public void GetIntegrationReferences_IncludesPackagesAndBasePackage()
+    {
+        var config = new AspireConfigFile
+        {
+            Packages = new Dictionary<string, string>
+            {
+                ["Aspire.Hosting.Redis"] = "13.2.0"
+            }
+        };
+
+        var refs = config.GetIntegrationReferences("13.2.0", "/tmp").ToList();
+
+        Assert.Equal(2, refs.Count);
+        Assert.Contains(refs, r => r.Name == "Aspire.Hosting");
+        Assert.Contains(refs, r => r.Name == "Aspire.Hosting.Redis");
+    }
+
+    [Fact]
+    public void Load_RoundTrips_WithProfiles()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var config = new AspireConfigFile
+        {
+            AppHost = new AspireConfigAppHost { Path = "App.csproj" },
+            Profiles = new Dictionary<string, AspireConfigProfile>
+            {
+                ["default"] = new AspireConfigProfile
+                {
+                    ApplicationUrl = "https://localhost:5001",
+                    EnvironmentVariables = new Dictionary<string, string>
+                    {
+                        ["ASPNETCORE_ENVIRONMENT"] = "Development"
+                    }
+                }
+            }
+        };
+
+        config.Save(workspace.WorkspaceRoot.FullName);
+        var loaded = AspireConfigFile.Load(workspace.WorkspaceRoot.FullName);
+
+        Assert.NotNull(loaded);
+        Assert.Equal("App.csproj", loaded.AppHost?.Path);
+        Assert.NotNull(loaded.Profiles);
+        Assert.True(loaded.Profiles.ContainsKey("default"));
+        Assert.Equal("https://localhost:5001", loaded.Profiles["default"].ApplicationUrl);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Configuration/ConfigurationHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Configuration/ConfigurationHelperTests.cs
@@ -1,0 +1,151 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
+using Microsoft.Extensions.Configuration;
+
+namespace Aspire.Cli.Tests.Configuration;
+
+public class ConfigurationHelperTests(ITestOutputHelper outputHelper)
+{
+    private static IConfiguration BuildConfigurationFromSettingsFile(
+        TemporaryWorkspace workspace, string content)
+    {
+        var settingsPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        File.WriteAllText(settingsPath, content);
+
+        var globalDir = workspace.CreateDirectory("global-aspire");
+        var globalSettingsFile = new FileInfo(Path.Combine(globalDir.FullName, AspireConfigFile.FileName));
+
+        var builder = new ConfigurationBuilder();
+        ConfigurationHelper.RegisterSettingsFiles(builder, workspace.WorkspaceRoot, globalSettingsFile);
+        return builder.Build();
+    }
+
+    [Fact]
+    public void RegisterSettingsFiles_LoadsValidJson()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var config = BuildConfigurationFromSettingsFile(workspace, """
+            {
+              "appHost": { "path": "MyApp.csproj" },
+              "channel": "daily"
+            }
+            """);
+
+        Assert.Equal("MyApp.csproj", config["appHost:path"]);
+        Assert.Equal("daily", config["channel"]);
+    }
+
+    [Fact]
+    public void RegisterSettingsFiles_HandlesJsonComments()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var config = BuildConfigurationFromSettingsFile(workspace, """
+            {
+              // This is a comment
+              "appHost": {
+                "path": "MyApp.csproj" // inline comment
+              },
+              "channel": "stable"
+            }
+            """);
+
+        Assert.Equal("MyApp.csproj", config["appHost:path"]);
+        Assert.Equal("stable", config["channel"]);
+    }
+
+    [Fact]
+    public void RegisterSettingsFiles_HandlesTrailingCommas()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var config = BuildConfigurationFromSettingsFile(workspace, """
+            {
+              "appHost": { "path": "MyApp.csproj", },
+              "channel": "stable",
+            }
+            """);
+
+        Assert.Equal("MyApp.csproj", config["appHost:path"]);
+    }
+
+    [Fact]
+    public void RegisterSettingsFiles_HandlesBlockComments()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var config = BuildConfigurationFromSettingsFile(workspace, """
+            {
+              /* Block comment */
+              "channel": "daily"
+            }
+            """);
+
+        Assert.Equal("daily", config["channel"]);
+    }
+
+    [Fact]
+    public void RegisterSettingsFiles_ThrowsJsonException_ForInvalidJson()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var settingsPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        File.WriteAllText(settingsPath, "{ invalid json }");
+
+        var globalDir = workspace.CreateDirectory("global-aspire");
+        var globalSettingsFile = new FileInfo(Path.Combine(globalDir.FullName, AspireConfigFile.FileName));
+
+        var builder = new ConfigurationBuilder();
+
+        var ex = Assert.Throws<JsonException>(
+            () => ConfigurationHelper.RegisterSettingsFiles(builder, workspace.WorkspaceRoot, globalSettingsFile));
+
+        Assert.Contains(settingsPath, ex.Message);
+        Assert.Contains("invalid JSON", ex.Message);
+    }
+
+    [Fact]
+    public void RegisterSettingsFiles_ThrowsJsonException_ForTruncatedJson()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var settingsPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        File.WriteAllText(settingsPath, """{ "appHost": { "path": """);
+
+        var globalDir = workspace.CreateDirectory("global-aspire");
+        var globalSettingsFile = new FileInfo(Path.Combine(globalDir.FullName, AspireConfigFile.FileName));
+
+        var builder = new ConfigurationBuilder();
+
+        var ex = Assert.Throws<JsonException>(
+            () => ConfigurationHelper.RegisterSettingsFiles(builder, workspace.WorkspaceRoot, globalSettingsFile));
+
+        Assert.Contains(settingsPath, ex.Message);
+    }
+
+    [Fact]
+    public void RegisterSettingsFiles_HandlesCommentsAndTrailingCommas()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var config = BuildConfigurationFromSettingsFile(workspace, """
+            {
+              // Full-line comment
+              "appHost": {
+                "path": "MyApp.csproj", // trailing comma after value
+              },
+              /* Block comment */
+              "channel": "daily", // trailing comma
+            }
+            """);
+
+        Assert.Equal("MyApp.csproj", config["appHost:path"]);
+        Assert.Equal("daily", config["channel"]);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Configuration/ConfigurationServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Configuration/ConfigurationServiceTests.cs
@@ -1,0 +1,228 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Configuration;
+
+public class ConfigurationServiceTests(ITestOutputHelper outputHelper)
+{
+    private static (ConfigurationService Service, string SettingsFilePath) CreateService(
+        TemporaryWorkspace workspace,
+        string? existingContent = null)
+    {
+        var globalSettingsDir = workspace.CreateDirectory(".aspire-global");
+        var globalSettingsFile = new FileInfo(Path.Combine(globalSettingsDir.FullName, AspireConfigFile.FileName));
+
+        var settingsFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        if (existingContent is not null)
+        {
+            File.WriteAllText(settingsFilePath, existingContent);
+        }
+
+        var logsDir = new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "logs"));
+        var executionContext = new CliExecutionContext(
+            workspace.WorkspaceRoot,
+            new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "hives")),
+            new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "cache")),
+            new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")),
+            logsDir,
+            "test.log");
+
+        var configBuilder = new ConfigurationBuilder();
+        var configuration = configBuilder.Build();
+
+        var logger = NullLogger<ConfigurationService>.Instance;
+        var service = new ConfigurationService(configuration, executionContext, globalSettingsFile, logger);
+
+        return (service, settingsFilePath);
+    }
+
+    [Fact]
+    public async Task SetConfigurationAsync_WorksWithJsonComments()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var contentWithComments = """
+            {
+              // This is a comment about the apphost
+              "appHost": {
+                "path": "MyApp.csproj" // path to the project
+              }
+            }
+            """;
+
+        var (service, settingsFilePath) = CreateService(workspace, contentWithComments);
+
+        await service.SetConfigurationAsync("channel", "daily", isGlobal: false);
+
+        var result = File.ReadAllText(settingsFilePath);
+        Assert.Contains("daily", result);
+        Assert.Contains("appHost", result);
+    }
+
+    [Fact]
+    public async Task SetConfigurationAsync_WorksWithTrailingCommas()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var contentWithTrailingCommas = """
+            {
+              "appHost": {
+                "path": "MyApp.csproj",
+              },
+              "channel": "stable",
+            }
+            """;
+
+        var (service, settingsFilePath) = CreateService(workspace, contentWithTrailingCommas);
+
+        await service.SetConfigurationAsync("features.polyglotSupportEnabled", "true", isGlobal: false);
+
+        var result = File.ReadAllText(settingsFilePath);
+        Assert.Contains("polyglotSupportEnabled", result);
+    }
+
+    [Fact]
+    public async Task SetConfigurationAsync_WorksWithCommentsAndTrailingCommas()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var content = """
+            {
+              // Comment
+              "appHost": {
+                "path": "MyApp.csproj", // trailing comma
+              },
+            }
+            """;
+
+        var (service, settingsFilePath) = CreateService(workspace, content);
+
+        await service.SetConfigurationAsync("channel", "daily", isGlobal: false);
+
+        var result = File.ReadAllText(settingsFilePath);
+        Assert.Contains("daily", result);
+    }
+
+    [Fact]
+    public async Task SetConfigurationAsync_CreatesNewFile_WhenNoneExists()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Delete the sentinel .aspire/settings.json so there is truly no settings file
+        var sentinelPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "settings.json");
+        if (File.Exists(sentinelPath))
+        {
+            File.Delete(sentinelPath);
+        }
+
+        var (service, settingsFilePath) = CreateService(workspace);
+
+        await service.SetConfigurationAsync("channel", "staging", isGlobal: false);
+
+        Assert.True(File.Exists(settingsFilePath));
+        var result = File.ReadAllText(settingsFilePath);
+        Assert.Contains("staging", result);
+    }
+
+    [Fact]
+    public async Task SetConfigurationAsync_HandlesEmptyFile()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var (service, settingsFilePath) = CreateService(workspace, "");
+
+        await service.SetConfigurationAsync("channel", "daily", isGlobal: false);
+
+        var result = File.ReadAllText(settingsFilePath);
+        Assert.Contains("daily", result);
+    }
+
+    [Fact]
+    public async Task DeleteConfigurationAsync_WorksWithJsonComments()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var contentWithComments = """
+            {
+              // Comment
+              "channel": "daily",
+              "appHost": { "path": "MyApp.csproj" }
+            }
+            """;
+
+        var (service, settingsFilePath) = CreateService(workspace, contentWithComments);
+
+        var deleted = await service.DeleteConfigurationAsync("channel", isGlobal: false);
+
+        Assert.True(deleted);
+        var result = File.ReadAllText(settingsFilePath);
+        Assert.DoesNotContain("daily", result);
+        Assert.Contains("appHost", result);
+    }
+
+    [Fact]
+    public async Task DeleteConfigurationAsync_ReturnsFalse_WhenFileDoesNotExist()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var (service, _) = CreateService(workspace);
+
+        var deleted = await service.DeleteConfigurationAsync("channel", isGlobal: false);
+
+        Assert.False(deleted);
+    }
+
+    [Fact]
+    public async Task DeleteConfigurationAsync_ReturnsFalse_WhenFileIsEmpty()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var (service, _) = CreateService(workspace, "");
+
+        var deleted = await service.DeleteConfigurationAsync("channel", isGlobal: false);
+
+        Assert.False(deleted);
+    }
+
+    [Fact]
+    public async Task GetAllConfigurationAsync_ParsesCommentsCorrectly()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var contentWithComments = """
+            {
+              // This config has comments
+              "channel": "daily",
+              "features": {
+                "polyglotSupportEnabled": true // enabled for testing
+              }
+            }
+            """;
+
+        var (service, _) = CreateService(workspace, contentWithComments);
+
+        var config = await service.GetAllConfigurationAsync();
+
+        Assert.Contains("channel", config.Keys);
+        Assert.Equal("daily", config["channel"]);
+    }
+
+    [Fact]
+    public async Task SetConfigurationAsync_SetsNestedValues()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var (service, settingsFilePath) = CreateService(workspace, "{}");
+
+        await service.SetConfigurationAsync("appHost.path", "MyApp/MyApp.csproj", isGlobal: false);
+
+        var result = File.ReadAllText(settingsFilePath);
+        Assert.Contains("appHost", result);
+        Assert.Contains("MyApp/MyApp.csproj", result);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.AspNetCore.InternalTesting;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
@@ -305,16 +304,16 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
 
         await locator.UseOrFindAppHostProjectFileAsync(null, createSettingsFile: true, CancellationToken.None).DefaultTimeout();
 
-        var settingsFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "settings.json"));
+        var settingsFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName));
         Assert.True(settingsFile.Exists, "Settings file should exist.");
 
         var settingsJson = await File.ReadAllTextAsync(settingsFile.FullName);
-        var settings = JsonSerializer.Deserialize<CliSettings>(settingsJson);
+        var settings = JsonSerializer.Deserialize<AspireConfigFile>(settingsJson);
 
         Assert.NotNull(settings);
-        Assert.NotNull(settings!.AppHostPath);
-        Assert.DoesNotContain('\\', settings.AppHostPath); // Ensure no backslashes
-        Assert.Contains('/', settings.AppHostPath); // Ensure forward slashes
+        Assert.NotNull(settings!.AppHost?.Path);
+        Assert.DoesNotContain('\\', settings.AppHost.Path); // Ensure no backslashes
+        Assert.Contains('/', settings.AppHost.Path); // Ensure forward slashes
     }
 
     [Fact]
@@ -615,13 +614,7 @@ builder.Build().Run();");
         Assert.True(result.FullName == csprojFile.FullName || result.FullName == appHostFile.FullName);
     }
 
-    private sealed class CliSettings
-    {
-        [JsonPropertyName("appHostPath")]
-        public string? AppHostPath { get; set; }
-    }
-
-    private sealed class TestConfigurationService : IConfigurationService
+    private sealed class TestConfigurationService(CliExecutionContext executionContext) : IConfigurationService
     {
         public Task SetConfigurationAsync(string key, string value, bool isGlobal = false, CancellationToken cancellationToken = default)
         {
@@ -658,7 +651,9 @@ builder.Build().Run();");
 
         public string GetSettingsFilePath(bool isGlobal)
         {
-            return string.Empty;
+            return isGlobal
+                ? Path.Combine(executionContext.HomeDirectory.FullName, ".aspire", AspireConfigFile.FileName)
+                : Path.Combine(executionContext.WorkingDirectory.FullName, AspireConfigFile.FileName);
         }
     }
 
@@ -1038,11 +1033,10 @@ builder.Build().Run();");
             logger,
             executionContext,
             interactionService ?? new TestInteractionService(),
-            configurationService ?? new TestConfigurationService(),
+            configurationService ?? new TestConfigurationService(executionContext),
             projectFactory ?? new TestAppHostProjectFactory(),
             languageDiscovery ?? new TestLanguageDiscovery(),
             sdkInstaller ?? new TestDotNetSdkInstaller(),
             telemetry ?? TestTelemetryHelper.CreateInitializedTelemetry());
     }
 }
-

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -298,7 +298,7 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
 
         var config = new ConfigurationBuilder().Build();
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-        var configurationService = new ConfigurationService(config, executionContext, globalSettingsFile);
+        var configurationService = new ConfigurationService(config, executionContext, globalSettingsFile, NullLogger<ConfigurationService>.Instance);
 
         var locator = CreateProjectLocator(executionContext, configurationService: configurationService, projectFactory: projectFactory);
 

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -323,7 +323,7 @@ internal sealed class CliServiceCollectionTestOptions
     {
         var configuration = serviceProvider.GetRequiredService<IConfiguration>();
         var executionContext = serviceProvider.GetRequiredService<CliExecutionContext>();
-        return new ConfigurationService(configuration, executionContext, GetGlobalSettingsFile(WorkingDirectory));
+        return new ConfigurationService(configuration, executionContext, GetGlobalSettingsFile(WorkingDirectory), NullLogger<ConfigurationService>.Instance);
     }
 
     private static FileInfo GetGlobalSettingsFile(DirectoryInfo workingDirectory)


### PR DESCRIPTION
## Description

Consolidates CLI configuration into a single `aspire.config.json` file, replacing the previous split across `.aspire/settings.json` and `apphost.run.json`.

### Changes

- **New `AspireConfigFile` model** - unified config format with `appHost` (path/language), `sdk` (version), `channel`, `features`, `profiles` (launch settings), and `packages` sections.
- **Auto-migration** - on first access, legacy `.aspire/settings.json` + `apphost.run.json` are merged into `aspire.config.json`, old files deleted, and empty `.aspire/` dirs cleaned up.
- **Global settings migration** - `globalsettings.json` to `aspire.config.json` in the user's Aspire directory.
- **Directory walk-up** - `ConfigurationService`, `ConfigurationHelper`, and `ProjectLocator` all prefer `aspire.config.json` over legacy files.
- **Templates updated** - `empty-apphost` and `ts-starter` templates now emit `aspire.config.json` directly (no more `apphost.run.json` or `.aspire/settings.json`).
- **Scaffolding** - post-scaffold merges codegen-produced `apphost.run.json` profiles into `aspire.config.json`.
- **Tests updated** - `NewCommandTests` updated to reference the new file name.

Fixes https://github.com/dotnet/aspire/issues/14741

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [ ] No

