### PR TITLE
Update Azure.Provisioning.Network to stable 1.0.0 and ship Aspire.Hosting.Azure.Network as stable

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,7 +48,7 @@
     <PackageVersion Include="Azure.Provisioning.EventHubs" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.KeyVault" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.Kusto" Version="1.0.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.Network" Version="1.0.0-beta.3" />
+    <PackageVersion Include="Azure.Provisioning.Network" Version="1.0.0" />
     <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="1.1.1" />
     <PackageVersion Include="Azure.Provisioning.PrivateDns" Version="1.0.0-beta.1" />

--- a/playground/AzureVirtualNetworkEndToEnd/AzureVirtualNetworkEndToEnd.AppHost/Program.cs
+++ b/playground/AzureVirtualNetworkEndToEnd/AzureVirtualNetworkEndToEnd.AppHost/Program.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable AZPROVISION001 // Azure.Provisioning.Network is experimental
+#pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 using Aspire.Hosting.Azure;
 using Azure.Provisioning.Network;

--- a/src/Aspire.Hosting.Azure.Network/Aspire.Hosting.Azure.Network.csproj
+++ b/src/Aspire.Hosting.Azure.Network/Aspire.Hosting.Azure.Network.csproj
@@ -6,7 +6,7 @@
     <PackageTags>aspire integration hosting azure network vnet virtual-network subnet nat-gateway public-ip cloud</PackageTags>
     <Description>Azure Virtual Network resource types for Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)Azure_256x.png</PackageIconFullPath>
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <NoWarn>$(NoWarn);AZPROVISION001;ASPIREAZURE003</NoWarn>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Azure.Network/AssemblyInfo.cs
+++ b/src/Aspire.Hosting.Azure.Network/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: Experimental("ASPIREAZURE003", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]

--- a/src/Aspire.Hosting.Azure.Sql/AdminDeploymentScriptSubnetAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AdminDeploymentScriptSubnetAnnotation.cs
@@ -1,8 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
+using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 
@@ -11,6 +10,7 @@ namespace Aspire.Hosting;
 /// <summary>
 /// Annotation that stores the ACI subnet reference for deployment script configuration.
 /// </summary>
+[Experimental("ASPIREAZURE003")]
 internal sealed class AdminDeploymentScriptSubnetAnnotation(AzureSubnetResource subnet) : IResourceAnnotation
 {
     /// <summary>

--- a/src/Aspire.Hosting.Azure.Sql/AdminDeploymentScriptSubnetAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AdminDeploymentScriptSubnetAnnotation.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 

--- a/src/Aspire.Hosting.Azure.Sql/SubnetAddressAllocator.cs
+++ b/src/Aspire.Hosting.Azure.Sql/SubnetAddressAllocator.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
 using System.Net;
 using System.Net.Sockets;
 using Aspire.Hosting.Azure;

--- a/src/Aspire.Hosting.Azure.Sql/SubnetAddressAllocator.cs
+++ b/src/Aspire.Hosting.Azure.Sql/SubnetAddressAllocator.cs
@@ -1,8 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Sockets;
 using Aspire.Hosting.Azure;
@@ -12,6 +11,7 @@ namespace Aspire.Hosting;
 /// <summary>
 /// Allocates subnet address space within a virtual network.
 /// </summary>
+[Experimental("ASPIREAZURE003")]
 internal static class SubnetAddressAllocator
 {
     /// <summary>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIREAZURE001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIREPIPELINES002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIREINTERACTION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIREPIPELINES001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.

--- a/tests/Aspire.Hosting.Azure.Tests/AzureNatGatewayExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureNatGatewayExtensionsTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
 using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.Azure.Tests;

--- a/tests/Aspire.Hosting.Azure.Tests/AzurePrivateEndpointLockdownTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzurePrivateEndpointLockdownTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
 using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.Azure.Tests;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourcePreparerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourcePreparerTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Azure.Provisioning.Storage;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureStoragePrivateEndpointLockdownTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureStoragePrivateEndpointLockdownTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
 using Aspire.Hosting.Utils;
 using Azure.Provisioning.Storage;
 


### PR DESCRIPTION
## Description

Update `Azure.Provisioning.Network` from `1.0.0-beta.3` to the stable `1.0.0` release, and ship `Aspire.Hosting.Azure.Network` as a stable package.

### Changes

- **Directory.Packages.props**: Bump `Azure.Provisioning.Network` version from `1.0.0-beta.3` to `1.0.0`.
- **Aspire.Hosting.Azure.Network.csproj**: Remove `SuppressFinalPackageVersion` so the package ships as stable. Add `DisablePackageBaselineValidation` since this is the first stable release and there is no prior baseline to validate against.

### Motivation

`Aspire.Hosting.Azure.Sql` depends on `Aspire.Hosting.Azure.Network` and cannot ship as stable with a prerelease dependency. Now that `Azure.Provisioning.Network` has a stable 1.0.0 release, we can promote `Aspire.Hosting.Azure.Network` to stable as well.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] https://github.com/microsoft/aspire.dev/pull/525
