### PR TITLE
Add AspireNew helper to centralize aspire new E2E test flows

### DIFF
--- a/.github/skills/cli-e2e-testing/SKILL.md
+++ b/.github/skills/cli-e2e-testing/SKILL.md
@@ -170,7 +170,7 @@ sequenceBuilder.WaitUntil(
 
 | Method | Description |
 |--------|-------------|
-| `AspireNew(projectName, counter, template?, useRedisCache?, createTestProject?)` | Runs `aspire new` interactively, handling template selection, project name, output path, URLs, Redis, and test project prompts |
+| `AspireNew(projectName, counter, template?, useRedisCache?)` | Runs `aspire new` interactively, handling template selection, project name, output path, URLs, Redis, and test project prompts |
 
 See [AspireNew Helper](#aspirenew-helper) below for detailed usage.
 
@@ -239,7 +239,6 @@ The `AspireNew` extension method centralizes the multi-step `aspire new` interac
 | `counter` | (required) | `SequenceCounter` for prompt tracking |
 | `template` | `AspireTemplate.Starter` | Which template to select |
 | `useRedisCache` | `true` | Accept Redis (Enter) or decline (Down+Enter). Only applies to Starter, JsReact, PythonReact. |
-| `createTestProject` | `false` | Accept test project (Down+Enter) or decline (Enter). Only applies to Starter. |
 
 ### Usage Examples
 
@@ -249,9 +248,6 @@ sequenceBuilder.AspireNew("MyProject", counter);
 
 // Starter template, no Redis
 sequenceBuilder.AspireNew("MyProject", counter, useRedisCache: false);
-
-// Starter template with test project
-sequenceBuilder.AspireNew("MyProject", counter, createTestProject: true);
 
 // JsReact template, no Redis
 sequenceBuilder.AspireNew("MyProject", counter, template: AspireTemplate.JsReact, useRedisCache: false);

--- a/.github/skills/cli-e2e-testing/SKILL.md
+++ b/.github/skills/cli-e2e-testing/SKILL.md
@@ -229,7 +229,7 @@ The `AspireNew` extension method centralizes the multi-step `aspire new` interac
 | `JsReact` | Starter App (ASP.NET Core/React) | Down ×1 |
 | `PythonReact` | Starter App (FastAPI/React) | Down ×2 |
 | `ExpressReact` | Starter App (Express/React) | Down ×3 |
-| `EmptyAppHost` | Empty App Host | Down ×4 |
+| `EmptyAppHost` | Empty AppHost | Down ×4 |
 
 ### Parameters
 

--- a/.github/skills/cli-e2e-testing/SKILL.md
+++ b/.github/skills/cli-e2e-testing/SKILL.md
@@ -166,6 +166,14 @@ sequenceBuilder.WaitUntil(
 
 ## Extension Methods
 
+### Hex1bTestHelpers Extensions (Shared)
+
+| Method | Description |
+|--------|-------------|
+| `AspireNew(projectName, counter, template?, useRedisCache?, createTestProject?)` | Runs `aspire new` interactively, handling template selection, project name, output path, URLs, Redis, and test project prompts |
+
+See [AspireNew Helper](#aspirenew-helper) below for detailed usage.
+
 ### CliE2ETestHelpers Extensions on Hex1bTerminalInputSequenceBuilder
 
 | Method | Description |
@@ -209,24 +217,87 @@ sequenceBuilder
     .WaitForSuccessPrompt(counter);
 ```
 
-## DO: Handle Interactive Prompts
+## AspireNew Helper
 
-For CLI commands with interactive prompts, wait for each prompt before responding:
+The `AspireNew` extension method centralizes the multi-step `aspire new` interactive flow. Use it instead of manually building the prompt sequence.
+
+### AspireTemplate Enum
+
+| Value | Template | Arrow Keys |
+|-------|----------|------------|
+| `Starter` (default) | Starter App (Blazor) | None (first option) |
+| `JsReact` | Starter App (ASP.NET Core/React) | Down ×1 |
+| `PythonReact` | Starter App (FastAPI/React) | Down ×2 |
+| `ExpressReact` | Starter App (Express/React) | Down ×3 |
+| `EmptyAppHost` | Empty App Host | Down ×4 |
+
+### Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `projectName` | (required) | Project name typed at the prompt |
+| `counter` | (required) | `SequenceCounter` for prompt tracking |
+| `template` | `AspireTemplate.Starter` | Which template to select |
+| `useRedisCache` | `true` | Accept Redis (Enter) or decline (Down+Enter). Only applies to Starter, JsReact, PythonReact. |
+| `createTestProject` | `false` | Accept test project (Down+Enter) or decline (Enter). Only applies to Starter. |
+
+### Usage Examples
 
 ```csharp
+// Starter template with defaults (Redis=Yes, TestProject=No)
+sequenceBuilder.AspireNew("MyProject", counter);
+
+// Starter template, no Redis
+sequenceBuilder.AspireNew("MyProject", counter, useRedisCache: false);
+
+// Starter template with test project
+sequenceBuilder.AspireNew("MyProject", counter, createTestProject: true);
+
+// JsReact template, no Redis
+sequenceBuilder.AspireNew("MyProject", counter, template: AspireTemplate.JsReact, useRedisCache: false);
+
+// PythonReact template
+sequenceBuilder.AspireNew("MyProject", counter,
+    template: AspireTemplate.PythonReact,
+    useRedisCache: false);
+
+// Empty app host
+sequenceBuilder.AspireNew("MyProject", counter, template: AspireTemplate.EmptyAppHost);
+```
+
+## DO: Handle Interactive Prompts
+
+For `aspire new`, use the `AspireNew` helper instead of manually building the prompt sequence:
+
+```csharp
+// DO: Use the helper
+sequenceBuilder.AspireNew("MyProject", counter);
+
+// DON'T: Manually build the sequence (this is what AspireNew does internally)
 var waitingForTemplatePrompt = new CellPatternSearcher()
     .FindPattern("> Starter App");
-
 var waitingForProjectNamePrompt = new CellPatternSearcher()
     .Find("Enter the project name");
-
 sequenceBuilder
     .Type("aspire new")
     .Enter()
     .WaitUntil(s => waitingForTemplatePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-    .Enter()  // Select first template
+    .Enter()
     .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
     .Type("MyProject")
+    .Enter();
+```
+
+For other interactive CLI commands, wait for each prompt before responding:
+
+```csharp
+var waitingForPrompt = new CellPatternSearcher()
+    .Find("Enter your choice");
+
+sequenceBuilder
+    .Type("aspire some-command")
+    .Enter()
+    .WaitUntil(s => waitingForPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
     .Enter();
 ```
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/BundleSmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/BundleSmokeTests.cs
@@ -27,24 +27,6 @@ public sealed class BundleSmokeTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .FindPattern("> Starter App");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt = new CellPatternSearcher()
-            .Find($"Enter the output path: (./BundleStarterApp): ");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find($"Use *.dev.localhost URLs");
-
-        var waitingForRedisPrompt = new CellPatternSearcher()
-            .Find($"Use Redis Cache");
-
-        var waitingForTestPrompt = new CellPatternSearcher()
-            .Find($"Do you want to create a test project?");
-
         // Verify the dashboard is actually reachable, not just that the URL was printed.
         // When the dashboard path bug was present, the URL appeared on screen but curling
         // it returned connection refused because the dashboard process failed to start.
@@ -66,23 +48,7 @@ public sealed class BundleSmokeTests(ITestOutputHelper output)
             sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
         }
 
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter() // select first template (Starter App)
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("BundleStarterApp")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter)
+        sequenceBuilder.AspireNew("BundleStarterApp", counter)
             // Start AppHost in detached mode and capture JSON output
             .Type("aspire run --detach --format json | tee /tmp/aspire-detach.json")
             .Enter()

--- a/tests/Aspire.Cli.EndToEnd.Tests/DescribeCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DescribeCommandTests.cs
@@ -26,25 +26,6 @@ public sealed class DescribeCommandTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Pattern searchers for aspire new prompts
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .Find("> Starter App");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt = new CellPatternSearcher()
-            .Find($"Enter the output path: (./AspireResourcesTestApp): ");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find($"Use *.dev.localhost URLs");
-
-        var waitingForRedisPrompt = new CellPatternSearcher()
-            .Find($"Use Redis Cache");
-
-        var waitingForTestPrompt = new CellPatternSearcher()
-            .Find($"Do you want to create a test project?");
-
         // Pattern searchers for start/stop/resources commands
         var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
             .Find("AppHost started successfully.");
@@ -80,23 +61,7 @@ public sealed class DescribeCommandTests(ITestOutputHelper output)
         }
 
         // Create a new project using aspire new
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter() // select first template (Starter App)
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("AspireResourcesTestApp")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        sequenceBuilder.AspireNew("AspireResourcesTestApp", counter);
 
         // Navigate to the AppHost directory
         sequenceBuilder.Type("cd AspireResourcesTestApp/AspireResourcesTestApp.AppHost")
@@ -162,25 +127,6 @@ public sealed class DescribeCommandTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Pattern searchers for aspire new prompts
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .Find("> Starter App");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt = new CellPatternSearcher()
-            .Find($"Enter the output path: (./AspireReplicaTestApp): ");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find($"Use *.dev.localhost URLs");
-
-        var waitingForRedisPrompt = new CellPatternSearcher()
-            .Find($"Use Redis Cache");
-
-        var waitingForTestPrompt = new CellPatternSearcher()
-            .Find($"Do you want to create a test project?");
-
         // Pattern searchers for start/stop commands
         var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
             .Find("AppHost started successfully.");
@@ -209,23 +155,7 @@ public sealed class DescribeCommandTests(ITestOutputHelper output)
         }
 
         // Create a new project using aspire new
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter() // select first template (Starter App)
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("AspireReplicaTestApp")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        sequenceBuilder.AspireNew("AspireReplicaTestApp", counter);
 
         // Navigate to the AppHost directory
         sequenceBuilder.Type("cd AspireReplicaTestApp/AspireReplicaTestApp.AppHost")

--- a/tests/Aspire.Cli.EndToEnd.Tests/DockerDeploymentTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DockerDeploymentTests.cs
@@ -29,28 +29,9 @@ public sealed class DockerDeploymentTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Pattern searchers for template selection
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .FindPattern("> Starter App");
-
         // In CI, aspire add shows a version selection prompt (but aspire new does not when channel is set)
         var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
             .Find("(based on NuGet.config)");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt = new CellPatternSearcher()
-            .Find($"Enter the output path: (./{ProjectName}): ");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find($"Use *.dev.localhost URLs");
-
-        var waitingForRedisPrompt = new CellPatternSearcher()
-            .Find($"Use Redis Cache");
-
-        var waitingForTestPrompt = new CellPatternSearcher()
-            .Find($"Do you want to create a test project?");
 
         var counter = new SequenceCounter();
         var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
@@ -64,28 +45,8 @@ public sealed class DockerDeploymentTests(ITestOutputHelper output)
             sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
         }
 
-        // Step 1: Create a new Aspire Starter App
-        // Note: When channel is set (CI), aspire new auto-selects version - no version prompt appears
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter() // select first template (Starter App)
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type(ProjectName)
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter() // accept default output path
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter() // select "No" for localhost URLs (default)
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            // For Redis prompt, default is "Yes" so we need to select "No" by pressing Down
-            .Key(Hex1b.Input.Hex1bKey.DownArrow)
-            .Enter() // select "No" for Redis Cache
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            // For test project prompt, default is "No" so just press Enter to accept it
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        // Step 1: Create a new Aspire Starter App (no Redis cache)
+        sequenceBuilder.AspireNew(ProjectName, counter, useRedisCache: false);
 
         // Step 2: Navigate into the project directory
         sequenceBuilder.Type($"cd {ProjectName}")
@@ -199,28 +160,9 @@ builder.Build().Run();
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Pattern searchers for template selection
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .FindPattern("> Starter App");
-
         // In CI, aspire add shows a version selection prompt (but aspire new does not when channel is set)
         var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
             .Find("(based on NuGet.config)");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt = new CellPatternSearcher()
-            .Find($"Enter the output path: (./{ProjectName}): ");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find($"Use *.dev.localhost URLs");
-
-        var waitingForRedisPrompt = new CellPatternSearcher()
-            .Find($"Use Redis Cache");
-
-        var waitingForTestPrompt = new CellPatternSearcher()
-            .Find($"Do you want to create a test project?");
 
         var counter = new SequenceCounter();
         var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
@@ -234,28 +176,8 @@ builder.Build().Run();
             sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
         }
 
-        // Step 1: Create a new Aspire Starter App
-        // Note: When channel is set (CI), aspire new auto-selects version - no version prompt appears
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter() // select first template (Starter App)
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type(ProjectName)
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter() // accept default output path
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter() // select "No" for localhost URLs (default)
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            // For Redis prompt, default is "Yes" so we need to select "No" by pressing Down
-            .Key(Hex1b.Input.Hex1bKey.DownArrow)
-            .Enter() // select "No" for Redis Cache
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            // For test project prompt, default is "No" so just press Enter to accept it
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        // Step 1: Create a new Aspire Starter App (no Redis cache)
+        sequenceBuilder.AspireNew(ProjectName, counter, useRedisCache: false);
 
         // Step 2: Navigate into the project directory
         sequenceBuilder.Type($"cd {ProjectName}")

--- a/tests/Aspire.Cli.EndToEnd.Tests/EmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/EmptyAppHostTemplateTests.cs
@@ -26,23 +26,6 @@ public sealed class EmptyAppHostTemplateTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Pattern for template selection - we need to find and select "Empty AppHost"
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .FindPattern("> Starter App");
-
-        // Wait for the Empty AppHost template to be highlighted (after pressing Down 3 times)
-        var waitingForEmptyAppHostTemplateSelected = new CellPatternSearcher()
-            .Find("> Empty AppHost");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt = new CellPatternSearcher()
-            .Find($"Enter the output path: (./AspireEmptyApp): ");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find($"Use *.dev.localhost URLs");
-
         // The purpose of this is to keep track of the number of actual shell commands we have
         // executed. This is important because we customize the shell prompt to show either
         // "[n OK] $ " or "[n ERR:exitcode] $ ". This allows us to deterministically wait for a
@@ -60,28 +43,10 @@ public sealed class EmptyAppHostTemplateTests(ITestOutputHelper output)
             sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
         }
 
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            // Navigate down to "Empty AppHost" which is the 5th option
-            .Key(Hex1b.Input.Hex1bKey.DownArrow)
-            .Key(Hex1b.Input.Hex1bKey.DownArrow)
-            .Key(Hex1b.Input.Hex1bKey.DownArrow)
-            .Key(Hex1b.Input.Hex1bKey.DownArrow)
-            .WaitUntil(s => waitingForEmptyAppHostTemplateSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
-            .Enter() // select "Empty AppHost"
-            .Enter() // select C#
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("AspireEmptyApp")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter() // accept default output path
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter() // select "No" for localhost URLs (default)
-            // Empty AppHost template doesn't have Redis or test project prompts
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter)
-            // Note: We don't run 'aspire run' for Empty AppHost since there's nothing to run
+        sequenceBuilder.AspireNew("AspireEmptyApp", counter, template: AspireTemplate.EmptyAppHost);
+
+        // Note: We don't run 'aspire run' for Empty AppHost since there's nothing to run
+        sequenceBuilder
             .Type("exit")
             .Enter();
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/JsReactTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/JsReactTemplateTests.cs
@@ -26,27 +26,6 @@ public sealed class JsReactTemplateTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Pattern for template selection - we need to find and select "Starter App (ASP.NET Core/React)"
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .FindPattern("> Starter App");
-
-        // Wait for the ASP.NET Core/React template to be highlighted (after pressing Down once)
-        // Use Find() instead of FindPattern() because parentheses and slashes are regex special characters
-        var waitingForJsReactTemplateSelected = new CellPatternSearcher()
-            .Find("> Starter App (ASP.NET Core/React)");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt = new CellPatternSearcher()
-            .Find($"Enter the output path: (./AspireJsReactApp): ");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find($"Use *.dev.localhost URLs");
-
-        var waitingForRedisPrompt = new CellPatternSearcher()
-            .Find($"Use Redis Cache");
-
         var waitForCtrlCMessage = new CellPatternSearcher()
             .Find($"Press CTRL+C to stop the apphost and exit.");
 
@@ -73,26 +52,9 @@ public sealed class JsReactTemplateTests(ITestOutputHelper output)
             sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
         }
 
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            // Navigate down to "Starter App (ASP.NET Core/React)" which is the 2nd option
-            .Key(Hex1b.Input.Hex1bKey.DownArrow)
-            .WaitUntil(s => waitingForJsReactTemplateSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
-            .Enter() // select "Starter App (ASP.NET Core/React)"
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("AspireJsReactApp")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter() // accept default output path
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter() // select "No" for localhost URLs (default)
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            // For Redis prompt, default is "Yes" so we need to select "No" by pressing Down
-            .Key(Hex1b.Input.Hex1bKey.DownArrow)
-            .Enter() // select "No" for Redis Cache
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter)
+        sequenceBuilder.AspireNew("AspireJsReactApp", counter, template: AspireTemplate.JsReact, useRedisCache: false);
+
+        sequenceBuilder
             .Type("aspire run")
             .Enter()
             .WaitUntil(s =>

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishTests.cs
@@ -43,28 +43,9 @@ public sealed class KubernetesPublishTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Pattern searchers for template selection
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .FindPattern("> Starter App");
-
         // In CI, aspire add shows a version selection prompt (but aspire new does not when channel is set)
         var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
             .Find("(based on NuGet.config)");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt = new CellPatternSearcher()
-            .Find($"Enter the output path: (./{ProjectName}): ");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find($"Use *.dev.localhost URLs");
-
-        var waitingForRedisPrompt = new CellPatternSearcher()
-            .Find($"Use Redis Cache");
-
-        var waitingForTestPrompt = new CellPatternSearcher()
-            .Find($"Do you want to create a test project?");
 
         var counter = new SequenceCounter();
         var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
@@ -141,27 +122,7 @@ public sealed class KubernetesPublishTests(ITestOutputHelper output)
         // =====================================================================
 
         // Step 1: Create a new Aspire Starter App
-        // Note: When channel is set (CI), aspire new auto-selects version - no version prompt appears
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter() // select first template (Starter App)
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type(ProjectName)
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter() // accept default output path
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter() // select "No" for localhost URLs (default)
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            // For Redis prompt, default is "Yes" so we need to select "No" by pressing Down
-            .Key(Hex1b.Input.Hex1bKey.DownArrow)
-            .Enter() // select "No" for Redis Cache
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            // For test project prompt, default is "No" so just press Enter to accept it
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        sequenceBuilder.AspireNew(ProjectName, counter, useRedisCache: false);
 
         // Step 2: Navigate into the project directory
         sequenceBuilder.Type($"cd {ProjectName}")

--- a/tests/Aspire.Cli.EndToEnd.Tests/LogsCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/LogsCommandTests.cs
@@ -26,25 +26,6 @@ public sealed class LogsCommandTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Pattern searchers for aspire new prompts
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .Find("> Starter App");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt = new CellPatternSearcher()
-            .Find($"Enter the output path: (./AspireLogsTestApp): ");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find($"Use *.dev.localhost URLs");
-
-        var waitingForRedisPrompt = new CellPatternSearcher()
-            .Find($"Use Redis Cache");
-
-        var waitingForTestPrompt = new CellPatternSearcher()
-            .Find($"Do you want to create a test project?");
-
         // Pattern searchers for start/stop commands
         var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
             .Find("AppHost started successfully.");
@@ -77,23 +58,7 @@ public sealed class LogsCommandTests(ITestOutputHelper output)
         }
 
         // Create a new project using aspire new
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter() // select first template (Starter App)
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("AspireLogsTestApp")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        sequenceBuilder.AspireNew("AspireLogsTestApp", counter);
 
         // Navigate to the AppHost directory
         sequenceBuilder.Type("cd AspireLogsTestApp/AspireLogsTestApp.AppHost")

--- a/tests/Aspire.Cli.EndToEnd.Tests/MultipleAppHostTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/MultipleAppHostTests.cs
@@ -26,25 +26,6 @@ public sealed class MultipleAppHostTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // aspire new prompts
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .FindPattern("> Starter App");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find("Enter the project name (");
-
-        var waitingForOutputPathPrompt = new CellPatternSearcher()
-            .Find("Enter the output path:");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find("Use *.dev.localhost URLs");
-
-        var waitingForRedisPrompt = new CellPatternSearcher()
-            .Find("Use Redis Cache");
-
-        var waitingForTestPrompt = new CellPatternSearcher()
-            .Find("Do you want to create a test project?");
-
         var counter = new SequenceCounter();
         var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
 
@@ -58,23 +39,7 @@ public sealed class MultipleAppHostTests(ITestOutputHelper output)
         }
 
         // Create a single project using aspire new
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter() // select Starter App
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("TestApp")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        sequenceBuilder.AspireNew("TestApp", counter);
 
         sequenceBuilder.ClearScreen(counter);
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/PlaywrightCliInstallTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PlaywrightCliInstallTests.cs
@@ -73,30 +73,7 @@ public sealed class PlaywrightCliInstallTests(ITestOutputHelper output)
             .WaitForSuccessPrompt(counter);
 
         // Step 2: Create an Aspire project (accept all defaults).
-        var starterAppTemplate = new CellPatternSearcher().FindPattern("> Starter App");
-        var projectNamePrompt = new CellPatternSearcher().Find("Enter the project name");
-        var outputPathPrompt = new CellPatternSearcher().Find("Enter the output path");
-        var urlsPrompt = new CellPatternSearcher().Find("*.dev.localhost URLs");
-        var redisPrompt = new CellPatternSearcher().Find("Use Redis Cache");
-        var testProjectPrompt = new CellPatternSearcher().Find("Do you want to create a test project?");
-
-        sequenceBuilder
-            .Type("aspire new")
-            .Enter()
-            .WaitUntil(s => starterAppTemplate.Search(s).Count > 0, TimeSpan.FromSeconds(60))
-            .Enter() // Select Starter App template
-            .WaitUntil(s => projectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Type("TestProject")
-            .Enter()
-            .WaitUntil(s => outputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter() // Accept default output path
-            .WaitUntil(s => urlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter() // Accept default URL setting
-            .WaitUntil(s => redisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter() // Accept default Redis setting
-            .WaitUntil(s => testProjectPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter() // Accept default test project setting
-            .WaitForSuccessPrompt(counter);
+        sequenceBuilder.AspireNew("TestProject", counter);
 
         // Step 3: Navigate into the project and create .claude folder to trigger Claude Code detection.
         sequenceBuilder

--- a/tests/Aspire.Cli.EndToEnd.Tests/PsCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PsCommandTests.cs
@@ -26,28 +26,6 @@ public sealed class PsCommandTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Pattern searchers for aspire new prompts
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .Find("> Starter App");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt = new CellPatternSearcher()
-            .Find($"Enter the output path: (./AspirePsTestApp): ");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find($"Use *.dev.localhost URLs");
-
-        var waitingForRedisPrompt = new CellPatternSearcher()
-            .Find($"Use Redis Cache");
-
-        var waitingForTestPrompt = new CellPatternSearcher()
-            .Find($"Do you want to create a test project?");
-
-        var waitForProjectCreatedSuccessfullyMessage = new CellPatternSearcher()
-            .Find("Project created successfully.");
-
         // Pattern searchers for start/stop/ps commands
         var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
             .Find("AppHost started successfully.");
@@ -80,23 +58,7 @@ public sealed class PsCommandTests(ITestOutputHelper output)
         }
 
         // Create a new project using aspire new
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter() // select first template (Starter App)
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("AspirePsTestApp")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        sequenceBuilder.AspireNew("AspirePsTestApp", counter);
 
         // Navigate to the AppHost directory
         sequenceBuilder.Type("cd AspirePsTestApp/AspirePsTestApp.AppHost")

--- a/tests/Aspire.Cli.EndToEnd.Tests/PythonReactTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PythonReactTemplateTests.cs
@@ -26,27 +26,6 @@ public sealed class PythonReactTemplateTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Pattern for template selection - we need to find and select "Starter App (FastAPI/React)"
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .FindPattern("> Starter App");
-
-        // Wait for the FastAPI/React template to be highlighted (after pressing Down twice)
-        // Use Find() instead of FindPattern() because parentheses and slashes are regex special characters
-        var waitingForPythonReactTemplateSelected = new CellPatternSearcher()
-            .Find("> Starter App (FastAPI/React)");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt = new CellPatternSearcher()
-            .Find($"Enter the output path: (./AspirePyReactApp): ");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find($"Use *.dev.localhost URLs");
-
-        var waitingForRedisPrompt = new CellPatternSearcher()
-            .Find($"Use Redis Cache");
-
         var waitForCtrlCMessage = new CellPatternSearcher()
             .Find($"Press CTRL+C to stop the apphost and exit.");
 
@@ -67,27 +46,9 @@ public sealed class PythonReactTemplateTests(ITestOutputHelper output)
             sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
         }
 
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            // Navigate down to "Starter App (FastAPI/React)" which is the 3rd option
-            .Key(Hex1b.Input.Hex1bKey.DownArrow)
-            .Key(Hex1b.Input.Hex1bKey.DownArrow)
-            .WaitUntil(s => waitingForPythonReactTemplateSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
-            .Enter() // select "Starter App (FastAPI/React)"
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("AspirePyReactApp")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter() // accept default output path
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter() // select "No" for localhost URLs (default)
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            // For Redis prompt, default is "Yes" so we need to select "No" by pressing Down
-            .Key(Hex1b.Input.Hex1bKey.DownArrow)
-            .Enter() // select "No" for Redis Cache
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter)
+        sequenceBuilder.AspireNew("AspirePyReactApp", counter, template: AspireTemplate.PythonReact, useRedisCache: false);
+
+        sequenceBuilder
             .Type("aspire run")
             .Enter()
             .WaitUntil(s => waitForCtrlCMessage.Search(s).Count > 0, TimeSpan.FromMinutes(2))

--- a/tests/Aspire.Cli.EndToEnd.Tests/SecretDotNetAppHostTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SecretDotNetAppHostTests.cs
@@ -37,41 +37,7 @@ public sealed class SecretDotNetAppHostTests(ITestOutputHelper output)
         }
 
         // Create an Empty AppHost project interactively
-        var waitingForTemplatePrompt = new CellPatternSearcher()
-            .Find("> Starter App");
-
-        var waitingForEmptySelected = new CellPatternSearcher()
-            .Find("> Empty AppHost");
-
-        var waitingForNamePrompt = new CellPatternSearcher()
-            .Find("Enter the project name");
-
-        var waitingForOutputPrompt = new CellPatternSearcher()
-            .Find("Enter the output path");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find("localhost");
-
-        sequenceBuilder
-            .Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplatePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Key(Hex1b.Input.Hex1bKey.DownArrow)
-            .Key(Hex1b.Input.Hex1bKey.DownArrow)
-            .Key(Hex1b.Input.Hex1bKey.DownArrow)
-            .Key(Hex1b.Input.Hex1bKey.DownArrow)
-            .WaitUntil(s => waitingForEmptySelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
-            .Enter() // select Empty AppHost
-            .Enter() // select C#
-            .WaitUntil(s => waitingForNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("TestSecrets")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        sequenceBuilder.AspireNew("TestSecrets", counter, template: AspireTemplate.EmptyAppHost);
 
         // cd into the project
         sequenceBuilder

--- a/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SmokeTests.cs
@@ -26,27 +26,6 @@ public sealed class SmokeTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .FindPattern("> Starter App");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt = new CellPatternSearcher()
-            .Find($"Enter the output path: (./AspireStarterApp): ");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find($"Use *.dev.localhost URLs");
-
-        var waitingForRedisPrompt = new CellPatternSearcher()
-            .Find($"Use Redis Cache");
-
-        var waitingForTestPrompt = new CellPatternSearcher()
-            .Find($"Do you want to create a test project?");
-
-        var waitForProjectCreatedSuccessfullyMessage = new CellPatternSearcher()
-            .Find("Project created successfully.");
-
         var waitForCtrlCMessage = new CellPatternSearcher()
             .Find($"Press CTRL+C to stop the apphost and exit.");
 
@@ -79,23 +58,7 @@ public sealed class SmokeTests(ITestOutputHelper output)
             sequenceBuilder.VerifyAspireCliVersion(commitSha, counter);
         }
 
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter() // select first template (Starter App)
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("AspireStarterApp")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter)
+        sequenceBuilder.AspireNew("AspireStarterApp", counter)
             .Type("aspire run")
             .Enter()
             .WaitUntil(s =>

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -26,28 +26,6 @@ public sealed class StartStopTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Pattern searchers for aspire new prompts
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .FindPattern("> Starter App");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt = new CellPatternSearcher()
-            .Find($"Enter the output path: (./AspireStarterApp): ");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find($"Use *.dev.localhost URLs");
-
-        var waitingForRedisPrompt = new CellPatternSearcher()
-            .Find($"Use Redis Cache");
-
-        var waitingForTestPrompt = new CellPatternSearcher()
-            .Find($"Do you want to create a test project?");
-
-        var waitForProjectCreatedSuccessfullyMessage = new CellPatternSearcher()
-            .Find("Project created successfully.");
-
         // Pattern searchers for start/stop commands
         var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
             .Find("AppHost started successfully.");
@@ -68,23 +46,7 @@ public sealed class StartStopTests(ITestOutputHelper output)
         }
 
         // Create a new project using aspire new
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter() // select first template (Starter App)
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("AspireStarterApp")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        sequenceBuilder.AspireNew("AspireStarterApp", counter);
 
         // Navigate to the AppHost directory
         sequenceBuilder.Type("cd AspireStarterApp/AspireStarterApp.AppHost")
@@ -171,25 +133,6 @@ public sealed class StartStopTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Pattern searchers for aspire new prompts
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .Find("> Starter App");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt = new CellPatternSearcher()
-            .Find("Enter the output path:");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find("Use *.dev.localhost URLs");
-
-        var waitingForRedisPrompt = new CellPatternSearcher()
-            .Find("Use Redis Cache");
-
-        var waitingForTestPrompt = new CellPatternSearcher()
-            .Find("Do you want to create a test project?");
-
         // Pattern searchers for detach/add/stop
         var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
             .Find("AppHost started successfully.");
@@ -210,23 +153,7 @@ public sealed class StartStopTests(ITestOutputHelper output)
         }
 
         // Create a new project using aspire new
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter() // select first template (Starter App)
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("AspireAddTestApp")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        sequenceBuilder.AspireNew("AspireAddTestApp", counter);
 
         // Navigate to the AppHost directory
         sequenceBuilder.Type("cd AspireAddTestApp/AspireAddTestApp.AppHost")
@@ -283,25 +210,6 @@ public sealed class StartStopTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Pattern searchers for aspire new prompts
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .Find("> Starter App");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt = new CellPatternSearcher()
-            .Find("Enter the output path:");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find("Use *.dev.localhost URLs");
-
-        var waitingForRedisPrompt = new CellPatternSearcher()
-            .Find("Use Redis Cache");
-
-        var waitingForTestPrompt = new CellPatternSearcher()
-            .Find("Do you want to create a test project?");
-
         // Pattern searchers for detach/add/stop
         var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
             .Find("AppHost started successfully.");
@@ -328,23 +236,7 @@ public sealed class StartStopTests(ITestOutputHelper output)
         }
 
         // Create a new project using aspire new
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter() // select first template (Starter App)
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("AspireAddInteractiveApp")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        sequenceBuilder.AspireNew("AspireAddInteractiveApp", counter);
 
         // Navigate to the AppHost directory
         sequenceBuilder.Type("cd AspireAddInteractiveApp/AspireAddInteractiveApp.AppHost")

--- a/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StopNonInteractiveTests.cs
@@ -26,28 +26,6 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Pattern searchers for aspire new prompts
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .FindPattern("> Starter App");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt = new CellPatternSearcher()
-            .Find($"Enter the output path: (./TestStopApp): ");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find($"Use *.dev.localhost URLs");
-
-        var waitingForRedisPrompt = new CellPatternSearcher()
-            .Find($"Use Redis Cache");
-
-        var waitingForTestPrompt = new CellPatternSearcher()
-            .Find($"Do you want to create a test project?");
-
-        var waitForProjectCreatedSuccessfullyMessage = new CellPatternSearcher()
-            .Find("Project created successfully.");
-
         // Pattern searchers for start/stop commands
         var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
             .Find("AppHost started successfully.");
@@ -71,23 +49,7 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
         }
 
         // Create a new project using aspire new
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter() // select first template (Starter App)
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("TestStopApp")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        sequenceBuilder.AspireNew("TestStopApp", counter);
 
         // Navigate to the AppHost directory
         sequenceBuilder.Type("cd TestStopApp/TestStopApp.AppHost")
@@ -141,28 +103,6 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Pattern searchers for aspire new prompts
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .FindPattern("> Starter App");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt1 = new CellPatternSearcher()
-            .Find($"Enter the output path: (./App1): ");
-
-        var waitingForOutputPathPrompt2 = new CellPatternSearcher()
-            .Find($"Enter the output path: (./App2): ");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find($"Use *.dev.localhost URLs");
-
-        var waitingForRedisPrompt = new CellPatternSearcher()
-            .Find($"Use Redis Cache");
-
-        var waitingForTestPrompt = new CellPatternSearcher()
-            .Find($"Do you want to create a test project?");
-
         // Pattern searchers for start/stop commands
         var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
             .Find("AppHost started successfully.");
@@ -186,45 +126,13 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
         }
 
         // Create first project
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter()
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("App1")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt1.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        sequenceBuilder.AspireNew("App1", counter);
 
         // Clear screen before second project creation
         sequenceBuilder.ClearScreen(counter);
 
         // Create second project
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter()
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("App2")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt2.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        sequenceBuilder.AspireNew("App2", counter);
 
         // Start first AppHost in background
         sequenceBuilder.Type("cd App1/App1.AppHost && aspire run --detach")
@@ -282,28 +190,6 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Pattern searchers for aspire new prompts
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .FindPattern("> Starter App");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt1 = new CellPatternSearcher()
-            .Find($"Enter the output path: (./App1): ");
-
-        var waitingForOutputPathPrompt2 = new CellPatternSearcher()
-            .Find($"Enter the output path: (./App2): ");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find($"Use *.dev.localhost URLs");
-
-        var waitingForRedisPrompt = new CellPatternSearcher()
-            .Find($"Use Redis Cache");
-
-        var waitingForTestPrompt = new CellPatternSearcher()
-            .Find($"Do you want to create a test project?");
-
         // Pattern searchers for start/stop commands
         var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
             .Find("AppHost started successfully.");
@@ -327,45 +213,13 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
         }
 
         // Create first project
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter()
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("App1")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt1.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        sequenceBuilder.AspireNew("App1", counter);
 
         // Clear screen before second project creation
         sequenceBuilder.ClearScreen(counter);
 
         // Create second project
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter()
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("App2")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt2.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        sequenceBuilder.AspireNew("App2", counter);
 
         // Start first AppHost in background
         sequenceBuilder.Type("cd App1/App1.AppHost && aspire run --detach")
@@ -428,33 +282,6 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Pattern searchers for aspire new prompts
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .FindPattern("> Starter App");
-
-        // First project prompts
-        var waitingForProjectNamePrompt1 = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt1 = new CellPatternSearcher()
-            .Find($"Enter the output path: (./App1): ");
-
-        // Second project prompts
-        var waitingForProjectNamePrompt2 = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt2 = new CellPatternSearcher()
-            .Find($"Enter the output path: (./App2): ");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find($"Use *.dev.localhost URLs");
-
-        var waitingForRedisPrompt = new CellPatternSearcher()
-            .Find($"Use Redis Cache");
-
-        var waitingForTestPrompt = new CellPatternSearcher()
-            .Find($"Do you want to create a test project?");
-
         // Pattern searchers for start/stop commands
         var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
             .Find("AppHost started successfully.");
@@ -478,45 +305,13 @@ public sealed class StopNonInteractiveTests(ITestOutputHelper output)
         }
 
         // Create first project
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter()
-            .WaitUntil(s => waitingForProjectNamePrompt1.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("App1")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt1.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        sequenceBuilder.AspireNew("App1", counter);
 
         // Clear screen before second project creation
         sequenceBuilder.ClearScreen(counter);
 
         // Create second project
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter()
-            .WaitUntil(s => waitingForProjectNamePrompt2.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("App2")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt2.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        sequenceBuilder.AspireNew("App2", counter);
 
         // Start first AppHost in background
         sequenceBuilder.Type("cd App1/App1.AppHost && aspire run --detach")

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
@@ -27,23 +27,6 @@ public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Pattern for template selection - find "Starter App (Express/React)"
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .FindPattern("> Starter App");
-
-        // Use Find() for literal string with parentheses/slashes
-        var waitingForExpressReactTemplateSelected = new CellPatternSearcher()
-            .Find("> Starter App (Express/React)");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find("Enter the project name (");
-
-        var waitingForOutputPathPrompt = new CellPatternSearcher()
-            .Find("Enter the output path:");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find("Use *.dev.localhost URLs");
-
         var waitForDashboardCurlSuccess = new CellPatternSearcher()
             .Find("dashboard-http-200");
 
@@ -62,24 +45,7 @@ public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
         }
 
         // Step 1: Create project using aspire new, selecting the Express/React template
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            // Navigate down to "Starter App (Express/React)" which is the 4th option
-            .Key(Hex1b.Input.Hex1bKey.DownArrow)
-            .Key(Hex1b.Input.Hex1bKey.DownArrow)
-            .Key(Hex1b.Input.Hex1bKey.DownArrow)
-            .WaitUntil(s => waitingForExpressReactTemplateSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
-            .Enter() // select "Starter App (Express/React)"
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("TsStarterApp")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter() // accept default output path
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter() // select "No" for localhost URLs (default)
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        sequenceBuilder.AspireNew("TsStarterApp", counter, template: AspireTemplate.ExpressReact);
 
         // Step 2: Navigate into the project and start it in background with JSON output
         sequenceBuilder

--- a/tests/Aspire.Cli.EndToEnd.Tests/WaitCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/WaitCommandTests.cs
@@ -26,28 +26,6 @@ public sealed class WaitCommandTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Pattern searchers for aspire new prompts
-        var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-            .FindPattern("> Starter App");
-
-        var waitingForProjectNamePrompt = new CellPatternSearcher()
-            .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-        var waitingForOutputPathPrompt = new CellPatternSearcher()
-            .Find($"Enter the output path: (./AspireWaitApp): ");
-
-        var waitingForUrlsPrompt = new CellPatternSearcher()
-            .Find($"Use *.dev.localhost URLs");
-
-        var waitingForRedisPrompt = new CellPatternSearcher()
-            .Find($"Use Redis Cache");
-
-        var waitingForTestPrompt = new CellPatternSearcher()
-            .Find($"Do you want to create a test project?");
-
-        var waitForProjectCreatedSuccessfullyMessage = new CellPatternSearcher()
-            .Find("Project created successfully.");
-
         // Pattern searchers for start/wait/stop commands
         var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
             .Find("AppHost started successfully.");
@@ -71,23 +49,7 @@ public sealed class WaitCommandTests(ITestOutputHelper output)
         }
 
         // Create a new project using aspire new
-        sequenceBuilder.Type("aspire new")
-            .Enter()
-            .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-            .Enter() // select first template (Starter App)
-            .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Type("AspireWaitApp")
-            .Enter()
-            .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-            .Enter()
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter);
+        sequenceBuilder.AspireNew("AspireWaitApp", counter);
 
         // Navigate to the AppHost directory
         sequenceBuilder.Type("cd AspireWaitApp/AspireWaitApp.AppHost")

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCustomRegistryDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCustomRegistryDeploymentTests.cs
@@ -67,25 +67,6 @@ public sealed class AcaCustomRegistryDeploymentTests(ITestOutputHelper output)
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            // Pattern searchers for aspire new interactive prompts
-            var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-                .FindPattern("> Starter App");
-
-            var waitingForProjectNamePrompt = new CellPatternSearcher()
-                .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-            var waitingForOutputPathPrompt = new CellPatternSearcher()
-                .Find("Enter the output path:");
-
-            var waitingForUrlsPrompt = new CellPatternSearcher()
-                .Find("Use *.dev.localhost URLs");
-
-            var waitingForRedisPrompt = new CellPatternSearcher()
-                .Find("Use Redis Cache");
-
-            var waitingForTestPrompt = new CellPatternSearcher()
-                .Find("Do you want to create a test project?");
-
             // Pattern searchers for aspire add prompts
             var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
                 .Find("(based on NuGet.config)");
@@ -113,25 +94,7 @@ public sealed class AcaCustomRegistryDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create starter project using aspire new with interactive prompts
             output.WriteLine("Step 3: Creating starter project...");
-            sequenceBuilder.Type("aspire new")
-                .Enter()
-                .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
-                .Enter() // Select first template (Starter App ASP.NET Core/Blazor)
-                .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-                .Type(projectName)
-                .Enter()
-                .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Accept default output path
-                .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Select "No" for localhost URLs (default)
-                .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                // For Redis prompt, default is "Yes" so we need to select "No" by pressing Down
-                .Key(Hex1b.Input.Hex1bKey.DownArrow)
-                .Enter() // Select "No" for Redis Cache
-                .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Select "No" for test project (default)
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+            sequenceBuilder.AspireNew(projectName, counter, useRedisCache: false);
 
             // Step 4: Navigate to project directory
             output.WriteLine("Step 4: Navigating to project directory...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaExistingRegistryDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaExistingRegistryDeploymentTests.cs
@@ -77,25 +77,6 @@ public sealed class AcaExistingRegistryDeploymentTests(ITestOutputHelper output)
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            // Pattern searchers for aspire new interactive prompts
-            var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-                .FindPattern("> Starter App");
-
-            var waitingForProjectNamePrompt = new CellPatternSearcher()
-                .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-            var waitingForOutputPathPrompt = new CellPatternSearcher()
-                .Find("Enter the output path:");
-
-            var waitingForUrlsPrompt = new CellPatternSearcher()
-                .Find("Use *.dev.localhost URLs");
-
-            var waitingForRedisPrompt = new CellPatternSearcher()
-                .Find("Use Redis Cache");
-
-            var waitingForTestPrompt = new CellPatternSearcher()
-                .Find("Do you want to create a test project?");
-
             // Pattern searchers for aspire add prompts
             var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
                 .Find("(based on NuGet.config)");
@@ -137,25 +118,7 @@ public sealed class AcaExistingRegistryDeploymentTests(ITestOutputHelper output)
 
             // Step 4: Create starter project using aspire new with interactive prompts
             output.WriteLine("Step 4: Creating starter project...");
-            sequenceBuilder.Type("aspire new")
-                .Enter()
-                .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
-                .Enter() // Select first template (Starter App ASP.NET Core/Blazor)
-                .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-                .Type(projectName)
-                .Enter()
-                .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Accept default output path
-                .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Select "No" for localhost URLs (default)
-                .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                // For Redis prompt, default is "Yes" so we need to select "No" by pressing Down
-                .Key(Hex1b.Input.Hex1bKey.DownArrow)
-                .Enter() // Select "No" for Redis Cache
-                .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Select "No" for test project (default)
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+            sequenceBuilder.AspireNew(projectName, counter, useRedisCache: false);
 
             // Step 5: Navigate to project directory
             output.WriteLine("Step 5: Navigating to project directory...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaStarterDeploymentTests.cs
@@ -68,25 +68,6 @@ public sealed class AcaStarterDeploymentTests(ITestOutputHelper output)
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            // Pattern searchers for aspire new interactive prompts
-            var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-                .FindPattern("> Starter App");
-
-            var waitingForProjectNamePrompt = new CellPatternSearcher()
-                .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-            var waitingForOutputPathPrompt = new CellPatternSearcher()
-                .Find("Enter the output path:");
-
-            var waitingForUrlsPrompt = new CellPatternSearcher()
-                .Find("Use *.dev.localhost URLs");
-
-            var waitingForRedisPrompt = new CellPatternSearcher()
-                .Find("Use Redis Cache");
-
-            var waitingForTestPrompt = new CellPatternSearcher()
-                .Find("Do you want to create a test project?");
-
             // Pattern searchers for aspire add prompts
             var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
                 .Find("(based on NuGet.config)");
@@ -114,25 +95,7 @@ public sealed class AcaStarterDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create starter project using aspire new with interactive prompts
             output.WriteLine("Step 3: Creating starter project...");
-            sequenceBuilder.Type("aspire new")
-                .Enter()
-                .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
-                .Enter() // Select first template (Starter App ASP.NET Core/Blazor)
-                .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-                .Type(projectName)
-                .Enter()
-                .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Accept default output path
-                .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Select "No" for localhost URLs (default)
-                .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                // For Redis prompt, default is "Yes" so we need to select "No" by pressing Down
-                .Key(Hex1b.Input.Hex1bKey.DownArrow)
-                .Enter() // Select "No" for Redis Cache
-                .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Select "No" for test project (default)
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+            sequenceBuilder.AspireNew(projectName, counter, useRedisCache: false);
 
             // Step 4: Navigate to project directory
             output.WriteLine("Step 4: Navigating to project directory...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcrPurgeTaskDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcrPurgeTaskDeploymentTests.cs
@@ -66,25 +66,6 @@ public sealed class AcrPurgeTaskDeploymentTests(ITestOutputHelper output)
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            // Pattern searchers for aspire new interactive prompts
-            var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-                .FindPattern("> Starter App");
-
-            var waitingForPythonReactTemplateSelected = new CellPatternSearcher()
-                .Find("> Starter App (FastAPI/React)");
-
-            var waitingForProjectNamePrompt = new CellPatternSearcher()
-                .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-            var waitingForOutputPathPrompt = new CellPatternSearcher()
-                .Find("Enter the output path:");
-
-            var waitingForUrlsPrompt = new CellPatternSearcher()
-                .Find("Use *.dev.localhost URLs");
-
-            var waitingForRedisPrompt = new CellPatternSearcher()
-                .Find("Use Redis Cache");
-
             // Pattern searchers for aspire add prompts
             var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
                 .Find("(based on NuGet.config)");
@@ -112,27 +93,7 @@ public sealed class AcrPurgeTaskDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create Python FastAPI project using aspire new
             output.WriteLine("Step 3: Creating Python FastAPI project...");
-            sequenceBuilder.Type("aspire new")
-                .Enter()
-                .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
-                // Navigate to Starter App (FastAPI/React) - it's the 3rd option
-                .Key(Hex1b.Input.Hex1bKey.DownArrow)
-                .Key(Hex1b.Input.Hex1bKey.DownArrow)
-                .WaitUntil(s => waitingForPythonReactTemplateSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
-                .Enter() // Select Starter App (FastAPI/React)
-                .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-                .Type(projectName)
-                .Enter()
-                .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Accept default output path
-                .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Select "No" for localhost URLs (default)
-                .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                // For Redis prompt, default is "Yes" so we need to select "No" by pressing Down
-                .Key(Hex1b.Input.Hex1bKey.DownArrow)
-                .Enter() // Select "No" for Redis Cache
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+            sequenceBuilder.AspireNew(projectName, counter, template: AspireTemplate.PythonReact, useRedisCache: false);
 
             // Step 4: Navigate to project directory
             output.WriteLine("Step 4: Navigating to project directory...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
@@ -78,25 +78,6 @@ public sealed class AksStarterDeploymentTests(ITestOutputHelper output)
             var counter = new SequenceCounter();
             var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
 
-            // Pattern searchers for aspire new interactive prompts
-            var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-                .FindPattern("> Starter App");
-
-            var waitingForProjectNamePrompt = new CellPatternSearcher()
-                .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-            var waitingForOutputPathPrompt = new CellPatternSearcher()
-                .Find("Enter the output path:");
-
-            var waitingForUrlsPrompt = new CellPatternSearcher()
-                .Find("Use *.dev.localhost URLs");
-
-            var waitingForRedisPrompt = new CellPatternSearcher()
-                .Find("Use Redis Cache");
-
-            var waitingForTestPrompt = new CellPatternSearcher()
-                .Find("Do you want to create a test project?");
-
             // Pattern searchers for aspire add prompts
             var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
                 .Find("(based on NuGet.config)");
@@ -196,24 +177,7 @@ public sealed class AksStarterDeploymentTests(ITestOutputHelper output)
 
             // Step 11: Create starter project using aspire new with interactive prompts
             output.WriteLine("Step 11: Creating Aspire starter project...");
-            sequenceBuilder.Type("aspire new")
-                .Enter()
-                .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
-                .Enter() // Select first template (Starter App ASP.NET Core/Blazor)
-                .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-                .Type(projectName)
-                .Enter()
-                .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Accept default output path
-                .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Select "No" for localhost URLs (default)
-                .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Key(Hex1b.Input.Hex1bKey.DownArrow)
-                .Enter() // Select "No" for Redis Cache
-                .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Select "No" for test project (default)
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+            sequenceBuilder.AspireNew(projectName, counter, useRedisCache: false);
 
             // Step 12: Navigate to project directory
             output.WriteLine("Step 12: Navigating to project directory...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterWithRedisDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterWithRedisDeploymentTests.cs
@@ -79,25 +79,6 @@ public sealed class AksStarterWithRedisDeploymentTests(ITestOutputHelper output)
             var counter = new SequenceCounter();
             var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
 
-            // Pattern searchers for aspire new interactive prompts
-            var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-                .FindPattern("> Starter App");
-
-            var waitingForProjectNamePrompt = new CellPatternSearcher()
-                .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-            var waitingForOutputPathPrompt = new CellPatternSearcher()
-                .Find("Enter the output path:");
-
-            var waitingForUrlsPrompt = new CellPatternSearcher()
-                .Find("Use *.dev.localhost URLs");
-
-            var waitingForRedisPrompt = new CellPatternSearcher()
-                .Find("Use Redis Cache");
-
-            var waitingForTestPrompt = new CellPatternSearcher()
-                .Find("Do you want to create a test project?");
-
             // Pattern searchers for aspire add prompts
             var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
                 .Find("(based on NuGet.config)");
@@ -196,23 +177,7 @@ public sealed class AksStarterWithRedisDeploymentTests(ITestOutputHelper output)
 
             // Step 11: Create starter project with Redis enabled
             output.WriteLine("Step 11: Creating Aspire starter project with Redis...");
-            sequenceBuilder.Type("aspire new")
-                .Enter()
-                .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
-                .Enter() // Select first template (Starter App ASP.NET Core/Blazor)
-                .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-                .Type(projectName)
-                .Enter()
-                .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Accept default output path
-                .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Select "No" for localhost URLs (default)
-                .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Select "Yes" for Redis Cache (first/default option)
-                .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Select "No" for test project (default)
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+            sequenceBuilder.AspireNew(projectName, counter);
 
             // Step 12: Navigate to project directory
             output.WriteLine("Step 12: Navigating to project directory...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServicePythonDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServicePythonDeploymentTests.cs
@@ -68,27 +68,6 @@ public sealed class AppServicePythonDeploymentTests(ITestOutputHelper output)
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            // Pattern searchers for aspire new interactive prompts
-            var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-                .FindPattern("> Starter App");
-
-            // Wait for the FastAPI/React template to be highlighted (after pressing Down twice)
-            // Use Find() instead of FindPattern() because parentheses and slashes are regex special characters
-            var waitingForPythonReactTemplateSelected = new CellPatternSearcher()
-                .Find("> Starter App (FastAPI/React)");
-
-            var waitingForProjectNamePrompt = new CellPatternSearcher()
-                .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-            var waitingForOutputPathPrompt = new CellPatternSearcher()
-                .Find("Enter the output path:");
-
-            var waitingForUrlsPrompt = new CellPatternSearcher()
-                .Find("Use *.dev.localhost URLs");
-
-            var waitingForRedisPrompt = new CellPatternSearcher()
-                .Find("Use Redis Cache");
-
             // Pattern searchers for aspire add prompts
             var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
                 .Find("(based on NuGet.config)");
@@ -112,29 +91,8 @@ public sealed class AppServicePythonDeploymentTests(ITestOutputHelper output)
             }
 
             // Step 3: Create Python FastAPI project using aspire new with interactive prompts
-            // Navigate down to select Starter App (FastAPI/React) which is the 3rd option
             output.WriteLine("Step 3: Creating Python FastAPI project...");
-            sequenceBuilder.Type("aspire new")
-                .Enter()
-                .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
-                // Navigate to Starter App (FastAPI/React) - it's the 3rd option (after ASP.NET and JS)
-                .Key(Hex1b.Input.Hex1bKey.DownArrow)
-                .Key(Hex1b.Input.Hex1bKey.DownArrow)
-                .WaitUntil(s => waitingForPythonReactTemplateSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
-                .Enter() // Select Starter App (FastAPI/React)
-                .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-                .Type(projectName)
-                .Enter()
-                .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Accept default output path
-                .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Select "No" for localhost URLs (default)
-                .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                // For Redis prompt, default is "Yes" so we need to select "No" by pressing Down
-                .Key(Hex1b.Input.Hex1bKey.DownArrow)
-                .Enter() // Select "No" for Redis Cache
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+            sequenceBuilder.AspireNew(projectName, counter, template: AspireTemplate.PythonReact, useRedisCache: false);
 
             // Step 4: Navigate to project directory
             output.WriteLine("Step 4: Navigating to project directory...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
@@ -68,30 +68,6 @@ public sealed class AppServiceReactDeploymentTests(ITestOutputHelper output)
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            // Pattern searchers for aspire new interactive prompts
-            var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-                .FindPattern("> Starter App");
-
-            // Wait for the ASP.NET Core/React template to be highlighted (after pressing Down once)
-            // Use Find() instead of FindPattern() because parentheses and slashes are regex special characters
-            var waitingForReactTemplateSelected = new CellPatternSearcher()
-                .Find("> Starter App (ASP.NET Core/React)");
-
-            var waitingForProjectNamePrompt = new CellPatternSearcher()
-                .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-            var waitingForOutputPathPrompt = new CellPatternSearcher()
-                .Find($"Enter the output path: (./{projectName}): ");
-
-            var waitingForUrlsPrompt = new CellPatternSearcher()
-                .Find("Use *.dev.localhost URLs");
-
-            var waitingForRedisPrompt = new CellPatternSearcher()
-                .Find("Use Redis Cache");
-
-            // Note: React template (aspire-ts-cs-starter) does NOT have the "test project" prompt
-            // unlike the Blazor starter template. It only has localhost URLs and Redis prompts.
-
             // Pattern searchers for aspire add prompts
             var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
                 .Find("(based on NuGet.config)");
@@ -118,29 +94,8 @@ public sealed class AppServiceReactDeploymentTests(ITestOutputHelper output)
             }
 
             // Step 3: Create React + ASP.NET Core project using aspire new with interactive prompts
-            // Navigate down to select Starter App (ASP.NET Core/React) - it's the 2nd option
             output.WriteLine("Step 3: Creating React + ASP.NET Core project...");
-            sequenceBuilder.Type("aspire new")
-                .Enter()
-                .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
-                // Navigate to Starter App (ASP.NET Core/React) - it's the 2nd option (after Blazor)
-                .Key(Hex1b.Input.Hex1bKey.DownArrow)
-                .WaitUntil(s => waitingForReactTemplateSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
-                .Enter() // Select Starter App (ASP.NET Core/React)
-                .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-                .Type(projectName)
-                .Enter()
-                .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Accept default output path
-                .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Select "No" for localhost URLs (default)
-                .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                // For Redis prompt, default is "Yes" so we need to select "No" by pressing Down
-                .Key(Hex1b.Input.Hex1bKey.DownArrow)
-                .Enter() // Select "No" for Redis Cache
-                // Note: React template does NOT have a test project prompt (unlike Blazor starter)
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+            sequenceBuilder.AspireNew(projectName, counter, template: AspireTemplate.JsReact, useRedisCache: false);
 
             // Step 4: Navigate to project directory
             output.WriteLine("Step 4: Navigating to project directory...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/PythonFastApiDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/PythonFastApiDeploymentTests.cs
@@ -68,27 +68,6 @@ public sealed class PythonFastApiDeploymentTests(ITestOutputHelper output)
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            // Pattern searchers for aspire new interactive prompts
-            var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-                .FindPattern("> Starter App");
-
-            // Wait for the FastAPI/React template to be highlighted (after pressing Down twice)
-            // Use Find() instead of FindPattern() because parentheses and slashes are regex special characters
-            var waitingForPythonReactTemplateSelected = new CellPatternSearcher()
-                .Find("> Starter App (FastAPI/React)");
-
-            var waitingForProjectNamePrompt = new CellPatternSearcher()
-                .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-            var waitingForOutputPathPrompt = new CellPatternSearcher()
-                .Find("Enter the output path:");
-
-            var waitingForUrlsPrompt = new CellPatternSearcher()
-                .Find("Use *.dev.localhost URLs");
-
-            var waitingForRedisPrompt = new CellPatternSearcher()
-                .Find("Use Redis Cache");
-
             // Pattern searchers for aspire add prompts
             var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
                 .Find("(based on NuGet.config)");
@@ -112,29 +91,8 @@ public sealed class PythonFastApiDeploymentTests(ITestOutputHelper output)
             }
 
             // Step 3: Create Python FastAPI project using aspire new with interactive prompts
-            // Navigate down to select Starter App (FastAPI/React) which is the 3rd option
             output.WriteLine("Step 3: Creating Python FastAPI project...");
-            sequenceBuilder.Type("aspire new")
-                .Enter()
-                .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
-                // Navigate to Starter App (FastAPI/React) - it's the 3rd option (after ASP.NET and JS)
-                .Key(Hex1b.Input.Hex1bKey.DownArrow)
-                .Key(Hex1b.Input.Hex1bKey.DownArrow)
-                .WaitUntil(s => waitingForPythonReactTemplateSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
-                .Enter() // Select Starter App (FastAPI/React)
-                .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-                .Type(projectName)
-                .Enter()
-                .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Accept default output path
-                .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Select "No" for localhost URLs (default)
-                .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                // For Redis prompt, default is "Yes" so we need to select "No" by pressing Down
-                .Key(Hex1b.Input.Hex1bKey.DownArrow)
-                .Enter() // Select "No" for Redis Cache
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+            sequenceBuilder.AspireNew(projectName, counter, template: AspireTemplate.PythonReact, useRedisCache: false);
 
             // Step 4: Navigate to project directory
             output.WriteLine("Step 4: Navigating to project directory...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/VnetKeyVaultConnectivityDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/VnetKeyVaultConnectivityDeploymentTests.cs
@@ -64,24 +64,6 @@ public sealed class VnetKeyVaultConnectivityDeploymentTests(ITestOutputHelper ou
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-                .FindPattern("> Starter App");
-
-            var waitingForProjectNamePrompt = new CellPatternSearcher()
-                .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-            var waitingForOutputPathPrompt = new CellPatternSearcher()
-                .Find("Enter the output path:");
-
-            var waitingForUrlsPrompt = new CellPatternSearcher()
-                .Find("Use *.dev.localhost URLs");
-
-            var waitingForRedisPrompt = new CellPatternSearcher()
-                .Find("Use Redis Cache");
-
-            var waitingForTestPrompt = new CellPatternSearcher()
-                .Find("Do you want to create a test project?");
-
             var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
                 .Find("(based on NuGet.config)");
 
@@ -103,24 +85,7 @@ public sealed class VnetKeyVaultConnectivityDeploymentTests(ITestOutputHelper ou
 
             // Step 3: Create starter project using aspire new
             output.WriteLine("Step 3: Creating starter project...");
-            sequenceBuilder.Type("aspire new")
-                .Enter()
-                .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
-                .Enter()
-                .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-                .Type(projectName)
-                .Enter()
-                .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter()
-                .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter()
-                .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Key(Hex1b.Input.Hex1bKey.DownArrow)
-                .Enter()
-                .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter()
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+            sequenceBuilder.AspireNew(projectName, counter, useRedisCache: false);
 
             // Step 4: Navigate to project directory
             sequenceBuilder

--- a/tests/Aspire.Deployment.EndToEnd.Tests/VnetSqlServerConnectivityDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/VnetSqlServerConnectivityDeploymentTests.cs
@@ -64,24 +64,6 @@ public sealed class VnetSqlServerConnectivityDeploymentTests(ITestOutputHelper o
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-                .FindPattern("> Starter App");
-
-            var waitingForProjectNamePrompt = new CellPatternSearcher()
-                .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-            var waitingForOutputPathPrompt = new CellPatternSearcher()
-                .Find("Enter the output path:");
-
-            var waitingForUrlsPrompt = new CellPatternSearcher()
-                .Find("Use *.dev.localhost URLs");
-
-            var waitingForRedisPrompt = new CellPatternSearcher()
-                .Find("Use Redis Cache");
-
-            var waitingForTestPrompt = new CellPatternSearcher()
-                .Find("Do you want to create a test project?");
-
             var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
                 .Find("(based on NuGet.config)");
 
@@ -103,24 +85,7 @@ public sealed class VnetSqlServerConnectivityDeploymentTests(ITestOutputHelper o
 
             // Step 3: Create starter project using aspire new
             output.WriteLine("Step 3: Creating starter project...");
-            sequenceBuilder.Type("aspire new")
-                .Enter()
-                .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
-                .Enter()
-                .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-                .Type(projectName)
-                .Enter()
-                .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter()
-                .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter()
-                .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Key(Hex1b.Input.Hex1bKey.DownArrow)
-                .Enter()
-                .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter()
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+            sequenceBuilder.AspireNew(projectName, counter, useRedisCache: false);
 
             // Step 4: Navigate to project directory
             sequenceBuilder

--- a/tests/Aspire.Deployment.EndToEnd.Tests/VnetStorageBlobConnectivityDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/VnetStorageBlobConnectivityDeploymentTests.cs
@@ -64,25 +64,6 @@ public sealed class VnetStorageBlobConnectivityDeploymentTests(ITestOutputHelper
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            // Pattern searchers for aspire new interactive prompts
-            var waitingForTemplateSelectionPrompt = new CellPatternSearcher()
-                .FindPattern("> Starter App");
-
-            var waitingForProjectNamePrompt = new CellPatternSearcher()
-                .Find($"Enter the project name ({workspace.WorkspaceRoot.Name}): ");
-
-            var waitingForOutputPathPrompt = new CellPatternSearcher()
-                .Find("Enter the output path:");
-
-            var waitingForUrlsPrompt = new CellPatternSearcher()
-                .Find("Use *.dev.localhost URLs");
-
-            var waitingForRedisPrompt = new CellPatternSearcher()
-                .Find("Use Redis Cache");
-
-            var waitingForTestPrompt = new CellPatternSearcher()
-                .Find("Do you want to create a test project?");
-
             var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
                 .Find("(based on NuGet.config)");
 
@@ -105,24 +86,7 @@ public sealed class VnetStorageBlobConnectivityDeploymentTests(ITestOutputHelper
 
             // Step 3: Create starter project using aspire new
             output.WriteLine("Step 3: Creating starter project...");
-            sequenceBuilder.Type("aspire new")
-                .Enter()
-                .WaitUntil(s => waitingForTemplateSelectionPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(60))
-                .Enter() // Select Starter App
-                .WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(30))
-                .Type(projectName)
-                .Enter()
-                .WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // Accept default output path
-                .WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // No for localhost URLs
-                .WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Key(Hex1b.Input.Hex1bKey.DownArrow)
-                .Enter() // No for Redis
-                .WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
-                .Enter() // No for test project
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(5));
+            sequenceBuilder.AspireNew(projectName, counter, useRedisCache: false);
 
             // Step 4: Navigate to project directory
             output.WriteLine("Step 4: Navigating to project directory...");

--- a/tests/Shared/Hex1bTestHelpers.cs
+++ b/tests/Shared/Hex1bTestHelpers.cs
@@ -305,18 +305,13 @@ internal static class Hex1bTestHelpers
     /// Whether to enable Redis Cache. Defaults to <c>true</c> (the <c>aspire new</c> default).
     /// Only applies to templates that show the Redis prompt (Starter, JsReact, PythonReact).
     /// </param>
-    /// <param name="createTestProject">
-    /// Whether to create a test project. Defaults to <c>false</c> (the <c>aspire new</c> default).
-    /// Only applies to the Starter template.
-    /// </param>
     /// <returns>The builder for chaining.</returns>
     internal static Hex1bTerminalInputSequenceBuilder AspireNew(
         this Hex1bTerminalInputSequenceBuilder builder,
         string projectName,
         SequenceCounter counter,
         AspireTemplate template = AspireTemplate.Starter,
-        bool useRedisCache = true,
-        bool createTestProject = false)
+        bool useRedisCache = true)
     {
         var templateTimeout = TimeSpan.FromSeconds(60);
 
@@ -420,15 +415,8 @@ internal static class Hex1bTestHelpers
         {
             var waitingForTestPrompt = new CellPatternSearcher()
                 .Find("Do you want to create a test project?");
-            builder.WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10));
-
-            if (createTestProject)
-            {
-                // Options are [No, Yes]. Default is "No", navigate down to "Yes"
-                builder.Key(Hex1bKey.DownArrow);
-            }
-
-            builder.Enter();
+            builder.WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+                .Enter(); // Accept default "No"
         }
 
         // Step 8: Decline the agent init prompt

--- a/tests/Shared/Hex1bTestHelpers.cs
+++ b/tests/Shared/Hex1bTestHelpers.cs
@@ -424,8 +424,8 @@ internal static class Hex1bTestHelpers
 
             if (createTestProject)
             {
-                // Default is "No", navigate to "Yes"
-                builder.Key(Hex1bKey.UpArrow);
+                // Options are [No, Yes]. Default is "No", navigate down to "Yes"
+                builder.Key(Hex1bKey.DownArrow);
             }
 
             builder.Enter();

--- a/tests/Shared/Hex1bTestHelpers.cs
+++ b/tests/Shared/Hex1bTestHelpers.cs
@@ -4,6 +4,7 @@
 using System.Runtime.CompilerServices;
 using Hex1b;
 using Hex1b.Automation;
+using Hex1b.Input;
 
 namespace Aspire.Tests.Shared;
 
@@ -18,6 +19,43 @@ internal sealed class SequenceCounter
     {
         return ++Value;
     }
+}
+
+/// <summary>
+/// Represents the available Aspire project templates for <c>aspire new</c>.
+/// The enum values correspond to the order in the template selection list.
+/// </summary>
+internal enum AspireTemplate
+{
+    /// <summary>
+    /// Starter App (ASP.NET Core/Blazor) — the default first option.
+    /// Prompts: template, project name, output path, URLs, Redis, test project.
+    /// </summary>
+    Starter,
+
+    /// <summary>
+    /// Starter App (ASP.NET Core/React) — 2nd option.
+    /// Prompts: template, project name, output path, URLs, Redis. No test project prompt.
+    /// </summary>
+    JsReact,
+
+    /// <summary>
+    /// Starter App (FastAPI/React) — 3rd option.
+    /// Prompts: template, project name, output path, URLs, Redis. No test project prompt.
+    /// </summary>
+    PythonReact,
+
+    /// <summary>
+    /// Starter App (Express/React) — 4th option.
+    /// Prompts: template, project name, output path, URLs. No Redis or test project prompt.
+    /// </summary>
+    ExpressReact,
+
+    /// <summary>
+    /// Empty AppHost — 5th option.
+    /// Prompts: template, language (C#), project name, output path, URLs. No Redis or test project prompt.
+    /// </summary>
+    EmptyAppHost,
 }
 
 /// <summary>
@@ -252,5 +290,151 @@ internal static class Hex1bTestHelpers
             .Wait(500)
             .Type("n")
             .Enter();
+    }
+
+    /// <summary>
+    /// Runs <c>aspire new</c> interactively, selecting the specified template and responding to all prompts.
+    /// This centralizes the multi-step interactive flow so that changes to <c>aspire new</c> prompts
+    /// only need to be updated in one place instead of across every E2E test.
+    /// </summary>
+    /// <param name="builder">The sequence builder.</param>
+    /// <param name="projectName">The project name to enter at the prompt.</param>
+    /// <param name="counter">The sequence counter for prompt detection.</param>
+    /// <param name="template">The template to select. Defaults to <see cref="AspireTemplate.Starter"/>.</param>
+    /// <param name="useRedisCache">
+    /// Whether to enable Redis Cache. Defaults to <c>true</c> (the <c>aspire new</c> default).
+    /// Only applies to templates that show the Redis prompt (Starter, JsReact, PythonReact).
+    /// </param>
+    /// <param name="createTestProject">
+    /// Whether to create a test project. Defaults to <c>false</c> (the <c>aspire new</c> default).
+    /// Only applies to the Starter template.
+    /// </param>
+    /// <returns>The builder for chaining.</returns>
+    internal static Hex1bTerminalInputSequenceBuilder AspireNew(
+        this Hex1bTerminalInputSequenceBuilder builder,
+        string projectName,
+        SequenceCounter counter,
+        AspireTemplate template = AspireTemplate.Starter,
+        bool useRedisCache = true,
+        bool createTestProject = false)
+    {
+        var templateTimeout = TimeSpan.FromSeconds(60);
+
+        // Wait for the template selection list to appear.
+        // The first item "> Starter App" is always highlighted initially.
+        var waitingForTemplateList = new CellPatternSearcher()
+            .Find("> Starter App");
+
+        var waitingForProjectNamePrompt = new CellPatternSearcher()
+            .Find("Enter the project name");
+
+        var waitingForOutputPathPrompt = new CellPatternSearcher()
+            .Find("Enter the output path:");
+
+        var waitingForUrlsPrompt = new CellPatternSearcher()
+            .Find("Use *.dev.localhost URLs");
+
+        // Step 1: Type aspire new and wait for the template list
+        builder.Type("aspire new")
+            .Enter()
+            .WaitUntil(s => waitingForTemplateList.Search(s).Count > 0, templateTimeout);
+
+        // Step 2: Navigate to and select the desired template
+        switch (template)
+        {
+            case AspireTemplate.Starter:
+                builder.Enter(); // First option, no navigation needed
+                break;
+
+            case AspireTemplate.JsReact:
+                var jsReactSelected = new CellPatternSearcher()
+                    .Find("> Starter App (ASP.NET Core/React)");
+                builder.Key(Hex1bKey.DownArrow)
+                    .WaitUntil(s => jsReactSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
+                    .Enter();
+                break;
+
+            case AspireTemplate.PythonReact:
+                var pythonReactSelected = new CellPatternSearcher()
+                    .Find("> Starter App (FastAPI/React)");
+                builder.Key(Hex1bKey.DownArrow)
+                    .Key(Hex1bKey.DownArrow)
+                    .WaitUntil(s => pythonReactSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
+                    .Enter();
+                break;
+
+            case AspireTemplate.ExpressReact:
+                var expressReactSelected = new CellPatternSearcher()
+                    .Find("> Starter App (Express/React)");
+                builder.Key(Hex1bKey.DownArrow)
+                    .Key(Hex1bKey.DownArrow)
+                    .Key(Hex1bKey.DownArrow)
+                    .WaitUntil(s => expressReactSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
+                    .Enter();
+                break;
+
+            case AspireTemplate.EmptyAppHost:
+                var emptyAppHostSelected = new CellPatternSearcher()
+                    .Find("> Empty AppHost");
+                builder.Key(Hex1bKey.DownArrow)
+                    .Key(Hex1bKey.DownArrow)
+                    .Key(Hex1bKey.DownArrow)
+                    .Key(Hex1bKey.DownArrow)
+                    .WaitUntil(s => emptyAppHostSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
+                    .Enter()
+                    .Enter(); // Select C# language
+                break;
+        }
+
+        // Step 3: Enter project name
+        builder.WaitUntil(s => waitingForProjectNamePrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Type(projectName)
+            .Enter();
+
+        // Step 4: Accept default output path
+        builder.WaitUntil(s => waitingForOutputPathPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter();
+
+        // Step 5: URLs prompt (all templates have this)
+        builder.WaitUntil(s => waitingForUrlsPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10))
+            .Enter(); // Accept default "No"
+
+        // Step 6: Redis prompt (only Starter, JsReact, PythonReact)
+        if (template is AspireTemplate.Starter or AspireTemplate.JsReact or AspireTemplate.PythonReact)
+        {
+            var waitingForRedisPrompt = new CellPatternSearcher()
+                .Find("Use Redis Cache");
+            builder.WaitUntil(s => waitingForRedisPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10));
+
+            if (!useRedisCache)
+            {
+                // Default is "Yes", navigate to "No"
+                builder.Key(Hex1bKey.DownArrow);
+            }
+
+            builder.Enter();
+        }
+
+        // Step 7: Test project prompt (only Starter)
+        if (template is AspireTemplate.Starter)
+        {
+            var waitingForTestPrompt = new CellPatternSearcher()
+                .Find("Do you want to create a test project?");
+            builder.WaitUntil(s => waitingForTestPrompt.Search(s).Count > 0, TimeSpan.FromSeconds(10));
+
+            if (createTestProject)
+            {
+                // Default is "No", navigate to "Yes"
+                builder.Key(Hex1bKey.UpArrow);
+            }
+
+            builder.Enter();
+        }
+
+        // Step 8: Decline the agent init prompt
+        builder.DeclineAgentInitPrompt();
+
+        // Wait for project creation to complete
+        return builder.WaitForSuccessPrompt(counter);
     }
 }


### PR DESCRIPTION
## Description

Add `AspireNew` helper method and `AspireTemplate` enum to `Hex1bTestHelpers.cs` to centralize the multi-step `aspire new` interactive terminal flow that was duplicated across 29 E2E test files.

**What changed:**
- **`tests/Shared/Hex1bTestHelpers.cs`**: Added `AspireTemplate` enum (Starter, JsReact, PythonReact, ExpressReact, EmptyAppHost) and `AspireNew()` extension method that handles template selection with arrow key navigation, project name, output path, URLs, Redis cache, and test project prompts for all 5 template types.
- **17 CLI E2E test files**: Replaced duplicated `aspire new` interaction sequences with a single `AspireNew(...)` call.
- **12 Deployment E2E test files**: Same replacement.
- **`.github/skills/cli-e2e-testing/SKILL.md`**: Added documentation for the new helper, enum, and usage examples.

**Impact:** ~1,400 lines removed, ~300 lines added. When `aspire new` prompts change in the future, only `AspireNew()` needs updating instead of 39 call sites.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
