### PR TITLE
Hide available features in 'aspire config list' behind --available flag

### DIFF
--- a/src/Aspire.Cli/Commands/ConfigCommand.cs
+++ b/src/Aspire.Cli/Commands/ConfigCommand.cs
@@ -198,17 +198,33 @@ internal sealed class ConfigCommand : BaseCommand
         }
     }
 
-    private sealed class ListCommand(IConfigurationService configurationService, IInteractionService interactionService, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, AspireCliTelemetry telemetry)
-        : BaseConfigSubCommand("list", ConfigCommandStrings.ListCommand_Description, features, updateNotifier, configurationService, executionContext, interactionService, telemetry)
+    private sealed class ListCommand : BaseConfigSubCommand
     {
+        private static readonly Option<bool> s_availableOption = new("--available")
+        {
+            Description = ConfigCommandStrings.ListCommand_AvailableOptionDescription
+        };
+
+        public ListCommand(IConfigurationService configurationService, IInteractionService interactionService, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, AspireCliTelemetry telemetry)
+            : base("list", ConfigCommandStrings.ListCommand_Description, features, updateNotifier, configurationService, executionContext, interactionService, telemetry)
+        {
+            Options.Add(s_availableOption);
+        }
+
         protected override bool UpdateNotificationsEnabled => false;
 
         protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
         {
-            return InteractiveExecuteAsync(cancellationToken);
+            var showAvailable = parseResult.GetValue(s_availableOption);
+            return ExecuteAsync(showAvailable, cancellationToken);
         }
 
-        public override async Task<int> InteractiveExecuteAsync(CancellationToken cancellationToken)
+        public override Task<int> InteractiveExecuteAsync(CancellationToken cancellationToken)
+        {
+            return ExecuteAsync(showAvailable: false, cancellationToken);
+        }
+
+        private async Task<int> ExecuteAsync(bool showAvailable, CancellationToken cancellationToken)
         {
             if (InteractionService is ExtensionInteractionService extensionInteractionService)
             {
@@ -256,16 +272,25 @@ internal sealed class ConfigCommand : BaseCommand
 
             if (unconfiguredFeatures.Count > 0)
             {
-                InteractionService.DisplayEmptyLine();
-                InteractionService.DisplayMarkdown($"**{ConfigCommandStrings.AvailableFeaturesHeader}:**");
-                foreach (var feature in unconfiguredFeatures)
+                if (showAvailable)
                 {
-                    var defaultText = feature.DefaultValue ? "true" : "false";
-                    InteractionService.DisplayMarkupLine($"  [cyan]{feature.Name.EscapeMarkup()}[/] [dim](default: {defaultText})[/]");
-                    InteractionService.DisplayMarkupLine($"    [dim]{feature.Description.EscapeMarkup()}[/]");
+                    InteractionService.DisplayEmptyLine();
+                    InteractionService.DisplayMarkdown($"**{ConfigCommandStrings.AvailableFeaturesHeader}:**");
+                    foreach (var feature in unconfiguredFeatures)
+                    {
+                        var defaultText = feature.DefaultValue ? "true" : "false";
+                        InteractionService.DisplayMarkupLine($"  [cyan]{feature.Name.EscapeMarkup()}[/] [dim](default: {defaultText})[/]");
+                        InteractionService.DisplayMarkupLine($"    [dim]{feature.Description.EscapeMarkup()}[/]");
+                    }
+                    InteractionService.DisplayEmptyLine();
+                    InteractionService.DisplayMarkupLine($"  [dim]{ConfigCommandStrings.SetFeatureHint.EscapeMarkup()}[/]");
                 }
-                InteractionService.DisplayEmptyLine();
-                InteractionService.DisplayMarkupLine($"  [dim]{ConfigCommandStrings.SetFeatureHint.EscapeMarkup()}[/]");
+                else
+                {
+                    InteractionService.DisplayEmptyLine();
+                    InteractionService.DisplayMarkdown($"**{ConfigCommandStrings.AvailableFeaturesHeader}:**");
+                    InteractionService.DisplayMarkupLine($"  [dim]{ConfigCommandStrings.ListCommand_AvailableFeaturesHint.EscapeMarkup()}[/]");
+                }
             }
 
             return ExitCodeConstants.Success;

--- a/src/Aspire.Cli/Commands/ConfigCommand.cs
+++ b/src/Aspire.Cli/Commands/ConfigCommand.cs
@@ -200,31 +200,31 @@ internal sealed class ConfigCommand : BaseCommand
 
     private sealed class ListCommand : BaseConfigSubCommand
     {
-        private static readonly Option<bool> s_availableOption = new("--available")
+        private static readonly Option<bool> s_allOption = new("--all")
         {
-            Description = ConfigCommandStrings.ListCommand_AvailableOptionDescription
+            Description = ConfigCommandStrings.ListCommand_AllOptionDescription
         };
 
         public ListCommand(IConfigurationService configurationService, IInteractionService interactionService, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, AspireCliTelemetry telemetry)
             : base("list", ConfigCommandStrings.ListCommand_Description, features, updateNotifier, configurationService, executionContext, interactionService, telemetry)
         {
-            Options.Add(s_availableOption);
+            Options.Add(s_allOption);
         }
 
         protected override bool UpdateNotificationsEnabled => false;
 
         protected override Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
         {
-            var showAvailable = parseResult.GetValue(s_availableOption);
-            return ExecuteAsync(showAvailable, cancellationToken);
+            var showAll = parseResult.GetValue(s_allOption);
+            return ExecuteAsync(showAll, cancellationToken);
         }
 
         public override Task<int> InteractiveExecuteAsync(CancellationToken cancellationToken)
         {
-            return ExecuteAsync(showAvailable: false, cancellationToken);
+            return ExecuteAsync(showAll: false, cancellationToken);
         }
 
-        private async Task<int> ExecuteAsync(bool showAvailable, CancellationToken cancellationToken)
+        private async Task<int> ExecuteAsync(bool showAll, CancellationToken cancellationToken)
         {
             if (InteractionService is ExtensionInteractionService extensionInteractionService)
             {
@@ -272,10 +272,11 @@ internal sealed class ConfigCommand : BaseCommand
 
             if (unconfiguredFeatures.Count > 0)
             {
-                if (showAvailable)
+                InteractionService.DisplayEmptyLine();
+                InteractionService.DisplayMarkdown($"**{ConfigCommandStrings.AvailableFeaturesHeader}:**");
+
+                if (showAll)
                 {
-                    InteractionService.DisplayEmptyLine();
-                    InteractionService.DisplayMarkdown($"**{ConfigCommandStrings.AvailableFeaturesHeader}:**");
                     foreach (var feature in unconfiguredFeatures)
                     {
                         var defaultText = feature.DefaultValue ? "true" : "false";
@@ -287,9 +288,7 @@ internal sealed class ConfigCommand : BaseCommand
                 }
                 else
                 {
-                    InteractionService.DisplayEmptyLine();
-                    InteractionService.DisplayMarkdown($"**{ConfigCommandStrings.AvailableFeaturesHeader}:**");
-                    InteractionService.DisplayMarkupLine($"  [dim]{ConfigCommandStrings.ListCommand_AvailableFeaturesHint.EscapeMarkup()}[/]");
+                    InteractionService.DisplayMarkupLine($"  [dim]{ConfigCommandStrings.ListCommand_AllFeaturesHint.EscapeMarkup()}[/]");
                 }
             }
 

--- a/src/Aspire.Cli/Resources/ConfigCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ConfigCommandStrings.Designer.cs
@@ -195,6 +195,24 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Show all available features that can be configured..
+        /// </summary>
+        public static string ListCommand_AvailableOptionDescription {
+            get {
+                return ResourceManager.GetString("ListCommand_AvailableOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Run 'aspire config list --available' to see all available feature flags..
+        /// </summary>
+        public static string ListCommand_AvailableFeaturesHint {
+            get {
+                return ResourceManager.GetString("ListCommand_AvailableFeaturesHint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No configuration values found..
         /// </summary>
         public static string NoConfigurationValuesFound {

--- a/src/Aspire.Cli/Resources/ConfigCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ConfigCommandStrings.Designer.cs
@@ -197,18 +197,18 @@ namespace Aspire.Cli.Resources {
         /// <summary>
         ///   Looks up a localized string similar to Show all available features that can be configured..
         /// </summary>
-        public static string ListCommand_AvailableOptionDescription {
+        public static string ListCommand_AllOptionDescription {
             get {
-                return ResourceManager.GetString("ListCommand_AvailableOptionDescription", resourceCulture);
+                return ResourceManager.GetString("ListCommand_AllOptionDescription", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Run 'aspire config list --available' to see all available feature flags..
+        ///   Looks up a localized string similar to Run 'aspire config list --all' to see all available feature flags..
         /// </summary>
-        public static string ListCommand_AvailableFeaturesHint {
+        public static string ListCommand_AllFeaturesHint {
             get {
-                return ResourceManager.GetString("ListCommand_AvailableFeaturesHint", resourceCulture);
+                return ResourceManager.GetString("ListCommand_AllFeaturesHint", resourceCulture);
             }
         }
         

--- a/src/Aspire.Cli/Resources/ConfigCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/ConfigCommandStrings.resx
@@ -138,6 +138,12 @@
   <data name="ListCommand_Description" xml:space="preserve">
     <value>List all configuration values.</value>
   </data>
+  <data name="ListCommand_AvailableOptionDescription" xml:space="preserve">
+    <value>Show all available features that can be configured.</value>
+  </data>
+  <data name="ListCommand_AvailableFeaturesHint" xml:space="preserve">
+    <value>Run 'aspire config list --available' to see all available feature flags.</value>
+  </data>
   <data name="NoConfigurationValuesFound" xml:space="preserve">
     <value>No configuration values found.</value>
   </data>

--- a/src/Aspire.Cli/Resources/ConfigCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/ConfigCommandStrings.resx
@@ -138,11 +138,11 @@
   <data name="ListCommand_Description" xml:space="preserve">
     <value>List all configuration values.</value>
   </data>
-  <data name="ListCommand_AvailableOptionDescription" xml:space="preserve">
+  <data name="ListCommand_AllOptionDescription" xml:space="preserve">
     <value>Show all available features that can be configured.</value>
   </data>
-  <data name="ListCommand_AvailableFeaturesHint" xml:space="preserve">
-    <value>Run 'aspire config list --available' to see all available feature flags.</value>
+  <data name="ListCommand_AllFeaturesHint" xml:space="preserve">
+    <value>Run 'aspire config list --all' to see all available feature flags.</value>
   </data>
   <data name="NoConfigurationValuesFound" xml:space="preserve">
     <value>No configuration values found.</value>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.cs.xlf
@@ -112,12 +112,12 @@
         <target state="translated">Vlastnosti souboru nastavení</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableFeaturesHint">
-        <source>Run 'aspire config list --available' to see all available feature flags.</source>
-        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+      <trans-unit id="ListCommand_AllFeaturesHint">
+        <source>Run 'aspire config list --all' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --all' to see all available feature flags.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableOptionDescription">
+      <trans-unit id="ListCommand_AllOptionDescription">
         <source>Show all available features that can be configured.</source>
         <target state="new">Show all available features that can be configured.</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.cs.xlf
@@ -112,6 +112,16 @@
         <target state="translated">Vlastnosti souboru nastavení</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListCommand_AvailableFeaturesHint">
+        <source>Run 'aspire config list --available' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommand_AvailableOptionDescription">
+        <source>Show all available features that can be configured.</source>
+        <target state="new">Show all available features that can be configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListCommand_Description">
         <source>List all configuration values.</source>
         <target state="translated">Umožňuje vypsat všechny hodnoty konfigurace.</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.de.xlf
@@ -112,12 +112,12 @@
         <target state="translated">Eigenschaften der Einstellungsdatei</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableFeaturesHint">
-        <source>Run 'aspire config list --available' to see all available feature flags.</source>
-        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+      <trans-unit id="ListCommand_AllFeaturesHint">
+        <source>Run 'aspire config list --all' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --all' to see all available feature flags.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableOptionDescription">
+      <trans-unit id="ListCommand_AllOptionDescription">
         <source>Show all available features that can be configured.</source>
         <target state="new">Show all available features that can be configured.</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.de.xlf
@@ -112,6 +112,16 @@
         <target state="translated">Eigenschaften der Einstellungsdatei</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListCommand_AvailableFeaturesHint">
+        <source>Run 'aspire config list --available' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommand_AvailableOptionDescription">
+        <source>Show all available features that can be configured.</source>
+        <target state="new">Show all available features that can be configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListCommand_Description">
         <source>List all configuration values.</source>
         <target state="translated">Listen Sie alle Konfigurationswerte auf.</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.es.xlf
@@ -112,6 +112,16 @@
         <target state="translated">Propiedades del archivo de configuración</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListCommand_AvailableFeaturesHint">
+        <source>Run 'aspire config list --available' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommand_AvailableOptionDescription">
+        <source>Show all available features that can be configured.</source>
+        <target state="new">Show all available features that can be configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListCommand_Description">
         <source>List all configuration values.</source>
         <target state="translated">Enumera todos los valores de configuración.</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.es.xlf
@@ -112,12 +112,12 @@
         <target state="translated">Propiedades del archivo de configuración</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableFeaturesHint">
-        <source>Run 'aspire config list --available' to see all available feature flags.</source>
-        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+      <trans-unit id="ListCommand_AllFeaturesHint">
+        <source>Run 'aspire config list --all' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --all' to see all available feature flags.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableOptionDescription">
+      <trans-unit id="ListCommand_AllOptionDescription">
         <source>Show all available features that can be configured.</source>
         <target state="new">Show all available features that can be configured.</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.fr.xlf
@@ -112,6 +112,16 @@
         <target state="translated">Propriétés du fichier de paramètres</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListCommand_AvailableFeaturesHint">
+        <source>Run 'aspire config list --available' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommand_AvailableOptionDescription">
+        <source>Show all available features that can be configured.</source>
+        <target state="new">Show all available features that can be configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListCommand_Description">
         <source>List all configuration values.</source>
         <target state="translated">Répertoriez toutes les valeurs de configuration.</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.fr.xlf
@@ -112,12 +112,12 @@
         <target state="translated">Propriétés du fichier de paramètres</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableFeaturesHint">
-        <source>Run 'aspire config list --available' to see all available feature flags.</source>
-        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+      <trans-unit id="ListCommand_AllFeaturesHint">
+        <source>Run 'aspire config list --all' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --all' to see all available feature flags.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableOptionDescription">
+      <trans-unit id="ListCommand_AllOptionDescription">
         <source>Show all available features that can be configured.</source>
         <target state="new">Show all available features that can be configured.</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.it.xlf
@@ -112,6 +112,16 @@
         <target state="translated">Proprietà del file di impostazioni</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListCommand_AvailableFeaturesHint">
+        <source>Run 'aspire config list --available' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommand_AvailableOptionDescription">
+        <source>Show all available features that can be configured.</source>
+        <target state="new">Show all available features that can be configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListCommand_Description">
         <source>List all configuration values.</source>
         <target state="translated">Elenca tutti i valori di configurazione.</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.it.xlf
@@ -112,12 +112,12 @@
         <target state="translated">Proprietà del file di impostazioni</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableFeaturesHint">
-        <source>Run 'aspire config list --available' to see all available feature flags.</source>
-        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+      <trans-unit id="ListCommand_AllFeaturesHint">
+        <source>Run 'aspire config list --all' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --all' to see all available feature flags.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableOptionDescription">
+      <trans-unit id="ListCommand_AllOptionDescription">
         <source>Show all available features that can be configured.</source>
         <target state="new">Show all available features that can be configured.</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ja.xlf
@@ -112,12 +112,12 @@
         <target state="translated">設定ファイルのプロパティ</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableFeaturesHint">
-        <source>Run 'aspire config list --available' to see all available feature flags.</source>
-        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+      <trans-unit id="ListCommand_AllFeaturesHint">
+        <source>Run 'aspire config list --all' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --all' to see all available feature flags.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableOptionDescription">
+      <trans-unit id="ListCommand_AllOptionDescription">
         <source>Show all available features that can be configured.</source>
         <target state="new">Show all available features that can be configured.</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ja.xlf
@@ -112,6 +112,16 @@
         <target state="translated">設定ファイルのプロパティ</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListCommand_AvailableFeaturesHint">
+        <source>Run 'aspire config list --available' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommand_AvailableOptionDescription">
+        <source>Show all available features that can be configured.</source>
+        <target state="new">Show all available features that can be configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListCommand_Description">
         <source>List all configuration values.</source>
         <target state="translated">すべての構成値を一覧表示します。</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ko.xlf
@@ -112,12 +112,12 @@
         <target state="translated">설정 파일 속성</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableFeaturesHint">
-        <source>Run 'aspire config list --available' to see all available feature flags.</source>
-        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+      <trans-unit id="ListCommand_AllFeaturesHint">
+        <source>Run 'aspire config list --all' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --all' to see all available feature flags.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableOptionDescription">
+      <trans-unit id="ListCommand_AllOptionDescription">
         <source>Show all available features that can be configured.</source>
         <target state="new">Show all available features that can be configured.</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ko.xlf
@@ -112,6 +112,16 @@
         <target state="translated">설정 파일 속성</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListCommand_AvailableFeaturesHint">
+        <source>Run 'aspire config list --available' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommand_AvailableOptionDescription">
+        <source>Show all available features that can be configured.</source>
+        <target state="new">Show all available features that can be configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListCommand_Description">
         <source>List all configuration values.</source>
         <target state="translated">모든 구성 값을 나열합니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.pl.xlf
@@ -112,12 +112,12 @@
         <target state="translated">Właściwości pliku ustawień</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableFeaturesHint">
-        <source>Run 'aspire config list --available' to see all available feature flags.</source>
-        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+      <trans-unit id="ListCommand_AllFeaturesHint">
+        <source>Run 'aspire config list --all' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --all' to see all available feature flags.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableOptionDescription">
+      <trans-unit id="ListCommand_AllOptionDescription">
         <source>Show all available features that can be configured.</source>
         <target state="new">Show all available features that can be configured.</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.pl.xlf
@@ -112,6 +112,16 @@
         <target state="translated">Właściwości pliku ustawień</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListCommand_AvailableFeaturesHint">
+        <source>Run 'aspire config list --available' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommand_AvailableOptionDescription">
+        <source>Show all available features that can be configured.</source>
+        <target state="new">Show all available features that can be configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListCommand_Description">
         <source>List all configuration values.</source>
         <target state="translated">Wyświetl listę wszystkich wartości konfiguracji.</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.pt-BR.xlf
@@ -112,12 +112,12 @@
         <target state="translated">Propriedades do arquivo de configurações</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableFeaturesHint">
-        <source>Run 'aspire config list --available' to see all available feature flags.</source>
-        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+      <trans-unit id="ListCommand_AllFeaturesHint">
+        <source>Run 'aspire config list --all' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --all' to see all available feature flags.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableOptionDescription">
+      <trans-unit id="ListCommand_AllOptionDescription">
         <source>Show all available features that can be configured.</source>
         <target state="new">Show all available features that can be configured.</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.pt-BR.xlf
@@ -112,6 +112,16 @@
         <target state="translated">Propriedades do arquivo de configurações</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListCommand_AvailableFeaturesHint">
+        <source>Run 'aspire config list --available' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommand_AvailableOptionDescription">
+        <source>Show all available features that can be configured.</source>
+        <target state="new">Show all available features that can be configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListCommand_Description">
         <source>List all configuration values.</source>
         <target state="translated">Liste todos os valores de configuração.</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ru.xlf
@@ -112,12 +112,12 @@
         <target state="translated">Свойства файла параметров</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableFeaturesHint">
-        <source>Run 'aspire config list --available' to see all available feature flags.</source>
-        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+      <trans-unit id="ListCommand_AllFeaturesHint">
+        <source>Run 'aspire config list --all' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --all' to see all available feature flags.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableOptionDescription">
+      <trans-unit id="ListCommand_AllOptionDescription">
         <source>Show all available features that can be configured.</source>
         <target state="new">Show all available features that can be configured.</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.ru.xlf
@@ -112,6 +112,16 @@
         <target state="translated">Свойства файла параметров</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListCommand_AvailableFeaturesHint">
+        <source>Run 'aspire config list --available' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommand_AvailableOptionDescription">
+        <source>Show all available features that can be configured.</source>
+        <target state="new">Show all available features that can be configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListCommand_Description">
         <source>List all configuration values.</source>
         <target state="translated">Перечислить все значения конфигурации.</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.tr.xlf
@@ -112,6 +112,16 @@
         <target state="translated">Ayar dosyası özellikleri</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListCommand_AvailableFeaturesHint">
+        <source>Run 'aspire config list --available' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommand_AvailableOptionDescription">
+        <source>Show all available features that can be configured.</source>
+        <target state="new">Show all available features that can be configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListCommand_Description">
         <source>List all configuration values.</source>
         <target state="translated">Tüm yapılandırma değerlerini listeleyin.</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.tr.xlf
@@ -112,12 +112,12 @@
         <target state="translated">Ayar dosyası özellikleri</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableFeaturesHint">
-        <source>Run 'aspire config list --available' to see all available feature flags.</source>
-        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+      <trans-unit id="ListCommand_AllFeaturesHint">
+        <source>Run 'aspire config list --all' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --all' to see all available feature flags.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableOptionDescription">
+      <trans-unit id="ListCommand_AllOptionDescription">
         <source>Show all available features that can be configured.</source>
         <target state="new">Show all available features that can be configured.</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.zh-Hans.xlf
@@ -112,6 +112,16 @@
         <target state="translated">设置文件属性</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListCommand_AvailableFeaturesHint">
+        <source>Run 'aspire config list --available' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommand_AvailableOptionDescription">
+        <source>Show all available features that can be configured.</source>
+        <target state="new">Show all available features that can be configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListCommand_Description">
         <source>List all configuration values.</source>
         <target state="translated">列出所有配置值。</target>

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.zh-Hans.xlf
@@ -112,12 +112,12 @@
         <target state="translated">设置文件属性</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableFeaturesHint">
-        <source>Run 'aspire config list --available' to see all available feature flags.</source>
-        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+      <trans-unit id="ListCommand_AllFeaturesHint">
+        <source>Run 'aspire config list --all' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --all' to see all available feature flags.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableOptionDescription">
+      <trans-unit id="ListCommand_AllOptionDescription">
         <source>Show all available features that can be configured.</source>
         <target state="new">Show all available features that can be configured.</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.zh-Hant.xlf
@@ -112,12 +112,12 @@
         <target state="translated">設定檔案屬性</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableFeaturesHint">
-        <source>Run 'aspire config list --available' to see all available feature flags.</source>
-        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+      <trans-unit id="ListCommand_AllFeaturesHint">
+        <source>Run 'aspire config list --all' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --all' to see all available feature flags.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommand_AvailableOptionDescription">
+      <trans-unit id="ListCommand_AllOptionDescription">
         <source>Show all available features that can be configured.</source>
         <target state="new">Show all available features that can be configured.</target>
         <note />

--- a/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ConfigCommandStrings.zh-Hant.xlf
@@ -112,6 +112,16 @@
         <target state="translated">設定檔案屬性</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListCommand_AvailableFeaturesHint">
+        <source>Run 'aspire config list --available' to see all available feature flags.</source>
+        <target state="new">Run 'aspire config list --available' to see all available feature flags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommand_AvailableOptionDescription">
+        <source>Show all available features that can be configured.</source>
+        <target state="new">Show all available features that can be configured.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListCommand_Description">
         <source>List all configuration values.</source>
         <target state="translated">列出所有設定值。</target>

--- a/tests/Aspire.Cli.Tests/Commands/ConfigCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ConfigCommandTests.cs
@@ -308,6 +308,58 @@ public class ConfigCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ConfigListCommand_WithoutAllFlag_ShowsHintInsteadOfFeatures()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = outputWriter;
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
+
+        // Set a value so config list has something to display
+        var setResult = command.Parse("config set testkey testvalue");
+        await setResult.InvokeAsync().DefaultTimeout();
+
+        // List without --all
+        var listResult = command.Parse("config list");
+        var listExitCode = await listResult.InvokeAsync().DefaultTimeout();
+        Assert.Equal(0, listExitCode);
+
+        var output = string.Join("\n", outputWriter.Logs);
+        Assert.Contains("--all", output);
+    }
+
+    [Fact]
+    public async Task ConfigListCommand_WithAllFlag_ShowsFeatureDetails()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = outputWriter;
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<Aspire.Cli.Commands.RootCommand>();
+
+        // Set a value so config list has something to display
+        var setResult = command.Parse("config set testkey testvalue");
+        await setResult.InvokeAsync().DefaultTimeout();
+
+        // List with --all
+        var listResult = command.Parse("config list --all");
+        var listExitCode = await listResult.InvokeAsync().DefaultTimeout();
+        Assert.Equal(0, listExitCode);
+
+        var output = string.Join("\n", outputWriter.Logs);
+        Assert.Contains("default:", output);
+    }
+
+    [Fact]
     public async Task FeatureFlags_WhenSetToTrue_ReturnsTrue()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);


### PR DESCRIPTION
## Summary

The list of available feature flags in `aspire config list` was so long it scrolled the actual set configuration off the screen.

## Changes

- Added `--available` option to `aspire config list`
- Without the flag: shows the **Available Features** heading with a hint: *Run 'aspire config list --available' to see all available feature flags.*
- With the flag: shows the full feature list (previous behavior)

## Before
`aspire config list` showed all unconfigured features, pushing config tables off screen.

## After
`aspire config list` shows config tables + hint.
`aspire config list --available` shows config tables + full feature list.