### PR TITLE
Make .NET SDK check in aspire doctor based on apphost language

### DIFF
--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -25,8 +25,7 @@ internal interface IProjectLocator
     /// user interaction or recursive filesystem scanning. Returns <c>null</c> when no settings
     /// file or <c>appHostPath</c> entry is found.
     /// </summary>
-    Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default)
-        => Task.FromResult<FileInfo?>(null);
+    Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default);
 }
 
 internal sealed class ProjectLocator(

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -19,6 +19,14 @@ internal interface IProjectLocator
 {
     Task<AppHostProjectSearchResult> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, MultipleAppHostProjectsFoundBehavior multipleAppHostProjectsFoundBehavior, bool createSettingsFile, CancellationToken cancellationToken = default);
     Task<FileInfo?> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, bool createSettingsFile, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Resolves the AppHost project file from <c>.aspire/settings.json</c> only, without any
+    /// user interaction or recursive filesystem scanning. Returns <c>null</c> when no settings
+    /// file or <c>appHostPath</c> entry is found.
+    /// </summary>
+    Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<FileInfo?>(null);
 }
 
 internal sealed class ProjectLocator(
@@ -152,7 +160,18 @@ internal sealed class ProjectLocator(
         });
     }
 
+    /// <inheritdoc />
+    public async Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default)
+    {
+        return await GetAppHostProjectFileFromSettingsAsync(silent: true, cancellationToken);
+    }
+
     private async Task<FileInfo?> GetAppHostProjectFileFromSettingsAsync(CancellationToken cancellationToken)
+    {
+        return await GetAppHostProjectFileFromSettingsAsync(silent: false, cancellationToken);
+    }
+
+    private async Task<FileInfo?> GetAppHostProjectFileFromSettingsAsync(bool silent, CancellationToken cancellationToken)
     {
         var searchDirectory = executionContext.WorkingDirectory;
 
@@ -178,7 +197,10 @@ internal sealed class ProjectLocator(
                     else
                     {
                         // AppHost file was specified but doesn't exist, return null to trigger fallback logic
-                        interactionService.DisplayMessage(KnownEmojis.Warning, string.Format(CultureInfo.CurrentCulture, ErrorStrings.AppHostWasSpecifiedButDoesntExist, settingsFile.FullName, qualifiedAppHostPath));
+                        if (!silent)
+                        {
+                            interactionService.DisplayMessage(KnownEmojis.Warning, string.Format(CultureInfo.CurrentCulture, ErrorStrings.AppHostWasSpecifiedButDoesntExist, settingsFile.FullName, qualifiedAppHostPath));
+                        }
                         return null;
                     }
                 }

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DotNetSdkCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DotNetSdkCheck.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.DotNet;
+using Aspire.Cli.Projects;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Utils.EnvironmentChecker;
@@ -9,7 +10,15 @@ namespace Aspire.Cli.Utils.EnvironmentChecker;
 /// <summary>
 /// Checks if the .NET SDK is installed and meets the minimum version requirement.
 /// </summary>
-internal sealed class DotNetSdkCheck(IDotNetSdkInstaller sdkInstaller, ILogger<DotNetSdkCheck> logger) : IEnvironmentCheck
+/// <remarks>
+/// This check is skipped when the detected AppHost is a non-.NET project (e.g., TypeScript, Python, Go),
+/// since .NET SDK is not required for polyglot scenarios.
+/// </remarks>
+internal sealed class DotNetSdkCheck(
+    IDotNetSdkInstaller sdkInstaller,
+    IProjectLocator projectLocator,
+    ILanguageDiscovery languageDiscovery,
+    ILogger<DotNetSdkCheck> logger) : IEnvironmentCheck
 {
     public int Order => 30; // File system check - slightly more expensive
 
@@ -17,6 +26,12 @@ internal sealed class DotNetSdkCheck(IDotNetSdkInstaller sdkInstaller, ILogger<D
     {
         try
         {
+            if (await IsNonDotNetAppHostAsync(cancellationToken))
+            {
+                logger.LogDebug("Skipping .NET SDK check because a non-.NET AppHost was detected");
+                return [];
+            }
+
             var (success, highestVersion, minimumRequiredVersion) = await sdkInstaller.CheckAsync(cancellationToken);
 
             if (!success)
@@ -62,6 +77,43 @@ internal sealed class DotNetSdkCheck(IDotNetSdkInstaller sdkInstaller, ILogger<D
                 Message = "Error checking .NET SDK",
                 Details = ex.Message
             }];
+        }
+    }
+
+    /// <summary>
+    /// Determines whether the current directory contains a non-.NET AppHost, making the .NET SDK check unnecessary.
+    /// Uses a silent settings-only lookup to avoid interaction output and recursive filesystem scanning.
+    /// </summary>
+    private async Task<bool> IsNonDotNetAppHostAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Use the silent settings-only lookup to find the apphost without
+            // emitting interaction output or performing recursive filesystem scans.
+            var appHostFile = await projectLocator.GetAppHostFromSettingsAsync(cancellationToken);
+
+            if (appHostFile is null)
+            {
+                // No apphost configured in settings — can't determine language, run .NET check
+                return false;
+            }
+
+            var language = languageDiscovery.GetLanguageByFile(appHostFile);
+            if (language is null)
+            {
+                return false;
+            }
+
+            return !language.LanguageId.Value.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Error detecting AppHost language, falling back to .NET SDK check");
+            return false;
         }
     }
 }

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DotNetSdkCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DotNetSdkCheck.cs
@@ -26,9 +26,9 @@ internal sealed class DotNetSdkCheck(
     {
         try
         {
-            if (await IsNonDotNetAppHostAsync(cancellationToken))
+            if (!await IsDotNetAppHostAsync(cancellationToken))
             {
-                logger.LogDebug("Skipping .NET SDK check because a non-.NET AppHost was detected");
+                logger.LogDebug("Skipping .NET SDK check because no .NET AppHost was detected");
                 return [];
             }
 
@@ -81,10 +81,11 @@ internal sealed class DotNetSdkCheck(
     }
 
     /// <summary>
-    /// Determines whether the current directory contains a non-.NET AppHost, making the .NET SDK check unnecessary.
-    /// Uses a silent settings-only lookup to avoid interaction output and recursive filesystem scanning.
+    /// Determines whether a .NET AppHost is positively detected, meaning the .NET SDK check should run.
+    /// Only returns <c>true</c> when a settings file is found and the apphost is a .NET project.
+    /// When no settings file exists or the apphost is non-.NET, the check is skipped.
     /// </summary>
-    private async Task<bool> IsNonDotNetAppHostAsync(CancellationToken cancellationToken)
+    private async Task<bool> IsDotNetAppHostAsync(CancellationToken cancellationToken)
     {
         try
         {
@@ -94,7 +95,7 @@ internal sealed class DotNetSdkCheck(
 
             if (appHostFile is null)
             {
-                // No apphost configured in settings — can't determine language, run .NET check
+                // No apphost configured in settings — can't determine language, skip .NET check
                 return false;
             }
 
@@ -104,7 +105,7 @@ internal sealed class DotNetSdkCheck(
                 return false;
             }
 
-            return !language.LanguageId.Value.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase);
+            return language.LanguageId.Value.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -112,7 +113,7 @@ internal sealed class DotNetSdkCheck(
         }
         catch (Exception ex)
         {
-            logger.LogDebug(ex, "Error detecting AppHost language, falling back to .NET SDK check");
+            logger.LogDebug(ex, "Error detecting AppHost language, skipping .NET SDK check");
             return false;
         }
     }

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DotNetSdkCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DotNetSdkCheck.cs
@@ -107,7 +107,9 @@ internal sealed class DotNetSdkCheck(
                 return false;
             }
 
-            // Limit recursive scan to avoid expensive file system operations in large workspaces. We just want a quick signal that a .NET apphost is probably present.
+            // Scan file system directly instead of using ProjectLocator for performance.
+            // Limit recursive scan to avoid expensive file system operations in large workspaces.
+            // We don't want a complete list of all possible project files, just a quick signal that a .NET apphost is probably present.
             var match = FileSystemHelper.FindFirstFile(executionContext.WorkingDirectory.FullName, recurseLimit: 5, csharp.DetectionPatterns);
             return match is not null;
         }

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DotNetSdkCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DotNetSdkCheck.cs
@@ -18,6 +18,7 @@ internal sealed class DotNetSdkCheck(
     IDotNetSdkInstaller sdkInstaller,
     IProjectLocator projectLocator,
     ILanguageDiscovery languageDiscovery,
+    CliExecutionContext executionContext,
     ILogger<DotNetSdkCheck> logger) : IEnvironmentCheck
 {
     public int Order => 30; // File system check - slightly more expensive
@@ -93,19 +94,22 @@ internal sealed class DotNetSdkCheck(
             // emitting interaction output or performing recursive filesystem scans.
             var appHostFile = await projectLocator.GetAppHostFromSettingsAsync(cancellationToken);
 
-            if (appHostFile is null)
+            if (appHostFile is not null && languageDiscovery.GetLanguageByFile(appHostFile) is { } language)
             {
-                // No apphost configured in settings — can't determine language, skip .NET check
+                return language.LanguageId.Value.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase);
+            }
+
+            // No apphost configured in settings. Look for possible .NET app hosts on file system (projects or apphost.cs)
+            // This doesn't guarantee the apphost is .NET, but it's a signal that it might be and worth checking for .NET SDK.
+            var csharp = languageDiscovery.GetLanguageById(KnownLanguageId.CSharp);
+            if (csharp is null)
+            {
                 return false;
             }
 
-            var language = languageDiscovery.GetLanguageByFile(appHostFile);
-            if (language is null)
-            {
-                return false;
-            }
-
-            return language.LanguageId.Value.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase);
+            // Limit recursive scan to avoid expensive file system operations in large workspaces. We just want a quick signal that a .NET apphost is probably present.
+            var match = FileSystemHelper.FindFirstFile(executionContext.WorkingDirectory.FullName, recurseLimit: 5, csharp.DetectionPatterns);
+            return match is not null;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/src/Aspire.Cli/Utils/FileSystemHelper.cs
+++ b/src/Aspire.Cli/Utils/FileSystemHelper.cs
@@ -51,4 +51,55 @@ internal static class FileSystemHelper
             }
         }
     }
+
+    /// <summary>
+    /// Recursively searches for the first file matching any of the given patterns.
+    /// Stops immediately when a match is found.
+    /// </summary>
+    /// <param name="root">Root folder to start search</param>
+    /// <param name="recurseLimit">Maximum directory depth to search. Use 0 to search only the root, or -1 for unlimited depth.</param>
+    /// <param name="patterns">File name patterns, e.g., "*.csproj", "apphost.cs"</param>
+    /// <returns>Full path to first matching file, or null if none found</returns>
+    public static string? FindFirstFile(string root, int recurseLimit = -1, params string[] patterns)
+    {
+        if (!Directory.Exists(root) || patterns.Length == 0)
+        {
+            return null;
+        }
+
+        var dirs = new Stack<(string Path, int Depth)>();
+        dirs.Push((root, 0));
+
+        while (dirs.Count > 0)
+        {
+            var (dir, depth) = dirs.Pop();
+
+            try
+            {
+                // Check for each pattern in this directory
+                foreach (var pattern in patterns)
+                {
+                    foreach (var file in Directory.EnumerateFiles(dir, pattern))
+                    {
+                        return file; // first match, exit immediately
+                    }
+                }
+
+                // Push subdirectories for further search if within depth limit
+                if (recurseLimit < 0 || depth < recurseLimit)
+                {
+                    foreach (var sub in Directory.EnumerateDirectories(dir))
+                    {
+                        dirs.Push((sub, depth + 1));
+                    }
+                }
+            }
+            catch
+            {
+                // Skip directories we can't access (permissions, etc.)
+            }
+        }
+
+        return null;
+    }
 }

--- a/tests/Aspire.Cli.Tests/Commands/DotNetSdkCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DotNetSdkCheckTests.cs
@@ -13,31 +13,9 @@ namespace Aspire.Cli.Tests.Commands;
 public class DotNetSdkCheckTests(ITestOutputHelper outputHelper)
 {
     [Fact]
-    public async Task CheckAsync_ReturnsPass_WhenSdkInstalled_AndNoAppHostFound()
+    public async Task CheckAsync_SkipsCheck_WhenNoAppHostFound()
     {
-        // No apphost in settings — falls through to normal .NET SDK check
-        var sdkInstaller = new TestDotNetSdkInstaller();
-        var projectLocator = new TestProjectLocator
-        {
-            GetAppHostFromSettingsAsyncCallback = _ => Task.FromResult<FileInfo?>(null)
-        };
-        var languageDiscovery = new TestLanguageDiscovery();
-
-        var check = new DotNetSdkCheck(
-            sdkInstaller,
-            projectLocator,
-            languageDiscovery,
-            NullLogger<DotNetSdkCheck>.Instance);
-
-        var results = await check.CheckAsync().DefaultTimeout();
-
-        Assert.Single(results);
-        Assert.Equal(EnvironmentCheckStatus.Pass, results[0].Status);
-    }
-
-    [Fact]
-    public async Task CheckAsync_ReturnsFail_WhenSdkNotInstalled_AndNoAppHostFound()
-    {
+        // No apphost in settings — skip .NET SDK check entirely
         var sdkInstaller = new TestDotNetSdkInstaller
         {
             CheckAsyncCallback = _ => (false, null, "10.0.100")
@@ -56,9 +34,7 @@ public class DotNetSdkCheckTests(ITestOutputHelper outputHelper)
 
         var results = await check.CheckAsync().DefaultTimeout();
 
-        Assert.Single(results);
-        Assert.Equal(EnvironmentCheckStatus.Fail, results[0].Status);
-        Assert.Contains(".NET SDK not found", results[0].Message);
+        Assert.Empty(results);
     }
 
     [Fact]
@@ -114,9 +90,38 @@ public class DotNetSdkCheckTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task CheckAsync_RunsCheck_WhenNoSettingsFileExists()
+    public async Task CheckAsync_ReturnsFail_WhenDotNetAppHostFound_AndSdkNotInstalled()
     {
-        // No settings.json — can't determine language, runs .NET check
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "MyAppHost.csproj"));
+
+        var sdkInstaller = new TestDotNetSdkInstaller
+        {
+            CheckAsyncCallback = _ => (false, null, "10.0.100")
+        };
+        var projectLocator = new TestProjectLocator
+        {
+            GetAppHostFromSettingsAsyncCallback = _ => Task.FromResult<FileInfo?>(appHostFile)
+        };
+        var languageDiscovery = new TestLanguageDiscoveryWithPolyglot();
+
+        var check = new DotNetSdkCheck(
+            sdkInstaller,
+            projectLocator,
+            languageDiscovery,
+            NullLogger<DotNetSdkCheck>.Instance);
+
+        var results = await check.CheckAsync().DefaultTimeout();
+
+        Assert.Single(results);
+        Assert.Equal(EnvironmentCheckStatus.Fail, results[0].Status);
+        Assert.Contains(".NET SDK not found", results[0].Message);
+    }
+
+    [Fact]
+    public async Task CheckAsync_SkipsCheck_WhenNoSettingsFileExists()
+    {
+        // No settings.json — can't determine language, skip .NET check
         var sdkInstaller = new TestDotNetSdkInstaller();
         var projectLocator = new TestProjectLocator
         {
@@ -132,12 +137,11 @@ public class DotNetSdkCheckTests(ITestOutputHelper outputHelper)
 
         var results = await check.CheckAsync().DefaultTimeout();
 
-        Assert.Single(results);
-        Assert.Equal(EnvironmentCheckStatus.Pass, results[0].Status);
+        Assert.Empty(results);
     }
 
     [Fact]
-    public async Task CheckAsync_RunsCheck_WhenLanguageNotRecognized()
+    public async Task CheckAsync_SkipsCheck_WhenLanguageNotRecognized()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "unknown.xyz"));
@@ -157,9 +161,8 @@ public class DotNetSdkCheckTests(ITestOutputHelper outputHelper)
 
         var results = await check.CheckAsync().DefaultTimeout();
 
-        // Unrecognized file — falls through to normal .NET check
-        Assert.Single(results);
-        Assert.Equal(EnvironmentCheckStatus.Pass, results[0].Status);
+        // Unrecognized file — skip .NET check
+        Assert.Empty(results);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Commands/DotNetSdkCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DotNetSdkCheckTests.cs
@@ -1,0 +1,243 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Projects;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils.EnvironmentChecker;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Commands;
+
+public class DotNetSdkCheckTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task CheckAsync_ReturnsPass_WhenSdkInstalled_AndNoAppHostFound()
+    {
+        // No apphost in settings — falls through to normal .NET SDK check
+        var sdkInstaller = new TestDotNetSdkInstaller();
+        var projectLocator = new TestProjectLocator
+        {
+            GetAppHostFromSettingsAsyncCallback = _ => Task.FromResult<FileInfo?>(null)
+        };
+        var languageDiscovery = new TestLanguageDiscovery();
+
+        var check = new DotNetSdkCheck(
+            sdkInstaller,
+            projectLocator,
+            languageDiscovery,
+            NullLogger<DotNetSdkCheck>.Instance);
+
+        var results = await check.CheckAsync().DefaultTimeout();
+
+        Assert.Single(results);
+        Assert.Equal(EnvironmentCheckStatus.Pass, results[0].Status);
+    }
+
+    [Fact]
+    public async Task CheckAsync_ReturnsFail_WhenSdkNotInstalled_AndNoAppHostFound()
+    {
+        var sdkInstaller = new TestDotNetSdkInstaller
+        {
+            CheckAsyncCallback = _ => (false, null, "10.0.100")
+        };
+        var projectLocator = new TestProjectLocator
+        {
+            GetAppHostFromSettingsAsyncCallback = _ => Task.FromResult<FileInfo?>(null)
+        };
+        var languageDiscovery = new TestLanguageDiscovery();
+
+        var check = new DotNetSdkCheck(
+            sdkInstaller,
+            projectLocator,
+            languageDiscovery,
+            NullLogger<DotNetSdkCheck>.Instance);
+
+        var results = await check.CheckAsync().DefaultTimeout();
+
+        Assert.Single(results);
+        Assert.Equal(EnvironmentCheckStatus.Fail, results[0].Status);
+        Assert.Contains(".NET SDK not found", results[0].Message);
+    }
+
+    [Fact]
+    public async Task CheckAsync_SkipsCheck_WhenNonDotNetAppHostFound()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"));
+
+        var sdkInstaller = new TestDotNetSdkInstaller
+        {
+            CheckAsyncCallback = _ => (false, null, "10.0.100")
+        };
+        var projectLocator = new TestProjectLocator
+        {
+            GetAppHostFromSettingsAsyncCallback = _ => Task.FromResult<FileInfo?>(appHostFile)
+        };
+        var languageDiscovery = new TestLanguageDiscoveryWithPolyglot();
+
+        var check = new DotNetSdkCheck(
+            sdkInstaller,
+            projectLocator,
+            languageDiscovery,
+            NullLogger<DotNetSdkCheck>.Instance);
+
+        var results = await check.CheckAsync().DefaultTimeout();
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task CheckAsync_RunsCheck_WhenDotNetAppHostFound()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "MyAppHost.csproj"));
+
+        var sdkInstaller = new TestDotNetSdkInstaller();
+        var projectLocator = new TestProjectLocator
+        {
+            GetAppHostFromSettingsAsyncCallback = _ => Task.FromResult<FileInfo?>(appHostFile)
+        };
+        var languageDiscovery = new TestLanguageDiscoveryWithPolyglot();
+
+        var check = new DotNetSdkCheck(
+            sdkInstaller,
+            projectLocator,
+            languageDiscovery,
+            NullLogger<DotNetSdkCheck>.Instance);
+
+        var results = await check.CheckAsync().DefaultTimeout();
+
+        Assert.Single(results);
+        Assert.Equal(EnvironmentCheckStatus.Pass, results[0].Status);
+    }
+
+    [Fact]
+    public async Task CheckAsync_RunsCheck_WhenNoSettingsFileExists()
+    {
+        // No settings.json — can't determine language, runs .NET check
+        var sdkInstaller = new TestDotNetSdkInstaller();
+        var projectLocator = new TestProjectLocator
+        {
+            GetAppHostFromSettingsAsyncCallback = _ => Task.FromResult<FileInfo?>(null)
+        };
+        var languageDiscovery = new TestLanguageDiscoveryWithPolyglot();
+
+        var check = new DotNetSdkCheck(
+            sdkInstaller,
+            projectLocator,
+            languageDiscovery,
+            NullLogger<DotNetSdkCheck>.Instance);
+
+        var results = await check.CheckAsync().DefaultTimeout();
+
+        Assert.Single(results);
+        Assert.Equal(EnvironmentCheckStatus.Pass, results[0].Status);
+    }
+
+    [Fact]
+    public async Task CheckAsync_RunsCheck_WhenLanguageNotRecognized()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "unknown.xyz"));
+
+        var sdkInstaller = new TestDotNetSdkInstaller();
+        var projectLocator = new TestProjectLocator
+        {
+            GetAppHostFromSettingsAsyncCallback = _ => Task.FromResult<FileInfo?>(appHostFile)
+        };
+        var languageDiscovery = new TestLanguageDiscoveryWithPolyglot();
+
+        var check = new DotNetSdkCheck(
+            sdkInstaller,
+            projectLocator,
+            languageDiscovery,
+            NullLogger<DotNetSdkCheck>.Instance);
+
+        var results = await check.CheckAsync().DefaultTimeout();
+
+        // Unrecognized file — falls through to normal .NET check
+        Assert.Single(results);
+        Assert.Equal(EnvironmentCheckStatus.Pass, results[0].Status);
+    }
+
+    /// <summary>
+    /// Test implementation of ILanguageDiscovery that includes polyglot language support.
+    /// </summary>
+    private sealed class TestLanguageDiscoveryWithPolyglot : ILanguageDiscovery
+    {
+        private static readonly LanguageInfo[] s_allLanguages =
+        [
+            new LanguageInfo(
+                LanguageId: new LanguageId(KnownLanguageId.CSharp),
+                DisplayName: KnownLanguageId.CSharpDisplayName,
+                PackageName: "",
+                DetectionPatterns: ["*.csproj", "*.fsproj", "*.vbproj", "apphost.cs"],
+                CodeGenerator: "",
+                AppHostFileName: null),
+            new LanguageInfo(
+                LanguageId: new LanguageId(KnownLanguageId.TypeScript),
+                DisplayName: "TypeScript (Node.js)",
+                PackageName: "Aspire.Hosting.CodeGeneration.TypeScript",
+                DetectionPatterns: ["apphost.ts"],
+                CodeGenerator: "TypeScript",
+                AppHostFileName: "apphost.ts"),
+        ];
+
+        public Task<IEnumerable<LanguageInfo>> GetAvailableLanguagesAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IEnumerable<LanguageInfo>>(s_allLanguages);
+
+        public Task<string?> GetPackageForLanguageAsync(LanguageId languageId, CancellationToken cancellationToken = default)
+        {
+            var language = s_allLanguages.FirstOrDefault(l =>
+                string.Equals(l.LanguageId.Value, languageId.Value, StringComparison.OrdinalIgnoreCase));
+            return Task.FromResult(language?.PackageName);
+        }
+
+        public Task<LanguageId?> DetectLanguageAsync(DirectoryInfo directory, CancellationToken cancellationToken = default)
+        {
+            foreach (var language in s_allLanguages)
+            {
+                foreach (var pattern in language.DetectionPatterns)
+                {
+                    if (pattern.StartsWith("*.", StringComparison.Ordinal))
+                    {
+                        var extension = pattern[1..];
+                        if (directory.Exists && directory.EnumerateFiles().Any(f => f.Name.EndsWith(extension, StringComparison.OrdinalIgnoreCase)))
+                        {
+                            return Task.FromResult<LanguageId?>(language.LanguageId);
+                        }
+                    }
+                    else
+                    {
+                        var filePath = Path.Combine(directory.FullName, pattern);
+                        if (File.Exists(filePath))
+                        {
+                            return Task.FromResult<LanguageId?>(language.LanguageId);
+                        }
+                    }
+                }
+            }
+            return Task.FromResult<LanguageId?>(null);
+        }
+
+        public LanguageInfo? GetLanguageById(LanguageId languageId) =>
+            s_allLanguages.FirstOrDefault(l =>
+                string.Equals(l.LanguageId.Value, languageId.Value, StringComparison.OrdinalIgnoreCase));
+
+        public LanguageInfo? GetLanguageByFile(FileInfo file) =>
+            s_allLanguages.FirstOrDefault(l =>
+                l.DetectionPatterns.Any(p => MatchesPattern(file.Name, p)));
+
+        private static bool MatchesPattern(string fileName, string pattern)
+        {
+            if (pattern.StartsWith("*.", StringComparison.Ordinal))
+            {
+                var extension = pattern[1..];
+                return fileName.EndsWith(extension, StringComparison.OrdinalIgnoreCase);
+            }
+            return fileName.Equals(pattern, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/DotNetSdkCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DotNetSdkCheckTests.cs
@@ -16,21 +16,10 @@ public class DotNetSdkCheckTests(ITestOutputHelper outputHelper)
     public async Task CheckAsync_SkipsCheck_WhenNoAppHostFound()
     {
         // No apphost in settings — skip .NET SDK check entirely
-        var sdkInstaller = new TestDotNetSdkInstaller
-        {
-            CheckAsyncCallback = _ => (false, null, "10.0.100")
-        };
-        var projectLocator = new TestProjectLocator
-        {
-            GetAppHostFromSettingsAsyncCallback = _ => Task.FromResult<FileInfo?>(null)
-        };
-        var languageDiscovery = new TestLanguageDiscovery();
-
-        var check = new DotNetSdkCheck(
-            sdkInstaller,
-            projectLocator,
-            languageDiscovery,
-            NullLogger<DotNetSdkCheck>.Instance);
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var check = CreateDotNetSdkCheck(workspace,
+            sdkCheckResult: (false, null, "10.0.100"),
+            languageDiscovery: new TestLanguageDiscovery());
 
         var results = await check.CheckAsync().DefaultTimeout();
 
@@ -41,23 +30,9 @@ public class DotNetSdkCheckTests(ITestOutputHelper outputHelper)
     public async Task CheckAsync_SkipsCheck_WhenNonDotNetAppHostFound()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"));
-
-        var sdkInstaller = new TestDotNetSdkInstaller
-        {
-            CheckAsyncCallback = _ => (false, null, "10.0.100")
-        };
-        var projectLocator = new TestProjectLocator
-        {
-            GetAppHostFromSettingsAsyncCallback = _ => Task.FromResult<FileInfo?>(appHostFile)
-        };
-        var languageDiscovery = new TestLanguageDiscoveryWithPolyglot();
-
-        var check = new DotNetSdkCheck(
-            sdkInstaller,
-            projectLocator,
-            languageDiscovery,
-            NullLogger<DotNetSdkCheck>.Instance);
+        var check = CreateDotNetSdkCheck(workspace,
+            appHostFileName: "apphost.ts",
+            sdkCheckResult: (false, null, "10.0.100"));
 
         var results = await check.CheckAsync().DefaultTimeout();
 
@@ -68,48 +43,18 @@ public class DotNetSdkCheckTests(ITestOutputHelper outputHelper)
     public async Task CheckAsync_RunsCheck_WhenDotNetAppHostFound()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "MyAppHost.csproj"));
-
-        var sdkInstaller = new TestDotNetSdkInstaller();
-        var projectLocator = new TestProjectLocator
-        {
-            GetAppHostFromSettingsAsyncCallback = _ => Task.FromResult<FileInfo?>(appHostFile)
-        };
-        var languageDiscovery = new TestLanguageDiscoveryWithPolyglot();
-
-        var check = new DotNetSdkCheck(
-            sdkInstaller,
-            projectLocator,
-            languageDiscovery,
-            NullLogger<DotNetSdkCheck>.Instance);
+        var check = CreateDotNetSdkCheck(workspace, appHostFileName: "MyAppHost.csproj");
 
         var results = await check.CheckAsync().DefaultTimeout();
-
-        Assert.Single(results);
-        Assert.Equal(EnvironmentCheckStatus.Pass, results[0].Status);
     }
 
     [Fact]
     public async Task CheckAsync_ReturnsFail_WhenDotNetAppHostFound_AndSdkNotInstalled()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "MyAppHost.csproj"));
-
-        var sdkInstaller = new TestDotNetSdkInstaller
-        {
-            CheckAsyncCallback = _ => (false, null, "10.0.100")
-        };
-        var projectLocator = new TestProjectLocator
-        {
-            GetAppHostFromSettingsAsyncCallback = _ => Task.FromResult<FileInfo?>(appHostFile)
-        };
-        var languageDiscovery = new TestLanguageDiscoveryWithPolyglot();
-
-        var check = new DotNetSdkCheck(
-            sdkInstaller,
-            projectLocator,
-            languageDiscovery,
-            NullLogger<DotNetSdkCheck>.Instance);
+        var check = CreateDotNetSdkCheck(workspace,
+            appHostFileName: "MyAppHost.csproj",
+            sdkCheckResult: (false, null, "10.0.100"));
 
         var results = await check.CheckAsync().DefaultTimeout();
 
@@ -122,18 +67,8 @@ public class DotNetSdkCheckTests(ITestOutputHelper outputHelper)
     public async Task CheckAsync_SkipsCheck_WhenNoSettingsFileExists()
     {
         // No settings.json — can't determine language, skip .NET check
-        var sdkInstaller = new TestDotNetSdkInstaller();
-        var projectLocator = new TestProjectLocator
-        {
-            GetAppHostFromSettingsAsyncCallback = _ => Task.FromResult<FileInfo?>(null)
-        };
-        var languageDiscovery = new TestLanguageDiscoveryWithPolyglot();
-
-        var check = new DotNetSdkCheck(
-            sdkInstaller,
-            projectLocator,
-            languageDiscovery,
-            NullLogger<DotNetSdkCheck>.Instance);
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var check = CreateDotNetSdkCheck(workspace);
 
         var results = await check.CheckAsync().DefaultTimeout();
 
@@ -144,20 +79,7 @@ public class DotNetSdkCheckTests(ITestOutputHelper outputHelper)
     public async Task CheckAsync_SkipsCheck_WhenLanguageNotRecognized()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "unknown.xyz"));
-
-        var sdkInstaller = new TestDotNetSdkInstaller();
-        var projectLocator = new TestProjectLocator
-        {
-            GetAppHostFromSettingsAsyncCallback = _ => Task.FromResult<FileInfo?>(appHostFile)
-        };
-        var languageDiscovery = new TestLanguageDiscoveryWithPolyglot();
-
-        var check = new DotNetSdkCheck(
-            sdkInstaller,
-            projectLocator,
-            languageDiscovery,
-            NullLogger<DotNetSdkCheck>.Instance);
+        var check = CreateDotNetSdkCheck(workspace, appHostFileName: "unknown.xyz");
 
         var results = await check.CheckAsync().DefaultTimeout();
 
@@ -165,82 +87,82 @@ public class DotNetSdkCheckTests(ITestOutputHelper outputHelper)
         Assert.Empty(results);
     }
 
-    /// <summary>
-    /// Test implementation of ILanguageDiscovery that includes polyglot language support.
-    /// </summary>
-    private sealed class TestLanguageDiscoveryWithPolyglot : ILanguageDiscovery
+    [Theory]
+    [InlineData("MyAppHost.csproj", true)]
+    [InlineData("apphost.cs", true)]
+    [InlineData("readme.txt", false)]
+    [InlineData("src/MyAppHost.csproj", true)]
+    [InlineData("src/AppHost/apphost.cs", true)]
+    [InlineData("src/deep/nested/readme.txt", false)]
+    [InlineData("a/b/c/d/e/f/apphost.cs", false)]
+    public async Task CheckAsync_FallsBackToFileSystemScan_WhenNoSettingsFile(string relativePath, bool shouldRunCheck)
     {
-        private static readonly LanguageInfo[] s_allLanguages =
-        [
-            new LanguageInfo(
-                LanguageId: new LanguageId(KnownLanguageId.CSharp),
-                DisplayName: KnownLanguageId.CSharpDisplayName,
-                PackageName: "",
-                DetectionPatterns: ["*.csproj", "*.fsproj", "*.vbproj", "apphost.cs"],
-                CodeGenerator: "",
-                AppHostFileName: null),
-            new LanguageInfo(
-                LanguageId: new LanguageId(KnownLanguageId.TypeScript),
-                DisplayName: "TypeScript (Node.js)",
-                PackageName: "Aspire.Hosting.CodeGeneration.TypeScript",
-                DetectionPatterns: ["apphost.ts"],
-                CodeGenerator: "TypeScript",
-                AppHostFileName: "apphost.ts"),
-        ];
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var check = CreateDotNetSdkCheck(workspace);
 
-        public Task<IEnumerable<LanguageInfo>> GetAvailableLanguagesAsync(CancellationToken cancellationToken = default)
-            => Task.FromResult<IEnumerable<LanguageInfo>>(s_allLanguages);
+        // Create the file on disk (with nested directories) so FindFirstFile can discover it
+        var filePath = Path.Combine(workspace.WorkspaceRoot.FullName, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+        await File.WriteAllTextAsync(filePath, "");
 
-        public Task<string?> GetPackageForLanguageAsync(LanguageId languageId, CancellationToken cancellationToken = default)
+        var results = await check.CheckAsync().DefaultTimeout();
+
+        if (shouldRunCheck)
         {
-            var language = s_allLanguages.FirstOrDefault(l =>
-                string.Equals(l.LanguageId.Value, languageId.Value, StringComparison.OrdinalIgnoreCase));
-            return Task.FromResult(language?.PackageName);
+            Assert.Single(results);
+            Assert.Equal(EnvironmentCheckStatus.Pass, results[0].Status);
+        }
+        else
+        {
+            Assert.Empty(results);
+        }
+    }
+
+    private static readonly LanguageInfo s_typeScriptLanguage = new(
+        LanguageId: new LanguageId(KnownLanguageId.TypeScript),
+        DisplayName: "TypeScript (Node.js)",
+        PackageName: "Aspire.Hosting.CodeGeneration.TypeScript",
+        DetectionPatterns: ["apphost.ts"],
+        CodeGenerator: "TypeScript",
+        AppHostFileName: "apphost.ts");
+
+    private static CliExecutionContext CreateExecutionContext(TemporaryWorkspace workspace) =>
+        new(
+            workingDirectory: workspace.WorkspaceRoot,
+            hivesDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire-hives"),
+            cacheDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire-cache"),
+            sdksDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire-sdks"),
+            logsDirectory: workspace.WorkspaceRoot.CreateSubdirectory(".aspire-logs"),
+            logFilePath: "test.log");
+
+    private static DotNetSdkCheck CreateDotNetSdkCheck(
+        TemporaryWorkspace workspace,
+        string? appHostFileName = null,
+        (bool Success, string? HighestVersion, string MinimumRequired)? sdkCheckResult = null,
+        ILanguageDiscovery? languageDiscovery = null)
+    {
+        var appHostFile = appHostFileName is not null
+            ? new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, appHostFileName))
+            : null;
+
+        var sdkInstaller = new TestDotNetSdkInstaller();
+        if (sdkCheckResult is var (success, highest, minimum))
+        {
+            sdkInstaller.CheckAsyncCallback = _ => (success, highest, minimum);
         }
 
-        public Task<LanguageId?> DetectLanguageAsync(DirectoryInfo directory, CancellationToken cancellationToken = default)
+        var projectLocator = new TestProjectLocator
         {
-            foreach (var language in s_allLanguages)
-            {
-                foreach (var pattern in language.DetectionPatterns)
-                {
-                    if (pattern.StartsWith("*.", StringComparison.Ordinal))
-                    {
-                        var extension = pattern[1..];
-                        if (directory.Exists && directory.EnumerateFiles().Any(f => f.Name.EndsWith(extension, StringComparison.OrdinalIgnoreCase)))
-                        {
-                            return Task.FromResult<LanguageId?>(language.LanguageId);
-                        }
-                    }
-                    else
-                    {
-                        var filePath = Path.Combine(directory.FullName, pattern);
-                        if (File.Exists(filePath))
-                        {
-                            return Task.FromResult<LanguageId?>(language.LanguageId);
-                        }
-                    }
-                }
-            }
-            return Task.FromResult<LanguageId?>(null);
-        }
+            GetAppHostFromSettingsAsyncCallback = _ => Task.FromResult(appHostFile)
+        };
 
-        public LanguageInfo? GetLanguageById(LanguageId languageId) =>
-            s_allLanguages.FirstOrDefault(l =>
-                string.Equals(l.LanguageId.Value, languageId.Value, StringComparison.OrdinalIgnoreCase));
+        var executionContext = CreateExecutionContext(workspace);
 
-        public LanguageInfo? GetLanguageByFile(FileInfo file) =>
-            s_allLanguages.FirstOrDefault(l =>
-                l.DetectionPatterns.Any(p => MatchesPattern(file.Name, p)));
-
-        private static bool MatchesPattern(string fileName, string pattern)
-        {
-            if (pattern.StartsWith("*.", StringComparison.Ordinal))
-            {
-                var extension = pattern[1..];
-                return fileName.EndsWith(extension, StringComparison.OrdinalIgnoreCase);
-            }
-            return fileName.Equals(pattern, StringComparison.OrdinalIgnoreCase);
-        }
+        return new DotNetSdkCheck(
+            sdkInstaller,
+            projectLocator,
+            languageDiscovery ?? new TestLanguageDiscovery(s_typeScriptLanguage),
+            executionContext,
+            NullLogger<DotNetSdkCheck>.Instance);
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/ExecCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ExecCommandTests.cs
@@ -177,6 +177,8 @@ public class ExecCommandTests
         {
             throw new Aspire.Cli.Projects.ProjectLocatorException("No project file found.", Aspire.Cli.Projects.ProjectLocatorFailureReason.NoProjectFileFound);
         }
+
+        public Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult<FileInfo?>(null);
     }
 
     private sealed class MultipleProjectFilesProjectLocator : Aspire.Cli.Projects.IProjectLocator
@@ -190,6 +192,8 @@ public class ExecCommandTests
         {
             throw new Aspire.Cli.Projects.ProjectLocatorException("Multiple project files found.", Aspire.Cli.Projects.ProjectLocatorFailureReason.MultipleProjectFilesFound);
         }
+
+        public Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult<FileInfo?>(null);
     }
 
     private sealed class ProjectFileDoesNotExistLocator : Aspire.Cli.Projects.IProjectLocator
@@ -203,5 +207,7 @@ public class ExecCommandTests
         {
             throw new Aspire.Cli.Projects.ProjectLocatorException("Project file does not exist.", Aspire.Cli.Projects.ProjectLocatorFailureReason.ProjectFileDoesntExist);
         }
+
+        public Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult<FileInfo?>(null);
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/ExtensionInternalCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ExtensionInternalCommandTests.cs
@@ -243,6 +243,8 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
         {
             throw new NotImplementedException();
         }
+
+        public Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult<FileInfo?>(null);
     }
 
     private sealed class MultipleProjectsProjectLocator : IProjectLocator
@@ -296,6 +298,8 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
         {
             throw new NotImplementedException();
         }
+
+        public Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult<FileInfo?>(null);
     }
 
     private sealed class NoProjectFileProjectLocator : IProjectLocator
@@ -341,6 +345,8 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
         {
             throw new NotImplementedException();
         }
+
+        public Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult<FileInfo?>(null);
     }
 
     private sealed class ThrowingProjectLocator : IProjectLocator
@@ -386,5 +392,7 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
         {
             throw new NotImplementedException();
         }
+
+        public Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult<FileInfo?>(null);
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -172,6 +172,8 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         {
             throw new Aspire.Cli.Projects.ProjectLocatorException("Project file does not exist.", Aspire.Cli.Projects.ProjectLocatorFailureReason.ProjectFileDoesntExist);
         }
+
+        public Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult<FileInfo?>(null);
     }
 
     [Fact]
@@ -225,6 +227,8 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         {
             throw new Aspire.Cli.Projects.ProjectLocatorException("No project file found.", Aspire.Cli.Projects.ProjectLocatorFailureReason.NoProjectFileFound);
         }
+
+        public Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult<FileInfo?>(null);
     }
 
     private sealed class MultipleProjectFilesProjectLocator : IProjectLocator
@@ -238,6 +242,8 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         {
             throw new Aspire.Cli.Projects.ProjectLocatorException("Multiple project files found.", Aspire.Cli.Projects.ProjectLocatorFailureReason.MultipleProjectFilesFound);
         }
+
+        public Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult<FileInfo?>(null);
     }
 
     private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
@@ -1266,6 +1272,8 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
             // Return a .cs file to simulate single file AppHost
             return Task.FromResult<FileInfo?>(new FileInfo("/tmp/apphost.cs"));
         }
+
+        public Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult<FileInfo?>(null);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/TestServices/NoProjectFileProjectLocator.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/NoProjectFileProjectLocator.cs
@@ -16,4 +16,6 @@ internal sealed class NoProjectFileProjectLocator : IProjectLocator
     {
         throw new ProjectLocatorException("No project file found.", ProjectLocatorFailureReason.NoProjectFileFound);
     }
+
+    public Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default) => Task.FromResult<FileInfo?>(null);
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestLanguageDiscovery.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestLanguageDiscovery.cs
@@ -7,10 +7,11 @@ namespace Aspire.Cli.Tests.TestServices;
 
 /// <summary>
 /// Test implementation of <see cref="ILanguageDiscovery"/> that includes C# support for testing.
+/// Optionally accepts additional languages for polyglot scenarios.
 /// </summary>
 internal sealed class TestLanguageDiscovery : ILanguageDiscovery
 {
-    private static readonly LanguageInfo[] s_allLanguages =
+    private static readonly LanguageInfo[] s_defaultLanguages =
     [
         new LanguageInfo(
             LanguageId: new LanguageId(KnownLanguageId.CSharp),
@@ -21,19 +22,26 @@ internal sealed class TestLanguageDiscovery : ILanguageDiscovery
             AppHostFileName: null),
     ];
 
+    private readonly LanguageInfo[] _allLanguages;
+
+    public TestLanguageDiscovery(params LanguageInfo[] additionalLanguages)
+    {
+        _allLanguages = [.. s_defaultLanguages, .. additionalLanguages];
+    }
+
     public Task<IEnumerable<LanguageInfo>> GetAvailableLanguagesAsync(CancellationToken cancellationToken = default)
-        => Task.FromResult<IEnumerable<LanguageInfo>>(s_allLanguages);
+        => Task.FromResult<IEnumerable<LanguageInfo>>(_allLanguages);
 
     public Task<string?> GetPackageForLanguageAsync(LanguageId languageId, CancellationToken cancellationToken = default)
     {
-        var language = s_allLanguages.FirstOrDefault(l =>
+        var language = _allLanguages.FirstOrDefault(l =>
             string.Equals(l.LanguageId.Value, languageId.Value, StringComparison.OrdinalIgnoreCase));
         return Task.FromResult(language?.PackageName);
     }
 
     public Task<LanguageId?> DetectLanguageAsync(DirectoryInfo directory, CancellationToken cancellationToken = default)
     {
-        foreach (var language in s_allLanguages)
+        foreach (var language in _allLanguages)
         {
             foreach (var pattern in language.DetectionPatterns)
             {
@@ -60,13 +68,13 @@ internal sealed class TestLanguageDiscovery : ILanguageDiscovery
 
     public LanguageInfo? GetLanguageById(LanguageId languageId)
     {
-        return s_allLanguages.FirstOrDefault(l =>
+        return _allLanguages.FirstOrDefault(l =>
             string.Equals(l.LanguageId.Value, languageId.Value, StringComparison.OrdinalIgnoreCase));
     }
 
     public LanguageInfo? GetLanguageByFile(FileInfo file)
     {
-        return s_allLanguages.FirstOrDefault(l =>
+        return _allLanguages.FirstOrDefault(l =>
             l.DetectionPatterns.Any(p => MatchesPattern(file.Name, p)));
     }
 

--- a/tests/Aspire.Cli.Tests/TestServices/TestProjectLocator.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestProjectLocator.cs
@@ -12,6 +12,8 @@ internal sealed class TestProjectLocator : IProjectLocator
 
     public Func<FileInfo?, MultipleAppHostProjectsFoundBehavior, bool, CancellationToken, Task<AppHostProjectSearchResult>>? UseOrFindAppHostProjectFileWithBehaviorAsyncCallback { get; set; }
 
+    public Func<CancellationToken, Task<FileInfo?>>? GetAppHostFromSettingsAsyncCallback { get; set; }
+
     public async Task<FileInfo?> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, bool createSettingsFile, CancellationToken cancellationToken)
     {
         if (UseOrFindAppHostProjectFileAsyncCallback != null)
@@ -44,6 +46,17 @@ internal sealed class TestProjectLocator : IProjectLocator
         }
 
         return new AppHostProjectSearchResult(appHostFile, [appHostFile]);
+    }
+
+    public async Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default)
+    {
+        if (GetAppHostFromSettingsAsyncCallback != null)
+        {
+            return await GetAppHostFromSettingsAsyncCallback(cancellationToken);
+        }
+
+        // Default: no settings file found
+        return null;
     }
 }
 


### PR DESCRIPTION
## Description

Make the .NET SDK check in `aspire doctor` aware of the AppHost language. When the detected AppHost is a non-.NET project (TypeScript, Python, Go, etc.), the .NET SDK check is skipped since it's not required for polyglot scenarios.

Uses the same `IProjectLocator` pattern as `aspire run` to find the AppHost, then checks its language via `ILanguageDiscovery.GetLanguageByFile()`. Falls through to the normal .NET SDK check when no AppHost is found, multiple are found, or the AppHost is a .NET project.

Fixes #14404

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
