### PR TITLE
Reduce PR validation time by decoupling CLI archive dependencies

### DIFF
--- a/.github/workflows/build-cli-native-archives.yml
+++ b/.github/workflows/build-cli-native-archives.yml
@@ -33,12 +33,38 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
-      # Download RID-specific NuGet packages (for DCP) used by Bundle.proj
-      - name: Download RID-specific NuGets
-        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806  # v4.1.9
-        with:
-          name: built-nugets-for-${{ matrix.targets.rids }}
-          path: artifacts/packages/Release/Shipping
+      # Build RID-specific NuGet packages (DCP + Dashboard) locally instead of
+      # downloading them from the build_packages job. This allows the CLI archive
+      # build to run in parallel with build_packages.
+      - name: Build RID-specific packages (Windows)
+        if: ${{ matrix.targets.os == 'windows-latest' }}
+        shell: pwsh
+        run: >
+          .\build.cmd
+          -ci
+          -restore
+          -build
+          -pack
+          -configuration ${{ inputs.configuration }}
+          /bl:${{ github.workspace }}/artifacts/log/${{ inputs.configuration }}/BuildBundleDeps.binlog
+          /p:ContinuousIntegrationBuild=true
+          /p:BuildBundleDepsOnly=true
+          ${{ inputs.versionOverrideArg }}
+
+      - name: Build RID-specific packages (Unix)
+        if: ${{ matrix.targets.os != 'windows-latest' }}
+        shell: bash
+        run: >
+          ./build.sh
+          --ci
+          --restore
+          --build
+          --pack
+          --configuration ${{ inputs.configuration }}
+          /bl:${{ github.workspace }}/artifacts/log/${{ inputs.configuration }}/BuildBundleDeps.binlog
+          /p:ContinuousIntegrationBuild=true
+          /p:BuildBundleDepsOnly=true
+          ${{ inputs.versionOverrideArg }}
 
       - name: Build bundle payload archive (Windows)
         if: ${{ matrix.targets.os == 'windows-latest' }}

--- a/.github/workflows/build-cli-native-archives.yml
+++ b/.github/workflows/build-cli-native-archives.yml
@@ -10,6 +10,18 @@ on:
         required: false
         type: string
         default: Debug
+      targets:
+        description: >
+          JSON array of target objects to build. Each object must have 'os', 'runner', and 'rids' keys.
+          Defaults to all platforms (linux-x64, win-x64, osx-arm64).
+        required: false
+        type: string
+        default: >-
+          [
+            {"os": "ubuntu-latest", "runner": "8-core-ubuntu-latest", "rids": "linux-x64"},
+            {"os": "windows-latest", "runner": "windows-latest", "rids": "win-x64"},
+            {"os": "macos-latest", "runner": "macos-latest", "rids": "osx-arm64"}
+          ]
 
 jobs:
 
@@ -18,16 +30,7 @@ jobs:
     runs-on: ${{ matrix.targets.runner }}
     strategy:
       matrix:
-        targets:
-          - os: ubuntu-latest
-            runner: 8-core-ubuntu-latest
-            rids: linux-x64
-          - os: windows-latest
-            runner: windows-latest
-            rids: win-x64
-          - os: macos-latest
-            runner: macos-latest
-            rids: osx-arm64
+        targets: ${{ fromJson(inputs.targets) }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build-cli-native-archives.yml
+++ b/.github/workflows/build-cli-native-archives.yml
@@ -69,6 +69,17 @@ jobs:
           /p:BuildBundleDepsOnly=true
           ${{ inputs.versionOverrideArg }}
 
+      # Upload DCP + Dashboard NuGets so test/polyglot jobs can download them
+      - name: Upload RID-specific NuGets
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1  # v4.6.1
+        with:
+          name: built-nugets-for-${{ matrix.targets.rids }}
+          path: |
+            artifacts/packages/${{ inputs.configuration }}/Shipping/Aspire.Hosting.Orchestration.${{ matrix.targets.rids }}.*.nupkg
+            artifacts/packages/${{ inputs.configuration }}/Shipping/Aspire.Dashboard.Sdk.${{ matrix.targets.rids }}.*.nupkg
+          if-no-files-found: error
+          retention-days: 15
+
       - name: Build bundle payload archive (Windows)
         if: ${{ runner.os == 'Windows' }}
         shell: pwsh

--- a/.github/workflows/build-cli-native-archives.yml
+++ b/.github/workflows/build-cli-native-archives.yml
@@ -40,7 +40,7 @@ jobs:
       # downloading them from the build_packages job. This allows the CLI archive
       # build to run in parallel with build_packages.
       - name: Build RID-specific packages (Windows)
-        if: ${{ matrix.targets.os == 'windows-latest' }}
+        if: ${{ runner.os == 'Windows' }}
         shell: pwsh
         run: >
           .\build.cmd
@@ -55,7 +55,7 @@ jobs:
           ${{ inputs.versionOverrideArg }}
 
       - name: Build RID-specific packages (Unix)
-        if: ${{ matrix.targets.os != 'windows-latest' }}
+        if: ${{ runner.os != 'Windows' }}
         shell: bash
         run: >
           ./build.sh
@@ -70,7 +70,7 @@ jobs:
           ${{ inputs.versionOverrideArg }}
 
       - name: Build bundle payload archive (Windows)
-        if: ${{ matrix.targets.os == 'windows-latest' }}
+        if: ${{ runner.os == 'Windows' }}
         shell: pwsh
         run: >
           .\dotnet.cmd
@@ -86,7 +86,7 @@ jobs:
           ${{ inputs.versionOverrideArg }}
 
       - name: Build bundle payload archive (Unix)
-        if: ${{ matrix.targets.os != 'windows-latest' }}
+        if: ${{ runner.os != 'Windows' }}
         shell: bash
         run: >
           ./dotnet.sh
@@ -102,7 +102,7 @@ jobs:
           ${{ inputs.versionOverrideArg }}
 
       - name: Build CLI packages (Windows)
-        if: ${{ matrix.targets.os == 'windows-latest' }}
+        if: ${{ runner.os == 'Windows' }}
         shell: pwsh
         run: >
           .\build.cmd
@@ -118,7 +118,7 @@ jobs:
           ${{ inputs.versionOverrideArg }}
 
       - name: Build CLI packages (Unix)
-        if: ${{ matrix.targets.os != 'windows-latest' }}
+        if: ${{ runner.os != 'Windows' }}
         shell: bash
         run: >
           ./build.sh

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -6,17 +6,11 @@ on:
       versionOverrideArg:
         required: false
         type: string
-    outputs:
-      arch_rids:
-        description: JSON array of architecture-specific RIDs discovered during packaging
-        value: ${{ jobs.build_packages.outputs.arch_rids }}
 
 jobs:
   build_packages:
     name: Build packages
     runs-on: 8-core-ubuntu-latest
-    outputs:
-      arch_rids: ${{ steps.stage_rid_specific.outputs.rids }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -29,67 +23,13 @@ jobs:
           rm -rf artifacts/bin
           rm -rf artifacts/obj
 
-      - name: Stage RID-specific NuGets and remaining packages
-        id: stage_rid_specific
-        shell: bash
-        run: |
-          set -euo pipefail
-          set -x
-          shopt -s nullglob
-          mkdir -p staging/built-nugets staging/rid
-          # Copy full packages tree first (so structure expected by downstream tests is preserved)
-          rsync -a artifacts/packages/ staging/built-nugets/
-
-          declare -A RID_SET=()
-          # Find target packages (dcp and dashboard)
-          while IFS= read -r -d '' pkg; do
-            bn="$(basename "$pkg")"
-            rid=""
-            if [[ $bn =~ ^Aspire\.Hosting\.Orchestration\.([^.]+)\..*\.nupkg$ ]]; then
-              rid="${BASH_REMATCH[1]}"
-            elif [[ $bn =~ ^Aspire\.Dashboard\.Sdk\.([^.]+)\..*\.nupkg$ ]]; then
-              rid="${BASH_REMATCH[1]}"
-            else
-              continue
-            fi
-            if [[ -n $rid ]]; then
-              RID_SET["$rid"]=1
-              mkdir -p "staging/rid/$rid"
-              cp "$pkg" "staging/rid/$rid/"
-              # Remove from built-nugets staging copy so it is excluded there
-              rel="${pkg#artifacts/packages/}"
-              rm -f "staging/built-nugets/$rel" || true
-            fi
-          done < <(find artifacts/packages -type f \( -name 'Aspire.Hosting.Orchestration.*.nupkg' -o -name 'Aspire.Dashboard.Sdk.*.nupkg' \) -print0)
-
-          # Build JSON array of RIDs
-          if (( ${#RID_SET[@]} )); then
-            printf '%s\n' "${!RID_SET[@]}" | sort -u > /tmp/rids.txt
-            # Build a compact single-line JSON array (avoid pretty-print newlines which break $GITHUB_OUTPUT)
-            json=$(jq -R . < /tmp/rids.txt | jq -s -c .)
-          else
-            json='[]'
-          fi
-          echo "Discovered RIDs: $json"
-          # Use printf to safely write (single line) to GITHUB_OUTPUT
-          printf 'rids=%s\n' "$json" >> "$GITHUB_OUTPUT"
-
-      - name: Upload built NuGets (excluding RID-specific orchestration/dashboard)
+      - name: Upload built NuGets
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: built-nugets
-          path: staging/built-nugets
+          path: artifacts/packages
           if-no-files-found: error
           retention-days: 15
-
-      - name: Upload consolidated RID-specific NuGets
-        if: ${{ steps.stage_rid_specific.outputs.rids != '[]' }}
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
-        with:
-          name: built-nugets-for-rid-all
-          path: staging/rid
-          if-no-files-found: error
-          retention-days: 1
 
       # Always upload logs, even if the build fails, to enable debugging
       - name: Upload logs
@@ -99,28 +39,4 @@ jobs:
           name: build_packages_logs
           path: artifacts/log
           retention-days: 5
-
-  upload_arch_specific_nugets:
-    name: Upload arch-specific NuGets
-    needs: build_packages
-    if: ${{ needs.build_packages.outputs.arch_rids != '[]' }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        rid: ${{ fromJson(needs.build_packages.outputs.arch_rids) }}
-    steps:
-      - name: Download consolidated RID-specific NuGets
-        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
-        with:
-          name: built-nugets-for-rid-all
-          path: rid-nugets
-
-      - name: Upload per-RID NuGets
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
-        with:
-          name: built-nugets-for-${{ matrix.rid }}
-          path: rid-nugets/${{ matrix.rid }}/*.nupkg
-          if-no-files-found: error
-          retention-days: 15
 

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -21,11 +21,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Install VSCE tool
-        run: npm i -g @vscode/vsce@3.7.1
-
       - name: Build with packages
-        run: ./build.sh -restore -build -build-extension -ci -pack -bl -p:InstallBrowsersForPlaywright=false -p:SkipTestProjects=true -p:SkipPlaygroundProjects=true ${{ inputs.versionOverrideArg }}
+        run: ./build.sh -restore -build -ci -pack -bl -p:InstallBrowsersForPlaywright=false -p:SkipTestProjects=true -p:SkipPlaygroundProjects=true -p:SkipBundleDeps=true ${{ inputs.versionOverrideArg }}
 
       - name: Clean up artifacts
         run: |

--- a/.github/workflows/specialized-test-runner.yml
+++ b/.github/workflows/specialized-test-runner.yml
@@ -101,9 +101,15 @@ jobs:
     if: ${{ github.repository_owner == 'dotnet' && needs.generate_tests_matrix.outputs.requiresNugets == 'true' }}
     uses: ./.github/workflows/build-packages.yml
 
+  build_cli_archives:
+    name: Build native CLI archives
+    needs: [generate_tests_matrix]
+    if: ${{ github.repository_owner == 'dotnet' && needs.generate_tests_matrix.outputs.requiresNugets == 'true' }}
+    uses: ./.github/workflows/build-cli-native-archives.yml
+
   run_tests:
     name: ${{ matrix.tests.project }}
-    needs: [generate_tests_matrix, build_packages]
+    needs: [generate_tests_matrix, build_packages, build_cli_archives]
     strategy:
       fail-fast: false
       matrix:
@@ -123,7 +129,7 @@ jobs:
     if: ${{ always() && github.repository_owner == 'dotnet' }}
     runs-on: ubuntu-latest
     name: Final Results
-    needs: [generate_tests_matrix, build_packages, run_tests]
+    needs: [generate_tests_matrix, build_packages, build_cli_archives, run_tests]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -184,7 +190,8 @@ jobs:
       - name: Fail if any dependency failed
         # 'skipped' can be when a transitive dependency fails and the dependent job gets 'skipped'.
         # For example, one of setup_* jobs failing and the Integration test jobs getting 'skipped'
-        # Note: build_packages being skipped is expected when requiresNugets is false, so we check it separately
+        # Note: build_packages/build_cli_archives being skipped is expected when requiresNugets is false,
+        # so we check them separately.
         if: >-
           ${{
             always() && (
@@ -194,7 +201,9 @@ jobs:
               needs.run_tests.result == 'cancelled' ||
               needs.run_tests.result == 'skipped' ||
               (needs.build_packages.result == 'failure') ||
-              (needs.build_packages.result == 'cancelled')
+              (needs.build_packages.result == 'cancelled') ||
+              (needs.build_cli_archives.result == 'failure') ||
+              (needs.build_cli_archives.result == 'cancelled')
             )
           }}
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,11 +38,19 @@ jobs:
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
 
-  build_cli_archives:
-    name: Build native CLI archives
+  build_cli_archive_linux:
+    name: Build native CLI archive (Linux)
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
+      targets: '[{"os": "ubuntu-latest", "runner": "8-core-ubuntu-latest", "rids": "linux-x64"}]'
+
+  build_cli_archives_other:
+    name: Build native CLI archives (Windows, macOS)
+    uses: ./.github/workflows/build-cli-native-archives.yml
+    with:
+      versionOverrideArg: ${{ inputs.versionOverrideArg }}
+      targets: '[{"os": "windows-latest", "runner": "windows-latest", "rids": "win-x64"}, {"os": "macos-latest", "runner": "macos-latest", "rids": "osx-arm64"}]'
 
   tests_no_nugets:
     name: ${{ matrix.shortname }}
@@ -85,7 +93,7 @@ jobs:
   tests_requires_nugets:
     name: ${{ matrix.shortname }}
     uses: ./.github/workflows/run-tests.yml
-    needs: [setup_for_tests, build_packages]
+    needs: [setup_for_tests, build_packages, build_cli_archive_linux]
     if: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets).include[0] != null }}
     strategy:
       fail-fast: false
@@ -104,7 +112,7 @@ jobs:
   tests_requires_cli_archive:
     name: ${{ matrix.shortname }}
     uses: ./.github/workflows/run-tests.yml
-    needs: [setup_for_tests, build_packages, build_cli_archives]
+    needs: [setup_for_tests, build_packages, build_cli_archive_linux]
     if: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_cli_archive).include[0] != null }}
     strategy:
       fail-fast: false
@@ -124,7 +132,7 @@ jobs:
   polyglot_validation:
     name: Polyglot SDK Validation
     uses: ./.github/workflows/polyglot-validation.yml
-    needs: [build_packages, build_cli_archives]
+    needs: [build_packages, build_cli_archive_linux]
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
 
@@ -158,6 +166,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Final Test Results
     needs: [
+      setup_for_tests,
+      build_packages,
+      build_cli_archive_linux,
+      build_cli_archives_other,
       extension_tests_win,
       tests_no_nugets,
       tests_no_nugets_overflow,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,9 @@ jobs:
     outputs:
       tests_matrix_no_nugets: ${{ steps.split_matrix.outputs.tests_matrix_no_nugets }}
       tests_matrix_no_nugets_overflow: ${{ steps.split_matrix.outputs.tests_matrix_no_nugets_overflow }}
-      tests_matrix_requires_nugets: ${{ steps.split_matrix.outputs.tests_matrix_requires_nugets }}
+      tests_matrix_requires_nugets_linux: ${{ steps.split_matrix.outputs.tests_matrix_requires_nugets_linux }}
+      tests_matrix_requires_nugets_windows: ${{ steps.split_matrix.outputs.tests_matrix_requires_nugets_windows }}
+      tests_matrix_requires_nugets_macos: ${{ steps.split_matrix.outputs.tests_matrix_requires_nugets_macos }}
       tests_matrix_requires_cli_archive: ${{ steps.split_matrix.outputs.tests_matrix_requires_cli_archive }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -45,12 +47,23 @@ jobs:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
       targets: '[{"os": "ubuntu-latest", "runner": "8-core-ubuntu-latest", "rids": "linux-x64"}]'
 
-  build_cli_archives_other:
-    name: Build native CLI archives (Windows, macOS)
+  # Per-OS CLI archive builds produce RID-specific DCP and Dashboard NuGets.
+  # Split by OS so that test jobs can depend on just their platform's archive,
+  # allowing Linux tests to start as soon as the Linux archive completes
+  # without waiting for the slower Windows/macOS builds.
+  build_cli_archive_windows:
+    name: Build native CLI archive (Windows)
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
-      targets: '[{"os": "windows-latest", "runner": "windows-latest", "rids": "win-x64"}, {"os": "macos-latest", "runner": "macos-latest", "rids": "osx-arm64"}]'
+      targets: '[{"os": "windows-latest", "runner": "windows-latest", "rids": "win-x64"}]'
+
+  build_cli_archive_macos:
+    name: Build native CLI archive (macOS)
+    uses: ./.github/workflows/build-cli-native-archives.yml
+    with:
+      versionOverrideArg: ${{ inputs.versionOverrideArg }}
+      targets: '[{"os": "macos-latest", "runner": "macos-latest", "rids": "osx-arm64"}]'
 
   tests_no_nugets:
     name: ${{ matrix.shortname }}
@@ -90,14 +103,54 @@ jobs:
       requiresNugets: ${{ matrix.requiresNugets }}
       requiresTestSdk: ${{ matrix.requiresTestSdk }}
 
-  tests_requires_nugets:
+  # Split requires-nugets tests by OS so each group depends only on
+  # the CLI archive build for its platform, avoiding cross-OS blocking.
+  tests_requires_nugets_linux:
     name: ${{ matrix.shortname }}
     uses: ./.github/workflows/run-tests.yml
     needs: [setup_for_tests, build_packages, build_cli_archive_linux]
-    if: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets).include[0] != null }}
+    if: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_linux).include[0] != null }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets) }}
+      matrix: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_linux) }}
+    with:
+      testShortName: ${{ matrix.shortname }}
+      os: ${{ matrix.runs-on }}
+      testProjectPath: ${{ matrix.testProjectPath }}
+      testSessionTimeout: ${{ matrix.testSessionTimeout }}
+      testHangTimeout: ${{ matrix.testHangTimeout }}
+      extraTestArgs: "--filter-not-trait \"quarantined=true\" --filter-not-trait \"outerloop=true\" ${{ matrix.extraTestArgs }}"
+      versionOverrideArg: ${{ inputs.versionOverrideArg }}
+      requiresNugets: ${{ matrix.requiresNugets }}
+      requiresTestSdk: ${{ matrix.requiresTestSdk }}
+
+  tests_requires_nugets_windows:
+    name: ${{ matrix.shortname }}
+    uses: ./.github/workflows/run-tests.yml
+    needs: [setup_for_tests, build_packages, build_cli_archive_windows]
+    if: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_windows).include[0] != null }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_windows) }}
+    with:
+      testShortName: ${{ matrix.shortname }}
+      os: ${{ matrix.runs-on }}
+      testProjectPath: ${{ matrix.testProjectPath }}
+      testSessionTimeout: ${{ matrix.testSessionTimeout }}
+      testHangTimeout: ${{ matrix.testHangTimeout }}
+      extraTestArgs: "--filter-not-trait \"quarantined=true\" --filter-not-trait \"outerloop=true\" ${{ matrix.extraTestArgs }}"
+      versionOverrideArg: ${{ inputs.versionOverrideArg }}
+      requiresNugets: ${{ matrix.requiresNugets }}
+      requiresTestSdk: ${{ matrix.requiresTestSdk }}
+
+  tests_requires_nugets_macos:
+    name: ${{ matrix.shortname }}
+    uses: ./.github/workflows/run-tests.yml
+    needs: [setup_for_tests, build_packages, build_cli_archive_macos]
+    if: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_macos).include[0] != null }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_macos) }}
     with:
       testShortName: ${{ matrix.shortname }}
       os: ${{ matrix.runs-on }}
@@ -169,11 +222,14 @@ jobs:
       setup_for_tests,
       build_packages,
       build_cli_archive_linux,
-      build_cli_archives_other,
+      build_cli_archive_windows,
+      build_cli_archive_macos,
       extension_tests_win,
       tests_no_nugets,
       tests_no_nugets_overflow,
-      tests_requires_nugets,
+      tests_requires_nugets_linux,
+      tests_requires_nugets_windows,
+      tests_requires_nugets_macos,
       tests_requires_cli_archive,
       polyglot_validation,
     ]
@@ -228,13 +284,17 @@ jobs:
                (github.event_name == 'pull_request' &&
                 (needs.extension_tests_win.result == 'skipped' ||
                  needs.tests_no_nugets.result == 'skipped' ||
-                 needs.tests_requires_nugets.result == 'skipped' ||
+                 needs.tests_requires_nugets_linux.result == 'skipped' ||
+                 needs.tests_requires_nugets_windows.result == 'skipped' ||
+                 needs.tests_requires_nugets_macos.result == 'skipped' ||
                  needs.tests_requires_cli_archive.result == 'skipped' ||
                  needs.polyglot_validation.result == 'skipped')) ||
                (github.event_name != 'pull_request' &&
                 (needs.extension_tests_win.result == 'skipped' ||
                  needs.tests_no_nugets.result == 'skipped' ||
-                 needs.tests_requires_nugets.result == 'skipped' ||
+                 needs.tests_requires_nugets_linux.result == 'skipped' ||
+                 needs.tests_requires_nugets_windows.result == 'skipped' ||
+                 needs.tests_requires_nugets_macos.result == 'skipped' ||
                  needs.polyglot_validation.result == 'skipped'))) }}
         run: |
           echo "One or more dependent jobs failed."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,6 @@ jobs:
 
   build_cli_archives:
     name: Build native CLI archives
-    needs: build_packages
     uses: ./.github/workflows/build-cli-native-archives.yml
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -264,13 +264,14 @@ jobs:
 
       - name: Generate test results summary
         if: always()
-        run: >
-          ${{ github.workspace }}/dotnet.sh
-          run
-          --project ${{ github.workspace }}/tools/GenerateTestSummary/GenerateTestSummary.csproj
-          --
-          ${{ github.workspace }}/testresults
-          --combined
+        shell: bash
+        run: |
+          ${{ github.workspace }}/dotnet.sh \
+            run \
+            --project ${{ github.workspace }}/tools/GenerateTestSummary/GenerateTestSummary.csproj \
+            -- \
+            ${{ github.workspace }}/testresults \
+            --combined
 
       - name: Fail if any dependency failed
         # 'skipped' can be when a transitive dependency fails and the dependent job gets 'skipped'.

--- a/docs/ci/TestingOnCI.md
+++ b/docs/ci/TestingOnCI.md
@@ -123,12 +123,9 @@ Each CI platform has a thin script that transforms the canonical matrix:
 **GitHub Actions** (`eng/scripts/expand-test-matrix-github.ps1`):
 - Expands each entry for every OS in its `supportedOSes` array
 - Maps OS names to GitHub runners (`linux` → `ubuntu-latest`, etc.)
-- Splits entries into categories by dependency requirements:
-  - `no_nugets` — tests with no package dependencies
-  - `requires_nugets` — tests needing built NuGet packages
-  - `requires_cli_archive` — tests needing native CLI archives
+- Preserves dependency metadata such as `requiresNugets`, `requiresCliArchive`, and custom runner overrides on each expanded entry
 - Applies overflow splitting for the `no_nugets` category (threshold: 250 entries) to stay under the GitHub Actions 256-job-per-matrix limit
-- Outputs 4 GitHub Actions matrices: `no_nugets` (primary), `no_nugets_overflow`, `requires_nugets`, `requires_cli_archive`
+- Outputs a single `all_tests` matrix, which `.github/workflows/tests.yml` further splits by dependency type and OS using `eng/scripts/split-test-matrix-by-deps.ps1`
 
 **Azure DevOps** (future):
 - Would map OS names to vmImage or pool names
@@ -140,16 +137,36 @@ This separation keeps 90% of the logic platform-agnostic while allowing each CI 
 
 In `.github/workflows/tests.yml`, the workflow:
 
-1. Receives 4 pre-split matrices from the `enumerate-tests` action (split by `expand-test-matrix-github.ps1`)
-2. Runs 4 job groups using the split matrices:
-   - `tests_no_nugets`: Runs immediately after enumeration
-   - `tests_no_nugets_overflow`: Runs immediately (handles entries beyond the 250-entry threshold)
-   - `tests_requires_nugets`: Waits for `build_packages` job
-   - `tests_requires_cli_archive`: Waits for both `build_packages` and `build_cli_archives` jobs
+1. Receives the OS-expanded `all_tests` matrix from the `enumerate-tests` action
+2. Splits that matrix with `eng/scripts/split-test-matrix-by-deps.ps1` into 6 buckets:
+   - `tests_matrix_no_nugets`
+   - `tests_matrix_no_nugets_overflow`
+   - `tests_matrix_requires_nugets_linux`
+   - `tests_matrix_requires_nugets_windows`
+   - `tests_matrix_requires_nugets_macos`
+   - `tests_matrix_requires_cli_archive`
+3. Runs the CI jobs so the critical path stays as short as possible:
+    - `tests_no_nugets`: Runs immediately after enumeration
+    - `tests_no_nugets_overflow`: Runs immediately (handles entries beyond the 250-entry threshold)
+    - `build_packages`: Produces the shared package feed used by all package-dependent jobs
+    - `build_cli_archive_linux`, `build_cli_archive_windows`, `build_cli_archive_macos`: Build native CLI archives and the matching RID-specific DCP/Dashboard packages in parallel with `build_packages`
+    - `tests_requires_nugets_linux`, `tests_requires_nugets_windows`, `tests_requires_nugets_macos`: Wait for `build_packages` plus only the CLI archive job for their OS
+    - `tests_requires_cli_archive`: Waits for `build_packages` and `build_cli_archive_linux`
+    - `polyglot_validation`: Waits for `build_packages` and `build_cli_archive_linux`
 
 Each job invokes `.github/workflows/run-tests.yml` with matrix parameters including `extraTestArgs` for filtering (e.g., `--filter-trait "Partition=X"`).
 
 > **Note:** The workflow automatically prepends `--filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` before any `extraTestArgs`, ensuring quarantined and outerloop tests are always excluded from the main test run.
+
+### Why the jobs are structured this way
+
+The workflow intentionally favors shorter dependency chains over a smaller number of larger jobs:
+
+1. **`no_nugets` jobs start first** so pure managed/unit test coverage begins as soon as enumeration finishes.
+2. **`build_packages` and the CLI archive jobs run in parallel** because the CLI archive workflow builds its own RID-specific DCP and Dashboard packages locally. That removes a serial dependency where archive creation would otherwise wait for the shared package build.
+3. **`requires_nugets` is split by OS** because each OS-specific test group needs the RID-specific DCP/Dashboard packages produced by that platform's CLI archive job. Splitting the jobs prevents Linux tests from waiting on the slower Windows or macOS archive builds.
+4. **`tests_requires_cli_archive` and `polyglot_validation` only depend on the Linux archive** because the current consumers in those buckets use the Linux CLI archive path. That keeps linux-only validation on the fastest available path instead of blocking on unrelated Windows or macOS work.
+5. **The `results` job depends on every relevant lane** so the workflow still reports a single final status after the parallelized work completes.
 
 #### GitHub Actions 256-Job Limit
 
@@ -222,7 +239,7 @@ For tests that need the built Aspire packages (e.g., template tests, end-to-end 
 </PropertyGroup>
 ```
 
-These tests wait for the `build_packages` job before running.
+These tests wait for the `build_packages` job before running. In the main `tests.yml` workflow they are then split by OS so each lane can also wait for the matching RID-specific packages produced by that platform's CLI archive job.
 
 ## Requiring CLI Native Archives
 
@@ -235,7 +252,7 @@ For tests that need native CLI archives (e.g., CLI end-to-end tests):
 </PropertyGroup>
 ```
 
-These tests wait for both the `build_packages` and `build_cli_archives` jobs before running. The workflow also sets `GH_TOKEN`, `GITHUB_PR_NUMBER`, and `GITHUB_PR_HEAD_SHA` environment variables for CLI E2E test scenarios.
+These tests wait for both the `build_packages` job and the Linux CLI archive job before running. Today that lane is Linux-only, so it depends on `build_cli_archive_linux` instead of every CLI archive build. The workflow also sets `GH_TOKEN`, `GITHUB_PR_NUMBER`, and `GITHUB_PR_HEAD_SHA` environment variables for CLI E2E test scenarios.
 
 ## Enabling Playwright
 

--- a/docs/ci/ci-pipeline-optimizations.md
+++ b/docs/ci/ci-pipeline-optimizations.md
@@ -1,0 +1,173 @@
+# CI Pipeline Optimizations
+
+This document explains the CI pipeline optimizations in the current test workflow, why the jobs are structured the way they are, and what to verify when changing that structure.
+
+## Goals
+
+The test pipeline is optimized for three things:
+
+1. **Short time to first useful test signal**
+2. **Short total wall-clock time**
+3. **Clear dependency boundaries between shared artifacts and test jobs**
+
+Those goals are the reason the workflow prefers several smaller, dependency-aware jobs over a single large serialized build-and-test lane.
+
+## Current structure
+
+The main test workflow in `.github/workflows/tests.yml` is organized into these phases:
+
+1. `setup_for_tests`
+   - Enumerates tests and produces the expanded `all_tests` matrix
+   - Splits the matrix into dependency buckets with `eng/scripts/split-test-matrix-by-deps.ps1`
+
+2. `build_packages`
+   - Produces the shared Aspire package feed used by package-dependent tests
+   - Uses `-p:SkipBundleDeps=true` so it does not duplicate the RID-specific DCP/Dashboard work handled by the CLI archive jobs
+
+3. `build_cli_archive_linux`, `build_cli_archive_windows`, `build_cli_archive_macos`
+   - Build native CLI archives per RID
+   - Build the matching RID-specific DCP and Dashboard packages locally with `BuildBundleDepsOnly`
+   - Upload `built-nugets-for-{rid}` artifacts for downstream tests
+   - Upload `cli-native-archives-{rid}` artifacts for archive consumers such as polyglot validation
+
+4. Test execution lanes
+   - `tests_no_nugets`
+   - `tests_no_nugets_overflow`
+   - `tests_requires_nugets_linux`
+   - `tests_requires_nugets_windows`
+   - `tests_requires_nugets_macos`
+   - `tests_requires_cli_archive`
+   - `polyglot_validation`
+   - `extension_tests_win`
+
+5. `results`
+   - Aggregates the final workflow status after all required lanes finish
+
+## Why the jobs are split this way
+
+### 1. Package build and CLI archive build run in parallel
+
+`build_packages` and the CLI archive jobs intentionally run side by side.
+
+Without that split, CLI archive creation would sit behind the shared package build even though most of the archive work is independent. The archive workflow now builds the RID-specific DCP and Dashboard packages it needs locally, so there is no reason to serialize it behind `build_packages`.
+
+This reduces time-to-artifact for:
+
+- CLI archive consumers
+- polyglot validation
+- any tests that need RID-specific DCP or Dashboard packages
+
+### 2. CLI archive builds are per OS
+
+The workflow uses one CLI archive job per platform instead of one combined matrix dependency.
+
+That allows downstream jobs to wait only for the archive that matches their runner and RID:
+
+- Linux tests wait for `build_cli_archive_linux`
+- Windows tests wait for `build_cli_archive_windows`
+- macOS tests wait for `build_cli_archive_macos`
+
+If these stayed grouped behind one logical dependency, the slowest platform would delay every dependent test lane.
+
+### 3. `requires_nugets` tests are split by OS
+
+Tests that need built packages also need the correct RID-specific DCP/Dashboard packages. Because those packages are produced by the CLI archive job for the same OS, the workflow splits the `requires_nugets` bucket into Linux, Windows, and macOS lanes.
+
+That keeps the dependency graph aligned with artifact production:
+
+- the Linux lane does not wait for Windows or macOS artifacts
+- the Windows lane does not wait for Linux or macOS artifacts
+- the macOS lane does not wait for Linux or Windows artifacts
+
+### 4. `tests_requires_cli_archive` depends only on the Linux CLI archive lane
+
+The current `requires_cli_archive` consumers run on Linux, so the workflow depends on `build_cli_archive_linux` instead of every CLI archive job. It still waits for `build_packages`, but among the CLI archive jobs it only needs the Linux lane.
+
+This is intentional. Requiring all CLI archive builds would add wait time with no benefit for the current consumers. If future archive-dependent tests are added for Windows or macOS, this dependency should be revisited.
+
+### 5. `tests_no_nugets` starts as soon as possible
+
+The `no_nugets` buckets are the fastest way to get broad CI feedback because they do not depend on package or archive production. Starting them immediately reduces the time before developers see failures in unit tests and other self-contained lanes.
+
+### 6. `results` stays centralized
+
+Even though execution is more parallel, the workflow still uses a single `results` job so GitHub reports one final, easy-to-understand outcome for the overall test pipeline.
+
+## Additional optimizations in the current workflow
+
+### 1. Linux critical-path builds use the 8-core runner
+
+`build_cli_archive_linux` and `build_packages` both run on `8-core-ubuntu-latest`. The Linux CLI archive is on the critical path for linux-only consumers such as `tests_requires_cli_archive` and `polyglot_validation`, and `build_packages` is shared by every package-dependent lane.
+
+That makes Linux the best place to spend extra build capacity: finishing the shared package build and Linux archive earlier directly reduces the time before downstream validation lanes can start.
+
+### 2. `build_packages` skips RID-specific bundle dependencies
+
+`build_packages` uses `SkipBundleDeps=true`, while the CLI archive jobs use `BuildBundleDepsOnly=true`.
+
+Those two settings work together:
+
+- the shared package build avoids work that would otherwise be duplicated
+- each CLI archive job becomes responsible for the RID-specific dependencies it actually needs
+- package build and archive build can proceed in parallel without racing to produce the same artifacts
+
+### 3. The VS Code extension is built in its dedicated test lane
+
+The extension work now lives in `extension_tests_win` instead of also being folded into `build_packages`.
+
+That keeps `build_packages` focused on the shared package feed, and because `extension_tests_win` has no dependency on the package or archive jobs it can run independently instead of lengthening those critical paths.
+
+## Supporting workflow details
+
+### `build-packages.yml`
+
+`build_packages` uses:
+
+```bash
+./build.sh -restore -build -ci -pack -bl -p:InstallBrowsersForPlaywright=false -p:SkipTestProjects=true -p:SkipPlaygroundProjects=true -p:SkipBundleDeps=true
+```
+
+`SkipBundleDeps=true` matters because the RID-specific bundle dependencies are produced by the per-OS CLI archive jobs, not by the shared package build.
+
+### `build-cli-native-archives.yml`
+
+Each CLI archive job:
+
+1. Builds RID-specific DCP and Dashboard packages locally
+2. Uploads them as `built-nugets-for-{rid}`
+3. Builds the bundle payload
+4. Builds the native CLI archive
+5. Uploads the native archive as `cli-native-archives-{rid}`
+
+This makes the archive job self-sufficient for the RID-specific artifacts it needs.
+
+### `run-tests.yml`
+
+When a test lane sets `requiresNugets: true`, `run-tests.yml`:
+
+1. Downloads the shared `built-nugets` artifact
+2. Computes the lane RID from `runner.os`
+3. Downloads `built-nugets-for-{rid}`
+4. Merges those RID-specific packages into the local package feed before running tests
+
+That is why the dependency graph must preserve the OS relationship between test lane and CLI archive lane.
+
+## What to validate when changing this area
+
+When changing the CI structure, verify:
+
+1. **Artifact production still matches artifact consumption**
+   - `build_packages` still publishes the shared package feed
+   - each CLI archive lane still publishes the correct `built-nugets-for-{rid}` artifact
+
+2. **Each test lane waits only for the work it actually needs**
+   - avoid adding cross-OS dependencies unless a consumer truly needs them
+
+3. **Linux-only consumers stay on the shortest path**
+   - especially `tests_requires_cli_archive` and `polyglot_validation`
+
+4. **Matrix bucket sizes stay under GitHub's limits**
+   - `split-test-matrix-by-deps.ps1` enforces the 256-job hard limit
+
+5. **Documentation stays in sync**
+   - update this file and `docs/ci/TestingOnCI.md` whenever the dependency graph changes

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -7,6 +7,7 @@
       BuildTestsOnly         - if 'true', builds only test projects, defaults to 'false'
       SkipTestProjects       - if 'true', skips building test projects, defaults to 'false'
       SkipPlaygroundProjects - if 'true', skips building playground projects, defaults to 'false'
+      BuildBundleDepsOnly    - if 'true', builds only eng/dcppack and eng/dashboardpack projects (for CLI bundle), defaults to 'false'
       TargetRids             - colon separated list of RIDs to build native projects for
   -->
 
@@ -21,10 +22,21 @@
     <TargetRids Condition="'$(TargetRids)' == ''">$(BuildRid)</TargetRids>
   </PropertyGroup>
 
+  <!-- `$(BuildBundleDepsOnly)` builds only the DCP and Dashboard packaging projects needed
+        by the CLI bundle. This allows the CLI native archive build to produce these packages
+        independently without waiting for the full build_packages job. -->
+  <ItemGroup Condition="'$(BuildBundleDepsOnly)' == 'true'">
+    <ProjectToBuild Include="$(RepoRoot)eng\dcppack\**\*.csproj" />
+    <ProjectToBuild Include="$(RepoRoot)eng\dashboardpack\**\*.csproj" />
+    <!-- Dashboard is invoked by dashboardpack via MSBuild task (not ProjectReference),
+         so it must be explicitly included to ensure restore generates its assets file. -->
+    <ProjectToBuild Include="$(RepoRoot)src\Aspire.Dashboard\Aspire.Dashboard.csproj" />
+  </ItemGroup>
+
   <!-- `$(BuildTestsOnly)` allows building only test projects, skipping the following directories:
         src, playground, eng/dcppack, and eng/dashboardpack. This is useful for reducing disk space
         usage when only test projects need to be built, such as during test runsheet generation. -->
-  <ItemGroup Condition="'$(SkipManagedBuild)' != 'true' and '$(BuildTestsOnly)' != 'true'">
+  <ItemGroup Condition="'$(SkipManagedBuild)' != 'true' and '$(BuildTestsOnly)' != 'true' and '$(BuildBundleDepsOnly)' != 'true'">
     <!-- Project name validation runs once in the outer build -->
     <ProjectToBuild Include="$(RepoRoot)eng\OuterPreBuild.proj" />
 
@@ -42,17 +54,17 @@
   <!-- `$(SkipTestProjects)` allows skipping test projects from being
         included in the build at all. This is useful for cases like when we are
         just building the packages, and don't need to build the test projects. -->
-  <ItemGroup Condition="'$(SkipManagedBuild)' != 'true' and '$(SkipTestProjects)' != 'true'">
+  <ItemGroup Condition="'$(SkipManagedBuild)' != 'true' and '$(SkipTestProjects)' != 'true' and '$(BuildBundleDepsOnly)' != 'true'">
     <ProjectToBuild Include="$(RepoRoot)tests\**\*.csproj" />
   </ItemGroup>
 
   <!-- Extension build project -->
-  <ItemGroup Condition="'$(BuildExtension)' == 'true'">
+  <ItemGroup Condition="'$(BuildExtension)' == 'true' and '$(BuildBundleDepsOnly)' != 'true'">
     <ProjectToBuild Include="$(RepoRoot)extension\Extension.proj" />
   </ItemGroup>
 
   <!-- Native build only -->
-  <ItemGroup Condition="'$(SkipNativeBuild)' != 'true'">
+  <ItemGroup Condition="'$(SkipNativeBuild)' != 'true' and '$(BuildBundleDepsOnly)' != 'true'">
     <!-- Add Aspire.Cli project here for native-only builds so it gets picked
          up Restore, because Aspire.Cli.$(RID).csproj uses MSBuild task to build
          instead of a ProjectReference -->

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -7,8 +7,8 @@
       BuildTestsOnly         - if 'true', builds only test projects, defaults to 'false'
       SkipTestProjects       - if 'true', skips building test projects, defaults to 'false'
       SkipPlaygroundProjects - if 'true', skips building playground projects, defaults to 'false'
-      SkipBundleDeps         - if 'true', skips building eng/dcppack, eng/dashboardpack, and Aspire.Dashboard projects, defaults to 'false'
-      BuildBundleDepsOnly    - if 'true', builds only eng/dcppack and eng/dashboardpack projects (for CLI bundle), defaults to 'false'
+      SkipBundleDeps         - if 'true', skips building eng/dcppack, eng/dashboardpack, Aspire.Dashboard, and Aspire.Cli projects during the main managed build, defaults to 'false'
+      BuildBundleDepsOnly    - if 'true', builds only the RID-specific eng/dcppack and eng/dashboardpack projects for $(TargetRids), plus Aspire.Dashboard for restore, defaults to 'false'
       TargetRids             - colon separated list of RIDs to build native projects for
   -->
 
@@ -23,12 +23,14 @@
     <TargetRids Condition="'$(TargetRids)' == ''">$(BuildRid)</TargetRids>
   </PropertyGroup>
 
-  <!-- `$(BuildBundleDepsOnly)` builds only the DCP and Dashboard packaging projects needed
-        by the CLI bundle. This allows the CLI native archive build to produce these packages
-        independently without waiting for the full build_packages job. -->
+  <!-- `$(BuildBundleDepsOnly)` builds only the RID-specific DCP and Dashboard packaging projects
+        needed by the CLI bundle for $(TargetRids). This allows the CLI native archive build to
+        produce these packages independently without waiting for the full build_packages job. -->
   <ItemGroup Condition="'$(BuildBundleDepsOnly)' == 'true'">
-    <ProjectToBuild Include="$(RepoRoot)eng\dcppack\**\*.csproj" />
-    <ProjectToBuild Include="$(RepoRoot)eng\dashboardpack\**\*.csproj" />
+    <_BundleDependencyTargetRid Include="$(TargetRids.Split(':'))" />
+    <_BundleDependencyProject Include="@(_BundleDependencyTargetRid -> '$(RepoRoot)eng\dcppack\Aspire.Hosting.Orchestration.%(Identity).csproj')" />
+    <_BundleDependencyProject Include="@(_BundleDependencyTargetRid -> '$(RepoRoot)eng\dashboardpack\Aspire.Dashboard.Sdk.%(Identity).csproj')" />
+    <ProjectToBuild Include="@(_BundleDependencyProject->Exists())" />
     <!-- Dashboard is invoked by dashboardpack via MSBuild task (not ProjectReference),
          so it must be explicitly included to ensure restore generates its assets file. -->
     <ProjectToBuild Include="$(RepoRoot)src\Aspire.Dashboard\Aspire.Dashboard.csproj" />

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -7,6 +7,7 @@
       BuildTestsOnly         - if 'true', builds only test projects, defaults to 'false'
       SkipTestProjects       - if 'true', skips building test projects, defaults to 'false'
       SkipPlaygroundProjects - if 'true', skips building playground projects, defaults to 'false'
+      SkipBundleDeps         - if 'true', skips building eng/dcppack, eng/dashboardpack, and Aspire.Dashboard projects, defaults to 'false'
       BuildBundleDepsOnly    - if 'true', builds only eng/dcppack and eng/dashboardpack projects (for CLI bundle), defaults to 'false'
       TargetRids             - colon separated list of RIDs to build native projects for
   -->
@@ -41,8 +42,10 @@
     <ProjectToBuild Include="$(RepoRoot)eng\OuterPreBuild.proj" />
 
     <ProjectToBuild Include="$(RepoRoot)src\**\*.csproj" Exclude="$(RepoRoot)src\Aspire.ProjectTemplates\templates\**\*.csproj" />
-    <ProjectToBuild Include="$(RepoRoot)eng\dcppack\**\*.csproj" />
-    <ProjectToBuild Include="$(RepoRoot)eng\dashboardpack\**\*.csproj" />
+    <ProjectToBuild Remove="$(RepoRoot)src\Aspire.Cli\Aspire.Cli.*csproj" Condition="'$(SkipBundleDeps)' == 'true'" />
+    <ProjectToBuild Remove="$(RepoRoot)src\Aspire.Dashboard\Aspire.Dashboard.csproj" Condition="'$(SkipBundleDeps)' == 'true'" />
+    <ProjectToBuild Include="$(RepoRoot)eng\dcppack\**\*.csproj" Condition="'$(SkipBundleDeps)' != 'true'" />
+    <ProjectToBuild Include="$(RepoRoot)eng\dashboardpack\**\*.csproj" Condition="'$(SkipBundleDeps)' != 'true'" />
 
     <!-- Exclude only the MAUI client project as it requires the .NET MAUI workload.
          Other projects in the AspireWithMaui playground can still be built. -->

--- a/eng/scripts/split-test-matrix-by-deps.ps1
+++ b/eng/scripts/split-test-matrix-by-deps.ps1
@@ -4,10 +4,12 @@
 
 .DESCRIPTION
   Takes a flat all_tests matrix JSON (already OS-expanded) and splits it into
-  four dependency-based matrices for GitHub Actions consumption:
+  dependency-based matrices for GitHub Actions consumption:
   1. tests_matrix_no_nugets (primary) — tests with no package dependencies
   2. tests_matrix_no_nugets_overflow — overflow when primary exceeds threshold
-  3. tests_matrix_requires_nugets — tests needing built NuGet packages
+  3. tests_matrix_requires_nugets_{linux,windows,macos} — tests needing built
+     NuGet packages, split by OS so each group can depend on the per-OS CLI
+     archive build that produces its RID-specific DCP/Dashboard NuGets
   4. tests_matrix_requires_cli_archive — tests needing CLI native archives
 
   The overflow mechanism keeps each matrix under GitHub Actions' 256-job limit.
@@ -87,6 +89,22 @@ Write-Host "  - No nugets: $($noNugetEntries.Count)"
 Write-Host "  - Requires nugets: $($nugetEntries.Count)"
 Write-Host "  - Requires CLI archive: $($cliArchiveEntries.Count)"
 
+# Further split nuget entries by OS so test jobs can depend on
+# the per-OS CLI archive build that produces their RID-specific NuGets.
+function Get-OsCategory([string]$runsOn) {
+  if ($runsOn -match 'ubuntu|linux') { return 'linux' }
+  if ($runsOn -match 'windows')      { return 'windows' }
+  if ($runsOn -match 'macos')        { return 'macos' }
+  Write-Warning "Unknown runs-on value '$runsOn', defaulting to 'linux'"
+  return 'linux'
+}
+
+$nugetEntriesLinux   = @($nugetEntries | Where-Object { (Get-OsCategory $_.'runs-on') -eq 'linux' })
+$nugetEntriesWindows = @($nugetEntries | Where-Object { (Get-OsCategory $_.'runs-on') -eq 'windows' })
+$nugetEntriesMacos   = @($nugetEntries | Where-Object { (Get-OsCategory $_.'runs-on') -eq 'macos' })
+
+Write-Host "    ↳ nugets linux: $($nugetEntriesLinux.Count), windows: $($nugetEntriesWindows.Count), macos: $($nugetEntriesMacos.Count)"
+
 # Split no_nugets into primary + overflow
 $noNugetPrimary = @()
 $noNugetOverflow = @()
@@ -103,7 +121,9 @@ if ($noNugetEntries.Count -le $OverflowThreshold) {
 $buckets = @{
   'tests_matrix_no_nugets' = $noNugetPrimary
   'tests_matrix_no_nugets_overflow' = $noNugetOverflow
-  'tests_matrix_requires_nugets' = $nugetEntries
+  'tests_matrix_requires_nugets_linux' = $nugetEntriesLinux
+  'tests_matrix_requires_nugets_windows' = $nugetEntriesWindows
+  'tests_matrix_requires_nugets_macos' = $nugetEntriesMacos
   'tests_matrix_requires_cli_archive' = $cliArchiveEntries
 }
 

--- a/tests/Infrastructure.Tests/PowerShellScripts/ExpandTestMatrixGitHubTests.cs
+++ b/tests/Infrastructure.Tests/PowerShellScripts/ExpandTestMatrixGitHubTests.cs
@@ -577,7 +577,9 @@ public class ExpandTestMatrixGitHubTests : IDisposable
         var splitOutputs = ParseGitHubOutputFile(githubOutputFile);
         var noNugets = splitOutputs["tests_matrix_no_nugets"];
         var noNugetsOverflow = splitOutputs["tests_matrix_no_nugets_overflow"];
-        var nugetsMatrix = splitOutputs["tests_matrix_requires_nugets"];
+        var nugetsLinux = splitOutputs["tests_matrix_requires_nugets_linux"];
+        var nugetsWindows = splitOutputs["tests_matrix_requires_nugets_windows"];
+        var nugetsMacos = splitOutputs["tests_matrix_requires_nugets_macos"];
         var cliArchiveMatrix = splitOutputs["tests_matrix_requires_cli_archive"];
 
         var allNoNugets = noNugets.Include.Concat(noNugetsOverflow.Include).ToArray();
@@ -593,8 +595,8 @@ public class ExpandTestMatrixGitHubTests : IDisposable
         Assert.Equal(2, splitEntries.Count(e => e.RunsOn == "windows-latest"));
         Assert.Equal(2, splitEntries.Count(e => e.RunsOn == "macos-latest"));
 
-        // Linux-only E2E: 1 project × 1 OS = 1, in requires-nugets matrix
-        var e2eEntries = nugetsMatrix.Include.Where(e => e.ProjectName == "LinuxE2E").ToArray();
+        // Linux-only E2E: 1 project × 1 OS = 1, in requires-nugets-linux matrix
+        var e2eEntries = nugetsLinux.Include.Where(e => e.ProjectName == "LinuxE2E").ToArray();
         Assert.Single(e2eEntries);
         Assert.Equal("ubuntu-latest", e2eEntries[0].RunsOn);
         Assert.True(e2eEntries[0].RequiresNugets);
@@ -605,9 +607,11 @@ public class ExpandTestMatrixGitHubTests : IDisposable
         Assert.Equal("ubuntu-latest", cliE2eEntries[0].RunsOn);
         Assert.True(cliE2eEntries[0].RequiresCliArchive);
 
-        // Total no-nugets: 3 + 6 = 9, Total nugets: 1, Total cli-archive: 1
+        // Total no-nugets: 3 + 6 = 9, Total nugets: 1 (linux only), Total cli-archive: 1
         Assert.Equal(9, allNoNugets.Length);
-        Assert.Single(nugetsMatrix.Include);
+        Assert.Single(nugetsLinux.Include);
+        Assert.Empty(nugetsWindows.Include);
+        Assert.Empty(nugetsMacos.Include);
         Assert.Single(cliArchiveMatrix.Include);
     }
 

--- a/tests/Infrastructure.Tests/PowerShellScripts/SplitTestMatrixByDepsTests.cs
+++ b/tests/Infrastructure.Tests/PowerShellScripts/SplitTestMatrixByDepsTests.cs
@@ -41,7 +41,7 @@ public class SplitTestMatrixByDepsTests : IDisposable
 
         var outputs = ParseGitHubOutputFile();
         Assert.Equal(2, outputs["tests_matrix_no_nugets"].Include.Length);
-        Assert.Empty(outputs["tests_matrix_requires_nugets"].Include);
+        Assert.Empty(outputs["tests_matrix_requires_nugets_linux"].Include);
         Assert.Empty(outputs["tests_matrix_requires_cli_archive"].Include);
     }
 
@@ -60,8 +60,30 @@ public class SplitTestMatrixByDepsTests : IDisposable
         var outputs = ParseGitHubOutputFile();
         Assert.Single(outputs["tests_matrix_no_nugets"].Include);
         Assert.Equal("Plain", outputs["tests_matrix_no_nugets"].Include[0].Name);
-        Assert.Single(outputs["tests_matrix_requires_nugets"].Include);
-        Assert.Equal("NugetTest", outputs["tests_matrix_requires_nugets"].Include[0].Name);
+        Assert.Single(outputs["tests_matrix_requires_nugets_linux"].Include);
+        Assert.Equal("NugetTest", outputs["tests_matrix_requires_nugets_linux"].Include[0].Name);
+    }
+
+    [Fact]
+    [RequiresTools(["pwsh"])]
+    public async Task SplitsRequiresNugetsByOs()
+    {
+        var matrixJson = BuildMatrixJson(
+            new { name = "LinuxNuget", shortname = "ln", runs_on = "ubuntu-latest", requiresNugets = true },
+            new { name = "WinNuget", shortname = "wn", runs_on = "windows-latest", requiresNugets = true },
+            new { name = "MacNuget", shortname = "mn", runs_on = "macos-latest", requiresNugets = true });
+
+        var result = await RunScript(allTestsMatrix: matrixJson);
+
+        result.EnsureSuccessful();
+
+        var outputs = ParseGitHubOutputFile();
+        Assert.Single(outputs["tests_matrix_requires_nugets_linux"].Include);
+        Assert.Equal("LinuxNuget", outputs["tests_matrix_requires_nugets_linux"].Include[0].Name);
+        Assert.Single(outputs["tests_matrix_requires_nugets_windows"].Include);
+        Assert.Equal("WinNuget", outputs["tests_matrix_requires_nugets_windows"].Include[0].Name);
+        Assert.Single(outputs["tests_matrix_requires_nugets_macos"].Include);
+        Assert.Equal("MacNuget", outputs["tests_matrix_requires_nugets_macos"].Include[0].Name);
     }
 
     [Fact]
@@ -95,7 +117,7 @@ public class SplitTestMatrixByDepsTests : IDisposable
 
         var outputs = ParseGitHubOutputFile();
         Assert.Single(outputs["tests_matrix_requires_cli_archive"].Include);
-        Assert.Empty(outputs["tests_matrix_requires_nugets"].Include);
+        Assert.Empty(outputs["tests_matrix_requires_nugets_linux"].Include);
     }
 
     [Fact]
@@ -147,13 +169,15 @@ public class SplitTestMatrixByDepsTests : IDisposable
         var outputs = ParseGitHubOutputFile();
         Assert.Empty(outputs["tests_matrix_no_nugets"].Include);
         Assert.Empty(outputs["tests_matrix_no_nugets_overflow"].Include);
-        Assert.Empty(outputs["tests_matrix_requires_nugets"].Include);
+        Assert.Empty(outputs["tests_matrix_requires_nugets_linux"].Include);
+        Assert.Empty(outputs["tests_matrix_requires_nugets_windows"].Include);
+        Assert.Empty(outputs["tests_matrix_requires_nugets_macos"].Include);
         Assert.Empty(outputs["tests_matrix_requires_cli_archive"].Include);
     }
 
     [Fact]
     [RequiresTools(["pwsh"])]
-    public async Task AllFourOutputKeysAlwaysPresent()
+    public async Task AllOutputKeysAlwaysPresent()
     {
         var matrixJson = BuildMatrixJson(
             new { name = "T", shortname = "t", runs_on = "ubuntu-latest" });
@@ -165,7 +189,9 @@ public class SplitTestMatrixByDepsTests : IDisposable
         var outputs = ParseGitHubOutputFile();
         Assert.True(outputs.ContainsKey("tests_matrix_no_nugets"));
         Assert.True(outputs.ContainsKey("tests_matrix_no_nugets_overflow"));
-        Assert.True(outputs.ContainsKey("tests_matrix_requires_nugets"));
+        Assert.True(outputs.ContainsKey("tests_matrix_requires_nugets_linux"));
+        Assert.True(outputs.ContainsKey("tests_matrix_requires_nugets_windows"));
+        Assert.True(outputs.ContainsKey("tests_matrix_requires_nugets_macos"));
         Assert.True(outputs.ContainsKey("tests_matrix_requires_cli_archive"));
     }
 
@@ -257,7 +283,21 @@ public class SplitTestMatrixByDepsTests : IDisposable
 
     private static string BuildMatrixJson(params object[] entries)
     {
-        var matrix = new { include = entries };
+        // Use dictionaries to produce JSON with the exact property names the PS script expects.
+        // In particular, 'runs-on' requires a hyphen which C# identifiers cannot express.
+        var convertedEntries = new List<Dictionary<string, object>>();
+        foreach (var entry in entries)
+        {
+            var dict = new Dictionary<string, object>();
+            foreach (var prop in entry.GetType().GetProperties())
+            {
+                var key = prop.Name == "runs_on" ? "runs-on" : prop.Name;
+                dict[key] = prop.GetValue(entry)!;
+            }
+            convertedEntries.Add(dict);
+        }
+
+        var matrix = new { include = convertedEntries };
         return JsonSerializer.Serialize(matrix);
     }
 


### PR DESCRIPTION
## Why

The main goal of this change is to reduce total PR validation time. Today the workflow serializes more CI work than necessary, which delays when test lanes can begin and stretches the full end-to-end validation path for a pull request.

## How

- decouple the CLI archive workflow from `build_packages` by letting the archive workflow build the bundle dependencies it needs itself
- remove duplicated work from `build_packages` so shared package production and CLI archive production can proceed in parallel
- move RID-specific DCP/Dashboard NuGet publication to the CLI archive lanes that actually produce those artifacts
- split CLI archive builds by platform and split `requires_nugets` test lanes by OS so each lane waits only for the artifacts it consumes
- remove stale summary scaffolding from `tests.yml`
- document the dependency graph and pipeline shape in `docs/ci/TestingOnCI.md` and `docs/ci/ci-pipeline-optimizations.md`

## Benefit

- package-dependent and CLI-dependent tests can start sooner
- the workflow does less duplicated work and spends less time blocked on unrelated lanes
- overall PR validation wall-clock time goes down because dependencies are better aligned with the order in which artifacts are built and consumed
- the CI topology is easier to maintain because the new dependency model is documented

## Notes

This is workflow and infrastructure work only; it does not change product behavior.

## Before
<img width="2342" height="375" alt="Screenshot 2026-03-06 at 22 37 06" src="https://github.com/user-attachments/assets/ec94d8bf-1912-4c7e-bc2f-2a752dc7743d" />


## After
<img width="1308" height="768" alt="Screenshot 2026-03-06 at 22 38 01" src="https://github.com/user-attachments/assets/7f2fe13e-15c4-42fd-9464-a27aa2b2de91" />

## Must check before merging

- [x] Run the outerloop workflow
- [x] Run the quarantine workflow
- [x] Run the get-aspire-cli-pr scripts and confirm that they still work
