### PR TITLE
Enhancements to Azure Network integration

### DIFF
--- a/src/Aspire.Hosting.Azure.Network/AzureNetworkSecurityGroupExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzureNetworkSecurityGroupExtensions.cs
@@ -131,12 +131,36 @@ public static class AzureNetworkSecurityGroupExtensions
                 Direction = rule.Direction,
                 Access = rule.Access,
                 Protocol = rule.Protocol,
-                SourceAddressPrefix = rule.SourceAddressPrefix,
                 SourcePortRange = rule.SourcePortRange,
-                DestinationAddressPrefix = rule.DestinationAddressPrefix,
                 DestinationPortRange = rule.DestinationPortRange,
                 Parent = nsg,
             };
+
+            if (rule.Description is { } description)
+            {
+                securityRule.Description = description;
+            }
+
+            // When a reference expression is provided (e.g. a PIP IP resolved at deploy time),
+            // use it as a provisioning parameter; otherwise use the static address prefix.
+            if (rule.SourceAddressPrefixReference is { } sourceAddressReference)
+            {
+                securityRule.SourceAddressPrefix = sourceAddressReference.AsProvisioningParameter(infra);
+            }
+            else
+            {
+                securityRule.SourceAddressPrefix = rule.SourceAddressPrefix;
+            }
+
+            if (rule.DestinationAddressPrefixReference is { } destinationAddressReference)
+            {
+                securityRule.DestinationAddressPrefix = destinationAddressReference.AsProvisioningParameter(infra);
+            }
+            else
+            {
+                securityRule.DestinationAddressPrefix = rule.DestinationAddressPrefix;
+            }
+
             infra.Add(securityRule);
         }
 

--- a/src/Aspire.Hosting.Azure.Network/AzurePublicIPAddressExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzurePublicIPAddressExtensions.cs
@@ -80,5 +80,10 @@ public static class AzurePublicIPAddressExtensions
         {
             Value = pip.Name
         });
+
+        infra.Add(new ProvisioningOutput("ipAddress", typeof(string))
+        {
+            Value = pip.IPAddress
+        });
     }
 }

--- a/src/Aspire.Hosting.Azure.Network/AzurePublicIPAddressResource.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzurePublicIPAddressResource.cs
@@ -28,6 +28,11 @@ public class AzurePublicIPAddressResource(string name, Action<AzureResourceInfra
     /// </summary>
     public BicepOutputReference NameOutput => new("name", this);
 
+    /// <summary>
+    /// Gets the "ipAddress" output reference containing the allocated IP address for the resource.
+    /// </summary>
+    public BicepOutputReference IpAddress => new("ipAddress", this);
+
     /// <inheritdoc/>
     public override ProvisionableResource AddAsExistingResource(AzureResourceInfrastructure infra)
     {

--- a/src/Aspire.Hosting.Azure.Network/AzureSecurityRule.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzureSecurityRule.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.ApplicationModel;
 using Azure.Provisioning.Network;
 
 namespace Aspire.Hosting.Azure;
@@ -18,6 +19,11 @@ public sealed class AzureSecurityRule
     /// Gets or sets the name of the security rule. This name must be unique within the Network Security Group.
     /// </summary>
     public required string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional description for the security rule.
+    /// </summary>
+    public string? Description { get; set; }
 
     /// <summary>
     /// Gets or sets the priority of the rule. Valid values are between 100 and 4096. Lower numbers have higher priority.
@@ -45,6 +51,13 @@ public sealed class AzureSecurityRule
     public string SourceAddressPrefix { get; set; } = "*";
 
     /// <summary>
+    /// Gets or sets a <see cref="ReferenceExpression"/> whose value is resolved at deploy time
+    /// and used as the source address prefix for the rule. Takes precedence over
+    /// <see cref="SourceAddressPrefix"/>.
+    /// </summary>
+    public ReferenceExpression? SourceAddressPrefixReference { get; set; }
+
+    /// <summary>
     /// Gets or sets the source port range. Defaults to "*" (any).
     /// </summary>
     public string SourcePortRange { get; set; } = "*";
@@ -53,6 +66,13 @@ public sealed class AzureSecurityRule
     /// Gets or sets the destination address prefix. Defaults to "*" (any).
     /// </summary>
     public string DestinationAddressPrefix { get; set; } = "*";
+
+    /// <summary>
+    /// Gets or sets a <see cref="ReferenceExpression"/> whose value is resolved at deploy time
+    /// and used as the destination address prefix for the rule. Takes precedence over
+    /// <see cref="DestinationAddressPrefix"/>.
+    /// </summary>
+    public ReferenceExpression? DestinationAddressPrefixReference { get; set; }
 
     /// <summary>
     /// Gets or sets the destination port range. Use "*" for any, or a range like "80-443".

--- a/tests/Aspire.Hosting.Azure.Tests/AzureManifestUtils.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureManifestUtils.cs
@@ -48,7 +48,7 @@ public sealed class AzureManifestUtils
 
     public static async Task VerifyAllAzureBicep(IDistributedApplicationBuilder builder)
     {
-        var app = builder.Build();
+        await using var app = builder.Build();
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
         await ExecuteBeforeStartHooksAsync(app, default);
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureManifestUtils.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureManifestUtils.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Text.Json.Nodes;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Tests.Utils;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Utils;
@@ -42,6 +44,33 @@ public sealed class AzureManifestUtils
 
         var bicepText = await File.ReadAllTextAsync(Path.Combine(manifestDir, path));
         return (manifestNode, bicepText);
+    }
+
+    public static async Task VerifyAllAzureBicep(IDistributedApplicationBuilder builder)
+    {
+        var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        // Collect bicep for all Azure provisioning resources, ordered by name for deterministic output
+        var azureResources = model.Resources
+            .OfType<AzureProvisioningResource>()
+            .OrderBy(r => r.Name)
+            .ToList();
+
+        var sb = new StringBuilder();
+
+        foreach (var resource in azureResources)
+        {
+            var (_, bicep) = await GetManifestWithBicep(resource, skipPreparer: true);
+
+            sb.AppendLine($"// Resource: {resource.Name}");
+            sb.AppendLine(bicep);
+            sb.AppendLine();
+        }
+
+        await Verify(sb.ToString(), extension: "bicep")
+            .ScrubLinesWithReplace(s => s.Replace("\\r\\n", "\\n"));
     }
 
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "ExecuteBeforeStartHooksAsync")]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureNatGatewayExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureNatGatewayExtensionsTests.cs
@@ -91,4 +91,14 @@ public class AzureNatGatewayExtensionsTests
 
         await Verify(manifest.BicepText, extension: "bicep");
     }
+
+    [Fact]
+    public void AddPublicIPAddress_HasIpAddressOutputReference()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var pip = builder.AddPublicIPAddress("mypip");
+
+        Assert.Equal("ipAddress", pip.Resource.IpAddress.Name);
+    }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureNetworkSecurityGroupExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureNetworkSecurityGroupExtensionsTests.cs
@@ -4,6 +4,7 @@
 #pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
+using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Azure.Provisioning.Network;
 
@@ -58,6 +59,7 @@ public class AzureNetworkSecurityGroupExtensionsTests
             .WithSecurityRule(new AzureSecurityRule
             {
                 Name = "allow-https",
+                Description = "Allow HTTPS traffic from any source",
                 Priority = 100,
                 Direction = SecurityRuleDirection.Inbound,
                 Access = SecurityRuleAccess.Allow,
@@ -77,9 +79,7 @@ public class AzureNetworkSecurityGroupExtensionsTests
         vnet.AddSubnet("web-subnet", "10.0.1.0/24")
             .WithNetworkSecurityGroup(nsg);
 
-        var manifest = await AzureManifestUtils.GetManifestWithBicep(vnet.Resource);
-
-        await Verify(manifest.BicepText, extension: "bicep");
+        await AzureManifestUtils.VerifyAllAzureBicep(builder);
     }
 
     [Fact]
@@ -135,9 +135,7 @@ public class AzureNetworkSecurityGroupExtensionsTests
         vnet.AddSubnet("web-subnet", "10.0.1.0/24")
             .WithNetworkSecurityGroup(nsg);
 
-        var manifest = await AzureManifestUtils.GetManifestWithBicep(vnet.Resource);
-
-        await Verify(manifest.BicepText, extension: "bicep");
+        await AzureManifestUtils.VerifyAllAzureBicep(builder);
     }
 
     [Fact]
@@ -165,9 +163,7 @@ public class AzureNetworkSecurityGroupExtensionsTests
         vnet.AddSubnet("subnet2", "10.0.2.0/24")
             .WithNetworkSecurityGroup(nsg);
 
-        var manifest = await AzureManifestUtils.GetManifestWithBicep(vnet.Resource);
-
-        await Verify(manifest.BicepText, extension: "bicep");
+        await AzureManifestUtils.VerifyAllAzureBicep(builder);
     }
 
     [Fact]
@@ -258,9 +254,7 @@ public class AzureNetworkSecurityGroupExtensionsTests
         vnet.AddSubnet("subnet2", "10.0.2.0/24")
             .WithNetworkSecurityGroup(nsg2);
 
-        var manifest = await AzureManifestUtils.GetManifestWithBicep(vnet.Resource);
-
-        await Verify(manifest.BicepText, extension: "bicep");
+        await AzureManifestUtils.VerifyAllAzureBicep(builder);
     }
 
     [Fact]
@@ -299,5 +293,49 @@ public class AzureNetworkSecurityGroupExtensionsTests
         var manifest = await AzureManifestUtils.GetManifestWithBicep(nsg.Resource);
 
         await Verify(manifest.BicepText, extension: "bicep");
+    }
+
+    [Fact]
+    public async Task AddNetworkSecurityGroup_WithSourceAddressPrefixReference_GeneratesCorrectBicep()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var pip = builder.AddPublicIPAddress("mypip");
+
+        var nsg = builder.AddNetworkSecurityGroup("web-nsg")
+            .WithSecurityRule(new AzureSecurityRule
+            {
+                Name = "allow-from-pip",
+                Priority = 100,
+                Direction = SecurityRuleDirection.Inbound,
+                Access = SecurityRuleAccess.Allow,
+                Protocol = SecurityRuleProtocol.Tcp,
+                DestinationPortRange = "443",
+                SourceAddressPrefixReference = ReferenceExpression.Create($"{pip.Resource.IpAddress}")
+            });
+
+        await AzureManifestUtils.VerifyAllAzureBicep(builder);
+    }
+
+    [Fact]
+    public async Task AddNetworkSecurityGroup_WithDestinationAddressPrefixReference_GeneratesCorrectBicep()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var pip = builder.AddPublicIPAddress("mypip");
+
+        var nsg = builder.AddNetworkSecurityGroup("web-nsg")
+            .WithSecurityRule(new AzureSecurityRule
+            {
+                Name = "route-to-pip",
+                Priority = 100,
+                Direction = SecurityRuleDirection.Outbound,
+                Access = SecurityRuleAccess.Allow,
+                Protocol = SecurityRuleProtocol.Tcp,
+                DestinationPortRange = "443",
+                DestinationAddressPrefixReference = ReferenceExpression.Create($"{pip.Resource.IpAddress}")
+            });
+
+        await AzureManifestUtils.VerifyAllAzureBicep(builder);
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureNetworkSecurityGroupExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureNetworkSecurityGroupExtensionsTests.cs
@@ -302,7 +302,7 @@ public class AzureNetworkSecurityGroupExtensionsTests
 
         var pip = builder.AddPublicIPAddress("mypip");
 
-        var nsg = builder.AddNetworkSecurityGroup("web-nsg")
+        builder.AddNetworkSecurityGroup("web-nsg")
             .WithSecurityRule(new AzureSecurityRule
             {
                 Name = "allow-from-pip",
@@ -324,7 +324,7 @@ public class AzureNetworkSecurityGroupExtensionsTests
 
         var pip = builder.AddPublicIPAddress("mypip");
 
-        var nsg = builder.AddNetworkSecurityGroup("web-nsg")
+        builder.AddNetworkSecurityGroup("web-nsg")
             .WithSecurityRule(new AzureSecurityRule
             {
                 Name = "route-to-pip",

--- a/tests/Aspire.Hosting.Azure.Tests/AzureSqlDeploymentScriptTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureSqlDeploymentScriptTests.cs
@@ -3,10 +3,7 @@
 
 #pragma warning disable ASPIREAZURE003
 
-using System.Text;
-using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
-using Microsoft.Extensions.DependencyInjection;
 using static Aspire.Hosting.Utils.AzureManifestUtils;
 
 namespace Aspire.Hosting.Azure.Tests;
@@ -170,39 +167,6 @@ public class AzureSqlDeploymentScriptTests
             .WithReference(db);
 
         await VerifyAllAzureBicep(builder);
-    }
-
-    private static async Task VerifyAllAzureBicep(IDistributedApplicationBuilder builder)
-    {
-        var app = builder.Build();
-        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
-        await ExecuteBeforeStartHooksAsync(app, default);
-
-        // Collect bicep for all Azure provisioning resources, ordered by name for deterministic output
-        var azureResources = model.Resources
-            .OfType<AzureProvisioningResource>()
-            .OrderBy(r => r.Name)
-            .ToList();
-
-        var sb = new StringBuilder();
-
-        foreach (var resource in azureResources)
-        {
-            var bicep = await GetBicep(resource);
-
-            sb.AppendLine($"// Resource: {resource.Name}");
-            sb.AppendLine(bicep);
-            sb.AppendLine();
-        }
-
-        await Verify(sb.ToString(), extension: "bicep")
-            .ScrubLinesWithReplace(s => s.Replace("\\r\\n", "\\n"));
-    }
-
-    private static async Task<string> GetBicep(IResource resource)
-    {
-        var (_, bicep) = await AzureManifestUtils.GetManifestWithBicep(resource, skipPreparer: true);
-        return bicep;
     }
 
     private sealed class Project : IProjectMetadata

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureNatGatewayExtensionsTests.AddPublicIPAddress_GeneratesCorrectBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureNatGatewayExtensionsTests.AddPublicIPAddress_GeneratesCorrectBicep.verified.bicep
@@ -18,3 +18,5 @@ resource mypip 'Microsoft.Network/publicIPAddresses@2025-05-01' = {
 output id string = mypip.id
 
 output name string = mypip.name
+
+output ipAddress string = mypip.properties.ipAddress

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureNetworkSecurityGroupExtensionsTests.AddNetworkSecurityGroup_SharedAcrossSubnets_GeneratesCorrectBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureNetworkSecurityGroupExtensionsTests.AddNetworkSecurityGroup_SharedAcrossSubnets_GeneratesCorrectBicep.verified.bicep
@@ -1,4 +1,5 @@
-﻿@description('The location for the resource(s) to be deployed.')
+﻿// Resource: myvnet
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param shared_nsg_outputs_id string
@@ -50,3 +51,35 @@ output subnet2_Id string = subnet2.id
 output id string = myvnet.id
 
 output name string = myvnet.name
+
+// Resource: shared-nsg
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+resource shared_nsg 'Microsoft.Network/networkSecurityGroups@2025-05-01' = {
+  name: take('shared_nsg-${uniqueString(resourceGroup().id)}', 80)
+  location: location
+  tags: {
+    'aspire-resource-name': 'shared-nsg'
+  }
+}
+
+resource shared_nsg_allow_https 'Microsoft.Network/networkSecurityGroups/securityRules@2025-05-01' = {
+  name: 'allow-https'
+  properties: {
+    access: 'Allow'
+    destinationAddressPrefix: '*'
+    destinationPortRange: '443'
+    direction: 'Inbound'
+    priority: 100
+    protocol: 'Tcp'
+    sourceAddressPrefix: '*'
+    sourcePortRange: '*'
+  }
+  parent: shared_nsg
+}
+
+output id string = shared_nsg.id
+
+output name string = shared_nsg.name
+

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureNetworkSecurityGroupExtensionsTests.AddNetworkSecurityGroup_WithDestinationAddressPrefixReference_GeneratesCorrectBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureNetworkSecurityGroupExtensionsTests.AddNetworkSecurityGroup_WithDestinationAddressPrefixReference_GeneratesCorrectBicep.verified.bicep
@@ -1,0 +1,57 @@
+﻿// Resource: mypip
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+resource mypip 'Microsoft.Network/publicIPAddresses@2025-05-01' = {
+  name: take('mypip-${uniqueString(resourceGroup().id)}', 80)
+  location: location
+  properties: {
+    publicIPAllocationMethod: 'Static'
+  }
+  sku: {
+    name: 'Standard'
+  }
+  tags: {
+    'aspire-resource-name': 'mypip'
+  }
+}
+
+output id string = mypip.id
+
+output name string = mypip.name
+
+output ipAddress string = mypip.properties.ipAddress
+
+// Resource: web-nsg
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param mypip_outputs_ipaddress string
+
+resource web_nsg 'Microsoft.Network/networkSecurityGroups@2025-05-01' = {
+  name: take('web_nsg-${uniqueString(resourceGroup().id)}', 80)
+  location: location
+  tags: {
+    'aspire-resource-name': 'web-nsg'
+  }
+}
+
+resource web_nsg_route_to_pip 'Microsoft.Network/networkSecurityGroups/securityRules@2025-05-01' = {
+  name: 'route-to-pip'
+  properties: {
+    access: 'Allow'
+    destinationAddressPrefix: mypip_outputs_ipaddress
+    destinationPortRange: '443'
+    direction: 'Outbound'
+    priority: 100
+    protocol: 'Tcp'
+    sourceAddressPrefix: '*'
+    sourcePortRange: '*'
+  }
+  parent: web_nsg
+}
+
+output id string = web_nsg.id
+
+output name string = web_nsg.name
+

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureNetworkSecurityGroupExtensionsTests.AddNetworkSecurityGroup_WithSecurityRules_GeneratesCorrectBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureNetworkSecurityGroupExtensionsTests.AddNetworkSecurityGroup_WithSecurityRules_GeneratesCorrectBicep.verified.bicep
@@ -1,4 +1,5 @@
-﻿@description('The location for the resource(s) to be deployed.')
+﻿// Resource: myvnet
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param web_nsg_outputs_id string
@@ -34,3 +35,51 @@ output web_subnet_Id string = web_subnet.id
 output id string = myvnet.id
 
 output name string = myvnet.name
+
+// Resource: web-nsg
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+resource web_nsg 'Microsoft.Network/networkSecurityGroups@2025-05-01' = {
+  name: take('web_nsg-${uniqueString(resourceGroup().id)}', 80)
+  location: location
+  tags: {
+    'aspire-resource-name': 'web-nsg'
+  }
+}
+
+resource web_nsg_allow_https 'Microsoft.Network/networkSecurityGroups/securityRules@2025-05-01' = {
+  name: 'allow-https'
+  properties: {
+    access: 'Allow'
+    description: 'Allow HTTPS traffic from any source'
+    destinationAddressPrefix: '*'
+    destinationPortRange: '443'
+    direction: 'Inbound'
+    priority: 100
+    protocol: 'Tcp'
+    sourceAddressPrefix: '*'
+    sourcePortRange: '*'
+  }
+  parent: web_nsg
+}
+
+resource web_nsg_deny_all_inbound 'Microsoft.Network/networkSecurityGroups/securityRules@2025-05-01' = {
+  name: 'deny-all-inbound'
+  properties: {
+    access: 'Deny'
+    destinationAddressPrefix: '*'
+    destinationPortRange: '*'
+    direction: 'Inbound'
+    priority: 4096
+    protocol: '*'
+    sourceAddressPrefix: '*'
+    sourcePortRange: '*'
+  }
+  parent: web_nsg
+}
+
+output id string = web_nsg.id
+
+output name string = web_nsg.name
+

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureNetworkSecurityGroupExtensionsTests.AddNetworkSecurityGroup_WithSourceAddressPrefixReference_GeneratesCorrectBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureNetworkSecurityGroupExtensionsTests.AddNetworkSecurityGroup_WithSourceAddressPrefixReference_GeneratesCorrectBicep.verified.bicep
@@ -1,0 +1,57 @@
+﻿// Resource: mypip
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+resource mypip 'Microsoft.Network/publicIPAddresses@2025-05-01' = {
+  name: take('mypip-${uniqueString(resourceGroup().id)}', 80)
+  location: location
+  properties: {
+    publicIPAllocationMethod: 'Static'
+  }
+  sku: {
+    name: 'Standard'
+  }
+  tags: {
+    'aspire-resource-name': 'mypip'
+  }
+}
+
+output id string = mypip.id
+
+output name string = mypip.name
+
+output ipAddress string = mypip.properties.ipAddress
+
+// Resource: web-nsg
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param mypip_outputs_ipaddress string
+
+resource web_nsg 'Microsoft.Network/networkSecurityGroups@2025-05-01' = {
+  name: take('web_nsg-${uniqueString(resourceGroup().id)}', 80)
+  location: location
+  tags: {
+    'aspire-resource-name': 'web-nsg'
+  }
+}
+
+resource web_nsg_allow_from_pip 'Microsoft.Network/networkSecurityGroups/securityRules@2025-05-01' = {
+  name: 'allow-from-pip'
+  properties: {
+    access: 'Allow'
+    destinationAddressPrefix: '*'
+    destinationPortRange: '443'
+    direction: 'Inbound'
+    priority: 100
+    protocol: 'Tcp'
+    sourceAddressPrefix: mypip_outputs_ipaddress
+    sourcePortRange: '*'
+  }
+  parent: web_nsg
+}
+
+output id string = web_nsg.id
+
+output name string = web_nsg.name
+

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureNetworkSecurityGroupExtensionsTests.AddSubnet_WithNetworkSecurityGroup_GeneratesCorrectBicep.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureNetworkSecurityGroupExtensionsTests.AddSubnet_WithNetworkSecurityGroup_GeneratesCorrectBicep.verified.bicep
@@ -1,4 +1,5 @@
-﻿@description('The location for the resource(s) to be deployed.')
+﻿// Resource: myvnet
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param web_nsg_outputs_id string
@@ -34,3 +35,35 @@ output web_subnet_Id string = web_subnet.id
 output id string = myvnet.id
 
 output name string = myvnet.name
+
+// Resource: web-nsg
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+resource web_nsg 'Microsoft.Network/networkSecurityGroups@2025-05-01' = {
+  name: take('web_nsg-${uniqueString(resourceGroup().id)}', 80)
+  location: location
+  tags: {
+    'aspire-resource-name': 'web-nsg'
+  }
+}
+
+resource web_nsg_allow_https 'Microsoft.Network/networkSecurityGroups/securityRules@2025-05-01' = {
+  name: 'allow-https'
+  properties: {
+    access: 'Allow'
+    destinationAddressPrefix: '*'
+    destinationPortRange: '443'
+    direction: 'Inbound'
+    priority: 100
+    protocol: 'Tcp'
+    sourceAddressPrefix: '*'
+    sourcePortRange: '*'
+  }
+  parent: web_nsg
+}
+
+output id string = web_nsg.id
+
+output name string = web_nsg.name
+

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureNetworkSecurityGroupExtensionsTests.MultipleNSGs_WithSameRuleName_GeneratesDistinctBicepIdentifiers.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureNetworkSecurityGroupExtensionsTests.MultipleNSGs_WithSameRuleName_GeneratesDistinctBicepIdentifiers.verified.bicep
@@ -1,4 +1,5 @@
-﻿@description('The location for the resource(s) to be deployed.')
+﻿// Resource: myvnet
+@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param nsg_one_outputs_id string
@@ -52,3 +53,66 @@ output subnet2_Id string = subnet2.id
 output id string = myvnet.id
 
 output name string = myvnet.name
+
+// Resource: nsg-one
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+resource nsg_one 'Microsoft.Network/networkSecurityGroups@2025-05-01' = {
+  name: take('nsg_one-${uniqueString(resourceGroup().id)}', 80)
+  location: location
+  tags: {
+    'aspire-resource-name': 'nsg-one'
+  }
+}
+
+resource nsg_one_allow_https 'Microsoft.Network/networkSecurityGroups/securityRules@2025-05-01' = {
+  name: 'allow-https'
+  properties: {
+    access: 'Allow'
+    destinationAddressPrefix: '*'
+    destinationPortRange: '443'
+    direction: 'Inbound'
+    priority: 100
+    protocol: 'Tcp'
+    sourceAddressPrefix: '*'
+    sourcePortRange: '*'
+  }
+  parent: nsg_one
+}
+
+output id string = nsg_one.id
+
+output name string = nsg_one.name
+
+// Resource: nsg-two
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+resource nsg_two 'Microsoft.Network/networkSecurityGroups@2025-05-01' = {
+  name: take('nsg_two-${uniqueString(resourceGroup().id)}', 80)
+  location: location
+  tags: {
+    'aspire-resource-name': 'nsg-two'
+  }
+}
+
+resource nsg_two_allow_https 'Microsoft.Network/networkSecurityGroups/securityRules@2025-05-01' = {
+  name: 'allow-https'
+  properties: {
+    access: 'Allow'
+    destinationAddressPrefix: '*'
+    destinationPortRange: '443'
+    direction: 'Inbound'
+    priority: 100
+    protocol: 'Tcp'
+    sourceAddressPrefix: 'VirtualNetwork'
+    sourcePortRange: '*'
+  }
+  parent: nsg_two
+}
+
+output id string = nsg_two.id
+
+output name string = nsg_two.name
+


### PR DESCRIPTION
## Description

Add IpAddress output and enhance security rules in Azure.Network

- Add IpAddress BicepOutputReference to AzurePublicIPAddressResource, emitting the allocated IP address as a provisioning output
 - Add SourceAddressPrefixReference and DestinationAddressPrefixReference (ReferenceExpression) to AzureSecurityRule for deploy-time resolved address prefixes in NSG rules
- Add optional Description property to AzureSecurityRule
- Add tests and Bicep snapshots for all new features

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
