### PR TITLE
Reduce the number of PR validation jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -276,26 +276,35 @@ jobs:
       - name: Fail if any dependency failed
         # 'skipped' can be when a transitive dependency fails and the dependent job gets 'skipped'.
         # For example, one of setup_* jobs failing and the dependent test jobs getting 'skipped'.
-        # Overflow jobs are intentionally skipped when below the overflow threshold, so we
-        # check specific job names rather than using contains(needs.*.result, 'skipped').
+        # Some matrix jobs are also intentionally skipped when their split matrix is empty, so only
+        # treat skipped matrix-backed jobs as failures when setup_for_tests populated their matrix.
         if: >-
           ${{ always() &&
               (contains(needs.*.result, 'failure') ||
                contains(needs.*.result, 'cancelled') ||
                (github.event_name == 'pull_request' &&
                 (needs.extension_tests_win.result == 'skipped' ||
-                 needs.tests_no_nugets.result == 'skipped' ||
-                 needs.tests_requires_nugets_linux.result == 'skipped' ||
-                 needs.tests_requires_nugets_windows.result == 'skipped' ||
-                 needs.tests_requires_nugets_macos.result == 'skipped' ||
-                 needs.tests_requires_cli_archive.result == 'skipped' ||
+                 (fromJson(needs.setup_for_tests.outputs.tests_matrix_no_nugets).include[0] != null &&
+                  needs.tests_no_nugets.result == 'skipped') ||
+                 (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_linux).include[0] != null &&
+                  needs.tests_requires_nugets_linux.result == 'skipped') ||
+                 (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_windows).include[0] != null &&
+                  needs.tests_requires_nugets_windows.result == 'skipped') ||
+                 (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_macos).include[0] != null &&
+                  needs.tests_requires_nugets_macos.result == 'skipped') ||
+                 (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_cli_archive).include[0] != null &&
+                  needs.tests_requires_cli_archive.result == 'skipped') ||
                  needs.polyglot_validation.result == 'skipped')) ||
                (github.event_name != 'pull_request' &&
                 (needs.extension_tests_win.result == 'skipped' ||
-                 needs.tests_no_nugets.result == 'skipped' ||
-                 needs.tests_requires_nugets_linux.result == 'skipped' ||
-                 needs.tests_requires_nugets_windows.result == 'skipped' ||
-                 needs.tests_requires_nugets_macos.result == 'skipped' ||
+                 (fromJson(needs.setup_for_tests.outputs.tests_matrix_no_nugets).include[0] != null &&
+                  needs.tests_no_nugets.result == 'skipped') ||
+                 (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_linux).include[0] != null &&
+                  needs.tests_requires_nugets_linux.result == 'skipped') ||
+                 (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_windows).include[0] != null &&
+                  needs.tests_requires_nugets_windows.result == 'skipped') ||
+                 (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_macos).include[0] != null &&
+                  needs.tests_requires_nugets_macos.result == 'skipped') ||
                  needs.polyglot_validation.result == 'skipped'))) }}
         run: |
           echo "One or more dependent jobs failed."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -276,36 +276,34 @@ jobs:
       - name: Fail if any dependency failed
         # 'skipped' can be when a transitive dependency fails and the dependent job gets 'skipped'.
         # For example, one of setup_* jobs failing and the dependent test jobs getting 'skipped'.
-        # Some matrix jobs are also intentionally skipped when their split matrix is empty, so only
-        # treat skipped matrix-backed jobs as failures when setup_for_tests populated their matrix.
+        # Some jobs are optional and can have an empty matrix. In those cases we allow a 'skipped'
+        # result. Specifically:
+        # - tests_no_nugets_overflow: this overflow bucket is expected to be empty unless the
+        #   primary no-nugets matrix exceeds the overflow threshold.
+        # - tests_requires_nugets_macos: some runs intentionally produce no macOS requires-nugets
+        #   tests, so an empty matrix and 'skipped' result are expected.
+        # All other jobs in this gate are required, and a 'skipped' result is treated as a failure.
         if: >-
           ${{ always() &&
               (contains(needs.*.result, 'failure') ||
-               contains(needs.*.result, 'cancelled') ||
-               (github.event_name == 'pull_request' &&
-                (needs.extension_tests_win.result == 'skipped' ||
-                 (fromJson(needs.setup_for_tests.outputs.tests_matrix_no_nugets).include[0] != null &&
-                  needs.tests_no_nugets.result == 'skipped') ||
-                 (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_linux).include[0] != null &&
-                  needs.tests_requires_nugets_linux.result == 'skipped') ||
-                 (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_windows).include[0] != null &&
-                  needs.tests_requires_nugets_windows.result == 'skipped') ||
-                 (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_macos).include[0] != null &&
-                  needs.tests_requires_nugets_macos.result == 'skipped') ||
-                 (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_cli_archive).include[0] != null &&
-                  needs.tests_requires_cli_archive.result == 'skipped') ||
-                 needs.polyglot_validation.result == 'skipped')) ||
-               (github.event_name != 'pull_request' &&
-                (needs.extension_tests_win.result == 'skipped' ||
-                 (fromJson(needs.setup_for_tests.outputs.tests_matrix_no_nugets).include[0] != null &&
-                  needs.tests_no_nugets.result == 'skipped') ||
-                 (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_linux).include[0] != null &&
-                  needs.tests_requires_nugets_linux.result == 'skipped') ||
-                 (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_windows).include[0] != null &&
-                  needs.tests_requires_nugets_windows.result == 'skipped') ||
-                 (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_macos).include[0] != null &&
-                  needs.tests_requires_nugets_macos.result == 'skipped') ||
-                 needs.polyglot_validation.result == 'skipped'))) }}
+                contains(needs.*.result, 'cancelled') ||
+                (github.event_name == 'pull_request' &&
+                 (needs.extension_tests_win.result == 'skipped' ||
+                   needs.tests_no_nugets.result == 'skipped' ||
+                   needs.tests_requires_nugets_linux.result == 'skipped' ||
+                   needs.tests_requires_nugets_windows.result == 'skipped' ||
+                   (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_macos).include[0] != null &&
+                    needs.tests_requires_nugets_macos.result == 'skipped') ||
+                   needs.tests_requires_cli_archive.result == 'skipped' ||
+                  needs.polyglot_validation.result == 'skipped')) ||
+                (github.event_name != 'pull_request' &&
+                 (needs.extension_tests_win.result == 'skipped' ||
+                   needs.tests_no_nugets.result == 'skipped' ||
+                   needs.tests_requires_nugets_linux.result == 'skipped' ||
+                   needs.tests_requires_nugets_windows.result == 'skipped' ||
+                   (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_macos).include[0] != null &&
+                    needs.tests_requires_nugets_macos.result == 'skipped') ||
+                  needs.polyglot_validation.result == 'skipped'))) }}
         run: |
           echo "One or more dependent jobs failed."
           exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,6 +318,7 @@ dotnet run --project tools/QuarantineTools -- -u -m activeissue Full.Namespace.T
 ## Outerloop tests
 
 - Tests that are long-running, resource-intensive, or require special infrastructure are marked with the `OuterloopTest` attribute.
+- In this repository, always use `OuterloopTest` for outerloop coverage; do not replace it with Arcade's `OuterLoop` attribute because our CI scripts and some test projects rely on assembly-level use of the custom trait.
 - Such tests are not run as part of the regular tests workflow (`tests.yml`).
     - Instead they are run in the `Outerloop` workflow (`tests-outerloop.yml`).
 - An optional reason can be provided with the attribute

--- a/eng/Testing.props
+++ b/eng/Testing.props
@@ -8,10 +8,14 @@
     <UncollectedTestsSessionTimeout Condition="'$(UncollectedTestsSessionTimeout)' == ''">15m</UncollectedTestsSessionTimeout>
     <UncollectedTestsHangTimeout Condition="'$(UncollectedTestsHangTimeout)' == ''">10m</UncollectedTestsHangTimeout>
 
+    <!-- Detect if we're running in the context of a GitHub pull request -->
+    <IsGithubPullRequest Condition="'$(GITHUB_EVENT_NAME)' == 'pull_request'">true</IsGithubPullRequest>
+
     <!-- By default any test can run on all test platforms -->
     <RunOnGithubActionsWindows>true</RunOnGithubActionsWindows>
     <RunOnGithubActionsLinux>true</RunOnGithubActionsLinux>
-    <RunOnGithubActionsMacOS>true</RunOnGithubActionsMacOS>
+    <RunOnGithubActionsMacOS Condition="'$(RunOnGithubActionsMacOS)' == '' and '$(IsGithubPullRequest)' == 'true' and $(MSBuildProjectName.StartsWith('Aspire.')) and !$(MSBuildProjectName.StartsWith('Aspire.Cli'))">false</RunOnGithubActionsMacOS>
+    <RunOnGithubActionsMacOS Condition="'$(RunOnGithubActionsMacOS)' == ''">true</RunOnGithubActionsMacOS>
     <RunOnAzdoCIWindows>true</RunOnAzdoCIWindows>
     <RunOnAzdoCILinux>true</RunOnAzdoCILinux>
     <RunOnAzdoHelixWindows>true</RunOnAzdoHelixWindows>

--- a/eng/scripts/generate-specialized-test-projects-list.sh
+++ b/eng/scripts/generate-specialized-test-projects-list.sh
@@ -20,8 +20,10 @@ OUTPUT_FILE="$2"
 
 mkdir -p "$(dirname "$OUTPUT_FILE")"
 
-# Find all test files with the attribute and extract unique top-level test directories
-PROJECTS=$(grep -rl "^ *\[${ATTRIBUTE_NAME}(\"[^\"]*\")\]" "$REPO_ROOT/tests" 2>/dev/null \
+# Find all test files with the attribute and extract unique top-level test directories.
+# Match both method/class-level attributes like [OuterloopTest("reason")] and
+# assembly-level attributes like [assembly: OuterloopTest("reason")].
+PROJECTS=$(grep -Erl "^[[:space:]]*\\[(assembly:[[:space:]]*)?${ATTRIBUTE_NAME}(Attribute)?(\\(\"[^\"]*\"\\))?\\]" "$REPO_ROOT/tests" 2>/dev/null \
     | while read -r file; do
         # Extract the top-level test directory (e.g., tests/Aspire.Hosting.Tests)
         rel_path="${file#$REPO_ROOT/}"

--- a/eng/scripts/split-test-projects-for-ci.ps1
+++ b/eng/scripts/split-test-projects-for-ci.ps1
@@ -131,7 +131,7 @@ if ($mode -eq 'class') {
   Write-Host "No partitions found. Running --list-tests to extract class names..."
 
   # Run the test assembly with --list-tests to get all test names
-  $testOutput = & $RunCommand --filter-not-trait category=failing --list-tests 2>&1
+  $testOutput = & $RunCommand --filter-not-trait category=failing --list-tests --filter-not-trait outerloop=true --filter-not-trait quarantined=true 2>&1
 
   if ($LASTEXITCODE -ne 0) {
     Write-Error "Test listing command failed with exit code $LASTEXITCODE"

--- a/tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj
@@ -14,7 +14,6 @@
 
     <!-- Deployment tests run on Linux via deployment-tests.yml (excluded from tests.yml via OnlyDeploymentTests) -->
     <RunOnGithubActionsWindows>false</RunOnGithubActionsWindows>
-    <RunOnGithubActionsMacOS>false</RunOnGithubActionsMacOS>
     <RunOnGithubActionsLinux>true</RunOnGithubActionsLinux>
 
     <!-- Do not run tests in Helix - use GitHub Actions matrix strategy instead -->

--- a/tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj
+++ b/tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <!-- Only run on Linux; no docker support on Windows yet -->
     <RunOnGithubActionsWindows>false</RunOnGithubActionsWindows>
-    <!-- Issue: https://github.com/dotnet/aspire/issues/9198 -->
-    <RunOnGithubActionsMacOS>false</RunOnGithubActionsMacOS>
     <RunOnAzdoCIWindows>false</RunOnAzdoCIWindows>
     <RunOnAzdoHelixWindows>false</RunOnAzdoHelixWindows>
 

--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/Aspire.Oracle.EntityFrameworkCore.Tests.csproj
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/Aspire.Oracle.EntityFrameworkCore.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(AllTargetFrameworks)</TargetFrameworks>
+    <SkipTests Condition="'$(IsGitHubActionsRunner)' == 'true' and '$(RunOuterloopTests)' != 'true'">true</SkipTests>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -11,7 +11,6 @@
 
     <!-- Only run on Linux; no docker support on Windows yet -->
     <RunOnGithubActionsWindows>false</RunOnGithubActionsWindows>
-    <RunOnGithubActionsMacOS>false</RunOnGithubActionsMacOS>
     <RunOnAzdoCIWindows>false</RunOnAzdoCIWindows>
     <RunOnAzdoHelixWindows>false</RunOnAzdoHelixWindows>
 

--- a/tests/Aspire.Templates.Tests/BuildAndRunStarterTemplateBuiltInTest.cs
+++ b/tests/Aspire.Templates.Tests/BuildAndRunStarterTemplateBuiltInTest.cs
@@ -28,7 +28,7 @@ public class BuildAndRunStarterTemplateBuiltInTest : TemplateTestsBase
 
     [Theory]
     [MemberData(nameof(TestFrameworkTypeWithConfig))]
-    [RequiresFeature(TestFeature.SSLCertificate)]
+    [RequiresFeature(TestFeature.Docker | TestFeature.SSLCertificate)]
     [Trait("category", "basic-build")]
     public async Task BuildAndRunStarterTemplateBuiltInTest_Test(string config, string testType)
     {

--- a/tests/Aspire.Templates.Tests/BuildAndRunTemplateTests.cs
+++ b/tests/Aspire.Templates.Tests/BuildAndRunTemplateTests.cs
@@ -30,7 +30,7 @@ public partial class BuildAndRunTemplateTests : TemplateTestsBase
     [MemberData(nameof(BuildConfigurationsForTestData))]
     [RequiresFeature(TestFeature.SSLCertificate), RequiresFeature(TestFeature.Playwright)]
     [Trait("category", "basic-build")]
-    [OuterLoop("playwright test")]
+    [OuterloopTest("playwright test")]
     public async Task BuildAndRunAspireTemplate(string config)
     {
         string id = GetNewProjectId(prefix: $"aspire_{config}");
@@ -165,7 +165,7 @@ public partial class BuildAndRunTemplateTests : TemplateTestsBase
     [MemberData(nameof(BuildConfigurationsForTestData))]
     [RequiresFeature(TestFeature.SSLCertificate), RequiresFeature(TestFeature.Playwright)]
     [Trait("category", "basic-build")]
-    [OuterLoop("playwright test")]
+    [OuterloopTest("playwright test")]
     public async Task StarterTemplateNewAndRunWithoutExplicitBuild(string config)
     {
         var id = GetNewProjectId(prefix: $"aspire_starter_run_{config}");
@@ -181,7 +181,7 @@ public partial class BuildAndRunTemplateTests : TemplateTestsBase
 
     [Fact]
     [RequiresFeature(TestFeature.Playwright)]
-    [OuterLoop("playwright test")]
+    [OuterloopTest("playwright test")]
     [ActiveIssue("https://github.com/dotnet/aspire/issues/9155", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOS))]
     public async Task ProjectWithNoHTTPSRequiresExplicitOverrideWithEnvironmentVariable()
     {

--- a/tests/Aspire.Templates.Tests/PerTestFrameworkTemplatesTests.cs
+++ b/tests/Aspire.Templates.Tests/PerTestFrameworkTemplatesTests.cs
@@ -22,7 +22,7 @@ public abstract partial class PerTestFrameworkTemplatesTests : TemplateTestsBase
     [MemberData(nameof(ProjectNames_TestData))]
     [RequiresFeature(TestFeature.Playwright)]
     [Trait("category", "basic-build")]
-    [OuterLoop("playwright test")]
+    [OuterloopTest("playwright test")]
     [ActiveIssue("https://github.com/dotnet/aspire/issues/8011")]
     public async Task TemplatesForIndividualTestFrameworks(string prefix)
     {

--- a/tests/Aspire.Templates.Tests/StarterTemplateProjectNamesTests.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateProjectNamesTests.cs
@@ -22,7 +22,7 @@ public abstract class StarterTemplateProjectNamesTests : TemplateTestsBase
     [MemberData(nameof(ProjectNames_TestData))]
     [RequiresFeature(TestFeature.SSLCertificate)]
     [RequiresFeature(TestFeature.Playwright)]
-    [OuterLoop("playwright test")]
+    [OuterloopTest("playwright test")]
     public async Task StarterTemplateWithTest_ProjectNames(string prefix)
     {
         string id = $"{prefix}-{_testType}";

--- a/tests/QuarantineTools.Tests/QuarantineTools.Tests.csproj
+++ b/tests/QuarantineTools.Tests/QuarantineTools.Tests.csproj
@@ -5,6 +5,14 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>
+
+    <RunOnGithubActionsLinux>true</RunOnGithubActionsLinux>
+    <RunOnGithubActionsWindows>false</RunOnGithubActionsWindows>
+    <RunOnGithubActionsMacOS>false</RunOnGithubActionsMacOS>
+
+    <!-- Run only on Linux in Azdo Helix -->
+    <RunOnAzdoHelixWindows>false</RunOnAzdoHelixWindows>
+    <RunOnAzdoHelixLinux>false</RunOnAzdoHelixLinux>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/QuarantineTools/QuarantineTools.csproj
+++ b/tools/QuarantineTools/QuarantineTools.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
## Description

This change reduces the jobs we run during PR validation and fixes unnecessary jobs that were still being scheduled because of test-enumeration mismatches.

This PR is organized into five focused commits while preserving the same final tree:

1. **Exclude outerloop and quarantined tests from class enumeration**
   - Updates `split-test-projects-for-ci.ps1` so class-based partition discovery does not enumerate tests that regular CI already excludes.

2. **Make Aspire test macOS selection PR-aware**
   - GitHub-hosted macOS runners are less available and can add unnecessary delay to PR validation.
   - Adds `IsGithubPullRequest` in `eng/Testing.props` and, for GitHub pull requests only, defaults `RunOnGithubActionsMacOS=false` for `Aspire.*` test projects except `Aspire.Cli*` unless a project explicitly overrides it.
   - This keeps fuller CI coverage outside PR validation while reducing queue pressure on PRs.
   - Removes now-redundant per-project macOS overrides from `Aspire.Deployment.EndToEnd.Tests`, `Aspire.EndToEnd.Tests`, and `Aspire.Playground.Tests`.

3. **Prefer `OuterloopTest` in repository guidance**
   - Switches the remaining template tests on this branch back to the repository's `OuterloopTest` attribute.
   - Adds AGENTS guidance to keep using `OuterloopTest` in this repo instead of Arcade's `OuterLoop` attribute.

4. **Require Docker for the built-in starter template test**
   - Marks `BuildAndRunStarterTemplateBuiltInTest_Test` with the missing Docker feature requirement so CI only schedules it where Docker is available.

5. **Limit `QuarantineTools.Tests` scheduling**
   - Restricts `QuarantineTools.Tests` to the intended GitHub Actions Linux environment to avoid unnecessary runs on other CI lanes.

## Must check before merge

- [x] Outerloop workflow works and correctly runs `Aspire.Oracle.EntityFrameworkCore.Tests`.
- [x] Regular CI does **not** run `Aspire.Oracle.EntityFrameworkCore.Tests`.