### PR TITLE
Fix GenAI dashboard error when content is an array of content parts

### DIFF
--- a/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
@@ -32,7 +32,63 @@ public class TextPart : MessagePart
         Type = TextType;
     }
 
+    [JsonConverter(typeof(TextContentConverter))]
     public string? Content { get; set; } = default!;
+}
+
+/// <summary>
+/// Handles deserializing <c>content</c> that can be either a plain string
+/// or an array of content parts (e.g. <c>[{"type":"text","text":"..."}]</c>).
+/// This format is used by Anthropic's Claude API.
+/// </summary>
+internal sealed class TextContentConverter : JsonConverter<string?>
+{
+    public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType is JsonTokenType.Null)
+        {
+            return null;
+        }
+
+        if (reader.TokenType is JsonTokenType.String)
+        {
+            return reader.GetString();
+        }
+
+        if (reader.TokenType is JsonTokenType.StartArray)
+        {
+            var sb = new System.Text.StringBuilder();
+            using var doc = JsonDocument.ParseValue(ref reader);
+            foreach (var element in doc.RootElement.EnumerateArray())
+            {
+                if (element.ValueKind is JsonValueKind.String)
+                {
+                    sb.Append(element.GetString());
+                }
+                else if (element.ValueKind is JsonValueKind.Object &&
+                         element.TryGetProperty("text", out var textProp) &&
+                         textProp.ValueKind is JsonValueKind.String)
+                {
+                    sb.Append(textProp.GetString());
+                }
+            }
+            return sb.ToString();
+        }
+
+        throw new JsonException($"Unexpected token type '{reader.TokenType}' when reading text content.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, string? value, JsonSerializerOptions options)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+        }
+        else
+        {
+            writer.WriteStringValue(value);
+        }
+    }
 }
 
 /// <summary>

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
@@ -39,7 +39,7 @@ public class TextPart : MessagePart
 /// <summary>
 /// Handles deserializing <c>content</c> that can be either a plain string
 /// or an array of content parts (e.g. <c>[{"type":"text","text":"..."}]</c>).
-/// This format is used by Anthropic's Claude API.
+/// This format is used by multiple GenAI chat APIs, such as Anthropic Claude and OpenAI multimodal models.
 /// </summary>
 internal sealed class TextContentConverter : JsonConverter<string?>
 {

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIVisualizerDialogViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIVisualizerDialogViewModelTests.cs
@@ -2129,4 +2129,95 @@ public sealed class GenAIVisualizerDialogViewModelTests
         Assert.Null(invalidParam.Type); // Type should be null since it couldn't be parsed
         Assert.Equal("A parameter with invalid type structure", invalidParam.Description);
     }
+
+    [Fact]
+    public void Create_GenAISpanAttributes_ArrayContentInTextPart_HasMessages()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        // Input messages where content is an array of content parts instead of a plain string.
+        // This format is used by OpenAI-compatible APIs for multi-part content.
+        var inputMessages = """
+            [
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "type": "text",
+                            "content": [
+                                { "type": "text", "text": "Hello, " },
+                                { "type": "text", "text": "world!" }
+                            ]
+                        }
+                    ]
+                }
+            ]
+            """;
+
+        var outputMessages = """
+            [
+                {
+                    "role": "assistant",
+                    "parts": [
+                        {
+                            "type": "text",
+                            "content": "Plain string response"
+                        }
+                    ]
+                }
+            ]
+            """;
+
+        var attributes = new KeyValuePair<string, string>[]
+        {
+            KeyValuePair.Create(GenAIHelpers.GenAISystem, "System!"),
+            KeyValuePair.Create("server.address", "ai-server.address"),
+            KeyValuePair.Create(GenAIHelpers.GenAIInputMessages, inputMessages),
+            KeyValuePair.Create(GenAIHelpers.GenAIOutputInstructions, outputMessages)
+        };
+
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10), attributes: attributes)
+                        }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, addContext.FailureCount);
+
+        var span = repository.GetSpan(GetHexId("1"), GetHexId("1-1"))!;
+        var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
+
+        // Act
+        var vm = Create(repository, spanDetailsViewModel);
+
+        // Assert - array content parts should be concatenated into a single string
+        Assert.Collection(vm.Items,
+            m =>
+            {
+                Assert.Equal(GenAIItemType.UserMessage, m.Type);
+                Assert.Collection(m.ItemParts,
+                    p => Assert.Equal("Hello, world!", Assert.IsType<TextPart>(p.MessagePart).Content));
+            },
+            m =>
+            {
+                Assert.Equal(GenAIItemType.OutputMessage, m.Type);
+                Assert.Collection(m.ItemParts,
+                    p => Assert.Equal("Plain string response", Assert.IsType<TextPart>(p.MessagePart).Content));
+            });
+        Assert.Null(vm.DisplayErrorMessage);
+    }
 }


### PR DESCRIPTION
## Description

Fix `System.InvalidOperationException: Cannot get the value of a token type 'StartArray' as a string` when viewing GenAI spans in the dashboard.

Some GenAI providers (e.g., Anthropic Claude, OpenAI for multimodal) send `content` as an array of content parts rather than a plain string in `gen_ai.input.messages` telemetry. The dashboard's `TextPart.Content` deserialization expected only a string value, causing a `JsonException` that was recorded as a telemetry error on every trace view refresh.

### Changes
- Added `TextContentConverter` on `TextPart.Content` that handles both:
  - Plain string: `"content": "hello"` (existing behavior, unchanged)
  - Array of content parts: `"content": [{"type": "text", "text": "hello"}]` (new)
- Added test `Create_GenAISpanAttributes_ArrayContentInTextPart_HasMessages`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
