### PR TITLE
🔍 [DO NOT MERGE] Investigation: fix flaky WithDockerfileTest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,7 @@
 name: CI
 
 on:
-  pull_request:
-    branches:
-      - main
-      - 'release/**'
-
-  push:
-    branches:
-      - main
-      - 'release/**'
+  workflow_dispatch: {}  # Only manual trigger — disabled for investigation branch
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/reproduce-flaky-tests.yml
+++ b/.github/workflows/reproduce-flaky-tests.yml
@@ -20,7 +20,7 @@ on:
 env:
   # Test project shortname (maps to tests/Aspire.{name}.Tests/ or tests/{name}.Tests/)
   # Examples: Hosting, Core, Dashboard, Components.Common, Cli.EndToEnd
-  TEST_PROJECT: "Hosting"
+  TEST_PROJECT: "Playground"
 
   # Test filter arguments passed to dotnet test (after the -- separator).
   # Use quotes around wildcard patterns to prevent shell glob expansion.
@@ -28,18 +28,18 @@ env:
   #   --filter-method "*.TestMethodName"
   #   --filter-class "*.TestClassName"
   #   --filter-method "*.Test1" --filter-method "*.Test2"
-  TEST_FILTER: '--filter-method "*.YourTestMethodName"'
+  TEST_FILTER: '--filter-method "*.WithDockerfileTest"'
 
   # Target operating systems (comma-separated)
   # Options: ubuntu-latest, windows-latest, macos-latest
-  TARGET_OSES: "ubuntu-latest,windows-latest"
+  TARGET_OSES: "ubuntu-latest"
 
   # Number of parallel runners per OS
   # Total jobs = RUNNERS_PER_OS × number of OSes (must be ≤ 256)
-  RUNNERS_PER_OS: "3"
+  RUNNERS_PER_OS: "5"
 
   # Number of test iterations each runner executes
-  ITERATIONS_PER_RUNNER: "3"
+  ITERATIONS_PER_RUNNER: "5"
 
 jobs:
 

--- a/playground/withdockerfile/WithDockerfile.AppHost/Program.cs
+++ b/playground/withdockerfile/WithDockerfile.AppHost/Program.cs
@@ -25,8 +25,8 @@ builder.AddContainer("dynamic-sync", "dynamic-sync-image")
             FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23 AS builder
             WORKDIR /app
             COPY . .
-            RUN echo "Built at {timestamp}" > /build-info.txt
             RUN go build -o qots .
+            RUN echo "Built at {timestamp}" > /build-info.txt
             
             FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
             COPY --from=builder /app/qots /qots

--- a/playground/withdockerfile/WithDockerfile.AppHost/dynamic-sync.Dockerfile
+++ b/playground/withdockerfile/WithDockerfile.AppHost/dynamic-sync.Dockerfile
@@ -1,8 +1,8 @@
 FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23 AS builder
 WORKDIR /app
 COPY . .
-RUN echo "Built at 20260119162134" > /build-info.txt
 RUN go build -o qots .
+RUN echo "Built at 20260119162134" > /build-info.txt
 
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0.20260102
 COPY --from=builder /app/qots /qots


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — Investigation Branch

This is a temporary branch for reproducing and verifying a fix for a flaky test.

**Issue**: #9171
**Test**: `Aspire.Playground.Tests.ProjectSpecificTests.WithDockerfileTest`

### What's changed on this branch
- `ci.yml` disabled (prevents full CI on investigation pushes)
- `reproduce-flaky-tests.yml` configured for the target test (5 runners × 5 iterations × ubuntu-latest)
- Code fix applied

### Root Cause
In `Program.cs`, the `dynamic-sync` container's generated Dockerfile has `RUN echo "Built at {timestamp}" > /build-info.txt` **before** `RUN go build -o qots .`. This invalidates Docker's layer cache for Go compilation on every test run, because any change to a Dockerfile instruction invalidates all subsequent layers. This forces a full Go compilation (2-5 minutes on cold CI machines) on every run, causing `WaitForResources()` to exceed the 6-minute `ExtraLongTimeoutTimeSpan`.

### Fix
Moved `RUN echo "Built at {timestamp}" > /build-info.txt` to **after** `RUN go build -o qots .` in both `Program.cs` and `dynamic-sync.Dockerfile`. This allows Docker to cache the expensive Go compilation step while still demonstrating dynamic Dockerfile content with an embedded timestamp.

### Status
- [ ] Reproduction confirmed
- [ ] Fix applied ✅ 
- [ ] Fix verified on CI
- [ ] Clean fix PR created

This branch will be deleted after the fix is verified and a clean PR is created.