### PR TITLE
Improve GenAI message parsing: content array support and truncation tolerance

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -89,7 +89,11 @@
                             <div class="tab-container">
                                 @foreach (var itemPart in selectedItem.ItemParts)
                                 {
-                                    if (TryGetDataPart(itemPart, MimeTypeHelpers.SupportedImageTypes, out var imageData))
+                                    if (itemPart.ErrorMessage is not null)
+                                    {
+                                        <span class="error-message-text">@itemPart.ErrorMessage</span>
+                                    }
+                                    else if (TryGetDataPart(itemPart, MimeTypeHelpers.SupportedImageTypes, out var imageData))
                                     {
                                         <img src="@imageData.Url" />
                                     }
@@ -139,6 +143,18 @@
                                         if (itemPart.MessagePart is ToolCallRequestPart toolCallPart && !string.IsNullOrEmpty(toolCallPart.Name))
                                         {
                                             if (Content.ToolDefinitions.FirstOrDefault(d => d.ToolDefinition.Name == toolCallPart.Name) is { } toolVM)
+                                            {
+                                                <div class="tool-button-container">
+                                                    <FluentButton OnClick="@(() => ViewToolDefinition(toolVM))">
+                                                        <FluentIcon Value="@s_wrenchIcon" Style="vertical-align: sub;" slot="start" />
+                                                        Tool definition
+                                                    </FluentButton>
+                                                </div>
+                                            }
+                                        }
+                                        else if (itemPart.MessagePart is ServerToolCallPart serverToolCallPart && !string.IsNullOrEmpty(serverToolCallPart.Name))
+                                        {
+                                            if (Content.ToolDefinitions.FirstOrDefault(d => d.ToolDefinition.Name == serverToolCallPart.Name) is { } toolVM)
                                             {
                                                 <div class="tool-button-container">
                                                     <FluentButton OnClick="@(() => ViewToolDefinition(toolVM))">
@@ -464,7 +480,7 @@
                             {
                                 if (itemPart.ErrorMessage is not null)
                                 {
-                                    <div style="color: var(--error);">@itemPart.ErrorMessage</div>
+                                    <div class="error-message-text">@itemPart.ErrorMessage</div>
                                 }
                                 else
                                 {

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -462,7 +462,14 @@
                         {
                             foreach (var itemPart in itemParts)
                             {
-                                <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" HideLineNumbers="true" Virtualize="false" />
+                                if (itemPart.ErrorMessage is not null)
+                                {
+                                    <div style="color: var(--error);">@itemPart.ErrorMessage</div>
+                                }
+                                else
+                                {
+                                    <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" HideLineNumbers="true" Virtualize="false" />
+                                }
                             }
                         }
                         else

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
@@ -262,36 +262,36 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
 
     private static bool TryGetDataPart(GenAIItemPartViewModel itemPart, HashSet<string>? matchingMimeTypes, [NotNullWhen(true)] out DataInfo? dataInfo)
     {
-        switch (itemPart.MessagePart?.Type)
+        switch (itemPart.MessagePart)
         {
-            case "blob":
+            case BlobPart blobPart:
                 {
-                    if (MatchMimeType(itemPart, matchingMimeTypes, out var mimeType))
+                    if (MatchMimeType(blobPart.MimeType, matchingMimeTypes))
                     {
-                        if (itemPart.TryGetPropertyValue("content", out var content))
+                        if (!string.IsNullOrEmpty(blobPart.Content))
                         {
                             dataInfo = new DataInfo(
-                                Url: $"data:{mimeType};base64,{content}",
-                                MimeType: mimeType,
-                                FileName: CalculateFileName(currentFileName: null, mimeType));
+                                Url: $"data:{blobPart.MimeType};base64,{blobPart.Content}",
+                                MimeType: blobPart.MimeType!,
+                                FileName: CalculateFileName(currentFileName: null, blobPart.MimeType!));
                             return true;
                         }
                     }
                     break;
                 }
-            case "uri":
+            case UriPart uriPart:
                 {
-                    if (MatchMimeType(itemPart, matchingMimeTypes, out var mimeType))
+                    if (MatchMimeType(uriPart.MimeType, matchingMimeTypes))
                     {
-                        if (itemPart.TryGetPropertyValue("uri", out var uri))
+                        if (!string.IsNullOrEmpty(uriPart.Uri))
                         {
                             // Only attempt to display image if it is an http/https address.
-                            if (Uri.TryCreate(uri, UriKind.Absolute, out var result) && result.Scheme.ToLowerInvariant() is "http" or "https")
+                            if (Uri.TryCreate(uriPart.Uri, UriKind.Absolute, out var result) && result.Scheme.ToLowerInvariant() is "http" or "https")
                             {
                                 dataInfo = new DataInfo(
-                                    Url: uri,
-                                    MimeType: mimeType,
-                                    FileName: CalculateFileName(Path.GetFileName(result.LocalPath), mimeType));
+                                    Url: uriPart.Uri,
+                                    MimeType: uriPart.MimeType!,
+                                    FileName: CalculateFileName(Path.GetFileName(result.LocalPath), uriPart.MimeType!));
                                 return true;
                             }
                         }
@@ -303,11 +303,11 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
         dataInfo = null;
         return false;
 
-        static bool MatchMimeType(GenAIItemPartViewModel viewModel, HashSet<string>? matchingMimeTypes, [NotNullWhen(true)] out string? mimeType)
+        static bool MatchMimeType(string? mimeType, HashSet<string>? matchingMimeTypes)
         {
-            if (viewModel.TryGetPropertyValue("mime_type", out mimeType))
+            if (!string.IsNullOrEmpty(mimeType))
             {
-                return matchingMimeTypes == null || matchingMimeTypes.Contains(mimeType);
+                return matchingMimeTypes is null || matchingMimeTypes.Contains(mimeType);
             }
 
             return false;

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
@@ -174,6 +174,7 @@
     flex-direction: column;
     row-gap: 12px;
     width: 100%;
+    margin-bottom: 4px;
 }
 
 ::deep .span-details-layout, ::deep .property-grid-container {
@@ -214,6 +215,11 @@
 
 ::deep .display-error-message {
     color: var(--error);
+}
+
+::deep .error-message-text {
+    color: var(--error);
+    font-weight: 500;
 }
 
 ::deep .display-error-content {

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIItemPartViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIItemPartViewModel.cs
@@ -90,6 +90,42 @@ public sealed class GenAIItemPartViewModel
 
             return new TextVisualizerViewModel(toolResponseContent, indentText: true, fallbackFormat: DashboardUIHelpers.MarkdownFormat);
         }
+        if (p is BlobPart blobPart)
+        {
+            return new TextVisualizerViewModel(blobPart.Content ?? string.Empty, indentText: true);
+        }
+        if (p is UriPart uriPart)
+        {
+            return new TextVisualizerViewModel(uriPart.Uri ?? string.Empty, indentText: true);
+        }
+        if (p is FilePart filePart)
+        {
+            return new TextVisualizerViewModel(filePart.FileId ?? string.Empty, indentText: true);
+        }
+        if (p is ReasoningPart reasoningPart)
+        {
+            return new TextVisualizerViewModel(reasoningPart.Content ?? string.Empty, indentText: true, fallbackFormat: DashboardUIHelpers.MarkdownFormat);
+        }
+        if (p is ServerToolCallPart serverToolCallPart)
+        {
+            var serverToolCallText = serverToolCallPart.ServerToolCall switch
+            {
+                null => string.Empty,
+                JsonObject obj when obj.Count == 0 => string.Empty,
+                JsonArray arr when arr.Count == 0 => string.Empty,
+                _ => serverToolCallPart.ServerToolCall.ToJsonString()
+            };
+
+            return new TextVisualizerViewModel($"{serverToolCallPart.Name}({serverToolCallText})", indentText: true, knownFormat: DashboardUIHelpers.JavascriptFormat);
+        }
+        if (p is ServerToolCallResponsePart serverToolCallResponsePart)
+        {
+            var responseContent = (serverToolCallResponsePart.ServerToolCallResponse?.GetValueKind() == JsonValueKind.String)
+                ? serverToolCallResponsePart.ServerToolCallResponse.GetValue<string>()
+                : serverToolCallResponsePart.ServerToolCallResponse?.ToJsonString() ?? string.Empty;
+
+            return new TextVisualizerViewModel(responseContent, indentText: true, fallbackFormat: DashboardUIHelpers.MarkdownFormat);
+        }
 
         var additionalProperties = p is GenericPart genericPart ? genericPart.AdditionalProperties ?? [] : [];
         var content = additionalProperties.Count > 0 ? ToJsonObject(additionalProperties).ToJsonString(s_jsonSerializerOptions) : string.Empty;

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIItemViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIItemViewModel.cs
@@ -37,7 +37,7 @@ public class GenAIItemViewModel
         }
         if (Type == GenAIItemType.OutputMessage)
         {
-            if (ItemParts.Any(p => p.MessagePart?.Type == MessagePart.ToolCallType))
+            if (ItemParts.Any(p => p.MessagePart?.Type is MessagePart.ToolCallType or MessagePart.ServerToolCallType))
             {
                 return new BadgeDetail(loc[nameof(Dialogs.GenAIMessageCategoryToolCalls)], "output", s_toolCallsIcon);
             }
@@ -46,11 +46,11 @@ public class GenAIItemViewModel
                 return new BadgeDetail(loc[nameof(Dialogs.GenAIMessageCategoryOutput)], "output", s_messageIcon);
             }
         }
-        if (ItemParts.Any(p => p.MessagePart?.Type == MessagePart.ToolCallType))
+        if (ItemParts.Any(p => p.MessagePart?.Type is MessagePart.ToolCallType or MessagePart.ServerToolCallType))
         {
             return new BadgeDetail(loc[nameof(Dialogs.GenAIMessageCategoryToolCalls)], "tool-calls", s_toolCallsIcon);
         }
-        if (ItemParts.Any(p => p.MessagePart?.Type == MessagePart.ToolCallResponseType))
+        if (ItemParts.Any(p => p.MessagePart?.Type is MessagePart.ToolCallResponseType or MessagePart.ServerToolCallResponseType))
         {
             return new BadgeDetail(loc[nameof(Dialogs.GenAIMessageCategoryToolResponse)], "tool-response", s_messageIcon);
         }

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIMessageParsingHelper.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIMessageParsingHelper.cs
@@ -141,6 +141,12 @@ internal static class GenAIMessageParsingHelper
             },
             "tool_use" => ReadToolUsePart(item),
             "tool_result" => ReadToolResultPart(item),
+            MessagePart.BlobType => JsonSerializer.Deserialize(item.GetRawText(), GenAIMessagesContext.Default.BlobPart),
+            MessagePart.FileType => JsonSerializer.Deserialize(item.GetRawText(), GenAIMessagesContext.Default.FilePart),
+            MessagePart.UriType => JsonSerializer.Deserialize(item.GetRawText(), GenAIMessagesContext.Default.UriPart),
+            MessagePart.ReasoningType => JsonSerializer.Deserialize(item.GetRawText(), GenAIMessagesContext.Default.ReasoningPart),
+            MessagePart.ServerToolCallType => JsonSerializer.Deserialize(item.GetRawText(), GenAIMessagesContext.Default.ServerToolCallPart),
+            MessagePart.ServerToolCallResponseType => JsonSerializer.Deserialize(item.GetRawText(), GenAIMessagesContext.Default.ServerToolCallResponsePart),
             _ => JsonSerializer.Deserialize(item.GetRawText(), GenAIMessagesContext.Default.GenericPart),
         };
     }

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIMessageParsingHelper.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIMessageParsingHelper.cs
@@ -101,6 +101,12 @@ internal static class GenAIMessageParsingHelper
             MessagePart.TextType => JsonSerializer.Deserialize(root.GetRawText(), GenAIMessagesContext.Default.TextPart),
             MessagePart.ToolCallType => JsonSerializer.Deserialize(root.GetRawText(), GenAIMessagesContext.Default.ToolCallRequestPart),
             MessagePart.ToolCallResponseType => JsonSerializer.Deserialize(root.GetRawText(), GenAIMessagesContext.Default.ToolCallResponsePart),
+            MessagePart.BlobType => JsonSerializer.Deserialize(root.GetRawText(), GenAIMessagesContext.Default.BlobPart),
+            MessagePart.FileType => JsonSerializer.Deserialize(root.GetRawText(), GenAIMessagesContext.Default.FilePart),
+            MessagePart.UriType => JsonSerializer.Deserialize(root.GetRawText(), GenAIMessagesContext.Default.UriPart),
+            MessagePart.ReasoningType => JsonSerializer.Deserialize(root.GetRawText(), GenAIMessagesContext.Default.ReasoningPart),
+            MessagePart.ServerToolCallType => JsonSerializer.Deserialize(root.GetRawText(), GenAIMessagesContext.Default.ServerToolCallPart),
+            MessagePart.ServerToolCallResponseType => JsonSerializer.Deserialize(root.GetRawText(), GenAIMessagesContext.Default.ServerToolCallResponsePart),
             _ => JsonSerializer.Deserialize(root.GetRawText(), GenAIMessagesContext.Default.GenericPart),
         };
 

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIMessageParsingHelper.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIMessageParsingHelper.cs
@@ -1,0 +1,242 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Aspire.Dashboard.Model.GenAI;
+
+/// <summary>
+/// Provides truncation-tolerant JSON array deserialization for GenAI message parsing.
+/// </summary>
+internal static class GenAIMessageParsingHelper
+{
+    internal delegate T? ReadElement<T>(ref Utf8JsonReader reader);
+
+    internal static (List<T> items, bool truncated) DeserializeArrayIncrementally<T>(string json, ReadElement<T> readElement)
+    {
+        var bytes = Encoding.UTF8.GetBytes(json);
+        var readerOptions = new JsonReaderOptions
+        {
+            CommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true,
+        };
+        var reader = new Utf8JsonReader(bytes, readerOptions);
+        return DeserializeArrayIncrementally(ref reader, readElement);
+    }
+
+    internal static (List<T> items, bool truncated) DeserializeArrayIncrementally<T>(ref Utf8JsonReader reader, ReadElement<T> readElement)
+    {
+        var items = new List<T>();
+
+        // Read start of array. Let exceptions propagate for truly invalid JSON.
+        if (!reader.Read() || reader.TokenType != JsonTokenType.StartArray)
+        {
+            throw new JsonException("Expected a JSON array.");
+        }
+
+        while (true)
+        {
+            bool readSuccess;
+            try
+            {
+                readSuccess = reader.Read();
+            }
+            catch (JsonException)
+            {
+                return (items, true);
+            }
+
+            if (!readSuccess)
+            {
+                return (items, true);
+            }
+
+            if (reader.TokenType == JsonTokenType.EndArray)
+            {
+                break;
+            }
+
+            try
+            {
+                var item = readElement(ref reader);
+                if (item is not null)
+                {
+                    items.Add(item);
+                }
+            }
+            catch (JsonException)
+            {
+                return (items, true);
+            }
+        }
+
+        return (items, false);
+    }
+
+    internal static List<MessagePart> ReadMessageParts(ref Utf8JsonReader reader)
+    {
+        using var doc = JsonDocument.ParseValue(ref reader);
+        var root = doc.RootElement;
+
+        if (!root.TryGetProperty("type", out var typeProp))
+        {
+            throw new JsonException("Missing 'type' property.");
+        }
+
+        var type = typeProp.GetString();
+
+        // For text parts with content as an array, each content item becomes a separate part.
+        if (type == MessagePart.TextType &&
+            root.TryGetProperty("content", out var contentProp) &&
+            contentProp.ValueKind == JsonValueKind.Array)
+        {
+            return ReadContentArrayParts(contentProp);
+        }
+
+        // Single part for non-array cases.
+        MessagePart? part = type switch
+        {
+            MessagePart.TextType => JsonSerializer.Deserialize(root.GetRawText(), GenAIMessagesContext.Default.TextPart),
+            MessagePart.ToolCallType => JsonSerializer.Deserialize(root.GetRawText(), GenAIMessagesContext.Default.ToolCallRequestPart),
+            MessagePart.ToolCallResponseType => JsonSerializer.Deserialize(root.GetRawText(), GenAIMessagesContext.Default.ToolCallResponsePart),
+            _ => JsonSerializer.Deserialize(root.GetRawText(), GenAIMessagesContext.Default.GenericPart),
+        };
+
+        return part is not null ? [part] : [];
+    }
+
+    private static List<MessagePart> ReadContentArrayParts(JsonElement contentArray)
+    {
+        var parts = new List<MessagePart>();
+        foreach (var item in contentArray.EnumerateArray())
+        {
+            var part = ReadContentItem(item);
+            if (part is not null)
+            {
+                parts.Add(part);
+            }
+        }
+        return parts;
+    }
+
+    private static MessagePart? ReadContentItem(JsonElement item)
+    {
+        var type = item.TryGetProperty("type", out var typeProp) ? typeProp.GetString() : null;
+
+        return type switch
+        {
+            "text" => new TextPart
+            {
+                Content = item.TryGetProperty("text", out var textProp) && textProp.ValueKind == JsonValueKind.String
+                    ? textProp.GetString()
+                    : null
+            },
+            "tool_use" => ReadToolUsePart(item),
+            "tool_result" => ReadToolResultPart(item),
+            _ => JsonSerializer.Deserialize(item.GetRawText(), GenAIMessagesContext.Default.GenericPart),
+        };
+    }
+
+    private static ToolCallRequestPart ReadToolUsePart(JsonElement item)
+    {
+        var id = item.TryGetProperty("id", out var idProp) && idProp.ValueKind == JsonValueKind.String
+            ? idProp.GetString()
+            : null;
+
+        var name = item.TryGetProperty("name", out var nameProp) && nameProp.ValueKind == JsonValueKind.String
+            ? nameProp.GetString()
+            : null;
+
+        JsonNode? arguments = item.TryGetProperty("input", out var inputProp)
+            ? JsonNode.Parse(inputProp.GetRawText())
+            : null;
+
+        return new ToolCallRequestPart { Id = id, Name = name, Arguments = arguments };
+    }
+
+    private static ToolCallResponsePart ReadToolResultPart(JsonElement item)
+    {
+        var id = item.TryGetProperty("tool_use_id", out var idProp) && idProp.ValueKind == JsonValueKind.String
+            ? idProp.GetString()
+            : null;
+
+        JsonNode? response = item.TryGetProperty("content", out var contentProp)
+            ? TryJoinTextContent(contentProp) ?? JsonNode.Parse(contentProp.GetRawText())
+            : null;
+
+        return new ToolCallResponsePart { Id = id, Response = response };
+    }
+
+    private static JsonNode? TryJoinTextContent(JsonElement contentElement)
+    {
+        if (contentElement.ValueKind is not JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        var sb = new StringBuilder();
+        foreach (var arrayItem in contentElement.EnumerateArray())
+        {
+            if (arrayItem.ValueKind is not JsonValueKind.Object
+                || !arrayItem.TryGetProperty("type", out var typeProp)
+                || typeProp.GetString() is not "text"
+                || !arrayItem.TryGetProperty("text", out var textProp)
+                || textProp.ValueKind is not JsonValueKind.String)
+            {
+                return null;
+            }
+
+            sb.Append(textProp.GetString());
+        }
+
+        return JsonValue.Create(sb.ToString());
+    }
+
+    internal static (string role, List<MessagePart> parts, bool partsTruncated) ReadChatMessage(ref Utf8JsonReader reader)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            throw new JsonException("Expected start of chat message object.");
+        }
+
+        string? role = null;
+        List<MessagePart>? parts = null;
+        var partsTruncated = false;
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                break;
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw new JsonException("Expected property name.");
+            }
+
+            var propertyName = reader.GetString();
+
+            switch (propertyName)
+            {
+                case "role":
+                    reader.Read();
+                    role = reader.GetString();
+                    break;
+                case "parts":
+                    // DeserializeArrayIncrementally reads the StartArray token itself.
+                    (var partsResults, partsTruncated) = DeserializeArrayIncrementally<List<MessagePart>>(ref reader, ReadMessageParts);
+                    parts = partsResults.SelectMany(p => p).ToList();
+                    break;
+                default:
+                    reader.Read();
+                    reader.TrySkip();
+                    break;
+            }
+        }
+
+        return (role ?? string.Empty, parts ?? [], partsTruncated);
+    }
+}

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -13,7 +12,10 @@ namespace Aspire.Dashboard.Model.GenAI;
 /// <summary>
 /// Represents text, tool calls, and generic parts.
 /// </summary>
-[JsonConverter(typeof(MessagePartConverter))]
+[JsonDerivedType(typeof(TextPart))]
+[JsonDerivedType(typeof(ToolCallRequestPart))]
+[JsonDerivedType(typeof(ToolCallResponsePart))]
+[JsonDerivedType(typeof(GenericPart))]
 public abstract class MessagePart
 {
     public const string TextType = "text";
@@ -96,55 +98,6 @@ public class ToolDefinition
     public string? Name { get; set; }
     public string? Description { get; set; }
     public OpenApiSchema? Parameters { get; set; }
-}
-
-/// <summary>
-/// Custom converter to handle polymorphic message parts.
-/// </summary>
-public class MessagePartConverter : JsonConverter<MessagePart>
-{
-    public override MessagePart? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-    {
-        using var doc = JsonDocument.ParseValue(ref reader);
-        if (!doc.RootElement.TryGetProperty("type", out var typeProp))
-        {
-            throw new JsonException("Missing 'type' property.");
-        }
-
-        var type = typeProp.GetString();
-        return type switch
-        {
-            MessagePart.TextType => DeserializeTextPart(doc.RootElement, options),
-            MessagePart.ToolCallType => JsonSerializer.Deserialize<ToolCallRequestPart>(doc.RootElement.GetRawText(), options),
-            MessagePart.ToolCallResponseType => JsonSerializer.Deserialize<ToolCallResponsePart>(doc.RootElement.GetRawText(), options),
-            _ => JsonSerializer.Deserialize<GenericPart>(doc.RootElement.GetRawText(), options),
-        };
-    }
-
-    private static TextPart DeserializeTextPart(JsonElement element, JsonSerializerOptions options)
-    {
-        // Handle content being either a string or an array of content parts.
-        // Some SDKs emit content as an array, e.g. [{"type":"text","text":"..."}]
-        if (element.TryGetProperty("content", out var contentProp) && contentProp.ValueKind == JsonValueKind.Array)
-        {
-            var sb = new StringBuilder();
-            foreach (var item in contentProp.EnumerateArray())
-            {
-                if (item.TryGetProperty("text", out var textProp) && textProp.ValueKind == JsonValueKind.String)
-                {
-                    sb.Append(textProp.GetString());
-                }
-            }
-            return new TextPart { Content = sb.ToString() };
-        }
-
-        return JsonSerializer.Deserialize<TextPart>(element.GetRawText(), options)!;
-    }
-
-    public override void Write(Utf8JsonWriter writer, MessagePart value, JsonSerializerOptions options)
-    {
-        JsonSerializer.Serialize(writer, (object)value, value.GetType(), options);
-    }
 }
 
 [JsonSourceGenerationOptions(

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -113,11 +114,31 @@ public class MessagePartConverter : JsonConverter<MessagePart>
         var type = typeProp.GetString();
         return type switch
         {
-            MessagePart.TextType => JsonSerializer.Deserialize<TextPart>(doc.RootElement.GetRawText(), options),
+            MessagePart.TextType => DeserializeTextPart(doc.RootElement, options),
             MessagePart.ToolCallType => JsonSerializer.Deserialize<ToolCallRequestPart>(doc.RootElement.GetRawText(), options),
             MessagePart.ToolCallResponseType => JsonSerializer.Deserialize<ToolCallResponsePart>(doc.RootElement.GetRawText(), options),
             _ => JsonSerializer.Deserialize<GenericPart>(doc.RootElement.GetRawText(), options),
         };
+    }
+
+    private static TextPart DeserializeTextPart(JsonElement element, JsonSerializerOptions options)
+    {
+        // Handle content being either a string or an array of content parts.
+        // Some SDKs emit content as an array, e.g. [{"type":"text","text":"..."}]
+        if (element.TryGetProperty("content", out var contentProp) && contentProp.ValueKind == JsonValueKind.Array)
+        {
+            var sb = new StringBuilder();
+            foreach (var item in contentProp.EnumerateArray())
+            {
+                if (item.TryGetProperty("text", out var textProp) && textProp.ValueKind == JsonValueKind.String)
+                {
+                    sb.Append(textProp.GetString());
+                }
+            }
+            return new TextPart { Content = sb.ToString() };
+        }
+
+        return JsonSerializer.Deserialize<TextPart>(element.GetRawText(), options)!;
     }
 
     public override void Write(Utf8JsonWriter writer, MessagePart value, JsonSerializerOptions options)

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
@@ -10,17 +10,29 @@ using Microsoft.OpenApi;
 namespace Aspire.Dashboard.Model.GenAI;
 
 /// <summary>
-/// Represents text, tool calls, and generic parts.
+/// Represents text, tool calls, data parts, and generic parts.
 /// </summary>
 [JsonDerivedType(typeof(TextPart))]
 [JsonDerivedType(typeof(ToolCallRequestPart))]
 [JsonDerivedType(typeof(ToolCallResponsePart))]
+[JsonDerivedType(typeof(BlobPart))]
+[JsonDerivedType(typeof(FilePart))]
+[JsonDerivedType(typeof(UriPart))]
+[JsonDerivedType(typeof(ReasoningPart))]
+[JsonDerivedType(typeof(ServerToolCallPart))]
+[JsonDerivedType(typeof(ServerToolCallResponsePart))]
 [JsonDerivedType(typeof(GenericPart))]
 public abstract class MessagePart
 {
     public const string TextType = "text";
     public const string ToolCallType = "tool_call";
     public const string ToolCallResponseType = "tool_call_response";
+    public const string BlobType = "blob";
+    public const string FileType = "file";
+    public const string UriType = "uri";
+    public const string ReasoningType = "reasoning";
+    public const string ServerToolCallType = "server_tool_call";
+    public const string ServerToolCallResponseType = "server_tool_call_response";
 
     public string Type { get; set; } = default!;
 }
@@ -68,6 +80,93 @@ public class ToolCallResponsePart : MessagePart
 }
 
 /// <summary>
+/// Represents blob binary data sent inline to the model.
+/// </summary>
+public class BlobPart : MessagePart
+{
+    public BlobPart()
+    {
+        Type = BlobType;
+    }
+
+    public string? MimeType { get; set; }
+    public string? Modality { get; set; }
+    public string? Content { get; set; }
+}
+
+/// <summary>
+/// Represents an external referenced file sent to the model by file ID.
+/// </summary>
+public class FilePart : MessagePart
+{
+    public FilePart()
+    {
+        Type = FileType;
+    }
+
+    public string? MimeType { get; set; }
+    public string? Modality { get; set; }
+    public string? FileId { get; set; }
+}
+
+/// <summary>
+/// Represents an external referenced file sent to the model by URI.
+/// </summary>
+public class UriPart : MessagePart
+{
+    public UriPart()
+    {
+        Type = UriType;
+    }
+
+    public string? MimeType { get; set; }
+    public string? Modality { get; set; }
+    public string? Uri { get; set; }
+}
+
+/// <summary>
+/// Represents reasoning/thinking content received from the model.
+/// </summary>
+public class ReasoningPart : MessagePart
+{
+    public ReasoningPart()
+    {
+        Type = ReasoningType;
+    }
+
+    public string? Content { get; set; }
+}
+
+/// <summary>
+/// Represents a server-side tool call invocation.
+/// </summary>
+public class ServerToolCallPart : MessagePart
+{
+    public ServerToolCallPart()
+    {
+        Type = ServerToolCallType;
+    }
+
+    public string? Id { get; set; }
+    public string? Name { get; set; }
+    public JsonNode? ServerToolCall { get; set; }
+}
+
+/// <summary>
+/// Represents a server-side tool call response.
+/// </summary>
+public class ServerToolCallResponsePart : MessagePart
+{
+    public ServerToolCallResponsePart()
+    {
+        Type = ServerToolCallResponseType;
+    }
+
+    public string? Id { get; set; }
+    public JsonNode? ServerToolCallResponse { get; set; }
+}
+
+/// <summary>
 /// Represents an arbitrary message part with any type and properties.
 /// </summary>
 public class GenericPart : MessagePart
@@ -109,6 +208,12 @@ public class ToolDefinition
 [JsonSerializable(typeof(TextPart))]
 [JsonSerializable(typeof(ToolCallRequestPart))]
 [JsonSerializable(typeof(ToolCallResponsePart))]
+[JsonSerializable(typeof(BlobPart))]
+[JsonSerializable(typeof(FilePart))]
+[JsonSerializable(typeof(UriPart))]
+[JsonSerializable(typeof(ReasoningPart))]
+[JsonSerializable(typeof(ServerToolCallPart))]
+[JsonSerializable(typeof(ServerToolCallResponsePart))]
 [JsonSerializable(typeof(GenericPart))]
 [JsonSerializable(typeof(ChatMessage))]
 [JsonSerializable(typeof(List<ChatMessage>))]

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -227,6 +227,45 @@ public sealed class GenAIVisualizerDialogViewModel
                 {
                     return false;
                 }
+                else if (partViewModel.MessagePart is BlobPart blobPart)
+                {
+                    if (!string.IsNullOrEmpty(blobPart.Content))
+                    {
+                        return false;
+                    }
+                }
+                else if (partViewModel.MessagePart is UriPart uriPart)
+                {
+                    if (!string.IsNullOrEmpty(uriPart.Uri))
+                    {
+                        return false;
+                    }
+                }
+                else if (partViewModel.MessagePart is FilePart filePart)
+                {
+                    if (!string.IsNullOrEmpty(filePart.FileId))
+                    {
+                        return false;
+                    }
+                }
+                else if (partViewModel.MessagePart is ReasoningPart reasoningPart)
+                {
+                    if (!string.IsNullOrEmpty(reasoningPart.Content))
+                    {
+                        return false;
+                    }
+                }
+                else if (partViewModel.MessagePart is ServerToolCallPart)
+                {
+                    return false;
+                }
+                else if (partViewModel.MessagePart is ServerToolCallResponsePart serverToolCallResponsePart)
+                {
+                    if (serverToolCallResponsePart.ServerToolCallResponse is not null)
+                    {
+                        return false;
+                    }
+                }
             }
         }
 

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -249,8 +249,8 @@ public sealed class GenAIVisualizerDialogViewModel
         {
             if (!string.IsNullOrEmpty(systemInstructions))
             {
-                var (instructionParts, truncated) = DeserializeArrayIncrementally(systemInstructions, (ref Utf8JsonReader r) => JsonSerializer.Deserialize(ref r, GenAIMessagesContext.Default.MessagePart));
-                var parts = instructionParts.Select(GenAIItemPartViewModel.CreateMessagePart).ToList();
+                var (instructionParts, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally<List<MessagePart>>(systemInstructions, GenAIMessageParsingHelper.ReadMessageParts);
+                var parts = instructionParts.SelectMany(p => p).Select(GenAIItemPartViewModel.CreateMessagePart).ToList();
                 if (truncated)
                 {
                     parts.Add(GenAIItemPartViewModel.CreateErrorMessage(Resources.Dialogs.GenAIUnexpectedOrTruncatedContent));
@@ -315,18 +315,22 @@ public sealed class GenAIVisualizerDialogViewModel
 
     private static int ParseMessages(GenAIVisualizerDialogViewModel viewModel, string messages, bool isOutput, ref int currentIndex)
     {
-        var (chatMessages, truncated) = DeserializeArrayIncrementally(messages, (ref Utf8JsonReader r) => JsonSerializer.Deserialize(ref r, GenAIMessagesContext.Default.ChatMessage));
-        foreach (var msg in chatMessages)
+        var (chatMessages, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(messages, GenAIMessageParsingHelper.ReadChatMessage);
+        foreach (var (role, parts, partsTruncated) in chatMessages)
         {
-            var parts = msg.Parts.Select(GenAIItemPartViewModel.CreateMessagePart).ToList();
-            var type = msg.Role switch
+            var viewParts = parts.Select(GenAIItemPartViewModel.CreateMessagePart).ToList();
+            if (partsTruncated)
+            {
+                viewParts.Add(GenAIItemPartViewModel.CreateErrorMessage(Resources.Dialogs.GenAIUnexpectedOrTruncatedContent));
+            }
+            var type = role switch
             {
                 "system" => GenAIItemType.SystemMessage,
-                "user" => msg.Parts.All(p => p is ToolCallResponsePart) ? GenAIItemType.ToolMessage : GenAIItemType.UserMessage,
+                "user" => parts.All(p => p is ToolCallResponsePart) ? GenAIItemType.ToolMessage : GenAIItemType.UserMessage,
                 "assistant" => isOutput ? GenAIItemType.OutputMessage : GenAIItemType.AssistantMessage,
                 _ => GenAIItemType.UserMessage
             };
-            viewModel.Items.Add(CreateMessage(viewModel, currentIndex, type, parts, internalId: null));
+            viewModel.Items.Add(CreateMessage(viewModel, currentIndex, type, viewParts, internalId: null));
             currentIndex++;
         }
 
@@ -514,69 +518,6 @@ public sealed class GenAIVisualizerDialogViewModel
                 }
             }
         }
-    }
-
-    private delegate T? ReadElement<T>(ref Utf8JsonReader reader);
-
-    private static (List<T> items, bool truncated) DeserializeArrayIncrementally<T>(string json, ReadElement<T> readElement)
-    {
-        var bytes = Encoding.UTF8.GetBytes(json);
-        var readerOptions = new JsonReaderOptions
-        {
-            CommentHandling = JsonCommentHandling.Skip,
-            AllowTrailingCommas = true,
-        };
-        var reader = new Utf8JsonReader(bytes, readerOptions);
-        return DeserializeArrayIncrementally(ref reader, readElement);
-    }
-
-    private static (List<T> items, bool truncated) DeserializeArrayIncrementally<T>(ref Utf8JsonReader reader, ReadElement<T> readElement)
-    {
-        var items = new List<T>();
-
-        // Read start of array. Let exceptions propagate for truly invalid JSON.
-        if (!reader.Read() || reader.TokenType != JsonTokenType.StartArray)
-        {
-            throw new JsonException("Expected a JSON array.");
-        }
-
-        while (true)
-        {
-            bool readSuccess;
-            try
-            {
-                readSuccess = reader.Read();
-            }
-            catch (JsonException)
-            {
-                return (items, true);
-            }
-
-            if (!readSuccess)
-            {
-                return (items, true);
-            }
-
-            if (reader.TokenType == JsonTokenType.EndArray)
-            {
-                break;
-            }
-
-            try
-            {
-                var item = readElement(ref reader);
-                if (item is not null)
-                {
-                    items.Add(item);
-                }
-            }
-            catch (JsonException)
-            {
-                return (items, true);
-            }
-        }
-
-        return (items, false);
     }
 
     private static TValue DeserializeWithErrorHandling<TValue>(string description, string json, JsonTypeInfo<TValue> jsonTypeInfo)

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -249,17 +249,22 @@ public sealed class GenAIVisualizerDialogViewModel
         {
             if (!string.IsNullOrEmpty(systemInstructions))
             {
-                var instructionParts = DeserializeWithErrorHandling(GenAIHelpers.GenAISystemInstructions, systemInstructions, GenAIMessagesContext.Default.ListMessagePart)!;
-                viewModel.Items.Add(CreateMessage(viewModel, currentIndex, GenAIItemType.SystemMessage, instructionParts.Select(GenAIItemPartViewModel.CreateMessagePart).ToList(), internalId: null));
+                var (instructionParts, truncated) = DeserializeArrayIncrementally(systemInstructions, (ref Utf8JsonReader r) => JsonSerializer.Deserialize(ref r, GenAIMessagesContext.Default.MessagePart));
+                var parts = instructionParts.Select(GenAIItemPartViewModel.CreateMessagePart).ToList();
+                if (truncated)
+                {
+                    parts.Add(GenAIItemPartViewModel.CreateErrorMessage(Resources.Dialogs.GenAIUnexpectedOrTruncatedContent));
+                }
+                viewModel.Items.Add(CreateMessage(viewModel, currentIndex, GenAIItemType.SystemMessage, parts, internalId: null));
                 currentIndex++;
             }
             if (!string.IsNullOrEmpty(inputMessages))
             {
-                ParseMessages(viewModel, inputMessages, GenAIHelpers.GenAIInputMessages, isOutput: false, ref currentIndex);
+                ParseMessages(viewModel, inputMessages, isOutput: false, ref currentIndex);
             }
             if (!string.IsNullOrEmpty(outputMessages))
             {
-                ParseMessages(viewModel, outputMessages, GenAIHelpers.GenAIOutputInstructions, isOutput: true, ref currentIndex);
+                ParseMessages(viewModel, outputMessages, isOutput: true, ref currentIndex);
             }
 
             return;
@@ -308,10 +313,10 @@ public sealed class GenAIVisualizerDialogViewModel
         ParseLangSmithFormat(viewModel, ref currentIndex);
     }
 
-    private static int ParseMessages(GenAIVisualizerDialogViewModel viewModel, string messages, string description, bool isOutput, ref int currentIndex)
+    private static int ParseMessages(GenAIVisualizerDialogViewModel viewModel, string messages, bool isOutput, ref int currentIndex)
     {
-        var inputParts = DeserializeWithErrorHandling(description, messages, GenAIMessagesContext.Default.ListChatMessage)!;
-        foreach (var msg in inputParts)
+        var (chatMessages, truncated) = DeserializeArrayIncrementally(messages, (ref Utf8JsonReader r) => JsonSerializer.Deserialize(ref r, GenAIMessagesContext.Default.ChatMessage));
+        foreach (var msg in chatMessages)
         {
             var parts = msg.Parts.Select(GenAIItemPartViewModel.CreateMessagePart).ToList();
             var type = msg.Role switch
@@ -322,6 +327,13 @@ public sealed class GenAIVisualizerDialogViewModel
                 _ => GenAIItemType.UserMessage
             };
             viewModel.Items.Add(CreateMessage(viewModel, currentIndex, type, parts, internalId: null));
+            currentIndex++;
+        }
+
+        if (truncated)
+        {
+            var truncationType = isOutput ? GenAIItemType.OutputMessage : GenAIItemType.UserMessage;
+            viewModel.Items.Add(CreateMessage(viewModel, currentIndex, truncationType, [GenAIItemPartViewModel.CreateErrorMessage(Resources.Dialogs.GenAIUnexpectedOrTruncatedContent)], internalId: null));
             currentIndex++;
         }
 
@@ -502,6 +514,69 @@ public sealed class GenAIVisualizerDialogViewModel
                 }
             }
         }
+    }
+
+    private delegate T? ReadElement<T>(ref Utf8JsonReader reader);
+
+    private static (List<T> items, bool truncated) DeserializeArrayIncrementally<T>(string json, ReadElement<T> readElement)
+    {
+        var bytes = Encoding.UTF8.GetBytes(json);
+        var readerOptions = new JsonReaderOptions
+        {
+            CommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true,
+        };
+        var reader = new Utf8JsonReader(bytes, readerOptions);
+        return DeserializeArrayIncrementally(ref reader, readElement);
+    }
+
+    private static (List<T> items, bool truncated) DeserializeArrayIncrementally<T>(ref Utf8JsonReader reader, ReadElement<T> readElement)
+    {
+        var items = new List<T>();
+
+        // Read start of array. Let exceptions propagate for truly invalid JSON.
+        if (!reader.Read() || reader.TokenType != JsonTokenType.StartArray)
+        {
+            throw new JsonException("Expected a JSON array.");
+        }
+
+        while (true)
+        {
+            bool readSuccess;
+            try
+            {
+                readSuccess = reader.Read();
+            }
+            catch (JsonException)
+            {
+                return (items, true);
+            }
+
+            if (!readSuccess)
+            {
+                return (items, true);
+            }
+
+            if (reader.TokenType == JsonTokenType.EndArray)
+            {
+                break;
+            }
+
+            try
+            {
+                var item = readElement(ref reader);
+                if (item is not null)
+                {
+                    items.Add(item);
+                }
+            }
+            catch (JsonException)
+            {
+                return (items, true);
+            }
+        }
+
+        return (items, false);
     }
 
     private static TValue DeserializeWithErrorHandling<TValue>(string description, string json, JsonTypeInfo<TValue> jsonTypeInfo)

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -250,7 +250,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unexpected or truncated content..
+        ///   Looks up a localized string similar to Unexpected or truncated message content..
         /// </summary>
         public static string GenAIUnexpectedOrTruncatedContent {
             get {

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -250,6 +250,15 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unexpected or truncated content..
+        /// </summary>
+        public static string GenAIUnexpectedOrTruncatedContent {
+            get {
+                return ResourceManager.GetString("GenAIUnexpectedOrTruncatedContent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Duration.
         /// </summary>
         public static string GenAIDurationLabel {

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -433,7 +433,7 @@
     <value>Error displaying GenAI content:</value>
   </data>
   <data name="GenAIUnexpectedOrTruncatedContent" xml:space="preserve">
-    <value>Unexpected or truncated content.</value>
+    <value>Unexpected or truncated message content.</value>
   </data>
   <data name="McpServerDialogIntroduction" xml:space="preserve">
     <value>Aspire MCP connects AI assistants to Aspire app data. AI can use Aspire MCP to get information about app resources, health checks, commands, console logs and real-time telemetry.</value>

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -432,6 +432,9 @@
   <data name="GenAIDisplayErrorMessageText" xml:space="preserve">
     <value>Error displaying GenAI content:</value>
   </data>
+  <data name="GenAIUnexpectedOrTruncatedContent" xml:space="preserve">
+    <value>Unexpected or truncated content.</value>
+  </data>
   <data name="McpServerDialogIntroduction" xml:space="preserve">
     <value>Aspire MCP connects AI assistants to Aspire app data. AI can use Aspire MCP to get information about app resources, health checks, commands, console logs and real-time telemetry.</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -278,8 +278,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GenAIUnexpectedOrTruncatedContent">
-        <source>Unexpected or truncated content.</source>
-        <target state="new">Unexpected or truncated content.</target>
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -277,6 +277,11 @@
         <target state="translated">Nástroje</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated content.</source>
+        <target state="new">Unexpected or truncated content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">Navigace na úrovni webu</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -278,8 +278,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GenAIUnexpectedOrTruncatedContent">
-        <source>Unexpected or truncated content.</source>
-        <target state="new">Unexpected or truncated content.</target>
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -277,6 +277,11 @@
         <target state="translated">Tools</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated content.</source>
+        <target state="new">Unexpected or truncated content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">Websiteweite Navigation</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -278,8 +278,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GenAIUnexpectedOrTruncatedContent">
-        <source>Unexpected or truncated content.</source>
-        <target state="new">Unexpected or truncated content.</target>
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -277,6 +277,11 @@
         <target state="translated">Herramientas</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated content.</source>
+        <target state="new">Unexpected or truncated content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">Navegación en todo el sitio</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -278,8 +278,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GenAIUnexpectedOrTruncatedContent">
-        <source>Unexpected or truncated content.</source>
-        <target state="new">Unexpected or truncated content.</target>
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -277,6 +277,11 @@
         <target state="translated">Outils</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated content.</source>
+        <target state="new">Unexpected or truncated content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">Navigation à l’échelle du site</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -278,8 +278,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GenAIUnexpectedOrTruncatedContent">
-        <source>Unexpected or truncated content.</source>
-        <target state="new">Unexpected or truncated content.</target>
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -277,6 +277,11 @@
         <target state="translated">Strumenti</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated content.</source>
+        <target state="new">Unexpected or truncated content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">Spostamento a livello di sito</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -278,8 +278,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GenAIUnexpectedOrTruncatedContent">
-        <source>Unexpected or truncated content.</source>
-        <target state="new">Unexpected or truncated content.</target>
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -277,6 +277,11 @@
         <target state="translated">ツール</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated content.</source>
+        <target state="new">Unexpected or truncated content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">サイト全体のナビゲーション</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -278,8 +278,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GenAIUnexpectedOrTruncatedContent">
-        <source>Unexpected or truncated content.</source>
-        <target state="new">Unexpected or truncated content.</target>
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -277,6 +277,11 @@
         <target state="translated">도구</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated content.</source>
+        <target state="new">Unexpected or truncated content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">사이트 전체 탐색</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -278,8 +278,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GenAIUnexpectedOrTruncatedContent">
-        <source>Unexpected or truncated content.</source>
-        <target state="new">Unexpected or truncated content.</target>
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -277,6 +277,11 @@
         <target state="translated">Narzędzia</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated content.</source>
+        <target state="new">Unexpected or truncated content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">Nawigacja w całej witrynie</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -278,8 +278,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GenAIUnexpectedOrTruncatedContent">
-        <source>Unexpected or truncated content.</source>
-        <target state="new">Unexpected or truncated content.</target>
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -277,6 +277,11 @@
         <target state="translated">Ferramentas</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated content.</source>
+        <target state="new">Unexpected or truncated content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">Navegação em todo o site</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -278,8 +278,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GenAIUnexpectedOrTruncatedContent">
-        <source>Unexpected or truncated content.</source>
-        <target state="new">Unexpected or truncated content.</target>
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -277,6 +277,11 @@
         <target state="translated">Инструменты</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated content.</source>
+        <target state="new">Unexpected or truncated content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">Навигация на уровне сайта</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -278,8 +278,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GenAIUnexpectedOrTruncatedContent">
-        <source>Unexpected or truncated content.</source>
-        <target state="new">Unexpected or truncated content.</target>
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -277,6 +277,11 @@
         <target state="translated">Araçlar</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated content.</source>
+        <target state="new">Unexpected or truncated content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">Site genelinde gezinti</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -278,8 +278,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GenAIUnexpectedOrTruncatedContent">
-        <source>Unexpected or truncated content.</source>
-        <target state="new">Unexpected or truncated content.</target>
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -277,6 +277,11 @@
         <target state="translated">工具</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated content.</source>
+        <target state="new">Unexpected or truncated content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">网站范围导航</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -278,8 +278,8 @@
         <note />
       </trans-unit>
       <trans-unit id="GenAIUnexpectedOrTruncatedContent">
-        <source>Unexpected or truncated content.</source>
-        <target state="new">Unexpected or truncated content.</target>
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -277,6 +277,11 @@
         <target state="translated">工具</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated content.</source>
+        <target state="new">Unexpected or truncated content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">全網站瀏覽</target>

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIMessageParsingHelperTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIMessageParsingHelperTests.cs
@@ -253,4 +253,160 @@ public sealed class GenAIMessageParsingHelperTests
         // Since the array contains a non-text item, it falls back to raw JSON.
         Assert.Equal(JsonValueKind.Array, toolResponse.Response.GetValueKind());
     }
+
+    [Fact]
+    public void ReadMessageParts_BlobPart_ParsesAllProperties()
+    {
+        var json = """[{"type":"blob","mime_type":"image/png","modality":"image","content":"iVBORw0KGgo="}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.False(truncated);
+        Assert.Single(items);
+
+        var parts = items[0];
+        var blobPart = Assert.IsType<BlobPart>(Assert.Single(parts));
+        Assert.Equal("blob", blobPart.Type);
+        Assert.Equal("image/png", blobPart.MimeType);
+        Assert.Equal("image", blobPart.Modality);
+        Assert.Equal("iVBORw0KGgo=", blobPart.Content);
+    }
+
+    [Fact]
+    public void ReadMessageParts_FilePart_ParsesAllProperties()
+    {
+        var json = """[{"type":"file","mime_type":"application/pdf","modality":"image","file_id":"file-abc123"}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.False(truncated);
+        Assert.Single(items);
+
+        var parts = items[0];
+        var filePart = Assert.IsType<FilePart>(Assert.Single(parts));
+        Assert.Equal("file", filePart.Type);
+        Assert.Equal("application/pdf", filePart.MimeType);
+        Assert.Equal("image", filePart.Modality);
+        Assert.Equal("file-abc123", filePart.FileId);
+    }
+
+    [Fact]
+    public void ReadMessageParts_UriPart_ParsesAllProperties()
+    {
+        var json = """[{"type":"uri","mime_type":"image/jpeg","modality":"image","uri":"https://example.com/photo.jpg"}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.False(truncated);
+        Assert.Single(items);
+
+        var parts = items[0];
+        var uriPart = Assert.IsType<UriPart>(Assert.Single(parts));
+        Assert.Equal("uri", uriPart.Type);
+        Assert.Equal("image/jpeg", uriPart.MimeType);
+        Assert.Equal("image", uriPart.Modality);
+        Assert.Equal("https://example.com/photo.jpg", uriPart.Uri);
+    }
+
+    [Fact]
+    public void ReadMessageParts_ReasoningPart_ParsesContent()
+    {
+        var json = """[{"type":"reasoning","content":"Let me think about this step by step..."}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.False(truncated);
+        Assert.Single(items);
+
+        var parts = items[0];
+        var reasoningPart = Assert.IsType<ReasoningPart>(Assert.Single(parts));
+        Assert.Equal("reasoning", reasoningPart.Type);
+        Assert.Equal("Let me think about this step by step...", reasoningPart.Content);
+    }
+
+    [Fact]
+    public void ReadMessageParts_ServerToolCallPart_ParsesAllProperties()
+    {
+        var json = """[{"type":"server_tool_call","id":"stc_1","name":"web_search","server_tool_call":{"type":"web_search","query":"latest news"}}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.False(truncated);
+        Assert.Single(items);
+
+        var parts = items[0];
+        var serverToolCallPart = Assert.IsType<ServerToolCallPart>(Assert.Single(parts));
+        Assert.Equal("server_tool_call", serverToolCallPart.Type);
+        Assert.Equal("stc_1", serverToolCallPart.Id);
+        Assert.Equal("web_search", serverToolCallPart.Name);
+        Assert.NotNull(serverToolCallPart.ServerToolCall);
+        Assert.Equal("latest news", serverToolCallPart.ServerToolCall["query"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void ReadMessageParts_ServerToolCallResponsePart_ParsesAllProperties()
+    {
+        var json = """[{"type":"server_tool_call_response","id":"stc_1","server_tool_call_response":{"type":"web_search","results":["result1","result2"]}}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.False(truncated);
+        Assert.Single(items);
+
+        var parts = items[0];
+        var serverToolCallResponsePart = Assert.IsType<ServerToolCallResponsePart>(Assert.Single(parts));
+        Assert.Equal("server_tool_call_response", serverToolCallResponsePart.Type);
+        Assert.Equal("stc_1", serverToolCallResponsePart.Id);
+        Assert.NotNull(serverToolCallResponsePart.ServerToolCallResponse);
+        Assert.Equal("web_search", serverToolCallResponsePart.ServerToolCallResponse["type"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void ReadMessageParts_ContentArray_BlobPart_ParsesCorrectly()
+    {
+        var json = """
+            [{"type":"text","content":[{"type":"blob","mime_type":"audio/mp3","modality":"audio","content":"AAAA"}]}]
+            """;
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.False(truncated);
+        Assert.Single(items);
+
+        var parts = items[0];
+        var blobPart = Assert.IsType<BlobPart>(Assert.Single(parts));
+        Assert.Equal("audio/mp3", blobPart.MimeType);
+        Assert.Equal("audio", blobPart.Modality);
+        Assert.Equal("AAAA", blobPart.Content);
+    }
+
+    [Fact]
+    public void ReadMessageParts_MixedNewPartTypes_ParsesCorrectly()
+    {
+        var json = """
+            [
+                {"type":"text","content":"Hello"},
+                {"type":"reasoning","content":"Thinking..."},
+                {"type":"blob","mime_type":"image/png","modality":"image","content":"base64data"},
+                {"type":"uri","mime_type":"image/jpeg","modality":"image","uri":"https://example.com/img.jpg"},
+                {"type":"file","mime_type":"application/pdf","modality":"image","file_id":"f1"},
+                {"type":"server_tool_call","id":"s1","name":"code_interpreter","server_tool_call":{"type":"code_interpreter"}},
+                {"type":"server_tool_call_response","id":"s1","server_tool_call_response":{"type":"code_interpreter","output":"42"}}
+            ]
+            """;
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.False(truncated);
+        Assert.Equal(7, items.Count);
+
+        Assert.Collection(items,
+            parts => Assert.IsType<TextPart>(Assert.Single(parts)),
+            parts => Assert.IsType<ReasoningPart>(Assert.Single(parts)),
+            parts => Assert.IsType<BlobPart>(Assert.Single(parts)),
+            parts => Assert.IsType<UriPart>(Assert.Single(parts)),
+            parts => Assert.IsType<FilePart>(Assert.Single(parts)),
+            parts => Assert.IsType<ServerToolCallPart>(Assert.Single(parts)),
+            parts => Assert.IsType<ServerToolCallResponsePart>(Assert.Single(parts)));
+    }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIMessageParsingHelperTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIMessageParsingHelperTests.cs
@@ -1,0 +1,256 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.Dashboard.Model.GenAI;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Model;
+
+public sealed class GenAIMessageParsingHelperTests
+{
+    [Fact]
+    public void DeserializeArrayIncrementally_CompleteArray_ReturnsFalseForTruncated()
+    {
+        var json = """[{"type":"text","content":"Hello"},{"type":"text","content":"World"}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.False(truncated);
+        Assert.Equal(2, items.Count);
+    }
+
+    [Fact]
+    public void DeserializeArrayIncrementally_TruncatedAfterFirstElement_ReturnsTrueForTruncated()
+    {
+        // JSON is cut off mid-way through the second element.
+        var json = """[{"type":"text","content":"Hello"},{"type":"text","con""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.True(truncated);
+        Assert.Single(items);
+        var parts = items[0];
+        var textPart = Assert.IsType<TextPart>(Assert.Single(parts));
+        Assert.Equal("Hello", textPart.Content);
+    }
+
+    [Fact]
+    public void DeserializeArrayIncrementally_TruncatedMidFirstElement_ReturnsTrueAndEmptyList()
+    {
+        // JSON is cut off in the middle of the first element.
+        var json = """[{"type":"text","con""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.True(truncated);
+        Assert.Empty(items);
+    }
+
+    [Fact]
+    public void DeserializeArrayIncrementally_TruncatedAfterArrayStart_ReturnsTrueAndEmptyList()
+    {
+        var json = """[""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.True(truncated);
+        Assert.Empty(items);
+    }
+
+    [Fact]
+    public void DeserializeArrayIncrementally_TruncatedAfterComma_ReturnsTrueWithParsedItems()
+    {
+        // JSON has a trailing comma but no next element.
+        var json = """[{"type":"text","content":"Hello"},""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.True(truncated);
+        Assert.Single(items);
+    }
+
+    [Fact]
+    public void ReadChatMessage_TruncatedParts_ReturnsPartsTruncatedTrue()
+    {
+        // First message completes, second message has truncated parts.
+        var json = """[{"role":"system","parts":[{"type":"text","content":"OK"}]},{"role":"user","parts":[{"type":"text","content":"Hello"},{"type":"text","con""";
+
+        var (chatMessages, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadChatMessage);
+
+        // The outer array is also truncated because the second message never closes.
+        Assert.True(truncated);
+
+        // The first message was fully parsed.
+        Assert.Single(chatMessages);
+        var (role, parts, partsTruncated) = chatMessages[0];
+        Assert.Equal("system", role);
+        Assert.False(partsTruncated);
+        Assert.Single(parts);
+    }
+
+    [Fact]
+    public void ReadChatMessage_CompleteParts_ReturnsPartsTruncatedFalse()
+    {
+        var json = """[{"role":"assistant","parts":[{"type":"text","content":"Hi there"}]}]""";
+
+        var (chatMessages, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadChatMessage);
+
+        Assert.False(truncated);
+        Assert.Single(chatMessages);
+
+        var (role, parts, partsTruncated) = chatMessages[0];
+        Assert.Equal("assistant", role);
+        Assert.False(partsTruncated);
+        Assert.Single(parts);
+        var textPart = Assert.IsType<TextPart>(parts[0]);
+        Assert.Equal("Hi there", textPart.Content);
+    }
+
+    [Fact]
+    public void ReadMessageParts_TextPartWithContentArray_ReturnsMultipleParts()
+    {
+        var json = """
+            [{"type":"text","content":[{"type":"text","text":"part one"},{"type":"text","text":"part two"}]}]
+            """;
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.False(truncated);
+        Assert.Single(items);
+
+        var parts = items[0];
+        Assert.Equal(2, parts.Count);
+
+        var part1 = Assert.IsType<TextPart>(parts[0]);
+        Assert.Equal("part one", part1.Content);
+
+        var part2 = Assert.IsType<TextPart>(parts[1]);
+        Assert.Equal("part two", part2.Content);
+    }
+
+    [Fact]
+    public void ReadMessageParts_TextPartWithContentArray_ToolUsePart()
+    {
+        var json = """
+            [{"type":"text","content":[{"type":"tool_use","id":"call_1","name":"get_weather","input":{"city":"Seattle"}}]}]
+            """;
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.False(truncated);
+        Assert.Single(items);
+
+        var parts = items[0];
+        var toolPart = Assert.IsType<ToolCallRequestPart>(Assert.Single(parts));
+        Assert.Equal("call_1", toolPart.Id);
+        Assert.Equal("get_weather", toolPart.Name);
+        Assert.NotNull(toolPart.Arguments);
+        Assert.Equal("Seattle", toolPart.Arguments["city"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void ReadMessageParts_TextPartWithContentArray_ToolResultPart()
+    {
+        var json = """
+            [{"type":"text","content":[{"type":"tool_result","tool_use_id":"call_1","content":"72°F"}]}]
+            """;
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.False(truncated);
+        Assert.Single(items);
+
+        var parts = items[0];
+        var toolResponse = Assert.IsType<ToolCallResponsePart>(Assert.Single(parts));
+        Assert.Equal("call_1", toolResponse.Id);
+        Assert.NotNull(toolResponse.Response);
+    }
+
+    [Fact]
+    public void ReadMessageParts_TextPartWithContentArray_MixedPartTypes()
+    {
+        var json = """
+            [{"type":"text","content":[{"type":"text","text":"Hello"},{"type":"tool_use","id":"t1","name":"search","input":{}},{"type":"unknown_type","data":123}]}]
+            """;
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.False(truncated);
+        Assert.Single(items);
+
+        var parts = items[0];
+        Assert.Equal(3, parts.Count);
+        Assert.IsType<TextPart>(parts[0]);
+        Assert.IsType<ToolCallRequestPart>(parts[1]);
+        Assert.IsType<GenericPart>(parts[2]);
+    }
+
+    [Fact]
+    public void ReadMessageParts_TextPartWithStringContent_ReturnsSingleTextPart()
+    {
+        var json = """[{"type":"text","content":"simple string"}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.False(truncated);
+        Assert.Single(items);
+
+        var parts = items[0];
+        var textPart = Assert.IsType<TextPart>(Assert.Single(parts));
+        Assert.Equal("simple string", textPart.Content);
+    }
+
+    [Fact]
+    public void ReadMessageParts_TextPartWithEmptyContentArray_ReturnsEmptyParts()
+    {
+        var json = """[{"type":"text","content":[]}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.False(truncated);
+        Assert.Single(items);
+
+        var parts = items[0];
+        Assert.Empty(parts);
+    }
+
+    [Fact]
+    public void ReadToolResultPart_ContentIsTextArray_JoinsTextIntoResponse()
+    {
+        var json = """
+            [{"type":"text","content":[{"type":"tool_result","tool_use_id":"call_1","content":[{"type":"text","text":"Hello "},{"type":"text","text":"World"}]}]}]
+            """;
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.False(truncated);
+        Assert.Single(items);
+
+        var parts = items[0];
+        var toolResponse = Assert.IsType<ToolCallResponsePart>(Assert.Single(parts));
+        Assert.Equal("call_1", toolResponse.Id);
+        Assert.NotNull(toolResponse.Response);
+        Assert.Equal("Hello World", toolResponse.Response.GetValue<string>());
+    }
+
+    [Fact]
+    public void ReadToolResultPart_ContentIsMixedArray_FallsBackToRawJson()
+    {
+        var json = """
+            [{"type":"text","content":[{"type":"tool_result","tool_use_id":"call_2","content":[{"type":"text","text":"Hi"},{"type":"image","url":"pic.png"}]}]}]
+            """;
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessageParts);
+
+        Assert.False(truncated);
+        Assert.Single(items);
+
+        var parts = items[0];
+        var toolResponse = Assert.IsType<ToolCallResponsePart>(Assert.Single(parts));
+        Assert.Equal("call_2", toolResponse.Id);
+        Assert.NotNull(toolResponse.Response);
+        // Since the array contains a non-text item, it falls back to raw JSON.
+        Assert.Equal(JsonValueKind.Array, toolResponse.Response.GetValueKind());
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIVisualizerDialogViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIVisualizerDialogViewModelTests.cs
@@ -2195,7 +2195,8 @@ public sealed class GenAIVisualizerDialogViewModelTests
             {
                 Assert.Equal(GenAIItemType.UserMessage, m.Type);
                 Assert.Collection(m.ItemParts,
-                    p => Assert.Equal("Hello World!", Assert.IsType<TextPart>(p.MessagePart).Content));
+                    p => Assert.Equal("Hello ", Assert.IsType<TextPart>(p.MessagePart).Content),
+                    p => Assert.Equal("World!", Assert.IsType<TextPart>(p.MessagePart).Content));
             });
     }
 

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIVisualizerDialogViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIVisualizerDialogViewModelTests.cs
@@ -672,7 +672,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
 
         // Assert
         Assert.Empty(vm.Items);
-        Assert.StartsWith("System.InvalidOperationException: ", vm.DisplayErrorMessage);
+        Assert.NotNull(vm.DisplayErrorMessage);
     }
 
     [Fact]
@@ -2128,5 +2128,294 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var invalidParam = tool.ToolDefinition.Parameters.Properties["invalidParam"];
         Assert.Null(invalidParam.Type); // Type should be null since it couldn't be parsed
         Assert.Equal("A parameter with invalid type structure", invalidParam.Description);
+    }
+
+    [Fact]
+    public void Create_GenAISpanAttributes_ContentAsArray_ExtractsText()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        // Content is an array of parts like [{"type":"text","text":"..."}] instead of a plain string.
+        var inputMessages = """
+            [
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "type": "text",
+                            "content": [
+                                {"type": "text", "text": "Hello "},
+                                {"type": "text", "text": "World!"}
+                            ]
+                        }
+                    ]
+                }
+            ]
+            """;
+
+        var attributes = new KeyValuePair<string, string>[]
+        {
+            KeyValuePair.Create(GenAIHelpers.GenAISystem, "System!"),
+            KeyValuePair.Create("server.address", "ai-server.address"),
+            KeyValuePair.Create(GenAIHelpers.GenAIInputMessages, inputMessages)
+        };
+
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10), attributes: attributes)
+                        }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, addContext.FailureCount);
+
+        var span = repository.GetSpan(GetHexId("1"), GetHexId("1-1"))!;
+        var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
+
+        // Act
+        var vm = Create(repository, spanDetailsViewModel);
+
+        // Assert
+        Assert.Null(vm.DisplayErrorMessage);
+        Assert.Collection(vm.Items,
+            m =>
+            {
+                Assert.Equal(GenAIItemType.UserMessage, m.Type);
+                Assert.Collection(m.ItemParts,
+                    p => Assert.Equal("Hello World!", Assert.IsType<TextPart>(p.MessagePart).Content));
+            });
+    }
+
+    [Fact]
+    public void Create_GenAISpanAttributes_TruncatedInputMessages_DisplaysAvailableMessages()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        var inputMessages = JsonSerializer.Serialize(new List<ChatMessage>
+        {
+            new ChatMessage
+            {
+                Role = "user",
+                Parts = [new TextPart { Content = "First message" }]
+            },
+            new ChatMessage
+            {
+                Role = "assistant",
+                Parts = [new TextPart { Content = "Second message" }]
+            },
+            new ChatMessage
+            {
+                Role = "user",
+                Parts = [new TextPart { Content = "Third message that will be truncated" }]
+            }
+        }, GenAIMessagesContext.Default.ListChatMessage);
+
+        // Truncate the JSON mid-way through the third message
+        var truncatedInput = inputMessages.Substring(0, inputMessages.IndexOf("Third"));
+
+        var attributes = new KeyValuePair<string, string>[]
+        {
+            KeyValuePair.Create(GenAIHelpers.GenAISystem, "System!"),
+            KeyValuePair.Create("server.address", "ai-server.address"),
+            KeyValuePair.Create(GenAIHelpers.GenAIInputMessages, truncatedInput)
+        };
+
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10), attributes: attributes)
+                        }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, addContext.FailureCount);
+
+        var span = repository.GetSpan(GetHexId("1"), GetHexId("1-1"))!;
+        var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
+
+        // Act
+        var vm = Create(repository, spanDetailsViewModel);
+
+        // Assert - first two messages parsed, third truncated, plus truncation indicator
+        Assert.Null(vm.DisplayErrorMessage);
+        Assert.Collection(vm.Items,
+            m =>
+            {
+                Assert.Equal(GenAIItemType.UserMessage, m.Type);
+                Assert.Collection(m.ItemParts,
+                    p => Assert.Equal("First message", Assert.IsType<TextPart>(p.MessagePart).Content));
+            },
+            m =>
+            {
+                Assert.Equal(GenAIItemType.AssistantMessage, m.Type);
+                Assert.Collection(m.ItemParts,
+                    p => Assert.Equal("Second message", Assert.IsType<TextPart>(p.MessagePart).Content));
+            },
+            m =>
+            {
+                Assert.Equal(GenAIItemType.UserMessage, m.Type);
+                Assert.Collection(m.ItemParts,
+                    p => Assert.Equal(Resources.Dialogs.GenAIUnexpectedOrTruncatedContent, p.ErrorMessage));
+            });
+    }
+
+    [Fact]
+    public void Create_GenAISpanAttributes_TruncatedSystemInstructions_DisplaysPartialContent()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        var systemInstruction = JsonSerializer.Serialize(new List<MessagePart>
+        {
+            new TextPart { Content = "First instruction" },
+            new TextPart { Content = "Second instruction that will be truncated" }
+        }, GenAIMessagesContext.Default.ListMessagePart);
+
+        // Truncate the JSON mid-way through the second instruction
+        var truncatedInstruction = systemInstruction.Substring(0, systemInstruction.IndexOf("Second"));
+
+        var attributes = new KeyValuePair<string, string>[]
+        {
+            KeyValuePair.Create(GenAIHelpers.GenAISystem, "System!"),
+            KeyValuePair.Create("server.address", "ai-server.address"),
+            KeyValuePair.Create(GenAIHelpers.GenAISystemInstructions, truncatedInstruction)
+        };
+
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10), attributes: attributes)
+                        }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, addContext.FailureCount);
+
+        var span = repository.GetSpan(GetHexId("1"), GetHexId("1-1"))!;
+        var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
+
+        // Act
+        var vm = Create(repository, spanDetailsViewModel);
+
+        // Assert - first instruction parsed, second truncated, plus truncation indicator
+        Assert.Null(vm.DisplayErrorMessage);
+        Assert.Collection(vm.Items,
+            m =>
+            {
+                Assert.Equal(GenAIItemType.SystemMessage, m.Type);
+                Assert.Collection(m.ItemParts,
+                    p => Assert.Equal("First instruction", Assert.IsType<TextPart>(p.MessagePart).Content),
+                    p => Assert.Equal(Resources.Dialogs.GenAIUnexpectedOrTruncatedContent, p.ErrorMessage));
+            });
+    }
+
+    [Fact]
+    public void Create_GenAISpanAttributes_TruncatedOutputMessages_DisplaysAvailableMessages()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        var outputMessages = JsonSerializer.Serialize(new List<ChatMessage>
+        {
+            new ChatMessage
+            {
+                Role = "assistant",
+                Parts = [new TextPart { Content = "Complete output" }]
+            },
+            new ChatMessage
+            {
+                Role = "assistant",
+                Parts = [new TextPart { Content = "Truncated output message" }]
+            }
+        }, GenAIMessagesContext.Default.ListChatMessage);
+
+        // Truncate the JSON mid-way through the second message
+        var truncatedOutput = outputMessages.Substring(0, outputMessages.IndexOf("Truncated"));
+
+        var attributes = new KeyValuePair<string, string>[]
+        {
+            KeyValuePair.Create(GenAIHelpers.GenAISystem, "System!"),
+            KeyValuePair.Create("server.address", "ai-server.address"),
+            KeyValuePair.Create(GenAIHelpers.GenAIOutputInstructions, truncatedOutput)
+        };
+
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10), attributes: attributes)
+                        }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, addContext.FailureCount);
+
+        var span = repository.GetSpan(GetHexId("1"), GetHexId("1-1"))!;
+        var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
+
+        // Act
+        var vm = Create(repository, spanDetailsViewModel);
+
+        // Assert - first output message parsed, second truncated, plus truncation indicator
+        Assert.Null(vm.DisplayErrorMessage);
+        Assert.Collection(vm.Items,
+            m =>
+            {
+                Assert.Equal(GenAIItemType.OutputMessage, m.Type);
+                Assert.Collection(m.ItemParts,
+                    p => Assert.Equal("Complete output", Assert.IsType<TextPart>(p.MessagePart).Content));
+            },
+            m =>
+            {
+                Assert.Equal(GenAIItemType.OutputMessage, m.Type);
+                Assert.Collection(m.ItemParts,
+                    p => Assert.Equal(Resources.Dialogs.GenAIUnexpectedOrTruncatedContent, p.ErrorMessage));
+            });
     }
 }


### PR DESCRIPTION
## Description

Improve GenAI message parsing in the Aspire Dashboard to properly handle content arrays and improve truncation tolerance.

### Changes

- **Refactor `ReadMessagePart` → `ReadMessageParts`**: Returns `List<MessagePart>` instead of a single part, enabling content arrays that contain mixed part types (text, tool_use, tool_result, unknown) to each be parsed as separate message parts.
- **Extract parsing logic**: Moved `DeserializeArrayIncrementally` and message part parsing from `GenAIVisualizerDialogViewModel.cs` and `MessagePartConverter` in `GenAIMessages.cs` into the dedicated `GenAIMessageParsingHelper.cs` for better separation of concerns and testability.
- **`ReadToolResultPart` text joining**: When a `tool_result` content is an array of all `{"type":"text","text":"..."}` objects, the text values are joined into a single string response. Mixed arrays fall back to raw JSON.
- **Per-message truncation errors**: `ParseMessages` now checks `partsTruncated` on each individual chat message and appends an error part when a message's parts were truncated.
- **New test file**: Added `GenAIMessageParsingHelperTests.cs` with 15 tests covering truncated JSON scenarios, content array parsing with various part types, and tool result text joining.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
