### PR TITLE
GenAI tools view: move description to expanded content and sort by name

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -301,7 +301,7 @@
                                 @if (Content.ToolDefinitions.Count > 0)
                                 {
                                     <FluentAccordion Class="tools-list">
-                                        @foreach (var toolVM in Content.ToolDefinitions.Where(t => t.ToolDefinition.Type == "function").OrderBy(t => t.ToolDefinition.Name))
+                                        @foreach (var toolVM in Content.ToolDefinitions.Where(t => t.ToolDefinition.Type == "function").OrderBy(t => t.ToolDefinition.Name, StringComparer.OrdinalIgnoreCase))
                                         {
                                             <FluentAccordionItem @bind-Expanded="toolVM.Expanded" HeadingTooltip="@GetToolHeadingTooltip(toolVM)">
                                                 <HeadingTemplate>
@@ -315,8 +315,10 @@
                                                 <ChildContent>
                                                     @if (!string.IsNullOrEmpty(toolVM.ToolDefinition.Description))
                                                     {
-                                                        <p class="tool-description">@toolVM.ToolDefinition.Description</p>
-                                                        <hr />
+                                                        <div class="tool-description">
+                                                            <MarkdownRenderer MarkdownProcessor="@_markdownProcess" Markdown="@toolVM.ToolDefinition.Description" />
+                                                        </div>
+                                                        <FluentDivider />
                                                     }
                                                     @if (toolVM.ToolDefinition.Parameters is { Properties: { Count: > 0 } properties })
                                                     {

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -318,7 +318,7 @@
                                                         <div class="tool-description">
                                                             <MarkdownRenderer MarkdownProcessor="@_markdownProcess" Markdown="@toolVM.ToolDefinition.Description" />
                                                         </div>
-                                                        <FluentDivider />
+                                                        <hr />
                                                     }
                                                     @if (toolVM.ToolDefinition.Parameters is { Properties: { Count: > 0 } properties })
                                                     {

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -301,7 +301,7 @@
                                 @if (Content.ToolDefinitions.Count > 0)
                                 {
                                     <FluentAccordion Class="tools-list">
-                                        @foreach (var toolVM in Content.ToolDefinitions.Where(t => t.ToolDefinition.Type == "function"))
+                                        @foreach (var toolVM in Content.ToolDefinitions.Where(t => t.ToolDefinition.Type == "function").OrderBy(t => t.ToolDefinition.Name))
                                         {
                                             <FluentAccordionItem @bind-Expanded="toolVM.Expanded" HeadingTooltip="@GetToolHeadingTooltip(toolVM)">
                                                 <HeadingTemplate>
@@ -310,13 +310,14 @@
                                                             @toolVM.ToolDefinition.Type
                                                         </FluentBadge>
                                                         <span class="tool-name">@toolVM.ToolDefinition.Name</span>
-                                                        @if (!string.IsNullOrEmpty(toolVM.ToolDefinition.Description))
-                                                        {
-                                                            <span>@FormatHelpers.TruncateText(toolVM.ToolDefinition.Description, maxLength: 100)</span>
-                                                        }
                                                     </div>
                                                 </HeadingTemplate>
                                                 <ChildContent>
+                                                    @if (!string.IsNullOrEmpty(toolVM.ToolDefinition.Description))
+                                                    {
+                                                        <p class="tool-description">@toolVM.ToolDefinition.Description</p>
+                                                        <hr />
+                                                    }
                                                     @if (toolVM.ToolDefinition.Parameters is { Properties: { Count: > 0 } properties })
                                                     {
                                                         <table class="tool-parameters-table">

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
@@ -223,6 +223,15 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
         Content = dialogViewModel;
         _currentSpanContextIndex = _contextSpans.IndexOf(newSpan);
 
+        if (OverviewActiveView is OverviewViewKind.Tools && Content.ToolDefinitions.Count == 0)
+        {
+            OverviewActiveView = OverviewViewKind.InputOutput;
+        }
+        else if (OverviewActiveView is OverviewViewKind.Evaluations && Content.Evaluations.Count == 0)
+        {
+            OverviewActiveView = OverviewViewKind.InputOutput;
+        }
+
         return true;
     }
 

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
@@ -279,8 +279,14 @@
     margin-right: 0.25rem;
 }
 
+::deep .tab-container .tool-description {
+    margin: 0 0 8px 4px;
+    font-size: small;
+}
+
 ::deep .tab-container .tool-footer {
     padding-left: 4px;
+    font-weight: 500;
 }
 
 ::deep .tab-container .tool-parameters-table {

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
@@ -284,6 +284,10 @@
     font-size: small;
 }
 
+::deep .tab-container .tool-description * {
+    font-size: inherit;
+}
+
 ::deep .tab-container .tool-footer {
     padding-left: 4px;
     font-weight: 500;

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
@@ -291,6 +291,7 @@
 ::deep .tab-container .tool-footer {
     padding-left: 4px;
     font-weight: 500;
+    margin-bottom: 8px;
 }
 
 ::deep .tab-container .tool-parameters-table {

--- a/src/Aspire.Dashboard/Properties/launchSettings.json
+++ b/src/Aspire.Dashboard/Properties/launchSettings.json
@@ -12,7 +12,8 @@
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:4318"
       },
       "applicationUrl": "http://localhost:15889"
     }


### PR DESCRIPTION
## Description

The tools view didn't display well with complex, real world content.

Update the GenAI visualizer tools view in the Dashboard:
- Move tool description from the expand/collapse header to the expanded content area, reducing header clutter
- Sort tools alphabetically by name for easier discovery
- Render description as markdown

After:
<img width="1270" height="975" alt="image" src="https://github.com/user-attachments/assets/2fce1836-51c0-4723-ad4d-a30d25abfb89" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
