### PR TITLE
Fix GenAI tool call display escaping non-ASCII characters

### DIFF
--- a/playground/Stress/Stress.ApiService/Program.cs
+++ b/playground/Stress/Stress.ApiService/Program.cs
@@ -494,7 +494,7 @@ app.MapGet("/genai-trace", async () =>
                   {
                     "type": "tool_call",
                     "name": "get_weather",
-                    "call_id": "call_abc123",
+                    "id": "call_abc123",
                     "arguments": "{\"location\": \"東京\", \"unit\": \"celsius\"}"
                   }
                 ]
@@ -504,7 +504,7 @@ app.MapGet("/genai-trace", async () =>
                 "parts": [
                   {
                     "type": "tool_call_response",
-                    "call_id": "call_abc123",
+                    "id": "call_abc123",
                     "response": "- First (最初)\r\n- Second (二番目)\r\n- 天気予報: 東京は晴れ、気温25度です。"
                   }
                 ]

--- a/playground/Stress/Stress.ApiService/Program.cs
+++ b/playground/Stress/Stress.ApiService/Program.cs
@@ -490,6 +490,12 @@ app.MapGet("/genai-trace", async () =>
                   {
                     "type": "text",
                     "content": "Assistant content"
+                  },
+                  {
+                    "type": "tool_call",
+                    "name": "get_weather",
+                    "call_id": "call_abc123",
+                    "arguments": "{\"location\": \"東京\", \"unit\": \"celsius\"}"
                   }
                 ]
               },
@@ -498,7 +504,8 @@ app.MapGet("/genai-trace", async () =>
                 "parts": [
                   {
                     "type": "tool_call_response",
-                    "response": "- First\r\n- Second"
+                    "call_id": "call_abc123",
+                    "response": "- First (最初)\r\n- Second (二番目)\r\n- 天気予報: 東京は晴れ、気温25度です。"
                   }
                 ]
               },

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIItemPartViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIItemPartViewModel.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Dashboard.Components.Controls;
@@ -19,6 +20,11 @@ public sealed class GenAIPartPropertyViewModel : IPropertyGridItem
 
 public sealed class GenAIItemPartViewModel
 {
+    private static readonly JsonSerializerOptions s_jsonSerializerOptions = new()
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
     public MessagePart? MessagePart { get; init; }
     public string? ErrorMessage { get; init; }
     public required TextVisualizerViewModel TextVisualizerViewModel { get; init; }
@@ -68,7 +74,7 @@ public sealed class GenAIItemPartViewModel
                 null => string.Empty,
                 JsonObject obj when obj.Count == 0 => string.Empty,
                 JsonArray arr when arr.Count == 0 => string.Empty,
-                _ => toolCallRequestPart.Arguments.ToJsonString()
+                _ => toolCallRequestPart.Arguments.ToJsonString(s_jsonSerializerOptions)
             };
 
             return new TextVisualizerViewModel($"{toolCallRequestPart.Name}({argumentsText})", indentText: true, knownFormat: DashboardUIHelpers.JavascriptFormat);
@@ -80,13 +86,13 @@ public sealed class GenAIItemPartViewModel
             // And it allows possible Markdown content inside the string to be formatted.
             var toolResponseContent = (toolCallResponsePart.Response?.GetValueKind() == JsonValueKind.String)
                 ? toolCallResponsePart.Response.GetValue<string>()
-                : toolCallResponsePart.Response?.ToJsonString() ?? string.Empty;
+                : toolCallResponsePart.Response?.ToJsonString(s_jsonSerializerOptions) ?? string.Empty;
 
             return new TextVisualizerViewModel(toolResponseContent, indentText: true, fallbackFormat: DashboardUIHelpers.MarkdownFormat);
         }
 
         var additionalProperties = p is GenericPart genericPart ? genericPart.AdditionalProperties ?? [] : [];
-        var content = additionalProperties.Count > 0 ? ToJsonObject(additionalProperties).ToJsonString() : string.Empty;
+        var content = additionalProperties.Count > 0 ? ToJsonObject(additionalProperties).ToJsonString(s_jsonSerializerOptions) : string.Empty;
 
         return new TextVisualizerViewModel(content, indentText: true);
     }

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIItemPartViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIItemPartViewModelTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Dashboard.Model.GenAI;
 using Aspire.Dashboard.Utils;
@@ -94,5 +95,62 @@ public sealed class GenAIItemPartViewModelTests
         // Assert
         Assert.Equal("""{"name":"Jack","age":30}""", itemPart.TextVisualizerViewModel.Text);
         Assert.Equal(DashboardUIHelpers.JsonFormat, itemPart.TextVisualizerViewModel.FormatKind);
+    }
+
+    [Fact]
+    public void CreateMessagePart_ToolCallRequest_NonAsciiArguments_PreservesCharacters()
+    {
+        // Arrange
+        var requestPart = new ToolCallRequestPart
+        {
+            Name = "get_weather",
+            Arguments = JsonNode.Parse("""{"location":"東京","unit":"celsius"}""")
+        };
+
+        // Act
+        var itemPart = GenAIItemPartViewModel.CreateMessagePart(requestPart);
+
+        // Assert
+        Assert.Contains("東京", itemPart.TextVisualizerViewModel.Text);
+        Assert.Equal(DashboardUIHelpers.JavascriptFormat, itemPart.TextVisualizerViewModel.FormatKind);
+    }
+
+    [Fact]
+    public void CreateMessagePart_ToolCallResponse_NonAsciiObjectResponse_PreservesCharacters()
+    {
+        // Arrange
+        var responsePart = new ToolCallResponsePart
+        {
+            Response = JsonNode.Parse("""{"weather":"晴れ","city":"東京"}""")
+        };
+
+        // Act
+        var itemPart = GenAIItemPartViewModel.CreateMessagePart(responsePart);
+
+        // Assert
+        Assert.Contains("晴れ", itemPart.TextVisualizerViewModel.Text);
+        Assert.Contains("東京", itemPart.TextVisualizerViewModel.Text);
+        Assert.Equal(DashboardUIHelpers.JavascriptFormat, itemPart.TextVisualizerViewModel.FormatKind);
+    }
+
+    [Fact]
+    public void CreateMessagePart_GenericPart_NonAsciiProperties_PreservesCharacters()
+    {
+        // Arrange
+        var genericPart = new GenericPart
+        {
+            Type = "custom",
+            AdditionalProperties = new Dictionary<string, JsonElement>
+            {
+                ["message"] = JsonDocument.Parse("""{"text":"こんにちは"}""").RootElement.GetProperty("text")
+            }
+        };
+
+        // Act
+        var itemPart = GenAIItemPartViewModel.CreateMessagePart(genericPart);
+
+        // Assert
+        Assert.Contains("こんにちは", itemPart.TextVisualizerViewModel.Text);
+        Assert.Equal(DashboardUIHelpers.JavascriptFormat, itemPart.TextVisualizerViewModel.FormatKind);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIItemPartViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIItemPartViewModelTests.cs
@@ -130,7 +130,7 @@ public sealed class GenAIItemPartViewModelTests
         // Assert
         Assert.Contains("晴れ", itemPart.TextVisualizerViewModel.Text);
         Assert.Contains("東京", itemPart.TextVisualizerViewModel.Text);
-        Assert.Equal(DashboardUIHelpers.JavascriptFormat, itemPart.TextVisualizerViewModel.FormatKind);
+        Assert.Equal(DashboardUIHelpers.JsonFormat, itemPart.TextVisualizerViewModel.FormatKind);
     }
 
     [Fact]
@@ -151,6 +151,6 @@ public sealed class GenAIItemPartViewModelTests
 
         // Assert
         Assert.Contains("こんにちは", itemPart.TextVisualizerViewModel.Text);
-        Assert.Equal(DashboardUIHelpers.JavascriptFormat, itemPart.TextVisualizerViewModel.FormatKind);
+        Assert.DoesNotContain("\\u", itemPart.TextVisualizerViewModel.Text);
     }
 }


### PR DESCRIPTION
## Description

Fix the GenAI visualizer raw view escaping non-ASCII characters (e.g. Japanese) as `\uXXXX` sequences in tool call request arguments, tool call responses, and generic part properties.

**Changes:**
- Use `JavaScriptEncoder.UnsafeRelaxedJsonEscaping` for all `ToJsonString()` calls in `GenAIItemPartViewModel` so non-ASCII characters display correctly.
- Fix stress test tool call type from `tool_call_request` to `tool_call` to match the dashboard's expected type discriminator.
- Add tool call request with Japanese arguments and Japanese content in tool call response to the stress test GenAI sample.
- Add tests verifying non-ASCII characters are preserved in tool call request arguments, tool call response content, and generic part properties.

Fixes https://github.com/dotnet/aspire/issues/14444

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
