### PR TITLE
Improve GenAI visualizer: truncation tolerance, new part types

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -89,7 +89,11 @@
                             <div class="tab-container">
                                 @foreach (var itemPart in selectedItem.ItemParts)
                                 {
-                                    if (TryGetDataPart(itemPart, MimeTypeHelpers.SupportedImageTypes, out var imageData))
+                                    if (itemPart.ErrorMessage is not null)
+                                    {
+                                        <span class="error-message-text">@itemPart.ErrorMessage</span>
+                                    }
+                                    else if (TryGetDataPart(itemPart, MimeTypeHelpers.SupportedImageTypes, out var imageData))
                                     {
                                         <img src="@imageData.Url" />
                                     }
@@ -150,6 +154,18 @@
                                         if (itemPart.MessagePart is ToolCallRequestPart toolCallPart && !string.IsNullOrEmpty(toolCallPart.Name))
                                         {
                                             if (Content.ToolDefinitions.FirstOrDefault(d => d.ToolDefinition.Name == toolCallPart.Name) is { } toolVM)
+                                            {
+                                                <div class="tool-button-container">
+                                                    <FluentButton OnClick="@(() => ViewToolDefinitionAsync(toolVM))">
+                                                        <FluentIcon Value="@s_wrenchIcon" Style="vertical-align: sub;" slot="start" />
+                                                        Tool definition
+                                                    </FluentButton>
+                                                </div>
+                                            }
+                                        }
+                                        else if (itemPart.MessagePart is ServerToolCallPart serverToolCallPart && !string.IsNullOrEmpty(serverToolCallPart.Name))
+                                        {
+                                            if (Content.ToolDefinitions.FirstOrDefault(d => d.ToolDefinition.Name == serverToolCallPart.Name) is { } toolVM)
                                             {
                                                 <div class="tool-button-container">
                                                     <FluentButton OnClick="@(() => ViewToolDefinitionAsync(toolVM))">
@@ -473,7 +489,14 @@
                         {
                             foreach (var itemPart in itemParts)
                             {
-                                <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" HideLineNumbers="true" Virtualize="false" />
+                                if (itemPart.ErrorMessage is not null)
+                                {
+                                    <div class="error-message-text">@itemPart.ErrorMessage</div>
+                                }
+                                else
+                                {
+                                    <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" HideLineNumbers="true" Virtualize="false" />
+                                }
                             }
                         }
                         else

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
@@ -289,36 +289,36 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
 
     private static bool TryGetDataPart(GenAIItemPartViewModel itemPart, HashSet<string>? matchingMimeTypes, [NotNullWhen(true)] out DataInfo? dataInfo)
     {
-        switch (itemPart.MessagePart?.Type)
+        switch (itemPart.MessagePart)
         {
-            case "blob":
+            case BlobPart blobPart:
                 {
-                    if (MatchMimeType(itemPart, matchingMimeTypes, out var mimeType))
+                    if (MatchMimeType(blobPart.MimeType, matchingMimeTypes))
                     {
-                        if (itemPart.TryGetPropertyValue("content", out var content))
+                        if (!string.IsNullOrEmpty(blobPart.Content))
                         {
                             dataInfo = new DataInfo(
-                                Url: $"data:{mimeType};base64,{content}",
-                                MimeType: mimeType,
-                                FileName: CalculateFileName(currentFileName: null, mimeType));
+                                Url: $"data:{blobPart.MimeType};base64,{blobPart.Content}",
+                                MimeType: blobPart.MimeType!,
+                                FileName: CalculateFileName(currentFileName: null, blobPart.MimeType!));
                             return true;
                         }
                     }
                     break;
                 }
-            case "uri":
+            case UriPart uriPart:
                 {
-                    if (MatchMimeType(itemPart, matchingMimeTypes, out var mimeType))
+                    if (MatchMimeType(uriPart.MimeType, matchingMimeTypes))
                     {
-                        if (itemPart.TryGetPropertyValue("uri", out var uri))
+                        if (!string.IsNullOrEmpty(uriPart.Uri))
                         {
                             // Only attempt to display image if it is an http/https address.
-                            if (Uri.TryCreate(uri, UriKind.Absolute, out var result) && result.Scheme.ToLowerInvariant() is "http" or "https")
+                            if (Uri.TryCreate(uriPart.Uri, UriKind.Absolute, out var result) && result.Scheme.ToLowerInvariant() is "http" or "https")
                             {
                                 dataInfo = new DataInfo(
-                                    Url: uri,
-                                    MimeType: mimeType,
-                                    FileName: CalculateFileName(Path.GetFileName(result.LocalPath), mimeType));
+                                    Url: uriPart.Uri,
+                                    MimeType: uriPart.MimeType!,
+                                    FileName: CalculateFileName(Path.GetFileName(result.LocalPath), uriPart.MimeType!));
                                 return true;
                             }
                         }
@@ -330,11 +330,11 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
         dataInfo = null;
         return false;
 
-        static bool MatchMimeType(GenAIItemPartViewModel viewModel, HashSet<string>? matchingMimeTypes, [NotNullWhen(true)] out string? mimeType)
+        static bool MatchMimeType(string? mimeType, HashSet<string>? matchingMimeTypes)
         {
-            if (viewModel.TryGetPropertyValue("mime_type", out mimeType))
+            if (!string.IsNullOrEmpty(mimeType))
             {
-                return matchingMimeTypes == null || matchingMimeTypes.Contains(mimeType);
+                return matchingMimeTypes is null || matchingMimeTypes.Contains(mimeType);
             }
 
             return false;

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
@@ -174,6 +174,7 @@
     flex-direction: column;
     row-gap: 12px;
     width: 100%;
+    margin-bottom: 4px;
 }
 
 ::deep .span-details-layout, ::deep .property-grid-container {
@@ -214,6 +215,11 @@
 
 ::deep .display-error-message {
     color: var(--error);
+}
+
+::deep .error-message-text {
+    color: var(--error);
+    font-weight: 500;
 }
 
 ::deep .display-error-content {

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIItemPartViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIItemPartViewModel.cs
@@ -90,6 +90,42 @@ public sealed class GenAIItemPartViewModel
 
             return new TextVisualizerViewModel(toolResponseContent, indentText: true, fallbackFormat: DashboardUIHelpers.MarkdownFormat);
         }
+        if (p is BlobPart blobPart)
+        {
+            return new TextVisualizerViewModel(blobPart.Content ?? string.Empty, indentText: true);
+        }
+        if (p is UriPart uriPart)
+        {
+            return new TextVisualizerViewModel(uriPart.Uri ?? string.Empty, indentText: true);
+        }
+        if (p is FilePart filePart)
+        {
+            return new TextVisualizerViewModel(filePart.FileId ?? string.Empty, indentText: true);
+        }
+        if (p is ReasoningPart reasoningPart)
+        {
+            return new TextVisualizerViewModel(reasoningPart.Content ?? string.Empty, indentText: true, fallbackFormat: DashboardUIHelpers.MarkdownFormat);
+        }
+        if (p is ServerToolCallPart serverToolCallPart)
+        {
+            var serverToolCallText = serverToolCallPart.ServerToolCall switch
+            {
+                null => string.Empty,
+                JsonObject obj when obj.Count == 0 => string.Empty,
+                JsonArray arr when arr.Count == 0 => string.Empty,
+                _ => serverToolCallPart.ServerToolCall.ToJsonString(s_jsonSerializerOptions)
+            };
+
+            return new TextVisualizerViewModel($"{serverToolCallPart.Name}({serverToolCallText})", indentText: true, knownFormat: DashboardUIHelpers.JavascriptFormat);
+        }
+        if (p is ServerToolCallResponsePart serverToolCallResponsePart)
+        {
+            var responseContent = (serverToolCallResponsePart.ServerToolCallResponse?.GetValueKind() == JsonValueKind.String)
+                ? serverToolCallResponsePart.ServerToolCallResponse.GetValue<string>()
+                : serverToolCallResponsePart.ServerToolCallResponse?.ToJsonString(s_jsonSerializerOptions) ?? string.Empty;
+
+            return new TextVisualizerViewModel(responseContent, indentText: true, fallbackFormat: DashboardUIHelpers.MarkdownFormat);
+        }
 
         var additionalProperties = p is GenericPart genericPart ? genericPart.AdditionalProperties ?? [] : [];
         var content = additionalProperties.Count > 0 ? ToJsonObject(additionalProperties).ToJsonString(s_jsonSerializerOptions) : string.Empty;

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIItemViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIItemViewModel.cs
@@ -37,7 +37,7 @@ public class GenAIItemViewModel
         }
         if (Type == GenAIItemType.OutputMessage)
         {
-            if (ItemParts.Any(p => p.MessagePart?.Type == MessagePart.ToolCallType))
+            if (ItemParts.Any(p => p.MessagePart?.Type is MessagePart.ToolCallType or MessagePart.ServerToolCallType))
             {
                 return new BadgeDetail(loc[nameof(Dialogs.GenAIMessageCategoryToolCalls)], "output", s_toolCallsIcon);
             }
@@ -46,11 +46,11 @@ public class GenAIItemViewModel
                 return new BadgeDetail(loc[nameof(Dialogs.GenAIMessageCategoryOutput)], "output", s_messageIcon);
             }
         }
-        if (ItemParts.Any(p => p.MessagePart?.Type == MessagePart.ToolCallType))
+        if (ItemParts.Any(p => p.MessagePart?.Type is MessagePart.ToolCallType or MessagePart.ServerToolCallType))
         {
             return new BadgeDetail(loc[nameof(Dialogs.GenAIMessageCategoryToolCalls)], "tool-calls", s_toolCallsIcon);
         }
-        if (ItemParts.Any(p => p.MessagePart?.Type == MessagePart.ToolCallResponseType))
+        if (ItemParts.Any(p => p.MessagePart?.Type is MessagePart.ToolCallResponseType or MessagePart.ServerToolCallResponseType))
         {
             return new BadgeDetail(loc[nameof(Dialogs.GenAIMessageCategoryToolResponse)], "tool-response", s_messageIcon);
         }

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIMessageParsingHelper.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIMessageParsingHelper.cs
@@ -1,0 +1,140 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using System.Text.Json;
+
+namespace Aspire.Dashboard.Model.GenAI;
+
+/// <summary>
+/// Provides truncation-tolerant JSON array deserialization for GenAI message parsing.
+/// </summary>
+internal static class GenAIMessageParsingHelper
+{
+    internal delegate T? ReadElement<T>(ref Utf8JsonReader reader);
+
+    internal static (List<T> items, bool truncated) DeserializeArrayIncrementally<T>(string json, ReadElement<T> readElement)
+    {
+        var bytes = Encoding.UTF8.GetBytes(json);
+        var readerOptions = new JsonReaderOptions
+        {
+            CommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true,
+        };
+        var reader = new Utf8JsonReader(bytes, readerOptions);
+        return DeserializeArrayIncrementally(ref reader, readElement);
+    }
+
+    internal static (List<T> items, bool truncated) DeserializeArrayIncrementally<T>(ref Utf8JsonReader reader, ReadElement<T> readElement)
+    {
+        var items = new List<T>();
+
+        // Read start of array. Let exceptions propagate for truly invalid JSON.
+        if (!reader.Read() || reader.TokenType != JsonTokenType.StartArray)
+        {
+            throw new JsonException("Expected a JSON array.");
+        }
+
+        while (true)
+        {
+            bool readSuccess;
+            try
+            {
+                readSuccess = reader.Read();
+            }
+            catch (JsonException)
+            {
+                return (items, true);
+            }
+
+            if (!readSuccess)
+            {
+                return (items, true);
+            }
+
+            if (reader.TokenType == JsonTokenType.EndArray)
+            {
+                break;
+            }
+
+            try
+            {
+                var item = readElement(ref reader);
+                if (item is not null)
+                {
+                    items.Add(item);
+                }
+            }
+            catch (JsonException)
+            {
+                return (items, true);
+            }
+            catch (InvalidOperationException)
+            {
+                return (items, true);
+            }
+        }
+
+        return (items, false);
+    }
+
+    internal static MessagePart? ReadMessagePart(ref Utf8JsonReader reader)
+    {
+        return JsonSerializer.Deserialize(ref reader, GenAIMessagesContext.Default.MessagePart);
+    }
+
+    internal static (string role, List<MessagePart> parts, bool partsTruncated) ReadChatMessage(ref Utf8JsonReader reader)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            throw new JsonException("Expected start of chat message object.");
+        }
+
+        string? role = null;
+        List<MessagePart>? parts = null;
+        var partsTruncated = false;
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                break;
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw new JsonException("Expected property name.");
+            }
+
+            var propertyName = reader.GetString();
+
+            switch (propertyName)
+            {
+                case "role":
+                    if (!reader.Read())
+                    {
+                        throw new JsonException("Unexpected end of JSON while reading role value.");
+                    }
+                    role = reader.GetString();
+                    break;
+                case "parts":
+                    // DeserializeArrayIncrementally reads the StartArray token itself.
+                    (parts, partsTruncated) = DeserializeArrayIncrementally<MessagePart>(ref reader, ReadMessagePart);
+                    break;
+                default:
+                    if (!reader.Read())
+                    {
+                        throw new JsonException("Unexpected end of JSON while reading property value.");
+                    }
+
+                    if (!reader.TrySkip())
+                    {
+                        throw new JsonException("Unexpected end of JSON while skipping property value.");
+                    }
+                    break;
+            }
+        }
+
+        return (role ?? string.Empty, parts ?? [], partsTruncated);
+    }
+}

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
@@ -10,7 +10,7 @@ using Microsoft.OpenApi;
 namespace Aspire.Dashboard.Model.GenAI;
 
 /// <summary>
-/// Represents text, tool calls, and generic parts.
+/// Represents text, tool calls, data parts, and generic parts.
 /// </summary>
 [JsonConverter(typeof(MessagePartConverter))]
 public abstract class MessagePart
@@ -18,6 +18,12 @@ public abstract class MessagePart
     public const string TextType = "text";
     public const string ToolCallType = "tool_call";
     public const string ToolCallResponseType = "tool_call_response";
+    public const string BlobType = "blob";
+    public const string FileType = "file";
+    public const string UriType = "uri";
+    public const string ReasoningType = "reasoning";
+    public const string ServerToolCallType = "server_tool_call";
+    public const string ServerToolCallResponseType = "server_tool_call_response";
 
     public string Type { get; set; } = default!;
 }
@@ -65,6 +71,93 @@ public class ToolCallResponsePart : MessagePart
 }
 
 /// <summary>
+/// Represents blob binary data sent inline to the model.
+/// </summary>
+public class BlobPart : MessagePart
+{
+    public BlobPart()
+    {
+        Type = BlobType;
+    }
+
+    public string? MimeType { get; set; }
+    public string? Modality { get; set; }
+    public string? Content { get; set; }
+}
+
+/// <summary>
+/// Represents an external referenced file sent to the model by file ID.
+/// </summary>
+public class FilePart : MessagePart
+{
+    public FilePart()
+    {
+        Type = FileType;
+    }
+
+    public string? MimeType { get; set; }
+    public string? Modality { get; set; }
+    public string? FileId { get; set; }
+}
+
+/// <summary>
+/// Represents an external referenced file sent to the model by URI.
+/// </summary>
+public class UriPart : MessagePart
+{
+    public UriPart()
+    {
+        Type = UriType;
+    }
+
+    public string? MimeType { get; set; }
+    public string? Modality { get; set; }
+    public string? Uri { get; set; }
+}
+
+/// <summary>
+/// Represents reasoning/thinking content received from the model.
+/// </summary>
+public class ReasoningPart : MessagePart
+{
+    public ReasoningPart()
+    {
+        Type = ReasoningType;
+    }
+
+    public string? Content { get; set; }
+}
+
+/// <summary>
+/// Represents a server-side tool call invocation.
+/// </summary>
+public class ServerToolCallPart : MessagePart
+{
+    public ServerToolCallPart()
+    {
+        Type = ServerToolCallType;
+    }
+
+    public string? Id { get; set; }
+    public string? Name { get; set; }
+    public JsonNode? ServerToolCall { get; set; }
+}
+
+/// <summary>
+/// Represents a server-side tool call response.
+/// </summary>
+public class ServerToolCallResponsePart : MessagePart
+{
+    public ServerToolCallResponsePart()
+    {
+        Type = ServerToolCallResponseType;
+    }
+
+    public string? Id { get; set; }
+    public JsonNode? ServerToolCallResponse { get; set; }
+}
+
+/// <summary>
 /// Represents an arbitrary message part with any type and properties.
 /// </summary>
 public class GenericPart : MessagePart
@@ -98,9 +191,9 @@ public class ToolDefinition
 }
 
 /// <summary>
-/// Custom converter to handle polymorphic message parts.
+/// Handles polymorphic serialization and deserialization of <see cref="MessagePart"/> types.
 /// </summary>
-public class MessagePartConverter : JsonConverter<MessagePart>
+internal sealed class MessagePartConverter : JsonConverter<MessagePart>
 {
     public override MessagePart? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
@@ -113,10 +206,16 @@ public class MessagePartConverter : JsonConverter<MessagePart>
         var type = typeProp.GetString();
         return type switch
         {
-            MessagePart.TextType => JsonSerializer.Deserialize<TextPart>(doc.RootElement.GetRawText(), options),
-            MessagePart.ToolCallType => JsonSerializer.Deserialize<ToolCallRequestPart>(doc.RootElement.GetRawText(), options),
-            MessagePart.ToolCallResponseType => JsonSerializer.Deserialize<ToolCallResponsePart>(doc.RootElement.GetRawText(), options),
-            _ => JsonSerializer.Deserialize<GenericPart>(doc.RootElement.GetRawText(), options),
+            MessagePart.TextType => doc.RootElement.Deserialize<TextPart>(options),
+            MessagePart.ToolCallType => doc.RootElement.Deserialize<ToolCallRequestPart>(options),
+            MessagePart.ToolCallResponseType => doc.RootElement.Deserialize<ToolCallResponsePart>(options),
+            MessagePart.BlobType => doc.RootElement.Deserialize<BlobPart>(options),
+            MessagePart.FileType => doc.RootElement.Deserialize<FilePart>(options),
+            MessagePart.UriType => doc.RootElement.Deserialize<UriPart>(options),
+            MessagePart.ReasoningType => doc.RootElement.Deserialize<ReasoningPart>(options),
+            MessagePart.ServerToolCallType => doc.RootElement.Deserialize<ServerToolCallPart>(options),
+            MessagePart.ServerToolCallResponseType => doc.RootElement.Deserialize<ServerToolCallResponsePart>(options),
+            _ => doc.RootElement.Deserialize<GenericPart>(options),
         };
     }
 
@@ -135,6 +234,12 @@ public class MessagePartConverter : JsonConverter<MessagePart>
 [JsonSerializable(typeof(TextPart))]
 [JsonSerializable(typeof(ToolCallRequestPart))]
 [JsonSerializable(typeof(ToolCallResponsePart))]
+[JsonSerializable(typeof(BlobPart))]
+[JsonSerializable(typeof(FilePart))]
+[JsonSerializable(typeof(UriPart))]
+[JsonSerializable(typeof(ReasoningPart))]
+[JsonSerializable(typeof(ServerToolCallPart))]
+[JsonSerializable(typeof(ServerToolCallResponsePart))]
 [JsonSerializable(typeof(GenericPart))]
 [JsonSerializable(typeof(ChatMessage))]
 [JsonSerializable(typeof(List<ChatMessage>))]

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -227,6 +227,45 @@ public sealed class GenAIVisualizerDialogViewModel
                 {
                     return false;
                 }
+                else if (partViewModel.MessagePart is BlobPart blobPart)
+                {
+                    if (!string.IsNullOrEmpty(blobPart.Content))
+                    {
+                        return false;
+                    }
+                }
+                else if (partViewModel.MessagePart is UriPart uriPart)
+                {
+                    if (!string.IsNullOrEmpty(uriPart.Uri))
+                    {
+                        return false;
+                    }
+                }
+                else if (partViewModel.MessagePart is FilePart filePart)
+                {
+                    if (!string.IsNullOrEmpty(filePart.FileId))
+                    {
+                        return false;
+                    }
+                }
+                else if (partViewModel.MessagePart is ReasoningPart reasoningPart)
+                {
+                    if (!string.IsNullOrEmpty(reasoningPart.Content))
+                    {
+                        return false;
+                    }
+                }
+                else if (partViewModel.MessagePart is ServerToolCallPart)
+                {
+                    return false;
+                }
+                else if (partViewModel.MessagePart is ServerToolCallResponsePart serverToolCallResponsePart)
+                {
+                    if (serverToolCallResponsePart.ServerToolCallResponse is not null)
+                    {
+                        return false;
+                    }
+                }
             }
         }
 
@@ -249,17 +288,22 @@ public sealed class GenAIVisualizerDialogViewModel
         {
             if (!string.IsNullOrEmpty(systemInstructions))
             {
-                var instructionParts = DeserializeWithErrorHandling(GenAIHelpers.GenAISystemInstructions, systemInstructions, GenAIMessagesContext.Default.ListMessagePart)!;
-                viewModel.Items.Add(CreateMessage(viewModel, currentIndex, GenAIItemType.SystemMessage, instructionParts.Select(GenAIItemPartViewModel.CreateMessagePart).ToList(), internalId: null));
+                var (instructionParts, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally<MessagePart>(systemInstructions, GenAIMessageParsingHelper.ReadMessagePart);
+                var parts = instructionParts.Select(GenAIItemPartViewModel.CreateMessagePart).ToList();
+                if (truncated)
+                {
+                    parts.Add(GenAIItemPartViewModel.CreateErrorMessage(Resources.Dialogs.GenAIUnexpectedOrTruncatedContent));
+                }
+                viewModel.Items.Add(CreateMessage(viewModel, currentIndex, GenAIItemType.SystemMessage, parts, internalId: null));
                 currentIndex++;
             }
             if (!string.IsNullOrEmpty(inputMessages))
             {
-                ParseMessages(viewModel, inputMessages, GenAIHelpers.GenAIInputMessages, isOutput: false, ref currentIndex);
+                ParseMessages(viewModel, inputMessages, isOutput: false, ref currentIndex);
             }
             if (!string.IsNullOrEmpty(outputMessages))
             {
-                ParseMessages(viewModel, outputMessages, GenAIHelpers.GenAIOutputInstructions, isOutput: true, ref currentIndex);
+                ParseMessages(viewModel, outputMessages, isOutput: true, ref currentIndex);
             }
 
             return;
@@ -308,20 +352,31 @@ public sealed class GenAIVisualizerDialogViewModel
         ParseLangSmithFormat(viewModel, ref currentIndex);
     }
 
-    private static int ParseMessages(GenAIVisualizerDialogViewModel viewModel, string messages, string description, bool isOutput, ref int currentIndex)
+    private static int ParseMessages(GenAIVisualizerDialogViewModel viewModel, string messages, bool isOutput, ref int currentIndex)
     {
-        var inputParts = DeserializeWithErrorHandling(description, messages, GenAIMessagesContext.Default.ListChatMessage)!;
-        foreach (var msg in inputParts)
+        var (chatMessages, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(messages, GenAIMessageParsingHelper.ReadChatMessage);
+        foreach (var (role, parts, partsTruncated) in chatMessages)
         {
-            var parts = msg.Parts.Select(GenAIItemPartViewModel.CreateMessagePart).ToList();
-            var type = msg.Role switch
+            var viewParts = parts.Select(GenAIItemPartViewModel.CreateMessagePart).ToList();
+            if (partsTruncated)
+            {
+                viewParts.Add(GenAIItemPartViewModel.CreateErrorMessage(Resources.Dialogs.GenAIUnexpectedOrTruncatedContent));
+            }
+            var type = role switch
             {
                 "system" => GenAIItemType.SystemMessage,
-                "user" => msg.Parts.All(p => p is ToolCallResponsePart) ? GenAIItemType.ToolMessage : GenAIItemType.UserMessage,
+                "user" => parts.All(p => p is ToolCallResponsePart or ServerToolCallResponsePart) ? GenAIItemType.ToolMessage : GenAIItemType.UserMessage,
                 "assistant" => isOutput ? GenAIItemType.OutputMessage : GenAIItemType.AssistantMessage,
                 _ => GenAIItemType.UserMessage
             };
-            viewModel.Items.Add(CreateMessage(viewModel, currentIndex, type, parts, internalId: null));
+            viewModel.Items.Add(CreateMessage(viewModel, currentIndex, type, viewParts, internalId: null));
+            currentIndex++;
+        }
+
+        if (truncated)
+        {
+            var truncationType = isOutput ? GenAIItemType.OutputMessage : GenAIItemType.UserMessage;
+            viewModel.Items.Add(CreateMessage(viewModel, currentIndex, truncationType, [GenAIItemPartViewModel.CreateErrorMessage(Resources.Dialogs.GenAIUnexpectedOrTruncatedContent)], internalId: null));
             currentIndex++;
         }
 

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -250,6 +250,15 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unexpected or truncated message content..
+        /// </summary>
+        public static string GenAIUnexpectedOrTruncatedContent {
+            get {
+                return ResourceManager.GetString("GenAIUnexpectedOrTruncatedContent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Duration.
         /// </summary>
         public static string GenAIDurationLabel {

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -432,6 +432,9 @@
   <data name="GenAIDisplayErrorMessageText" xml:space="preserve">
     <value>Error displaying GenAI content:</value>
   </data>
+  <data name="GenAIUnexpectedOrTruncatedContent" xml:space="preserve">
+    <value>Unexpected or truncated message content.</value>
+  </data>
   <data name="McpServerDialogIntroduction" xml:space="preserve">
     <value>Aspire MCP connects AI assistants to Aspire app data. AI can use Aspire MCP to get information about app resources, health checks, commands, console logs and real-time telemetry.</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -277,6 +277,11 @@
         <target state="translated">Nástroje</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">Navigace na úrovni webu</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -277,6 +277,11 @@
         <target state="translated">Tools</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">Websiteweite Navigation</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -277,6 +277,11 @@
         <target state="translated">Herramientas</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">Navegación en todo el sitio</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -277,6 +277,11 @@
         <target state="translated">Outils</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">Navigation à l’échelle du site</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -277,6 +277,11 @@
         <target state="translated">Strumenti</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">Spostamento a livello di sito</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -277,6 +277,11 @@
         <target state="translated">ツール</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">サイト全体のナビゲーション</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -277,6 +277,11 @@
         <target state="translated">도구</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">사이트 전체 탐색</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -277,6 +277,11 @@
         <target state="translated">Narzędzia</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">Nawigacja w całej witrynie</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -277,6 +277,11 @@
         <target state="translated">Ferramentas</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">Navegação em todo o site</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -277,6 +277,11 @@
         <target state="translated">Инструменты</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">Навигация на уровне сайта</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -277,6 +277,11 @@
         <target state="translated">Araçlar</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">Site genelinde gezinti</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -277,6 +277,11 @@
         <target state="translated">工具</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">网站范围导航</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -277,6 +277,11 @@
         <target state="translated">工具</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIUnexpectedOrTruncatedContent">
+        <source>Unexpected or truncated message content.</source>
+        <target state="new">Unexpected or truncated message content.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HelpDialogCategoryNavigation">
         <source>Site-wide navigation</source>
         <target state="translated">全網站瀏覽</target>

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIMessageParsingHelperTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIMessageParsingHelperTests.cs
@@ -1,0 +1,310 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.Dashboard.Model.GenAI;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Model;
+
+public sealed class GenAIMessageParsingHelperTests
+{
+    [Theory]
+    [InlineData("""[{"type":"text","content":"Hello"},{"type":"text","content":"World"}]""", false, 2)]
+    [InlineData("""[]""", false, 0)]
+    [InlineData("""[{"type":"text","content":"Hello"},{"type":"text","con""", true, 1)]
+    [InlineData("""[{"type":"text","con""", true, 0)]
+    [InlineData("""[""", true, 0)]
+    [InlineData("""[{"type":"text","content":"Hello"},""", true, 1)]
+    [InlineData("""[{"type":"text","content":"Hello Wor""", true, 0)]
+    [InlineData("""[{"type":"text","content":"A"},{"type":"text","content":"B"},{"type":"text","content":"C is ver""", true, 2)]
+    public void DeserializeArrayIncrementally_ReturnsExpectedTruncationAndCount(string json, bool expectedTruncated, int expectedCount)
+    {
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessagePart);
+
+        Assert.Equal(expectedTruncated, truncated);
+        Assert.Equal(expectedCount, items.Count);
+    }
+
+    [Fact]
+    public void DeserializeArrayIncrementally_InvalidJsonNotArray_ThrowsJsonException()
+    {
+        var json = """{"type":"text"}""";
+
+        Assert.Throws<JsonException>(() =>
+            GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessagePart));
+    }
+
+    [Fact]
+    public void ReadChatMessage_TruncatedParts_ReturnsPartsTruncatedTrue()
+    {
+        var json = """[{"role":"system","parts":[{"type":"text","content":"OK"}]},{"role":"user","parts":[{"type":"text","content":"Hello"},{"type":"text","con""";
+
+        var (chatMessages, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadChatMessage);
+
+        Assert.True(truncated);
+        Assert.Single(chatMessages);
+        var (role, parts, partsTruncated) = chatMessages[0];
+        Assert.Equal("system", role);
+        Assert.False(partsTruncated);
+        Assert.Single(parts);
+    }
+
+    [Fact]
+    public void ReadChatMessage_CompleteParts_ReturnsPartsTruncatedFalse()
+    {
+        var json = """[{"role":"assistant","parts":[{"type":"text","content":"Hi there"}]}]""";
+
+        var (chatMessages, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadChatMessage);
+
+        Assert.False(truncated);
+        Assert.Single(chatMessages);
+        var (role, parts, partsTruncated) = chatMessages[0];
+        Assert.Equal("assistant", role);
+        Assert.False(partsTruncated);
+        var textPart = Assert.IsType<TextPart>(Assert.Single(parts));
+        Assert.Equal("Hi there", textPart.Content);
+    }
+
+    [Theory]
+    [InlineData("""[{"role""", 0)]
+    [InlineData("""[{"role":"user","parts":[{"type":"text","content":"OK"}]},{"role":"assistant","finish_reason":"sto""", 1)]
+    public void ReadChatMessage_TruncatedJson_ReturnsTruncated(string json, int expectedMessageCount)
+    {
+        var (chatMessages, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadChatMessage);
+
+        Assert.True(truncated);
+        Assert.Equal(expectedMessageCount, chatMessages.Count);
+    }
+
+    [Theory]
+    [InlineData("""[{"role":"assistant","finish_reason":"stop","model":"gpt-4","parts":[{"type":"text","content":"Done"}]}]""")]
+    [InlineData("""[{"role":"user","metadata":{"key":"value","nested":{"a":1}},"parts":[{"type":"text","content":"Hi"}]}]""")]
+    public void ReadChatMessage_WithUnknownProperties_SkipsThemSuccessfully(string json)
+    {
+        var (chatMessages, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadChatMessage);
+
+        Assert.False(truncated);
+        Assert.Single(chatMessages);
+        Assert.Single(chatMessages[0].parts);
+    }
+
+    [Fact]
+    public void ReadChatMessage_MultipleChatMessages_ParsesAll()
+    {
+        var json = """
+            [
+                {"role":"system","parts":[{"type":"text","content":"You are helpful."}]},
+                {"role":"user","parts":[{"type":"text","content":"Hello"}]},
+                {"role":"assistant","parts":[{"type":"text","content":"Hi!"}]}
+            ]
+            """;
+
+        var (chatMessages, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadChatMessage);
+
+        Assert.False(truncated);
+        Assert.Equal(3, chatMessages.Count);
+        Assert.Equal("system", chatMessages[0].role);
+        Assert.Equal("user", chatMessages[1].role);
+        Assert.Equal("assistant", chatMessages[2].role);
+    }
+
+    [Fact]
+    public void ReadMessagePart_TextPart_ParsesStringAndNullContent()
+    {
+        var json = """[{"type":"text","content":"simple string"},{"type":"text","content":null}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessagePart);
+
+        Assert.False(truncated);
+        Assert.Equal(2, items.Count);
+        Assert.Equal("simple string", Assert.IsType<TextPart>(items[0]).Content);
+        Assert.Null(Assert.IsType<TextPart>(items[1]).Content);
+    }
+
+    [Fact]
+    public void ReadMessagePart_ToolCallRequestPart_ParsesAllProperties()
+    {
+        var json = """[{"type":"tool_call","id":"call_abc","name":"get_weather","arguments":{"location":"Seattle","unit":"celsius"}}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessagePart);
+
+        Assert.False(truncated);
+        var toolCallPart = Assert.IsType<ToolCallRequestPart>(Assert.Single(items));
+        Assert.Equal("tool_call", toolCallPart.Type);
+        Assert.Equal("call_abc", toolCallPart.Id);
+        Assert.Equal("get_weather", toolCallPart.Name);
+        Assert.NotNull(toolCallPart.Arguments);
+        Assert.Equal("Seattle", toolCallPart.Arguments["location"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void ReadMessagePart_ToolCallResponsePart_ParsesObjectAndStringResponses()
+    {
+        var json = """[{"type":"tool_call_response","id":"call_abc","response":{"temperature":72}},{"type":"tool_call_response","id":"call_xyz","response":"plain text result"}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessagePart);
+
+        Assert.False(truncated);
+        Assert.Equal(2, items.Count);
+
+        var objectResponse = Assert.IsType<ToolCallResponsePart>(items[0]);
+        Assert.Equal("call_abc", objectResponse.Id);
+        Assert.Equal(72, objectResponse.Response!["temperature"]!.GetValue<int>());
+
+        var stringResponse = Assert.IsType<ToolCallResponsePart>(items[1]);
+        Assert.Equal("call_xyz", stringResponse.Id);
+        Assert.Equal("plain text result", stringResponse.Response!.GetValue<string>());
+    }
+
+    [Fact]
+    public void ReadMessagePart_BlobPart_ParsesAllProperties()
+    {
+        var json = """[{"type":"blob","mime_type":"image/png","modality":"image","content":"iVBORw0KGgo="}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessagePart);
+
+        Assert.False(truncated);
+        var blobPart = Assert.IsType<BlobPart>(Assert.Single(items));
+        Assert.Equal("blob", blobPart.Type);
+        Assert.Equal("image/png", blobPart.MimeType);
+        Assert.Equal("image", blobPart.Modality);
+        Assert.Equal("iVBORw0KGgo=", blobPart.Content);
+    }
+
+    [Fact]
+    public void ReadMessagePart_FilePart_ParsesAllProperties()
+    {
+        var json = """[{"type":"file","mime_type":"application/pdf","modality":"image","file_id":"file-abc123"}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessagePart);
+
+        Assert.False(truncated);
+        var filePart = Assert.IsType<FilePart>(Assert.Single(items));
+        Assert.Equal("file", filePart.Type);
+        Assert.Equal("application/pdf", filePart.MimeType);
+        Assert.Equal("image", filePart.Modality);
+        Assert.Equal("file-abc123", filePart.FileId);
+    }
+
+    [Fact]
+    public void ReadMessagePart_UriPart_ParsesAllProperties()
+    {
+        var json = """[{"type":"uri","mime_type":"image/jpeg","modality":"image","uri":"https://example.com/photo.jpg"}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessagePart);
+
+        Assert.False(truncated);
+        var uriPart = Assert.IsType<UriPart>(Assert.Single(items));
+        Assert.Equal("uri", uriPart.Type);
+        Assert.Equal("image/jpeg", uriPart.MimeType);
+        Assert.Equal("image", uriPart.Modality);
+        Assert.Equal("https://example.com/photo.jpg", uriPart.Uri);
+    }
+
+    [Fact]
+    public void ReadMessagePart_ReasoningPart_ParsesContent()
+    {
+        var json = """[{"type":"reasoning","content":"Let me think about this step by step..."}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessagePart);
+
+        Assert.False(truncated);
+        var reasoningPart = Assert.IsType<ReasoningPart>(Assert.Single(items));
+        Assert.Equal("reasoning", reasoningPart.Type);
+        Assert.Equal("Let me think about this step by step...", reasoningPart.Content);
+    }
+
+    [Fact]
+    public void ReadMessagePart_ServerToolCallPart_ParsesAllProperties()
+    {
+        var json = """[{"type":"server_tool_call","id":"stc_1","name":"web_search","server_tool_call":{"type":"web_search","query":"latest news"}}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessagePart);
+
+        Assert.False(truncated);
+        var serverToolCallPart = Assert.IsType<ServerToolCallPart>(Assert.Single(items));
+        Assert.Equal("server_tool_call", serverToolCallPart.Type);
+        Assert.Equal("stc_1", serverToolCallPart.Id);
+        Assert.Equal("web_search", serverToolCallPart.Name);
+        Assert.NotNull(serverToolCallPart.ServerToolCall);
+        Assert.Equal("latest news", serverToolCallPart.ServerToolCall["query"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void ReadMessagePart_ServerToolCallResponsePart_ParsesAllProperties()
+    {
+        var json = """[{"type":"server_tool_call_response","id":"stc_1","server_tool_call_response":{"type":"web_search","results":["result1","result2"]}}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessagePart);
+
+        Assert.False(truncated);
+        var serverToolCallResponsePart = Assert.IsType<ServerToolCallResponsePart>(Assert.Single(items));
+        Assert.Equal("server_tool_call_response", serverToolCallResponsePart.Type);
+        Assert.Equal("stc_1", serverToolCallResponsePart.Id);
+        Assert.NotNull(serverToolCallResponsePart.ServerToolCallResponse);
+        Assert.Equal("web_search", serverToolCallResponsePart.ServerToolCallResponse["type"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void ReadMessagePart_GenericPart_ParsesUnknownTypes()
+    {
+        var json = """[{"type":"custom_widget","widget_id":"w1","color":"blue","count":42},{"type":"unknown"}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessagePart);
+
+        Assert.False(truncated);
+        Assert.Equal(2, items.Count);
+
+        var richGeneric = Assert.IsType<GenericPart>(items[0]);
+        Assert.Equal("custom_widget", richGeneric.Type);
+        Assert.NotNull(richGeneric.AdditionalProperties);
+        Assert.Equal("w1", richGeneric.AdditionalProperties["widget_id"].GetString());
+        Assert.Equal("blue", richGeneric.AdditionalProperties["color"].GetString());
+        Assert.Equal(42, richGeneric.AdditionalProperties["count"].GetInt32());
+
+        var bareGeneric = Assert.IsType<GenericPart>(items[1]);
+        Assert.Equal("unknown", bareGeneric.Type);
+    }
+
+    [Fact]
+    public void ReadMessagePart_MixedPartTypes_ParsesCorrectly()
+    {
+        var json = """
+            [
+                {"type":"text","content":"Hello"},
+                {"type":"reasoning","content":"Thinking..."},
+                {"type":"blob","mime_type":"image/png","modality":"image","content":"base64data"},
+                {"type":"uri","mime_type":"image/jpeg","modality":"image","uri":"https://example.com/img.jpg"},
+                {"type":"file","mime_type":"application/pdf","modality":"image","file_id":"f1"},
+                {"type":"server_tool_call","id":"s1","name":"code_interpreter","server_tool_call":{"type":"code_interpreter"}},
+                {"type":"server_tool_call_response","id":"s1","server_tool_call_response":{"type":"code_interpreter","output":"42"}}
+            ]
+            """;
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessagePart);
+
+        Assert.False(truncated);
+        Assert.Equal(7, items.Count);
+
+        Assert.Collection(items,
+            part => Assert.IsType<TextPart>(part),
+            part => Assert.IsType<ReasoningPart>(part),
+            part => Assert.IsType<BlobPart>(part),
+            part => Assert.IsType<UriPart>(part),
+            part => Assert.IsType<FilePart>(part),
+            part => Assert.IsType<ServerToolCallPart>(part),
+            part => Assert.IsType<ServerToolCallResponsePart>(part));
+    }
+
+    [Fact]
+    public void ReadMessagePart_MissingTypeProperty_ReturnsTruncated()
+    {
+        var json = """[{"content":"no type here"}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessagePart);
+
+        Assert.True(truncated);
+        Assert.Empty(items);
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIVisualizerDialogViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIVisualizerDialogViewModelTests.cs
@@ -672,7 +672,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
 
         // Assert
         Assert.Empty(vm.Items);
-        Assert.StartsWith("System.InvalidOperationException: ", vm.DisplayErrorMessage);
+        Assert.NotNull(vm.DisplayErrorMessage);
     }
 
     [Fact]
@@ -2128,5 +2128,225 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var invalidParam = tool.ToolDefinition.Parameters.Properties["invalidParam"];
         Assert.Null(invalidParam.Type); // Type should be null since it couldn't be parsed
         Assert.Equal("A parameter with invalid type structure", invalidParam.Description);
+    }
+
+    [Fact]
+    public void Create_GenAISpanAttributes_TruncatedInputMessages_DisplaysAvailableMessages()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        var inputMessages = JsonSerializer.Serialize(new List<ChatMessage>
+        {
+            new ChatMessage
+            {
+                Role = "user",
+                Parts = [new TextPart { Content = "First message" }]
+            },
+            new ChatMessage
+            {
+                Role = "assistant",
+                Parts = [new TextPart { Content = "Second message" }]
+            },
+            new ChatMessage
+            {
+                Role = "user",
+                Parts = [new TextPart { Content = "Third message that will be truncated" }]
+            }
+        }, GenAIMessagesContext.Default.ListChatMessage);
+
+        // Truncate the JSON mid-way through the third message
+        var truncatedInput = inputMessages.Substring(0, inputMessages.IndexOf("Third"));
+
+        var attributes = new KeyValuePair<string, string>[]
+        {
+            KeyValuePair.Create(GenAIHelpers.GenAISystem, "System!"),
+            KeyValuePair.Create("server.address", "ai-server.address"),
+            KeyValuePair.Create(GenAIHelpers.GenAIInputMessages, truncatedInput)
+        };
+
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10), attributes: attributes)
+                        }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, addContext.FailureCount);
+
+        var span = repository.GetSpan(GetHexId("1"), GetHexId("1-1"))!;
+        var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
+
+        // Act
+        var vm = Create(repository, spanDetailsViewModel);
+
+        // Assert - first two messages parsed, third truncated, plus truncation indicator
+        Assert.Null(vm.DisplayErrorMessage);
+        Assert.Collection(vm.Items,
+            m =>
+            {
+                Assert.Equal(GenAIItemType.UserMessage, m.Type);
+                Assert.Collection(m.ItemParts,
+                    p => Assert.Equal("First message", Assert.IsType<TextPart>(p.MessagePart).Content));
+            },
+            m =>
+            {
+                Assert.Equal(GenAIItemType.AssistantMessage, m.Type);
+                Assert.Collection(m.ItemParts,
+                    p => Assert.Equal("Second message", Assert.IsType<TextPart>(p.MessagePart).Content));
+            },
+            m =>
+            {
+                Assert.Equal(GenAIItemType.UserMessage, m.Type);
+                Assert.Collection(m.ItemParts,
+                    p => Assert.Equal(Resources.Dialogs.GenAIUnexpectedOrTruncatedContent, p.ErrorMessage));
+            });
+    }
+
+    [Fact]
+    public void Create_GenAISpanAttributes_TruncatedSystemInstructions_DisplaysPartialContent()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        var systemInstruction = JsonSerializer.Serialize(new List<MessagePart>
+        {
+            new TextPart { Content = "First instruction" },
+            new TextPart { Content = "Second instruction that will be truncated" }
+        }, GenAIMessagesContext.Default.ListMessagePart);
+
+        // Truncate the JSON mid-way through the second instruction
+        var truncatedInstruction = systemInstruction.Substring(0, systemInstruction.IndexOf("Second"));
+
+        var attributes = new KeyValuePair<string, string>[]
+        {
+            KeyValuePair.Create(GenAIHelpers.GenAISystem, "System!"),
+            KeyValuePair.Create("server.address", "ai-server.address"),
+            KeyValuePair.Create(GenAIHelpers.GenAISystemInstructions, truncatedInstruction)
+        };
+
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10), attributes: attributes)
+                        }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, addContext.FailureCount);
+
+        var span = repository.GetSpan(GetHexId("1"), GetHexId("1-1"))!;
+        var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
+
+        // Act
+        var vm = Create(repository, spanDetailsViewModel);
+
+        // Assert - first instruction parsed, second truncated, plus truncation indicator
+        Assert.Null(vm.DisplayErrorMessage);
+        Assert.Collection(vm.Items,
+            m =>
+            {
+                Assert.Equal(GenAIItemType.SystemMessage, m.Type);
+                Assert.Collection(m.ItemParts,
+                    p => Assert.Equal("First instruction", Assert.IsType<TextPart>(p.MessagePart).Content),
+                    p => Assert.Equal(Resources.Dialogs.GenAIUnexpectedOrTruncatedContent, p.ErrorMessage));
+            });
+    }
+
+    [Fact]
+    public void Create_GenAISpanAttributes_TruncatedOutputMessages_DisplaysAvailableMessages()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        var outputMessages = JsonSerializer.Serialize(new List<ChatMessage>
+        {
+            new ChatMessage
+            {
+                Role = "assistant",
+                Parts = [new TextPart { Content = "Complete output" }]
+            },
+            new ChatMessage
+            {
+                Role = "assistant",
+                Parts = [new TextPart { Content = "Truncated output message" }]
+            }
+        }, GenAIMessagesContext.Default.ListChatMessage);
+
+        // Truncate the JSON mid-way through the second message
+        var truncatedOutput = outputMessages.Substring(0, outputMessages.IndexOf("Truncated"));
+
+        var attributes = new KeyValuePair<string, string>[]
+        {
+            KeyValuePair.Create(GenAIHelpers.GenAISystem, "System!"),
+            KeyValuePair.Create("server.address", "ai-server.address"),
+            KeyValuePair.Create(GenAIHelpers.GenAIOutputInstructions, truncatedOutput)
+        };
+
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10), attributes: attributes)
+                        }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, addContext.FailureCount);
+
+        var span = repository.GetSpan(GetHexId("1"), GetHexId("1-1"))!;
+        var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
+
+        // Act
+        var vm = Create(repository, spanDetailsViewModel);
+
+        // Assert - first output message parsed, second truncated, plus truncation indicator
+        Assert.Null(vm.DisplayErrorMessage);
+        Assert.Collection(vm.Items,
+            m =>
+            {
+                Assert.Equal(GenAIItemType.OutputMessage, m.Type);
+                Assert.Collection(m.ItemParts,
+                    p => Assert.Equal("Complete output", Assert.IsType<TextPart>(p.MessagePart).Content));
+            },
+            m =>
+            {
+                Assert.Equal(GenAIItemType.OutputMessage, m.Type);
+                Assert.Collection(m.ItemParts,
+                    p => Assert.Equal(Resources.Dialogs.GenAIUnexpectedOrTruncatedContent, p.ErrorMessage));
+            });
     }
 }


### PR DESCRIPTION
## Description

Improve GenAI visualizer message parsing with truncation tolerance, new message part types, and a custom `JsonConverter`.

- Add `GenAIMessageParsingHelper` with `DeserializeArrayIncrementally` for truncation-tolerant JSON array deserialization. When GenAI message data is truncated (e.g. large payloads cut off), the parser now returns successfully parsed items instead of failing.
- Add new message part types from OpenTelemetry semantic conventions: `BlobPart`, `FilePart`, `UriPart`, `ReasoningPart`, `ServerToolCallPart`, `ServerToolCallResponsePart`, `GenericPart`.
- Display a user-facing message when content is unexpectedly truncated.
- Add comprehensive unit tests for incremental deserialization, all part types, and truncation scenarios.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
