### PR TITLE
Fix AzDO playground, buildx, and Helix retry failures

### DIFF
--- a/docs/ci/azdo-public-pipeline.md
+++ b/docs/ci/azdo-public-pipeline.md
@@ -221,7 +221,7 @@ The `eng/test-configuration.json` configures test retries:
 
 - **Local reruns**: 1 retry
 - **Remote (Helix) reruns**: 3 retries
-- **Retry-on rules**: Matches Docker image pull failures (`open.*docker.*GetImageBlob.*: no such file or directory`)
+- **Retry-on rules**: Matches reported Testcontainers Ryuk image failures (`No such image: .*testcontainers/ryuk:.*`)
 
 ## Known Breakage Patterns (from Real Incidents)
 

--- a/docs/ci/azdo-public-pipeline.md
+++ b/docs/ci/azdo-public-pipeline.md
@@ -219,7 +219,7 @@ This disables parallel test execution within assemblies on Helix (parallelism is
 
 The `eng/test-configuration.json` configures test retries:
 
-- **Local reruns**: 1 retry
+- **Local reruns**: 0 retries (disabled so the first retry is queued on a different machine)
 - **Remote (Helix) reruns**: 3 retries
 - **Retry-on rules**: Matches reported Testcontainers Ryuk image failures (`No such image: .*testcontainers/ryuk:.*`)
 

--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "defaultOnFailure": "fail",
-  "localRerunCount": 1,
+  "localRerunCount": 0,
   "remoteRerunCount": 3,
   "retryOnRules": [
     { "failureMessage" : { "regex" : "No such image: .*testcontainers/ryuk:.*" } }

--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -4,6 +4,6 @@
   "localRerunCount": 1,
   "remoteRerunCount": 3,
   "retryOnRules": [
-    { "failureMessage" : { "regex" : "open.*docker.*GetImageBlob.*: no such file or directory" } }
+    { "failureMessage" : { "regex" : "No such image: .*testcontainers/ryuk:.*" } }
   ]
 }

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposeTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposeTests.cs
@@ -349,6 +349,7 @@ public class DockerComposeTests(ITestOutputHelper output)
 
     [Fact]
     [RequiresFeature(TestFeature.Docker)]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/15078", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
     public async Task DeployWithDashboard_PrintsDashboardAndServiceEndpoints()
     {
         using var tempDir = new TestTempDirectory();

--- a/tests/Aspire.Hosting.Tests/ContainerTunnelTests.cs
+++ b/tests/Aspire.Hosting.Tests/ContainerTunnelTests.cs
@@ -13,7 +13,7 @@ namespace Aspire.Hosting.Tests;
 public class ContainerTunnelTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
     public async Task ContainerTunnelWorksWithYarp()
     {
         const string testName = "container-tunnel-works-with-yarp";
@@ -44,7 +44,7 @@ public class ContainerTunnelTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
     public async Task ProxylessEndpointWorksWithContainerTunnel()
     {
         var port = await Helpers.Network.GetAvailablePortAsync();

--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -52,6 +52,7 @@
     <Compile Condition="'$(RepoRoot)' != ''" Include="$(SharedDir)X509Certificate2Extensions.cs" />
     <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)tests\Aspire.Hosting.Tests\Utils\LoggerNotificationExtensions.cs" />
     <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)src\Shared\PathLookupHelper.cs" />
+    <Compile Condition="'$(RepoRoot)' == ''" Include="$(MSBuildThisFileDirectory)..\..\src\Shared\PathLookupHelper.cs" />
     <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)tests\Aspire.TestUtilities\FileUtil.cs" />
     <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)tests\Aspire.TestUtilities\PlatformDetection.cs" />
     <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)tests\Aspire.TestUtilities\QuarantinedTestAttribute.cs" />

--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -106,6 +106,7 @@
     <None Include="$(RepoRoot)tests\Aspire.TestUtilities\PlatformDetection.cs" Link="$(DeployOutsideOfRepoSupportFilesRelativeDir)tests\$(MSBuildProjectName)\%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(RepoRoot)tests\Aspire.TestUtilities\QuarantinedTestAttribute.cs" Link="$(DeployOutsideOfRepoSupportFilesRelativeDir)tests\$(MSBuildProjectName)\%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(RepoRoot)tests\Aspire.TestUtilities\Requires*.cs" Link="$(DeployOutsideOfRepoSupportFilesRelativeDir)tests\$(MSBuildProjectName)\%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(RepoRoot)tests\Aspire.TestUtilities\TestFeature.cs" Link="$(DeployOutsideOfRepoSupportFilesRelativeDir)tests\$(MSBuildProjectName)\%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
 
     <None Include="..\helix\xunit.runner.json" Link="$(DeployOutsideOfRepoSupportFilesRelativeDir)tests\$(MSBuildProjectName)\xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>


### PR DESCRIPTION
## Description

This PR addresses the Azure DevOps failures from build `1325767` by:
- staging `TestFeature.cs` into the `Aspire.Playground.Tests` Helix archive so the out-of-repo Helix layout compiles correctly
- requiring `TestFeature.DockerPluginBuildx` for the container tunnel tests so they skip on AzDO/Helix where buildx is unsupported
- disabling `DockerComposeTests.DeployWithDashboard_PrintsDashboardAndServiceEndpoints` on AzDO with `ActiveIssue` while `#15078` tracks the real compatibility fix
- updating `eng/test-configuration.json` so Helix retries match the reported Testcontainers Ryuk image failure message (`No such image: .*testcontainers/ryuk:.*`) instead of the raw console-only `GetImageBlob` line

Fixes #15076
Fixes #15077
Addresses #15078
Addresses #11820

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
