### PR TITLE
Minor GenAI visualizer improvements and bug fixes

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/GenAIItemTitle.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GenAIItemTitle.razor
@@ -3,7 +3,10 @@
 @if (_titleBadge is { } titleBadge)
 {
     <span class="message-name">
-        <FluentIcon Value="@titleBadge.Icon" Width="18px" Color="Color.Custom" CustomColor="@ColorGenerator.Instance.GetColorVariableByKey(ResourceName)" />
+        @if (ShowIcon)
+        {
+            <FluentIcon Value="@titleBadge.Icon" Width="18px" Color="Color.Custom" CustomColor="@ColorGenerator.Instance.GetColorVariableByKey(ResourceName)" />
+        }
         @titleBadge.Text
     </span>
 }

--- a/src/Aspire.Dashboard/Components/Controls/GenAIItemTitle.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/GenAIItemTitle.razor.cs
@@ -15,6 +15,9 @@ public partial class GenAIItemTitle
     [Parameter, EditorRequired]
     public required string ResourceName { get; set; }
 
+    [Parameter]
+    public bool ShowIcon { get; set; } = true;
+
     [Inject]
     public required IStringLocalizer<Resources.Dialogs> Loc { get; init; }
 

--- a/src/Aspire.Dashboard/Components/Controls/TreeGenAISelector.razor
+++ b/src/Aspire.Dashboard/Components/Controls/TreeGenAISelector.razor
@@ -1,9 +1,10 @@
-﻿@using Metrics = Aspire.Dashboard.Resources.Metrics
+﻿@using Aspire.Dashboard.Resources
+@using Metrics = Aspire.Dashboard.Resources.Metrics
 
 <FluentTreeView Class="genai-message-tree" @bind-CurrentSelected="@PageViewModel.SelectedTreeItem" @bind-CurrentSelected:after="HandleSelectedTreeItemChangedAsync">
     <ChildContent>
         <FluentTreeItem @key="@PageViewModel.Span" Data="@PageViewModel.Span" title="@PageViewModel.Span.Name" InitiallySelected="@(SelectedItem is null)">
-            <span class="llm-badge">LLM</span> @PageViewModel.Span.Name
+            <span class="llm-badge">@Loc[nameof(Dialogs.GenAILLMBadgeText)]</span> @PageViewModel.Span.Name
         </FluentTreeItem>
 
         @foreach (var itemVM in PageViewModel.Items)

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -53,6 +53,11 @@
                         <div>
                             <div class="message-header">
                                 <GenAIItemTitle Item="@selectedItem" ResourceName="@selectedItem.ResourceName" />
+                                <FluentButton Class="back-button"
+                                              Appearance="Appearance.Stealth"
+                                              OnClick="@GoBackAsync">
+                                    <FluentIcon Value="@(new Icons.Regular.Size16.ArrowHookUpLeft())" />
+                                </FluentButton>
                             </div>
                             @*
                                 Tab content isn't nested inside FluentTab elements. The tab control is just used to display the tabs.
@@ -473,7 +478,7 @@
                 {
                     var itemParts = item.ItemParts.Where(p => !string.IsNullOrEmpty(p.TextVisualizerViewModel.Text)).ToList();
 
-                    <div class="message-container">
+                    <div class="message-container" id="@($"genai-message-{item.Index}")">
                         @if (item.Type != GenAIItemType.Error)
                         {
                             <div class="message-title">

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -477,7 +477,7 @@
                         @if (item.Type != GenAIItemType.Error)
                         {
                             <div class="message-title">
-                                @GetItemTitle(item)
+                                <GenAIItemTitle Item="@item" ResourceName="@item.ResourceName" ShowIcon="false" />
                             </div>
                         }
                         <span class="defaultHidden">

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -158,7 +158,7 @@
                                                 <div class="tool-button-container">
                                                     <FluentButton OnClick="@(() => ViewToolDefinitionAsync(toolVM))">
                                                         <FluentIcon Value="@s_wrenchIcon" Style="vertical-align: sub;" slot="start" />
-                                                        Tool definition
+                                                        @Loc[nameof(Dialogs.GenAIToolDefinitionButtonText)]
                                                     </FluentButton>
                                                 </div>
                                             }
@@ -170,7 +170,7 @@
                                                 <div class="tool-button-container">
                                                     <FluentButton OnClick="@(() => ViewToolDefinitionAsync(toolVM))">
                                                         <FluentIcon Value="@s_wrenchIcon" Style="vertical-align: sub;" slot="start" />
-                                                        Tool definition
+                                                        @Loc[nameof(Dialogs.GenAIToolDefinitionButtonText)]
                                                     </FluentButton>
                                                 </div>
                                             }
@@ -182,14 +182,14 @@
                                                 <div class="tool-button-container">
                                                     <FluentButton OnClick="@(() => OnViewItem(itemVM))">
                                                         <FluentIcon Value="@s_toolIcon" Style="vertical-align: sub;" slot="start" />
-                                                        Tool call
+                                                        @Loc[nameof(Dialogs.GenAIToolCallButtonText)]
                                                     </FluentButton>
 
                                                     @if (Content.ToolDefinitions.FirstOrDefault(d => d.ToolDefinition.Name == toolCallRequestPart.Name) is { } toolVM)
                                                     {
                                                         <FluentButton OnClick="@(() => ViewToolDefinitionAsync(toolVM))">
                                                             <FluentIcon Value="@s_wrenchIcon" Style="vertical-align: sub;" slot="start" />
-                                                            Tool definition
+                                                            @Loc[nameof(Dialogs.GenAIToolDefinitionButtonText)]
                                                         </FluentButton>
                                                     }
                                                 </div>
@@ -223,7 +223,7 @@
                     {
                         <div>
                             <div class="message-header">
-                                <span class="llm-badge">LLM</span>
+                                <span class="llm-badge">@Loc[nameof(Dialogs.GenAILLMBadgeText)]</span>
                                 <div class="message-header-title">
                                     <span>@Content.Span.Name</span>
                                     <span class="message-header-date">@FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, Content.Span.StartTime, MillisecondsDisplay.Truncated)</span>

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
@@ -136,6 +136,20 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
         SelectedItem = viewModel;
     }
 
+    private async Task GoBackAsync()
+    {
+        var previousIndex = SelectedItem?.Index;
+        SelectedItem = null;
+        OverviewActiveView = OverviewViewKind.InputOutput;
+
+        if (previousIndex is { } index)
+        {
+            // Allow the UI to render the overview before scrolling.
+            await Task.Delay(50);
+            await JS.InvokeVoidAsync("scrollToElement", $"genai-message-{index}");
+        }
+    }
+
     private async Task ViewToolDefinitionAsync(ToolDefinitionViewModel toolDefinition)
     {
         SelectedItem = null;
@@ -261,19 +275,6 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
 
         return true;
     }
-
-    //private string GetItemTitle(GenAIItemViewModel e)
-    //{
-    //    return e.Type switch
-    //    {
-    //        GenAIItemType.SystemMessage => Loc[nameof(Resources.Dialogs.GenAIMessageTitleSystem)],
-    //        GenAIItemType.UserMessage => Loc[nameof(Resources.Dialogs.GenAIMessageTitleUser)],
-    //        GenAIItemType.AssistantMessage or GenAIItemType.OutputMessage => Loc[nameof(Resources.Dialogs.GenAIMessageTitleAssistant)],
-    //        GenAIItemType.ToolMessage => Loc[nameof(Resources.Dialogs.GenAIMessageTitleTool)],
-    //        GenAIItemType.Error => "Error",
-    //        _ => string.Empty
-    //    };
-    //}
 
     private static string GetToolHeadingTooltip(ToolDefinitionViewModel vm)
     {

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
@@ -262,18 +262,18 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
         return true;
     }
 
-    private string GetItemTitle(GenAIItemViewModel e)
-    {
-        return e.Type switch
-        {
-            GenAIItemType.SystemMessage => Loc[nameof(Resources.Dialogs.GenAIMessageTitleSystem)],
-            GenAIItemType.UserMessage => Loc[nameof(Resources.Dialogs.GenAIMessageTitleUser)],
-            GenAIItemType.AssistantMessage or GenAIItemType.OutputMessage => Loc[nameof(Resources.Dialogs.GenAIMessageTitleAssistant)],
-            GenAIItemType.ToolMessage => Loc[nameof(Resources.Dialogs.GenAIMessageTitleTool)],
-            GenAIItemType.Error => "Error",
-            _ => string.Empty
-        };
-    }
+    //private string GetItemTitle(GenAIItemViewModel e)
+    //{
+    //    return e.Type switch
+    //    {
+    //        GenAIItemType.SystemMessage => Loc[nameof(Resources.Dialogs.GenAIMessageTitleSystem)],
+    //        GenAIItemType.UserMessage => Loc[nameof(Resources.Dialogs.GenAIMessageTitleUser)],
+    //        GenAIItemType.AssistantMessage or GenAIItemType.OutputMessage => Loc[nameof(Resources.Dialogs.GenAIMessageTitleAssistant)],
+    //        GenAIItemType.ToolMessage => Loc[nameof(Resources.Dialogs.GenAIMessageTitleTool)],
+    //        GenAIItemType.Error => "Error",
+    //        _ => string.Empty
+    //    };
+    //}
 
     private static string GetToolHeadingTooltip(ToolDefinitionViewModel vm)
     {

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
@@ -13,6 +13,10 @@
     background: var(--main-container-background-color);
 }
 
+::deep .span-messages-container fluent-button.back-button::part(control):not(:hover) {
+    background: var(--main-container-background-color);
+}
+
 ::deep .span-messages-sidebar {
     height: 65vh;
     overflow-y: auto;
@@ -30,6 +34,8 @@
 
 ::deep .message-container .message-title {
     font-size: var(--type-ramp-plus-1-font-size);
+    display: flex;
+    align-items: center;
 }
 
 ::deep .section-title {
@@ -126,6 +132,10 @@
     display: flex;
     align-items: center;
     height: 50px;
+}
+
+::deep .back-button {
+    margin-left: auto;
 }
 
 ::deep .message-header-details {

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -580,41 +580,18 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
                 _resources,
                 () =>
                 {
-                    // Update the context with all visible log entries with a GenAI system property.
-                    var filters = ViewModel.GetFilters();
-                    filters.Add(new FieldTelemetryFilter
+                    var trace = TelemetryRepository.GetTrace(logEntry.TraceId);
+                    if (trace is null)
                     {
-                        Field = KnownStructuredLogFields.SpanIdField,
-                        Condition = FilterCondition.NotEqual,
-                        Value = string.Empty
-                    });
-                    filters.Add(new FieldTelemetryFilter
-                    {
-                        Field = KnownStructuredLogFields.TraceIdField,
-                        Condition = FilterCondition.NotEqual,
-                        Value = string.Empty
-                    });
-
-                    var logs = TelemetryRepository.GetLogs(new GetLogsContext
-                    {
-                        ResourceKey = ViewModel.ResourceKey,
-                        StartIndex = 0,
-                        Count = int.MaxValue,
-                        Filters = filters
-                    });
+                        return [];
+                    }
 
                     var genAISpans = new List<OtlpSpan>();
-                    foreach (var l in logs.Items.DistinctBy(l => (l.SpanId, l.TraceId)))
+                    foreach (var s in trace.Spans)
                     {
-                        var span = TelemetryRepository.GetSpan(l.TraceId, l.SpanId);
-                        if (span == null)
+                        if (GenAIHelpers.HasGenAIAttribute(s.Attributes))
                         {
-                            continue;
-                        }
-
-                        if (GenAIHelpers.HasGenAIAttribute(l.Attributes) || GenAIHelpers.HasGenAIAttribute(span.Attributes))
-                        {
-                            genAISpans.Add(span);
+                            genAISpans.Add(s);
                         }
                     }
 

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -111,11 +111,26 @@
                             <AspireTemplateColumn ColumnId="@TimestampColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.TimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(TimeProvider, context.FirstSpan.StartTime, MillisecondsDisplay.Full, CultureInfo.CurrentCulture))" Tooltip="true">
                                 @FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, context.FirstSpan.StartTime, MillisecondsDisplay.Truncated)
                             </AspireTemplateColumn>
-                            <AspireTemplateColumn ColumnId="@NameColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Tooltip="true" TooltipText="@(trace => GetNameTooltip(trace))">
-                                <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorVariableByKey(GetResourceName((context.RootOrFirstSpan).Source)));">
-                                    <FluentHighlighter HighlightedText="@(TracesViewModel.FilterText)" Text="@(context.FullName)" />
-                                </span>
-                                <span class="trace-id">@OtlpHelpers.ToShortenedId(context.TraceId)</span>
+                            <AspireTemplateColumn ColumnId="@NameColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Tooltip="true" TooltipText="@(trace => GetNameTooltip(trace))" Class="no-ellipsis">
+                                <div class="trace-name-container">
+                                    <span class="trace-name-content">
+                                        <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorVariableByKey(GetResourceName((context.RootOrFirstSpan).Source)));">
+                                            <FluentHighlighter HighlightedText="@(TracesViewModel.FilterText)" Text="@(context.FullName)" />
+                                        </span>
+                                        <span class="trace-id">@OtlpHelpers.ToShortenedId(context.TraceId)</span>
+                                    </span>
+                                    <span @onclick:stopPropagation="true">
+                                        @if (HasGenAISpans(context))
+                                        {
+                                            <FluentButton Appearance="Appearance.Lightweight"
+                                                          Title="@ControlsStringsLoc[nameof(ControlsStrings.GenAIDetailsTitle)]"
+                                                          OnClick="() => OnGenAIClickedAsync(context)">
+                                                <FluentIcon Icon="Icons.Regular.Size20.Sparkle"
+                                                            Color="Color.Accent" />
+                                            </FluentButton>
+                                        }
+                                    </span>
+                                </div>
                             </AspireTemplateColumn>
                             <AspireTemplateColumn ColumnId="@SpansColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Traces.TracesSpansColumnHeader)]">
                                 <FluentOverflow>

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -10,6 +10,7 @@ using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Assistant;
 using Aspire.Dashboard.Model.Assistant.Prompts;
+using Aspire.Dashboard.Model.GenAI;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
@@ -96,6 +97,9 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
 
     [Inject]
     public required ComponentTelemetryContextProvider TelemetryContextProvider { get; init; }
+
+    [Inject]
+    public required ITelemetryErrorRecorder ErrorRecorder { get; init; }
 
     [CascadingParameter]
     public required ViewportInformation ViewportInformation { get; set; }
@@ -427,6 +431,45 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
             filterLoc: FilterLoc,
             dialogsLoc: DialogsLoc,
             contentLayout: _contentLayout);
+    }
+
+    private static bool HasGenAISpans(OtlpTrace trace)
+    {
+        foreach (var span in trace.Spans)
+        {
+            if (GenAIHelpers.HasGenAIAttribute(span.Attributes))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private async Task OnGenAIClickedAsync(OtlpTrace trace)
+    {
+        var firstSpan = trace.Spans.FirstOrDefault(s => GenAIHelpers.HasGenAIAttribute(s.Attributes));
+        if (firstSpan == null)
+        {
+            return;
+        }
+
+        await GenAIVisualizerDialog.OpenDialogAsync(
+            DialogService,
+            firstSpan,
+            selectedLogEntryId: null,
+            TelemetryRepository,
+            ErrorRecorder,
+            _resources,
+            () =>
+            {
+                var latestTrace = TelemetryRepository.GetTrace(trace.TraceId);
+                if (latestTrace is null)
+                {
+                    return [];
+                }
+                return latestTrace.Spans.Where(span => GenAIHelpers.HasGenAIAttribute(span.Attributes)).ToList();
+            });
     }
 
     private AIContext CreateAIContext()

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
@@ -14,6 +14,20 @@
     font-weight: normal;
 }
 
+::deep .trace-name-container {
+    display: flex;
+    align-items: center;
+    width: 100%;
+}
+
+::deep .trace-name-content {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
+}
+
 .trace-tag {
     display: flex;
     align-items: center;

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIItemPartViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIItemPartViewModel.cs
@@ -22,7 +22,8 @@ public sealed class GenAIItemPartViewModel
 {
     private static readonly JsonSerializerOptions s_jsonSerializerOptions = new()
     {
-        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        WriteIndented = true
     };
 
     public MessagePart? MessagePart { get; init; }

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIMessageParsingHelper.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIMessageParsingHelper.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace Aspire.Dashboard.Model.GenAI;
 
@@ -136,5 +137,29 @@ internal static class GenAIMessageParsingHelper
         }
 
         return (role ?? string.Empty, parts ?? [], partsTruncated);
+    }
+
+    /// <summary>
+    /// If the node is a JSON string that parses to a JSON object or array, return the parsed node instead.
+    /// </summary>
+    internal static JsonNode? TryParseStringJsonNode(JsonNode? node)
+    {
+        if (node?.GetValueKind() == JsonValueKind.String && node.GetValue<string>() is { } json)
+        {
+            try
+            {
+                var parsed = JsonNode.Parse(json);
+                if (parsed?.GetValueKind() is JsonValueKind.Object or JsonValueKind.Array)
+                {
+                    return parsed;
+                }
+            }
+            catch (JsonException)
+            {
+                // Not valid JSON. Keep the original string value.
+            }
+        }
+
+        return node;
     }
 }

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
@@ -207,13 +207,13 @@ internal sealed class MessagePartConverter : JsonConverter<MessagePart>
         return type switch
         {
             MessagePart.TextType => doc.RootElement.Deserialize<TextPart>(options),
-            MessagePart.ToolCallType => doc.RootElement.Deserialize<ToolCallRequestPart>(options),
+            MessagePart.ToolCallType => TryParseStringArguments(doc.RootElement.Deserialize<ToolCallRequestPart>(options)),
             MessagePart.ToolCallResponseType => doc.RootElement.Deserialize<ToolCallResponsePart>(options),
             MessagePart.BlobType => doc.RootElement.Deserialize<BlobPart>(options),
             MessagePart.FileType => doc.RootElement.Deserialize<FilePart>(options),
             MessagePart.UriType => doc.RootElement.Deserialize<UriPart>(options),
             MessagePart.ReasoningType => doc.RootElement.Deserialize<ReasoningPart>(options),
-            MessagePart.ServerToolCallType => doc.RootElement.Deserialize<ServerToolCallPart>(options),
+            MessagePart.ServerToolCallType => TryParseServerToolCallArguments(doc.RootElement.Deserialize<ServerToolCallPart>(options)),
             MessagePart.ServerToolCallResponseType => doc.RootElement.Deserialize<ServerToolCallResponsePart>(options),
             _ => doc.RootElement.Deserialize<GenericPart>(options),
         };
@@ -222,6 +222,29 @@ internal sealed class MessagePartConverter : JsonConverter<MessagePart>
     public override void Write(Utf8JsonWriter writer, MessagePart value, JsonSerializerOptions options)
     {
         JsonSerializer.Serialize(writer, (object)value, value.GetType(), options);
+    }
+
+    /// <summary>
+    /// If the tool call arguments are a string, try parsing them as JSON and replace with the parsed object.
+    /// </summary>
+    private static ToolCallRequestPart? TryParseStringArguments(ToolCallRequestPart? part)
+    {
+        if (part is { Arguments: not null })
+        {
+            part.Arguments = GenAIMessageParsingHelper.TryParseStringJsonNode(part.Arguments);
+        }
+
+        return part;
+    }
+
+    private static ServerToolCallPart? TryParseServerToolCallArguments(ServerToolCallPart? part)
+    {
+        if (part is { ServerToolCall: not null })
+        {
+            part.ServerToolCall = GenAIMessageParsingHelper.TryParseStringJsonNode(part.ServerToolCall);
+        }
+
+        return part;
     }
 }
 

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -515,7 +515,7 @@ public sealed class GenAIVisualizerDialogViewModel
                 break;
             case GenAIItemType.ToolMessage:
                 var toolEvent = DeserializeEventJson(message, GenAIEventsContext.Default.ToolEvent)!;
-                var toolResponse = ProcessJsonPayload(toolEvent.Content);
+                var toolResponse = GenAIMessageParsingHelper.TryParseStringJsonNode(toolEvent.Content);
                 messagePartViewModels.Add(GenAIItemPartViewModel.CreateMessagePart(new ToolCallResponsePart { Id = toolEvent.Id, Response = toolResponse }));
                 break;
             case GenAIItemType.OutputMessage:
@@ -552,7 +552,7 @@ public sealed class GenAIVisualizerDialogViewModel
                         continue;
                     }
 
-                    var args = ProcessJsonPayload(function.Arguments);
+                    var args = GenAIMessageParsingHelper.TryParseStringJsonNode(function.Arguments);
                     messagePartViewModels.Add(GenAIItemPartViewModel.CreateMessagePart(new ToolCallRequestPart { Name = function.Name, Arguments = args }));
                 }
             }
@@ -575,29 +575,6 @@ public sealed class GenAIVisualizerDialogViewModel
                 Content description: {description}
                 """, ex);
         }
-    }
-
-    // Args might be a serialized object string instead of a raw object.
-    // To avoid extra escaping in displaying serialized object string, attempt to convert to object.
-    private static JsonNode? ProcessJsonPayload(JsonNode? args)
-    {
-        if (args?.GetValueKind() == JsonValueKind.String && args.GetValue<string>() is { } argsJson)
-        {
-            try
-            {
-                var node = JsonNode.Parse(argsJson);
-                if (node?.GetValueKind() is JsonValueKind.Object or JsonValueKind.Array)
-                {
-                    args = node;
-                }
-            }
-            catch (Exception)
-            {
-                // Not a JSON string. Ignore.
-            }
-        }
-
-        return args;
     }
 
     private static bool TryMapEventName(string name, [NotNullWhen(true)] out GenAIItemType? type)

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -313,6 +313,15 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to LLM.
+        /// </summary>
+        public static string GenAILLMBadgeText {
+            get {
+                return ResourceManager.GetString("GenAILLMBadgeText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Message.
         /// </summary>
         public static string GenAIMessageCategoryMessage {
@@ -507,6 +516,24 @@ namespace Aspire.Dashboard.Resources {
         public static string GenAITokensLabel {
             get {
                 return ResourceManager.GetString("GenAITokensLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tool call.
+        /// </summary>
+        public static string GenAIToolCallButtonText {
+            get {
+                return ResourceManager.GetString("GenAIToolCallButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tool definition.
+        /// </summary>
+        public static string GenAIToolDefinitionButtonText {
+            get {
+                return ResourceManager.GetString("GenAIToolDefinitionButtonText", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -419,6 +419,12 @@
   <data name="GenAIToolRequiredParameter" xml:space="preserve">
     <value>Required parameter</value>
   </data>
+  <data name="GenAIToolCallButtonText" xml:space="preserve">
+    <value>Tool call</value>
+  </data>
+  <data name="GenAIToolDefinitionButtonText" xml:space="preserve">
+    <value>Tool definition</value>
+  </data>
   <data name="GenAIToolNoParameters" xml:space="preserve">
     <value>No parameters</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -361,6 +361,9 @@
   <data name="GenAIOutputHeaderText" xml:space="preserve">
     <value>Output</value>
   </data>
+  <data name="GenAILLMBadgeText" xml:space="preserve">
+    <value>LLM</value>
+  </data>
   <data name="GenAIMessageCategoryToolCalls" xml:space="preserve">
     <value>Tool calls</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -252,6 +252,16 @@
         <target state="translated">Tokeny</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIToolCallButtonText">
+        <source>Tool call</source>
+        <target state="new">Tool call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GenAIToolDefinitionButtonText">
+        <source>Tool definition</source>
+        <target state="new">Tool definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIToolNoParameters">
         <source>No parameters</source>
         <target state="translated">Žádné parametry</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Vstupní tokeny: {0}</target>
         <note>{0} is the number of tokens</note>
       </trans-unit>
+      <trans-unit id="GenAILLMBadgeText">
+        <source>LLM</source>
+        <target state="new">LLM</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIMessageCategoryMessage">
         <source>Message</source>
         <target state="translated">Zpráva</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -252,6 +252,16 @@
         <target state="translated">Token</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIToolCallButtonText">
+        <source>Tool call</source>
+        <target state="new">Tool call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GenAIToolDefinitionButtonText">
+        <source>Tool definition</source>
+        <target state="new">Tool definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIToolNoParameters">
         <source>No parameters</source>
         <target state="translated">Keine Parameter</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Eingabetoken: {0}</target>
         <note>{0} is the number of tokens</note>
       </trans-unit>
+      <trans-unit id="GenAILLMBadgeText">
+        <source>LLM</source>
+        <target state="new">LLM</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIMessageCategoryMessage">
         <source>Message</source>
         <target state="translated">Nachricht</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Tokens de entrada: {0}</target>
         <note>{0} is the number of tokens</note>
       </trans-unit>
+      <trans-unit id="GenAILLMBadgeText">
+        <source>LLM</source>
+        <target state="new">LLM</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIMessageCategoryMessage">
         <source>Message</source>
         <target state="translated">Mensaje</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -252,6 +252,16 @@
         <target state="translated">Tokens</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIToolCallButtonText">
+        <source>Tool call</source>
+        <target state="new">Tool call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GenAIToolDefinitionButtonText">
+        <source>Tool definition</source>
+        <target state="new">Tool definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIToolNoParameters">
         <source>No parameters</source>
         <target state="translated">No hay parámetros</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -252,6 +252,16 @@
         <target state="translated">Jetons</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIToolCallButtonText">
+        <source>Tool call</source>
+        <target state="new">Tool call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GenAIToolDefinitionButtonText">
+        <source>Tool definition</source>
+        <target state="new">Tool definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIToolNoParameters">
         <source>No parameters</source>
         <target state="translated">Aucun paramètre</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Jetons d’entrée : {0}</target>
         <note>{0} is the number of tokens</note>
       </trans-unit>
+      <trans-unit id="GenAILLMBadgeText">
+        <source>LLM</source>
+        <target state="new">LLM</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIMessageCategoryMessage">
         <source>Message</source>
         <target state="translated">Message</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Token di input: {0}</target>
         <note>{0} is the number of tokens</note>
       </trans-unit>
+      <trans-unit id="GenAILLMBadgeText">
+        <source>LLM</source>
+        <target state="new">LLM</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIMessageCategoryMessage">
         <source>Message</source>
         <target state="translated">Messaggio</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -252,6 +252,16 @@
         <target state="translated">Token</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIToolCallButtonText">
+        <source>Tool call</source>
+        <target state="new">Tool call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GenAIToolDefinitionButtonText">
+        <source>Tool definition</source>
+        <target state="new">Tool definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIToolNoParameters">
         <source>No parameters</source>
         <target state="translated">Nessun parametro</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -137,6 +137,11 @@
         <target state="translated">入力トークン: {0}</target>
         <note>{0} is the number of tokens</note>
       </trans-unit>
+      <trans-unit id="GenAILLMBadgeText">
+        <source>LLM</source>
+        <target state="new">LLM</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIMessageCategoryMessage">
         <source>Message</source>
         <target state="translated">メッセージ</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -252,6 +252,16 @@
         <target state="translated">トークン</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIToolCallButtonText">
+        <source>Tool call</source>
+        <target state="new">Tool call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GenAIToolDefinitionButtonText">
+        <source>Tool definition</source>
+        <target state="new">Tool definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIToolNoParameters">
         <source>No parameters</source>
         <target state="translated">パラメーターがありません</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -252,6 +252,16 @@
         <target state="translated">토큰</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIToolCallButtonText">
+        <source>Tool call</source>
+        <target state="new">Tool call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GenAIToolDefinitionButtonText">
+        <source>Tool definition</source>
+        <target state="new">Tool definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIToolNoParameters">
         <source>No parameters</source>
         <target state="translated">매개 변수 없음</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -137,6 +137,11 @@
         <target state="translated">입력 토큰: {0}</target>
         <note>{0} is the number of tokens</note>
       </trans-unit>
+      <trans-unit id="GenAILLMBadgeText">
+        <source>LLM</source>
+        <target state="new">LLM</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIMessageCategoryMessage">
         <source>Message</source>
         <target state="translated">메시지</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Tokeny wejściowe: {0}</target>
         <note>{0} is the number of tokens</note>
       </trans-unit>
+      <trans-unit id="GenAILLMBadgeText">
+        <source>LLM</source>
+        <target state="new">LLM</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIMessageCategoryMessage">
         <source>Message</source>
         <target state="translated">Wiadomość</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -252,6 +252,16 @@
         <target state="translated">Tokeny</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIToolCallButtonText">
+        <source>Tool call</source>
+        <target state="new">Tool call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GenAIToolDefinitionButtonText">
+        <source>Tool definition</source>
+        <target state="new">Tool definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIToolNoParameters">
         <source>No parameters</source>
         <target state="translated">Brak parametrów</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -252,6 +252,16 @@
         <target state="translated">Tokens</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIToolCallButtonText">
+        <source>Tool call</source>
+        <target state="new">Tool call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GenAIToolDefinitionButtonText">
+        <source>Tool definition</source>
+        <target state="new">Tool definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIToolNoParameters">
         <source>No parameters</source>
         <target state="translated">Nenhum parâmetro</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Tokens de entrada: {0}</target>
         <note>{0} is the number of tokens</note>
       </trans-unit>
+      <trans-unit id="GenAILLMBadgeText">
+        <source>LLM</source>
+        <target state="new">LLM</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIMessageCategoryMessage">
         <source>Message</source>
         <target state="translated">Mensagem</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -252,6 +252,16 @@
         <target state="translated">Токены</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIToolCallButtonText">
+        <source>Tool call</source>
+        <target state="new">Tool call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GenAIToolDefinitionButtonText">
+        <source>Tool definition</source>
+        <target state="new">Tool definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIToolNoParameters">
         <source>No parameters</source>
         <target state="translated">Нет параметров</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Входные токены: {0}</target>
         <note>{0} is the number of tokens</note>
       </trans-unit>
+      <trans-unit id="GenAILLMBadgeText">
+        <source>LLM</source>
+        <target state="new">LLM</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIMessageCategoryMessage">
         <source>Message</source>
         <target state="translated">Сообщение</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Giriş belirteçleri: {0}</target>
         <note>{0} is the number of tokens</note>
       </trans-unit>
+      <trans-unit id="GenAILLMBadgeText">
+        <source>LLM</source>
+        <target state="new">LLM</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIMessageCategoryMessage">
         <source>Message</source>
         <target state="translated">İleti</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -252,6 +252,16 @@
         <target state="translated">Belirteçler</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIToolCallButtonText">
+        <source>Tool call</source>
+        <target state="new">Tool call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GenAIToolDefinitionButtonText">
+        <source>Tool definition</source>
+        <target state="new">Tool definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIToolNoParameters">
         <source>No parameters</source>
         <target state="translated">Parametre yok</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -252,6 +252,16 @@
         <target state="translated">词元</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIToolCallButtonText">
+        <source>Tool call</source>
+        <target state="new">Tool call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GenAIToolDefinitionButtonText">
+        <source>Tool definition</source>
+        <target state="new">Tool definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIToolNoParameters">
         <source>No parameters</source>
         <target state="translated">无参数</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -137,6 +137,11 @@
         <target state="translated">输入词元数: {0}</target>
         <note>{0} is the number of tokens</note>
       </trans-unit>
+      <trans-unit id="GenAILLMBadgeText">
+        <source>LLM</source>
+        <target state="new">LLM</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIMessageCategoryMessage">
         <source>Message</source>
         <target state="translated">消息</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -252,6 +252,16 @@
         <target state="translated">權杖</target>
         <note />
       </trans-unit>
+      <trans-unit id="GenAIToolCallButtonText">
+        <source>Tool call</source>
+        <target state="new">Tool call</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GenAIToolDefinitionButtonText">
+        <source>Tool definition</source>
+        <target state="new">Tool definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIToolNoParameters">
         <source>No parameters</source>
         <target state="translated">無參數</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -137,6 +137,11 @@
         <target state="translated">輸入權杖: {0}</target>
         <note>{0} is the number of tokens</note>
       </trans-unit>
+      <trans-unit id="GenAILLMBadgeText">
+        <source>LLM</source>
+        <target state="new">LLM</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GenAIMessageCategoryMessage">
         <source>Message</source>
         <target state="translated">訊息</target>

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIItemPartViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIItemPartViewModelTests.cs
@@ -68,7 +68,14 @@ public sealed class GenAIItemPartViewModelTests
         var itemPart = GenAIItemPartViewModel.CreateMessagePart(responsePart);
 
         // Assert
-        Assert.Equal("""["Jack","Jane"]""", itemPart.TextVisualizerViewModel.Text);
+        Assert.Equal(
+            """
+            [
+              "Jack",
+              "Jane"
+            ]
+            """,
+            itemPart.TextVisualizerViewModel.Text);
         Assert.Equal(DashboardUIHelpers.JsonFormat, itemPart.TextVisualizerViewModel.FormatKind);
         Assert.Equal(
             """
@@ -93,7 +100,14 @@ public sealed class GenAIItemPartViewModelTests
         var itemPart = GenAIItemPartViewModel.CreateMessagePart(responsePart);
 
         // Assert
-        Assert.Equal("""{"name":"Jack","age":30}""", itemPart.TextVisualizerViewModel.Text);
+        Assert.Equal(
+            """
+            {
+              "name": "Jack",
+              "age": 30
+            }
+            """,
+            itemPart.TextVisualizerViewModel.Text);
         Assert.Equal(DashboardUIHelpers.JsonFormat, itemPart.TextVisualizerViewModel.FormatKind);
     }
 

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIMessageParsingHelperTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIMessageParsingHelperTests.cs
@@ -139,6 +139,21 @@ public sealed class GenAIMessageParsingHelperTests
     }
 
     [Fact]
+    public void ReadMessagePart_ToolCallRequestPart_ParsesStringArgumentsAsJson()
+    {
+        var json = """[{"type":"tool_call","id":"call_abc","name":"get_weather","arguments":"{\"location\":\"Seattle\",\"unit\":\"celsius\"}"}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessagePart);
+
+        Assert.False(truncated);
+        var toolCallPart = Assert.IsType<ToolCallRequestPart>(Assert.Single(items));
+        Assert.Equal("get_weather", toolCallPart.Name);
+        Assert.NotNull(toolCallPart.Arguments);
+        Assert.Equal(JsonValueKind.Object, toolCallPart.Arguments.GetValueKind());
+        Assert.Equal("Seattle", toolCallPart.Arguments["location"]!.GetValue<string>());
+    }
+
+    [Fact]
     public void ReadMessagePart_ToolCallResponsePart_ParsesObjectAndStringResponses()
     {
         var json = """[{"type":"tool_call_response","id":"call_abc","response":{"temperature":72}},{"type":"tool_call_response","id":"call_xyz","response":"plain text result"}]""";


### PR DESCRIPTION
## Description

Minor improvements and bug fixes for the GenAI visualizer in the dashboard:

### Bug fixes
- **Structured logs GenAI context**: Fixed the `getContextGenAISpans` callback in `StructuredLogs.razor.cs` to use trace-based span lookup instead of filtering log entries. Previously it queried logs with filters and looked up spans one-by-one; now it fetches the trace by ID and iterates its spans directly, which is simpler and more reliable.

### Improvements
- **GenAI sparkle button on Traces page**: Added a sparkle icon button to the Traces page name column that appears when a trace contains GenAI spans. Clicking it opens the GenAI visualizer dialog directly from the traces list. Includes new CSS for `trace-name-container` and `trace-name-content` layout, and `no-ellipsis` column class.
- **Tool call string arguments parsing**: Tool call arguments that arrive as serialized JSON strings (instead of raw JSON objects) are now parsed during deserialization via `MessagePartConverter`. Previously this was only handled in the event-based code path (`GenAIVisualizerDialogViewModel`). Extracted the shared `ProcessJsonPayload` logic into `GenAIMessageParsingHelper.TryParseStringJsonNode` for reuse in both code paths.
- **Localized UI strings**: Replaced hard-coded `LLM`, `Tool call`, and `Tool definition` text with localized resource strings (`GenAILLMBadgeText`, `GenAIToolCallButtonText`, `GenAIToolDefinitionButtonText`) in `TreeGenAISelector.razor` and `GenAIVisualizerDialog.razor`. Added corresponding entries to `Dialogs.resx`, `Dialogs.Designer.cs`, and all xlf translation files.

### Tests
- Added `ReadMessagePart_ToolCallRequestPart_ParsesStringArgumentsAsJson` test to verify that tool call parts with string-encoded JSON arguments are correctly parsed into JSON objects during deserialization.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
