### PR TITLE
Fix TypeScriptAppHost environment callback sample

### DIFF
--- a/playground/TypeScriptAppHost/apphost.ts
+++ b/playground/TypeScriptAppHost/apphost.ts
@@ -55,7 +55,7 @@ await builder
         // Custom environment callback logic
         var ep = await api.getEndpoint("http");
 
-        ctx.environmentVariables.set("API_ENDPOINT", refExpr`${ep}`);
+        await ctx.environmentVariables.set("API_ENDPOINT", refExpr`${ep}`);
     });
 
 console.log("Added Vite frontend with reference to API");

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
@@ -951,25 +951,6 @@ public class AtsTypeScriptCodeGeneratorTests
         Assert.Contains("ReferenceExpression", types[1].FullName ?? types[1].Name);
     }
 
-    [Fact]
-    public void TypeScriptAppHost_PlaygroundAwaitsEnvironmentVariableMutationInEnvironmentCallback()
-    {
-        var appHostPath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory,
-            "..",
-            "..",
-            "..",
-            "..",
-            "..",
-            "playground",
-            "TypeScriptAppHost",
-            "apphost.ts"));
-
-        var appHostSource = File.ReadAllText(appHostPath);
-
-        Assert.Contains("await ctx.environmentVariables.set(\"API_ENDPOINT\", refExpr`${ep}`);", appHostSource);
-    }
-
     // ===== CapabilityKind Tests =====
 
     [Fact]

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
@@ -951,6 +951,25 @@ public class AtsTypeScriptCodeGeneratorTests
         Assert.Contains("ReferenceExpression", types[1].FullName ?? types[1].Name);
     }
 
+    [Fact]
+    public void TypeScriptAppHost_PlaygroundAwaitsEnvironmentVariableMutationInEnvironmentCallback()
+    {
+        var appHostPath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            "..",
+            "playground",
+            "TypeScriptAppHost",
+            "apphost.ts"));
+
+        var appHostSource = File.ReadAllText(appHostPath);
+
+        Assert.Contains("await ctx.environmentVariables.set(\"API_ENDPOINT\", refExpr`${ep}`);", appHostSource);
+    }
+
     // ===== CapabilityKind Tests =====
 
     [Fact]


### PR DESCRIPTION
## Description

Fixes the `playground/TypeScriptAppHost` sample to await `EnvironmentCallbackContext.environmentVariables.set(...)` inside `withEnvironmentCallback`, which matches the generated TypeScript polyglot API where environment-variable mutations are async.

Adds a regression test to keep the playground sample using the awaited pattern.

Validation:
- `dotnet test tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.csproj -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Fixes #15029

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
