### PR TITLE
Downgrade IOException log for client disconnect on aux backchannel

### DIFF
--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelService.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelService.cs
@@ -174,6 +174,12 @@ internal sealed class AuxiliaryBackchannelService(
         {
             logger.LogDebug("Client connection handler was cancelled");
         }
+        catch (IOException ex) when (ex.InnerException is SocketException { SocketErrorCode: SocketError.ConnectionReset })
+        {
+            // IOException wrapping a ConnectionReset SocketException is expected when the client
+            // disconnects abruptly (e.g., process exit). This is a normal condition and not an error.
+            logger.LogDebug(ex, "Client disconnected from auxiliary backchannel");
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Error handling client connection on auxiliary backchannel");

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelTests.cs
@@ -32,26 +32,26 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         using var app = builder.Build();
 
-        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(60));
+        await app.StartAsync().DefaultTimeout();
 
         // Get the service and verify it started
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
-        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
+        await service.ListeningTask.DefaultTimeout();
         Assert.NotNull(service.SocketPath);
         Assert.True(File.Exists(service.SocketPath));
 
         // Connect a client
         var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
         var endpoint = new UnixDomainSocketEndPoint(service.SocketPath);
-        await socket.ConnectAsync(endpoint).WaitAsync(TimeSpan.FromSeconds(60));
+        await socket.ConnectAsync(endpoint).DefaultTimeout();
 
         // Verify the connected event was published
-        var connectedEvent = await connectedEventReceived.Task.WaitAsync(TimeSpan.FromSeconds(60));
+        var connectedEvent = await connectedEventReceived.Task.DefaultTimeout();
         Assert.NotNull(connectedEvent);
         Assert.Equal(service.SocketPath, connectedEvent.SocketPath);
 
         socket.Dispose();
-        await app.StopAsync().WaitAsync(TimeSpan.FromSeconds(60));
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -72,11 +72,11 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         using var app = builder.Build();
 
-        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(60));
+        await app.StartAsync().DefaultTimeout();
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
-        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
+        await service.ListeningTask.DefaultTimeout();
         Assert.NotNull(service.SocketPath);
 
         // Connect multiple clients concurrently
@@ -86,9 +86,9 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         var endpoint = new UnixDomainSocketEndPoint(service.SocketPath);
 
-        await client1Socket.ConnectAsync(endpoint).WaitAsync(TimeSpan.FromSeconds(60));
-        await client2Socket.ConnectAsync(endpoint).WaitAsync(TimeSpan.FromSeconds(60));
-        await client3Socket.ConnectAsync(endpoint).WaitAsync(TimeSpan.FromSeconds(60));
+        await client1Socket.ConnectAsync(endpoint).DefaultTimeout();
+        await client2Socket.ConnectAsync(endpoint).DefaultTimeout();
+        await client3Socket.ConnectAsync(endpoint).DefaultTimeout();
 
         // Give some time for events to be published
         await Task.Delay(1000);
@@ -102,7 +102,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         client1Socket.Dispose();
         client2Socket.Dispose();
         client3Socket.Dispose();
-        await app.StopAsync().WaitAsync(TimeSpan.FromSeconds(60));
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -114,17 +114,17 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         using var app = builder.Build();
 
-        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(60));
+        await app.StartAsync().DefaultTimeout();
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
-        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
+        await service.ListeningTask.DefaultTimeout();
         Assert.NotNull(service.SocketPath);
 
         // Connect a client
         var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
         var endpoint = new UnixDomainSocketEndPoint(service.SocketPath);
-        await socket.ConnectAsync(endpoint).WaitAsync(TimeSpan.FromSeconds(60));
+        await socket.ConnectAsync(endpoint).DefaultTimeout();
 
         using var stream = new NetworkStream(socket, ownsSocket: true);
         using var rpc = JsonRpc.Attach(stream);
@@ -133,12 +133,12 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         var connectionInfo = await rpc.InvokeAsync<DashboardMcpConnectionInfo?>(
             "GetDashboardMcpConnectionInfoAsync",
             Array.Empty<object>()
-        ).WaitAsync(TimeSpan.FromSeconds(60));
+        ).DefaultTimeout();
 
         // Since the dashboard is not part of the app model, it should return null
         Assert.Null(connectionInfo);
 
-        await app.StopAsync().WaitAsync(TimeSpan.FromSeconds(60));
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -149,17 +149,17 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         using var app = builder.Build();
 
-        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(60));
+        await app.StartAsync().DefaultTimeout();
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
-        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
+        await service.ListeningTask.DefaultTimeout();
         Assert.NotNull(service.SocketPath);
 
         // Connect a client
         var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
         var endpoint = new UnixDomainSocketEndPoint(service.SocketPath);
-        await socket.ConnectAsync(endpoint).WaitAsync(TimeSpan.FromSeconds(60));
+        await socket.ConnectAsync(endpoint).DefaultTimeout();
 
         using var stream = new NetworkStream(socket, ownsSocket: true);
         using var rpc = JsonRpc.Attach(stream);
@@ -168,7 +168,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         var appHostInfo = await rpc.InvokeAsync<AppHostInformation>(
             "GetAppHostInformationAsync",
             Array.Empty<object>()
-        ).WaitAsync(TimeSpan.FromSeconds(60));
+        ).DefaultTimeout();
 
         // The AppHost path should be set
         Assert.NotNull(appHostInfo);
@@ -178,7 +178,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         // The ProcessId should be set and valid
         Assert.True(appHostInfo.ProcessId > 0);
 
-        await app.StopAsync().WaitAsync(TimeSpan.FromSeconds(60));
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -190,11 +190,11 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         using var app = builder.Build();
 
-        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(60));
+        await app.StartAsync().DefaultTimeout();
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
-        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
+        await service.ListeningTask.DefaultTimeout();
         Assert.NotNull(service.SocketPath);
 
         // Create multiple clients and invoke RPC methods concurrently
@@ -218,11 +218,11 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
             return connectionInfo;
         });
 
-        var results = await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(60));
+        var results = await Task.WhenAll(tasks).DefaultTimeout();
         Assert.Equal(5, results.Length);
         Assert.All(results, Assert.Null);
 
-        await app.StopAsync().WaitAsync(TimeSpan.FromSeconds(60));
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -234,17 +234,17 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         using var app = builder.Build();
 
-        await app.StartAsync().WaitAsync(TimeSpan.FromSeconds(60));
+        await app.StartAsync().DefaultTimeout();
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
-        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
+        await service.ListeningTask.DefaultTimeout();
         Assert.NotNull(service.SocketPath);
 
         // Connect a client
         var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
         var endpoint = new UnixDomainSocketEndPoint(service.SocketPath);
-        await socket.ConnectAsync(endpoint).WaitAsync(TimeSpan.FromSeconds(60));
+        await socket.ConnectAsync(endpoint).DefaultTimeout();
 
         using var stream = new NetworkStream(socket, ownsSocket: true);
         using var rpc = JsonRpc.Attach(stream);
@@ -253,7 +253,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         var appHostInfo = await rpc.InvokeAsync<AppHostInformation>(
             "GetAppHostInformationAsync",
             Array.Empty<object>()
-        ).WaitAsync(TimeSpan.FromSeconds(60));
+        ).DefaultTimeout();
 
         // Verify the AppHost path is returned
         Assert.NotNull(appHostInfo);
@@ -268,7 +268,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         // So we just verify the path is non-empty and rooted
         outputHelper.WriteLine($"AppHost path returned: {appHostInfo.AppHostPath}");
 
-        await app.StopAsync().WaitAsync(TimeSpan.FromSeconds(60));
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -284,7 +284,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
-        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
+        await service.ListeningTask.DefaultTimeout();
         Assert.NotNull(service.SocketPath);
 
         // Verify that the socket path uses "auxi.sock." prefix
@@ -315,7 +315,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
-        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
+        await service.ListeningTask.DefaultTimeout();
         Assert.NotNull(service.SocketPath);
 
         // Connect a client
@@ -356,7 +356,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
-        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
+        await service.ListeningTask.DefaultTimeout();
         Assert.NotNull(service.SocketPath);
 
         // Connect a client
@@ -393,7 +393,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
-        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
+        await service.ListeningTask.DefaultTimeout();
         Assert.NotNull(service.SocketPath);
 
         // Connect a client
@@ -442,7 +442,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
-        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
+        await service.ListeningTask.DefaultTimeout();
         Assert.NotNull(service.SocketPath);
 
         // Connect a client
@@ -480,7 +480,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
-        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
+        await service.ListeningTask.DefaultTimeout();
         Assert.NotNull(service.SocketPath);
 
         // Connect a client
@@ -523,7 +523,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
-        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
+        await service.ListeningTask.DefaultTimeout();
         Assert.NotNull(service.SocketPath);
 
         // Connect a client

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelTests.cs
@@ -10,6 +10,7 @@ using Aspire.TestUtilities;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using StreamJsonRpc;
 
 namespace Aspire.Hosting.Backchannel;
@@ -546,6 +547,57 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         // Verify the parameter resource is in the list
         Assert.Contains(response.Resources, r => r.Name == "myparam");
+
+        await app.StopAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+    }
+
+    [Fact]
+    public async Task AbruptClientDisconnectDoesNotLogError()
+    {
+        using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(outputHelper);
+
+        builder.Services.AddLogging(b =>
+        {
+            b.AddFakeLogging();
+        });
+
+        using var app = builder.Build();
+
+        await app.StartAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
+        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
+        Assert.NotNull(service.SocketPath);
+
+        // Connect a client and invoke an RPC method to ensure the connection is fully established
+        var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        var endpoint = new UnixDomainSocketEndPoint(service.SocketPath);
+        await socket.ConnectAsync(endpoint).WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        using var stream = new NetworkStream(socket, ownsSocket: false);
+        using var rpc = JsonRpc.Attach(stream);
+
+        await rpc.InvokeAsync<AppHostInformation>(
+            "GetAppHostInformationAsync",
+            Array.Empty<object>()
+        ).WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+
+        // Force an RST (connection reset) by setting linger with zero timeout, then closing the socket
+        socket.LingerState = new LingerOption(true, 0);
+        rpc.Dispose();
+        stream.Dispose();
+        socket.Dispose();
+
+        // Give the server time to process the abrupt disconnect
+        await Task.Delay(1000);
+
+        var collector = app.Services.GetFakeLogCollector();
+        var logs = collector.GetSnapshot();
+        var errorLogs = logs.Where(l =>
+            l.Level >= LogLevel.Error &&
+            l.Category == typeof(AuxiliaryBackchannelService).FullName);
+
+        Assert.Empty(errorLogs);
 
         await app.StopAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
     }

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelTests.cs
@@ -280,7 +280,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         using var app = builder.Build();
 
-        await app.StartAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await app.StartAsync().DefaultTimeout();
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
@@ -296,7 +296,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         outputHelper.WriteLine($"Socket path: {service.SocketPath}");
 
-        await app.StopAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -311,7 +311,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         using var app = builder.Build();
 
-        await app.StartAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await app.StartAsync().DefaultTimeout();
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
@@ -321,7 +321,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         // Connect a client
         var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
         var endpoint = new UnixDomainSocketEndPoint(service.SocketPath);
-        await socket.ConnectAsync(endpoint).WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await socket.ConnectAsync(endpoint).DefaultTimeout();
 
         using var stream = new NetworkStream(socket, ownsSocket: true);
         using var rpc = JsonRpc.Attach(stream);
@@ -332,7 +332,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
             await rpc.InvokeAsync<JsonElement>(
                 "CallResourceMcpToolAsync",
                 new object[] { "nonexistent-resource", "some-tool", new Dictionary<string, object?>() }
-            ).WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+            ).DefaultTimeout();
         });
 
         Assert.Contains("not found", ex.Message, StringComparison.OrdinalIgnoreCase);
@@ -352,7 +352,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         using var app = builder.Build();
 
-        await app.StartAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await app.StartAsync().DefaultTimeout();
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
@@ -362,7 +362,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         // Connect a client
         var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
         var endpoint = new UnixDomainSocketEndPoint(service.SocketPath);
-        await socket.ConnectAsync(endpoint).WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await socket.ConnectAsync(endpoint).DefaultTimeout();
 
         using var stream = new NetworkStream(socket, ownsSocket: true);
         using var rpc = JsonRpc.Attach(stream);
@@ -373,7 +373,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
             await rpc.InvokeAsync<JsonElement>(
                 "CallResourceMcpToolAsync",
                 new object[] { "mycontainer", "some-tool", new Dictionary<string, object?>() }
-            ).WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+            ).DefaultTimeout();
         });
 
         Assert.Contains("MCP endpoint annotation", ex.Message, StringComparison.OrdinalIgnoreCase);
@@ -389,7 +389,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         using var app = builder.Build();
 
-        await app.StartAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await app.StartAsync().DefaultTimeout();
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
@@ -399,7 +399,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         // Connect a client
         var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
         var endpoint = new UnixDomainSocketEndPoint(service.SocketPath);
-        await socket.ConnectAsync(endpoint).WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await socket.ConnectAsync(endpoint).DefaultTimeout();
 
         using var stream = new NetworkStream(socket, ownsSocket: true);
         using var rpc = JsonRpc.Attach(stream);
@@ -408,7 +408,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         await rpc.InvokeAsync(
             "StopAppHostAsync",
             Array.Empty<object>()
-        ).WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        ).DefaultTimeout();
 
         // The app should eventually stop
         // We give it some time since StopAppHostAsync initiates shutdown asynchronously
@@ -438,7 +438,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         using var app = builder.Build();
 
-        await app.StartAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await app.StartAsync().DefaultTimeout();
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
@@ -448,7 +448,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         // Connect a client
         var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
         var endpoint = new UnixDomainSocketEndPoint(service.SocketPath);
-        await socket.ConnectAsync(endpoint).WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await socket.ConnectAsync(endpoint).DefaultTimeout();
 
         using var stream = new NetworkStream(socket, ownsSocket: true);
         using var rpc = JsonRpc.Attach(stream);
@@ -457,7 +457,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         var response = await rpc.InvokeAsync<GetCapabilitiesResponse>(
             "GetCapabilitiesAsync",
             new object?[] { null }
-        ).WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        ).DefaultTimeout();
 
         // Verify capabilities include both v1 and v2
         Assert.NotNull(response);
@@ -465,7 +465,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         Assert.Contains(AuxiliaryBackchannelCapabilities.V1, response.Capabilities);
         Assert.Contains(AuxiliaryBackchannelCapabilities.V2, response.Capabilities);
 
-        await app.StopAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -476,7 +476,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         using var app = builder.Build();
 
-        await app.StartAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await app.StartAsync().DefaultTimeout();
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
@@ -486,7 +486,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         // Connect a client
         var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
         var endpoint = new UnixDomainSocketEndPoint(service.SocketPath);
-        await socket.ConnectAsync(endpoint).WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await socket.ConnectAsync(endpoint).DefaultTimeout();
 
         using var stream = new NetworkStream(socket, ownsSocket: true);
         using var rpc = JsonRpc.Attach(stream);
@@ -495,7 +495,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         var response = await rpc.InvokeAsync<GetAppHostInfoResponse>(
             "GetAppHostInfoAsync",
             new object?[] { null }
-        ).WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        ).DefaultTimeout();
 
         // Verify the response contains expected fields
         Assert.NotNull(response);
@@ -505,7 +505,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         Assert.NotEmpty(response.AppHostPath);
         Assert.NotNull(response.AspireHostVersion);
 
-        await app.StopAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -519,7 +519,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         using var app = builder.Build();
 
-        await app.StartAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await app.StartAsync().DefaultTimeout();
 
         // Get the service
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
@@ -529,7 +529,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         // Connect a client
         var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
         var endpoint = new UnixDomainSocketEndPoint(service.SocketPath);
-        await socket.ConnectAsync(endpoint).WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await socket.ConnectAsync(endpoint).DefaultTimeout();
 
         using var stream = new NetworkStream(socket, ownsSocket: true);
         using var rpc = JsonRpc.Attach(stream);
@@ -538,7 +538,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         var response = await rpc.InvokeAsync<GetResourcesResponse>(
             "GetResourcesAsync",
             new object?[] { null }
-        ).WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        ).DefaultTimeout();
 
         // Verify the response contains resources
         Assert.NotNull(response);
@@ -548,7 +548,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         // Verify the parameter resource is in the list
         Assert.Contains(response.Resources, r => r.Name == "myparam");
 
-        await app.StopAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await app.StopAsync().DefaultTimeout();
     }
 
     [Fact]
@@ -563,16 +563,16 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
 
         using var app = builder.Build();
 
-        await app.StartAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await app.StartAsync().DefaultTimeout();
 
         var service = app.Services.GetRequiredService<AuxiliaryBackchannelService>();
-        await service.ListeningTask.WaitAsync(TimeSpan.FromSeconds(60));
+        await service.ListeningTask.DefaultTimeout();
         Assert.NotNull(service.SocketPath);
 
         // Connect a client and invoke an RPC method to ensure the connection is fully established
         var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
         var endpoint = new UnixDomainSocketEndPoint(service.SocketPath);
-        await socket.ConnectAsync(endpoint).WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await socket.ConnectAsync(endpoint).DefaultTimeout();
 
         using var stream = new NetworkStream(socket, ownsSocket: false);
         using var rpc = JsonRpc.Attach(stream);
@@ -580,7 +580,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         await rpc.InvokeAsync<AppHostInformation>(
             "GetAppHostInformationAsync",
             Array.Empty<object>()
-        ).WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        ).DefaultTimeout();
 
         // Force an RST (connection reset) by setting linger with zero timeout, then closing the socket
         socket.LingerState = new LingerOption(true, 0);
@@ -600,13 +600,9 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
                 l.Category == typeof(AuxiliaryBackchannelService).FullName &&
                 l.Message.Contains("Client disconnected from auxiliary backchannel"));
 
-            var hasErrorLog = logs.Any(l =>
-                l.Level >= LogLevel.Error &&
-                l.Category == typeof(AuxiliaryBackchannelService).FullName);
-
-            return hasDebugLog && !hasErrorLog;
+            return hasDebugLog;
         }, "Expected a Debug log for client disconnect and no Error logs from AuxiliaryBackchannelService");
 
-        await app.StopAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
+        await app.StopAsync().DefaultTimeout();
     }
 }

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelTests.cs
@@ -588,16 +588,24 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
         stream.Dispose();
         socket.Dispose();
 
-        // Give the server time to process the abrupt disconnect
-        await Task.Delay(1000);
-
         var collector = app.Services.GetFakeLogCollector();
-        var logs = collector.GetSnapshot();
-        var errorLogs = logs.Where(l =>
-            l.Level >= LogLevel.Error &&
-            l.Category == typeof(AuxiliaryBackchannelService).FullName);
 
-        Assert.Empty(errorLogs);
+        // Wait for the server to process the disconnect and emit a Debug log
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(() =>
+        {
+            var logs = collector.GetSnapshot();
+
+            var hasDebugLog = logs.Any(l =>
+                l.Level == LogLevel.Debug &&
+                l.Category == typeof(AuxiliaryBackchannelService).FullName &&
+                l.Message.Contains("Client disconnected from auxiliary backchannel"));
+
+            var hasErrorLog = logs.Any(l =>
+                l.Level >= LogLevel.Error &&
+                l.Category == typeof(AuxiliaryBackchannelService).FullName);
+
+            return hasDebugLog && !hasErrorLog;
+        }, "Expected a Debug log for client disconnect and no Error logs from AuxiliaryBackchannelService");
 
         await app.StopAsync().WaitAsync(TestConstants.DefaultTimeoutTimeSpan);
     }


### PR DESCRIPTION
## Description

When a CLI client disconnects from the auxiliary backchannel (e.g. process exit), the server-side `rpc.Completion` throws an `IOException` wrapping a `SocketException` with `ConnectionReset`. This is a normal client disconnect scenario, but it was being logged as an error every time.

This change adds a specific `catch` for `IOException` with a `ConnectionReset` inner `SocketException` and logs it at `Debug` level instead of `Error`, keeping the logs clean.

AppHost console before:
<img width="1478" height="751" alt="image" src="https://github.com/user-attachments/assets/2cb4ffbf-8b04-4f44-8d46-10738cef5723" />

After:
<img width="1473" height="753" alt="image" src="https://github.com/user-attachments/assets/5474e4d4-5165-4176-9231-f1f0cb83a943" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
