### PR TITLE
Use 'aspire logs' command for viewing resource logs in extension

### DIFF
--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -289,7 +289,11 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
     }
 
     viewResourceLogs(element: ResourceItem): void {
-        this._runResourceCommand(element, 'logs', '--follow');
+        const appHost = this._findAppHostForResource(element);
+        if (!appHost) {
+            return;
+        }
+        this._terminalProvider.sendAspireCommandToAspireTerminal(`logs "${element.resource.name}" --apphost "${appHost.appHostPath}" --follow`);
     }
 
     async executeResourceCommand(element: ResourceItem): Promise<void> {


### PR DESCRIPTION
## Description

The `aspire logs` command was introduced as a top-level CLI command (instead of `aspire resource <name> logs`). This PR updates the VS Code extension's "View Logs" tree action to use the new `aspire logs "<resource>" --apphost "<path>" --follow` command shape instead of routing through the `resource` subcommand.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
