### PR TITLE
Improve aspire run experience when dotnet is not installed

### DIFF
--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -92,23 +92,25 @@ internal abstract class BaseCommand : Command
         ArgumentNullException.ThrowIfNull(ex);
         ArgumentNullException.ThrowIfNull(interactionService);
 
-        var errorMessage = ex.Message switch
+        var (exitCode, errorMessage) = ex.FailureReason switch
         {
-            var m when string.Equals(m, ErrorStrings.ProjectFileNotAppHostProject, StringComparisons.CliInputOrOutput)
-                => InteractionServiceStrings.SpecifiedProjectFileNotAppHostProject,
-            var m when string.Equals(m, ErrorStrings.ProjectFileDoesntExist, StringComparisons.CliInputOrOutput)
-                => InteractionServiceStrings.ProjectOptionDoesntExist,
-            var m when string.Equals(m, ErrorStrings.MultipleProjectFilesFound, StringComparisons.CliInputOrOutput)
-                => InteractionServiceStrings.ProjectOptionNotSpecifiedMultipleAppHostsFound,
-            var m when string.Equals(m, ErrorStrings.NoProjectFileFound, StringComparisons.CliInputOrOutput)
-                => InteractionServiceStrings.ProjectOptionNotSpecifiedNoCsprojFound,
-            var m when string.Equals(m, ErrorStrings.AppHostsMayNotBeBuildable, StringComparisons.CliInputOrOutput)
-                => InteractionServiceStrings.UnbuildableAppHostsDetected,
-            _ => string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message)
+            ProjectLocatorFailureReason.UnsupportedProjects
+                => (ExitCodeConstants.SdkNotInstalled, "No supported app hosts were found."),
+            ProjectLocatorFailureReason.ProjectFileNotAppHostProject
+                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.SpecifiedProjectFileNotAppHostProject),
+            ProjectLocatorFailureReason.ProjectFileDoesntExist
+                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.ProjectOptionDoesntExist),
+            ProjectLocatorFailureReason.MultipleProjectFilesFound
+                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.ProjectOptionNotSpecifiedMultipleAppHostsFound),
+            ProjectLocatorFailureReason.NoProjectFileFound
+                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.ProjectOptionNotSpecifiedNoCsprojFound),
+            ProjectLocatorFailureReason.AppHostsMayNotBeBuildable
+                => (ExitCodeConstants.FailedToFindProject, InteractionServiceStrings.UnbuildableAppHostsDetected),
+            _ => (ExitCodeConstants.FailedToFindProject, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message))
         };
 
         telemetry.RecordError(errorMessage, ex);
         interactionService.DisplayError(errorMessage);
-        return ExitCodeConstants.FailedToFindProject;
+        return exitCode;
     }
 }

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -67,6 +67,9 @@ internal sealed class DotNetAppHostProject : IAppHostProject
     // ═══════════════════════════════════════════════════════════════
 
     /// <inheritdoc />
+    public bool IsUnsupported { get; set; }
+
+    /// <inheritdoc />
     public string LanguageId => KnownLanguageId.CSharp;
 
     /// <inheritdoc />
@@ -153,6 +156,11 @@ internal sealed class DotNetAppHostProject : IAppHostProject
     /// <inheritdoc />
     public async Task<AppHostValidationResult> ValidateAppHostAsync(FileInfo appHostFile, CancellationToken cancellationToken)
     {
+        if (IsUnsupported)
+        {
+            return new AppHostValidationResult(IsValid: false, IsUnsupported: true);
+        }
+
         var isSingleFile = appHostFile.Extension.Equals(".cs", StringComparison.OrdinalIgnoreCase);
 
         if (isSingleFile)

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -251,6 +251,11 @@ internal sealed class GuestAppHostProject : IAppHostProject
     /// <inheritdoc />
     public Task<AppHostValidationResult> ValidateAppHostAsync(FileInfo appHostFile, CancellationToken cancellationToken)
     {
+        if (IsUnsupported)
+        {
+            return Task.FromResult(new AppHostValidationResult(IsValid: false, IsUnsupported: true));
+        }
+
         // Check if the file exists
         if (!appHostFile.Exists)
         {

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -80,6 +80,9 @@ internal sealed class GuestAppHostProject : IAppHostProject
     // ═══════════════════════════════════════════════════════════════
 
     /// <inheritdoc />
+    public bool IsUnsupported { get; set; }
+
+    /// <inheritdoc />
     public string LanguageId => _resolvedLanguage.LanguageId;
 
     /// <inheritdoc />

--- a/src/Aspire.Cli/Projects/IAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/IAppHostProject.cs
@@ -12,6 +12,7 @@ namespace Aspire.Cli.Projects;
 internal record AppHostValidationResult(
     bool IsValid,
     bool IsPossiblyUnbuildable = false,
+    bool IsUnsupported = false,
     string? Message = null);
 
 /// <summary>
@@ -138,6 +139,11 @@ internal sealed class PublishContext
 /// </summary>
 internal interface IAppHostProject
 {
+    /// <summary>
+    /// Gets or sets whether this project type is unsupported in the current environment.
+    /// </summary>
+    bool IsUnsupported { get; set; }
+
     /// <summary>
     /// Gets the unique identifier for this language (e.g., "csharp", "typescript").
     /// Used for configuration storage and CLI arguments.

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Text.Json;
 using Aspire.Cli.Configuration;
+using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
@@ -27,6 +28,7 @@ internal sealed class ProjectLocator(
     IConfigurationService configurationService,
     IAppHostProjectFactory projectFactory,
     ILanguageDiscovery languageDiscovery,
+    IDotNetSdkInstaller sdkInstaller,
     AspireCliTelemetry telemetry) : IProjectLocator
 {
 
@@ -66,52 +68,82 @@ internal sealed class ProjectLocator(
 
             logger.LogDebug("Searching for patterns: {Patterns}", string.Join(", ", allPatterns));
 
-            // Process each pattern
+            // Collect all candidates with their handlers across all patterns
+            var candidatesWithHandlers = new List<(FileInfo File, IAppHostProject Handler)>();
+
             foreach (var pattern in allPatterns)
             {
                 var candidateFiles = searchDirectory.GetFiles(pattern, enumerationOptions);
                 logger.LogDebug("Found {CandidateCount} files matching pattern '{Pattern}'", candidateFiles.Length, pattern);
 
-                await Parallel.ForEachAsync(candidateFiles, parallelOptions, async (candidateFile, ct) =>
+                foreach (var candidateFile in candidateFiles)
                 {
                     logger.LogDebug("Checking candidate file {CandidateFile}", candidateFile.FullName);
 
-                    // Check if any handler can handle this file
                     var handler = projectFactory.TryGetProject(candidateFile);
                     if (handler is null)
                     {
                         logger.LogTrace("No handler found for {CandidateFile}", candidateFile.FullName);
-                        return;
+                        continue;
                     }
 
-                    // Validate the candidate file using the handler
-                    var validationResult = await handler.ValidateAppHostAsync(candidateFile, ct);
-
-                    if (validationResult.IsValid)
-                    {
-                        logger.LogDebug("Found {Language} apphost {CandidateFile}", handler.DisplayName, candidateFile.FullName);
-                        var relativePath = Path.GetRelativePath(executionContext.WorkingDirectory.FullName, candidateFile.FullName);
-                        interactionService.DisplaySubtleMessage(relativePath);
-                        lock (lockObject)
-                        {
-                            appHostProjects.Add(candidateFile);
-                        }
-                    }
-                    else if (validationResult.IsPossiblyUnbuildable)
-                    {
-                        var relativePath = Path.GetRelativePath(executionContext.WorkingDirectory.FullName, candidateFile.FullName);
-                        interactionService.DisplayMessage(KnownEmojis.Warning, string.Format(CultureInfo.CurrentCulture, ErrorStrings.ProjectFileMayBeUnbuildableAppHost, relativePath));
-                        lock (lockObject)
-                        {
-                            unbuildableSuspectedAppHostProjects.Add(candidateFile);
-                        }
-                    }
-                    else
-                    {
-                        logger.LogTrace("File {CandidateFile} is not a valid Aspire host", candidateFile.FullName);
-                    }
-                });
+                    candidatesWithHandlers.Add((candidateFile, handler));
+                }
             }
+
+            // If any candidates are .NET projects, ensure the SDK is available
+            if (candidatesWithHandlers.Any(c => c.Handler is DotNetAppHostProject))
+            {
+                if (!await SdkInstallHelper.EnsureSdkInstalledAsync(sdkInstaller, interactionService, telemetry, cancellationToken))
+                {
+                    logger.LogWarning("The .NET SDK is not available. Marking .NET projects as unsupported.");
+                    foreach (var (_, handler) in candidatesWithHandlers)
+                    {
+                        if (handler is DotNetAppHostProject dotNetHandler)
+                        {
+                            dotNetHandler.IsUnsupported = true;
+                        }
+                    }
+                }
+            }
+
+            await Parallel.ForEachAsync(candidatesWithHandlers, parallelOptions, async (candidate, ct) =>
+            {
+                var (candidateFile, handler) = candidate;
+
+                // Validate the candidate file using the handler
+                var validationResult = await handler.ValidateAppHostAsync(candidateFile, ct);
+
+                if (validationResult.IsValid)
+                {
+                    logger.LogDebug("Found {Language} apphost {CandidateFile}", handler.DisplayName, candidateFile.FullName);
+                    var relativePath = Path.GetRelativePath(executionContext.WorkingDirectory.FullName, candidateFile.FullName);
+                    interactionService.DisplaySubtleMessage(relativePath);
+                    lock (lockObject)
+                    {
+                        appHostProjects.Add(candidateFile);
+                    }
+                }
+                else if (validationResult.IsUnsupported)
+                {
+                    var relativePath = Path.GetRelativePath(executionContext.WorkingDirectory.FullName, candidateFile.FullName);
+                    interactionService.DisplayMessage(KnownEmojis.Warning, string.Format(CultureInfo.CurrentCulture, ErrorStrings.ProjectFileUnsupportedInCurrentEnvironment, relativePath));
+                    logger.LogDebug("Skipping unsupported project {CandidateFile}", candidateFile.FullName);
+                }
+                else if (validationResult.IsPossiblyUnbuildable)
+                {
+                    var relativePath = Path.GetRelativePath(executionContext.WorkingDirectory.FullName, candidateFile.FullName);
+                    interactionService.DisplayMessage(KnownEmojis.Warning, string.Format(CultureInfo.CurrentCulture, ErrorStrings.ProjectFileMayBeUnbuildableAppHost, relativePath));
+                    lock (lockObject)
+                    {
+                        unbuildableSuspectedAppHostProjects.Add(candidateFile);
+                    }
+                }
+                else
+                {
+                    logger.LogTrace("File {CandidateFile} is not a valid Aspire host", candidateFile.FullName);
+                }
+            });
 
             // This sort is done here to make results deterministic since we get all the app
             // host information in parallel and the order may vary.

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -95,6 +95,8 @@ internal sealed class ProjectLocator(
             var dotNetCandidate = candidatesWithHandlers.FirstOrDefault(c => c.Handler.LanguageId.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase));
             if (dotNetCandidate.Handler is { } dotNetHandler)
             {
+                // TODO: Consider moving this check inside the handler.
+                // Would need to support caching and reusing check across validations.
                 if (!await SdkInstallHelper.EnsureSdkInstalledAsync(sdkInstaller, interactionService, telemetry, cancellationToken))
                 {
                     logger.LogWarning("The .NET SDK is not available. Marking .NET projects as unsupported.");

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -92,18 +92,13 @@ internal sealed class ProjectLocator(
             }
 
             // If any candidates are .NET projects, ensure the SDK is available
-            if (candidatesWithHandlers.Any(c => c.Handler.LanguageId.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase)))
+            var dotNetCandidate = candidatesWithHandlers.FirstOrDefault(c => c.Handler.LanguageId.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase));
+            if (dotNetCandidate.Handler is { } dotNetHandler)
             {
                 if (!await SdkInstallHelper.EnsureSdkInstalledAsync(sdkInstaller, interactionService, telemetry, cancellationToken))
                 {
                     logger.LogWarning("The .NET SDK is not available. Marking .NET projects as unsupported.");
-                    foreach (var (_, handler) in candidatesWithHandlers)
-                    {
-                        if (handler.LanguageId.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase))
-                        {
-                            handler.IsUnsupported = true;
-                        }
-                    }
+                    dotNetHandler.IsUnsupported = true;
                 }
             }
 

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -38,7 +38,7 @@ internal sealed class ProjectLocator(
         return [..allCandidates.BuildableAppHost, ..allCandidates.UnbuildableSuspectedAppHostProjects];
     }
 
-    private async Task<(List<FileInfo> BuildableAppHost, List<FileInfo> UnbuildableSuspectedAppHostProjects)> FindAppHostProjectFilesAsync(DirectoryInfo searchDirectory, CancellationToken cancellationToken)
+    private async Task<(List<FileInfo> BuildableAppHost, List<FileInfo> UnbuildableSuspectedAppHostProjects, bool HasUnsupportedProjects)> FindAppHostProjectFilesAsync(DirectoryInfo searchDirectory, CancellationToken cancellationToken)
     {
         using var activity = telemetry.StartDiagnosticActivity();
 
@@ -46,6 +46,7 @@ internal sealed class ProjectLocator(
         {
             var appHostProjects = new List<FileInfo>();
             var unbuildableSuspectedAppHostProjects = new List<FileInfo>();
+            var hasUnsupportedProjects = false;
             var lockObject = new object();
             logger.LogDebug("Searching for project files in {SearchDirectory}", searchDirectory.FullName);
             var enumerationOptions = new EnumerationOptions
@@ -126,6 +127,7 @@ internal sealed class ProjectLocator(
                     var relativePath = Path.GetRelativePath(executionContext.WorkingDirectory.FullName, candidateFile.FullName);
                     interactionService.DisplayMessage(KnownEmojis.Warning, string.Format(CultureInfo.CurrentCulture, ErrorStrings.ProjectFileUnsupportedInCurrentEnvironment, relativePath));
                     logger.LogDebug("Skipping unsupported project {CandidateFile}", candidateFile.FullName);
+                    hasUnsupportedProjects = true;
                 }
                 else if (validationResult.IsPossiblyUnbuildable)
                 {
@@ -146,7 +148,7 @@ internal sealed class ProjectLocator(
             // host information in parallel and the order may vary.
             appHostProjects.Sort((x, y) => x.FullName.CompareTo(y.FullName));
 
-            return (appHostProjects, unbuildableSuspectedAppHostProjects);
+            return (appHostProjects, unbuildableSuspectedAppHostProjects, hasUnsupportedProjects);
         });
     }
 
@@ -213,8 +215,13 @@ internal sealed class ProjectLocator(
 
                 if (appHostProjects.Count == 0)
                 {
+                    if (searchResults.HasUnsupportedProjects)
+                    {
+                        throw new ProjectLocatorException(ErrorStrings.NoProjectFileFound, ProjectLocatorFailureReason.UnsupportedProjects);
+                    }
+
                     logger.LogError("No AppHost project files found in directory {Directory}", directory.FullName);
-                    throw new ProjectLocatorException(ErrorStrings.ProjectFileDoesntExist);
+                    throw new ProjectLocatorException(ErrorStrings.ProjectFileDoesntExist, ProjectLocatorFailureReason.ProjectFileDoesntExist);
                 }
                 else if (appHostProjects.Count == 1)
                 {
@@ -241,7 +248,7 @@ internal sealed class ProjectLocator(
                     else if (multipleAppHostProjectsFoundBehavior is MultipleAppHostProjectsFoundBehavior.Throw)
                     {
                         logger.LogError("Multiple AppHost project files found in directory {Directory}, throwing exception", directory.FullName);
-                        throw new ProjectLocatorException(ErrorStrings.MultipleProjectFilesFound);
+                        throw new ProjectLocatorException(ErrorStrings.MultipleProjectFilesFound, ProjectLocatorFailureReason.MultipleProjectFilesFound);
                     }
                 }
             }
@@ -252,7 +259,7 @@ internal sealed class ProjectLocator(
                 if (!projectFile.Exists)
                 {
                     logger.LogError("Project file {ProjectFile} does not exist.", projectFile.FullName);
-                    throw new ProjectLocatorException(ErrorStrings.ProjectFileDoesntExist);
+                    throw new ProjectLocatorException(ErrorStrings.ProjectFileDoesntExist, ProjectLocatorFailureReason.ProjectFileDoesntExist);
                 }
 
                 // Check if any handler can handle this file
@@ -276,7 +283,7 @@ internal sealed class ProjectLocator(
                 }
 
                 // No handler can process this file
-                throw new ProjectLocatorException(ErrorStrings.ProjectFileDoesntExist);
+                throw new ProjectLocatorException(ErrorStrings.ProjectFileDoesntExist, ProjectLocatorFailureReason.ProjectFileDoesntExist);
             }
         }
 
@@ -296,11 +303,16 @@ internal sealed class ProjectLocator(
 
         if (results.BuildableAppHost.Count == 0 && results.UnbuildableSuspectedAppHostProjects.Count == 0)
         {
-            throw new ProjectLocatorException(ErrorStrings.NoProjectFileFound);
+            if (results.HasUnsupportedProjects)
+            {
+                throw new ProjectLocatorException(ErrorStrings.NoProjectFileFound, ProjectLocatorFailureReason.UnsupportedProjects);
+            }
+
+            throw new ProjectLocatorException(ErrorStrings.NoProjectFileFound, ProjectLocatorFailureReason.NoProjectFileFound);
         }
         else if (results.BuildableAppHost.Count == 0 && results.UnbuildableSuspectedAppHostProjects.Count > 0)
         {
-            throw new ProjectLocatorException(ErrorStrings.AppHostsMayNotBeBuildable);
+            throw new ProjectLocatorException(ErrorStrings.AppHostsMayNotBeBuildable, ProjectLocatorFailureReason.AppHostsMayNotBeBuildable);
         }
         else if (results.BuildableAppHost.Count == 1)
         {
@@ -310,7 +322,7 @@ internal sealed class ProjectLocator(
         {
             selectedAppHost = multipleAppHostProjectsFoundBehavior switch
             {
-                MultipleAppHostProjectsFoundBehavior.Throw => throw new ProjectLocatorException(ErrorStrings.MultipleProjectFilesFound),
+                MultipleAppHostProjectsFoundBehavior.Throw => throw new ProjectLocatorException(ErrorStrings.MultipleProjectFilesFound, ProjectLocatorFailureReason.MultipleProjectFilesFound),
                 MultipleAppHostProjectsFoundBehavior.Prompt => await interactionService.PromptForSelectionAsync(InteractionServiceStrings.SelectAppHostToUse, results.BuildableAppHost, projectFile => $"{projectFile.Name.EscapeMarkup()} ({Path.GetRelativePath(executionContext.WorkingDirectory.FullName, projectFile.FullName).EscapeMarkup()})", cancellationToken),
                 MultipleAppHostProjectsFoundBehavior.None => null,
                 _ => selectedAppHost
@@ -364,9 +376,19 @@ internal sealed class ProjectLocator(
 
 }
 
-internal class ProjectLocatorException : System.Exception
+internal class ProjectLocatorException(string message, ProjectLocatorFailureReason failureReason) : System.Exception(message)
 {
-    public ProjectLocatorException(string message) : base(message) { }
+    public ProjectLocatorFailureReason FailureReason { get; } = failureReason;
+}
+
+internal enum ProjectLocatorFailureReason
+{
+    ProjectFileDoesntExist,
+    ProjectFileNotAppHostProject,
+    MultipleProjectFilesFound,
+    NoProjectFileFound,
+    AppHostsMayNotBeBuildable,
+    UnsupportedProjects,
 }
 
 internal record AppHostProjectSearchResult(FileInfo? SelectedProjectFile, List<FileInfo> AllProjectFileCandidates);

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -92,16 +92,16 @@ internal sealed class ProjectLocator(
             }
 
             // If any candidates are .NET projects, ensure the SDK is available
-            if (candidatesWithHandlers.Any(c => c.Handler is DotNetAppHostProject))
+            if (candidatesWithHandlers.Any(c => c.Handler.LanguageId.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase)))
             {
                 if (!await SdkInstallHelper.EnsureSdkInstalledAsync(sdkInstaller, interactionService, telemetry, cancellationToken))
                 {
                     logger.LogWarning("The .NET SDK is not available. Marking .NET projects as unsupported.");
                     foreach (var (_, handler) in candidatesWithHandlers)
                     {
-                        if (handler is DotNetAppHostProject dotNetHandler)
+                        if (handler.LanguageId.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase))
                         {
-                            dotNetHandler.IsUnsupported = true;
+                            handler.IsUnsupported = true;
                         }
                     }
                 }

--- a/src/Aspire.Cli/Resources/ErrorStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ErrorStrings.Designer.cs
@@ -329,5 +329,12 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("CommandNotSupportedWithSingleFileAppHost", resourceCulture);
             }
         }
+        public static string ProjectFileUnsupportedInCurrentEnvironment
+        {
+            get
+            {
+                return ResourceManager.GetString("ProjectFileUnsupportedInCurrentEnvironment", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Cli/Resources/ErrorStrings.resx
+++ b/src/Aspire.Cli/Resources/ErrorStrings.resx
@@ -226,4 +226,7 @@
   <data name="CommandNotSupportedWithSingleFileAppHost" xml:space="preserve">
     <value>This command is not yet supported with single file AppHosts.</value>
   </data>
+  <data name="ProjectFileUnsupportedInCurrentEnvironment" xml:space="preserve">
+    <value>Project is not supported in the current environment: {0}</value>
+  </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Soubor projektu není projekt Aspire AppHost.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectFileUnsupportedInCurrentEnvironment">
+        <source>Project is not supported in the current environment: {0}</source>
+        <target state="new">Project is not supported in the current environment: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectIsNotAppHost">
         <source>The project does not contain an Aspire apphost.</source>
         <target state="translated">Projekt neobsahuje hostitele aplikací Aspire.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Die Projektdatei ist kein Aspire-AppHost-Projekt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectFileUnsupportedInCurrentEnvironment">
+        <source>Project is not supported in the current environment: {0}</source>
+        <target state="new">Project is not supported in the current environment: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectIsNotAppHost">
         <source>The project does not contain an Aspire apphost.</source>
         <target state="translated">Das Projekt enthält keinen Aspire-AppHost.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
@@ -157,6 +157,11 @@
         <target state="translated">El archivo del proyecto no es un proyecto AppHost de Aspire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectFileUnsupportedInCurrentEnvironment">
+        <source>Project is not supported in the current environment: {0}</source>
+        <target state="new">Project is not supported in the current environment: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectIsNotAppHost">
         <source>The project does not contain an Aspire apphost.</source>
         <target state="translated">El proyecto no contiene ningún apphost de Aspire.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Le fichier projet n’est pas un projet Aspire AppHost.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectFileUnsupportedInCurrentEnvironment">
+        <source>Project is not supported in the current environment: {0}</source>
+        <target state="new">Project is not supported in the current environment: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectIsNotAppHost">
         <source>The project does not contain an Aspire apphost.</source>
         <target state="translated">Le projet ne contient pas d’Aspire AppHost.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Il file di progetto non è un progetto AppHost Aspire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectFileUnsupportedInCurrentEnvironment">
+        <source>Project is not supported in the current environment: {0}</source>
+        <target state="new">Project is not supported in the current environment: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectIsNotAppHost">
         <source>The project does not contain an Aspire apphost.</source>
         <target state="translated">Il progetto non contiene un AppHost Aspire.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Aspire AppHost プロジェクトではないプロジェクト ファイルです。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectFileUnsupportedInCurrentEnvironment">
+        <source>Project is not supported in the current environment: {0}</source>
+        <target state="new">Project is not supported in the current environment: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectIsNotAppHost">
         <source>The project does not contain an Aspire apphost.</source>
         <target state="translated">プロジェクトに Aspire AppHost が含まれていません。</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
@@ -157,6 +157,11 @@
         <target state="translated">프로젝트 파일이 Aspire AppHost 프로젝트가 아닙니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectFileUnsupportedInCurrentEnvironment">
+        <source>Project is not supported in the current environment: {0}</source>
+        <target state="new">Project is not supported in the current environment: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectIsNotAppHost">
         <source>The project does not contain an Aspire apphost.</source>
         <target state="translated">프로젝트에 Aspire AppHost가 포함되어 있지 않습니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Plik projektu nie jest projektem hosta AppHost platformy Aspire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectFileUnsupportedInCurrentEnvironment">
+        <source>Project is not supported in the current environment: {0}</source>
+        <target state="new">Project is not supported in the current environment: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectIsNotAppHost">
         <source>The project does not contain an Aspire apphost.</source>
         <target state="translated">Projekt nie zawiera hosta AppHost platformy Aspire.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
@@ -157,6 +157,11 @@
         <target state="translated">O arquivo de projeto não é um projeto AppHost do Aspire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectFileUnsupportedInCurrentEnvironment">
+        <source>Project is not supported in the current environment: {0}</source>
+        <target state="new">Project is not supported in the current environment: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectIsNotAppHost">
         <source>The project does not contain an Aspire apphost.</source>
         <target state="translated">O projeto não contém um AppHost do Aspire.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Файл проекта не является проектом Aspire AppHost.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectFileUnsupportedInCurrentEnvironment">
+        <source>Project is not supported in the current environment: {0}</source>
+        <target state="new">Project is not supported in the current environment: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectIsNotAppHost">
         <source>The project does not contain an Aspire apphost.</source>
         <target state="translated">Проект не содержит хост приложений Aspire.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
@@ -157,6 +157,11 @@
         <target state="translated">Proje dosyası bir Aspire AppHost projesi değil.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectFileUnsupportedInCurrentEnvironment">
+        <source>Project is not supported in the current environment: {0}</source>
+        <target state="new">Project is not supported in the current environment: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectIsNotAppHost">
         <source>The project does not contain an Aspire apphost.</source>
         <target state="translated">Proje bir Aspire AppHost içermiyor.</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
@@ -157,6 +157,11 @@
         <target state="translated">项目文件不是 Aspire AppHost 项目。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectFileUnsupportedInCurrentEnvironment">
+        <source>Project is not supported in the current environment: {0}</source>
+        <target state="new">Project is not supported in the current environment: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectIsNotAppHost">
         <source>The project does not contain an Aspire apphost.</source>
         <target state="translated">该项目不包含 Aspire 应用主机。</target>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
@@ -157,6 +157,11 @@
         <target state="translated">專案檔案不是 Aspire AppHost 專案。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectFileUnsupportedInCurrentEnvironment">
+        <source>Project is not supported in the current environment: {0}</source>
+        <target state="new">Project is not supported in the current environment: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectIsNotAppHost">
         <source>The project does not contain an Aspire apphost.</source>
         <target state="translated">該專案不包含 Aspire AppHost。</target>

--- a/src/Aspire.Dashboard/Properties/launchSettings.json
+++ b/src/Aspire.Dashboard/Properties/launchSettings.json
@@ -13,6 +13,7 @@
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:4317",
         "ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:4318"
       },
       "applicationUrl": "http://localhost:15889"

--- a/tests/Aspire.Cli.Tests/Commands/ExecCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ExecCommandTests.cs
@@ -170,12 +170,12 @@ public class ExecCommandTests
     {
         public Task<AppHostProjectSearchResult> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, MultipleAppHostProjectsFoundBehavior multipleAppHostProjectsFoundBehavior, bool createSettingsFile, CancellationToken cancellationToken)
         {
-            throw new Aspire.Cli.Projects.ProjectLocatorException("No project file found.");
+            throw new Aspire.Cli.Projects.ProjectLocatorException("No project file found.", Aspire.Cli.Projects.ProjectLocatorFailureReason.NoProjectFileFound);
         }
 
         public Task<FileInfo?> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, bool createSettingsFile, CancellationToken cancellationToken)
         {
-            throw new Aspire.Cli.Projects.ProjectLocatorException("No project file found.");
+            throw new Aspire.Cli.Projects.ProjectLocatorException("No project file found.", Aspire.Cli.Projects.ProjectLocatorFailureReason.NoProjectFileFound);
         }
     }
 
@@ -183,12 +183,12 @@ public class ExecCommandTests
     {
         public Task<AppHostProjectSearchResult> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, MultipleAppHostProjectsFoundBehavior multipleAppHostProjectsFoundBehavior, bool createSettingsFile, CancellationToken cancellationToken)
         {
-            throw new Aspire.Cli.Projects.ProjectLocatorException("Multiple project files found.");
+            throw new Aspire.Cli.Projects.ProjectLocatorException("Multiple project files found.", Aspire.Cli.Projects.ProjectLocatorFailureReason.MultipleProjectFilesFound);
         }
 
         public Task<FileInfo?> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, bool createSettingsFile, CancellationToken cancellationToken)
         {
-            throw new Aspire.Cli.Projects.ProjectLocatorException("Multiple project files found.");
+            throw new Aspire.Cli.Projects.ProjectLocatorException("Multiple project files found.", Aspire.Cli.Projects.ProjectLocatorFailureReason.MultipleProjectFilesFound);
         }
     }
 
@@ -196,12 +196,12 @@ public class ExecCommandTests
     {
         public Task<AppHostProjectSearchResult> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, MultipleAppHostProjectsFoundBehavior multipleAppHostProjectsFoundBehavior, bool createSettingsFile, CancellationToken cancellationToken)
         {
-            throw new Aspire.Cli.Projects.ProjectLocatorException("Project file does not exist.");
+            throw new Aspire.Cli.Projects.ProjectLocatorException("Project file does not exist.", Aspire.Cli.Projects.ProjectLocatorFailureReason.ProjectFileDoesntExist);
         }
 
         public Task<FileInfo?> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, bool createSettingsFile, CancellationToken cancellationToken)
         {
-            throw new Aspire.Cli.Projects.ProjectLocatorException("Project file does not exist.");
+            throw new Aspire.Cli.Projects.ProjectLocatorException("Project file does not exist.", Aspire.Cli.Projects.ProjectLocatorFailureReason.ProjectFileDoesntExist);
         }
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/ExtensionInternalCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ExtensionInternalCommandTests.cs
@@ -306,7 +306,7 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
             bool createSettingsFile, 
             CancellationToken cancellationToken)
         {
-            throw new ProjectLocatorException("No AppHost project found.");
+            throw new ProjectLocatorException("No AppHost project found.", ProjectLocatorFailureReason.NoProjectFileFound);
         }
 
         public Task<FileInfo?> UseOrFindAppHostProjectFileAsync(
@@ -314,7 +314,7 @@ public class ExtensionInternalCommandTests(ITestOutputHelper outputHelper)
             bool createSettingsFile, 
             CancellationToken cancellationToken)
         {
-            throw new ProjectLocatorException("No AppHost project found.");
+            throw new ProjectLocatorException("No AppHost project found.", ProjectLocatorFailureReason.NoProjectFileFound);
         }
 
         public Task<AppHostProjectSearchResult> UseOrFindServiceProjectFileAsync(

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -165,12 +165,12 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     {
         public Task<AppHostProjectSearchResult> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, MultipleAppHostProjectsFoundBehavior multipleAppHostProjectsFoundBehavior, bool createSettingsFile, CancellationToken cancellationToken)
         {
-            throw new Aspire.Cli.Projects.ProjectLocatorException("Project file does not exist.");
+            throw new Aspire.Cli.Projects.ProjectLocatorException("Project file does not exist.", Aspire.Cli.Projects.ProjectLocatorFailureReason.ProjectFileDoesntExist);
         }
 
         public Task<FileInfo?> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, bool createSettingsFile, CancellationToken cancellationToken)
         {
-            throw new Aspire.Cli.Projects.ProjectLocatorException("Project file does not exist.");
+            throw new Aspire.Cli.Projects.ProjectLocatorException("Project file does not exist.", Aspire.Cli.Projects.ProjectLocatorFailureReason.ProjectFileDoesntExist);
         }
     }
 
@@ -218,12 +218,12 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     {
         public Task<AppHostProjectSearchResult> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, MultipleAppHostProjectsFoundBehavior multipleAppHostProjectsFoundBehavior, bool createSettingsFile, CancellationToken cancellationToken)
         {
-            throw new Aspire.Cli.Projects.ProjectLocatorException("No project file found.");
+            throw new Aspire.Cli.Projects.ProjectLocatorException("No project file found.", Aspire.Cli.Projects.ProjectLocatorFailureReason.NoProjectFileFound);
         }
 
         public Task<FileInfo?> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, bool createSettingsFile, CancellationToken cancellationToken)
         {
-            throw new Aspire.Cli.Projects.ProjectLocatorException("No project file found.");
+            throw new Aspire.Cli.Projects.ProjectLocatorException("No project file found.", Aspire.Cli.Projects.ProjectLocatorFailureReason.NoProjectFileFound);
         }
     }
 
@@ -231,12 +231,12 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     {
         public Task<AppHostProjectSearchResult> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, MultipleAppHostProjectsFoundBehavior multipleAppHostProjectsFoundBehavior, bool createSettingsFile, CancellationToken cancellationToken)
         {
-            throw new Aspire.Cli.Projects.ProjectLocatorException("Multiple project files found.");
+            throw new Aspire.Cli.Projects.ProjectLocatorException("Multiple project files found.", Aspire.Cli.Projects.ProjectLocatorFailureReason.MultipleProjectFilesFound);
         }
 
         public Task<FileInfo?> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, bool createSettingsFile, CancellationToken cancellationToken)
         {
-            throw new Aspire.Cli.Projects.ProjectLocatorException("Multiple project files found.");
+            throw new Aspire.Cli.Projects.ProjectLocatorException("Multiple project files found.", Aspire.Cli.Projects.ProjectLocatorFailureReason.MultipleProjectFilesFound);
         }
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -176,7 +176,7 @@ public class UpdateCommandTests(ITestOutputHelper outputHelper)
                 UseOrFindAppHostProjectFileAsyncCallback = (projectFile, _, _) =>
                 {
                     // Simulate no project found by throwing ProjectLocatorException
-                    throw new ProjectLocatorException(ErrorStrings.NoProjectFileFound);
+                    throw new ProjectLocatorException(ErrorStrings.NoProjectFileFound, ProjectLocatorFailureReason.NoProjectFileFound);
                 }
             };
 

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -956,6 +956,74 @@ builder.Build().Run();");
         Assert.Equal(appHostCsFile.FullName, foundFiles[0].FullName);
     }
 
+    [Fact]
+    public async Task FindAppHostProjectFilesAsync_ExcludesDotNetProjectsWhenSdkNotAvailable()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
+
+        var sdkInstaller = new TestDotNetSdkInstaller
+        {
+            CheckAsyncCallback = _ => (false, null, "10.0.100")
+        };
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(executionContext, sdkInstaller: sdkInstaller);
+
+        var foundFiles = await projectLocator.FindAppHostProjectFilesAsync(workspace.WorkspaceRoot.FullName, CancellationToken.None).DefaultTimeout();
+
+        Assert.Empty(foundFiles);
+    }
+
+    [Fact]
+    public async Task FindAppHostProjectFilesAsync_IncludesDotNetProjectsWhenSdkAvailable()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var projectFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
+        await File.WriteAllTextAsync(projectFile.FullName, "Not a real project file.");
+
+        var sdkInstaller = new TestDotNetSdkInstaller
+        {
+            CheckAsyncCallback = _ => (true, "10.0.100", "10.0.100")
+        };
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(executionContext, sdkInstaller: sdkInstaller);
+
+        var foundFiles = await projectLocator.FindAppHostProjectFilesAsync(workspace.WorkspaceRoot.FullName, CancellationToken.None).DefaultTimeout();
+
+        Assert.Single(foundFiles);
+        Assert.Equal(projectFile.FullName, foundFiles[0].FullName);
+    }
+
+    [Fact]
+    public async Task FindAppHostProjectFilesAsync_DoesNotCheckSdkWhenNoDotNetProjects()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // No project files at all
+        var sdkCheckCalled = false;
+        var sdkInstaller = new TestDotNetSdkInstaller
+        {
+            CheckAsyncCallback = _ =>
+            {
+                sdkCheckCalled = true;
+                return (false, null, "10.0.100");
+            }
+        };
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(executionContext, sdkInstaller: sdkInstaller);
+
+        var foundFiles = await projectLocator.FindAppHostProjectFilesAsync(workspace.WorkspaceRoot.FullName, CancellationToken.None).DefaultTimeout();
+
+        Assert.Empty(foundFiles);
+        Assert.False(sdkCheckCalled);
+    }
+
     private static ProjectLocator CreateProjectLocator(
         CliExecutionContext executionContext,
         IInteractionService? interactionService = null,

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.InternalTesting;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Aspire.Cli.Configuration;
+using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
@@ -25,8 +26,8 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
         //       it in the temporary workspace directory.
         var settingsDirectory = workingDirectory.CreateSubdirectory(".aspire");
         var hivesDirectory = settingsDirectory.CreateSubdirectory("hives");
-    var cacheDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "cache"));
-    return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        var cacheDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "cache"));
+        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
     }
 
     [Fact]
@@ -961,6 +962,7 @@ builder.Build().Run();");
         IConfigurationService? configurationService = null,
         IAppHostProjectFactory? projectFactory = null,
         ILanguageDiscovery? languageDiscovery = null,
+        IDotNetSdkInstaller? sdkInstaller = null,
         AspireCliTelemetry? telemetry = null)
     {
         var logger = NullLogger<ProjectLocator>.Instance;
@@ -971,6 +973,7 @@ builder.Build().Run();");
             configurationService ?? new TestConfigurationService(),
             projectFactory ?? new TestAppHostProjectFactory(),
             languageDiscovery ?? new TestLanguageDiscovery(),
+            sdkInstaller ?? new TestDotNetSdkInstaller(),
             telemetry ?? TestTelemetryHelper.CreateInitializedTelemetry());
     }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/NoProjectFileProjectLocator.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/NoProjectFileProjectLocator.cs
@@ -9,11 +9,11 @@ internal sealed class NoProjectFileProjectLocator : IProjectLocator
 {
     public Task<AppHostProjectSearchResult> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, MultipleAppHostProjectsFoundBehavior multipleAppHostProjectsFoundBehavior, bool createSettingsFile, CancellationToken cancellationToken = default)
     {
-        throw new ProjectLocatorException("No project file found.");
+        throw new ProjectLocatorException("No project file found.", ProjectLocatorFailureReason.NoProjectFileFound);
     }
 
     public Task<FileInfo?> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, bool createSettingsFile, CancellationToken cancellationToken)
     {
-        throw new ProjectLocatorException("No project file found.");
+        throw new ProjectLocatorException("No project file found.", ProjectLocatorFailureReason.NoProjectFileFound);
     }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostProjectFactory.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostProjectFactory.cs
@@ -154,6 +154,11 @@ internal sealed class TestAppHostProjectFactory : IAppHostProjectFactory
 
         public Task<AppHostValidationResult> ValidateAppHostAsync(FileInfo appHostFile, CancellationToken cancellationToken)
         {
+            if (IsUnsupported)
+            {
+                return Task.FromResult(new AppHostValidationResult(IsValid: false, IsUnsupported: true));
+            }
+
             if (_factory.ValidateAppHostCallback is not null)
             {
                 return Task.FromResult(_factory.ValidateAppHostCallback(appHostFile));

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostProjectFactory.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostProjectFactory.cs
@@ -113,6 +113,7 @@ internal sealed class TestAppHostProjectFactory : IAppHostProjectFactory
             _factory = factory;
         }
 
+        public bool IsUnsupported { get; set; }
         public string LanguageId => "csharp";
         public string DisplayName => "C# (.NET)";
         public string? AppHostFileName => "AppHost.csproj";

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -343,8 +343,9 @@ internal sealed class CliServiceCollectionTestOptions
         var configurationService = serviceProvider.GetRequiredService<IConfigurationService>();
         var projectFactory = serviceProvider.GetService<IAppHostProjectFactory>() ?? new TestAppHostProjectFactory();
         var languageDiscovery = serviceProvider.GetService<ILanguageDiscovery>() ?? new TestLanguageDiscovery();
+        var sdkInstaller = serviceProvider.GetRequiredService<IDotNetSdkInstaller>();
         var telemetry = serviceProvider.GetRequiredService<AspireCliTelemetry>();
-        return new ProjectLocator(logger, executionContext, interactionService, configurationService, projectFactory, languageDiscovery, telemetry);
+        return new ProjectLocator(logger, executionContext, interactionService, configurationService, projectFactory, languageDiscovery, sdkInstaller, telemetry);
     }
 
     public ISolutionLocator CreateDefaultSolutionLocatorFactory(IServiceProvider serviceProvider)


### PR DESCRIPTION
## Description

Fixes https://github.com/dotnet/aspire/issues/15032

Refactors `ProjectLocator.FindAppHostProjectFilesAsync` to:

1. **Move `TryGetProject` out of `Parallel.ForEachAsync`** — Project handler resolution is now done sequentially when collecting candidates, and only the async `ValidateAppHostAsync` calls run in parallel.

2. **Check .NET SDK availability before validating .NET projects** — After collecting candidates, if any are .NET projects (`DotNetAppHostProject`), the SDK availability is checked via `SdkInstallHelper.EnsureSdkInstalledAsync`. If the SDK is not available, those projects are marked as `IsUnsupported`.

3. **Add `IsUnsupported` to `IAppHostProject`** — New property on the interface that project handlers can use to signal they cannot operate in the current environment. `DotNetAppHostProject.ValidateAppHostAsync` returns early with `IsUnsupported: true` when the SDK is missing.

4. **Add `IsUnsupported` to `AppHostValidationResult`** — New flag on the validation result record. `ProjectLocator` displays a warning when a project is unsupported.

After:
<img width="1399" height="370" alt="image" src="https://github.com/user-attachments/assets/f0e72eef-57c9-4d09-8ed5-7db278dc6cd9" />

You aren't prevented from selecting other app host languages, i.e. TypeScript, if found:
<img width="1259" height="485" alt="image" src="https://github.com/user-attachments/assets/4df2db7e-58b1-4a80-ad36-5f44b893c3f4" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
