### PR TITLE
Update the diagnotic ids of the AspireExportAnalyzer.

### DIFF
--- a/src/Aspire.Hosting.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Aspire.Hosting.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,16 +1,16 @@
-﻿; Unshipped analyzer release
+; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
 ### New Rules
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-ASPIRE007 | Design | Error | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIRE007)
-ASPIRE008 | Design | Error | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIRE008)
-ASPIRE009 | Design | Error | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIRE009)
-ASPIRE010 | Design | Error | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIRE010)
-ASPIRE011 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIRE011)
-ASPIRE012 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIRE012)
-ASPIRE013 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIRE013)
-ASPIRE014 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIRE014)
-ASPIRE015 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIRE015)
+ASPIREEXPORT001 | Design | Error | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT001)
+ASPIREEXPORT002 | Design | Error | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT002)
+ASPIREEXPORT003 | Design | Error | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT003)
+ASPIREEXPORT004 | Design | Error | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT004)
+ASPIREEXPORT005 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT005)
+ASPIREEXPORT006 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT006)
+ASPIREEXPORT007 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT007)
+ASPIREEXPORT008 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT008)
+ASPIREEXPORT009 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT009)

--- a/src/Aspire.Hosting.Analyzers/AspireExportAnalyzer.Diagnostics.cs
+++ b/src/Aspire.Hosting.Analyzers/AspireExportAnalyzer.Diagnostics.cs
@@ -10,7 +10,7 @@ public partial class AspireExportAnalyzer
 {
     internal static class Diagnostics
     {
-        private const string ExportMethodMustBeStaticId = "ASPIRE007";
+        private const string ExportMethodMustBeStaticId = "ASPIREEXPORT001";
         internal static readonly DiagnosticDescriptor s_exportMethodMustBeStatic = new(
             id: ExportMethodMustBeStaticId,
             title: "AspireExport method must be static",
@@ -20,7 +20,7 @@ public partial class AspireExportAnalyzer
             isEnabledByDefault: true,
             helpLinkUri: $"https://aka.ms/aspire/diagnostics/{ExportMethodMustBeStaticId}");
 
-        private const string InvalidExportIdFormatId = "ASPIRE008";
+        private const string InvalidExportIdFormatId = "ASPIREEXPORT002";
         internal static readonly DiagnosticDescriptor s_invalidExportIdFormat = new(
             id: InvalidExportIdFormatId,
             title: "Invalid AspireExport ID format",
@@ -30,7 +30,7 @@ public partial class AspireExportAnalyzer
             isEnabledByDefault: true,
             helpLinkUri: $"https://aka.ms/aspire/diagnostics/{InvalidExportIdFormatId}");
 
-        private const string ReturnTypeMustBeAtsCompatibleId = "ASPIRE009";
+        private const string ReturnTypeMustBeAtsCompatibleId = "ASPIREEXPORT003";
         internal static readonly DiagnosticDescriptor s_returnTypeMustBeAtsCompatible = new(
             id: ReturnTypeMustBeAtsCompatibleId,
             title: "AspireExport return type must be ATS-compatible",
@@ -40,7 +40,7 @@ public partial class AspireExportAnalyzer
             isEnabledByDefault: true,
             helpLinkUri: $"https://aka.ms/aspire/diagnostics/{ReturnTypeMustBeAtsCompatibleId}");
 
-        private const string ParameterTypeMustBeAtsCompatibleId = "ASPIRE010";
+        private const string ParameterTypeMustBeAtsCompatibleId = "ASPIREEXPORT004";
         internal static readonly DiagnosticDescriptor s_parameterTypeMustBeAtsCompatible = new(
             id: ParameterTypeMustBeAtsCompatibleId,
             title: "AspireExport parameter type must be ATS-compatible",
@@ -50,7 +50,7 @@ public partial class AspireExportAnalyzer
             isEnabledByDefault: true,
             helpLinkUri: $"https://aka.ms/aspire/diagnostics/{ParameterTypeMustBeAtsCompatibleId}");
 
-        private const string UnionRequiresAtLeastTwoTypesId = "ASPIRE011";
+        private const string UnionRequiresAtLeastTwoTypesId = "ASPIREEXPORT005";
         internal static readonly DiagnosticDescriptor s_unionRequiresAtLeastTwoTypes = new(
             id: UnionRequiresAtLeastTwoTypesId,
             title: "AspireUnion requires at least 2 types",
@@ -60,7 +60,7 @@ public partial class AspireExportAnalyzer
             isEnabledByDefault: true,
             helpLinkUri: $"https://aka.ms/aspire/diagnostics/{UnionRequiresAtLeastTwoTypesId}");
 
-        private const string UnionTypeMustBeAtsCompatibleId = "ASPIRE012";
+        private const string UnionTypeMustBeAtsCompatibleId = "ASPIREEXPORT006";
         internal static readonly DiagnosticDescriptor s_unionTypeMustBeAtsCompatible = new(
             id: UnionTypeMustBeAtsCompatibleId,
             title: "AspireUnion type must be ATS-compatible",
@@ -70,7 +70,7 @@ public partial class AspireExportAnalyzer
             isEnabledByDefault: true,
             helpLinkUri: $"https://aka.ms/aspire/diagnostics/{UnionTypeMustBeAtsCompatibleId}");
 
-        private const string DuplicateExportIdId = "ASPIRE013";
+        private const string DuplicateExportIdId = "ASPIREEXPORT007";
         internal static readonly DiagnosticDescriptor s_duplicateExportId = new(
             id: DuplicateExportIdId,
             title: "Duplicate AspireExport ID for same target type",
@@ -81,7 +81,7 @@ public partial class AspireExportAnalyzer
             helpLinkUri: $"https://aka.ms/aspire/diagnostics/{DuplicateExportIdId}",
             customTags: [WellKnownDiagnosticTags.CompilationEnd]);
 
-        private const string MissingExportAttributeId = "ASPIRE014";
+        private const string MissingExportAttributeId = "ASPIREEXPORT008";
         internal static readonly DiagnosticDescriptor s_missingExportAttribute = new(
             id: MissingExportAttributeId,
             title: "Extension method missing AspireExport or AspireExportIgnore attribute",
@@ -91,7 +91,7 @@ public partial class AspireExportAnalyzer
             isEnabledByDefault: true,
             helpLinkUri: $"https://aka.ms/aspire/diagnostics/{MissingExportAttributeId}");
 
-        private const string ExportNameShouldBeUniqueId = "ASPIRE015";
+        private const string ExportNameShouldBeUniqueId = "ASPIREEXPORT009";
         internal static readonly DiagnosticDescriptor s_exportNameShouldBeUnique = new(
             id: ExportNameShouldBeUniqueId,
             title: "Export name should be unique for methods targeting a specific resource type",

--- a/src/Aspire.Hosting.Analyzers/AspireExportAnalyzer.cs
+++ b/src/Aspire.Hosting.Analyzers/AspireExportAnalyzer.cs
@@ -44,7 +44,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Try to get AspireExportIgnoreAttribute for ASPIRE014
+        // Try to get AspireExportIgnoreAttribute for ASPIREEXPORT008
         INamedTypeSymbol? aspireExportIgnoreAttribute = null;
         try
         {
@@ -55,7 +55,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             // Type not found, missing attribute check won't run
         }
 
-        // Try to get AspireUnionAttribute for ASPIRE011/012 validation
+        // Try to get AspireUnionAttribute for ASPIREEXPORT005/006 validation
         INamedTypeSymbol? aspireUnionAttribute = null;
         try
         {
@@ -66,7 +66,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             // Type not found, union validation won't run
         }
 
-        // Collection for ASPIRE013: track export IDs to detect duplicates
+        // Collection for ASPIREEXPORT007: track export IDs to detect duplicates
         // Key: (exportId, targetTypeFullName), Value: list of (method, location)
         var exportsByKey = new ConcurrentDictionary<(string ExportId, string TargetType), ConcurrentBag<(IMethodSymbol Method, Location Location)>>();
 
@@ -109,7 +109,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        // ASPIRE014: Check for missing export attributes on builder extension methods
+        // ASPIREEXPORT008: Check for missing export attributes on builder extension methods
         if (exportAttribute is null && !hasExportIgnore && !isObsolete)
         {
             AnalyzeMissingExportAttribute(context, method, wellKnownTypes, aspireExportAttribute);
@@ -165,14 +165,14 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
                     method.Name));
             }
 
-            // Rule 5 (ASPIRE011/012): Validate [AspireUnion] on parameters
+            // Rule 5 (ASPIREEXPORT005/006): Validate [AspireUnion] on parameters
             if (aspireUnionAttribute is not null)
             {
                 AnalyzeUnionAttribute(context, parameter.GetAttributes(), aspireUnionAttribute, wellKnownTypes, aspireExportAttribute);
             }
         }
 
-        // Rule 6 (ASPIRE013): Track export for duplicate detection
+        // Rule 6 (ASPIREEXPORT007): Track export for duplicate detection
         if (exportId is not null && method.IsExtensionMethod && method.Parameters.Length > 0)
         {
             var targetType = method.Parameters[0].Type;
@@ -182,7 +182,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             bag.Add((method, location));
         }
 
-        // Rule 7 (ASPIRE015): Warn when export name may collide across integrations
+        // Rule 7 (ASPIREEXPORT009): Warn when export name may collide across integrations
         if (exportId is not null && method.IsExtensionMethod && method.Parameters.Length > 0)
         {
             AnalyzeExportNameUniqueness(context, method, exportId, wellKnownTypes, location);
@@ -537,7 +537,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             // Get the types from the constructor argument (params Type[] types)
             if (attr.ConstructorArguments.Length == 0)
             {
-                // No arguments - report ASPIRE011
+                // No arguments - report ASPIREEXPORT005
                 context.ReportDiagnostic(Diagnostic.Create(
                     Diagnostics.s_unionRequiresAtLeastTwoTypes,
                     attrLocation,
@@ -553,7 +553,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
 
             var types = typesArg.Values;
 
-            // ASPIRE011: Check that we have at least 2 types
+            // ASPIREEXPORT005: Check that we have at least 2 types
             if (types.Length < 2)
             {
                 context.ReportDiagnostic(Diagnostic.Create(
@@ -562,7 +562,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
                     types.Length));
             }
 
-            // ASPIRE012: Check that each type is ATS-compatible
+            // ASPIREEXPORT006: Check that each type is ATS-compatible
             foreach (var typeConstant in types)
             {
                 if (typeConstant.Value is INamedTypeSymbol typeSymbol)

--- a/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
+++ b/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
@@ -64,7 +64,7 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
-    public async Task InstanceMethod_ReportsASPIRE007()
+    public async Task InstanceMethod_ReportsASPIREEXPORT001()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_exportMethodMustBeStatic;
 
@@ -85,7 +85,7 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
-    public async Task InvalidIdFormat_WithSlash_ReportsASPIRE008()
+    public async Task InvalidIdFormat_WithSlash_ReportsASPIREEXPORT002()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_invalidExportIdFormat;
 
@@ -106,7 +106,7 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
-    public async Task InvalidIdFormat_WithAtSymbol_ReportsASPIRE008()
+    public async Task InvalidIdFormat_WithAtSymbol_ReportsASPIREEXPORT002()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_invalidExportIdFormat;
 
@@ -127,7 +127,7 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
-    public async Task InvalidReturnType_ReportsASPIRE009()
+    public async Task InvalidReturnType_ReportsASPIREEXPORT003()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_returnTypeMustBeAtsCompatible;
 
@@ -149,7 +149,7 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
-    public async Task InvalidParameterType_ReportsASPIRE010()
+    public async Task InvalidParameterType_ReportsASPIREEXPORT004()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_parameterTypeMustBeAtsCompatible;
 
@@ -411,7 +411,7 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
-    public async Task InvalidCollectionElementType_ReportsASPIRE010()
+    public async Task InvalidCollectionElementType_ReportsASPIREEXPORT004()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_parameterTypeMustBeAtsCompatible;
 
@@ -433,10 +433,10 @@ public class AspireExportAnalyzerTests
         await test.RunAsync();
     }
 
-    // ASPIRE011 Tests - Union requires at least 2 types
+    // ASPIREEXPORT005 Tests - Union requires at least 2 types
 
     [Fact]
-    public async Task UnionWithSingleType_ReportsASPIRE011()
+    public async Task UnionWithSingleType_ReportsASPIREEXPORT005()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_unionRequiresAtLeastTwoTypes;
 
@@ -457,7 +457,7 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
-    public async Task UnionWithEmptyTypes_ReportsASPIRE011()
+    public async Task UnionWithEmptyTypes_ReportsASPIREEXPORT005()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_unionRequiresAtLeastTwoTypes;
 
@@ -513,10 +513,10 @@ public class AspireExportAnalyzerTests
         await test.RunAsync();
     }
 
-    // ASPIRE012 Tests - Union types must be ATS-compatible
+    // ASPIREEXPORT006 Tests - Union types must be ATS-compatible
 
     [Fact]
-    public async Task UnionWithIncompatibleType_ReportsASPIRE012()
+    public async Task UnionWithIncompatibleType_ReportsASPIREEXPORT006()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_unionTypeMustBeAtsCompatible;
 
@@ -538,7 +538,7 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
-    public async Task UnionWithPlainClass_ReportsASPIRE012()
+    public async Task UnionWithPlainClass_ReportsASPIREEXPORT006()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_unionTypeMustBeAtsCompatible;
 
@@ -599,10 +599,10 @@ public class AspireExportAnalyzerTests
         await test.RunAsync();
     }
 
-    // ASPIRE013 Tests - No duplicate export IDs for same target type
+    // ASPIREEXPORT007 Tests - No duplicate export IDs for same target type
 
     [Fact]
-    public async Task DuplicateExportIdSameTargetType_ReportsASPIRE013()
+    public async Task DuplicateExportIdSameTargetType_ReportsASPIREEXPORT007()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_duplicateExportId;
 
@@ -682,7 +682,7 @@ public class AspireExportAnalyzerTests
     [Fact]
     public async Task NonExtensionMethod_NoDuplicateCheck()
     {
-        // Non-extension methods with same export ID should not trigger ASPIRE013
+        // Non-extension methods with same export ID should not trigger ASPIREEXPORT007
         // since they don't have a target type in the same way
         var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
             using Aspire.Hosting;
@@ -702,7 +702,7 @@ public class AspireExportAnalyzerTests
         await test.RunAsync();
     }
 
-    // Additional ASPIRE012 tests - valid ATS types in unions
+    // Additional ASPIREEXPORT006 tests - valid ATS types in unions
 
     [Fact]
     public async Task UnionWithIResource_NoDiagnostics()
@@ -765,7 +765,7 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
-    public async Task UnionWithMultipleInvalidTypes_ReportsMultipleASPIRE012()
+    public async Task UnionWithMultipleInvalidTypes_ReportsMultipleASPIREEXPORT006()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_unionTypeMustBeAtsCompatible;
 
@@ -791,10 +791,10 @@ public class AspireExportAnalyzerTests
         await test.RunAsync();
     }
 
-    // Additional ASPIRE013 tests - cross-class and multiple duplicates
+    // Additional ASPIREEXPORT007 tests - cross-class and multiple duplicates
 
     [Fact]
-    public async Task DuplicateExportIdAcrossClasses_ReportsASPIRE013()
+    public async Task DuplicateExportIdAcrossClasses_ReportsASPIREEXPORT007()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_duplicateExportId;
 
@@ -824,7 +824,7 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
-    public async Task ThreeOrMoreDuplicates_ReportsAllASPIRE013()
+    public async Task ThreeOrMoreDuplicates_ReportsAllASPIREEXPORT007()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_duplicateExportId;
 
@@ -854,10 +854,10 @@ public class AspireExportAnalyzerTests
         await test.RunAsync();
     }
 
-    // Combined ASPIRE011 + ASPIRE012 test
+    // Combined ASPIREEXPORT005 + ASPIREEXPORT006 test
 
     [Fact]
-    public async Task SingleInvalidType_ReportsBothASPIRE011AndASPIRE012()
+    public async Task SingleInvalidType_ReportsBothASPIREEXPORT005AndASPIREEXPORT006()
     {
         var asp011 = AspireExportAnalyzer.Diagnostics.s_unionRequiresAtLeastTwoTypes;
         var asp012 = AspireExportAnalyzer.Diagnostics.s_unionTypeMustBeAtsCompatible;
@@ -882,10 +882,10 @@ public class AspireExportAnalyzerTests
         await test.RunAsync();
     }
 
-    // ASPIRE014 Tests - Missing export attribute on builder extension methods
+    // ASPIREEXPORT008 Tests - Missing export attribute on builder extension methods
 
     [Fact]
-    public async Task MissingExportAttribute_OnBuilderExtensionMethod_ReportsASPIRE014()
+    public async Task MissingExportAttribute_OnBuilderExtensionMethod_ReportsASPIREEXPORT008()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_missingExportAttribute;
 
@@ -905,7 +905,7 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
-    public async Task MissingExportAttribute_WithIncompatibleParam_ReportsASPIRE014WithReason()
+    public async Task MissingExportAttribute_WithIncompatibleParam_ReportsASPIREEXPORT008WithReason()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_missingExportAttribute;
 
@@ -926,7 +926,7 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
-    public async Task MissingExportAttribute_WithOutParam_ReportsASPIRE014WithReason()
+    public async Task MissingExportAttribute_WithOutParam_ReportsASPIREEXPORT008WithReason()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_missingExportAttribute;
 
@@ -1034,10 +1034,10 @@ public class AspireExportAnalyzerTests
         await test.RunAsync();
     }
 
-    // ASPIRE015 Tests - Export name should be unique for target-specific methods
+    // ASPIREEXPORT009 Tests - Export name should be unique for target-specific methods
 
     [Fact]
-    public async Task ExportNameMatchesMethodName_WithConcreteTarget_ReportsASPIRE015()
+    public async Task ExportNameMatchesMethodName_WithConcreteTarget_ReportsASPIREEXPORT009()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_exportNameShouldBeUnique;
 

--- a/tests/Aspire.Hosting.Tests/MSBuildTests.cs
+++ b/tests/Aspire.Hosting.Tests/MSBuildTests.cs
@@ -450,9 +450,9 @@ public class MSBuildTests
 
         var buildOutput = output.ToString();
 
-        // Build should fail with ASPIREEXPORT002 error
+        // Build should fail with ASPIRE008 error
         Assert.NotEqual(0, process.ExitCode);
-        Assert.Contains("error ASPIREEXPORT002", buildOutput);
+        Assert.Contains("error ASPIRE008", buildOutput);
         Assert.Contains("GenerateAssemblyInfo", buildOutput);
     }
 }

--- a/tests/Aspire.Hosting.Tests/MSBuildTests.cs
+++ b/tests/Aspire.Hosting.Tests/MSBuildTests.cs
@@ -450,9 +450,9 @@ public class MSBuildTests
 
         var buildOutput = output.ToString();
 
-        // Build should fail with ASPIRE008 error
+        // Build should fail with ASPIREEXPORT002 error
         Assert.NotEqual(0, process.ExitCode);
-        Assert.Contains("error ASPIRE008", buildOutput);
+        Assert.Contains("error ASPIREEXPORT002", buildOutput);
         Assert.Contains("GenerateAssemblyInfo", buildOutput);
     }
 }


### PR DESCRIPTION
The current IDs conflict with existing diagnostic IDs that we've already shipped.

See https://aspire.dev/diagnostics/aspire007 and https://aspire.dev/diagnostics/aspire008