### PR TITLE
Expand Resources group by default in Aspire panel

### DIFF
--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -69,7 +69,7 @@ class DetailItem extends vscode.TreeItem {
 
 class ResourcesGroupItem extends vscode.TreeItem {
     constructor(public readonly resources: ResourceJson[], public readonly appHostPid: number) {
-        super(resourcesGroupLabel, vscode.TreeItemCollapsibleState.Collapsed);
+        super(resourcesGroupLabel, vscode.TreeItemCollapsibleState.Expanded);
         this.id = `resources:${appHostPid}`;
         this.iconPath = new vscode.ThemeIcon('layers', new vscode.ThemeColor('aspire.brandPurple'));
         this.contextValue = 'resourcesGroup';


### PR DESCRIPTION
## Description

Make the "Resources" group item in the Aspire panel tree view expanded by default, so users can immediately see their resources without an extra click.

Changes `TreeItemCollapsibleState.Collapsed` to `TreeItemCollapsibleState.Expanded` for the `ResourcesGroupItem` in `AspireAppHostTreeProvider.ts`.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
