### PR TITLE
Automatically rerun transient CI failures

### DIFF
--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -1,5 +1,3 @@
-const zlib = require('node:zlib');
-
 // Shared matcher, summary, and rerun helpers for the transient CI rerun workflow.
 const failureConclusions = new Set(['failure', 'cancelled', 'timed_out', 'startup_failure']);
 const ignoredJobs = new Set(['Final Results', 'Tests / Final Test Results']);
@@ -91,77 +89,6 @@ const ignoredBuildFailureLogOverridePatterns = [
 
 function matchesAny(value, patterns) {
     return patterns.some(pattern => pattern.test(value));
-}
-
-function findEndOfCentralDirectoryOffset(buffer) {
-    for (let offset = buffer.length - 22; offset >= 0; offset--) {
-        if (buffer.readUInt32LE(offset) === 0x06054b50) {
-            return offset;
-        }
-    }
-
-    return -1;
-}
-
-function extractTextFromZipArchiveBuffer(buffer) {
-    if (!Buffer.isBuffer(buffer)) {
-        return '';
-    }
-
-    const endOfCentralDirectoryOffset = findEndOfCentralDirectoryOffset(buffer);
-    if (endOfCentralDirectoryOffset < 0) {
-        return buffer.toString('utf8');
-    }
-
-    const entryCount = buffer.readUInt16LE(endOfCentralDirectoryOffset + 10);
-    const centralDirectoryOffset = buffer.readUInt32LE(endOfCentralDirectoryOffset + 16);
-    const textChunks = [];
-    let offset = centralDirectoryOffset;
-
-    for (let index = 0; index < entryCount; index++) {
-        if (buffer.readUInt32LE(offset) !== 0x02014b50) {
-            break;
-        }
-
-        const compressionMethod = buffer.readUInt16LE(offset + 10);
-        const compressedSize = buffer.readUInt32LE(offset + 20);
-        const fileNameLength = buffer.readUInt16LE(offset + 28);
-        const extraLength = buffer.readUInt16LE(offset + 30);
-        const commentLength = buffer.readUInt16LE(offset + 32);
-        const localHeaderOffset = buffer.readUInt32LE(offset + 42);
-        const fileName = buffer.toString('utf8', offset + 46, offset + 46 + fileNameLength);
-
-        offset += 46 + fileNameLength + extraLength + commentLength;
-
-        if (fileName.endsWith('/')) {
-            continue;
-        }
-
-        if (buffer.readUInt32LE(localHeaderOffset) !== 0x04034b50) {
-            continue;
-        }
-
-        const localFileNameLength = buffer.readUInt16LE(localHeaderOffset + 26);
-        const localExtraLength = buffer.readUInt16LE(localHeaderOffset + 28);
-        const dataOffset = localHeaderOffset + 30 + localFileNameLength + localExtraLength;
-        const compressedData = buffer.subarray(dataOffset, dataOffset + compressedSize);
-
-        let fileText;
-        switch (compressionMethod) {
-            case 0:
-                fileText = compressedData.toString('utf8');
-                break;
-            case 8:
-                fileText = zlib.inflateRawSync(compressedData).toString('utf8');
-                break;
-            default:
-                continue;
-        }
-
-        textChunks.push(fileText);
-    }
-
-    return textChunks.join('\n');
 }
 
 function parseCheckRunId(checkRunUrl) {
@@ -599,7 +526,6 @@ module.exports = {
     classifyFailedJob,
     computeRerunEligibility,
     defaultMaxRetryableJobs,
-    extractTextFromZipArchiveBuffer,
     getCheckRunIdForJob,
     getOpenPullRequestNumbers,
     getLatestRunAttempt,

--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -1,0 +1,608 @@
+const zlib = require('node:zlib');
+
+// Shared matcher, summary, and rerun helpers for the transient CI rerun workflow.
+const failureConclusions = new Set(['failure', 'cancelled', 'timed_out', 'startup_failure']);
+const ignoredJobs = new Set(['Final Results', 'Tests / Final Test Results']);
+const defaultMaxRetryableJobs = 5;
+
+const retryableWithAnnotationStepPatterns = [
+    /^Set up job$/i,
+    /^Checkout code$/i,
+    /^Set up \.NET Core$/i,
+    /^Install sdk for nuget based testing$/i,
+    /^Upload logs, and test results$/i,
+];
+
+const ignoredFailureStepPatterns = [
+    /^Run tests\b/i,
+    /^Run nuget dependent tests\b/i,
+    /^Build test project$/i,
+    /^Build and archive test project$/i,
+    /^Build RID-specific packages\b/i,
+    /^Build Python validation image$/i,
+    /^Build with packages$/i,
+    /^Run .*SDK validation$/i,
+    /^Check validation results$/i,
+    /^Generate test results summary$/i,
+    /^Copy CLI E2E recordings for upload$/i,
+    /^Upload CLI E2E recordings$/i,
+    /^Post Checkout code$/i,
+    /^Install dependencies$/i,
+];
+
+const transientAnnotationPatterns = [
+    /The job was not acquired by Runner of type hosted even after multiple attempts/i,
+    /The hosted runner lost communication with the server/i,
+    /Failed to resolve action download info/i,
+    /Failed to CreateArtifact: Unable to make request: ENOTFOUND/i,
+    /\bENOTFOUND\b/i,
+    /\bECONNRESET\b/i,
+    /\bEPROTO\b/i,
+    /\bBad Gateway\b/i,
+    /\bCould not resolve host\b/i,
+    /\bSSL connection could not be established\b/i,
+    /getaddrinfo ENOTFOUND builds\.dotnet\.microsoft\.com/i,
+    /(timed out|failed to connect|could not resolve|ENOTFOUND|ECONNRESET|EPROTO).{0,120}builds\.dotnet\.microsoft\.com/i,
+    /builds\.dotnet\.microsoft\.com.{0,120}(timed out|failed to connect|could not resolve|ENOTFOUND|ECONNRESET|EPROTO)/i,
+    /(timed out|failed to connect|failed to respond|ENOTFOUND|ECONNRESET|Bad Gateway|SSL connection could not be established).{0,120}api\.github\.com/i,
+    /api\.github\.com.{0,120}(timed out|failed to connect|failed to respond|ENOTFOUND|ECONNRESET|Bad Gateway|SSL connection could not be established)/i,
+    /expected 'packfile'/i,
+    /\bRPC failed\b/i,
+    /\bRecv failure\b/i,
+    /Couldn't connect to server/i,
+    /Failed to connect to github\.com port/i,
+    /The requested URL returned error:\s*(502|503|504)/i,
+];
+
+const ignoredFailureStepOverridePatterns = [
+    /The job was not acquired by Runner of type hosted even after multiple attempts/i,
+    /The hosted runner lost communication with the server/i,
+    /Failed to resolve action download info/i,
+    /Failed to download action .*api\.github\.com.*(502|503|504|Bad Gateway)/i,
+];
+
+const postTestCleanupFailureStepPatterns = [
+    /^Upload logs, and test results$/i,
+    /^Copy CLI E2E recordings for upload$/i,
+    /^Upload CLI E2E recordings$/i,
+    /^Generate test results summary$/i,
+    /^Post Checkout code$/i,
+];
+
+const windowsProcessInitializationFailurePatterns = [
+    /Process completed with exit code -1073741502/i,
+    /\b0xC0000142\b/i,
+];
+
+const feedNetworkFailureStepPatterns = [
+    /^Install sdk for nuget based testing$/i,
+    /^Build test project$/i,
+    /^Build and archive test project$/i,
+    /^Build with packages$/i,
+    /^Build RID-specific packages\b/i,
+    /^Build .*validation image$/i,
+    /^Run .*SDK validation$/i,
+    /^Rebuild for Azure Functions project$/i,
+];
+
+const ignoredBuildFailureLogOverridePatterns = [
+    /Unable to load the service index for source https:\/\/(?:pkgs\.dev\.azure\.com\/dnceng|dnceng\.pkgs\.visualstudio\.com)\/public\/_packaging\//i,
+];
+
+function matchesAny(value, patterns) {
+    return patterns.some(pattern => pattern.test(value));
+}
+
+function findEndOfCentralDirectoryOffset(buffer) {
+    for (let offset = buffer.length - 22; offset >= 0; offset--) {
+        if (buffer.readUInt32LE(offset) === 0x06054b50) {
+            return offset;
+        }
+    }
+
+    return -1;
+}
+
+function extractTextFromZipArchiveBuffer(buffer) {
+    if (!Buffer.isBuffer(buffer)) {
+        return '';
+    }
+
+    const endOfCentralDirectoryOffset = findEndOfCentralDirectoryOffset(buffer);
+    if (endOfCentralDirectoryOffset < 0) {
+        return buffer.toString('utf8');
+    }
+
+    const entryCount = buffer.readUInt16LE(endOfCentralDirectoryOffset + 10);
+    const centralDirectoryOffset = buffer.readUInt32LE(endOfCentralDirectoryOffset + 16);
+    const textChunks = [];
+    let offset = centralDirectoryOffset;
+
+    for (let index = 0; index < entryCount; index++) {
+        if (buffer.readUInt32LE(offset) !== 0x02014b50) {
+            break;
+        }
+
+        const compressionMethod = buffer.readUInt16LE(offset + 10);
+        const compressedSize = buffer.readUInt32LE(offset + 20);
+        const fileNameLength = buffer.readUInt16LE(offset + 28);
+        const extraLength = buffer.readUInt16LE(offset + 30);
+        const commentLength = buffer.readUInt16LE(offset + 32);
+        const localHeaderOffset = buffer.readUInt32LE(offset + 42);
+        const fileName = buffer.toString('utf8', offset + 46, offset + 46 + fileNameLength);
+
+        offset += 46 + fileNameLength + extraLength + commentLength;
+
+        if (fileName.endsWith('/')) {
+            continue;
+        }
+
+        if (buffer.readUInt32LE(localHeaderOffset) !== 0x04034b50) {
+            continue;
+        }
+
+        const localFileNameLength = buffer.readUInt16LE(localHeaderOffset + 26);
+        const localExtraLength = buffer.readUInt16LE(localHeaderOffset + 28);
+        const dataOffset = localHeaderOffset + 30 + localFileNameLength + localExtraLength;
+        const compressedData = buffer.subarray(dataOffset, dataOffset + compressedSize);
+
+        let fileText;
+        switch (compressionMethod) {
+            case 0:
+                fileText = compressedData.toString('utf8');
+                break;
+            case 8:
+                fileText = zlib.inflateRawSync(compressedData).toString('utf8');
+                break;
+            default:
+                continue;
+        }
+
+        textChunks.push(fileText);
+    }
+
+    return textChunks.join('\n');
+}
+
+function parseCheckRunId(checkRunUrl) {
+    if (typeof checkRunUrl !== 'string') {
+        return null;
+    }
+
+    const match = checkRunUrl.match(/\/check-runs\/(\d+)(?:\/|$)/);
+    if (!match) {
+        return null;
+    }
+
+    const checkRunId = Number(match[1]);
+    return Number.isInteger(checkRunId) && checkRunId > 0 ? checkRunId : null;
+}
+
+async function getCheckRunIdForJob({ job, getJobForWorkflowRun }) {
+    const checkRunIdFromJob = parseCheckRunId(job?.check_run_url);
+    if (checkRunIdFromJob) {
+        return checkRunIdFromJob;
+    }
+
+    if (!getJobForWorkflowRun || !Number.isInteger(job?.id) || job.id <= 0) {
+        return null;
+    }
+
+    const workflowJob = await getJobForWorkflowRun(job.id);
+    return parseCheckRunId(workflowJob?.check_run_url);
+}
+
+function getFailedSteps(job) {
+    return (job.steps || [])
+        .filter(step => failureConclusions.has(step.conclusion))
+        .map(step => step.name);
+}
+
+function annotationText(annotations) {
+    return (annotations || [])
+        .flatMap(annotation => [annotation.title, annotation.message, annotation.raw_details].filter(Boolean))
+        .join('\n');
+}
+
+function toAnnotationText(annotationsOrText) {
+    if (!annotationsOrText) {
+        return '';
+    }
+
+    if (typeof annotationsOrText === 'string') {
+        return annotationsOrText;
+    }
+
+    return annotationText(annotationsOrText);
+}
+
+function getFailureStepSignals(failedSteps) {
+    const hasRetryableStep = failedSteps.some(step => matchesAny(step, retryableWithAnnotationStepPatterns));
+    const hasIgnoredFailureStep = failedSteps.some(step => matchesAny(step, ignoredFailureStepPatterns));
+
+    return {
+        hasRetryableStep,
+        hasIgnoredFailureStep,
+        shouldInspectAnnotations: failedSteps.length === 0 || hasRetryableStep || hasIgnoredFailureStep,
+    };
+}
+
+function classifyFailedJob(job, annotationsOrText, jobLogText = '') {
+    const failedSteps = getFailedSteps(job);
+    const failedStepText = failedSteps.join(' | ');
+    const { hasRetryableStep, hasIgnoredFailureStep, shouldInspectAnnotations } = getFailureStepSignals(failedSteps);
+
+    if (!shouldInspectAnnotations) {
+        return {
+            retryable: false,
+            failedSteps,
+            reason: 'Failed steps are outside the retry-safe allowlist.',
+        };
+    }
+
+    const annotationsText = toAnnotationText(annotationsOrText);
+    const matchesTransientAnnotation = matchesAny(annotationsText, transientAnnotationPatterns);
+    const matchesIgnoredFailureStepOverride = matchesAny(annotationsText, ignoredFailureStepOverridePatterns);
+    const hasOnlyPostTestCleanupFailures = failedSteps.length > 0
+        && failedSteps.every(step => matchesAny(step, postTestCleanupFailureStepPatterns));
+    const matchesWindowsProcessInitializationFailure = matchesAny(annotationsText, windowsProcessInitializationFailurePatterns);
+
+    if (matchesTransientAnnotation && failedSteps.length === 0) {
+        return {
+            retryable: true,
+            failedSteps,
+            reason: 'Job-level runner or infrastructure failure matched the transient allowlist.',
+        };
+    }
+
+    if (hasOnlyPostTestCleanupFailures && matchesWindowsProcessInitializationFailure) {
+        return {
+            retryable: true,
+            failedSteps,
+            reason: `Post-test cleanup steps '${failedStepText}' matched the Windows process initialization failure override allowlist.`,
+        };
+    }
+
+    if (hasIgnoredFailureStep && matchesIgnoredFailureStepOverride) {
+        return {
+            retryable: true,
+            failedSteps,
+            reason: `Ignored failed step '${failedStepText}' matched the job-level infrastructure override allowlist.`,
+        };
+    }
+
+    if (hasRetryableStep && !hasIgnoredFailureStep && matchesTransientAnnotation) {
+        return {
+            retryable: true,
+            failedSteps,
+            reason: `Failed step '${failedStepText}' matched the transient annotation allowlist.`,
+        };
+    }
+
+    const hasIgnoredBuildFailureStep = failedSteps.some(step => matchesAny(step, feedNetworkFailureStepPatterns));
+    if (hasIgnoredBuildFailureStep && matchesAny(jobLogText, ignoredBuildFailureLogOverridePatterns)) {
+        return {
+            retryable: true,
+            failedSteps,
+            reason: `Ignored failed step '${failedStepText}' matched the feed network failure override allowlist.`,
+        };
+    }
+
+    return {
+        retryable: false,
+        failedSteps,
+        reason: annotationsText
+            ? 'Annotations did not match the transient allowlist.'
+            : 'No retry-safe step or annotation signature matched.',
+    };
+}
+
+async function analyzeFailedJobs({ jobs, getAnnotationsForJob, getJobLogTextForJob }) {
+    const failedJobs = (jobs || []).filter(job => failureConclusions.has(job.conclusion) && !ignoredJobs.has(job.name));
+    const retryableJobs = [];
+    const skippedJobs = [];
+
+    for (const job of failedJobs) {
+        const failedSteps = getFailedSteps(job);
+        const { shouldInspectAnnotations } = getFailureStepSignals(failedSteps);
+        const annotations = shouldInspectAnnotations && getAnnotationsForJob
+            ? await getAnnotationsForJob(job)
+            : '';
+        let classification = classifyFailedJob(
+            job,
+            annotations
+        );
+
+        const shouldInspectLogs =
+            !classification.retryable &&
+            getJobLogTextForJob &&
+            failedSteps.some(step => matchesAny(step, feedNetworkFailureStepPatterns));
+
+        if (shouldInspectLogs) {
+            classification = classifyFailedJob(
+                job,
+                annotations,
+                await getJobLogTextForJob(job)
+            );
+        }
+
+        const jobResult = {
+            id: job.id,
+            name: job.name,
+            htmlUrl: job.html_url || null,
+            failedSteps: classification.failedSteps,
+            reason: classification.reason,
+        };
+
+        if (classification.retryable) {
+            retryableJobs.push(jobResult);
+        }
+        else {
+            skippedJobs.push(jobResult);
+        }
+    }
+
+    return { failedJobs, retryableJobs, skippedJobs };
+}
+
+function computeRerunEligibility({ dryRun, retryableCount, maxRetryableJobs = defaultMaxRetryableJobs }) {
+    return !dryRun && retryableCount > 0 && retryableCount <= maxRetryableJobs;
+}
+
+async function writeAnalysisSummary({
+    summary,
+    failedJobs,
+    retryableJobs,
+    skippedJobs,
+    maxRetryableJobs = defaultMaxRetryableJobs,
+    dryRun,
+    rerunEligible,
+    sourceRunUrl,
+}) {
+    const summaryRows = [
+        [{ data: 'Category', header: true }, { data: 'Count', header: true }],
+        ['Failed jobs inspected', String(failedJobs.length)],
+        ['Retryable jobs', String(retryableJobs.length)],
+        ['Skipped jobs', String(skippedJobs.length)],
+        ['Max retryable jobs', String(maxRetryableJobs)],
+        ['Dry run', String(dryRun)],
+        ['Eligible to rerun', String(rerunEligible)],
+    ];
+    const sourceRunReference = sourceRunUrl
+        ? `[workflow run](${sourceRunUrl})`
+        : 'workflow run';
+
+    await summary
+        .addHeading('Transient CI rerun analysis')
+        .addTable(summaryRows)
+        .addRaw(`Source run: ${sourceRunReference}\n\n`);
+
+    if (retryableJobs.length > 0) {
+        await summary.addHeading('Retryable jobs', 2);
+        await summary.addTable([
+            [{ data: 'Job', header: true }, { data: 'Reason', header: true }],
+            ...retryableJobs.map(job => [job.name, job.reason]),
+        ]);
+    }
+
+    if (skippedJobs.length > 0) {
+        await summary.addHeading('Skipped jobs', 2);
+        await summary.addTable([
+            [{ data: 'Job', header: true }, { data: 'Reason', header: true }],
+            ...skippedJobs.slice(0, 25).map(job => [job.name, job.reason]),
+        ]);
+    }
+
+    if (retryableJobs.length > maxRetryableJobs) {
+        await summary
+            .addHeading('Automatic rerun skipped', 2)
+            .addRaw(`Matched ${retryableJobs.length} jobs, which exceeds the cap of ${maxRetryableJobs}.`, true);
+    }
+
+    await summary.write();
+}
+
+async function getOpenPullRequestNumbers({ github, owner, repo, pullRequestNumbers }) {
+    const openPullRequestNumbers = [];
+
+    for (const rawPullRequestNumber of new Set(pullRequestNumbers || [])) {
+        const pullRequestNumber = Number(rawPullRequestNumber);
+
+        if (!Number.isInteger(pullRequestNumber) || pullRequestNumber <= 0) {
+            continue;
+        }
+
+        const response = await github.request('GET /repos/{owner}/{repo}/issues/{issue_number}', {
+            owner,
+            repo,
+            issue_number: pullRequestNumber,
+        });
+
+        if (response.data.state === 'open' && response.data.pull_request) {
+            openPullRequestNumbers.push(pullRequestNumber);
+        }
+    }
+
+    return openPullRequestNumbers;
+}
+
+function buildWorkflowRunAttemptUrl(sourceRunUrl, runAttempt) {
+    if (!sourceRunUrl || !Number.isInteger(runAttempt) || runAttempt <= 0) {
+        return sourceRunUrl;
+    }
+
+    return `${sourceRunUrl.replace(/\/$/, '')}/attempts/${runAttempt}`;
+}
+
+function buildWorkflowRunReferenceText(sourceRunUrl, runAttempt) {
+    const workflowRunUrl = buildWorkflowRunAttemptUrl(sourceRunUrl, runAttempt);
+
+    if (!workflowRunUrl) {
+        return Number.isInteger(runAttempt) && runAttempt > 0
+            ? `workflow run attempt ${runAttempt}`
+            : 'workflow run';
+    }
+
+    const label = Number.isInteger(runAttempt) && runAttempt > 0
+        ? `workflow run attempt ${runAttempt}`
+        : 'workflow run';
+
+    return `[${label}](${workflowRunUrl})`;
+}
+
+async function getLatestRunAttempt({ github, owner, repo, runId }) {
+    if (!Number.isInteger(runId) || runId <= 0) {
+        return null;
+    }
+
+    try {
+        const response = await github.request('GET /repos/{owner}/{repo}/actions/runs/{run_id}', {
+            owner,
+            repo,
+            run_id: runId,
+        });
+
+        const runAttempt = Number(response.data.run_attempt);
+        return Number.isInteger(runAttempt) && runAttempt > 0 ? runAttempt : null;
+    }
+    catch {
+        return null;
+    }
+}
+
+function buildPullRequestCommentBody({
+    failedAttemptUrl,
+    rerunAttemptUrl,
+    retryableJobs,
+}) {
+    return [
+        `The transient CI rerun workflow requested reruns for the following jobs after analyzing [the failed attempt](${failedAttemptUrl}).`,
+        `GitHub's job rerun API also reruns dependent jobs, so the retry is being tracked in [the rerun attempt](${rerunAttemptUrl}).`,
+        'The job links below point to the failed attempt that matched the retry-safe transient failure rules.',
+        '',
+        ...retryableJobs.map(job => {
+            const jobReference = job.htmlUrl
+                ? `[${job.name}](${job.htmlUrl})`
+                : `\`${job.name}\``;
+
+            return `- ${jobReference} - ${job.reason}`;
+        }),
+    ].join('\n');
+}
+
+async function addPullRequestComments({ github, owner, repo, pullRequestNumbers, body }) {
+    for (const pullRequestNumber of pullRequestNumbers) {
+        await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/comments', {
+            owner,
+            repo,
+            issue_number: pullRequestNumber,
+            body,
+        });
+    }
+}
+
+async function rerunMatchedJobs({
+    github,
+    owner,
+    repo,
+    retryableJobs,
+    pullRequestNumbers = [],
+    summary,
+    sourceRunId,
+    sourceRunUrl,
+    sourceRunAttempt,
+}) {
+    if (retryableJobs.length === 0) {
+        return;
+    }
+
+    const openPullRequestNumbers = await getOpenPullRequestNumbers({
+        github,
+        owner,
+        repo,
+        pullRequestNumbers,
+    });
+
+    if (pullRequestNumbers.length > 0 && openPullRequestNumbers.length === 0) {
+        await summary
+            .addHeading('Automatic rerun skipped')
+            .addRaw('All associated pull requests are closed. No jobs were rerun.', true)
+            .write();
+        return;
+    }
+
+    for (const job of retryableJobs) {
+        await github.request('POST /repos/{owner}/{repo}/actions/jobs/{job_id}/rerun', {
+            owner,
+            repo,
+            job_id: job.id,
+        });
+    }
+
+    const normalizedSourceRunAttempt = Number.isInteger(sourceRunAttempt) && sourceRunAttempt > 0
+        ? sourceRunAttempt
+        : null;
+    const failedAttemptUrl = buildWorkflowRunAttemptUrl(sourceRunUrl, normalizedSourceRunAttempt);
+    const latestRunAttempt = await getLatestRunAttempt({
+        github,
+        owner,
+        repo,
+        runId: sourceRunId,
+    });
+    const rerunAttemptNumber = latestRunAttempt && normalizedSourceRunAttempt && latestRunAttempt > normalizedSourceRunAttempt
+        ? latestRunAttempt
+        : normalizedSourceRunAttempt ? normalizedSourceRunAttempt + 1 : null;
+    const rerunAttemptUrl = buildWorkflowRunAttemptUrl(sourceRunUrl, rerunAttemptNumber);
+    const failedAttemptReference = buildWorkflowRunReferenceText(sourceRunUrl, normalizedSourceRunAttempt);
+    const rerunAttemptReference = buildWorkflowRunReferenceText(sourceRunUrl, rerunAttemptNumber);
+
+    if (openPullRequestNumbers.length > 0) {
+        await addPullRequestComments({
+            github,
+            owner,
+            repo,
+            pullRequestNumbers: openPullRequestNumbers,
+            body: buildPullRequestCommentBody({
+                failedAttemptUrl,
+                rerunAttemptUrl,
+                retryableJobs,
+            }),
+        });
+    }
+
+    const commentedPullRequestsText = openPullRequestNumbers.length > 0
+        ? openPullRequestNumbers.map(number => `#${number}`).join(', ')
+        : null;
+
+    const summaryBuilder = summary
+        .addHeading('Rerun requested')
+        .addRaw(`Failed attempt: ${failedAttemptReference}\nRerun attempt: ${rerunAttemptReference}\n\n`)
+        .addTable([
+            [{ data: 'Job', header: true }, { data: 'Reason', header: true }],
+            ...retryableJobs.map(job => [job.name, job.reason]),
+        ]);
+
+    if (commentedPullRequestsText) {
+        summaryBuilder
+            .addHeading('Pull request comments', 2)
+            .addRaw(`Posted rerun details to ${commentedPullRequestsText}.`, true);
+    }
+
+    await summaryBuilder.write();
+}
+
+module.exports = {
+    addPullRequestComments,
+    analyzeFailedJobs,
+    annotationText,
+    buildPullRequestCommentBody,
+    classifyFailedJob,
+    computeRerunEligibility,
+    defaultMaxRetryableJobs,
+    extractTextFromZipArchiveBuffer,
+    getCheckRunIdForJob,
+    getOpenPullRequestNumbers,
+    getLatestRunAttempt,
+    rerunMatchedJobs,
+    writeAnalysisSummary,
+};

--- a/.github/workflows/auto-rerun-transient-ci-failures.yml
+++ b/.github/workflows/auto-rerun-transient-ci-failures.yml
@@ -164,7 +164,7 @@ jobs:
                   throw new Error(`HTTP ${response.status}`);
                 }
 
-                return rerunWorkflow.extractTextFromZipArchiveBuffer(Buffer.from(await response.arrayBuffer()));
+                return await response.text();
               }
               catch (error) {
                 core.warning(`Failed to fetch logs for job ${jobId}: ${error.message}`);

--- a/.github/workflows/auto-rerun-transient-ci-failures.yml
+++ b/.github/workflows/auto-rerun-transient-ci-failures.yml
@@ -1,0 +1,299 @@
+# Analyzes failed CI PR runs for retry-safe transient failures and requests reruns for
+# the matched jobs through GitHub's job-rerun API, which also reruns dependent jobs.
+# For the supported behaviors and safety rails, see
+# docs/ci/auto-rerun-transient-ci-failures.md.
+name: Auto rerun transient CI failures
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'CI workflow run ID to inspect'
+        required: true
+        type: number
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  analyze-transient-failures:
+    name: Analyze transient CI failures
+    if: >-
+      ${{
+          github.repository_owner == 'dotnet' &&
+          (github.event_name == 'workflow_dispatch' ||
+           (github.event.workflow_run.event == 'pull_request' &&
+            github.event.workflow_run.conclusion == 'failure' &&
+            github.event.workflow_run.run_attempt == 1))
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+    outputs:
+      source_run_id: ${{ steps.analyze.outputs.source_run_id }}
+      source_run_attempt: ${{ steps.analyze.outputs.source_run_attempt }}
+      source_run_url: ${{ steps.analyze.outputs.source_run_url }}
+      retryable_jobs: ${{ steps.analyze.outputs.retryable_jobs }}
+      pull_request_numbers: ${{ steps.analyze.outputs.pull_request_numbers }}
+      retryable_count: ${{ steps.analyze.outputs.retryable_count }}
+      skipped_count: ${{ steps.analyze.outputs.skipped_count }}
+      rerun_eligible: ${{ steps.analyze.outputs.rerun_eligible }}
+      dry_run: ${{ steps.analyze.outputs.dry_run }}
+      max_retryable_jobs: ${{ steps.analyze.outputs.max_retryable_jobs }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Analyze failed jobs
+        id: analyze
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          MANUAL_RUN_ID: ${{ inputs.run_id }}
+        with:
+          script: |
+            const rerunWorkflow = require('./.github/workflows/auto-rerun-transient-ci-failures.js');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const isWorkflowDispatch = context.eventName === 'workflow_dispatch';
+            const maxRetryableJobs = rerunWorkflow.defaultMaxRetryableJobs;
+
+            async function paginate(route, parameters, selectItems) {
+              const items = [];
+
+              for (let page = 1; ; page++) {
+                const response = await github.request(route, {
+                  ...parameters,
+                  per_page: 100,
+                  page,
+                });
+
+                items.push(...selectItems(response.data));
+
+                if (!response.headers.link || !response.headers.link.includes('rel="next"')) {
+                  return items;
+                }
+              }
+            }
+
+            async function getWorkflowRun() {
+              if (!isWorkflowDispatch) {
+                return context.payload.workflow_run;
+              }
+
+              const runId = Number(process.env.MANUAL_RUN_ID);
+
+              if (!Number.isInteger(runId) || runId <= 0) {
+                throw new Error('workflow_dispatch requires a valid run_id input.');
+              }
+
+              const response = await github.rest.actions.getWorkflowRun({
+                owner,
+                repo,
+                run_id: runId,
+              });
+
+              return response.data;
+            }
+
+            async function listJobsForAttempt(runId, attemptNumber) {
+              return paginate(
+                'GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs',
+                {
+                  owner,
+                  repo,
+                  run_id: runId,
+                  attempt_number: attemptNumber,
+                },
+                data => data.jobs || []);
+            }
+
+            async function listAnnotations(job) {
+              try {
+                const checkRunId = await rerunWorkflow.getCheckRunIdForJob({
+                  job,
+                  getJobForWorkflowRun: async jobId => {
+                    const response = await github.rest.actions.getJobForWorkflowRun({
+                      owner,
+                      repo,
+                      job_id: jobId,
+                    });
+
+                    return response.data;
+                  },
+                });
+
+                if (!checkRunId) {
+                  core.warning(`Unable to resolve a check run id for job ${job.id}.`);
+                  return [];
+                }
+
+                return await paginate(
+                  'GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations',
+                  {
+                    owner,
+                    repo,
+                    check_run_id: checkRunId,
+                  },
+                  data => Array.isArray(data) ? data : []);
+              }
+              catch (error) {
+                core.warning(`Failed to list annotations for job ${job.id}: ${error.message}`);
+                return [];
+              }
+            }
+
+            async function getJobLogText(jobId) {
+              try {
+                const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/actions/jobs/${jobId}/logs`, {
+                  headers: {
+                    authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+                    accept: 'application/vnd.github+json',
+                    'x-github-api-version': '2022-11-28',
+                  },
+                });
+
+                if (!response.ok) {
+                  throw new Error(`HTTP ${response.status}`);
+                }
+
+                return rerunWorkflow.extractTextFromZipArchiveBuffer(Buffer.from(await response.arrayBuffer()));
+              }
+              catch (error) {
+                core.warning(`Failed to fetch logs for job ${jobId}: ${error.message}`);
+                return '';
+              }
+            }
+
+            const workflowRun = await getWorkflowRun();
+            const dryRun = isWorkflowDispatch;
+            const sourceRunUrl = workflowRun.html_url || `https://github.com/${owner}/${repo}/actions/runs/${workflowRun.id}`;
+
+            core.setOutput('source_run_id', String(workflowRun.id));
+            core.setOutput('source_run_attempt', String(workflowRun.run_attempt || ''));
+            core.setOutput('source_run_url', sourceRunUrl);
+            core.setOutput('dry_run', String(dryRun));
+            core.setOutput('max_retryable_jobs', String(maxRetryableJobs));
+            core.setOutput('retryable_jobs', '[]');
+            core.setOutput('pull_request_numbers', '[]');
+            core.setOutput('retryable_count', '0');
+            core.setOutput('skipped_count', '0');
+            core.setOutput('rerun_eligible', 'false');
+
+            if (workflowRun.name && workflowRun.name !== 'CI') {
+              console.log(`Workflow run ${workflowRun.id} is '${workflowRun.name}', not 'CI'. Skipping.`);
+              return;
+            }
+
+            const pullRequestNumbers = [...new Set((workflowRun.pull_requests || [])
+              .map(pullRequest => pullRequest.number)
+              .filter(Number.isInteger))];
+            core.setOutput('pull_request_numbers', JSON.stringify(pullRequestNumbers));
+
+            if (pullRequestNumbers.length === 0) {
+              console.log('No pull request is associated with this workflow run. Skipping.');
+              return;
+            }
+
+            const runId = workflowRun.id;
+            const runAttempt = workflowRun.run_attempt;
+            const jobs = await listJobsForAttempt(runId, runAttempt);
+            const { failedJobs, retryableJobs, skippedJobs } = await rerunWorkflow.analyzeFailedJobs({
+              jobs,
+              getAnnotationsForJob: async job => listAnnotations(job),
+              getJobLogTextForJob: async job => getJobLogText(job.id),
+            });
+
+            core.setOutput('retryable_jobs', JSON.stringify(retryableJobs.map(job => ({
+              id: job.id,
+              name: job.name,
+              htmlUrl: job.htmlUrl,
+              reason: job.reason,
+            }))));
+            core.setOutput('retryable_count', String(retryableJobs.length));
+            core.setOutput('skipped_count', String(skippedJobs.length));
+
+            const rerunEligible = rerunWorkflow.computeRerunEligibility({
+              dryRun,
+              retryableCount: retryableJobs.length,
+              maxRetryableJobs,
+            });
+            core.setOutput('rerun_eligible', String(rerunEligible));
+
+            await rerunWorkflow.writeAnalysisSummary({
+              summary: core.summary,
+              failedJobs,
+              retryableJobs,
+              skippedJobs,
+              maxRetryableJobs,
+              dryRun,
+              rerunEligible,
+              sourceRunUrl,
+            });
+
+            if (retryableJobs.length === 0) {
+              console.log('No retryable failed jobs were detected.');
+              return;
+            }
+
+            if (dryRun) {
+              console.log('workflow_dispatch runs in dry-run mode. No jobs will be rerun.');
+              return;
+            }
+
+  rerun-transient-failures:
+    name: Rerun transient CI failures
+    needs: [analyze-transient-failures]
+    if: ${{ needs.analyze-transient-failures.outputs.rerun_eligible == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Rerun matched jobs
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        env:
+          RETRYABLE_JOBS: ${{ needs.analyze-transient-failures.outputs.retryable_jobs }}
+          PULL_REQUEST_NUMBERS: ${{ needs.analyze-transient-failures.outputs.pull_request_numbers }}
+          SOURCE_RUN_ID: ${{ needs.analyze-transient-failures.outputs.source_run_id }}
+          SOURCE_RUN_ATTEMPT: ${{ needs.analyze-transient-failures.outputs.source_run_attempt }}
+          SOURCE_RUN_URL: ${{ needs.analyze-transient-failures.outputs.source_run_url }}
+        with:
+          script: |
+            const rerunWorkflow = require('./.github/workflows/auto-rerun-transient-ci-failures.js');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const retryableJobs = JSON.parse(process.env.RETRYABLE_JOBS || '[]');
+            const pullRequestNumbers = JSON.parse(process.env.PULL_REQUEST_NUMBERS || '[]');
+            const sourceRunId = Number(process.env.SOURCE_RUN_ID);
+            const sourceRunAttempt = Number(process.env.SOURCE_RUN_ATTEMPT);
+            const sourceRunUrl = process.env.SOURCE_RUN_URL;
+
+            if (retryableJobs.length === 0) {
+              console.log('No retryable jobs were provided to the rerun job.');
+              return;
+            }
+
+            await rerunWorkflow.rerunMatchedJobs({
+              github,
+              owner,
+              repo,
+              retryableJobs,
+              pullRequestNumbers,
+              summary: core.summary,
+              sourceRunId,
+              sourceRunAttempt,
+              sourceRunUrl,
+            });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,7 @@ These switches can be repeated to run tests on multiple classes or methods at on
 - **`tests-outerloop.yml`**: Runs outerloop tests separately every 6 hours
 - **`ci.yml`**: Main CI workflow triggered on PRs and pushes to main/release branches
 - **Build validation**: Includes package generation, API compatibility checks, template validation
+- **Workflow matcher maintenance**: When changing CI workflow job or step names that are referenced by automation or tests, update the corresponding workflow helpers, behavior tests, and docs together. For the transient rerun workflow, keep `.github/workflows/auto-rerun-transient-ci-failures.js`, `tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs`, and `docs/ci/auto-rerun-transient-ci-failures.md` aligned with the live workflow YAML.
 
 ### Dependencies and Hidden Requirements
 - **Local .NET SDK**: Automatically uses local SDK when available after running restore due to paths configuration in global.json

--- a/docs/ci/auto-rerun-transient-ci-failures.md
+++ b/docs/ci/auto-rerun-transient-ci-failures.md
@@ -1,0 +1,46 @@
+# Auto-rerun transient CI failures
+
+This document describes the current behavior contract for `.github/workflows/auto-rerun-transient-ci-failures.yml`.
+
+## Overview
+
+The workflow analyzes failed `CI` pull request runs, identifies retry-safe transient infrastructure failures, requests reruns for the matched jobs through GitHub's job-rerun API, and comments on the open pull request with the rerun details.
+
+GitHub's job-rerun API also reruns downstream dependent jobs, so the workflow targets only the matched jobs when issuing rerun requests, but the resulting rerun attempt can include dependents that GitHub schedules automatically.
+
+It is intentionally conservative:
+
+- it does not rerun every failed job in a run
+- it treats mixed deterministic failures plus transient post-step noise as non-retryable by default
+- it keeps `workflow_dispatch` in dry-run mode for historical inspection and matcher tuning
+
+## Matcher behavior
+
+- Retry jobs with no failed steps only when their annotations contain an explicit job-level infrastructure signature.
+- Retry jobs whose failed step is on the retry-safe allowlist only when their annotations also contain a transient infrastructure signature.
+- Ignore aggregator jobs such as `Final Results` and `Tests / Final Test Results`.
+- Skip jobs whose failed steps are outside the retry-safe allowlist, even if their annotations contain generic failure text.
+- Keep the mixed-failure veto: if an ignored step such as `Run tests*` failed, do not rerun the job based only on unrelated transient post-step noise.
+- Allow a narrow override when an ignored failed step is paired with a high-confidence job-level infrastructure annotation such as runner loss or action-download failure.
+- Allow a narrow override for Windows jobs whose failures are limited to post-test cleanup or upload steps when the annotations report process initialization failure `-1073741502` (`0xC0000142`).
+- Allow a narrow log-based override for supported CI SDK bootstrap, build, package, and validation steps when the job log shows `Unable to load the service index` against the approved `dnceng` public feeds.
+
+## Safety rails
+
+- `workflow_dispatch` remains dry-run only. It exists for historical inspection and matcher tuning, not for issuing reruns.
+- Automatic rerun requires at least one retryable job.
+- Automatic rerun is suppressed when matched jobs exceed the configured cap.
+- Before issuing reruns, the workflow confirms that at least one associated pull request is still open.
+- The workflow targets only the matched jobs when issuing rerun requests rather than rerunning the entire source run, although GitHub's job-rerun API also reruns dependent jobs automatically.
+- The workflow summary links to the analyzed workflow run and, when reruns are requested, to both the failed attempt and the rerun attempt.
+- After successful rerun requests, the workflow comments on the open associated pull request with links to the failed attempt, the rerun attempt, per-job failed-attempt links, and retry reasons.
+
+## Tests
+
+The automated tests for this workflow live in `.github/workflows/auto-rerun-transient-ci-failures.test.js`.
+
+Those tests are intentionally behavior-focused rather than regex-focused:
+
+- they use representative fixtures for each supported behavior
+- they cover the mixed-failure veto and ignored-step override explicitly
+- they keep only a minimal set of safety-guard tests so the suite protects against retry loops and CI fan-out without over-specifying the YAML wiring

--- a/docs/ci/auto-rerun-transient-ci-failures.md
+++ b/docs/ci/auto-rerun-transient-ci-failures.md
@@ -37,7 +37,7 @@ It is intentionally conservative:
 
 ## Tests
 
-The automated tests for this workflow live in `.github/workflows/auto-rerun-transient-ci-failures.test.js`.
+The automated tests for this workflow live in `tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs`.
 
 Those tests are intentionally behavior-focused rather than regex-focused:
 

--- a/docs/ci/auto-rerun-transient-ci-failures.md
+++ b/docs/ci/auto-rerun-transient-ci-failures.md
@@ -42,5 +42,6 @@ The automated tests for this workflow live in `tests/Infrastructure.Tests/Workfl
 Those tests are intentionally behavior-focused rather than regex-focused:
 
 - they use representative fixtures for each supported behavior
+- they keep representative job and step fixtures anchored to the current CI workflow names so matcher coverage does not drift from the implementation
 - they cover the mixed-failure veto and ignored-step override explicitly
-- they keep only a minimal set of safety-guard tests so the suite protects against retry loops and CI fan-out without over-specifying the YAML wiring
+- they keep only a minimal set of YAML contract checks for safety rails such as `workflow_dispatch` dry-run mode, first-attempt-only automatic reruns, and gating the rerun job on `rerun_eligible`

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -1,0 +1,698 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Aspire.TestUtilities;
+using Xunit;
+
+namespace Infrastructure.Tests;
+
+/// <summary>
+/// Tests for .github/workflows/auto-rerun-transient-ci-failures.js.
+/// </summary>
+public sealed class AutoRerunTransientCiFailuresTests : IDisposable
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly TestTempDirectory _tempDir = new();
+    private readonly string _repoRoot;
+    private readonly string _harnessPath;
+    private readonly ITestOutputHelper _output;
+
+    public AutoRerunTransientCiFailuresTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _repoRoot = FindRepoRoot();
+        _harnessPath = Path.Combine(_repoRoot, "tests", "Infrastructure.Tests", "WorkflowScripts", "auto-rerun-transient-ci-failures.harness.js");
+    }
+
+    public void Dispose() => _tempDir.Dispose();
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task RetriesJobLevelInfrastructureFailureWithNoFailedSteps()
+    {
+        WorkflowJob job = CreateJob(failedSteps: []);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "The hosted runner lost communication with the server.");
+
+        Assert.Single(result.RetryableJobs);
+        Assert.Equal("Job-level runner or infrastructure failure matched the transient allowlist.", result.RetryableJobs[0].Reason);
+        Assert.Empty(result.SkippedJobs);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task RetriesRetrySafeFailedStepWhenAnnotationsMatchTransientSignature()
+    {
+        WorkflowJob job = CreateJob(failedSteps: ["Checkout code"]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "fatal: expected 'packfile'");
+
+        Assert.Single(result.RetryableJobs);
+        Assert.Equal("Failed step 'Checkout code' matched the transient annotation allowlist.", result.RetryableJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task SkipsJobsWhoseFailedStepsAreOutsideRetrySafeAllowlist()
+    {
+        WorkflowJob job = CreateJob(failedSteps: ["Compile project"]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "The hosted runner lost communication with the server.");
+
+        Assert.Empty(result.RetryableJobs);
+        Assert.Single(result.SkippedJobs);
+        Assert.Equal("Failed steps are outside the retry-safe allowlist.", result.SkippedJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task SkipsRetrySafeStepsWhenAnnotationsAreGeneric()
+    {
+        WorkflowJob job = CreateJob(failedSteps: ["Set up .NET Core"]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "Process completed with exit code 1.");
+
+        Assert.Empty(result.RetryableJobs);
+        Assert.Single(result.SkippedJobs);
+        Assert.Equal("Annotations did not match the transient allowlist.", result.SkippedJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task IgnoresAggregatorJobsEntirely()
+    {
+        WorkflowJob job = CreateJob(name: "Final Results", failedSteps: ["Set up job"]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "The hosted runner lost communication with the server.");
+
+        Assert.Empty(result.FailedJobs);
+        Assert.Empty(result.RetryableJobs);
+        Assert.Empty(result.SkippedJobs);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task KeepsMixedFailureVetoWhenIgnoredTestStepsFailAlongsideRetrySafeSteps()
+    {
+        WorkflowJob job = CreateJob(failedSteps: ["Run tests (Windows)", "Upload logs, and test results"]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "Failed to CreateArtifact: Unable to make request: ENOTFOUND");
+
+        Assert.Empty(result.RetryableJobs);
+        Assert.Single(result.SkippedJobs);
+        Assert.Equal("Annotations did not match the transient allowlist.", result.SkippedJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task AllowsNarrowOverrideForExplicitJobLevelInfrastructureAnnotationsOnIgnoredSteps()
+    {
+        WorkflowJob job = CreateJob(failedSteps: ["Run tests (Windows)"]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "The hosted runner lost communication with the server.");
+
+        Assert.Single(result.RetryableJobs);
+        Assert.Equal("Ignored failed step 'Run tests (Windows)' matched the job-level infrastructure override allowlist.", result.RetryableJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task AllowsNarrowOverrideForWindowsPostTestCleanupProcessInitializationFailures()
+    {
+        WorkflowJob job = CreateJob(failedSteps:
+        [
+            "Upload logs, and test results",
+            "Copy CLI E2E recordings for upload",
+            "Upload CLI E2E recordings",
+            "Generate test results summary",
+            "Post Checkout code"
+        ]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "Process completed with exit code -1073741502.");
+
+        Assert.Single(result.RetryableJobs);
+        Assert.Equal(
+            "Post-test cleanup steps 'Upload logs, and test results | Copy CLI E2E recordings for upload | Upload CLI E2E recordings | Generate test results summary | Post Checkout code' matched the Windows process initialization failure override allowlist.",
+            result.RetryableJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task DoesNotOverrideWindowsProcessInitializationFailuresWhenTestExecutionAlsoFailed()
+    {
+        WorkflowJob job = CreateJob(failedSteps:
+        [
+            "Run tests (Windows)",
+            "Upload logs, and test results",
+            "Generate test results summary"
+        ]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "Process completed with exit code -1073741502.");
+
+        Assert.Empty(result.RetryableJobs);
+        Assert.Single(result.SkippedJobs);
+        Assert.Equal("Annotations did not match the transient allowlist.", result.SkippedJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task AllowsNarrowLogBasedOverrideForDncengFeedServiceIndexFailuresInIgnoredBuildSteps()
+    {
+        WorkflowJob job = CreateJob(failedSteps: ["Build test project"]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(
+            job,
+            "Process completed with exit code 1.",
+            "error : Unable to load the service index for source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json.");
+
+        Assert.Single(result.RetryableJobs);
+        Assert.Equal("Ignored failed step 'Build test project' matched the feed network failure override allowlist.", result.RetryableJobs[0].Reason);
+    }
+
+    [Theory]
+    [InlineData("Install sdk for nuget based testing")]
+    [InlineData("Build with packages")]
+    [InlineData("Run TypeScript SDK validation")]
+    [InlineData("Build Python validation image")]
+    [RequiresTools(["node"])]
+    public async Task AllowsSameFeedOverrideForOtherCiBootstrapBuildAndValidationSteps(string failedStep)
+    {
+        WorkflowJob job = CreateJob(failedSteps: [failedStep]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(
+            job,
+            "Process completed with exit code 1.",
+            "error : Unable to load the service index for source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet9-transport/nuget/v3/index.json.");
+
+        Assert.Single(result.RetryableJobs);
+        Assert.Equal($"Ignored failed step '{failedStep}' matched the feed network failure override allowlist.", result.RetryableJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task DoesNotRetryIgnoredBuildStepsWhenTheLogLacksFeedNetworkSignature()
+    {
+        WorkflowJob job = CreateJob(failedSteps: ["Build test project"]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(
+            job,
+            "Process completed with exit code 1.",
+            "error MSB4236: The SDK specified could not be found.");
+
+        Assert.Empty(result.RetryableJobs);
+        Assert.Single(result.SkippedJobs);
+        Assert.Equal("Annotations did not match the transient allowlist.", result.SkippedJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ExtractTextFromZipArchiveBufferReadsDeflatedJobLogTextFromZipArchive()
+    {
+        string zipArchiveBase64 = CreateZipArchiveBase64(
+            new ZipEntryData("step-1.txt", "error : Unable to load the service index for source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json."),
+            new ZipEntryData("step-2.txt", "additional context"));
+
+        string extractedText = await InvokeHarnessAsync<string>(
+            "extractTextFromZipArchiveBuffer",
+            new { bufferBase64 = zipArchiveBase64 });
+
+        Assert.Contains("Unable to load the service index", extractedText);
+        Assert.Contains("additional context", extractedText);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ExtractTextFromZipArchiveBufferFallsBackToPlainTextWhenPayloadIsNotZipArchive()
+    {
+        string plainTextBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("plain-text log line with Unable to load the service index"));
+
+        string extractedText = await InvokeHarnessAsync<string>(
+            "extractTextFromZipArchiveBuffer",
+            new { bufferBase64 = plainTextBase64 });
+
+        Assert.Contains("plain-text log line", extractedText);
+        Assert.Contains("Unable to load the service index", extractedText);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task GetCheckRunIdForJobParsesCheckRunIdFromWorkflowJobPayload()
+    {
+        int? checkRunId = await InvokeHarnessAsync<int?>(
+            "getCheckRunIdForJob",
+            new
+            {
+                job = new WorkflowJob
+                {
+                    Id = 10,
+                    CheckRunUrl = "https://api.github.com/repos/dotnet/aspire/check-runs/123456789"
+                }
+            });
+
+        Assert.Equal(123456789, checkRunId);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task GetCheckRunIdForJobFallsBackToLoadingWorkflowJobWhenNeeded()
+    {
+        int? checkRunId = await InvokeHarnessAsync<int?>(
+            "getCheckRunIdForJob",
+            new
+            {
+                job = new WorkflowJob { Id = 42 },
+                workflowJob = new WorkflowJob
+                {
+                    CheckRunUrl = "https://api.github.com/repos/dotnet/aspire/check-runs/987654321"
+                }
+            });
+
+        Assert.Equal(987654321, checkRunId);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task GetCheckRunIdForJobReturnsNullWhenNoCheckRunIdCanBeResolved()
+    {
+        int? checkRunId = await InvokeHarnessAsync<int?>(
+            "getCheckRunIdForJob",
+            new
+            {
+                job = new WorkflowJob
+                {
+                    Id = 42,
+                    CheckRunUrl = "https://api.github.com/repos/dotnet/aspire/actions/jobs/42"
+                },
+                workflowJob = new WorkflowJob()
+            });
+
+        Assert.Null(checkRunId);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task WorkflowDispatchStaysDryRunEvenWhenRetryableJobsExist()
+    {
+        bool rerunEligible = await InvokeHarnessAsync<bool>(
+            "computeRerunEligibility",
+            new
+            {
+                dryRun = true,
+                retryableCount = 1
+            });
+
+        Assert.False(rerunEligible);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task AutomaticRerunRequiresAtLeastOneRetryableJob()
+    {
+        bool rerunEligible = await InvokeHarnessAsync<bool>(
+            "computeRerunEligibility",
+            new
+            {
+                dryRun = false,
+                retryableCount = 0
+            });
+
+        Assert.False(rerunEligible);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task AutomaticRerunIsSuppressedWhenMatchedJobsExceedTheCap()
+    {
+        bool rerunEligible = await InvokeHarnessAsync<bool>(
+            "computeRerunEligibility",
+            new
+            {
+                dryRun = false,
+                retryableCount = 6
+            });
+
+        Assert.False(rerunEligible);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task WriteAnalysisSummaryLinksTheAnalyzedWorkflowRun()
+    {
+        SummaryResult result = await InvokeHarnessAsync<SummaryResult>(
+            "writeAnalysisSummary",
+            new
+            {
+                failedJobs = new[]
+                {
+                    new SummaryJob { Id = 11, Name = "Tests / One", Reason = "Reason one" }
+                },
+                retryableJobs = new[]
+                {
+                    new SummaryJob { Id = 11, Name = "Tests / One", Reason = "Reason one" }
+                },
+                skippedJobs = Array.Empty<SummaryJob>(),
+                dryRun = false,
+                rerunEligible = true,
+                sourceRunUrl = "https://github.com/dotnet/aspire/actions/runs/123"
+            });
+
+        SummaryEvent rawEvent = Assert.Single(result.Events, e => e.Type == "raw");
+        Assert.Equal("Source run: [workflow run](https://github.com/dotnet/aspire/actions/runs/123)\n\n", rawEvent.Text);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task RerunMatchedJobsMakesNoRequestsWhenNoJobsAreSupplied()
+    {
+        RerunMatchedJobsResult result = await InvokeHarnessAsync<RerunMatchedJobsResult>(
+            "rerunMatchedJobs",
+            new
+            {
+                owner = "dotnet",
+                repo = "aspire",
+                retryableJobs = Array.Empty<RetryableJobInput>(),
+                sourceRunUrl = "https://github.com/dotnet/aspire/actions/runs/123"
+            });
+
+        Assert.Empty(result.Requests);
+        Assert.Empty(result.Events);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task RerunMatchedJobsRequestsOneRerunPerSelectedJobAndWritesTheSummary()
+    {
+        RerunMatchedJobsResult result = await InvokeHarnessAsync<RerunMatchedJobsResult>(
+            "rerunMatchedJobs",
+            new
+            {
+                owner = "dotnet",
+                repo = "aspire",
+                retryableJobs = new[]
+                {
+                    new RetryableJobInput
+                    {
+                        Id = 11,
+                        Name = "Tests / One",
+                        HtmlUrl = "https://github.com/dotnet/aspire/actions/runs/123/job/11",
+                        Reason = "Reason one"
+                    },
+                    new RetryableJobInput
+                    {
+                        Id = 22,
+                        Name = "Tests / Two",
+                        HtmlUrl = "https://github.com/dotnet/aspire/actions/runs/123/job/22",
+                        Reason = "Reason two"
+                    }
+                },
+                pullRequestNumbers = new[] { 15110 },
+                issueStatesByNumber = new Dictionary<string, string>
+                {
+                    ["15110"] = "open"
+                },
+                latestRunAttempt = 2,
+                sourceRunId = 123,
+                sourceRunAttempt = 1,
+                sourceRunUrl = "https://github.com/dotnet/aspire/actions/runs/123"
+            });
+
+        Assert.Collection(
+            result.Requests,
+            request =>
+            {
+                Assert.Equal("GET /repos/{owner}/{repo}/issues/{issue_number}", request.Route);
+                Assert.Equal("dotnet", request.Payload.GetProperty("owner").GetString());
+                Assert.Equal("aspire", request.Payload.GetProperty("repo").GetString());
+                Assert.Equal(15110, request.Payload.GetProperty("issue_number").GetInt32());
+            },
+            request =>
+            {
+                Assert.Equal("POST /repos/{owner}/{repo}/actions/jobs/{job_id}/rerun", request.Route);
+                Assert.Equal(11, request.Payload.GetProperty("job_id").GetInt32());
+            },
+            request =>
+            {
+                Assert.Equal("POST /repos/{owner}/{repo}/actions/jobs/{job_id}/rerun", request.Route);
+                Assert.Equal(22, request.Payload.GetProperty("job_id").GetInt32());
+            },
+            request =>
+            {
+                Assert.Equal("GET /repos/{owner}/{repo}/actions/runs/{run_id}", request.Route);
+                Assert.Equal(123, request.Payload.GetProperty("run_id").GetInt32());
+            },
+            request =>
+            {
+                Assert.Equal("POST /repos/{owner}/{repo}/issues/{issue_number}/comments", request.Route);
+                Assert.Equal(15110, request.Payload.GetProperty("issue_number").GetInt32());
+                Assert.Equal(
+                    "The transient CI rerun workflow requested reruns for the following jobs after analyzing [the failed attempt](https://github.com/dotnet/aspire/actions/runs/123/attempts/1).\nGitHub's job rerun API also reruns dependent jobs, so the retry is being tracked in [the rerun attempt](https://github.com/dotnet/aspire/actions/runs/123/attempts/2).\nThe job links below point to the failed attempt that matched the retry-safe transient failure rules.\n\n- [Tests / One](https://github.com/dotnet/aspire/actions/runs/123/job/11) - Reason one\n- [Tests / Two](https://github.com/dotnet/aspire/actions/runs/123/job/22) - Reason two",
+                    request.Payload.GetProperty("body").GetString());
+            });
+
+        SummaryEvent rawEvent = Assert.Single(result.Events, e => e.Type == "raw" && e.Text is not null && e.Text.Contains("Failed attempt:"));
+        Assert.Contains("Failed attempt: [workflow run attempt 1](https://github.com/dotnet/aspire/actions/runs/123/attempts/1)", rawEvent.Text);
+        Assert.Contains("Rerun attempt: [workflow run attempt 2](https://github.com/dotnet/aspire/actions/runs/123/attempts/2)", rawEvent.Text);
+
+        SummaryEvent tableEvent = Assert.Single(result.Events, e => e.Type == "table");
+        Assert.Equal("Job", tableEvent.Rows[0][0].GetProperty("data").GetString());
+        Assert.Equal("Reason", tableEvent.Rows[0][1].GetProperty("data").GetString());
+        Assert.Equal("Tests / One", tableEvent.Rows[1][0].GetString());
+        Assert.Equal("Reason one", tableEvent.Rows[1][1].GetString());
+        Assert.Equal("Tests / Two", tableEvent.Rows[2][0].GetString());
+        Assert.Equal("Reason two", tableEvent.Rows[2][1].GetString());
+
+        SummaryEvent commentEvent = Assert.Single(result.Events, e => e.Type == "raw" && e.Text is not null && e.Text.Contains("Posted rerun details to #15110."));
+        Assert.Contains("Posted rerun details to #15110.", commentEvent.Text);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task RerunMatchedJobsSkipsRerunsWhenAllAssociatedPullRequestsAreClosed()
+    {
+        RerunMatchedJobsResult result = await InvokeHarnessAsync<RerunMatchedJobsResult>(
+            "rerunMatchedJobs",
+            new
+            {
+                owner = "dotnet",
+                repo = "aspire",
+                retryableJobs = new[]
+                {
+                    new RetryableJobInput
+                    {
+                        Id = 11,
+                        Name = "Tests / One",
+                        HtmlUrl = "https://github.com/dotnet/aspire/actions/runs/123/job/11",
+                        Reason = "Reason one"
+                    }
+                },
+                pullRequestNumbers = new[] { 15110 },
+                issueStatesByNumber = new Dictionary<string, string>
+                {
+                    ["15110"] = "closed"
+                },
+                sourceRunUrl = "https://github.com/dotnet/aspire/actions/runs/123"
+            });
+
+        RequestRecord request = Assert.Single(result.Requests);
+        Assert.Equal("GET /repos/{owner}/{repo}/issues/{issue_number}", request.Route);
+        Assert.Equal(15110, request.Payload.GetProperty("issue_number").GetInt32());
+
+        SummaryEvent skippedHeading = Assert.Single(result.Events, e => e.Type == "heading" && e.Text == "Automatic rerun skipped");
+        Assert.Equal(1, skippedHeading.Level);
+
+        SummaryEvent skippedRaw = Assert.Single(result.Events, e => e.Type == "raw" && e.Text is not null && e.Text.Contains("All associated pull requests are closed."));
+        Assert.Contains("All associated pull requests are closed. No jobs were rerun.", skippedRaw.Text);
+    }
+
+    private async Task<AnalyzeFailedJobsResult> AnalyzeSingleJobAsync(WorkflowJob job, string annotationsOrText, string jobLogText = "")
+    {
+        Dictionary<string, string> annotationTextByJobId = new()
+        {
+            [job.Id.ToString()] = annotationsOrText
+        };
+
+        Dictionary<string, string>? jobLogTextByJobId = string.IsNullOrEmpty(jobLogText)
+            ? null
+            : new Dictionary<string, string>
+            {
+                [job.Id.ToString()] = jobLogText
+            };
+
+        return await InvokeHarnessAsync<AnalyzeFailedJobsResult>(
+            "analyzeFailedJobs",
+            new AnalyzeFailedJobsRequest
+            {
+                Jobs = [job],
+                AnnotationTextByJobId = annotationTextByJobId,
+                JobLogTextByJobId = jobLogTextByJobId
+            });
+    }
+
+    private async Task<T> InvokeHarnessAsync<T>(string operation, object payload)
+    {
+        string inputPath = Path.Combine(_tempDir.Path, $"{Guid.NewGuid():N}.json");
+        string requestJson = JsonSerializer.Serialize(new HarnessRequest
+        {
+            Operation = operation,
+            Payload = payload
+        }, s_jsonOptions);
+
+        await File.WriteAllTextAsync(inputPath, requestJson);
+
+        using NodeCommand command = new(_output, label: operation);
+        command.WithWorkingDirectory(_repoRoot).WithTimeout(TimeSpan.FromMinutes(1));
+
+        CommandResult result = await command.ExecuteScriptAsync(_harnessPath, inputPath);
+        result.EnsureSuccessful();
+
+        HarnessResponse<T>? response = JsonSerializer.Deserialize<HarnessResponse<T>>(result.Output, s_jsonOptions);
+        Assert.NotNull(response);
+
+        return response.Result!;
+    }
+
+    private static WorkflowJob CreateJob(int id = 1, string name = "Tests / Sample / Sample (ubuntu-latest)", string conclusion = "failure", string[]? failedSteps = null)
+        => new()
+        {
+            Id = id,
+            Name = name,
+            Conclusion = conclusion,
+            Steps = (failedSteps ?? []).Select(stepName => new WorkflowStep
+            {
+                Name = stepName,
+                Conclusion = "failure"
+            }).ToArray()
+        };
+
+    private static string CreateZipArchiveBase64(params ZipEntryData[] entries)
+    {
+        using MemoryStream stream = new();
+        using (ZipArchive archive = new(stream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (ZipEntryData entry in entries)
+            {
+                ZipArchiveEntry archiveEntry = archive.CreateEntry(entry.Name, CompressionLevel.SmallestSize);
+                using StreamWriter writer = new(archiveEntry.Open(), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                writer.Write(entry.Contents);
+            }
+        }
+
+        return Convert.ToBase64String(stream.ToArray());
+    }
+
+    private static string FindRepoRoot()
+    {
+        string? current = AppContext.BaseDirectory;
+
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current, "Aspire.slnx")))
+            {
+                return current;
+            }
+
+            current = Directory.GetParent(current)?.FullName;
+        }
+
+        throw new DirectoryNotFoundException("Could not find repository root containing Aspire.slnx");
+    }
+
+    private sealed class HarnessRequest
+    {
+        public string Operation { get; init; } = string.Empty;
+        public object? Payload { get; init; }
+    }
+
+    private sealed class HarnessResponse<T>
+    {
+        public T? Result { get; init; }
+    }
+
+    private sealed class AnalyzeFailedJobsRequest
+    {
+        public WorkflowJob[] Jobs { get; init; } = [];
+        public Dictionary<string, string> AnnotationTextByJobId { get; init; } = [];
+        public Dictionary<string, string>? JobLogTextByJobId { get; init; }
+    }
+
+    private sealed class AnalyzeFailedJobsResult
+    {
+        public AnalyzedJob[] FailedJobs { get; init; } = [];
+        public AnalyzedJob[] RetryableJobs { get; init; } = [];
+        public AnalyzedJob[] SkippedJobs { get; init; } = [];
+    }
+
+    private sealed class AnalyzedJob
+    {
+        public int Id { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public string? HtmlUrl { get; init; }
+        public string[] FailedSteps { get; init; } = [];
+        public string Reason { get; init; } = string.Empty;
+    }
+
+    private sealed class WorkflowJob
+    {
+        public int Id { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public string Conclusion { get; init; } = string.Empty;
+        public WorkflowStep[] Steps { get; init; } = [];
+
+        [JsonPropertyName("check_run_url")]
+        public string? CheckRunUrl { get; init; }
+    }
+
+    private sealed class WorkflowStep
+    {
+        public string Name { get; init; } = string.Empty;
+        public string Conclusion { get; init; } = string.Empty;
+    }
+
+    private sealed class SummaryResult
+    {
+        public SummaryEvent[] Events { get; init; } = [];
+    }
+
+    private sealed class SummaryEvent
+    {
+        public string Type { get; init; } = string.Empty;
+        public string? Text { get; init; }
+        public int? Level { get; init; }
+        public bool? AddEol { get; init; }
+        public JsonElement[][] Rows { get; init; } = [];
+    }
+
+    private sealed class SummaryJob
+    {
+        public int Id { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public string Reason { get; init; } = string.Empty;
+    }
+
+    private sealed class RetryableJobInput
+    {
+        public int Id { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public string? HtmlUrl { get; init; }
+        public string Reason { get; init; } = string.Empty;
+    }
+
+    private sealed class RerunMatchedJobsResult
+    {
+        public RequestRecord[] Requests { get; init; } = [];
+        public SummaryEvent[] Events { get; init; } = [];
+    }
+
+    private sealed class RequestRecord
+    {
+        public string Route { get; init; } = string.Empty;
+        public JsonElement Payload { get; init; }
+    }
+
+    private sealed record ZipEntryData(string Name, string Contents);
+}

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -82,11 +82,13 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         Assert.Equal("Annotations did not match the transient allowlist.", result.SkippedJobs[0].Reason);
     }
 
-    [Fact]
+    [Theory]
+    [InlineData("Final Results")]
+    [InlineData("Tests / Final Test Results")]
     [RequiresTools(["node"])]
-    public async Task IgnoresAggregatorJobsEntirely()
+    public async Task IgnoresConfiguredAggregatorJobsEntirely(string jobName)
     {
-        WorkflowJob job = CreateJob(name: "Final Results", failedSteps: ["Set up job"]);
+        WorkflowJob job = CreateJob(name: jobName, failedSteps: ["Set up job"]);
 
         AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, "The hosted runner lost communication with the server.");
 
@@ -326,6 +328,21 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task AutomaticRerunIsEligibleWhenRetryableJobsStayWithinTheCap()
+    {
+        bool rerunEligible = await InvokeHarnessAsync<bool>(
+            "computeRerunEligibility",
+            new
+            {
+                dryRun = false,
+                retryableCount = 2
+            });
+
+        Assert.True(rerunEligible);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task AutomaticRerunIsSuppressedWhenMatchedJobsExceedTheCap()
     {
         bool rerunEligible = await InvokeHarnessAsync<bool>(
@@ -337,6 +354,63 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
             });
 
         Assert.False(rerunEligible);
+    }
+
+    [Fact]
+    public async Task RepresentativeWorkflowFixturesStayAlignedWithCurrentWorkflowDefinitions()
+    {
+        Dictionary<string, string[]> expectations = new()
+        {
+            [".github/workflows/run-tests.yml"] =
+            [
+                "- name: Checkout code",
+                "- name: Set up .NET Core",
+                "- name: Install sdk for nuget based testing",
+                "- name: Build test project",
+                "- name: Run tests (Windows)",
+                "- name: Upload logs, and test results",
+                "- name: Copy CLI E2E recordings for upload",
+                "- name: Upload CLI E2E recordings",
+                "- name: Generate test results summary",
+            ],
+            [".github/workflows/build-packages.yml"] =
+            [
+                "- name: Build with packages",
+            ],
+            [".github/workflows/polyglot-validation.yml"] =
+            [
+                "- name: Build Python validation image",
+                "- name: Run TypeScript SDK validation",
+            ],
+            [".github/workflows/ci.yml"] =
+            [
+                "name: Final Results",
+            ],
+            [".github/workflows/tests.yml"] =
+            [
+                "name: Final Test Results",
+            ],
+        };
+
+        foreach ((string relativePath, string[] expectedLines) in expectations)
+        {
+            string workflowText = await ReadRepoFileAsync(relativePath);
+
+            foreach (string expectedLine in expectedLines)
+            {
+                Assert.Contains(expectedLine, workflowText);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task WorkflowYamlKeepsDocumentedSafetyRails()
+    {
+        string workflowText = await ReadRepoFileAsync(".github/workflows/auto-rerun-transient-ci-failures.yml");
+
+        Assert.Contains("workflow_dispatch:", workflowText);
+        Assert.Contains("github.event.workflow_run.run_attempt == 1", workflowText);
+        Assert.Contains("needs.analyze-transient-failures.outputs.rerun_eligible == 'true'", workflowText);
     }
 
     [Fact]
@@ -601,6 +675,9 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
         throw new DirectoryNotFoundException("Could not find repository root containing Aspire.slnx");
     }
+
+    private Task<string> ReadRepoFileAsync(string relativePath)
+        => File.ReadAllTextAsync(Path.Combine(_repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
 
     private sealed class HarnessRequest
     {

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.IO.Compression;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Aspire.TestUtilities;
@@ -209,36 +207,6 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         Assert.Empty(result.RetryableJobs);
         Assert.Single(result.SkippedJobs);
         Assert.Equal("Annotations did not match the transient allowlist.", result.SkippedJobs[0].Reason);
-    }
-
-    [Fact]
-    [RequiresTools(["node"])]
-    public async Task ExtractTextFromZipArchiveBufferReadsDeflatedJobLogTextFromZipArchive()
-    {
-        string zipArchiveBase64 = CreateZipArchiveBase64(
-            new ZipEntryData("step-1.txt", "error : Unable to load the service index for source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json."),
-            new ZipEntryData("step-2.txt", "additional context"));
-
-        string extractedText = await InvokeHarnessAsync<string>(
-            "extractTextFromZipArchiveBuffer",
-            new { bufferBase64 = zipArchiveBase64 });
-
-        Assert.Contains("Unable to load the service index", extractedText);
-        Assert.Contains("additional context", extractedText);
-    }
-
-    [Fact]
-    [RequiresTools(["node"])]
-    public async Task ExtractTextFromZipArchiveBufferFallsBackToPlainTextWhenPayloadIsNotZipArchive()
-    {
-        string plainTextBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("plain-text log line with Unable to load the service index"));
-
-        string extractedText = await InvokeHarnessAsync<string>(
-            "extractTextFromZipArchiveBuffer",
-            new { bufferBase64 = plainTextBase64 });
-
-        Assert.Contains("plain-text log line", extractedText);
-        Assert.Contains("Unable to load the service index", extractedText);
     }
 
     [Fact]
@@ -643,22 +611,6 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
             }).ToArray()
         };
 
-    private static string CreateZipArchiveBase64(params ZipEntryData[] entries)
-    {
-        using MemoryStream stream = new();
-        using (ZipArchive archive = new(stream, ZipArchiveMode.Create, leaveOpen: true))
-        {
-            foreach (ZipEntryData entry in entries)
-            {
-                ZipArchiveEntry archiveEntry = archive.CreateEntry(entry.Name, CompressionLevel.SmallestSize);
-                using StreamWriter writer = new(archiveEntry.Open(), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                writer.Write(entry.Contents);
-            }
-        }
-
-        return Convert.ToBase64String(stream.ToArray());
-    }
-
     private static string FindRepoRoot()
     {
         string? current = AppContext.BaseDirectory;
@@ -770,6 +722,4 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         public string Route { get; init; } = string.Empty;
         public JsonElement Payload { get; init; }
     }
-
-    private sealed record ZipEntryData(string Name, string Contents);
 }

--- a/tests/Infrastructure.Tests/WorkflowScripts/NodeCommand.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/NodeCommand.cs
@@ -1,0 +1,238 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Infrastructure.Tests;
+
+/// <summary>
+/// Executes Node.js scripts using <c>node</c>.
+/// </summary>
+public sealed class NodeCommand : IDisposable
+{
+    private readonly ITestOutputHelper _testOutput;
+    private readonly string _label;
+    private readonly string _msgPrefix;
+    private TimeSpan? _timeout;
+
+    public NodeCommand(ITestOutputHelper testOutput, string label = "")
+    {
+        _testOutput = testOutput;
+        _label = label;
+        _msgPrefix = string.IsNullOrEmpty(_label) ? string.Empty : $"[{_label}] ";
+    }
+
+    public Process? CurrentProcess { get; private set; }
+    public Dictionary<string, string> Environment { get; } = [];
+    public string? WorkingDirectory { get; private set; }
+
+    public NodeCommand WithEnvironmentVariable(string key, string value)
+    {
+        Environment[key] = value;
+        return this;
+    }
+
+    public NodeCommand WithTimeout(TimeSpan timeSpan)
+    {
+        _timeout = timeSpan;
+        return this;
+    }
+
+    public NodeCommand WithWorkingDirectory(string dir)
+    {
+        WorkingDirectory = dir;
+        return this;
+    }
+
+    public async Task<CommandResult> ExecuteScriptAsync(string scriptPath, params string[] args)
+    {
+        CancellationTokenSource cts = new();
+        if (_timeout is not null)
+        {
+            cts.CancelAfter((int)_timeout.Value.TotalMilliseconds);
+        }
+
+        try
+        {
+            return await ExecuteScriptAsyncInternal(scriptPath, args, cts.Token).ConfigureAwait(false);
+        }
+        catch (TaskCanceledException tce) when (cts.IsCancellationRequested)
+        {
+            throw new TaskCanceledException(
+                $"Command execution timed out after {_timeout!.Value.TotalSeconds} secs: node {scriptPath}",
+                tce);
+        }
+    }
+
+    public void Dispose()
+    {
+        CurrentProcess?.CloseAndKillProcessIfRunning();
+    }
+
+    private async Task<CommandResult> ExecuteScriptAsyncInternal(string scriptPath, string[] args, CancellationToken token)
+    {
+        Stopwatch runTimeStopwatch = new();
+        _testOutput.WriteLine($"{_msgPrefix}Executing - node {BuildDisplayArguments(scriptPath, args)} {WorkingDirectoryInfo()}");
+
+        object outputLock = new();
+        List<string> outputLines = [];
+
+        CurrentProcess = CreateProcess(scriptPath, args);
+
+        CurrentProcess.ErrorDataReceived += (s, e) =>
+        {
+            if (e.Data is null)
+            {
+                return;
+            }
+
+            lock (outputLock)
+            {
+                outputLines.Add(e.Data);
+            }
+
+            _testOutput.WriteLine($"{_msgPrefix}{e.Data}");
+        };
+
+        CurrentProcess.OutputDataReceived += (s, e) =>
+        {
+            if (e.Data is null)
+            {
+                return;
+            }
+
+            lock (outputLock)
+            {
+                outputLines.Add(e.Data);
+            }
+
+            _testOutput.WriteLine($"{_msgPrefix}{e.Data}");
+        };
+
+        try
+        {
+            runTimeStopwatch.Start();
+
+            TaskCompletionSource exitedTcs = new();
+            CurrentProcess.EnableRaisingEvents = true;
+            CurrentProcess.Exited += (_, _) =>
+            {
+                exitedTcs.SetResult();
+                runTimeStopwatch.Stop();
+            };
+
+            CurrentProcess.Start();
+            CurrentProcess.BeginOutputReadLine();
+            CurrentProcess.BeginErrorReadLine();
+
+            await exitedTcs.Task.WaitAsync(token).ConfigureAwait(false);
+
+            _testOutput.WriteLine($"{_msgPrefix}Got the Exited event, waiting on WaitForExitAsync");
+            var waitForExitTask = CurrentProcess.WaitForExitAsync(token);
+            var completedTask = await Task.WhenAny(waitForExitTask, Task.Delay(TimeSpan.FromSeconds(5), token)).ConfigureAwait(false);
+            if (completedTask != waitForExitTask)
+            {
+                _testOutput.WriteLine($"{_msgPrefix}Timed out waiting for it. Ignoring.");
+            }
+
+            _testOutput.WriteLine($"{_msgPrefix}Process ran for {runTimeStopwatch.Elapsed.TotalSeconds:F2} secs");
+
+            return new CommandResult(
+                CurrentProcess.StartInfo,
+                CurrentProcess.ExitCode,
+                GetFullOutput());
+        }
+        catch (Exception ex)
+        {
+            _testOutput.WriteLine($"Exception: {ex}");
+            _testOutput.WriteLine($"output: {GetFullOutput()}");
+            throw;
+        }
+        finally
+        {
+            if (!CurrentProcess.TryGetHasExited())
+            {
+                _testOutput.WriteLine($"{_msgPrefix}Process has been running for {runTimeStopwatch.Elapsed.TotalSeconds:F2} secs");
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    CurrentProcess.CloseMainWindow();
+                }
+
+                _testOutput.WriteLine("Killing");
+                CurrentProcess.Kill(entireProcessTree: true);
+            }
+
+            CurrentProcess.Dispose();
+        }
+
+        string GetFullOutput()
+        {
+            lock (outputLock)
+            {
+                return string.Join(System.Environment.NewLine, outputLines);
+            }
+        }
+    }
+
+    private Process CreateProcess(string scriptPath, string[] args)
+    {
+        ProcessStartInfo psi = new()
+        {
+            FileName = "node",
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            RedirectStandardInput = true,
+            UseShellExecute = false
+        };
+
+        psi.ArgumentList.Add(scriptPath);
+        foreach (string arg in args)
+        {
+            psi.ArgumentList.Add(arg);
+        }
+
+        AddEnvironmentVariablesTo(psi);
+        AddWorkingDirectoryTo(psi);
+
+        return new Process
+        {
+            StartInfo = psi,
+            EnableRaisingEvents = true
+        };
+    }
+
+    private void AddEnvironmentVariablesTo(ProcessStartInfo psi)
+    {
+        foreach ((string key, string value) in Environment)
+        {
+            _testOutput.WriteLine($"{_msgPrefix}\t[{key}] = {value}");
+            psi.Environment[key] = value;
+        }
+    }
+
+    private void AddWorkingDirectoryTo(ProcessStartInfo psi)
+    {
+        if (string.IsNullOrWhiteSpace(WorkingDirectory))
+        {
+            return;
+        }
+
+        if (!Directory.Exists(WorkingDirectory))
+        {
+            throw new DirectoryNotFoundException($"Working directory '{WorkingDirectory}' does not exist.");
+        }
+
+        psi.WorkingDirectory = WorkingDirectory;
+    }
+
+    private static string BuildDisplayArguments(string scriptPath, string[] args)
+        => string.Join(" ", [QuoteForDisplay(scriptPath), .. args.Select(QuoteForDisplay)]);
+
+    private static string QuoteForDisplay(string value)
+        => value.Contains(' ') ? $"\"{value}\"" : value;
+
+    private string WorkingDirectoryInfo()
+        => WorkingDirectory is null ? string.Empty : $" in pwd {WorkingDirectory}";
+}

--- a/tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js
@@ -47,9 +47,6 @@ async function dispatch(operation, payload) {
                 getJobLogTextForJob: async job => payload.jobLogTextByJobId?.[String(job.id)] ?? '',
             });
 
-        case 'extractTextFromZipArchiveBuffer':
-            return rerunWorkflow.extractTextFromZipArchiveBuffer(Buffer.from(payload.bufferBase64 ?? '', 'base64'));
-
         case 'getCheckRunIdForJob':
             return rerunWorkflow.getCheckRunIdForJob({
                 job: payload.job,

--- a/tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js
@@ -1,0 +1,125 @@
+const fs = require('node:fs/promises');
+const rerunWorkflow = require('../../../.github/workflows/auto-rerun-transient-ci-failures.js');
+
+class SummaryRecorder {
+    constructor() {
+        this.events = [];
+    }
+
+    addHeading(text, level = 1) {
+        this.events.push({ type: 'heading', text, level });
+        return this;
+    }
+
+    addTable(rows) {
+        this.events.push({ type: 'table', rows });
+        return this;
+    }
+
+    addRaw(text, addEol = false) {
+        this.events.push({ type: 'raw', text, addEol });
+        return this;
+    }
+
+    async write() {
+        this.events.push({ type: 'write' });
+        return this;
+    }
+}
+
+async function main() {
+    const inputPath = process.argv[2];
+    if (!inputPath) {
+        throw new Error('Expected the input payload file path as the first argument.');
+    }
+
+    const request = JSON.parse(await fs.readFile(inputPath, 'utf8'));
+    const result = await dispatch(request.operation, request.payload ?? {});
+    process.stdout.write(JSON.stringify({ result }));
+}
+
+async function dispatch(operation, payload) {
+    switch (operation) {
+        case 'analyzeFailedJobs':
+            return rerunWorkflow.analyzeFailedJobs({
+                jobs: payload.jobs ?? [],
+                getAnnotationsForJob: async job => payload.annotationTextByJobId?.[String(job.id)] ?? '',
+                getJobLogTextForJob: async job => payload.jobLogTextByJobId?.[String(job.id)] ?? '',
+            });
+
+        case 'extractTextFromZipArchiveBuffer':
+            return rerunWorkflow.extractTextFromZipArchiveBuffer(Buffer.from(payload.bufferBase64 ?? '', 'base64'));
+
+        case 'getCheckRunIdForJob':
+            return rerunWorkflow.getCheckRunIdForJob({
+                job: payload.job,
+                getJobForWorkflowRun: payload.workflowJob ? async () => payload.workflowJob : undefined,
+            });
+
+        case 'computeRerunEligibility':
+            return rerunWorkflow.computeRerunEligibility(payload);
+
+        case 'writeAnalysisSummary': {
+            const summary = new SummaryRecorder();
+            await rerunWorkflow.writeAnalysisSummary({
+                ...payload,
+                summary,
+            });
+
+            return { events: summary.events };
+        }
+
+        case 'rerunMatchedJobs': {
+            const requests = [];
+            const summary = new SummaryRecorder();
+            const github = createGitHubRecorder(payload, requests);
+
+            await rerunWorkflow.rerunMatchedJobs({
+                ...payload,
+                github,
+                summary,
+            });
+
+            return { requests, events: summary.events };
+        }
+
+        default:
+            throw new Error(`Unsupported operation '${operation}'.`);
+    }
+}
+
+function createGitHubRecorder(payload, requests) {
+    return {
+        request: async (route, requestPayload) => {
+            requests.push({ route, payload: requestPayload });
+
+            if (route === 'GET /repos/{owner}/{repo}/issues/{issue_number}') {
+                const issueNumber = String(requestPayload.issue_number);
+                const state = payload.issueStatesByNumber?.[issueNumber] ?? 'closed';
+                return {
+                    data: {
+                        state,
+                        pull_request: {
+                            url: `https://api.github.com/repos/${requestPayload.owner}/${requestPayload.repo}/pulls/${issueNumber}`,
+                        },
+                    },
+                };
+            }
+
+            if (route === 'GET /repos/{owner}/{repo}/actions/runs/{run_id}') {
+                return {
+                    data: {
+                        run_attempt: payload.latestRunAttempt ?? null,
+                    },
+                };
+            }
+
+            return { data: {} };
+        },
+    };
+}
+
+main().catch(error => {
+    process.stderr.write(`${error.stack ?? error}\n`);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
This PR adds a conservative automation that reruns failed CI jobs when they match common transient infrastructure failures.
It is intended to reduce manual reruns for issues like network, DNS, and feed/bootstrap connectivity failures while leaving ordinary test failures for investigation.

## Summary
- add an automatic retry workflow for common transient CI infrastructure failures such as network interruptions, DNS resolution failures, and feed/bootstrap connectivity issues
- keep the retry logic conservative by only rerunning explicitly allowlisted transient failures and by skipping ordinary test failures
- post a PR comment when a rerun is triggered so contributors can see which jobs were retried and why
- extract the rerun logic into a tested JavaScript helper, cover the behavior with C# infrastructure tests, and document the script-driven flow

## When it triggers
- after a `CI` `workflow_run` completes for a pull request with conclusion `failure`
- only on the first attempt of that CI run, after the analyzer finds at least one retry-safe failed job
- manual `workflow_dispatch` runs stay in dry-run mode for inspection and do not rerun jobs

## Safety rails
- do not retry regular test failures
- do not retry jobs unless the failure matches the conservative transient allowlist/signatures
- cap the number of retryable jobs so broader failures do not trigger automatic reruns

## Testing
- `dotnet test tests/Infrastructure.Tests/Infrastructure.Tests.csproj -- --filter-class "*.AutoRerunTransientCiFailuresTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/auto-rerun-transient-ci-failures.yml')"`
