### PR TITLE
[CI] Fix randomly failing tests on azdo due to docker+testcontainers/ryuk issues

### DIFF
--- a/docs/ci/azdo-public-pipeline.md
+++ b/docs/ci/azdo-public-pipeline.md
@@ -177,6 +177,8 @@ The system uses MSBuild properties to control where each test project runs. Thes
 
 When `PrepareForHelix=true` is passed during build, the following happens for each test project:
 
+This is also the easiest way to inspect locally what payload Helix agents will receive for test projects. After running a build with `PrepareForHelix=true`, review the generated `.zip` files under `artifacts/helix/*` to confirm that expected binaries, resources, snapshots, and support files were included before queueing Helix work items.
+
 1. **`ZipTestArchive` target** (in `tests/Directory.Build.targets`):
    - Runs after `Build` for projects where `IsTestProject=true`, `RunOnAzdoHelix=true`, and `IsTestUtilityProject!=true`
    - Zips the `$(OutDir)` contents to `artifacts/helix/<category>/<ProjectName>.zip`
@@ -222,6 +224,34 @@ The `eng/test-configuration.json` configures test retries:
 - **Local reruns**: 0 retries (disabled so the first retry is queued on a different machine)
 - **Remote (Helix) reruns**: 3 retries
 - **Retry-on rules**: Matches reported Testcontainers Ryuk image failures (`No such image: .*testcontainers/ryuk:.*`)
+
+## Local validation tip: Helix dry runs
+
+When changing Helix infrastructure, you can validate the generated work item commands locally without sending anything to Helix.
+
+First, build the Helix archives:
+
+```bash
+./build.sh --build /p:SkipNativeBuild=true /p:PrepareForHelix=true /p:ArchiveTests=true
+```
+
+Then run the Helix project in dry-run mode:
+
+```bash
+./dotnet.sh msbuild tests/helix/send-to-helix-ci.proj \
+  /t:Test \
+  /p:HelixDryRun=true \
+  /p:Configuration=Release \
+  /p:HelixTargetQueues=Ubuntu.2204.Amd64.Open
+```
+
+This prints `HelixWorkItem:` lines that include the generated command, pre-commands, and payload archive for each work item. It is a fast way to verify that environment variables, command-line arguments, and payload wiring are being propagated as expected.
+
+Important notes:
+
+- The dry run still requires the test archives under `artifacts/helix/*`, so run the build step above first.
+- Outside AzDO, you must pass `HelixTargetQueues` explicitly or the Helix SDK fails before printing any work items.
+- `HelixDryRun=true` intentionally stops the build after printing the generated work items.
 
 ## Known Breakage Patterns (from Real Incidents)
 

--- a/tests/helix/send-to-helix-inner.proj
+++ b/tests/helix/send-to-helix-inner.proj
@@ -46,6 +46,9 @@
 
     <_ShutdownDockerContainersCommand Condition="'$(OS)' != 'Windows_NT'">for f in `docker ps -aq`%3B do docker stop $f%3B docker rm $f%3B done</_ShutdownDockerContainersCommand>
     <_DeleteDockerVolumesCommand Condition="'$(OS)' != 'Windows_NT'">for f in `docker volume ls -q`%3B do docker volume rm $f%3B done</_DeleteDockerVolumesCommand>
+    <_UsesTestcontainersWorkItemCommand Condition="'$(OS)' != 'Windows_NT'">find "$HELIX_WORKITEM_ROOT" -type f \( -name 'Testcontainers*.dll' -o -name 'DotNet.Testcontainers*.dll' \) | grep -q .</_UsesTestcontainersWorkItemCommand>
+    <_DisableRyukForTestcontainersWorkItemCommand Condition="'$(OS)' != 'Windows_NT'">if $(_UsesTestcontainersWorkItemCommand)%3B then echo "Disabling Testcontainers Ryuk for this Helix work item." $(_ShellCommandSeparator) export TESTCONTAINERS_RYUK_DISABLED=true%3B fi</_DisableRyukForTestcontainersWorkItemCommand>
+    <_CleanupDockerForTestcontainersWorkItemCommand Condition="'$(OS)' != 'Windows_NT'">if $(_UsesTestcontainersWorkItemCommand)%3B then echo "Cleaning up Docker resources for this Testcontainers Helix work item." $(_ShellCommandSeparator) $(_ShutdownDockerContainersCommand) $(_ShellCommandSeparator) $(_DeleteDockerVolumesCommand) $(_ShellCommandSeparator) docker network prune -f%3B fi</_CleanupDockerForTestcontainersWorkItemCommand>
 
     <_CleanupProcessesCommand Condition="'$(OS)' == 'Windows_NT'">powershell -ExecutionPolicy ByPass -NoProfile -command "&amp; get-ciminstance win32_process | where-object ExecutablePath -Match 'dotnet-tests|dcp.exe' | foreach-object { echo $_.ProcessId $_.ExecutablePath %3B stop-process -id $_.ProcessId -force -ErrorAction SilentlyContinue }"</_CleanupProcessesCommand>
     <_CleanupProcessesCommand Condition="'$(OS)' != 'Windows_NT'">pgrep -lf "dotnet-tests|dcp.exe" | awk '{print %3B system("kill -9 "$1)}'</_CleanupProcessesCommand>
@@ -133,11 +136,11 @@
     <HelixPreCommand Include="$(_DeleteDockerVolumesCommand)" />
     <HelixPreCommand Include="docker network ls" />
     <HelixPreCommand Include="docker network prune -f" />
-
     <HelixPostCommand Include="docker container ls --all" />
     <HelixPostCommand Include="docker container ls --all --format json" />
     <HelixPostCommand Include="docker volume ls" />
     <HelixPostCommand Include="docker network ls" />
+    <HelixPostCommand Condition="'$(OS)' != 'Windows_NT'" Include="$(_CleanupDockerForTestcontainersWorkItemCommand)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -161,6 +164,7 @@
 
     <HelixPerWorkItemPreCommand Condition="'$(OS)' == 'Windows_NT'">$(HelixPerWorkItemPreCommand) &amp; set DOTNET_ROOT=%HELIX_CORRELATION_PAYLOAD%\$(_DefaultSdkDirNameForTests)</HelixPerWorkItemPreCommand>
     <HelixPerWorkItemPreCommand Condition="'$(OS)' != 'Windows_NT'">$(HelixPerWorkItemPreCommand) &amp;&amp; export DOTNET_ROOT=$HELIX_CORRELATION_PAYLOAD/$(_DefaultSdkDirNameForTests)</HelixPerWorkItemPreCommand>
+    <HelixPerWorkItemPreCommand Condition="'$(OS)' != 'Windows_NT'">$(HelixPerWorkItemPreCommand) &amp;&amp; $(_DisableRyukForTestcontainersWorkItemCommand)</HelixPerWorkItemPreCommand>
   </PropertyGroup>
 
   <Target Name="PrepareDependencies" DependsOnTargets="$(PrepareDependenciesDependsOn)" />


### PR DESCRIPTION
## Description

This change fixes the long-running Azure DevOps Helix/Testcontainers failure tracked by #11820.

For months, public AzDO Helix work items have intermittently failed because the default testcontainers/ryuk helper image was not reliably available on those agents. We also tried steering Ryuk through a different registry path via TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX, but that still did not make the problem go away consistently.

The core bug in our Helix wiring was that the Ryuk-disable logic was added as a shared HelixPreCommand, while the generated test command environment is built from HelixPerWorkItemPreCommand. As a result, TESTCONTAINERS_RYUK_DISABLED was not guaranteed to flow into the actual Helix work item command that runs the tests.

This PR moves the Linux Ryuk-disable logic into HelixPerWorkItemPreCommand so Testcontainers-based Helix work items run with TESTCONTAINERS_RYUK_DISABLED=true. It also updates the AzDO CI documentation with the local validation techniques we used while debugging this:

- using PrepareForHelix=true to generate and inspect the Helix test archives under artifacts/helix/*
- using HelixDryRun=true plus HelixTargetQueues to inspect the generated Helix work item commands locally

Fixes #11820