### PR TITLE
Add AspireExport opt-in for background-thread sync dispatch

### DIFF
--- a/src/Aspire.Cli/Properties/launchSettings.json
+++ b/src/Aspire.Cli/Properties/launchSettings.json
@@ -103,14 +103,6 @@
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
-    "run-typescript": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "commandLineArgs": "run --project ../../../../../playground/TypeScriptAppHost/apphost.ts",
-      "environmentVariables": {
-        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
-      }
-    },
     "exec-add-migration": {
       "commandName": "Project",
       "dotnetRunMessages": true,

--- a/src/Aspire.Cli/Properties/launchSettings.json
+++ b/src/Aspire.Cli/Properties/launchSettings.json
@@ -103,6 +103,14 @@
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
+    "run-typescript": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "commandLineArgs": "run --project ../../../../../playground/TypeScriptAppHost/apphost.ts",
+      "environmentVariables": {
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+      }
+    },
     "exec-add-migration": {
       "commandName": "Project",
       "dotnetRunMessages": true,

--- a/src/Aspire.Hosting.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Aspire.Hosting.Analyzers/AnalyzerReleases.Unshipped.md
@@ -14,3 +14,4 @@ ASPIREEXPORT006 | Design | Warning | AspireExportAnalyzer, [Documentation](https
 ASPIREEXPORT007 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT007)
 ASPIREEXPORT008 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT008)
 ASPIREEXPORT009 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT009)
+ASPIREEXPORT010 | Design | Warning | AspireExportAnalyzer, [Documentation](https://aka.ms/aspire/diagnostics/ASPIREEXPORT010)

--- a/src/Aspire.Hosting.Analyzers/AspireExportAnalyzer.Diagnostics.cs
+++ b/src/Aspire.Hosting.Analyzers/AspireExportAnalyzer.Diagnostics.cs
@@ -105,7 +105,7 @@ public partial class AspireExportAnalyzer
         internal static readonly DiagnosticDescriptor s_exportedSyncDelegateInvokedInline = new(
             id: ExportedSyncDelegateInvokedInlineId,
             title: "Exported synchronous callback should not be invoked inline",
-            messageFormat: "Exported builder method '{0}' directly invokes synchronous delegate parameter '{1}'. Defer the callback or expose an async delegate to avoid polyglot deadlocks.",
+            messageFormat: "Exported builder method '{0}' directly invokes synchronous delegate parameter '{1}'. Defer the callback, expose an async delegate, or set RunSyncOnBackgroundThread = true to avoid polyglot deadlocks.",
             category: "Design",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,

--- a/src/Aspire.Hosting.Analyzers/AspireExportAnalyzer.Diagnostics.cs
+++ b/src/Aspire.Hosting.Analyzers/AspireExportAnalyzer.Diagnostics.cs
@@ -101,6 +101,16 @@ public partial class AspireExportAnalyzer
             isEnabledByDefault: true,
             helpLinkUri: $"https://aka.ms/aspire/diagnostics/{ExportNameShouldBeUniqueId}");
 
+        private const string ExportedSyncDelegateInvokedInlineId = "ASPIREEXPORT010";
+        internal static readonly DiagnosticDescriptor s_exportedSyncDelegateInvokedInline = new(
+            id: ExportedSyncDelegateInvokedInlineId,
+            title: "Exported synchronous callback should not be invoked inline",
+            messageFormat: "Exported builder method '{0}' directly invokes synchronous delegate parameter '{1}'. Defer the callback or expose an async delegate to avoid polyglot deadlocks.",
+            category: "Design",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            helpLinkUri: $"https://aka.ms/aspire/diagnostics/{ExportedSyncDelegateInvokedInlineId}");
+
         public static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics = ImmutableArray.Create(
             s_exportMethodMustBeStatic,
             s_invalidExportIdFormat,
@@ -110,7 +120,8 @@ public partial class AspireExportAnalyzer
             s_unionTypeMustBeAtsCompatible,
             s_duplicateExportId,
             s_missingExportAttribute,
-            s_exportNameShouldBeUnique
+            s_exportNameShouldBeUnique,
+            s_exportedSyncDelegateInvokedInline
         );
     }
 }

--- a/src/Aspire.Hosting.Analyzers/AspireExportAnalyzer.cs
+++ b/src/Aspire.Hosting.Analyzers/AspireExportAnalyzer.cs
@@ -15,6 +15,8 @@ namespace Aspire.Hosting.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public partial class AspireExportAnalyzer : DiagnosticAnalyzer
 {
+    private const string RunSyncOnBackgroundThreadPropertyName = "RunSyncOnBackgroundThread";
+
     // Matches: valid method name (camelCase identifier, may contain dots for namespacing)
     // Examples: addRedis, addContainer, Dictionary.set
     private static readonly Regex s_exportIdPattern = new(
@@ -79,6 +81,9 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         // At the end of compilation, report duplicate export IDs
         context.RegisterCompilationEndAction(c => ReportDuplicateExports(c, exportsByKey));
 
+        // Warn when exported builder methods invoke synchronous callback delegates inline. Deferred callbacks
+        // that are stored for later execution are fine, and exports that opt into background-thread dispatch
+        // are handled safely by the runtime.
         context.RegisterOperationBlockStartAction(c =>
         {
             if (c.OwningSymbol is not IMethodSymbol method ||
@@ -333,7 +338,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
 
         if (invocation.TargetMethod.MethodKind != MethodKind.DelegateInvoke ||
             invocation.Syntax is not InvocationExpressionSyntax invocationSyntax ||
-            IsInsideNestedCallback(invocationSyntax))
+            IsInsideNestedCallback(context, invocationSyntax))
         {
             return;
         }
@@ -356,9 +361,63 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             parameter.Name));
     }
 
-    private static bool IsInsideNestedCallback(InvocationExpressionSyntax invocation)
+    private static bool IsInsideNestedCallback(OperationAnalysisContext context, InvocationExpressionSyntax invocation)
     {
-        return invocation.Ancestors().Any(a => a is AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax);
+        foreach (var ancestor in invocation.Ancestors())
+        {
+            switch (ancestor)
+            {
+                case AnonymousFunctionExpressionSyntax anonymousFunction:
+                    return !IsImmediatelyInvokedAnonymousFunction(anonymousFunction);
+                case LocalFunctionStatementSyntax localFunction:
+                    return !IsImmediatelyInvokedLocalFunction(context, localFunction);
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsImmediatelyInvokedAnonymousFunction(AnonymousFunctionExpressionSyntax anonymousFunction)
+    {
+        SyntaxNode current = anonymousFunction;
+
+        while (current.Parent is ParenthesizedExpressionSyntax or CastExpressionSyntax)
+        {
+            current = current.Parent;
+        }
+
+        return current.Parent is InvocationExpressionSyntax invocation &&
+            invocation.Expression == current;
+    }
+
+    private static bool IsImmediatelyInvokedLocalFunction(OperationAnalysisContext context, LocalFunctionStatementSyntax localFunction)
+    {
+        if (localFunction.Parent is null)
+        {
+            return false;
+        }
+
+        var semanticModel = context.Compilation.GetSemanticModel(localFunction.SyntaxTree);
+        if (semanticModel.GetDeclaredSymbol(localFunction, context.CancellationToken) is not IMethodSymbol localFunctionSymbol)
+        {
+            return false;
+        }
+
+        foreach (var invocation in localFunction.Parent.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (localFunction.Span.Contains(invocation.Span))
+            {
+                continue;
+            }
+
+            if (semanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol is IMethodSymbol invokedMethod &&
+                SymbolEqualityComparer.Default.Equals(invokedMethod.ReducedFrom ?? invokedMethod, localFunctionSymbol))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static string? GetInvokedDelegateParameterName(InvocationExpressionSyntax invocation)
@@ -775,7 +834,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
 
         foreach (var namedArgument in exportAttribute.NamedArguments)
         {
-            if (namedArgument.Key == "RunSyncOnBackgroundThread" &&
+            if (namedArgument.Key == RunSyncOnBackgroundThreadPropertyName &&
                 namedArgument.Value.Value is bool enabled)
             {
                 return enabled;

--- a/src/Aspire.Hosting.Analyzers/AspireExportAnalyzer.cs
+++ b/src/Aspire.Hosting.Analyzers/AspireExportAnalyzer.cs
@@ -338,7 +338,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
 
         if (invocation.TargetMethod.MethodKind != MethodKind.DelegateInvoke ||
             invocation.Syntax is not InvocationExpressionSyntax invocationSyntax ||
-            IsInsideNestedCallback(context, invocationSyntax))
+            IsInsideNestedCallback(invocationSyntax))
         {
             return;
         }
@@ -361,7 +361,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             parameter.Name));
     }
 
-    private static bool IsInsideNestedCallback(OperationAnalysisContext context, InvocationExpressionSyntax invocation)
+    private static bool IsInsideNestedCallback(InvocationExpressionSyntax invocation)
     {
         foreach (var ancestor in invocation.Ancestors())
         {
@@ -370,7 +370,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
                 case AnonymousFunctionExpressionSyntax anonymousFunction:
                     return !IsImmediatelyInvokedAnonymousFunction(anonymousFunction);
                 case LocalFunctionStatementSyntax localFunction:
-                    return !IsImmediatelyInvokedLocalFunction(context, localFunction);
+                    return !IsImmediatelyInvokedLocalFunction(localFunction);
             }
         }
 
@@ -390,18 +390,14 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             invocation.Expression == current;
     }
 
-    private static bool IsImmediatelyInvokedLocalFunction(OperationAnalysisContext context, LocalFunctionStatementSyntax localFunction)
+    private static bool IsImmediatelyInvokedLocalFunction(LocalFunctionStatementSyntax localFunction)
     {
         if (localFunction.Parent is null)
         {
             return false;
         }
 
-        var semanticModel = context.Compilation.GetSemanticModel(localFunction.SyntaxTree);
-        if (semanticModel.GetDeclaredSymbol(localFunction, context.CancellationToken) is not IMethodSymbol localFunctionSymbol)
-        {
-            return false;
-        }
+        var localFunctionName = localFunction.Identifier.ValueText;
 
         foreach (var invocation in localFunction.Parent.DescendantNodes().OfType<InvocationExpressionSyntax>())
         {
@@ -410,8 +406,8 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            if (semanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol is IMethodSymbol invokedMethod &&
-                SymbolEqualityComparer.Default.Equals(invokedMethod.ReducedFrom ?? invokedMethod, localFunctionSymbol))
+            if (invocation.Expression is IdentifierNameSyntax identifier &&
+                identifier.Identifier.ValueText == localFunctionName)
             {
                 return true;
             }

--- a/src/Aspire.Hosting.Analyzers/AspireExportAnalyzer.cs
+++ b/src/Aspire.Hosting.Analyzers/AspireExportAnalyzer.cs
@@ -6,7 +6,9 @@ using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 using Aspire.Hosting.Analyzers.Infrastructure;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Aspire.Hosting.Analyzers;
 
@@ -76,6 +78,35 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
 
         // At the end of compilation, report duplicate export IDs
         context.RegisterCompilationEndAction(c => ReportDuplicateExports(c, exportsByKey));
+
+        context.RegisterOperationBlockStartAction(c =>
+        {
+            if (c.OwningSymbol is not IMethodSymbol method ||
+                !method.IsExtensionMethod ||
+                method.Parameters.Length == 0 ||
+                !IsBuilderType(method.Parameters[0].Type, wellKnownTypes) ||
+                !TryGetEffectiveAspireExportAttribute(method, aspireExportAttribute, out var exportAttribute, out var containingTypeExportAttribute) ||
+                IsRunSyncOnBackgroundThreadEnabled(exportAttribute) ||
+                IsRunSyncOnBackgroundThreadEnabled(containingTypeExportAttribute))
+            {
+                return;
+            }
+
+            var synchronousDelegateParameters = method.Parameters
+                .Skip(1)
+                .Where(IsSynchronousDelegateParameter)
+                .ToDictionary(p => p.Name, p => p, StringComparer.Ordinal);
+
+            if (synchronousDelegateParameters.Count == 0)
+            {
+                return;
+            }
+
+            var reportedParameters = new ConcurrentDictionary<string, byte>(StringComparer.Ordinal);
+            c.RegisterOperationAction(
+                oc => AnalyzeInlineSynchronousDelegateInvocation(oc, method, synchronousDelegateParameters, reportedParameters),
+                OperationKind.Invocation);
+        });
     }
 
     private static void AnalyzeMethod(
@@ -290,6 +321,88 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             method.Name,
             concreteTargetTypeName,
             suggestedName));
+    }
+
+    private static void AnalyzeInlineSynchronousDelegateInvocation(
+        OperationAnalysisContext context,
+        IMethodSymbol method,
+        IReadOnlyDictionary<string, IParameterSymbol> synchronousDelegateParameters,
+        ConcurrentDictionary<string, byte> reportedParameters)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+
+        if (invocation.TargetMethod.MethodKind != MethodKind.DelegateInvoke ||
+            invocation.Syntax is not InvocationExpressionSyntax invocationSyntax ||
+            IsInsideNestedCallback(invocationSyntax))
+        {
+            return;
+        }
+
+        var parameterName = GetInvokedDelegateParameterName(invocationSyntax);
+        if (parameterName is null || !synchronousDelegateParameters.TryGetValue(parameterName, out var parameter))
+        {
+            return;
+        }
+
+        if (!reportedParameters.TryAdd(parameterName, default))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Diagnostics.s_exportedSyncDelegateInvokedInline,
+            invocationSyntax.GetLocation(),
+            method.Name,
+            parameter.Name));
+    }
+
+    private static bool IsInsideNestedCallback(InvocationExpressionSyntax invocation)
+    {
+        return invocation.Ancestors().Any(a => a is AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax);
+    }
+
+    private static string? GetInvokedDelegateParameterName(InvocationExpressionSyntax invocation)
+    {
+        return invocation.Expression switch
+        {
+            IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
+            MemberAccessExpressionSyntax
+            {
+                Name.Identifier.ValueText: "Invoke",
+                Expression: IdentifierNameSyntax identifier
+            } => identifier.Identifier.ValueText,
+            MemberBindingExpressionSyntax
+            {
+                Name.Identifier.ValueText: "Invoke"
+            } when invocation.Parent is ConditionalAccessExpressionSyntax
+            {
+                Expression: IdentifierNameSyntax identifier
+            } => identifier.Identifier.ValueText,
+            _ => null
+        };
+    }
+
+    private static bool IsSynchronousDelegateParameter(IParameterSymbol parameter)
+    {
+        if (parameter.Type is not INamedTypeSymbol namedType || !IsDelegateType(namedType))
+        {
+            return false;
+        }
+
+        var invokeMethod = namedType.DelegateInvokeMethod;
+        if (invokeMethod is null)
+        {
+            return false;
+        }
+
+        return !IsTaskReturnType(invokeMethod.ReturnType);
+    }
+
+    private static bool IsTaskReturnType(ITypeSymbol type)
+    {
+        return type is INamedTypeSymbol namedType
+            && namedType.Name == "Task"
+            && namedType.ContainingNamespace.ToDisplayString() == "System.Threading.Tasks";
     }
 
     /// <summary>
@@ -609,6 +722,67 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             return id;
         }
         return null;
+    }
+
+    private static bool TryGetEffectiveAspireExportAttribute(IMethodSymbol method, INamedTypeSymbol aspireExportAttribute, out AttributeData? exportAttribute, out AttributeData? containingTypeExportAttribute)
+    {
+        foreach (var attr in method.GetAttributes())
+        {
+            if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, aspireExportAttribute))
+            {
+                exportAttribute = attr;
+                containingTypeExportAttribute = GetContainingTypeAspireExportAttribute(method.ContainingType, aspireExportAttribute);
+                return true;
+            }
+        }
+
+        containingTypeExportAttribute = GetContainingTypeAspireExportAttribute(method.ContainingType, aspireExportAttribute);
+        if (containingTypeExportAttribute is not null)
+        {
+            exportAttribute = containingTypeExportAttribute;
+            return true;
+        }
+
+        exportAttribute = null;
+        containingTypeExportAttribute = null;
+        return false;
+    }
+
+    private static AttributeData? GetContainingTypeAspireExportAttribute(INamedTypeSymbol? type, INamedTypeSymbol aspireExportAttribute)
+    {
+        if (type is null)
+        {
+            return null;
+        }
+
+        foreach (var attr in type.GetAttributes())
+        {
+            if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, aspireExportAttribute))
+            {
+                return attr;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsRunSyncOnBackgroundThreadEnabled(AttributeData? exportAttribute)
+    {
+        if (exportAttribute is null)
+        {
+            return false;
+        }
+
+        foreach (var namedArgument in exportAttribute.NamedArguments)
+        {
+            if (namedArgument.Key == "RunSyncOnBackgroundThread" &&
+                namedArgument.Value.Value is bool enabled)
+            {
+                return enabled;
+            }
+        }
+
+        return false;
     }
 
     private static bool IsAtsCompatibleType(

--- a/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
@@ -93,7 +93,7 @@ public static class AzureAppConfigurationExtensions
     /// <param name="builder">The Azure App Configuration resource builder.</param>
     /// <param name="configureEmulator">Callback that exposes underlying container used for emulation to allow for customization.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("runAsEmulator", Description = "Configures Azure App Configuration to run with the local emulator")]
+    [AspireExport("runAsEmulator", Description = "Configures Azure App Configuration to run with the local emulator", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<AzureAppConfigurationResource> RunAsEmulator(this IResourceBuilder<AzureAppConfigurationResource> builder, Action<IResourceBuilder<AzureAppConfigurationEmulatorResource>>? configureEmulator = null)
     {
         if (builder.ApplicationBuilder.ExecutionContext.IsPublishMode)

--- a/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
@@ -191,7 +191,7 @@ public static class AzureOpenAIExtensions
     /// <param name="builder">The Azure OpenAI Deployment resource builder.</param>
     /// <param name="configure">A method that can be used for customizing the <see cref="AzureOpenAIDeploymentResource"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("withProperties", Description = "Configures properties of an Azure OpenAI deployment")]
+    [AspireExport("withProperties", Description = "Configures properties of an Azure OpenAI deployment", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<AzureOpenAIDeploymentResource> WithProperties(this IResourceBuilder<AzureOpenAIDeploymentResource> builder, Action<AzureOpenAIDeploymentResource> configure)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -57,7 +57,7 @@ public static class AzureCosmosExtensions
     /// For more information, see <a href="https://learn.microsoft.com/azure/cosmos-db/how-to-develop-emulator?tabs=docker-linux#export-the-emulators-tlsssl-certificate"></a>.
     /// This version of the package defaults to the <inheritdoc cref="CosmosDBEmulatorContainerImageTags.Tag"/> tag of the <inheritdoc cref="CosmosDBEmulatorContainerImageTags.Registry"/>/<inheritdoc cref="CosmosDBEmulatorContainerImageTags.Image"/> container image.
     /// </remarks>
-    [AspireExport("runAsEmulator", Description = "Configures the Azure Cosmos DB resource to run using the local emulator")]
+    [AspireExport("runAsEmulator", Description = "Configures the Azure Cosmos DB resource to run using the local emulator", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<AzureCosmosDBResource> RunAsEmulator(this IResourceBuilder<AzureCosmosDBResource> builder, Action<IResourceBuilder<AzureCosmosDBEmulatorResource>>? configureContainer = null)
         => RunAsEmulator(builder, configureContainer, useVNextPreview: false);
 
@@ -71,7 +71,7 @@ public static class AzureCosmosExtensions
     /// <remarks>
     /// This version of the package defaults to the <inheritdoc cref="CosmosDBEmulatorContainerImageTags.TagVNextPreview"/> tag of the <inheritdoc cref="CosmosDBEmulatorContainerImageTags.Registry"/>/<inheritdoc cref="CosmosDBEmulatorContainerImageTags.Image"/> container image.
     /// </remarks>
-    [AspireExport("runAsPreviewEmulator", Description = "Configures the Azure Cosmos DB resource to run using the preview emulator")]
+    [AspireExport("runAsPreviewEmulator", Description = "Configures the Azure Cosmos DB resource to run using the preview emulator", RunSyncOnBackgroundThread = true)]
     [Experimental("ASPIRECOSMOSDB001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static IResourceBuilder<AzureCosmosDBResource> RunAsPreviewEmulator(this IResourceBuilder<AzureCosmosDBResource> builder, Action<IResourceBuilder<AzureCosmosDBEmulatorResource>>? configureContainer = null)
         => RunAsEmulator(builder, configureContainer, useVNextPreview: true);

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -173,7 +173,7 @@ public static class AzureEventHubsExtensions
     /// <param name="builder">The Azure Event Hub resource builder.</param>
     /// <param name="configure">A method that can be used for customizing the <see cref="AzureEventHubResource"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("withProperties", Description = "Configures properties of an Azure Event Hub")]
+    [AspireExport("withProperties", Description = "Configures properties of an Azure Event Hub", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<AzureEventHubResource> WithProperties(this IResourceBuilder<AzureEventHubResource> builder, Action<AzureEventHubResource> configure)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -237,7 +237,7 @@ public static class AzureEventHubsExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
-    [AspireExport("runAsEmulator", Description = "Configures the Azure Event Hubs resource to run with the local emulator")]
+    [AspireExport("runAsEmulator", Description = "Configures the Azure Event Hubs resource to run with the local emulator", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<AzureEventHubsResource> RunAsEmulator(this IResourceBuilder<AzureEventHubsResource> builder, Action<IResourceBuilder<AzureEventHubsEmulatorResource>>? configureContainer = null)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
@@ -149,7 +149,7 @@ public static class AzureKustoBuilderExtensions
     /// Optional action to configure the Kusto emulator container.
     /// </param>
     /// <returns>The resource builder.</returns>
-    [AspireExport("runAsEmulator", Description = "Configures the Kusto cluster to run using the local emulator")]
+    [AspireExport("runAsEmulator", Description = "Configures the Kusto cluster to run using the local emulator", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<AzureKustoClusterResource> RunAsEmulator(
         this IResourceBuilder<AzureKustoClusterResource> builder,
         Action<IResourceBuilder<AzureKustoEmulatorResource>>? configureContainer = null)

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -211,7 +211,7 @@ public static class AzurePostgresExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    [AspireExport("runAsContainer", Description = "Configures the Azure PostgreSQL Flexible Server resource to run locally in a container")]
+    [AspireExport("runAsContainer", Description = "Configures the Azure PostgreSQL Flexible Server resource to run locally in a container", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<AzurePostgresFlexibleServerResource> RunAsContainer(this IResourceBuilder<AzurePostgresFlexibleServerResource> builder, Action<IResourceBuilder<PostgresServerResource>>? configureContainer = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -385,7 +385,7 @@ public static class AzurePostgresExtensions
     /// </para>
     /// </remarks>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("withPostgresMcp", Description = "Adds a Postgres MCP server container")]
+    [AspireExport("withPostgresMcp", Description = "Adds a Postgres MCP server container", RunSyncOnBackgroundThread = true)]
     [Experimental("ASPIREPOSTGRES001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static IResourceBuilder<AzurePostgresFlexibleServerDatabaseResource> WithPostgresMcp(
         this IResourceBuilder<AzurePostgresFlexibleServerDatabaseResource> builder,

--- a/src/Aspire.Hosting.Azure.Redis/AzureManagedRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureManagedRedisExtensions.cs
@@ -81,7 +81,7 @@ public static class AzureManagedRedisExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    [AspireExport("runAsContainer", Description = "Configures Azure Managed Redis to run in a local container")]
+    [AspireExport("runAsContainer", Description = "Configures Azure Managed Redis to run in a local container", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<AzureManagedRedisResource> RunAsContainer(
         this IResourceBuilder<AzureManagedRedisResource> builder,
         Action<IResourceBuilder<RedisResource>>? configureContainer = null)

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -187,7 +187,7 @@ public static class AzureServiceBusExtensions
     /// <param name="builder">The Azure Service Bus Queue resource builder.</param>
     /// <param name="configure">A method that can be used for customizing the <see cref="AzureServiceBusQueueResource"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("withQueueProperties", MethodName = "withProperties", Description = "Configures properties of an Azure Service Bus queue")]
+    [AspireExport("withQueueProperties", MethodName = "withProperties", Description = "Configures properties of an Azure Service Bus queue", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<AzureServiceBusQueueResource> WithProperties(this IResourceBuilder<AzureServiceBusQueueResource> builder, Action<AzureServiceBusQueueResource> configure)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -270,7 +270,7 @@ public static class AzureServiceBusExtensions
     /// <param name="builder">The Azure Service Bus Topic resource builder.</param>
     /// <param name="configure">A method that can be used for customizing the <see cref="AzureServiceBusTopicResource"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("withTopicProperties", MethodName = "withProperties", Description = "Configures properties of an Azure Service Bus topic")]
+    [AspireExport("withTopicProperties", MethodName = "withProperties", Description = "Configures properties of an Azure Service Bus topic", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<AzureServiceBusTopicResource> WithProperties(this IResourceBuilder<AzureServiceBusTopicResource> builder, Action<AzureServiceBusTopicResource> configure)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -340,7 +340,7 @@ public static class AzureServiceBusExtensions
     /// <param name="builder">The Azure Service Bus Subscription resource builder.</param>
     /// <param name="configure">A method that can be used for customizing the <see cref="AzureServiceBusSubscriptionResource"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("withSubscriptionProperties", MethodName = "withProperties", Description = "Configures properties of an Azure Service Bus subscription")]
+    [AspireExport("withSubscriptionProperties", MethodName = "withProperties", Description = "Configures properties of an Azure Service Bus subscription", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<AzureServiceBusSubscriptionResource> WithProperties(this IResourceBuilder<AzureServiceBusSubscriptionResource> builder, Action<AzureServiceBusSubscriptionResource> configure)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -376,7 +376,7 @@ public static class AzureServiceBusExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    [AspireExport("runAsEmulator", Description = "Configures the Azure Service Bus resource to run with the local emulator")]
+    [AspireExport("runAsEmulator", Description = "Configures the Azure Service Bus resource to run with the local emulator", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<AzureServiceBusResource> RunAsEmulator(this IResourceBuilder<AzureServiceBusResource> builder, Action<IResourceBuilder<AzureServiceBusEmulatorResource>>? configureContainer = null)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
+++ b/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
@@ -140,7 +140,7 @@ public static class AzureSignalRExtensions
     /// <param name="builder">The Azure SignalR resource builder.</param>
     /// <param name="configureContainer">Callback that exposes underlying container used for emulation to allow for customization.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("runAsEmulator", Description = "Configures an Azure SignalR resource to be emulated. This resource requires an  to be added to the application model. Please note that the resource will be emulated in Serverless mode.", RunSyncOnBackgroundThread = true)]
+    [AspireExport("runAsEmulator", Description = "Configures an Azure SignalR resource to be emulated. This resource requires an Azure SignalR resource to be added to the application model. Please note that the resource will be emulated in Serverless mode.", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<AzureSignalRResource> RunAsEmulator(this IResourceBuilder<AzureSignalRResource> builder, Action<IResourceBuilder<AzureSignalREmulatorResource>>? configureContainer = null)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
+++ b/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
@@ -140,7 +140,7 @@ public static class AzureSignalRExtensions
     /// <param name="builder">The Azure SignalR resource builder.</param>
     /// <param name="configureContainer">Callback that exposes underlying container used for emulation to allow for customization.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("runAsEmulator", Description = "Configures an Azure SignalR resource to be emulated. This resource requires an  to be added to the application model. Please note that the resource will be emulated in Serverless mode.")]
+    [AspireExport("runAsEmulator", Description = "Configures an Azure SignalR resource to be emulated. This resource requires an  to be added to the application model. Please note that the resource will be emulated in Serverless mode.", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<AzureSignalRResource> RunAsEmulator(this IResourceBuilder<AzureSignalRResource> builder, Action<IResourceBuilder<AzureSignalREmulatorResource>>? configureContainer = null)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
@@ -172,7 +172,7 @@ public static class AzureSqlExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    [AspireExport("runAsContainer", Description = "Configures the Azure SQL server to run locally in a SQL Server container")]
+    [AspireExport("runAsContainer", Description = "Configures the Azure SQL server to run locally in a SQL Server container", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<AzureSqlServerResource> RunAsContainer(this IResourceBuilder<AzureSqlServerResource> builder, Action<IResourceBuilder<SqlServerServerResource>>? configureContainer = null)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -174,7 +174,7 @@ public static class AzureStorageExtensions
     /// <param name="builder">The Azure storage resource builder.</param>
     /// <param name="configureContainer">Callback that exposes underlying container used for emulation to allow for customization.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("runAsEmulator", Description = "Configures the Azure Storage resource to be emulated using Azurite")]
+    [AspireExport("runAsEmulator", Description = "Configures the Azure Storage resource to be emulated using Azurite", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<AzureStorageResource> RunAsEmulator(this IResourceBuilder<AzureStorageResource> builder, Action<IResourceBuilder<AzureStorageEmulatorResource>>? configureContainer = null)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentExtensions.cs
@@ -62,7 +62,7 @@ public static class DockerComposeEnvironmentExtensions
     /// <param name="builder">The Docker Compose environment resource builder.</param>
     /// <param name="configure">A method that can be used for customizing the <see cref="DockerComposeEnvironmentResource"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("withProperties", Description = "Configures properties of the Docker Compose environment")]
+    [AspireExport("withProperties", Description = "Configures properties of the Docker Compose environment", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<DockerComposeEnvironmentResource> WithProperties(this IResourceBuilder<DockerComposeEnvironmentResource> builder, Action<DockerComposeEnvironmentResource> configure)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -135,7 +135,7 @@ public static class DockerComposeEnvironmentExtensions
     /// <param name="builder">The Docker Compose environment resource builder.</param>
     /// <param name="configure">A method that can be used for customizing the dashboard service.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("configureDashboard", MethodName = "configureDashboard", Description = "Configures the Aspire dashboard resource for the Docker Compose environment")]
+    [AspireExport("configureDashboard", MethodName = "configureDashboard", Description = "Configures the Aspire dashboard resource for the Docker Compose environment", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<DockerComposeEnvironmentResource> WithDashboard(this IResourceBuilder<DockerComposeEnvironmentResource> builder, Action<IResourceBuilder<DockerComposeAspireDashboardResource>> configure)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
@@ -90,7 +90,7 @@ public static class KafkaBuilderExtensions
     /// <param name="configureContainer">Configuration callback for KafkaUI container resource.</param>
     /// <param name="containerName">The name of the container (Optional).</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{KafkaServerResource}"/>.</returns>
-    [AspireExport("withKafkaUI", Description = "Adds a Kafka UI container to manage the Kafka resource")]
+    [AspireExport("withKafkaUI", Description = "Adds a Kafka UI container to manage the Kafka resource", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<KafkaServerResource> WithKafkaUI(this IResourceBuilder<KafkaServerResource> builder, Action<IResourceBuilder<KafkaUIContainerResource>>? configureContainer = null, string? containerName = null)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentExtensions.cs
@@ -57,7 +57,7 @@ public static class KubernetesEnvironmentExtensions
     /// <param name="builder">The Kubernetes environment resource builder.</param>
     /// <param name="configure">A method that can be used for customizing the <see cref="KubernetesEnvironmentResource"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("withProperties", Description = "Configures properties of a Kubernetes environment")]
+    [AspireExport("withProperties", Description = "Configures properties of a Kubernetes environment", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<KubernetesEnvironmentResource> WithProperties(this IResourceBuilder<KubernetesEnvironmentResource> builder, Action<KubernetesEnvironmentResource> configure)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.Milvus/MilvusBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Milvus/MilvusBuilderExtensions.cs
@@ -130,7 +130,7 @@ public static class MilvusBuilderExtensions
     /// <param name="configureContainer">Configuration callback for Attu container resource.</param>
     /// <param name="containerName">The name of the container (Optional).</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("withAttu", Description = "Adds the Attu administration tool for Milvus.")]
+    [AspireExport("withAttu", Description = "Adds the Attu administration tool for Milvus.", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<T> WithAttu<T>(this IResourceBuilder<T> builder, Action<IResourceBuilder<AttuResource>>? configureContainer = null, string? containerName = null) where T : MilvusServerResource
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
@@ -149,7 +149,7 @@ public static class MongoDBBuilderExtensions
     /// <param name="configureContainer">Configuration callback for Mongo Express container resource.</param>
     /// <param name="containerName">The name of the container (Optional).</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("withMongoExpress", Description = "Adds a MongoExpress administration platform for MongoDB")]
+    [AspireExport("withMongoExpress", Description = "Adds a MongoExpress administration platform for MongoDB", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<T> WithMongoExpress<T>(this IResourceBuilder<T> builder, Action<IResourceBuilder<MongoExpressContainerResource>>? configureContainer = null, string? containerName = null)
         where T : MongoDBServerResource
     {

--- a/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
@@ -220,7 +220,7 @@ public static class MySqlBuilderExtensions
     /// <param name="configureContainer">Callback to configure PhpMyAdmin container resource.</param>
     /// <param name="containerName">The name of the container (Optional).</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("withPhpMyAdmin", Description = "Adds phpMyAdmin management UI")]
+    [AspireExport("withPhpMyAdmin", Description = "Adds phpMyAdmin management UI", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<T> WithPhpMyAdmin<T>(this IResourceBuilder<T> builder, Action<IResourceBuilder<PhpMyAdminContainerResource>>? configureContainer = null, string? containerName = null) where T : MySqlServerResource
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -183,7 +183,7 @@ public static class PostgresBuilderExtensions
     /// <param name="configureContainer">Callback to configure PgAdmin container resource.</param>
     /// <param name="containerName">The name of the container (Optional).</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("withPgAdmin", Description = "Adds pgAdmin 4 management UI")]
+    [AspireExport("withPgAdmin", Description = "Adds pgAdmin 4 management UI", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<T> WithPgAdmin<T>(this IResourceBuilder<T> builder, Action<IResourceBuilder<PgAdminContainerResource>>? configureContainer = null, string? containerName = null)
         where T : PostgresServerResource
     {
@@ -293,7 +293,7 @@ public static class PostgresBuilderExtensions
     /// </example>
     /// </remarks>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("withPgWeb", Description = "Adds pgweb management UI")]
+    [AspireExport("withPgWeb", Description = "Adds pgweb management UI", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<PostgresServerResource> WithPgWeb(this IResourceBuilder<PostgresServerResource> builder, Action<IResourceBuilder<PgWebContainerResource>>? configureContainer = null, string? containerName = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -361,7 +361,7 @@ public static class PostgresBuilderExtensions
     /// This version of the package defaults to the <inheritdoc cref="PostgresContainerImageTags.PostgresMcpTag"/> tag of the <inheritdoc cref="PostgresContainerImageTags.PostgresMcpImage"/> container image.
     /// </remarks>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("withPostgresMcp", Description = "Adds Postgres MCP server")]
+    [AspireExport("withPostgresMcp", Description = "Adds Postgres MCP server", RunSyncOnBackgroundThread = true)]
     [Experimental("ASPIREPOSTGRES001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static IResourceBuilder<PostgresDatabaseResource> WithPostgresMcp(
         this IResourceBuilder<PostgresDatabaseResource> builder,

--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -209,7 +209,7 @@ public static class RedisBuilderExtensions
     /// <param name="configureContainer">Configuration callback for Redis Commander container resource.</param>
     /// <param name="containerName">Override the container name used for Redis Commander.</param>
     /// <returns></returns>
-    [AspireExport("withRedisCommander", Description = "Adds Redis Commander management UI")]
+    [AspireExport("withRedisCommander", Description = "Adds Redis Commander management UI", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<RedisResource> WithRedisCommander(this IResourceBuilder<RedisResource> builder, Action<IResourceBuilder<RedisCommanderResource>>? configureContainer = null, string? containerName = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -287,7 +287,7 @@ public static class RedisBuilderExtensions
     /// <param name="configureContainer">Configuration callback for Redis Insight container resource.</param>
     /// <param name="containerName">Override the container name used for Redis Insight.</param>
     /// <returns></returns>
-    [AspireExport("withRedisInsight", Description = "Adds Redis Insight management UI")]
+    [AspireExport("withRedisInsight", Description = "Adds Redis Insight management UI", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<RedisResource> WithRedisInsight(this IResourceBuilder<RedisResource> builder, Action<IResourceBuilder<RedisInsightResource>>? configureContainer = null, string? containerName = null)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
@@ -307,15 +307,7 @@ internal sealed class CapabilityDispatcher
             var invokeTarget = ResolveContextTarget(contextObj!, methodToInvoke.DeclaringType!);
 
             object? result;
-            try
-            {
-                // Invoke instance method on the context object
-                result = methodToInvoke.Invoke(invokeTarget, methodArgs);
-            }
-            catch (TargetInvocationException tie) when (tie.InnerException is not null)
-            {
-                throw tie.InnerException;
-            }
+            result = await InvokeMethodAsync(methodToInvoke, invokeTarget, methodArgs, capability.RunSyncOnBackgroundThread).ConfigureAwait(false);
 
             // Handle async methods - await instead of blocking
             if (result is Task task)
@@ -399,15 +391,7 @@ internal sealed class CapabilityDispatcher
             }
 
             object? result;
-            try
-            {
-                result = methodToInvoke.Invoke(null, methodArgs);
-            }
-            catch (TargetInvocationException tie) when (tie.InnerException is not null)
-            {
-                // Unwrap the TargetInvocationException to get the actual exception
-                throw tie.InnerException;
-            }
+            result = await InvokeMethodAsync(methodToInvoke, target: null, methodArgs, capability.RunSyncOnBackgroundThread).ConfigureAwait(false);
 
             // Handle async methods - await instead of blocking
             if (result is Task task)
@@ -517,6 +501,28 @@ internal sealed class CapabilityDispatcher
     public JsonNode? Invoke(string capabilityId, JsonObject? args)
     {
         return InvokeAsync(capabilityId, args).GetAwaiter().GetResult();
+    }
+
+    private static async Task<object?> InvokeMethodAsync(MethodInfo method, object? target, object?[] methodArgs, bool runSyncOnBackgroundThread)
+    {
+        if (runSyncOnBackgroundThread && !typeof(Task).IsAssignableFrom(method.ReturnType))
+        {
+            return await Task.Run(() => InvokeMethodCore(method, target, methodArgs)).ConfigureAwait(false);
+        }
+
+        return InvokeMethodCore(method, target, methodArgs);
+    }
+
+    private static object? InvokeMethodCore(MethodInfo method, object? target, object?[] methodArgs)
+    {
+        try
+        {
+            return method.Invoke(target, methodArgs);
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException is not null)
+        {
+            throw tie.InnerException;
+        }
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
@@ -103,7 +103,7 @@ public static class YarpResourceExtensions
     /// </summary>
     /// <param name="builder">The YARP resource to configure.</param>
     /// <param name="configurationBuilder">The delegate to configure YARP.</param>
-    [AspireExport("withConfiguration", Description = "Configure the YARP resource.")]
+    [AspireExport("withConfiguration", Description = "Configure the YARP resource.", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<YarpResource> WithConfiguration(this IResourceBuilder<YarpResource> builder, Action<IYarpConfigurationBuilder> configurationBuilder)
     {
         var configBuilder = new YarpConfigurationBuilder(builder);

--- a/src/Aspire.Hosting/Ats/AspireExportAttribute.cs
+++ b/src/Aspire.Hosting/Ats/AspireExportAttribute.cs
@@ -206,4 +206,21 @@ public sealed class AspireExportAttribute : Attribute
     /// </para>
     /// </remarks>
     public bool ExposeMethods { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether synchronous exported methods should be invoked on a background thread by the ATS dispatcher.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Set this to <see langword="true"/> for synchronous exports that may invoke synchronous callback delegates which in turn
+    /// re-enter the remote host through ATS. Running the export on a background thread allows the JSON-RPC request loop to
+    /// continue processing nested callback and capability invocations while the synchronous method waits for the callback to
+    /// complete.
+    /// </para>
+    /// <para>
+    /// This setting only affects synchronous exported methods. Async exports that already return <see cref="Task"/> or
+    /// <see cref="Task{TResult}"/> are awaited normally and do not use this option.
+    /// </para>
+    /// </remarks>
+    public bool RunSyncOnBackgroundThread { get; set; }
 }

--- a/src/Aspire.Hosting/Ats/AspireExportAttribute.cs
+++ b/src/Aspire.Hosting/Ats/AspireExportAttribute.cs
@@ -221,6 +221,10 @@ public sealed class AspireExportAttribute : Attribute
     /// This setting only affects synchronous exported methods. Async exports that already return <see cref="Task"/> or
     /// <see cref="Task{TResult}"/> are awaited normally and do not use this option.
     /// </para>
+    /// <para>
+    /// When applied to a type, this setting also applies to exported members discovered from that type unless an individual
+    /// member overrides it.
+    /// </para>
     /// </remarks>
     public bool RunSyncOnBackgroundThread { get; set; }
 }

--- a/src/Aspire.Hosting/Ats/AtsCapabilityInfo.cs
+++ b/src/Aspire.Hosting/Ats/AtsCapabilityInfo.cs
@@ -249,6 +249,11 @@ public sealed class AtsCapabilityInfo
     /// Format: "TypeName.MethodName" or "TypeName.PropertyName" for diagnostics.
     /// </remarks>
     public string? SourceLocation { get; init; }
+
+    /// <summary>
+    /// Gets or sets whether synchronous invocations of this capability should run on a background thread.
+    /// </summary>
+    public bool RunSyncOnBackgroundThread { get; init; }
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/Ats/AtsCapabilityScanner.cs
+++ b/src/Aspire.Hosting/Ats/AtsCapabilityScanner.cs
@@ -1020,6 +1020,7 @@ internal static class AtsCapabilityScanner
         // Check for ExposeProperties and ExposeMethods flags
         var exposeAllProperties = HasExposePropertiesAttribute(contextType);
         var exposeAllMethods = HasExposeMethodsAttribute(contextType);
+        var typeExportAttr = GetAspireExportAttribute(contextType);
 
         // Scan properties
         foreach (var property in contextType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
@@ -1142,7 +1143,7 @@ internal static class AtsCapabilityScanner
                         OwningTypeName = typeName,
                         Description = $"Gets the {property.Name} property",
                         Parameters = [
-                            new AtsParameterInfo
+                           new AtsParameterInfo
                             {
                                 Name = "context",
                                 Type = contextTypeRef,
@@ -1151,14 +1152,15 @@ internal static class AtsCapabilityScanner
                                 IsCallback = false,
                                 DefaultValue = null
                             }
-                        ],
+                       ],
                         ReturnType = propertyTypeRef!,
                         TargetTypeId = typeId,
                         TargetType = contextTypeRef,
                         TargetParameterName = "context",
                         ReturnsBuilder = false,
                         CapabilityKind = AtsCapabilityKind.PropertyGetter,
-                        SourceLocation = $"{fullName}.{property.Name}"
+                        SourceLocation = $"{fullName}.{property.Name}",
+                        RunSyncOnBackgroundThread = false
                     });
 
                     // Register property for runtime dispatch
@@ -1179,7 +1181,7 @@ internal static class AtsCapabilityScanner
                         OwningTypeName = typeName,
                         Description = $"Sets the {property.Name} property",
                         Parameters = [
-                            new AtsParameterInfo
+                           new AtsParameterInfo
                             {
                                 Name = "context",
                                 Type = contextTypeRef,
@@ -1197,14 +1199,15 @@ internal static class AtsCapabilityScanner
                                 IsCallback = false,
                                 DefaultValue = null
                             }
-                        ],
+                       ],
                         ReturnType = contextTypeRef,
                         TargetTypeId = typeId,
                         TargetType = contextTypeRef,
                         TargetParameterName = "context",
                         ReturnsBuilder = false,
                         CapabilityKind = AtsCapabilityKind.PropertySetter,
-                        SourceLocation = $"{fullName}.{property.Name}"
+                        SourceLocation = $"{fullName}.{property.Name}",
+                        RunSyncOnBackgroundThread = false
                     });
 
                     // Register property for runtime dispatch
@@ -1261,6 +1264,8 @@ internal static class AtsCapabilityScanner
             // Check if method should be exported
             // ExposeMethods=true exports public only; explicit [AspireExport] can export internal too
             var memberExportAttr = GetAspireExportAttribute(method);
+            var effectiveRunSyncOnBackgroundThread = (memberExportAttr?.RunSyncOnBackgroundThread ?? false) ||
+                (typeExportAttr?.RunSyncOnBackgroundThread ?? false);
             if (!ShouldExportMember(method.IsPublic, exposeAllMethods, memberExportAttr))
             {
                 continue;
@@ -1354,7 +1359,8 @@ internal static class AtsCapabilityScanner
                     TargetParameterName = "context",
                     ReturnsBuilder = false,
                     CapabilityKind = AtsCapabilityKind.InstanceMethod,
-                    SourceLocation = $"{contextType.FullName}.{method.Name}"
+                    SourceLocation = $"{contextType.FullName}.{method.Name}",
+                    RunSyncOnBackgroundThread = effectiveRunSyncOnBackgroundThread
                 });
 
                 // Register method for runtime dispatch
@@ -1476,7 +1482,9 @@ internal static class AtsCapabilityScanner
             TargetType = extendsTypeRef,
             TargetParameterName = targetParameterName,
             ReturnsBuilder = returnsBuilder,
-            SourceLocation = methodLocation
+            SourceLocation = methodLocation,
+            RunSyncOnBackgroundThread = exportAttr.RunSyncOnBackgroundThread ||
+                (method.DeclaringType is not null && (GetAspireExportAttribute(method.DeclaringType)?.RunSyncOnBackgroundThread ?? false))
         };
     }
 

--- a/src/Aspire.Hosting/Ats/AttributeDataReader.cs
+++ b/src/Aspire.Hosting/Ats/AttributeDataReader.cs
@@ -127,6 +127,7 @@ internal static class AttributeDataReader
         string? methodName = null;
         var exposeProperties = false;
         var exposeMethods = false;
+        var runSyncOnBackgroundThread = false;
 
         for (var i = 0; i < data.NamedArguments.Count; i++)
         {
@@ -157,6 +158,12 @@ internal static class AttributeDataReader
                         exposeMethods = em;
                     }
                     break;
+                case nameof(AspireExportData.RunSyncOnBackgroundThread):
+                    if (named.TypedValue.Value is bool rs)
+                    {
+                        runSyncOnBackgroundThread = rs;
+                    }
+                    break;
             }
         }
 
@@ -167,7 +174,8 @@ internal static class AttributeDataReader
             Description = description,
             MethodName = methodName,
             ExposeProperties = exposeProperties,
-            ExposeMethods = exposeMethods
+            ExposeMethods = exposeMethods,
+            RunSyncOnBackgroundThread = runSyncOnBackgroundThread
         };
     }
 
@@ -244,6 +252,11 @@ internal sealed class AspireExportData
     /// Gets whether to expose public instance methods of this type as ATS capabilities.
     /// </summary>
     public bool ExposeMethods { get; init; }
+
+    /// <summary>
+    /// Gets whether synchronous exported methods should be invoked on a background thread by the ATS dispatcher.
+    /// </summary>
+    public bool RunSyncOnBackgroundThread { get; init; }
 }
 
 /// <summary>

--- a/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
+++ b/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
@@ -389,6 +389,103 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
+    public async Task ExportedBuilderMethod_InvokesSyncCallbackInsideImmediatelyInvokedLambda_ReportsASPIREEXPORT010()
+    {
+        var diagnostic = AspireExportAnalyzer.Diagnostics.s_exportedSyncDelegateInvokedInline;
+
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using System;
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public sealed class TestResource(string name) : Resource(name);
+            public sealed class TestContext;
+
+            public static class TestExports
+            {
+                [AspireExport("withInlineLambdaCallback")]
+                public static IResourceBuilder<TestResource> WithInlineLambdaCallback(this IResourceBuilder<TestResource> builder, Action<TestContext> callback)
+                {
+                    ((Action)(() => callback(new TestContext())))();
+                    return builder;
+                }
+            }
+            """,
+            [new DiagnosticResult(diagnostic).WithLocation(15, 25).WithArguments("WithInlineLambdaCallback", "callback")]);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExportedBuilderMethod_PassesActionIntoDeferredLocalFunction_NoDiagnostics()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using System;
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public sealed class TestResource(string name) : Resource(name);
+            public sealed class TestContext;
+
+            public sealed class TestAnnotation : IResourceAnnotation
+            {
+                public TestAnnotation(Action<TestContext> callback) { }
+            }
+
+            public static class TestExports
+            {
+                [AspireExport("withDeferredLocalFunction")]
+                public static IResourceBuilder<TestResource> WithDeferredLocalFunction(this IResourceBuilder<TestResource> builder, Action<TestContext> callback)
+                {
+                    void InvokeCallback(TestContext context) => callback(context);
+                    return builder.WithAnnotation(new TestAnnotation(InvokeCallback));
+                }
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExportedBuilderMethod_InvokesSyncCallbackInsideInlineLocalFunction_ReportsASPIREEXPORT010()
+    {
+        var diagnostic = AspireExportAnalyzer.Diagnostics.s_exportedSyncDelegateInvokedInline;
+
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using System;
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public sealed class TestResource(string name) : Resource(name);
+            public sealed class TestContext;
+
+            public static class TestExports
+            {
+                [AspireExport("withInlineLocalFunction")]
+                public static IResourceBuilder<TestResource> WithInlineLocalFunction(this IResourceBuilder<TestResource> builder, Action<TestContext> callback)
+                {
+                    void InvokeCallback()
+                    {
+                        callback(new TestContext());
+                    }
+
+                    InvokeCallback();
+                    return builder;
+                }
+            }
+            """,
+            [new DiagnosticResult(diagnostic).WithLocation(17, 13).WithArguments("WithInlineLocalFunction", "callback")]);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
     public async Task ExportedBuilderMethod_WithBackgroundThreadOptIn_NoASPIREEXPORT010()
     {
         var test = AnalyzerTest.Create<AspireExportAnalyzer>("""

--- a/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
+++ b/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
@@ -268,6 +268,210 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
+    public async Task ExportedBuilderMethod_InvokesActionInline_ReportsASPIREEXPORT010()
+    {
+        var diagnostic = AspireExportAnalyzer.Diagnostics.s_exportedSyncDelegateInvokedInline;
+
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using System;
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public sealed class TestResource(string name) : Resource(name);
+            public sealed class TestContext;
+
+            public static class TestExports
+            {
+                [AspireExport("withInlineCallback")]
+                public static IResourceBuilder<TestResource> WithInlineCallback(this IResourceBuilder<TestResource> builder, Action<TestContext> callback)
+                {
+                    callback(new TestContext());
+                    return builder;
+                }
+            }
+            """,
+            [new DiagnosticResult(diagnostic).WithLocation(15, 9).WithArguments("WithInlineCallback", "callback")]);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExportedBuilderMethod_InvokesNullableActionViaInvoke_ReportsASPIREEXPORT010()
+    {
+        var diagnostic = AspireExportAnalyzer.Diagnostics.s_exportedSyncDelegateInvokedInline;
+
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using System;
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public sealed class TestResource(string name) : Resource(name);
+            public sealed class TestContext;
+
+            public static class TestExports
+            {
+                [AspireExport("withInlineOptionalCallback")]
+                public static IResourceBuilder<TestResource> WithInlineOptionalCallback(this IResourceBuilder<TestResource> builder, Action<TestContext>? callback)
+                {
+                    callback?.Invoke(new TestContext());
+                    return builder;
+                }
+            }
+            """,
+            [new DiagnosticResult(diagnostic).WithLocation(15, 18).WithArguments("WithInlineOptionalCallback", "callback")]);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExportedBuilderMethod_InvokesSyncFuncInline_ReportsASPIREEXPORT010()
+    {
+        var diagnostic = AspireExportAnalyzer.Diagnostics.s_exportedSyncDelegateInvokedInline;
+
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using System;
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public sealed class TestResource(string name) : Resource(name);
+            public sealed class TestContext;
+
+            public static class TestExports
+            {
+                [AspireExport("withInlineFunc")]
+                public static IResourceBuilder<TestResource> WithInlineFunc(this IResourceBuilder<TestResource> builder, Func<TestContext, string> callback)
+                {
+                    _ = callback(new TestContext());
+                    return builder;
+                }
+            }
+            """,
+            [new DiagnosticResult(diagnostic).WithLocation(15, 13).WithArguments("WithInlineFunc", "callback")]);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExportedBuilderMethod_PassesActionIntoDeferredLambda_NoDiagnostics()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using System;
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public sealed class TestResource(string name) : Resource(name);
+            public sealed class TestContext;
+
+            public sealed class TestAnnotation : IResourceAnnotation
+            {
+                public TestAnnotation(Action<TestContext> callback) { }
+            }
+
+            public static class TestExports
+            {
+                [AspireExport("withDeferredCallback")]
+                public static IResourceBuilder<TestResource> WithDeferredCallback(this IResourceBuilder<TestResource> builder, Action<TestContext> callback)
+                {
+                    return builder.WithAnnotation(new TestAnnotation(ctx => callback(ctx)));
+                }
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExportedBuilderMethod_WithBackgroundThreadOptIn_NoASPIREEXPORT010()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using System;
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public sealed class TestResource(string name) : Resource(name);
+            public sealed class TestContext;
+
+            public static class TestExports
+            {
+                [AspireExport("withInlineCallback", RunSyncOnBackgroundThread = true)]
+                public static IResourceBuilder<TestResource> WithInlineCallback(this IResourceBuilder<TestResource> builder, Action<TestContext> callback)
+                {
+                    callback(new TestContext());
+                    return builder;
+                }
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExportedBuilderMethod_WithContainingTypeBackgroundThreadOptIn_NoASPIREEXPORT010()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using System;
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public sealed class TestResource(string name) : Resource(name);
+            public sealed class TestContext;
+
+            [AspireExport(RunSyncOnBackgroundThread = true)]
+            public static class TestExports
+            {
+                [AspireExport("withInlineCallback")]
+                public static IResourceBuilder<TestResource> WithInlineCallback(this IResourceBuilder<TestResource> builder, Action<TestContext> callback)
+                {
+                    callback(new TestContext());
+                    return builder;
+                }
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExportedBuilderMethod_InvokesAsyncCallbackInline_NoDiagnostics()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using System;
+            using System.Threading.Tasks;
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public sealed class TestResource(string name) : Resource(name);
+            public sealed class TestContext;
+
+            public static class TestExports
+            {
+                [AspireExport("withAsyncCallback")]
+                public static async Task<IResourceBuilder<TestResource>> WithAsyncCallback(this IResourceBuilder<TestResource> builder, Func<TestContext, Task> callback)
+                {
+                    await callback(new TestContext());
+                    return builder;
+                }
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
     public async Task ValidBuilderParameter_NoDiagnostics()
     {
         var test = AnalyzerTest.Create<AspireExportAnalyzer>("""

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/AddTestRedisCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/AddTestRedisCapability.verified.txt
@@ -70,5 +70,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.AddTestRedis
+  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.AddTestRedis,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/HostingAddContainerCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/HostingAddContainerCapability.verified.txt
@@ -70,5 +70,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.ContainerResourceBuilderExtensions.AddContainer
+  SourceLocation: Aspire.Hosting.ContainerResourceBuilderExtensions.AddContainer,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/WithOptionalStringCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/WithOptionalStringCapability.verified.txt
@@ -91,5 +91,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithOptionalString
+  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithOptionalString,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/WithPersistenceCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/WithPersistenceCapability.verified.txt
@@ -57,5 +57,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithPersistence
+  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithPersistence,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/AddTestRedisCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/AddTestRedisCapability.verified.txt
@@ -70,5 +70,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.AddTestRedis
+  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.AddTestRedis,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/HostingAddContainerCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/HostingAddContainerCapability.verified.txt
@@ -70,5 +70,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.ContainerResourceBuilderExtensions.AddContainer
+  SourceLocation: Aspire.Hosting.ContainerResourceBuilderExtensions.AddContainer,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/WithOptionalStringCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/WithOptionalStringCapability.verified.txt
@@ -91,5 +91,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithOptionalString
+  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithOptionalString,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/WithPersistenceCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/WithPersistenceCapability.verified.txt
@@ -57,5 +57,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithPersistence
+  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithPersistence,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/AddTestRedisCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/AddTestRedisCapability.verified.txt
@@ -70,5 +70,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.AddTestRedis
+  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.AddTestRedis,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/HostingAddContainerCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/HostingAddContainerCapability.verified.txt
@@ -70,5 +70,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.ContainerResourceBuilderExtensions.AddContainer
+  SourceLocation: Aspire.Hosting.ContainerResourceBuilderExtensions.AddContainer,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/WithOptionalStringCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/WithOptionalStringCapability.verified.txt
@@ -91,5 +91,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithOptionalString
+  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithOptionalString,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/WithPersistenceCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/WithPersistenceCapability.verified.txt
@@ -57,5 +57,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithPersistence
+  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithPersistence,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/AddTestRedisCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/AddTestRedisCapability.verified.txt
@@ -70,5 +70,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.AddTestRedis
+  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.AddTestRedis,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/HostingAddContainerCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/HostingAddContainerCapability.verified.txt
@@ -70,5 +70,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.ContainerResourceBuilderExtensions.AddContainer
+  SourceLocation: Aspire.Hosting.ContainerResourceBuilderExtensions.AddContainer,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/WithOptionalStringCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/WithOptionalStringCapability.verified.txt
@@ -91,5 +91,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithOptionalString
+  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithOptionalString,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/WithPersistenceCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/WithPersistenceCapability.verified.txt
@@ -57,5 +57,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithPersistence
+  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithPersistence,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/AddTestRedisCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/AddTestRedisCapability.verified.txt
@@ -70,5 +70,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.AddTestRedis
+  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.AddTestRedis,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/HostingAddContainerCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/HostingAddContainerCapability.verified.txt
@@ -70,5 +70,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.ContainerResourceBuilderExtensions.AddContainer
+  SourceLocation: Aspire.Hosting.ContainerResourceBuilderExtensions.AddContainer,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/WithOptionalStringCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/WithOptionalStringCapability.verified.txt
@@ -91,5 +91,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithOptionalString
+  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithOptionalString,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/WithPersistenceCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/WithPersistenceCapability.verified.txt
@@ -57,5 +57,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithPersistence
+  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithPersistence,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/WithRedisSpecificCapability.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/WithRedisSpecificCapability.verified.txt
@@ -55,5 +55,6 @@
     }
   ],
   ReturnsBuilder: true,
-  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithRedisSpecific
+  SourceLocation: Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestExtensions.WithRedisSpecific,
+  RunSyncOnBackgroundThread: false
 }

--- a/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
@@ -655,6 +655,30 @@ public class CapabilityDispatcherTests
     }
 
     [Fact]
+    public void Invoke_SyncCapabilityWithoutBackgroundThreadOptIn_RunsInline()
+    {
+        var dispatcher = CreateDispatcher(typeof(TestCapabilitiesWithBackgroundThreadDispatch).Assembly);
+        var callerThreadId = Environment.CurrentManagedThreadId;
+
+        var result = dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/syncInlineThreadProbe", null);
+
+        Assert.NotNull(result);
+        Assert.Equal(callerThreadId, result.GetValue<int>());
+    }
+
+    [Fact]
+    public void Invoke_SyncCapabilityWithBackgroundThreadOptIn_RunsOnBackgroundThread()
+    {
+        var dispatcher = CreateDispatcher(typeof(TestCapabilitiesWithBackgroundThreadDispatch).Assembly);
+        var callerThreadId = Environment.CurrentManagedThreadId;
+
+        var result = dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/syncBackgroundThreadProbe", null);
+
+        Assert.NotNull(result);
+        Assert.NotEqual(callerThreadId, result.GetValue<int>());
+    }
+
+    [Fact]
     public void Invoke_MethodWithoutCallbackFactory_ThrowsForCallbackParameter()
     {
         var handles = new HandleRegistry();
@@ -1464,6 +1488,21 @@ internal static class TestCapabilitiesWithCallback
     public static int WithAsyncCallback(Func<Task<int>> callback)
     {
         return callback().GetAwaiter().GetResult();
+    }
+}
+
+internal static class TestCapabilitiesWithBackgroundThreadDispatch
+{
+    [AspireExport("syncInlineThreadProbe", Description = "Captures the current thread for inline sync invocation")]
+    public static int SyncInlineThreadProbe()
+    {
+        return Environment.CurrentManagedThreadId;
+    }
+
+    [AspireExport("syncBackgroundThreadProbe", Description = "Captures the current thread for background-thread sync invocation", RunSyncOnBackgroundThread = true)]
+    public static int SyncBackgroundThreadProbe()
+    {
+        return Environment.CurrentManagedThreadId;
     }
 }
 

--- a/tests/Aspire.Hosting.Tests/Ats/AtsCapabilityScannerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Ats/AtsCapabilityScannerTests.cs
@@ -246,6 +246,38 @@ public class AtsCapabilityScannerTests
         }
     }
 
+    [Fact]
+    public void ScanAssembly_YarpWithConfiguration_UsesBackgroundThreadOptIn()
+    {
+        var yarpAssembly = typeof(global::Aspire.Hosting.Yarp.YarpResource).Assembly;
+
+        var result = AtsCapabilityScanner.ScanAssembly(yarpAssembly);
+
+        var capability = Assert.Single(result.Capabilities,
+            c => c.CapabilityId.EndsWith("/withConfiguration", StringComparison.Ordinal));
+        var withConfigurationMethod = Assert.Single(result.Methods,
+            m => m.Key.EndsWith("/withConfiguration", StringComparison.Ordinal)).Value;
+
+        Assert.True(capability.RunSyncOnBackgroundThread);
+        Assert.Equal(typeof(IResourceBuilder<global::Aspire.Hosting.Yarp.YarpResource>), withConfigurationMethod.ReturnType);
+
+        var parameters = withConfigurationMethod.GetParameters();
+        Assert.Equal(2, parameters.Length);
+        Assert.Equal(typeof(IResourceBuilder<global::Aspire.Hosting.Yarp.YarpResource>), parameters[0].ParameterType);
+        Assert.Equal(typeof(Action<global::Aspire.Hosting.IYarpConfigurationBuilder>), parameters[1].ParameterType);
+    }
+
+    [Fact]
+    public void ScanAssembly_ClassLevelBackgroundThreadOptIn_AppliesToExportedMethods()
+    {
+        var result = AtsCapabilityScanner.ScanAssembly(typeof(AtsCapabilityScannerTests).Assembly);
+
+        var capability = Assert.Single(result.Capabilities,
+            c => c.CapabilityId.EndsWith("/classLevelBackgroundThreadProbe", StringComparison.Ordinal));
+
+        Assert.True(capability.RunSyncOnBackgroundThread);
+    }
+
     #endregion
 
     #region Test Types
@@ -280,6 +312,16 @@ public class AtsCapabilityScannerTests
         {
             _ = callback;
             return builder;
+        }
+    }
+
+    [AspireExport(RunSyncOnBackgroundThread = true)]
+    private static class ClassLevelBackgroundThreadExports
+    {
+        [AspireExport("classLevelBackgroundThreadProbe")]
+        public static void Probe(IDistributedApplicationBuilder builder)
+        {
+            _ = builder;
         }
     }
 


### PR DESCRIPTION
## Description

Introduce `RunSyncOnBackgroundThread` on `AspireExportAttribute` and flow it through ATS metadata and `CapabilityDispatcher` so selected synchronous exports are invoked via `Task.Run` and awaited by the interop layer. This allows sync exports that invoke callbacks to avoid polyglot deadlocks while preserving their synchronous C# API surface.

Update ASPIREEXPORT010 to skip diagnostics when the opt-in is present, and make class-level `AspireExport(RunSyncOnBackgroundThread = true)` apply to exported methods in the type. Replace the previous async export-overload workaround with targeted opt-ins on the affected exports and add regression coverage for scanner, dispatcher, and analyzer behavior.

Fix #15108

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
