### PR TITLE
Add Azure Functions debugging support to VS Code extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,6 @@ extension/package.nls.*.json
 
 # Playwright CLI artifacts
 .playwright-cli/
+
+# Azure Functions local settings (may contain encrypted secrets)
+local.settings.json

--- a/extension/src/capabilities.ts
+++ b/extension/src/capabilities.ts
@@ -14,7 +14,8 @@ export type Capability =
     | 'python' // Support for running Python projects
     | 'ms-python.python' // Older AppHost versions used this extension identifier instead of python
     | 'node' // Support for running Node.js projects
-    | 'browser'; // Support for browser debugging (built-in to VS Code via js-debug)
+    | 'browser' // Support for browser debugging (built-in to VS Code via js-debug)
+    | 'azure-functions'; // Support for running Azure Functions projects
 
 export type Capabilities = Capability[];
 
@@ -35,6 +36,10 @@ export function isPythonInstalled() {
     return isExtensionInstalled("ms-python.python");
 }
 
+export function isAzureFunctionsExtensionInstalled() {
+    return isExtensionInstalled("ms-azuretools.vscode-azurefunctions");
+}
+
 export function isNodeInstalled() {
     // Node.js debugging uses VS Code's built-in js-debug, no extension needed
     return true;
@@ -51,6 +56,12 @@ export function getSupportedCapabilities(): Capabilities {
     if (isCsharpInstalled()) {
         capabilities.push("project");
         capabilities.push("ms-dotnettools.csharp");
+
+        // Azure Functions debugging requires both C# (coreclr attach to the worker
+        // process) and the Azure Functions extension (to launch func host start).
+        if (isAzureFunctionsExtensionInstalled()) {
+            capabilities.push("azure-functions");
+        }
     }
 
     if (isPythonInstalled()) {

--- a/extension/src/dcp/AspireDcpServer.ts
+++ b/extension/src/dcp/AspireDcpServer.ts
@@ -6,7 +6,8 @@ import { createSelfSignedCertAsync, generateToken } from '../utils/security';
 import { extensionLogOutputChannel } from '../utils/logging';
 import { AspireResourceDebugSession, DcpServerConnectionInfo, ErrorDetails, ErrorResponse, ProcessRestartedNotification, RunSessionNotification, RunSessionPayload, ServiceLogsNotification, SessionMessageNotification, SessionTerminatedNotification } from './types';
 import { AspireDebugSession } from '../debugger/AspireDebugSession';
-import { createDebugSessionConfiguration, ResourceDebuggerExtension } from '../debugger/debuggerExtensions';
+import { createDebugSessionConfiguration, getResourceDebuggerExtensions } from '../debugger/debuggerExtensions';
+import { killFuncProcess } from '../debugger/languages/azureFunctions';
 import { timingSafeEqual } from 'crypto';
 import { getRunSessionInfo, getSupportedCapabilities } from '../capabilities';
 import { authorizationAndDcpHeadersRequired, authorizationHeaderMustStartWithBearer, encounteredErrorStartingResource, invalidOrMissingToken, invalidTokenLength } from '../loc/strings';
@@ -35,7 +36,7 @@ export default class AspireDcpServer {
         this.pendingNotificationQueueByDcpId = pendingNotificationQueueByDcpId;
     }
 
-    static async create(debuggerExtensions: ResourceDebuggerExtension[], getDebugSession: (debugSessionId: string) => AspireDebugSession | null): Promise<AspireDcpServer> {
+    static async create(getDebugSession: (debugSessionId: string) => AspireDebugSession | null): Promise<AspireDcpServer> {
         const runsBySession = new Map<string, AspireResourceDebugSession[]>();
         const wsBySession = new Map<string, WebSocket>();
         const pendingNotificationQueueByDcpId = new Map<string, RunSessionNotification[]>();
@@ -106,7 +107,7 @@ export default class AspireDcpServer {
                 }
 
                 const launchConfig = payload.launch_configurations[0];
-                const foundDebuggerExtension = debuggerExtensions.find(ext => ext.resourceType === launchConfig.type) ?? null;
+                const foundDebuggerExtension = getResourceDebuggerExtensions().find(ext => ext.resourceType === launchConfig.type) ?? null;
 
                 if (!foundDebuggerExtension) {
                     const error: ErrorDetails = {
@@ -135,37 +136,73 @@ export default class AspireDcpServer {
                     return;
                 }
 
-                const config = await createDebugSessionConfiguration(
-                    aspireDebugSession.configuration,
-                    launchConfig,
-                    payload.args ?? [],
-                    payload.env ?? [],
-                    { debug: launchConfig.mode === "Debug", runId, debugSessionId: dcpId, isApphost: false, debugSession: aspireDebugSession },
-                    foundDebuggerExtension
-                );
+                try {
+                    const config = await createDebugSessionConfiguration(
+                        aspireDebugSession.configuration,
+                        launchConfig,
+                        payload.args ?? [],
+                        payload.env ?? [],
+                        { debug: launchConfig.mode === "Debug", runId, debugSessionId: dcpId, isApphost: false, debugSession: aspireDebugSession },
+                        foundDebuggerExtension
+                    );
 
-                const resourceDebugSession = await aspireDebugSession.startAndGetDebugSession(config);
+                    const resourceDebugSession = await aspireDebugSession.startAndGetDebugSession(config);
 
-                if (!resourceDebugSession) {
+                    if (!resourceDebugSession) {
+                        // Clean up any background func process that may have been started
+                        killFuncProcess(runId);
+
+                        const error: ErrorDetails = {
+                            code: 'DebugSessionFailed',
+                            message: `Failed to start debug session for run ID ${runId}`,
+                            details: []
+                        };
+
+                        extensionLogOutputChannel.error(`Error creating debug session ${runId}: ${error.message}`);
+                        const response: ErrorResponse = { error };
+                        respondWithError(res, 500, response);
+                        return;
+                    }
+
+                    processes.push(resourceDebugSession);
+                    extensionLogOutputChannel.info(`Debugging session created with ID: ${runId}`);
+
+                    runsBySession.set(runId, processes);
+                    res.status(201).set('Location', `https://${req.get('host')}/run_session/${runId}`).end();
+                    extensionLogOutputChannel.info(`New run session created with ID: ${runId}`);
+                } catch (err) {
+                    extensionLogOutputChannel.error(`Error creating debug session ${runId}: ${err}`);
+
+                    // Clean up any background func process that may have been started
+                    killFuncProcess(runId);
+
+                    // Notify DCP via WebSocket that the session terminated so it can update
+                    // resource state, AND respond with HTTP 500 so the original POST /run_session
+                    // request gets a proper error. Both are needed: the 500 tells DCP the launch
+                    // failed synchronously, while sessionTerminated handles async cleanup.
+                    const notification: SessionTerminatedNotification = {
+                        notification_type: 'sessionTerminated',
+                        session_id: runId,
+                        dcp_id: dcpId,
+                        exit_code: -1
+                    };
+
+                    const ws = wsBySession.get(dcpId);
+                    if (ws && ws.readyState === WebSocket.OPEN) {
+                        AspireDcpServer.sendNotificationCore(notification, ws);
+                    } else {
+                        pendingNotificationQueueByDcpId.set(dcpId, [...(pendingNotificationQueueByDcpId.get(dcpId) || []), notification]);
+                    }
+
                     const error: ErrorDetails = {
                         code: 'DebugSessionFailed',
-                        message: `Failed to start debug session for run ID ${runId}`,
+                        message: `Failed to start debug session for run ID ${runId}: ${err instanceof Error ? err.message : String(err)}`,
                         details: []
                     };
 
-                    extensionLogOutputChannel.error(`Error creating debug session ${runId}: ${error.message}`);
                     const response: ErrorResponse = { error };
                     respondWithError(res, 500, response);
-                    return;
                 }
-
-                processes.push(resourceDebugSession);
-                extensionLogOutputChannel.info(`Debugging session created with ID: ${runId}`);
-
-
-                runsBySession.set(runId, processes);
-                res.status(201).set('Location', `https://${req.get('host')}/run_session/${runId}`).end();
-                extensionLogOutputChannel.info(`New run session created with ID: ${runId}`);
             });
 
             app.delete('/run_session/:id', requireHeaders, async (req: Request, res: Response) => {

--- a/extension/src/dcp/AspireDcpServer.ts
+++ b/extension/src/dcp/AspireDcpServer.ts
@@ -7,7 +7,7 @@ import { extensionLogOutputChannel } from '../utils/logging';
 import { AspireResourceDebugSession, DcpServerConnectionInfo, ErrorDetails, ErrorResponse, ProcessRestartedNotification, RunSessionNotification, RunSessionPayload, ServiceLogsNotification, SessionMessageNotification, SessionTerminatedNotification } from './types';
 import { AspireDebugSession } from '../debugger/AspireDebugSession';
 import { createDebugSessionConfiguration, getResourceDebuggerExtensions } from '../debugger/debuggerExtensions';
-import { killFuncProcess } from '../debugger/languages/azureFunctions';
+import { cleanupRun } from '../debugger/runCleanupRegistry';
 import { timingSafeEqual } from 'crypto';
 import { getRunSessionInfo, getSupportedCapabilities } from '../capabilities';
 import { authorizationAndDcpHeadersRequired, authorizationHeaderMustStartWithBearer, encounteredErrorStartingResource, invalidOrMissingToken, invalidTokenLength } from '../loc/strings';
@@ -149,8 +149,8 @@ export default class AspireDcpServer {
                     const resourceDebugSession = await aspireDebugSession.startAndGetDebugSession(config);
 
                     if (!resourceDebugSession) {
-                        // Clean up any background func process that may have been started
-                        killFuncProcess(runId);
+                        // Clean up any processes associated with this run (registered by resource-type extensions)
+                        cleanupRun(runId);
 
                         const error: ErrorDetails = {
                             code: 'DebugSessionFailed',
@@ -173,8 +173,8 @@ export default class AspireDcpServer {
                 } catch (err) {
                     extensionLogOutputChannel.error(`Error creating debug session ${runId}: ${err}`);
 
-                    // Clean up any background func process that may have been started
-                    killFuncProcess(runId);
+                    // Clean up any processes associated with this run (registered by resource-type extensions)
+                    cleanupRun(runId);
 
                     // Notify DCP via WebSocket that the session terminated so it can update
                     // resource state, AND respond with HTTP 500 so the original POST /run_session

--- a/extension/src/dcp/types.ts
+++ b/extension/src/dcp/types.ts
@@ -66,6 +66,15 @@ export function isBrowserLaunchConfiguration(obj: any): obj is BrowserLaunchConf
     return obj && obj.type === 'browser';
 }
 
+export interface AzureFunctionsLaunchConfiguration extends ExecutableLaunchConfiguration {
+    type: "azure-functions";
+    project_path: string;
+}
+
+export function isAzureFunctionsLaunchConfiguration(obj: any): obj is AzureFunctionsLaunchConfiguration {
+    return obj && obj.type === 'azure-functions';
+}
+
 export interface EnvVar {
     name: string;
     value: string;

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -9,7 +9,7 @@ import { spawnCliProcess } from "./languages/cli";
 import { disconnectingFromSession, launchingWithAppHost, launchingWithDirectory, processExceptionOccurred, processExitedWithCode, aspireDashboard } from "../loc/strings";
 import { projectDebuggerExtension } from "./languages/dotnet";
 import { nodeDebuggerExtension } from "./languages/node";
-import { killFuncProcess } from "./languages/azureFunctions";
+import { cleanupRun } from "./runCleanupRegistry";
 import AspireRpcServer from "../server/AspireRpcServer";
 import { createDebugSessionConfiguration } from "./debuggerExtensions";
 import { AspireTerminalProvider } from "../utils/AspireTerminalProvider";
@@ -330,8 +330,8 @@ export class AspireDebugSession implements vscode.DebugAdapter {
             extensionLogOutputChannel.info(`Stopping debug session: ${session.name} (run id: ${session.configuration.runId})`);
             vscode.debug.stopDebugging(session);
 
-            // Kill any background process associated with this debug session (e.g. func host for Azure Functions)
-            killFuncProcess(debugConfig.runId);
+            // Run any cleanup registered by resource-type extensions (e.g. func host for Azure Functions)
+            cleanupRun(debugConfig.runId);
           };
 
           const vsCodeDebugSession: AspireResourceDebugSession = {

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -9,6 +9,7 @@ import { spawnCliProcess } from "./languages/cli";
 import { disconnectingFromSession, launchingWithAppHost, launchingWithDirectory, processExceptionOccurred, processExitedWithCode, aspireDashboard } from "../loc/strings";
 import { projectDebuggerExtension } from "./languages/dotnet";
 import { nodeDebuggerExtension } from "./languages/node";
+import { killFuncProcess } from "./languages/azureFunctions";
 import AspireRpcServer from "../server/AspireRpcServer";
 import { createDebugSessionConfiguration } from "./debuggerExtensions";
 import { AspireTerminalProvider } from "../utils/AspireTerminalProvider";
@@ -328,6 +329,9 @@ export class AspireDebugSession implements vscode.DebugAdapter {
           const disposalFunction = () => {
             extensionLogOutputChannel.info(`Stopping debug session: ${session.name} (run id: ${session.configuration.runId})`);
             vscode.debug.stopDebugging(session);
+
+            // Kill any background process associated with this debug session (e.g. func host for Azure Functions)
+            killFuncProcess(debugConfig.runId);
           };
 
           const vsCodeDebugSession: AspireResourceDebugSession = {

--- a/extension/src/debugger/debuggerExtensions.ts
+++ b/extension/src/debugger/debuggerExtensions.ts
@@ -4,10 +4,11 @@ import { debugProject, runProject } from "../loc/strings";
 import { mergeEnvs } from "../utils/environment";
 import { extensionLogOutputChannel } from "../utils/logging";
 import { projectDebuggerExtension } from "./languages/dotnet";
-import { isCsharpInstalled, isPythonInstalled } from "../capabilities";
+import { isAzureFunctionsExtensionInstalled, isCsharpInstalled, isPythonInstalled } from '../capabilities';
 import { pythonDebuggerExtension } from "./languages/python";
 import { nodeDebuggerExtension } from "./languages/node";
 import { browserDebuggerExtension } from "./languages/browser";
+import { azureFunctionsDebuggerExtension } from "./languages/azureFunctions";
 import { isDirectory } from "../utils/io";
 
 // Represents a resource-specific debugger extension for when the default session configuration is not sufficient to launch the resource.
@@ -69,6 +70,10 @@ export function getResourceDebuggerExtensions(): ResourceDebuggerExtension[] {
     const extensions = [];
     if (isCsharpInstalled()) {
         extensions.push(projectDebuggerExtension);
+
+        if (isAzureFunctionsExtensionInstalled()) {
+            extensions.push(azureFunctionsDebuggerExtension);
+        }
     }
 
     if (isPythonInstalled()) {

--- a/extension/src/debugger/languages/azureFunctions.ts
+++ b/extension/src/debugger/languages/azureFunctions.ts
@@ -1,0 +1,172 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { AspireResourceExtendedDebugConfiguration, ExecutableLaunchConfiguration, isAzureFunctionsLaunchConfiguration, AzureFunctionsLaunchConfiguration } from '../../dcp/types';
+import { invalidLaunchConfiguration } from '../../loc/strings';
+import { extensionLogOutputChannel } from '../../utils/logging';
+import { ResourceDebuggerExtension } from '../debuggerExtensions';
+
+const AF_EXTENSION_ID = 'ms-azuretools.vscode-azurefunctions';
+
+/**
+ * Result from the Azure Functions extension's startFuncProcess API.
+ * processId is a string — it's the PID of the dotnet worker process
+ * (found via pickChildProcess which searches for a child matching /(dotnet|func)/).
+ */
+interface StartFuncProcessResult {
+    processId: string;
+    success: boolean;
+    error?: string;
+}
+
+/**
+ * The Azure Functions extension API (v1.10.0).
+ * Obtained via the @microsoft/vscode-azext-utils API provider pattern:
+ *   ext.exports.getApi('~1.10.0') → AzureFunctionsApi
+ */
+interface AzureFunctionsApi {
+    apiVersion: string;
+    startFuncProcess(buildPath: string, args: string[], env: Record<string, string>): Promise<StartFuncProcessResult>;
+}
+
+interface AzureFunctionsApiProvider {
+    getApi(apiVersion: string): AzureFunctionsApi;
+}
+
+/** Tracks worker PIDs by runId for cleanup. */
+const workerPidsByRunId = new Map<string, number>();
+
+/** Tracks the VS Code Task executions (func host start) by runId for cleanup. */
+const taskExecutionsByRunId = new Map<string, vscode.TaskExecution>();
+
+/** Kill the func host task and worker process for the given runId, if any. */
+export function killFuncProcess(runId: string): void {
+    // Terminate the VS Code Task running "func host start"
+    const taskExecution = taskExecutionsByRunId.get(runId);
+    if (taskExecution) {
+        extensionLogOutputChannel.info(`Terminating func host task for runId ${runId}`);
+        taskExecution.terminate();
+        taskExecutionsByRunId.delete(runId);
+    }
+
+    // Also kill the worker PID directly in case task termination doesn't propagate
+    const pid = workerPidsByRunId.get(runId);
+    if (pid !== undefined) {
+        extensionLogOutputChannel.info(`Killing func worker process for runId ${runId} (pid: ${pid})`);
+        try {
+            process.kill(pid);
+        } catch {
+            // Process may already be dead
+        }
+        workerPidsByRunId.delete(runId);
+    }
+}
+
+async function getAzureFunctionsApi(): Promise<AzureFunctionsApi> {
+    const ext = vscode.extensions.getExtension(AF_EXTENSION_ID);
+    if (!ext) {
+        throw new Error(`Azure Functions extension (${AF_EXTENSION_ID}) is not installed`);
+    }
+    if (!ext.isActive) {
+        await ext.activate();
+    }
+
+    // The AF extension uses the @microsoft/vscode-azext-utils API provider
+    // pattern. ext.exports has a getApi(version) method that returns the actual API.
+    const provider = ext.exports as AzureFunctionsApiProvider;
+    if (typeof provider?.getApi !== 'function') {
+        throw new Error('Azure Functions extension does not expose the expected getApi provider');
+    }
+
+    return provider.getApi('~1.10.0');
+}
+
+export const azureFunctionsDebuggerExtension: ResourceDebuggerExtension = {
+    resourceType: 'azure-functions',
+    debugAdapter: 'coreclr',
+    extensionId: 'ms-dotnettools.csharp',
+    getDisplayName: (launchConfig: ExecutableLaunchConfiguration) => {
+        if (isAzureFunctionsLaunchConfiguration(launchConfig) && launchConfig.project_path) {
+            return `Azure Functions: ${path.basename(launchConfig.project_path)}`;
+        }
+        return 'Azure Functions';
+    },
+    getSupportedFileTypes: () => ['.cs', '.csproj'],
+    getProjectFile: (launchConfig) => {
+        if (isAzureFunctionsLaunchConfiguration(launchConfig)) {
+            return launchConfig.project_path;
+        }
+        throw new Error(invalidLaunchConfiguration(JSON.stringify(launchConfig)));
+    },
+    createDebugSessionConfigurationCallback: async (launchConfig, args, env, launchOptions, debugConfiguration: AspireResourceExtendedDebugConfiguration): Promise<void> => {
+        if (!isAzureFunctionsLaunchConfiguration(launchConfig)) {
+            extensionLogOutputChannel.info(`The resource type was not azure-functions for ${JSON.stringify(launchConfig)}`);
+            throw new Error(invalidLaunchConfiguration(JSON.stringify(launchConfig)));
+        }
+
+        const projectPath = launchConfig.project_path;
+        // project_path from the C# side is the .csproj file path (resolved by
+        // AzureFunctionsProjectMetadata.ResolveProjectPath). The AF extension
+        // API expects the project *directory* as buildPath.
+        const projectDir = path.dirname(projectPath);
+
+        extensionLogOutputChannel.info(`Starting Azure Functions project via extension API: ${projectPath} (buildPath: ${projectDir})`);
+
+        // Only pass DCP-specific env vars to the AF extension. The VS Code Task
+        // it creates already inherits the VS Code process environment, so we
+        // don't need to merge process.env — that would just duplicate values.
+        const dcpEnv = Object.fromEntries(
+            (env ?? []).filter(e => e.value !== undefined).map(e => [e.name, e.value])
+        );
+
+        // Start func host via the Azure Functions extension API.
+        // The API creates a VS Code Task running "func host start", polls
+        // /admin/host/status until ready, then finds the dotnet worker child
+        // process and returns its PID. We let func handle the build itself
+        // so it outputs to its expected bin/output/ location.
+        //
+        // The AF extension API has no stopFuncProcess method, so we track the
+        // VS Code Task it creates by diffing taskExecutions before/after the call.
+        const api = await getAzureFunctionsApi();
+        extensionLogOutputChannel.info(`Got Azure Functions API (version ${api.apiVersion}), calling startFuncProcess`);
+
+        const executionsBefore = new Set(vscode.tasks.taskExecutions);
+        const result = await api.startFuncProcess(projectDir, args ?? [], dcpEnv);
+
+        // Find the new task execution that was created by startFuncProcess.
+        // Filter by task name containing "func" to reduce the chance of capturing
+        // an unrelated task started concurrently by another extension or user.
+        const newExecutions = [...vscode.tasks.taskExecutions].filter(exec => !executionsBefore.has(exec));
+        const funcExecution = newExecutions.find(exec => exec.task.name.toLowerCase().includes('func'));
+
+        if (funcExecution) {
+            extensionLogOutputChannel.info(`Captured func host task for runId ${debugConfiguration.runId}: ${funcExecution.task.name}`);
+            taskExecutionsByRunId.set(debugConfiguration.runId, funcExecution);
+        }
+        if (newExecutions.length > 1) {
+            extensionLogOutputChannel.warn(`Multiple new task executions detected after startFuncProcess (${newExecutions.length}); captured: ${funcExecution?.task.name}`);
+        }
+
+        if (!result.success) {
+            throw new Error(`Azure Functions extension failed to start func host: ${result.error ?? 'unknown error'}`);
+        }
+
+        const workerPid = result.processId;
+        extensionLogOutputChannel.info(`Azure Functions worker process started (PID: ${workerPid}), attaching debugger`);
+
+        // Track the worker PID for cleanup
+        const workerPidNumber = parseInt(workerPid, 10);
+        workerPidsByRunId.set(debugConfiguration.runId, workerPidNumber);
+
+        // Configure coreclr attach to the worker process
+        debugConfiguration.type = 'coreclr';
+        debugConfiguration.request = 'attach';
+        debugConfiguration.processId = String(workerPidNumber);
+
+        // Remove launch-mode properties that don't apply to attach
+        delete debugConfiguration.program;
+        delete debugConfiguration.args;
+        delete debugConfiguration.cwd;
+        delete debugConfiguration.console;
+        delete debugConfiguration.env;
+    }
+};

--- a/extension/src/debugger/languages/azureFunctions.ts
+++ b/extension/src/debugger/languages/azureFunctions.ts
@@ -4,6 +4,7 @@ import { AspireResourceExtendedDebugConfiguration, ExecutableLaunchConfiguration
 import { invalidLaunchConfiguration } from '../../loc/strings';
 import { extensionLogOutputChannel } from '../../utils/logging';
 import { ResourceDebuggerExtension } from '../debuggerExtensions';
+import { registerRunCleanup } from '../runCleanupRegistry';
 
 const AF_EXTENSION_ID = 'ms-azuretools.vscode-azurefunctions';
 
@@ -39,7 +40,7 @@ const workerPidsByRunId = new Map<string, number>();
 const taskExecutionsByRunId = new Map<string, vscode.TaskExecution>();
 
 /** Kill the func host task and worker process for the given runId, if any. */
-export function killFuncProcess(runId: string): void {
+function killFuncProcess(runId: string): void {
     // Terminate the VS Code Task running "func host start"
     const taskExecution = taskExecutionsByRunId.get(runId);
     if (taskExecution) {
@@ -102,6 +103,10 @@ export const azureFunctionsDebuggerExtension: ResourceDebuggerExtension = {
             extensionLogOutputChannel.info(`The resource type was not azure-functions for ${JSON.stringify(launchConfig)}`);
             throw new Error(invalidLaunchConfiguration(JSON.stringify(launchConfig)));
         }
+
+        // Register cleanup for this run up-front so that killFuncProcess is called
+        // via the generic cleanupRun path regardless of how the session ends.
+        registerRunCleanup(debugConfiguration.runId, () => killFuncProcess(debugConfiguration.runId));
 
         const projectPath = launchConfig.project_path;
         // project_path from the C# side is the .csproj file path (resolved by

--- a/extension/src/debugger/runCleanupRegistry.ts
+++ b/extension/src/debugger/runCleanupRegistry.ts
@@ -1,0 +1,27 @@
+/** Per-run cleanup handlers registered by resource-type extensions. */
+const runCleanupHandlers = new Map<string, Array<() => void>>();
+
+/**
+ * Registers a cleanup handler to be invoked when the run session for the given
+ * runId is stopped or encounters an error. Multiple handlers can be registered
+ * for the same runId; they are invoked in registration order.
+ */
+export function registerRunCleanup(runId: string, cleanup: () => void): void {
+    const handlers = runCleanupHandlers.get(runId) ?? [];
+    handlers.push(cleanup);
+    runCleanupHandlers.set(runId, handlers);
+}
+
+/**
+ * Invokes all registered cleanup handlers for the given runId and removes them.
+ * Safe to call even if no handlers are registered (no-op in that case).
+ */
+export function cleanupRun(runId: string): void {
+    const handlers = runCleanupHandlers.get(runId);
+    if (handlers) {
+        for (const handler of handlers) {
+            handler();
+        }
+        runCleanupHandlers.delete(runId);
+    }
+}

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -17,7 +17,6 @@ import { AspireExtensionContext } from './AspireExtensionContext';
 import AspireRpcServer, { RpcServerConnectionInfo } from './server/AspireRpcServer';
 import AspireDcpServer from './dcp/AspireDcpServer';
 import { configureLaunchJsonCommand } from './commands/configureLaunchJson';
-import { getResourceDebuggerExtensions } from './debugger/debuggerExtensions';
 import { AspireTerminalProvider } from './utils/AspireTerminalProvider';
 import { MessageConnection } from 'vscode-jsonrpc';
 import { openTerminalCommand } from './commands/openTerminal';
@@ -37,8 +36,6 @@ export async function activate(context: vscode.ExtensionContext) {
   extensionLogOutputChannel.info("Activating Aspire extension");
   initializeTelemetry(context);
 
-  const debuggerExtensions = getResourceDebuggerExtensions();
-
   const terminalProvider = new AspireTerminalProvider(context.subscriptions);
 
   const rpcServer = await AspireRpcServer.create(
@@ -48,7 +45,7 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   );
 
-  const dcpServer = await AspireDcpServer.create(debuggerExtensions, aspireExtensionContext.getAspireDebugSession.bind(aspireExtensionContext));
+  const dcpServer = await AspireDcpServer.create(aspireExtensionContext.getAspireDebugSession.bind(aspireExtensionContext));
 
   terminalProvider.rpcServerConnectionInfo = rpcServer.connectionInfo;
   terminalProvider.dcpServerConnectionInfo = dcpServer.connectionInfo;

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/AzureFunctionsEndToEnd.AppHost.csproj
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/AzureFunctionsEndToEnd.AppHost.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <IsAspireHost>true</IsAspireHost>
     <UserSecretsId>d824db17-effc-4f8c-aa80-f0ae6aba93eb</UserSecretsId>
+    <DefineConstants Condition="$([MSBuild]::IsOSPlatform('osx'))">$(DefineConstants);SKIP_UNSTABLE_EMULATORS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <DefineConstants Condition="$([MSBuild]::IsOSPlatform('osx'))">$(DefineConstants);SKIP_UNSTABLE_EMULATORS</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Text.Json.Serialization;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Utils;
@@ -182,9 +183,12 @@ public static class AzureFunctionsProjectResourceExtensions
 
         resource.HostStorage = storage;
 
+#pragma warning disable ASPIREEXTENSION001 // WithDebugSupport is experimental
         var functionsBuilder = builder.AddResource(resource)
             .WithAnnotation(projectMetadata)
-            .WithAnnotation(new AzureFunctionsAnnotation());
+            .WithAnnotation(new AzureFunctionsAnnotation())
+            .WithDebugSupport(mode => new AzureFunctionsLaunchConfiguration { ProjectPath = projectMetadata.ProjectPath, Mode = mode }, "azure-functions");
+#pragma warning restore ASPIREEXTENSION001
 
         // Only validate Azure Functions Core Tools in run mode (not during publish)
         if (builder.ExecutionContext.IsRunMode)
@@ -398,5 +402,21 @@ public static class AzureFunctionsProjectResourceExtensions
 
             return path;
         }
+    }
+
+    /// <summary>
+    /// Launch configuration for Azure Functions projects, serialized to JSON for DCP.
+    /// Uses type "azure-functions" so the VS Code extension can launch via func host start.
+    /// </summary>
+    private sealed class AzureFunctionsLaunchConfiguration
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = "azure-functions";
+
+        [JsonPropertyName("mode")]
+        public string Mode { get; set; } = string.Empty;
+
+        [JsonPropertyName("project_path")]
+        public string ProjectPath { get; set; } = string.Empty;
     }
 }

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1372,26 +1372,37 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
                 SetInitialResourceState(project, exe);
 
-                var projectLaunchConfiguration = new ProjectLaunchConfiguration();
-                projectLaunchConfiguration.ProjectPath = projectMetadata.ProjectPath;
-
                 var projectArgs = new List<string>();
 
-                if (project.SupportsDebugging(_configuration, out _))
+                if (project.SupportsDebugging(_configuration, out var supportsDebuggingAnnotation))
                 {
                     exe.Spec.ExecutionType = ExecutionType.IDE;
                     exe.Spec.FallbackExecutionTypes = [ ExecutionType.Process ];
 
-                    projectLaunchConfiguration.DisableLaunchProfile = project.TryGetLastAnnotation<ExcludeLaunchProfileAnnotation>(out _);
-                    // Use the effective launch profile which has fallback logic
-                    if (!projectLaunchConfiguration.DisableLaunchProfile && project.GetEffectiveLaunchProfile() is NamedLaunchProfile namedLaunchProfile)
+                    if (supportsDebuggingAnnotation.LaunchConfigurationType is "project")
                     {
-                        projectLaunchConfiguration.LaunchProfile = namedLaunchProfile.Name;
+                        var projectLaunchConfiguration = new ProjectLaunchConfiguration();
+                        projectLaunchConfiguration.ProjectPath = projectMetadata.ProjectPath;
+
+                        projectLaunchConfiguration.DisableLaunchProfile = project.TryGetLastAnnotation<ExcludeLaunchProfileAnnotation>(out _);
+                        // Use the effective launch profile which has fallback logic
+                        if (!projectLaunchConfiguration.DisableLaunchProfile && project.GetEffectiveLaunchProfile() is NamedLaunchProfile namedLaunchProfile)
+                        {
+                            projectLaunchConfiguration.LaunchProfile = namedLaunchProfile.Name;
+                        }
+
+                        // We want this annotation even if we are not using IDE execution; see ToSnapshot() for details.
+                        exe.AnnotateAsObjectList(Executable.LaunchConfigurationsAnnotation, projectLaunchConfiguration);
                     }
+                    // Non-project launch types (e.g. azure-functions) have their launch configuration
+                    // applied later in CreateExecutableAsync() after endpoints are allocated.
                 }
                 else
                 {
                     exe.Spec.ExecutionType = ExecutionType.Process;
+
+                    var projectLaunchConfiguration = new ProjectLaunchConfiguration();
+                    projectLaunchConfiguration.ProjectPath = projectMetadata.ProjectPath;
 
                     // `dotnet watch` does not work with file-based apps yet, so we have to use `dotnet run` in that case
                     if (_configuration.GetBool("DOTNET_WATCH") is not true || projectMetadata.IsFileBasedApp)
@@ -1430,10 +1441,11 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                     // and should be HIGHER priority than the launch profile settings).
                     // This means we need to apply the launch profile settings manually inside CreateExecutableAsync().
                     projectArgs.Add("--no-launch-profile");
+
+                    // We want this annotation even if we are not using IDE execution; see ToSnapshot() for details.
+                    exe.AnnotateAsObjectList(Executable.LaunchConfigurationsAnnotation, projectLaunchConfiguration);
                 }
 
-                // We want this annotation even if we are not using IDE execution; see ToSnapshot() for details.
-                exe.AnnotateAsObjectList(Executable.LaunchConfigurationsAnnotation, projectLaunchConfiguration);
                 exe.SetAnnotationAsObjectList(CustomResource.ResourceProjectArgsAnnotation, projectArgs);
 
                 var exeAppResource = new RenderedModelResource(project, exe);
@@ -1751,10 +1763,10 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             // Invoke the debug configuration callback now that endpoints are allocated.
             // This allows launch configurations to access endpoint URLs that were not
             // available during PrepareExecutables().
-            // Project resources configure their launch configs in PrepareProjectExecutables() directly,
-            // so we only invoke the annotator for non-project executables here.
-            if (er.ModelResource is not ProjectResource
-                && er.ModelResource.SupportsDebugging(_configuration, out var supportsDebuggingAnnotation))
+            // "project" launch types configure their launch configs in PrepareProjectExecutables() directly;
+            // all other types (plain executables and project subtypes like azure-functions) are handled here.
+            if (er.ModelResource.SupportsDebugging(_configuration, out var supportsDebuggingAnnotation)
+                && supportsDebuggingAnnotation.LaunchConfigurationType is not "project")
             {
                 var mode = _configuration[KnownConfigNames.DebugSessionRunMode] ?? ExecutableLaunchMode.NoDebug;
                 try

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -2328,6 +2328,158 @@ public class DcpExecutorTests
         Assert.Equal(ExecutionType.Process, exe.Spec.ExecutionType);
     }
 
+    [Fact]
+    public async Task Project_NonProjectLaunchConfig_ExtensionMode_RunsInIde()
+    {
+        // Arrange: A ProjectResource with a non-"project" launch config type (like Azure Functions)
+        // should get ExecutionType.IDE and have its launch config applied in CreateExecutableAsync.
+        var builder = DistributedApplication.CreateBuilder();
+
+        var projectBuilder = builder.AddProject<TestProject>("proj", launchProfileName: null);
+        // Remove the default "project" SupportsDebuggingAnnotation and replace with a non-"project" type
+        var annotationToRemove = projectBuilder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
+        if (annotationToRemove is not null)
+        {
+            projectBuilder.Resource.Annotations.Remove(annotationToRemove);
+        }
+        projectBuilder.WithDebugSupport(mode => new ExecutableLaunchConfiguration("azure-functions") { Mode = mode }, "azure-functions");
+
+        var configDict = new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+            [KnownConfigNames.DebugSessionInfo] = JsonSerializer.Serialize(new RunSessionInfo { ProtocolsSupported = ["coreclr"], SupportedLaunchConfigurations = ["azure-functions"] }),
+            [KnownConfigNames.ExtensionEndpoint] = "http://localhost:1234",
+            [KnownConfigNames.DebugSessionRunMode] = "Debug"
+        };
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+
+        // Act
+        await appExecutor.RunApplicationAsync();
+
+        // Assert
+        List<Executable> dcpExes = [];
+        var haveExes = RetryTillTrueOrTimeout(() =>
+        {
+            dcpExes.Clear();
+            dcpExes.AddRange(kubernetesService.CreatedResources.OfType<Executable>());
+            return dcpExes.Count == 1;
+        }, TestConstants.DefaultOrchestratorTestTimeout);
+        Assert.True(haveExes, $"Expected one executable but instead got {dcpExes.Count}");
+
+        var exe = Assert.Single(dcpExes, e => e.AppModelResourceName == "proj");
+        Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
+
+        // The launch config should have been applied in CreateExecutableAsync (not PrepareProjectExecutables)
+        Assert.True(exe.TryGetAnnotationAsObjectList<ExecutableLaunchConfiguration>(Executable.LaunchConfigurationsAnnotation, out var launchConfigs));
+        var config = Assert.Single(launchConfigs);
+        Assert.Equal("azure-functions", config.Type);
+        Assert.Equal(ExecutableLaunchMode.Debug, config.Mode);
+    }
+
+    [Fact]
+    public async Task Project_NonProjectLaunchConfig_AnnotatorThrows_FallsBackToProcess()
+    {
+        // Arrange: A ProjectResource with a non-"project" launch config where the annotator throws
+        // should fall back to ExecutionType.Process.
+        var builder = DistributedApplication.CreateBuilder();
+
+        var projectBuilder = builder.AddProject<TestProject>("proj", launchProfileName: null);
+        // Remove the default "project" SupportsDebuggingAnnotation and replace with a throwing one
+        var annotationToRemove = projectBuilder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
+        if (annotationToRemove is not null)
+        {
+            projectBuilder.Resource.Annotations.Remove(annotationToRemove);
+        }
+        projectBuilder.WithDebugSupport<ProjectResource, ExecutableLaunchConfiguration>(
+            _ => throw new InvalidOperationException("Test exception from launch configuration producer"),
+            "azure-functions");
+
+        var configDict = new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+            [KnownConfigNames.DebugSessionInfo] = JsonSerializer.Serialize(new RunSessionInfo { ProtocolsSupported = ["coreclr"], SupportedLaunchConfigurations = ["azure-functions"] }),
+            [KnownConfigNames.ExtensionEndpoint] = "http://localhost:1234"
+        };
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+
+        // Act
+        await appExecutor.RunApplicationAsync();
+
+        // Assert
+        List<Executable> dcpExes = [];
+        var haveExes = RetryTillTrueOrTimeout(() =>
+        {
+            dcpExes.Clear();
+            dcpExes.AddRange(kubernetesService.CreatedResources.OfType<Executable>());
+            return dcpExes.Count == 1;
+        }, TestConstants.DefaultOrchestratorTestTimeout);
+        Assert.True(haveExes, $"Expected one executable but instead got {dcpExes.Count}");
+
+        var exe = Assert.Single(dcpExes, e => e.AppModelResourceName == "proj");
+        // Should fall back to Process execution when the launch configuration producer throws
+        Assert.Equal(ExecutionType.Process, exe.Spec.ExecutionType);
+    }
+
+    [Fact]
+    public async Task Project_NonProjectLaunchConfig_UnsupportedByExtension_RunsInProcess()
+    {
+        // Arrange: A ProjectResource with a non-"project" launch config type that the extension
+        // does not support should run as ExecutionType.Process.
+        var builder = DistributedApplication.CreateBuilder();
+
+        var projectBuilder = builder.AddProject<TestProject>("proj", launchProfileName: null);
+        // Remove the default "project" SupportsDebuggingAnnotation and replace with "azure-functions"
+        var annotationToRemove = projectBuilder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
+        if (annotationToRemove is not null)
+        {
+            projectBuilder.Resource.Annotations.Remove(annotationToRemove);
+        }
+        projectBuilder.WithDebugSupport(mode => new ExecutableLaunchConfiguration("azure-functions") { Mode = mode }, "azure-functions");
+
+        // Extension does NOT list "azure-functions" in SupportedLaunchConfigurations
+        var configDict = new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+            [KnownConfigNames.DebugSessionInfo] = JsonSerializer.Serialize(new RunSessionInfo { ProtocolsSupported = ["coreclr"], SupportedLaunchConfigurations = ["project"] }),
+            [KnownConfigNames.ExtensionEndpoint] = "http://localhost:1234"
+        };
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+
+        // Act
+        await appExecutor.RunApplicationAsync();
+
+        // Assert
+        List<Executable> dcpExes = [];
+        var haveExes = RetryTillTrueOrTimeout(() =>
+        {
+            dcpExes.Clear();
+            dcpExes.AddRange(kubernetesService.CreatedResources.OfType<Executable>());
+            return dcpExes.Count == 1;
+        }, TestConstants.DefaultOrchestratorTestTimeout);
+        Assert.True(haveExes, $"Expected one executable but instead got {dcpExes.Count}");
+
+        var exe = Assert.Single(dcpExes, e => e.AppModelResourceName == "proj");
+        Assert.Equal(ExecutionType.Process, exe.Spec.ExecutionType);
+    }
+
     private static DcpExecutor CreateAppExecutor(
         DistributedApplicationModel distributedAppModel,
         IHostEnvironment? hostEnvironment = null,
@@ -2473,4 +2625,5 @@ public class DcpExecutorTests
     {
         public IResource Parent => parent;
     }
+
 }


### PR DESCRIPTION
## Description

Adds Azure Functions debugging support to the Aspire VS Code extension, enabling F5 debugging of Azure Functions projects orchestrated by Aspire.

Fixes https://github.com/dotnet/aspire/issues/14282

To test, I would recommend using the `AzureFunctionsEndToEnd` playground app!

### Architecture

The integration spans the C# hosting layer and the VS Code extension:

**C# Hosting Side (`Aspire.Hosting.Azure.Functions` + `Aspire.Hosting`)**
- `AzureFunctionsProjectResourceExtensions` calls `.WithDebugSupport()` to register a `SupportsDebuggingAnnotation` with launch configuration type `"azure-functions"` and a factory that produces an `AzureFunctionsLaunchConfiguration` (with `type`, `mode`, and `project_path`).
- `DcpExecutor.PrepareProjectExecutables()` checks `SupportsDebugging()`. When the annotation's `LaunchConfigurationType` is not `"project"`, it delegates to the annotation's `LaunchConfigurationAnnotator` instead of building the default `ProjectLaunchConfiguration`. This keeps the existing project path untouched while enabling custom launch configs for non-standard project types.

**VS Code Extension Side**
- **Capability gating**: The `"azure-functions"` capability is only reported to the apphost when both the C# extension and the Azure Functions extension (`ms-azuretools.vscode-azurefunctions`) are installed. If the AF extension is missing, the capability is omitted and the resource falls back to `ExecutionType.Process` (`dotnet run`) — identical to pre-PR behavior.
- **`azureFunctions.ts`**: A new `ResourceDebuggerExtension` that:
  1. Obtains the Azure Functions extension API via `ext.exports.getApi('~1.10.0')`
  2. Calls `startFuncProcess(buildPath, args, env)` which creates a VS Code Task running `func host start`, waits for the host to be ready, then returns the worker process PID
  3. Configures a `coreclr` attach debug session targeting that PID
  4. Tracks the VS Code Task execution and worker PID for cleanup via `killFuncProcess()`
- **Error handling**: The DCP server's run_session handler is wrapped in try/catch. On failure, it cleans up any started func process, sends a `sessionTerminated` WebSocket notification, and returns HTTP 500.

### Other changes
- Added `local.settings.json` to `.gitignore` (can contain encrypted secrets)
- Playground `.csproj` changes add `SKIP_UNSTABLE_EMULATORS` on macOS

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [ ] No
