### PR TITLE
[release/13.2] Handle brownfield TypeScript aspire init

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -125,6 +125,7 @@
     <Compile Include="$(SharedDir)ConsoleLogs\SharedAIHelpers.cs" Link="ConsoleLogs\SharedAIHelpers.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\TimestampParser.cs" Link="ConsoleLogs\TimestampParser.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\UrlParser.cs" Link="ConsoleLogs\UrlParser.cs" />
+    <Compile Include="$(SharedDir)NpmVersionHelper.cs" Link="Utils\NpmVersionHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Cli/Projects/GuestRuntime.cs
+++ b/src/Aspire.Cli/Projects/GuestRuntime.cs
@@ -139,6 +139,8 @@ internal sealed class GuestRuntime
     {
         var args = ReplacePlaceholders(commandSpec.Args, appHostFile, directory, additionalArgs);
 
+        await EnsureMigrationFilesExistAsync(directory, cancellationToken);
+
         var mergedEnvironment = new Dictionary<string, string>(environmentVariables);
         if (commandSpec.EnvironmentVariables is not null)
         {
@@ -150,6 +152,28 @@ internal sealed class GuestRuntime
 
         _logger.LogDebug("Launching: {Command} {Args}", commandSpec.Command, string.Join(" ", args));
         return await launcher.LaunchAsync(commandSpec.Command, args, directory, mergedEnvironment, cancellationToken);
+    }
+
+    /// <summary>
+    /// Creates any migration files that are required by the runtime but missing from the project directory.
+    /// This handles upgrade scenarios where a newer CLI introduces new required files.
+    /// </summary>
+    private async Task EnsureMigrationFilesExistAsync(DirectoryInfo directory, CancellationToken cancellationToken)
+    {
+        if (_spec.MigrationFiles is null or { Count: 0 })
+        {
+            return;
+        }
+
+        foreach (var (fileName, content) in _spec.MigrationFiles)
+        {
+            var filePath = Path.Combine(directory.FullName, fileName);
+            if (!File.Exists(filePath))
+            {
+                _logger.LogInformation("Creating missing required file: {FileName}", fileName);
+                await File.WriteAllTextAsync(filePath, content, cancellationToken);
+            }
+        }
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Scaffolding/PackageJsonMerger.cs
+++ b/src/Aspire.Cli/Scaffolding/PackageJsonMerger.cs
@@ -56,7 +56,7 @@ internal static class PackageJsonMerger
         }
         catch (Exception ex)
         {
-            logger?.LogDebug(ex, "Failed to merge existing package.json, using scaffold output as-is");
+            logger?.LogWarning(ex, "Failed to merge existing package.json, using scaffold output as-is");
             return scaffoldContent;
         }
     }
@@ -119,8 +119,7 @@ internal static class PackageJsonMerger
     {
         foreach (var (name, value) in scaffoldScripts)
         {
-            var command = value?.GetValue<string>();
-            if (command is null)
+            if (value is not JsonValue scriptValue || !scriptValue.TryGetValue<string>(out var command))
             {
                 continue;
             }
@@ -193,8 +192,7 @@ internal static class PackageJsonMerger
 
         foreach (var (packageName, versionNode) in scaffoldDeps)
         {
-            var desiredVersion = versionNode?.GetValue<string>();
-            if (desiredVersion is null)
+            if (versionNode is not JsonValue desiredValue || !desiredValue.TryGetValue<string>(out var desiredVersion))
             {
                 continue;
             }
@@ -206,8 +204,9 @@ internal static class PackageJsonMerger
             }
             else
             {
-                var existingVersion = existingVersionNode.GetValue<string>();
-                if (NpmVersionHelper.ShouldUpgrade(existingVersion, desiredVersion))
+                if (existingVersionNode is JsonValue existingValue
+                    && existingValue.TryGetValue<string>(out var existingVersion)
+                    && NpmVersionHelper.ShouldUpgrade(existingVersion, desiredVersion))
                 {
                     existingDeps[packageName] = desiredVersion;
                 }

--- a/src/Aspire.Cli/Scaffolding/PackageJsonMerger.cs
+++ b/src/Aspire.Cli/Scaffolding/PackageJsonMerger.cs
@@ -23,10 +23,19 @@ internal static class PackageJsonMerger
     private const string EnginesNodeKey = "node";
     private const string AspirePrefix = "aspire:";
 
+    // package.json standard uses 2-space indentation. These options produce output
+    // consistent with npm init / npm install formatting conventions.
     private static readonly JsonSerializerOptions s_jsonOptions = new()
     {
         WriteIndented = true,
-        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        IndentSize = 2
+    };
+
+    private static readonly JsonDocumentOptions s_jsonDocumentOptions = new()
+    {
+        CommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true
     };
 
     /// <summary>
@@ -36,34 +45,46 @@ internal static class PackageJsonMerger
     /// <c>aspire:X</c> scripts get a convenience alias <c>X</c> pointing to <c>npm run aspire:X</c>.
     /// </summary>
     /// <returns>The merged package.json content as a JSON string.</returns>
-    internal static string Merge(string existingContent, string scaffoldContent, ILogger? logger = null)
+    internal static string Merge(string existingContent, string scaffoldContent, ILogger logger)
     {
+        if (string.IsNullOrWhiteSpace(existingContent))
+        {
+            return scaffoldContent;
+        }
+
+        // Phase 1: Parse inputs. If either fails, return scaffold as-is.
+        JsonObject? existingJson;
+        JsonObject? scaffoldJson;
         try
         {
-            if (string.IsNullOrWhiteSpace(existingContent))
-            {
-                return scaffoldContent;
-            }
+            existingJson = JsonNode.Parse(existingContent, documentOptions: s_jsonDocumentOptions) as JsonObject;
+            scaffoldJson = JsonNode.Parse(scaffoldContent, documentOptions: s_jsonDocumentOptions) as JsonObject;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to parse package.json content, using scaffold output as-is.");
+            return scaffoldContent;
+        }
 
-            var existingJson = JsonNode.Parse(existingContent) as JsonObject;
-            var scaffoldJson = JsonNode.Parse(scaffoldContent) as JsonObject;
+        if (existingJson is null || scaffoldJson is null)
+        {
+            return scaffoldContent;
+        }
 
-            if (existingJson is null || scaffoldJson is null)
-            {
-                return scaffoldContent;
-            }
-
+        // Phase 2: Merge. If merge fails, return scaffold as-is.
+        try
+        {
             MergeObjects(existingJson, scaffoldJson);
             return existingJson.ToJsonString(s_jsonOptions);
         }
         catch (InvalidOperationException)
         {
-            // Programming error (e.g., unsupported array property in scaffold) — let it propagate
+            // Programming error (e.g., unsupported array property in scaffold) — let it propagate.
             throw;
         }
         catch (Exception ex)
         {
-            logger?.LogWarning(ex, "Failed to merge existing package.json, using scaffold output as-is");
+            logger.LogWarning(ex, "Failed to merge package.json content, using scaffold output as-is.");
             return scaffoldContent;
         }
     }

--- a/src/Aspire.Cli/Scaffolding/PackageJsonMerger.cs
+++ b/src/Aspire.Cli/Scaffolding/PackageJsonMerger.cs
@@ -1,0 +1,208 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Scaffolding;
+
+/// <summary>
+/// Merges scaffold-generated package.json with an existing one on disk.
+/// Handles script name conflicts by adding Aspire-specific scripts under the <c>aspire:</c>
+/// namespace prefix, and creates convenience aliases for non-conflicting names.
+/// </summary>
+internal static class PackageJsonMerger
+{
+    private const string ScriptsKey = "scripts";
+    private const string AspirePrefix = "aspire:";
+
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        WriteIndented = true,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
+    /// <summary>
+    /// Merges scaffold-generated package.json content with existing content.
+    /// Preserves all existing properties and scripts. Scaffold scripts that conflict
+    /// with existing names are added under the <c>aspire:</c> prefix. Non-conflicting
+    /// <c>aspire:X</c> scripts get a convenience alias <c>X</c> pointing to <c>npm run aspire:X</c>.
+    /// </summary>
+    /// <returns>The merged package.json content as a JSON string.</returns>
+    internal static string Merge(string existingContent, string scaffoldContent, ILogger? logger = null)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(existingContent))
+            {
+                return scaffoldContent;
+            }
+
+            var existingJson = JsonNode.Parse(existingContent)?.AsObject();
+            var scaffoldJson = JsonNode.Parse(scaffoldContent)?.AsObject();
+
+            if (existingJson is null || scaffoldJson is null)
+            {
+                return scaffoldContent;
+            }
+
+            MergeObjects(existingJson, scaffoldJson);
+            return existingJson.ToJsonString(s_jsonOptions);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogDebug(ex, "Failed to merge existing package.json, using scaffold output as-is");
+            return scaffoldContent;
+        }
+    }
+
+    /// <summary>
+    /// Merges all top-level properties from scaffold into existing.
+    /// Scripts get special conflict-aware handling; everything else uses deep merge.
+    /// </summary>
+    private static void MergeObjects(JsonObject existing, JsonObject scaffold)
+    {
+        // Handle scripts separately with conflict-aware logic
+        var scaffoldScripts = scaffold[ScriptsKey]?.AsObject();
+        if (scaffoldScripts is not null)
+        {
+            var existingScripts = EnsureObject(existing, ScriptsKey);
+            MergeScripts(existingScripts, scaffoldScripts);
+        }
+
+        // Deep merge everything else
+        foreach (var (key, sourceValue) in scaffold)
+        {
+            if (key == ScriptsKey || sourceValue is null)
+            {
+                continue;
+            }
+
+            var targetValue = existing[key];
+
+            if (targetValue is null)
+            {
+                existing[key] = sourceValue.DeepClone();
+            }
+            else if (targetValue is JsonObject targetObj && sourceValue is JsonObject sourceObj)
+            {
+                DeepMerge(targetObj, sourceObj);
+            }
+            // Scalar values in existing are preserved
+        }
+    }
+
+    /// <summary>
+    /// Merges scaffold scripts into existing scripts with conflict-aware handling.
+    /// </summary>
+    /// <remarks>
+    /// For each scaffold script:
+    /// <list type="bullet">
+    /// <item>Already <c>aspire:</c> prefixed → always added/updated</item>
+    /// <item>Not prefixed, conflicts with existing → added as <c>aspire:{name}</c></item>
+    /// <item>Not prefixed, no conflict → added with the original name</item>
+    /// </list>
+    /// After processing, for each <c>aspire:X</c> script where no non-prefixed <c>X</c> exists,
+    /// a convenience alias is added: <c>"X": "npm run aspire:X"</c>.
+    /// </remarks>
+    internal static void MergeScripts(JsonObject existingScripts, JsonObject scaffoldScripts)
+    {
+        foreach (var (name, value) in scaffoldScripts)
+        {
+            var command = value?.GetValue<string>();
+            if (command is null)
+            {
+                continue;
+            }
+
+            if (name.StartsWith(AspirePrefix, StringComparison.Ordinal))
+            {
+                // Already prefixed — always set it
+                existingScripts[name] = command;
+            }
+            else if (existingScripts[name] is not null)
+            {
+                // Conflict — add under aspire: prefix
+                existingScripts[$"{AspirePrefix}{name}"] = command;
+            }
+            else
+            {
+                // No conflict — add with original name
+                existingScripts[name] = command;
+            }
+        }
+
+        // Add convenience aliases for aspire: scripts that have no non-prefixed equivalent
+        AddConvenienceAliases(existingScripts);
+    }
+
+    /// <summary>
+    /// For each <c>aspire:X</c> script, if no script named <c>X</c> exists,
+    /// adds <c>"X": "npm run aspire:X"</c> as a convenience alias.
+    /// </summary>
+    private static void AddConvenienceAliases(JsonObject scripts)
+    {
+        // Collect aspire: keys first to avoid modifying during enumeration
+        var aspireScripts = new List<(string unprefixed, string prefixed)>();
+        foreach (var (name, _) in scripts)
+        {
+            if (name.StartsWith(AspirePrefix, StringComparison.Ordinal))
+            {
+                var unprefixed = name[AspirePrefix.Length..];
+                if (unprefixed.Length > 0)
+                {
+                    aspireScripts.Add((unprefixed, name));
+                }
+            }
+        }
+
+        foreach (var (unprefixed, prefixed) in aspireScripts)
+        {
+            if (scripts[unprefixed] is null)
+            {
+                scripts[unprefixed] = $"npm run {prefixed}";
+            }
+        }
+    }
+
+    /// <summary>
+    /// Deep merges properties from source into target. Existing target values are preserved.
+    /// For nested objects, recursively merges. Scalar values in target are never overwritten.
+    /// </summary>
+    internal static void DeepMerge(JsonObject target, JsonObject source)
+    {
+        foreach (var (key, sourceValue) in source)
+        {
+            if (sourceValue is null)
+            {
+                continue;
+            }
+
+            var targetValue = target[key];
+
+            if (targetValue is null)
+            {
+                target[key] = sourceValue.DeepClone();
+            }
+            else if (targetValue is JsonObject targetObj && sourceValue is JsonObject sourceObj)
+            {
+                DeepMerge(targetObj, sourceObj);
+            }
+            // Scalar values in target are preserved
+        }
+    }
+
+    private static JsonObject EnsureObject(JsonObject parent, string propertyName)
+    {
+        if (parent[propertyName] is JsonObject obj)
+        {
+            return obj;
+        }
+
+        obj = new JsonObject();
+        parent[propertyName] = obj;
+        return obj;
+    }
+}

--- a/src/Aspire.Cli/Scaffolding/PackageJsonMerger.cs
+++ b/src/Aspire.Cli/Scaffolding/PackageJsonMerger.cs
@@ -74,7 +74,7 @@ internal static class PackageJsonMerger
         // Phase 2: Merge. If merge fails, return scaffold as-is.
         try
         {
-            MergeObjects(existingJson, scaffoldJson);
+            MergeObjects(existingJson, scaffoldJson, logger);
             return existingJson.ToJsonString(s_jsonOptions);
         }
         catch (Exception ex)
@@ -89,24 +89,24 @@ internal static class PackageJsonMerger
     /// Scripts get special conflict-aware handling, dependency sections use semver-aware merging,
     /// and everything else uses deep merge.
     /// </summary>
-    private static void MergeObjects(JsonObject existing, JsonObject scaffold)
+    private static void MergeObjects(JsonObject existing, JsonObject scaffold, ILogger logger)
     {
         // Handle scripts separately with conflict-aware logic
         var scaffoldScripts = scaffold[ScriptsKey]?.AsObject();
         if (scaffoldScripts is not null)
         {
-            var existingScripts = EnsureObject(existing, ScriptsKey);
+            var existingScripts = EnsureObject(existing, ScriptsKey, logger);
             MergeScripts(existingScripts, scaffoldScripts);
         }
 
         // Handle dependency sections with semver-aware merging
-        MergeDependencySection(existing, scaffold, DependenciesKey);
-        MergeDependencySection(existing, scaffold, DevDependenciesKey);
+        MergeDependencySection(existing, scaffold, DependenciesKey, logger);
+        MergeDependencySection(existing, scaffold, DevDependenciesKey, logger);
 
         // Handle engines with overwrite semantics for "node" — since the user is running
         // "aspire init", we enforce our Node version constraint (required for ESLint 10
         // and TypeScript tooling compatibility). Other engines sub-keys are preserved.
-        MergeEngines(existing, scaffold);
+        MergeEngines(existing, scaffold, logger);
 
         // Deep merge everything else (scalars, nested objects).
         // Array properties (e.g., "keywords") are preserved from existing — the scaffold
@@ -211,7 +211,7 @@ internal static class PackageJsonMerger
     /// the scaffold specifies a newer version. Unparseable version ranges (union ranges, workspace
     /// references, etc.) are preserved as-is.
     /// </summary>
-    private static void MergeDependencySection(JsonObject existing, JsonObject scaffold, string sectionName)
+    private static void MergeDependencySection(JsonObject existing, JsonObject scaffold, string sectionName, ILogger logger)
     {
         var scaffoldDeps = scaffold[sectionName]?.AsObject();
         if (scaffoldDeps is null)
@@ -219,7 +219,7 @@ internal static class PackageJsonMerger
             return;
         }
 
-        var existingDeps = EnsureObject(existing, sectionName);
+        var existingDeps = EnsureObject(existing, sectionName, logger);
 
         foreach (var (packageName, versionNode) in scaffoldDeps)
         {
@@ -251,7 +251,7 @@ internal static class PackageJsonMerger
     /// specific Node.js versions for ESLint 10 and TypeScript tooling compatibility. Other
     /// <c>engines</c> sub-keys (e.g., <c>npm</c>) are preserved from the existing package.json.
     /// </summary>
-    private static void MergeEngines(JsonObject existing, JsonObject scaffold)
+    private static void MergeEngines(JsonObject existing, JsonObject scaffold, ILogger logger)
     {
         var scaffoldEngines = scaffold[EnginesKey]?.AsObject();
         if (scaffoldEngines is null)
@@ -259,7 +259,7 @@ internal static class PackageJsonMerger
             return;
         }
 
-        var existingEngines = EnsureObject(existing, EnginesKey);
+        var existingEngines = EnsureObject(existing, EnginesKey, logger);
 
         foreach (var (key, value) in scaffoldEngines)
         {
@@ -308,11 +308,18 @@ internal static class PackageJsonMerger
         }
     }
 
-    private static JsonObject EnsureObject(JsonObject parent, string propertyName)
+    private static JsonObject EnsureObject(JsonObject parent, string propertyName, ILogger? logger = null)
     {
         if (parent[propertyName] is JsonObject obj)
         {
             return obj;
+        }
+
+        if (parent[propertyName] is not null)
+        {
+            logger?.LogWarning(
+                "Replacing non-object '{PropertyName}' value with an empty object. The original value will be lost.",
+                propertyName);
         }
 
         obj = new JsonObject();

--- a/src/Aspire.Cli/Scaffolding/PackageJsonMerger.cs
+++ b/src/Aspire.Cli/Scaffolding/PackageJsonMerger.cs
@@ -308,7 +308,7 @@ internal static class PackageJsonMerger
         }
     }
 
-    private static JsonObject EnsureObject(JsonObject parent, string propertyName, ILogger? logger = null)
+    private static JsonObject EnsureObject(JsonObject parent, string propertyName, ILogger logger)
     {
         if (parent[propertyName] is JsonObject obj)
         {
@@ -317,7 +317,7 @@ internal static class PackageJsonMerger
 
         if (parent[propertyName] is not null)
         {
-            logger?.LogWarning(
+            logger.LogWarning(
                 "Replacing non-object '{PropertyName}' value with an empty object. The original value will be lost.",
                 propertyName);
         }

--- a/src/Aspire.Cli/Scaffolding/PackageJsonMerger.cs
+++ b/src/Aspire.Cli/Scaffolding/PackageJsonMerger.cs
@@ -4,6 +4,7 @@
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Aspire.Shared;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Scaffolding;
@@ -16,6 +17,8 @@ namespace Aspire.Cli.Scaffolding;
 internal static class PackageJsonMerger
 {
     private const string ScriptsKey = "scripts";
+    private const string DependenciesKey = "dependencies";
+    private const string DevDependenciesKey = "devDependencies";
     private const string AspirePrefix = "aspire:";
 
     private static readonly JsonSerializerOptions s_jsonOptions = new()
@@ -60,7 +63,8 @@ internal static class PackageJsonMerger
 
     /// <summary>
     /// Merges all top-level properties from scaffold into existing.
-    /// Scripts get special conflict-aware handling; everything else uses deep merge.
+    /// Scripts get special conflict-aware handling, dependency sections use semver-aware merging,
+    /// and everything else uses deep merge.
     /// </summary>
     private static void MergeObjects(JsonObject existing, JsonObject scaffold)
     {
@@ -72,10 +76,14 @@ internal static class PackageJsonMerger
             MergeScripts(existingScripts, scaffoldScripts);
         }
 
+        // Handle dependency sections with semver-aware merging
+        MergeDependencySection(existing, scaffold, DependenciesKey);
+        MergeDependencySection(existing, scaffold, DevDependenciesKey);
+
         // Deep merge everything else
         foreach (var (key, sourceValue) in scaffold)
         {
-            if (key == ScriptsKey || sourceValue is null)
+            if (key is ScriptsKey or DependenciesKey or DevDependenciesKey || sourceValue is null)
             {
                 continue;
             }
@@ -163,6 +171,46 @@ internal static class PackageJsonMerger
             if (scripts[unprefixed] is null)
             {
                 scripts[unprefixed] = $"npm run {prefixed}";
+            }
+        }
+    }
+
+    /// <summary>
+    /// Merges a dependency section (e.g., "dependencies", "devDependencies") from scaffold into existing
+    /// using semver-aware comparison. New packages are added; existing packages are upgraded only when
+    /// the scaffold specifies a newer version. Unparseable version ranges (union ranges, workspace
+    /// references, etc.) are preserved as-is.
+    /// </summary>
+    private static void MergeDependencySection(JsonObject existing, JsonObject scaffold, string sectionName)
+    {
+        var scaffoldDeps = scaffold[sectionName]?.AsObject();
+        if (scaffoldDeps is null)
+        {
+            return;
+        }
+
+        var existingDeps = EnsureObject(existing, sectionName);
+
+        foreach (var (packageName, versionNode) in scaffoldDeps)
+        {
+            var desiredVersion = versionNode?.GetValue<string>();
+            if (desiredVersion is null)
+            {
+                continue;
+            }
+
+            var existingVersionNode = existingDeps[packageName];
+            if (existingVersionNode is null)
+            {
+                existingDeps[packageName] = desiredVersion;
+            }
+            else
+            {
+                var existingVersion = existingVersionNode.GetValue<string>();
+                if (NpmVersionHelper.ShouldUpgrade(existingVersion, desiredVersion))
+                {
+                    existingDeps[packageName] = desiredVersion;
+                }
             }
         }
     }

--- a/src/Aspire.Cli/Scaffolding/PackageJsonMerger.cs
+++ b/src/Aspire.Cli/Scaffolding/PackageJsonMerger.cs
@@ -19,6 +19,8 @@ internal static class PackageJsonMerger
     private const string ScriptsKey = "scripts";
     private const string DependenciesKey = "dependencies";
     private const string DevDependenciesKey = "devDependencies";
+    private const string EnginesKey = "engines";
+    private const string EnginesNodeKey = "node";
     private const string AspirePrefix = "aspire:";
 
     private static readonly JsonSerializerOptions s_jsonOptions = new()
@@ -43,8 +45,8 @@ internal static class PackageJsonMerger
                 return scaffoldContent;
             }
 
-            var existingJson = JsonNode.Parse(existingContent)?.AsObject();
-            var scaffoldJson = JsonNode.Parse(scaffoldContent)?.AsObject();
+            var existingJson = JsonNode.Parse(existingContent) as JsonObject;
+            var scaffoldJson = JsonNode.Parse(scaffoldContent) as JsonObject;
 
             if (existingJson is null || scaffoldJson is null)
             {
@@ -53,6 +55,11 @@ internal static class PackageJsonMerger
 
             MergeObjects(existingJson, scaffoldJson);
             return existingJson.ToJsonString(s_jsonOptions);
+        }
+        catch (InvalidOperationException)
+        {
+            // Programming error (e.g., unsupported array property in scaffold) — let it propagate
+            throw;
         }
         catch (Exception ex)
         {
@@ -80,12 +87,28 @@ internal static class PackageJsonMerger
         MergeDependencySection(existing, scaffold, DependenciesKey);
         MergeDependencySection(existing, scaffold, DevDependenciesKey);
 
-        // Deep merge everything else
+        // Handle engines with overwrite semantics for "node" — since the user is running
+        // "aspire init", we enforce our Node version constraint (required for ESLint 10
+        // and TypeScript tooling compatibility). Other engines sub-keys are preserved.
+        MergeEngines(existing, scaffold);
+
+        // Deep merge everything else (scalars, nested objects).
+        // The scaffold currently only generates scalar and object properties at the top level.
+        // If an array property is ever added to the scaffold template, explicit merge logic
+        // must be written for it — the generic DeepMerge cannot handle arrays correctly
+        // (it would silently drop the scaffold's array when an existing value is present).
         foreach (var (key, sourceValue) in scaffold)
         {
-            if (key is ScriptsKey or DependenciesKey or DevDependenciesKey || sourceValue is null)
+            if (key is ScriptsKey or DependenciesKey or DevDependenciesKey or EnginesKey || sourceValue is null)
             {
                 continue;
+            }
+
+            if (sourceValue is JsonArray)
+            {
+                throw new InvalidOperationException(
+                    $"The scaffold template contains an array property '{key}' in package.json. " +
+                    $"Explicit merge logic must be added to {nameof(PackageJsonMerger)} for this property.");
             }
 
             var targetValue = existing[key];
@@ -211,6 +234,42 @@ internal static class PackageJsonMerger
                     existingDeps[packageName] = desiredVersion;
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Merges the <c>engines</c> section from scaffold into existing. The <c>engines.node</c>
+    /// constraint is always overwritten by the scaffold's value because <c>aspire init</c> requires
+    /// specific Node.js versions for ESLint 10 and TypeScript tooling compatibility. Other
+    /// <c>engines</c> sub-keys (e.g., <c>npm</c>) are preserved from the existing package.json.
+    /// </summary>
+    private static void MergeEngines(JsonObject existing, JsonObject scaffold)
+    {
+        var scaffoldEngines = scaffold[EnginesKey]?.AsObject();
+        if (scaffoldEngines is null)
+        {
+            return;
+        }
+
+        var existingEngines = EnsureObject(existing, EnginesKey);
+
+        foreach (var (key, value) in scaffoldEngines)
+        {
+            if (value is null)
+            {
+                continue;
+            }
+
+            if (key == EnginesNodeKey)
+            {
+                // Always overwrite engines.node — Aspire requires specific Node versions
+                existingEngines[key] = value.DeepClone();
+            }
+            else if (existingEngines[key] is null)
+            {
+                existingEngines[key] = value.DeepClone();
+            }
+            // Other existing engine constraints are preserved
         }
     }
 

--- a/src/Aspire.Cli/Scaffolding/PackageJsonMerger.cs
+++ b/src/Aspire.Cli/Scaffolding/PackageJsonMerger.cs
@@ -77,11 +77,6 @@ internal static class PackageJsonMerger
             MergeObjects(existingJson, scaffoldJson);
             return existingJson.ToJsonString(s_jsonOptions);
         }
-        catch (InvalidOperationException)
-        {
-            // Programming error (e.g., unsupported array property in scaffold) — let it propagate.
-            throw;
-        }
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Failed to merge package.json content, using scaffold output as-is.");
@@ -114,10 +109,8 @@ internal static class PackageJsonMerger
         MergeEngines(existing, scaffold);
 
         // Deep merge everything else (scalars, nested objects).
-        // The scaffold currently only generates scalar and object properties at the top level.
-        // If an array property is ever added to the scaffold template, explicit merge logic
-        // must be written for it — the generic DeepMerge cannot handle arrays correctly
-        // (it would silently drop the scaffold's array when an existing value is present).
+        // Array properties (e.g., "keywords") are preserved from existing — the scaffold
+        // echoes the original arrays unchanged, so the existing value is always correct.
         foreach (var (key, sourceValue) in scaffold)
         {
             if (key is ScriptsKey or DependenciesKey or DevDependenciesKey or EnginesKey || sourceValue is null)
@@ -125,24 +118,18 @@ internal static class PackageJsonMerger
                 continue;
             }
 
-            if (sourceValue is JsonArray)
-            {
-                throw new InvalidOperationException(
-                    $"The scaffold template contains an array property '{key}' in package.json. " +
-                    $"Explicit merge logic must be added to {nameof(PackageJsonMerger)} for this property.");
-            }
-
             var targetValue = existing[key];
 
             if (targetValue is null)
             {
+                // Property only in scaffold — add it (including arrays from scaffold-only)
                 existing[key] = sourceValue.DeepClone();
             }
             else if (targetValue is JsonObject targetObj && sourceValue is JsonObject sourceObj)
             {
                 DeepMerge(targetObj, sourceObj);
             }
-            // Scalar values in existing are preserved
+            // Arrays and scalar values in existing are preserved
         }
     }
 

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Json;
-using System.Text.Json.Nodes;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
@@ -113,7 +111,8 @@ internal sealed class ScaffoldingService : IScaffoldingService
             var contentToWrite = content;
             if (fileName.Equals(PackageJsonFileName, StringComparison.OrdinalIgnoreCase) && File.Exists(filePath))
             {
-                contentToWrite = MergePackageJson(filePath, content, _logger);
+                var existingContent = await File.ReadAllTextAsync(filePath, cancellationToken);
+                contentToWrite = PackageJsonMerger.Merge(existingContent, content, _logger);
             }
 
             await File.WriteAllTextAsync(filePath, contentToWrite, cancellationToken);
@@ -244,65 +243,4 @@ internal sealed class ScaffoldingService : IScaffoldingService
             language.LanguageId.Value.Equals(KnownLanguageId.TypeScriptAlias, StringComparison.OrdinalIgnoreCase);
     }
 
-    /// <summary>
-    /// Merges scaffold-generated package.json with an existing one on disk.
-    /// Preserves all existing properties and only adds new ones from the scaffold output.
-    /// For nested objects (scripts, dependencies), existing values are kept.
-    /// </summary>
-    private static string MergePackageJson(string existingFilePath, string scaffoldContent, ILogger logger)
-    {
-        try
-        {
-            var existingContent = File.ReadAllText(existingFilePath);
-            if (string.IsNullOrWhiteSpace(existingContent))
-            {
-                return scaffoldContent;
-            }
-
-            var existingJson = JsonNode.Parse(existingContent)?.AsObject();
-            var scaffoldJson = JsonNode.Parse(scaffoldContent)?.AsObject();
-
-            if (existingJson is null || scaffoldJson is null)
-            {
-                return scaffoldContent;
-            }
-
-            DeepMerge(existingJson, scaffoldJson);
-            return existingJson.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
-        }
-        catch (Exception ex)
-        {
-            logger.LogDebug(ex, "Failed to merge existing package.json, using scaffold output as-is");
-            return scaffoldContent;
-        }
-    }
-
-    /// <summary>
-    /// Deep merges properties from source into target. Existing target values are preserved.
-    /// For nested objects, recursively merges. Scalar values in target are never overwritten.
-    /// </summary>
-    private static void DeepMerge(JsonObject target, JsonObject source)
-    {
-        foreach (var (key, sourceValue) in source)
-        {
-            if (sourceValue is null)
-            {
-                continue;
-            }
-
-            var targetValue = target[key];
-
-            if (targetValue is null)
-            {
-                // Property doesn't exist in target — add it from scaffold
-                target[key] = sourceValue.DeepClone();
-            }
-            else if (targetValue is JsonObject targetObj && sourceValue is JsonObject sourceObj)
-            {
-                // Both are objects — recursively merge (e.g., scripts, dependencies)
-                DeepMerge(targetObj, sourceObj);
-            }
-            // else: target already has a non-object value — keep it
-        }
-    }
 }

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -15,6 +15,9 @@ namespace Aspire.Cli.Scaffolding;
 /// </summary>
 internal sealed class ScaffoldingService : IScaffoldingService
 {
+    private const string PackageJsonFileName = "package.json";
+    private const string JavaScriptHostingPackageName = "Aspire.Hosting.JavaScript";
+
     private readonly IAppHostServerProjectFactory _appHostServerProjectFactory;
     private readonly ILanguageDiscovery _languageDiscovery;
     private readonly IInteractionService _interactionService;
@@ -51,6 +54,7 @@ internal sealed class ScaffoldingService : IScaffoldingService
         // Step 1: Resolve SDK and package strategy
         var sdkVersion = VersionHelper.GetDefaultSdkVersion();
         var config = AspireConfigFile.LoadOrCreate(directory.FullName, sdkVersion);
+        PreAddJavaScriptHostingForBrownfieldTypeScript(config, directory, language, sdkVersion);
 
         // Include the code generation package for scaffolding and code gen
         var codeGenPackage = await _languageDiscovery.GetPackageForLanguageAsync(language.LanguageId, cancellationToken);
@@ -207,5 +211,66 @@ internal sealed class ScaffoldingService : IScaffoldingService
         }
 
         _logger.LogDebug("Generated {Count} code files in {Path}", generatedFiles.Count, outputPath);
+    }
+
+    private static void PreAddJavaScriptHostingForBrownfieldTypeScript(
+        AspireConfigFile config,
+        DirectoryInfo directory,
+        LanguageInfo language,
+        string defaultSdkVersion)
+    {
+        if (!IsTypeScriptLanguage(language) ||
+            !File.Exists(Path.Combine(directory.FullName, PackageJsonFileName)) ||
+            config.Packages?.ContainsKey(JavaScriptHostingPackageName) == true)
+        {
+            return;
+        }
+
+        config.AddOrUpdatePackage(JavaScriptHostingPackageName, config.GetEffectiveSdkVersion(defaultSdkVersion));
+    }
+
+    private static bool IsTypeScriptLanguage(LanguageInfo language)
+    {
+        return language.LanguageId.Value.Equals(KnownLanguageId.TypeScript, StringComparison.OrdinalIgnoreCase) ||
+            language.LanguageId.Value.Equals(KnownLanguageId.TypeScriptAlias, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Resolves the SDK version to use for scaffolding.
+    /// If a channel is configured globally, queries that channel for available versions.
+    /// Otherwise, falls back to the default SDK version.
+    /// </summary>
+    private async Task<string> ResolveSdkVersionAsync(CancellationToken cancellationToken)
+    {
+        // Check for global channel setting
+        var channelName = await _configurationService.GetConfigurationAsync("channel", cancellationToken);
+        if (string.IsNullOrEmpty(channelName))
+        {
+            return DotNetBasedAppHostServerProject.DefaultSdkVersion;
+        }
+
+        // Find the matching channel
+        var allChannels = await _packagingService.GetChannelsAsync(cancellationToken);
+        var channel = allChannels.FirstOrDefault(c => string.Equals(c.Name, channelName, StringComparison.OrdinalIgnoreCase));
+        if (channel is null)
+        {
+            _logger.LogWarning("Configured channel '{Channel}' not found, using default SDK version", channelName);
+            return DotNetBasedAppHostServerProject.DefaultSdkVersion;
+        }
+
+        // Get template packages from the channel to determine SDK version
+        var templatePackages = await channel.GetTemplatePackagesAsync(new DirectoryInfo(Environment.CurrentDirectory), cancellationToken);
+        var latestPackage = templatePackages
+            .OrderByDescending(p => SemVersion.Parse(p.Version), SemVersion.PrecedenceComparer)
+            .FirstOrDefault();
+
+        if (latestPackage is null)
+        {
+            _logger.LogWarning("No packages found in channel '{Channel}', using default SDK version", channelName);
+            return DotNetBasedAppHostServerProject.DefaultSdkVersion;
+        }
+
+        _logger.LogDebug("Resolved SDK version {Version} from channel {Channel}", latestPackage.Version, channelName);
+        return latestPackage.Version;
     }
 }

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -234,43 +234,4 @@ internal sealed class ScaffoldingService : IScaffoldingService
         return language.LanguageId.Value.Equals(KnownLanguageId.TypeScript, StringComparison.OrdinalIgnoreCase) ||
             language.LanguageId.Value.Equals(KnownLanguageId.TypeScriptAlias, StringComparison.OrdinalIgnoreCase);
     }
-
-    /// <summary>
-    /// Resolves the SDK version to use for scaffolding.
-    /// If a channel is configured globally, queries that channel for available versions.
-    /// Otherwise, falls back to the default SDK version.
-    /// </summary>
-    private async Task<string> ResolveSdkVersionAsync(CancellationToken cancellationToken)
-    {
-        // Check for global channel setting
-        var channelName = await _configurationService.GetConfigurationAsync("channel", cancellationToken);
-        if (string.IsNullOrEmpty(channelName))
-        {
-            return DotNetBasedAppHostServerProject.DefaultSdkVersion;
-        }
-
-        // Find the matching channel
-        var allChannels = await _packagingService.GetChannelsAsync(cancellationToken);
-        var channel = allChannels.FirstOrDefault(c => string.Equals(c.Name, channelName, StringComparison.OrdinalIgnoreCase));
-        if (channel is null)
-        {
-            _logger.LogWarning("Configured channel '{Channel}' not found, using default SDK version", channelName);
-            return DotNetBasedAppHostServerProject.DefaultSdkVersion;
-        }
-
-        // Get template packages from the channel to determine SDK version
-        var templatePackages = await channel.GetTemplatePackagesAsync(new DirectoryInfo(Environment.CurrentDirectory), cancellationToken);
-        var latestPackage = templatePackages
-            .OrderByDescending(p => SemVersion.Parse(p.Version), SemVersion.PrecedenceComparer)
-            .FirstOrDefault();
-
-        if (latestPackage is null)
-        {
-            _logger.LogWarning("No packages found in channel '{Channel}', using default SDK version", channelName);
-            return DotNetBasedAppHostServerProject.DefaultSdkVersion;
-        }
-
-        _logger.LogDebug("Resolved SDK version {Version} from channel {Channel}", latestPackage.Version, channelName);
-        return latestPackage.Version;
-    }
 }

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
@@ -98,7 +100,7 @@ internal sealed class ScaffoldingService : IScaffoldingService
             context.ProjectName,
             cancellationToken);
 
-        // Step 4: Write scaffold files to disk
+        // Step 4: Write scaffold files to disk, merging package.json with existing content
         foreach (var (fileName, content) in scaffoldFiles)
         {
             var filePath = Path.Combine(directory.FullName, fileName);
@@ -107,7 +109,14 @@ internal sealed class ScaffoldingService : IScaffoldingService
             {
                 Directory.CreateDirectory(fileDirectory);
             }
-            await File.WriteAllTextAsync(filePath, content, cancellationToken);
+
+            var contentToWrite = content;
+            if (fileName.Equals(PackageJsonFileName, StringComparison.OrdinalIgnoreCase) && File.Exists(filePath))
+            {
+                contentToWrite = MergePackageJson(filePath, content, _logger);
+            }
+
+            await File.WriteAllTextAsync(filePath, contentToWrite, cancellationToken);
         }
 
         _logger.LogDebug("Wrote {Count} scaffold files", scaffoldFiles.Count);
@@ -233,5 +242,67 @@ internal sealed class ScaffoldingService : IScaffoldingService
     {
         return language.LanguageId.Value.Equals(KnownLanguageId.TypeScript, StringComparison.OrdinalIgnoreCase) ||
             language.LanguageId.Value.Equals(KnownLanguageId.TypeScriptAlias, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Merges scaffold-generated package.json with an existing one on disk.
+    /// Preserves all existing properties and only adds new ones from the scaffold output.
+    /// For nested objects (scripts, dependencies), existing values are kept.
+    /// </summary>
+    private static string MergePackageJson(string existingFilePath, string scaffoldContent, ILogger logger)
+    {
+        try
+        {
+            var existingContent = File.ReadAllText(existingFilePath);
+            if (string.IsNullOrWhiteSpace(existingContent))
+            {
+                return scaffoldContent;
+            }
+
+            var existingJson = JsonNode.Parse(existingContent)?.AsObject();
+            var scaffoldJson = JsonNode.Parse(scaffoldContent)?.AsObject();
+
+            if (existingJson is null || scaffoldJson is null)
+            {
+                return scaffoldContent;
+            }
+
+            DeepMerge(existingJson, scaffoldJson);
+            return existingJson.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to merge existing package.json, using scaffold output as-is");
+            return scaffoldContent;
+        }
+    }
+
+    /// <summary>
+    /// Deep merges properties from source into target. Existing target values are preserved.
+    /// For nested objects, recursively merges. Scalar values in target are never overwritten.
+    /// </summary>
+    private static void DeepMerge(JsonObject target, JsonObject source)
+    {
+        foreach (var (key, sourceValue) in source)
+        {
+            if (sourceValue is null)
+            {
+                continue;
+            }
+
+            var targetValue = target[key];
+
+            if (targetValue is null)
+            {
+                // Property doesn't exist in target — add it from scaffold
+                target[key] = sourceValue.DeepClone();
+            }
+            else if (targetValue is JsonObject targetObj && sourceValue is JsonObject sourceObj)
+            {
+                // Both are objects — recursively merge (e.g., scripts, dependencies)
+                DeepMerge(targetObj, sourceObj);
+            }
+            // else: target already has a non-object value — keep it
+        }
     }
 }

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
@@ -61,10 +61,10 @@ internal sealed partial class CliTemplateFactory
                     _logger.LogDebug("Copying embedded TypeScript starter template files to '{OutputPath}'.", outputPath);
                     await CopyTemplateTreeToDiskAsync("ts-starter", outputPath, ApplyAllTokens, cancellationToken);
 
-                    // Write channel to settings.json before restore so package resolution uses the selected channel.
+                    // Write channel to aspire.config.json before restore so package resolution uses the selected channel.
                     if (!string.IsNullOrEmpty(inputs.Channel))
                     {
-                        var config = AspireJsonConfiguration.Load(outputPath);
+                        var config = AspireConfigFile.Load(outputPath);
                         if (config is not null)
                         {
                             config.Channel = inputs.Channel;

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/package.json
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/package.json
@@ -3,12 +3,16 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "lint": "eslint apphost.ts",
-    "predev": "npm run lint",
-    "dev": "aspire run",
-    "prebuild": "npm run lint",
-    "build": "tsc -p tsconfig.apphost.json",
-    "watch": "tsc --watch -p tsconfig.apphost.json"
+    "aspire:lint": "eslint apphost.ts",
+    "aspire:start": "aspire run",
+    "aspire:build": "tsc -p tsconfig.apphost.json",
+    "aspire:dev": "tsc --watch -p tsconfig.apphost.json",
+    "lint": "npm run aspire:lint",
+    "predev": "npm run aspire:lint",
+    "dev": "npm run aspire:start",
+    "prebuild": "npm run aspire:lint",
+    "build": "npm run aspire:build",
+    "watch": "npm run aspire:dev"
   },
   "dependencies": {
     "vscode-jsonrpc": "^8.2.0"

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/package.json
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/package.json
@@ -7,8 +7,8 @@
     "predev": "npm run lint",
     "dev": "aspire run",
     "prebuild": "npm run lint",
-    "build": "tsc",
-    "watch": "tsc --watch"
+    "build": "tsc -p tsconfig.apphost.json",
+    "watch": "tsc --watch -p tsconfig.apphost.json"
   },
   "dependencies": {
     "vscode-jsonrpc": "^8.2.0"

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/tsconfig.apphost.json
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/tsconfig.apphost.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist/apphost",
+    "rootDir": "."
+  },
+  "include": ["apphost.ts", ".modules/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/Aspire.Hosting.CodeGeneration.TypeScript.csproj
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/Aspire.Hosting.CodeGeneration.TypeScript.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Semver" />
     <ProjectReference Include="..\Aspire.TypeSystem\Aspire.TypeSystem.csproj" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/Aspire.Hosting.CodeGeneration.TypeScript.csproj
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/Aspire.Hosting.CodeGeneration.TypeScript.csproj
@@ -24,6 +24,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)NpmVersionHelper.cs" Link="NpmVersionHelper.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Semver" />
     <ProjectReference Include="..\Aspire.TypeSystem\Aspire.TypeSystem.csproj" />
   </ItemGroup>

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
@@ -29,7 +29,11 @@ public sealed class TypeScriptLanguageSupport : ILanguageSupport
     private const string AppHostFileName = "apphost.ts";
     private const string PackageJsonFileName = "package.json";
     private const string AppHostTsConfigFileName = "tsconfig.apphost.json";
-    private static readonly JsonSerializerOptions s_jsonSerializerOptions = new() { WriteIndented = true };
+    private static readonly JsonSerializerOptions s_jsonSerializerOptions = new()
+    {
+        WriteIndented = true,
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
     private static readonly string[] s_detectionPatterns = ["apphost.ts"];
 
     /// <inheritdoc />

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Aspire.TypeSystem;
 
 namespace Aspire.Hosting.CodeGeneration.TypeScript;
@@ -9,7 +11,7 @@ namespace Aspire.Hosting.CodeGeneration.TypeScript;
 /// Provides language support for TypeScript AppHosts.
 /// Implements scaffolding, detection, and runtime configuration.
 /// </summary>
-internal sealed class TypeScriptLanguageSupport : ILanguageSupport
+public sealed class TypeScriptLanguageSupport : ILanguageSupport
 {
     /// <summary>
     /// The language/runtime identifier for TypeScript with Node.js.
@@ -23,6 +25,10 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
     private const string CodeGenTarget = "TypeScript";
 
     private const string LanguageDisplayName = "TypeScript (Node.js)";
+    private const string AppHostFileName = "apphost.ts";
+    private const string PackageJsonFileName = "package.json";
+    private const string AppHostTsConfigFileName = "tsconfig.apphost.json";
+    private static readonly JsonSerializerOptions s_jsonSerializerOptions = new() { WriteIndented = true };
     private static readonly string[] s_detectionPatterns = ["apphost.ts"];
 
     /// <inheritdoc />
@@ -34,7 +40,7 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
         var files = new Dictionary<string, string>();
 
         // Create apphost.ts
-        files["apphost.ts"] = """
+        files[AppHostFileName] = """
             // Aspire TypeScript AppHost
             // For more information, see: https://aspire.dev
 
@@ -49,39 +55,7 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
             await builder.build().run();
             """;
 
-        // Create package.json
-        // NOTE: The engines.node constraint must match ESLint 10's own requirement
-        // (^20.19.0 || ^22.13.0 || >=24) to avoid install/runtime failures on unsupported Node versions.
-        var packageName = request.ProjectName?.ToLowerInvariant() ?? "aspire-apphost";
-        files["package.json"] = $$"""
-            {
-              "name": "{{packageName}}",
-              "private": true,
-              "type": "module",
-              "scripts": {
-                "lint": "eslint apphost.ts",
-                "predev": "npm run lint",
-                "dev": "aspire run",
-                "prebuild": "npm run lint",
-                "build": "tsc",
-                "watch": "tsc --watch"
-              },
-              "dependencies": {
-                "vscode-jsonrpc": "^8.2.0"
-              },
-              "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
-              },
-              "devDependencies": {
-                "@types/node": "^22.0.0",
-                "eslint": "^10.0.3",
-                "nodemon": "^3.1.14",
-                "tsx": "^4.21.0",
-                "typescript": "^5.9.3",
-                "typescript-eslint": "^8.57.1"
-              }
-            }
-            """;
+        files[PackageJsonFileName] = CreatePackageJson(request);
 
         // Create eslint.config.mjs for catching unawaited promises in apphost.ts
         files["eslint.config.mjs"] = """
@@ -105,8 +79,8 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
             });
             """;
 
-        // Create tsconfig.json for TypeScript configuration
-        files["tsconfig.json"] = """
+        // Create an apphost-specific tsconfig so existing brownfield TypeScript settings are preserved.
+        files[AppHostTsConfigFileName] = """
             {
               "compilerOptions": {
                 "target": "ES2022",
@@ -116,7 +90,7 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
                 "forceConsistentCasingInFileNames": true,
                 "strict": true,
                 "skipLibCheck": true,
-                "outDir": "./dist",
+                "outDir": "./dist/apphost",
                 "rootDir": "."
               },
               "include": ["apphost.ts", ".modules/**/*.ts"],
@@ -152,18 +126,92 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
         return files;
     }
 
+    private static string CreatePackageJson(ScaffoldRequest request)
+    {
+        var packageJsonPath = Path.Combine(request.TargetPath, PackageJsonFileName);
+        var packageJson = LoadExistingPackageJson(packageJsonPath);
+
+        if (packageJson is null)
+        {
+            var packageName = request.ProjectName?.ToLowerInvariant() ?? "aspire-apphost";
+            packageJson = new JsonObject
+            {
+                ["name"] = packageName,
+                ["version"] = "1.0.0",
+                ["type"] = "module"
+            };
+
+            // NOTE: The engines.node constraint must match ESLint 10's own requirement
+            // (^20.19.0 || ^22.13.0 || >=24) to avoid install/runtime failures on unsupported Node versions.
+            packageJson["engines"] = new JsonObject
+            {
+                ["node"] = "^20.19.0 || ^22.13.0 || >=24"
+            };
+        }
+
+        var scripts = EnsureObject(packageJson, "scripts");
+        scripts["aspire:lint"] = "eslint apphost.ts";
+        scripts["aspire:start"] = "aspire run";
+        scripts["aspire:build"] = $"npm run aspire:lint && tsc -p {AppHostTsConfigFileName}";
+        scripts["aspire:dev"] = $"tsc --watch -p {AppHostTsConfigFileName}";
+
+        EnsureDependency(packageJson, "dependencies", "vscode-jsonrpc", "^8.2.0");
+        EnsureDependency(packageJson, "devDependencies", "@types/node", "^22.0.0");
+        EnsureDependency(packageJson, "devDependencies", "eslint", "^10.0.3");
+        EnsureDependency(packageJson, "devDependencies", "nodemon", "^3.1.14");
+        EnsureDependency(packageJson, "devDependencies", "tsx", "^4.21.0");
+        EnsureDependency(packageJson, "devDependencies", "typescript", "^5.9.3");
+        EnsureDependency(packageJson, "devDependencies", "typescript-eslint", "^8.57.1");
+
+        return packageJson.ToJsonString(s_jsonSerializerOptions);
+    }
+
+    private static JsonObject? LoadExistingPackageJson(string packageJsonPath)
+    {
+        if (!File.Exists(packageJsonPath))
+        {
+            return null;
+        }
+
+        var content = File.ReadAllText(packageJsonPath);
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return new JsonObject();
+        }
+
+        return JsonNode.Parse(content)?.AsObject() ?? new JsonObject();
+    }
+
+    private static void EnsureDependency(JsonObject packageJson, string sectionName, string packageName, string version)
+    {
+        var section = EnsureObject(packageJson, sectionName);
+        section[packageName] ??= version;
+    }
+
+    private static JsonObject EnsureObject(JsonObject parent, string propertyName)
+    {
+        if (parent[propertyName] is JsonObject obj)
+        {
+            return obj;
+        }
+
+        obj = new JsonObject();
+        parent[propertyName] = obj;
+        return obj;
+    }
+
     /// <inheritdoc />
     public DetectionResult Detect(string directoryPath)
     {
         // Check for apphost.ts
-        var appHostPath = Path.Combine(directoryPath, "apphost.ts");
+        var appHostPath = Path.Combine(directoryPath, AppHostFileName);
         if (!File.Exists(appHostPath))
         {
             return DetectionResult.NotFound;
         }
 
         // Check for package.json (required for TypeScript/Node.js projects)
-        var packageJsonPath = Path.Combine(directoryPath, "package.json");
+        var packageJsonPath = Path.Combine(directoryPath, PackageJsonFileName);
         if (!File.Exists(packageJsonPath))
         {
             return DetectionResult.NotFound;
@@ -172,7 +220,7 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
         // Note: .csproj precedence is handled by the CLI, not here.
         // Language support should only check for its own language markers.
 
-        return DetectionResult.Found(LanguageId, "apphost.ts");
+        return DetectionResult.Found(LanguageId, AppHostFileName);
     }
 
     /// <inheritdoc />
@@ -193,7 +241,7 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
             Execute = new CommandSpec
             {
                 Command = "npx",
-                Args = ["tsx", "{appHostFile}"]
+                Args = ["tsx", "--tsconfig", AppHostTsConfigFileName, "{appHostFile}"]
             },
             WatchExecute = new CommandSpec
             {
@@ -205,7 +253,7 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
                     "--ext", "ts",
                     "--ignore", "node_modules/",
                     "--ignore", ".modules/",
-                    "--exec", "npx tsx {appHostFile}"
+                    "--exec", $"npx tsx --tsconfig {AppHostTsConfigFileName} {{appHostFile}}"
                 ]
             }
         };

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.TypeSystem;
+using Semver;
 
 namespace Aspire.Hosting.CodeGeneration.TypeScript;
 
@@ -185,7 +186,18 @@ public sealed class TypeScriptLanguageSupport : ILanguageSupport
     private static void EnsureDependency(JsonObject packageJson, string sectionName, string packageName, string version)
     {
         var section = EnsureObject(packageJson, sectionName);
-        section[packageName] ??= version;
+
+        var existingVersion = GetStringValue(section[packageName]);
+        if (existingVersion is null)
+        {
+            section[packageName] = version;
+            return;
+        }
+
+        if (ShouldUpgradeDependency(existingVersion, version))
+        {
+            section[packageName] = version;
+        }
     }
 
     private static JsonObject EnsureObject(JsonObject parent, string propertyName)
@@ -198,6 +210,66 @@ public sealed class TypeScriptLanguageSupport : ILanguageSupport
         obj = new JsonObject();
         parent[propertyName] = obj;
         return obj;
+    }
+
+    private static string? GetStringValue(JsonNode? node)
+    {
+        return node is JsonValue value && value.TryGetValue<string>(out var stringValue) ? stringValue : null;
+    }
+
+    private static bool ShouldUpgradeDependency(string existingVersion, string desiredVersion)
+    {
+        return TryParseComparableVersion(existingVersion, out var existingSemVersion)
+            && TryParseComparableVersion(desiredVersion, out var desiredSemVersion)
+            && SemVersion.ComparePrecedence(existingSemVersion, desiredSemVersion) < 0;
+    }
+
+    private static bool TryParseComparableVersion(string version, out SemVersion semVersion)
+    {
+        var normalizedVersion = version.Trim();
+        if (normalizedVersion.Contains("||", StringComparison.Ordinal) ||
+            normalizedVersion.StartsWith("workspace:", StringComparison.OrdinalIgnoreCase) ||
+            normalizedVersion.StartsWith("file:", StringComparison.OrdinalIgnoreCase) ||
+            normalizedVersion.StartsWith("link:", StringComparison.OrdinalIgnoreCase))
+        {
+            semVersion = default!;
+            return false;
+        }
+
+        while (normalizedVersion.Length > 0)
+        {
+            if (normalizedVersion.StartsWith(">=", StringComparison.Ordinal) ||
+                normalizedVersion.StartsWith("<=", StringComparison.Ordinal))
+            {
+                normalizedVersion = normalizedVersion[2..].TrimStart();
+                continue;
+            }
+
+            if (normalizedVersion[0] is '^' or '~' or '>' or '<' or '=')
+            {
+                normalizedVersion = normalizedVersion[1..].TrimStart();
+                continue;
+            }
+
+            break;
+        }
+
+        if (SemVersion.TryParse(normalizedVersion, SemVersionStyles.Strict, out var strictVersion) &&
+            strictVersion is not null)
+        {
+            semVersion = strictVersion;
+            return true;
+        }
+
+        if (SemVersion.TryParse(normalizedVersion, SemVersionStyles.Any, out var anyVersion) &&
+            anyVersion is not null)
+        {
+            semVersion = anyVersion;
+            return true;
+        }
+
+        semVersion = default!;
+        return false;
     }
 
     /// <inheritdoc />
@@ -241,19 +313,20 @@ public sealed class TypeScriptLanguageSupport : ILanguageSupport
             Execute = new CommandSpec
             {
                 Command = "npx",
-                Args = ["tsx", "--tsconfig", AppHostTsConfigFileName, "{appHostFile}"]
+                Args = ["--no-install", "tsx", "--tsconfig", AppHostTsConfigFileName, "{appHostFile}"]
             },
             WatchExecute = new CommandSpec
             {
                 Command = "npx",
                 Args = [
+                    "--no-install",
                     "nodemon",
                     "--signal", "SIGTERM",
                     "--watch", ".",
                     "--ext", "ts",
                     "--ignore", "node_modules/",
                     "--ignore", ".modules/",
-                    "--exec", $"npx tsx --tsconfig {AppHostTsConfigFileName} {{appHostFile}}"
+                    "--exec", $"npx --no-install tsx --tsconfig {AppHostTsConfigFileName} {{appHostFile}}"
                 ]
             }
         };

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
@@ -3,8 +3,8 @@
 
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Aspire.Shared;
 using Aspire.TypeSystem;
-using Semver;
 
 namespace Aspire.Hosting.CodeGeneration.TypeScript;
 
@@ -194,7 +194,7 @@ public sealed class TypeScriptLanguageSupport : ILanguageSupport
             return;
         }
 
-        if (ShouldUpgradeDependency(existingVersion, version))
+        if (NpmVersionHelper.ShouldUpgrade(existingVersion, version))
         {
             section[packageName] = version;
         }
@@ -215,61 +215,6 @@ public sealed class TypeScriptLanguageSupport : ILanguageSupport
     private static string? GetStringValue(JsonNode? node)
     {
         return node is JsonValue value && value.TryGetValue<string>(out var stringValue) ? stringValue : null;
-    }
-
-    private static bool ShouldUpgradeDependency(string existingVersion, string desiredVersion)
-    {
-        return TryParseComparableVersion(existingVersion, out var existingSemVersion)
-            && TryParseComparableVersion(desiredVersion, out var desiredSemVersion)
-            && SemVersion.ComparePrecedence(existingSemVersion, desiredSemVersion) < 0;
-    }
-
-    private static bool TryParseComparableVersion(string version, out SemVersion semVersion)
-    {
-        var normalizedVersion = version.Trim();
-        if (normalizedVersion.Contains("||", StringComparison.Ordinal) ||
-            normalizedVersion.StartsWith("workspace:", StringComparison.OrdinalIgnoreCase) ||
-            normalizedVersion.StartsWith("file:", StringComparison.OrdinalIgnoreCase) ||
-            normalizedVersion.StartsWith("link:", StringComparison.OrdinalIgnoreCase))
-        {
-            semVersion = default!;
-            return false;
-        }
-
-        while (normalizedVersion.Length > 0)
-        {
-            if (normalizedVersion.StartsWith(">=", StringComparison.Ordinal) ||
-                normalizedVersion.StartsWith("<=", StringComparison.Ordinal))
-            {
-                normalizedVersion = normalizedVersion[2..].TrimStart();
-                continue;
-            }
-
-            if (normalizedVersion[0] is '^' or '~' or '>' or '<' or '=')
-            {
-                normalizedVersion = normalizedVersion[1..].TrimStart();
-                continue;
-            }
-
-            break;
-        }
-
-        if (SemVersion.TryParse(normalizedVersion, SemVersionStyles.Strict, out var strictVersion) &&
-            strictVersion is not null)
-        {
-            semVersion = strictVersion;
-            return true;
-        }
-
-        if (SemVersion.TryParse(normalizedVersion, SemVersionStyles.Any, out var anyVersion) &&
-            anyVersion is not null)
-        {
-            semVersion = anyVersion;
-            return true;
-        }
-
-        semVersion = default!;
-        return false;
     }
 
     /// <inheritdoc />

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
@@ -12,7 +12,7 @@ namespace Aspire.Hosting.CodeGeneration.TypeScript;
 /// Provides language support for TypeScript AppHosts.
 /// Implements scaffolding, detection, and runtime configuration.
 /// </summary>
-public sealed class TypeScriptLanguageSupport : ILanguageSupport
+internal sealed class TypeScriptLanguageSupport : ILanguageSupport
 {
     /// <summary>
     /// The language/runtime identifier for TypeScript with Node.js.
@@ -143,16 +143,17 @@ public sealed class TypeScriptLanguageSupport : ILanguageSupport
             {
                 ["name"] = packageName,
                 ["version"] = "1.0.0",
+                ["private"] = true,
                 ["type"] = "module"
             };
-
-            // NOTE: The engines.node constraint must match ESLint 10's own requirement
-            // (^20.19.0 || ^22.13.0 || >=24) to avoid install/runtime failures on unsupported Node versions.
-            packageJson["engines"] = new JsonObject
-            {
-                ["node"] = "^20.19.0 || ^22.13.0 || >=24"
-            };
         }
+
+        // NOTE: The engines.node constraint must match ESLint 10's own requirement
+        // (^20.19.0 || ^22.13.0 || >=24) to avoid install/runtime failures on unsupported Node versions.
+        // This is set for both greenfield and brownfield scenarios — the user is opting into Aspire
+        // which requires these Node versions. The CLI-side MergeEngines also enforces this during merge.
+        var engines = EnsureObject(packageJson, "engines");
+        engines["node"] = "^20.19.0 || ^22.13.0 || >=24";
 
         var scripts = EnsureObject(packageJson, "scripts");
         scripts["aspire:lint"] = "eslint apphost.ts";
@@ -178,13 +179,22 @@ public sealed class TypeScriptLanguageSupport : ILanguageSupport
             return null;
         }
 
-        var content = File.ReadAllText(packageJsonPath);
-        if (string.IsNullOrWhiteSpace(content))
+        try
         {
+            var content = File.ReadAllText(packageJsonPath);
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return new JsonObject();
+            }
+
+            return JsonNode.Parse(content) as JsonObject ?? new JsonObject();
+        }
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            // Malformed JSON or I/O errors — return empty object so scaffolding can proceed.
+            // The CLI-side PackageJsonMerger provides additional fallback safety.
             return new JsonObject();
         }
-
-        return JsonNode.Parse(content)?.AsObject() ?? new JsonObject();
     }
 
     private static void EnsureDependency(JsonObject packageJson, string sectionName, string packageName, string version)

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
@@ -29,6 +29,28 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
     private const string AppHostFileName = "apphost.ts";
     private const string PackageJsonFileName = "package.json";
     private const string AppHostTsConfigFileName = "tsconfig.apphost.json";
+
+    /// <summary>
+    /// The default content for tsconfig.apphost.json, shared between scaffolding and migration.
+    /// </summary>
+    private const string AppHostTsConfigContent = """
+        {
+          "compilerOptions": {
+            "target": "ES2022",
+            "module": "NodeNext",
+            "moduleResolution": "NodeNext",
+            "esModuleInterop": true,
+            "forceConsistentCasingInFileNames": true,
+            "strict": true,
+            "skipLibCheck": true,
+            "outDir": "./dist/apphost",
+            "rootDir": "."
+          },
+          "include": ["apphost.ts", ".modules/**/*.ts"],
+          "exclude": ["node_modules"]
+        }
+        """;
+
     private static readonly JsonSerializerOptions s_jsonSerializerOptions = new()
     {
         WriteIndented = true,
@@ -85,23 +107,7 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
             """;
 
         // Create an apphost-specific tsconfig so existing brownfield TypeScript settings are preserved.
-        files[AppHostTsConfigFileName] = """
-            {
-              "compilerOptions": {
-                "target": "ES2022",
-                "module": "NodeNext",
-                "moduleResolution": "NodeNext",
-                "esModuleInterop": true,
-                "forceConsistentCasingInFileNames": true,
-                "strict": true,
-                "skipLibCheck": true,
-                "outDir": "./dist/apphost",
-                "rootDir": "."
-              },
-              "include": ["apphost.ts", ".modules/**/*.ts"],
-              "exclude": ["node_modules"]
-            }
-            """;
+        files[AppHostTsConfigFileName] = AppHostTsConfigContent;
 
         // Create apphost.run.json with random ports
         // Use PortSeed if provided (for testing), otherwise use random
@@ -133,19 +139,21 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
 
     private static string CreatePackageJson(ScaffoldRequest request)
     {
+        // Build scaffold output with only Aspire-desired content. We intentionally do NOT
+        // read the existing package.json here — the CLI-side PackageJsonMerger handles all
+        // combining with on-disk content. Including existing entries in the scaffold output
+        // would cause a double-merge where correctness depends on JsonObject iteration order.
+        var packageJson = new JsonObject();
         var packageJsonPath = Path.Combine(request.TargetPath, PackageJsonFileName);
-        var packageJson = LoadExistingPackageJson(packageJsonPath);
 
-        if (packageJson is null)
+        if (!File.Exists(packageJsonPath))
         {
+            // Greenfield: include root metadata so the scaffold output is a complete package.json.
             var packageName = request.ProjectName?.ToLowerInvariant() ?? "aspire-apphost";
-            packageJson = new JsonObject
-            {
-                ["name"] = packageName,
-                ["version"] = "1.0.0",
-                ["private"] = true,
-                ["type"] = "module"
-            };
+            packageJson["name"] = packageName;
+            packageJson["version"] = "1.0.0";
+            packageJson["private"] = true;
+            packageJson["type"] = "module";
         }
 
         // NOTE: The engines.node constraint must match ESLint 10's own requirement
@@ -170,31 +178,6 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
         EnsureDependency(packageJson, "devDependencies", "typescript-eslint", "^8.57.1");
 
         return packageJson.ToJsonString(s_jsonSerializerOptions);
-    }
-
-    private static JsonObject? LoadExistingPackageJson(string packageJsonPath)
-    {
-        if (!File.Exists(packageJsonPath))
-        {
-            return null;
-        }
-
-        try
-        {
-            var content = File.ReadAllText(packageJsonPath);
-            if (string.IsNullOrWhiteSpace(content))
-            {
-                return new JsonObject();
-            }
-
-            return JsonNode.Parse(content) as JsonObject ?? new JsonObject();
-        }
-        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException or InvalidOperationException)
-        {
-            // Malformed JSON or I/O errors — return empty object so scaffolding can proceed.
-            // The CLI-side PackageJsonMerger provides additional fallback safety.
-            return new JsonObject();
-        }
     }
 
     private static void EnsureDependency(JsonObject packageJson, string sectionName, string packageName, string version)
@@ -287,6 +270,10 @@ internal sealed class TypeScriptLanguageSupport : ILanguageSupport
                     "--ignore", ".modules/",
                     "--exec", $"npx --no-install tsx --tsconfig {AppHostTsConfigFileName} {{appHostFile}}"
                 ]
+            },
+            MigrationFiles = new Dictionary<string, string>
+            {
+                [AppHostTsConfigFileName] = AppHostTsConfigContent
             }
         };
     }

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
@@ -153,7 +153,7 @@ public sealed class TypeScriptLanguageSupport : ILanguageSupport
         var scripts = EnsureObject(packageJson, "scripts");
         scripts["aspire:lint"] = "eslint apphost.ts";
         scripts["aspire:start"] = "aspire run";
-        scripts["aspire:build"] = $"npm run aspire:lint && tsc -p {AppHostTsConfigFileName}";
+        scripts["aspire:build"] = $"tsc -p {AppHostTsConfigFileName}";
         scripts["aspire:dev"] = $"tsc --watch -p {AppHostTsConfigFileName}";
 
         EnsureDependency(packageJson, "dependencies", "vscode-jsonrpc", "^8.2.0");

--- a/src/Aspire.TypeSystem/RuntimeSpec.cs
+++ b/src/Aspire.TypeSystem/RuntimeSpec.cs
@@ -54,6 +54,13 @@ public sealed class RuntimeSpec
     /// this capability. When null, the CLI always uses the default process-based launcher.
     /// </summary>
     public string? ExtensionLaunchCapability { get; init; }
+
+    /// <summary>
+    /// Gets files that must exist in the project directory before execution.
+    /// If a file in this dictionary is missing, the CLI will create it with the provided content.
+    /// This supports upgrade scenarios where new runtime requirements are introduced.
+    /// </summary>
+    public Dictionary<string, string>? MigrationFiles { get; init; }
 }
 
 /// <summary>

--- a/src/Shared/NpmVersionHelper.cs
+++ b/src/Shared/NpmVersionHelper.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Semver;
+
+namespace Aspire.Shared;
+
+/// <summary>
+/// Helpers for parsing and comparing npm-style version ranges.
+/// </summary>
+internal static class NpmVersionHelper
+{
+    /// <summary>
+    /// Determines whether the existing dependency version should be upgraded to the desired version.
+    /// Returns <c>true</c> when both versions are parseable and the desired version is newer.
+    /// </summary>
+    internal static bool ShouldUpgrade(string existingVersion, string desiredVersion)
+    {
+        return TryParseNpmVersion(existingVersion, out var existingSemVersion)
+            && TryParseNpmVersion(desiredVersion, out var desiredSemVersion)
+            && SemVersion.ComparePrecedence(existingSemVersion, desiredSemVersion) < 0;
+    }
+
+    /// <summary>
+    /// Attempts to extract a comparable <see cref="SemVersion"/> from an npm version range string.
+    /// Strips range operators (<c>^</c>, <c>~</c>, <c>&gt;=</c>, <c>&lt;=</c>, <c>&gt;</c>, <c>&lt;</c>, <c>=</c>)
+    /// and parses the remaining version. Returns <c>false</c> for union ranges (<c>||</c>),
+    /// workspace references, file paths, and symlinks.
+    /// </summary>
+    internal static bool TryParseNpmVersion(string version, out SemVersion semVersion)
+    {
+        var normalizedVersion = version.Trim();
+        if (normalizedVersion.Contains("||", StringComparison.Ordinal) ||
+            normalizedVersion.StartsWith("workspace:", StringComparison.OrdinalIgnoreCase) ||
+            normalizedVersion.StartsWith("file:", StringComparison.OrdinalIgnoreCase) ||
+            normalizedVersion.StartsWith("link:", StringComparison.OrdinalIgnoreCase))
+        {
+            semVersion = default!;
+            return false;
+        }
+
+        while (normalizedVersion.Length > 0)
+        {
+            if (normalizedVersion.StartsWith(">=", StringComparison.Ordinal) ||
+                normalizedVersion.StartsWith("<=", StringComparison.Ordinal))
+            {
+                normalizedVersion = normalizedVersion[2..].TrimStart();
+                continue;
+            }
+
+            if (normalizedVersion[0] is '^' or '~' or '>' or '<' or '=')
+            {
+                normalizedVersion = normalizedVersion[1..].TrimStart();
+                continue;
+            }
+
+            break;
+        }
+
+        if (SemVersion.TryParse(normalizedVersion, SemVersionStyles.Strict, out var strictVersion) &&
+            strictVersion is not null)
+        {
+            semVersion = strictVersion;
+            return true;
+        }
+
+        if (SemVersion.TryParse(normalizedVersion, SemVersionStyles.Any, out var anyVersion) &&
+            anyVersion is not null)
+        {
+            semVersion = anyVersion;
+            return true;
+        }
+
+        semVersion = default!;
+        return false;
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Aspire.Cli.Tests.Utils;
 using Hex1b;
@@ -357,4 +358,83 @@ internal static class CliE2ETestHelpers
 
         return string.Equals(stabilize, "true", StringComparison.OrdinalIgnoreCase);
     }
+
+    /// <summary>
+    /// Prepares a local NuGet package channel for source-build E2E tests.
+    /// Copies packed Aspire.*.nupkg files to a workspace-local directory and extracts the SDK version.
+    /// Returns <c>null</c> for non-SourceBuild modes.
+    /// </summary>
+    /// <param name="repoRoot">The repo root directory containing artifacts/.</param>
+    /// <param name="workspace">The temporary workspace where the local channel directory will be created.</param>
+    /// <param name="installMode">The detected install mode.</param>
+    /// <param name="requiredPackagePrefixes">
+    /// Optional additional package name prefixes to validate beyond <c>Aspire.Hosting.</c>.
+    /// For example, <c>["Aspire.Hosting.CodeGeneration.TypeScript.", "Aspire.Hosting.JavaScript."]</c>.
+    /// </param>
+    /// <returns>A <see cref="LocalChannelInfo"/> with the packages path and SDK version, or <c>null</c> for non-SourceBuild.</returns>
+    internal static LocalChannelInfo? PrepareLocalChannel(
+        string repoRoot,
+        TemporaryWorkspace workspace,
+        DockerInstallMode installMode,
+        string[]? requiredPackagePrefixes = null)
+    {
+        if (installMode != DockerInstallMode.SourceBuild)
+        {
+            return null;
+        }
+
+        var shippingPackagesDirectory = Path.Combine(repoRoot, "artifacts", "packages", "Debug", "Shipping");
+        if (!Directory.Exists(shippingPackagesDirectory))
+        {
+            throw new InvalidOperationException("Local source-built E2E tests require packed Aspire packages. Run './build.sh --bundle --pack' first.");
+        }
+
+        var packageFiles = Directory.EnumerateFiles(shippingPackagesDirectory, "Aspire*.nupkg", SearchOption.TopDirectoryOnly)
+            .Where(file => !file.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        if (!packageFiles.Any(file => Path.GetFileName(file).StartsWith("Aspire.Hosting.", StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidOperationException("Local source-built E2E tests require packed Aspire.Hosting packages. Run './build.sh --bundle --pack' first.");
+        }
+
+        if (requiredPackagePrefixes is not null)
+        {
+            foreach (var prefix in requiredPackagePrefixes)
+            {
+                if (!packageFiles.Any(file => Path.GetFileName(file).StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
+                {
+                    throw new InvalidOperationException($"Local source-built E2E tests require packed {prefix.TrimEnd('.')} packages. Run './build.sh --bundle --pack' first.");
+                }
+            }
+        }
+
+        var localChannelPackagesPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire-local", "packages");
+        Directory.CreateDirectory(localChannelPackagesPath);
+
+        foreach (var packageFile in packageFiles)
+        {
+            File.Copy(packageFile, Path.Combine(localChannelPackagesPath, Path.GetFileName(packageFile)), overwrite: true);
+        }
+
+        var sdkVersion = packageFiles
+            .Select(Path.GetFileName)
+            .FirstOrDefault(fileName => fileName is not null && Regex.IsMatch(fileName, @"^Aspire\.Hosting\.\d+\.\d+\.\d+.*\.nupkg$", RegexOptions.IgnoreCase))
+            ?.Replace("Aspire.Hosting.", string.Empty, StringComparison.OrdinalIgnoreCase)
+            ?.Replace(".nupkg", string.Empty, StringComparison.OrdinalIgnoreCase);
+
+        if (string.IsNullOrEmpty(sdkVersion))
+        {
+            throw new InvalidOperationException("Local source-built E2E tests could not determine the Aspire SDK version from packed packages.");
+        }
+
+        return new LocalChannelInfo(localChannelPackagesPath, sdkVersion);
+    }
+
+    /// <summary>
+    /// Information about a local NuGet package channel for source-build E2E tests.
+    /// </summary>
+    /// <param name="PackagesPath">The directory path containing the local .nupkg files.</param>
+    /// <param name="SdkVersion">The Aspire SDK version extracted from the package filenames.</param>
+    internal sealed record LocalChannelInfo(string PackagesPath, string SdkVersion);
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Nodes;
 using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Tests.Utils;
 using Hex1b.Automation;
@@ -96,4 +97,175 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
 
         await pendingRun;
     }
+
+    [Fact]
+    public async Task InitTypeScriptAppHost_AugmentsExistingViteRepoAtRoot()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+        var workspace = TemporaryWorkspace.Create(output);
+        var localChannel = PrepareLocalChannel(repoRoot, workspace, installMode);
+        var channelArgument = localChannel is not null ? " --channel local" : string.Empty;
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, installMode, output, variant: CliE2ETestHelpers.DockerfileVariant.DotNet, mountDockerSocket: true, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        string? originalDevScript = null;
+        string? originalBuildScript = null;
+        string? originalPreviewScript = null;
+        string? originalTsConfig = null;
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+
+        await auto.InstallAspireCliInDockerAsync(installMode, counter);
+
+        await auto.EnablePolyglotSupportAsync(counter);
+
+        if (localChannel is not null)
+        {
+            var containerLocalChannelPackagesPath = CliE2ETestHelpers.ToContainerPath(localChannel.PackagesPath, workspace);
+            await auto.TypeAsync($"mkdir -p ~/.aspire/hives/local && rm -rf ~/.aspire/hives/local/packages && ln -s '{containerLocalChannelPackagesPath}' ~/.aspire/hives/local/packages");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+        }
+
+        // Create brownfield Vite project
+        await auto.TypeAsync("mkdir brownfield && cd brownfield");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("npm create -y vite@latest . -- --template vanilla-ts --no-interactive");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+        // Capture original package.json scripts and tsconfig before aspire init
+        var projectRoot = Path.Combine(workspace.WorkspaceRoot.FullName, "brownfield");
+        var packageJson = JsonNode.Parse(File.ReadAllText(Path.Combine(projectRoot, "package.json")))!.AsObject();
+        var scripts = packageJson["scripts"]!.AsObject();
+        originalDevScript = scripts["dev"]?.GetValue<string>();
+        originalBuildScript = scripts["build"]?.GetValue<string>();
+        originalPreviewScript = scripts["preview"]?.GetValue<string>();
+        originalTsConfig = File.ReadAllText(Path.Combine(projectRoot, "tsconfig.json"));
+
+        if (localChannel is not null)
+        {
+            WriteLocalChannelSettings(projectRoot, localChannel.SdkVersion);
+        }
+
+        // Run aspire init in brownfield mode
+        await auto.TypeAsync($"aspire init --language typescript --non-interactive{channelArgument}");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("Created apphost.ts", timeout: TimeSpan.FromMinutes(2));
+        await auto.DeclineAgentInitPromptAsync(counter);
+
+        // Verify brownfield augmentation preserved existing config
+        Assert.NotNull(originalDevScript);
+        Assert.NotNull(originalBuildScript);
+        Assert.NotNull(originalPreviewScript);
+        Assert.NotNull(originalTsConfig);
+
+        packageJson = JsonNode.Parse(File.ReadAllText(Path.Combine(projectRoot, "package.json")))!.AsObject();
+        scripts = packageJson["scripts"]!.AsObject();
+        var dependencies = packageJson["dependencies"]!.AsObject();
+        var devDependencies = packageJson["devDependencies"]!.AsObject();
+
+        Assert.Equal(originalDevScript, scripts["dev"]?.GetValue<string>());
+        Assert.Equal(originalBuildScript, scripts["build"]?.GetValue<string>());
+        Assert.Equal(originalPreviewScript, scripts["preview"]?.GetValue<string>());
+        Assert.Equal("aspire run", scripts["aspire:start"]?.GetValue<string>());
+        Assert.Equal("tsc -p tsconfig.apphost.json", scripts["aspire:build"]?.GetValue<string>());
+        Assert.Equal("tsc --watch -p tsconfig.apphost.json", scripts["aspire:dev"]?.GetValue<string>());
+        Assert.False(scripts.ContainsKey("start"));
+
+        Assert.Equal("module", packageJson["type"]?.GetValue<string>());
+        Assert.NotNull(dependencies["vscode-jsonrpc"]);
+        Assert.NotNull(devDependencies["@types/node"]);
+        Assert.NotNull(devDependencies["nodemon"]);
+        Assert.NotNull(devDependencies["tsx"]);
+        Assert.NotNull(devDependencies["typescript"]);
+
+        Assert.Equal(originalTsConfig, File.ReadAllText(Path.Combine(projectRoot, "tsconfig.json")));
+        Assert.True(File.Exists(Path.Combine(projectRoot, "tsconfig.apphost.json")));
+
+        // Run the apphost to verify it works
+        await auto.TypeAsync("aspire run");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("Press CTRL+C to stop the apphost and exit.", timeout: TimeSpan.FromMinutes(3));
+
+        await auto.Ctrl().KeyAsync(Hex1bKey.C);
+        await auto.WaitForSuccessPromptAsync(counter);
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+    }
+
+    private static void WriteLocalChannelSettings(string projectRoot, string sdkVersion)
+    {
+        var settingsPath = Path.Combine(projectRoot, ".aspire", "settings.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(settingsPath)!);
+
+        var settings = new JsonObject
+        {
+            ["channel"] = "local",
+            ["sdkVersion"] = sdkVersion
+        };
+
+        File.WriteAllText(settingsPath, settings.ToJsonString());
+    }
+
+    private static LocalChannelInfo? PrepareLocalChannel(
+        string repoRoot,
+        TemporaryWorkspace workspace,
+        CliE2ETestHelpers.DockerInstallMode installMode)
+    {
+        if (installMode != CliE2ETestHelpers.DockerInstallMode.SourceBuild)
+        {
+            return null;
+        }
+
+        var shippingPackagesDirectory = Path.Combine(repoRoot, "artifacts", "packages", "Debug", "Shipping");
+        if (!Directory.Exists(shippingPackagesDirectory))
+        {
+            throw new InvalidOperationException("Local source-built TypeScript E2E tests require packed Aspire packages. Run './build.sh --bundle --pack' first.");
+        }
+
+        var packageFiles = Directory.EnumerateFiles(shippingPackagesDirectory, "Aspire*.nupkg", SearchOption.TopDirectoryOnly)
+            .Where(file => !file.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        if (!packageFiles.Any(file => Path.GetFileName(file).StartsWith("Aspire.Hosting.CodeGeneration.TypeScript.", StringComparison.OrdinalIgnoreCase)) ||
+            !packageFiles.Any(file => Path.GetFileName(file).StartsWith("Aspire.Hosting.JavaScript.", StringComparison.OrdinalIgnoreCase)) ||
+            !packageFiles.Any(file => Path.GetFileName(file).StartsWith("Aspire.Hosting.", StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidOperationException("Local source-built TypeScript E2E tests require packed Aspire.Hosting, Aspire.Hosting.JavaScript, and Aspire.Hosting.CodeGeneration.TypeScript packages. Run './build.sh --bundle --pack' first.");
+        }
+
+        var localChannelPackagesPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire-local", "packages");
+        Directory.CreateDirectory(localChannelPackagesPath);
+
+        foreach (var packageFile in packageFiles)
+        {
+            File.Copy(packageFile, Path.Combine(localChannelPackagesPath, Path.GetFileName(packageFile)), overwrite: true);
+        }
+
+        var sdkVersion = packageFiles
+            .Select(Path.GetFileName)
+            .FirstOrDefault(fileName => fileName is not null && System.Text.RegularExpressions.Regex.IsMatch(fileName, @"^Aspire\.Hosting\.\d+\.\d+\.\d+.*\.nupkg$", System.Text.RegularExpressions.RegexOptions.IgnoreCase))
+            ?.Replace("Aspire.Hosting.", string.Empty, StringComparison.OrdinalIgnoreCase)
+            ?.Replace(".nupkg", string.Empty, StringComparison.OrdinalIgnoreCase);
+
+        if (string.IsNullOrEmpty(sdkVersion))
+        {
+            throw new InvalidOperationException("Local source-built TypeScript E2E tests could not determine the Aspire SDK version from packed packages.");
+        }
+
+        return new LocalChannelInfo(localChannelPackagesPath, sdkVersion);
+    }
+
+    private sealed record LocalChannelInfo(string PackagesPath, string SdkVersion);
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
@@ -191,6 +191,31 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
         Assert.Equal(originalTsConfig, File.ReadAllText(Path.Combine(projectRoot, "tsconfig.json")));
         Assert.True(File.Exists(Path.Combine(projectRoot, "tsconfig.apphost.json")));
 
+        // Verify Aspire.Hosting.JavaScript was pre-added in config
+        var configPath = Path.Combine(projectRoot, "aspire.config.json");
+        var config = JsonNode.Parse(File.ReadAllText(configPath))!.AsObject();
+        var packagesNode = config["packages"];
+        Assert.NotNull(packagesNode);
+        var packages = packagesNode!.AsObject();
+        Assert.NotNull(packages["Aspire.Hosting.JavaScript"]);
+
+        // Modify apphost.ts to add the Vite app before running
+        var appHostPath = Path.Combine(projectRoot, "apphost.ts");
+        var newContent = """
+            // Aspire TypeScript AppHost
+            // For more information, see: https://aspire.dev
+
+            import { createBuilder } from './.modules/aspire.js';
+
+            const builder = await createBuilder();
+
+            await builder.addViteApp("brownfield", ".");
+
+            await builder.build().run();
+            """;
+
+        File.WriteAllText(appHostPath, newContent);
+
         // Run the apphost to verify it works
         await auto.TypeAsync("aspire run");
         await auto.EnterAsync();
@@ -206,16 +231,15 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
 
     private static void WriteLocalChannelSettings(string projectRoot, string sdkVersion)
     {
-        var settingsPath = Path.Combine(projectRoot, ".aspire", "settings.json");
-        Directory.CreateDirectory(Path.GetDirectoryName(settingsPath)!);
+        var configPath = Path.Combine(projectRoot, "aspire.config.json");
 
-        var settings = new JsonObject
+        var config = new JsonObject
         {
             ["channel"] = "local",
-            ["sdkVersion"] = sdkVersion
+            ["sdk"] = new JsonObject { ["version"] = sdkVersion }
         };
 
-        File.WriteAllText(settingsPath, settings.ToJsonString());
+        File.WriteAllText(configPath, config.ToJsonString());
     }
 
     private static LocalChannelInfo? PrepareLocalChannel(

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
@@ -179,7 +179,7 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
         Assert.Equal("aspire run", scripts["aspire:start"]?.GetValue<string>());
         Assert.Equal("tsc -p tsconfig.apphost.json", scripts["aspire:build"]?.GetValue<string>());
         Assert.Equal("tsc --watch -p tsconfig.apphost.json", scripts["aspire:dev"]?.GetValue<string>());
-        Assert.False(scripts.ContainsKey("start"));
+        Assert.Equal("npm run aspire:start", scripts["start"]?.GetValue<string>());
 
         Assert.Equal("module", packageJson["type"]?.GetValue<string>());
         Assert.NotNull(dependencies["vscode-jsonrpc"]);

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
@@ -104,7 +104,8 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
         var workspace = TemporaryWorkspace.Create(output);
-        var localChannel = PrepareLocalChannel(repoRoot, workspace, installMode);
+        var localChannel = CliE2ETestHelpers.PrepareLocalChannel(repoRoot, workspace, installMode,
+            ["Aspire.Hosting.CodeGeneration.TypeScript.", "Aspire.Hosting.JavaScript."]);
         var channelArgument = localChannel is not null ? " --channel local" : string.Empty;
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, installMode, output, variant: CliE2ETestHelpers.DockerfileVariant.DotNet, mountDockerSocket: true, workspace: workspace);
@@ -241,55 +242,4 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
 
         File.WriteAllText(configPath, config.ToJsonString());
     }
-
-    private static LocalChannelInfo? PrepareLocalChannel(
-        string repoRoot,
-        TemporaryWorkspace workspace,
-        CliE2ETestHelpers.DockerInstallMode installMode)
-    {
-        if (installMode != CliE2ETestHelpers.DockerInstallMode.SourceBuild)
-        {
-            return null;
-        }
-
-        var shippingPackagesDirectory = Path.Combine(repoRoot, "artifacts", "packages", "Debug", "Shipping");
-        if (!Directory.Exists(shippingPackagesDirectory))
-        {
-            throw new InvalidOperationException("Local source-built TypeScript E2E tests require packed Aspire packages. Run './build.sh --bundle --pack' first.");
-        }
-
-        var packageFiles = Directory.EnumerateFiles(shippingPackagesDirectory, "Aspire*.nupkg", SearchOption.TopDirectoryOnly)
-            .Where(file => !file.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase))
-            .ToArray();
-
-        if (!packageFiles.Any(file => Path.GetFileName(file).StartsWith("Aspire.Hosting.CodeGeneration.TypeScript.", StringComparison.OrdinalIgnoreCase)) ||
-            !packageFiles.Any(file => Path.GetFileName(file).StartsWith("Aspire.Hosting.JavaScript.", StringComparison.OrdinalIgnoreCase)) ||
-            !packageFiles.Any(file => Path.GetFileName(file).StartsWith("Aspire.Hosting.", StringComparison.OrdinalIgnoreCase)))
-        {
-            throw new InvalidOperationException("Local source-built TypeScript E2E tests require packed Aspire.Hosting, Aspire.Hosting.JavaScript, and Aspire.Hosting.CodeGeneration.TypeScript packages. Run './build.sh --bundle --pack' first.");
-        }
-
-        var localChannelPackagesPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire-local", "packages");
-        Directory.CreateDirectory(localChannelPackagesPath);
-
-        foreach (var packageFile in packageFiles)
-        {
-            File.Copy(packageFile, Path.Combine(localChannelPackagesPath, Path.GetFileName(packageFile)), overwrite: true);
-        }
-
-        var sdkVersion = packageFiles
-            .Select(Path.GetFileName)
-            .FirstOrDefault(fileName => fileName is not null && System.Text.RegularExpressions.Regex.IsMatch(fileName, @"^Aspire\.Hosting\.\d+\.\d+\.\d+.*\.nupkg$", System.Text.RegularExpressions.RegexOptions.IgnoreCase))
-            ?.Replace("Aspire.Hosting.", string.Empty, StringComparison.OrdinalIgnoreCase)
-            ?.Replace(".nupkg", string.Empty, StringComparison.OrdinalIgnoreCase);
-
-        if (string.IsNullOrEmpty(sdkVersion))
-        {
-            throw new InvalidOperationException("Local source-built TypeScript E2E tests could not determine the Aspire SDK version from packed packages.");
-        }
-
-        return new LocalChannelInfo(localChannelPackagesPath, sdkVersion);
-    }
-
-    private sealed record LocalChannelInfo(string PackagesPath, string SdkVersion);
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.RegularExpressions;
 using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Tests.Utils;
 using Hex1b.Automation;
@@ -22,7 +21,7 @@ public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
         var workspace = TemporaryWorkspace.Create(output);
-        var localChannel = PrepareLocalChannel(repoRoot, workspace, installMode);
+        var localChannel = CliE2ETestHelpers.PrepareLocalChannel(repoRoot, workspace, installMode);
         var bundlePath = FindLocalBundlePath(repoRoot, installMode);
 
         var additionalVolumes = new List<string>();
@@ -107,53 +106,6 @@ public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
     /// Copies locally-built NuGet packages to the workspace for SourceBuild mode.
     /// Returns null for non-SourceBuild modes (CI installs packages via the PR script).
     /// </summary>
-    private static LocalChannelInfo? PrepareLocalChannel(
-        string repoRoot,
-        TemporaryWorkspace workspace,
-        CliE2ETestHelpers.DockerInstallMode installMode)
-    {
-        if (installMode != CliE2ETestHelpers.DockerInstallMode.SourceBuild)
-        {
-            return null;
-        }
-
-        var shippingPackagesDirectory = Path.Combine(repoRoot, "artifacts", "packages", "Debug", "Shipping");
-        if (!Directory.Exists(shippingPackagesDirectory))
-        {
-            throw new InvalidOperationException("Local source-built TypeScript E2E tests require packed Aspire packages. Run './build.sh --bundle --pack' first.");
-        }
-
-        var packageFiles = Directory.EnumerateFiles(shippingPackagesDirectory, "Aspire*.nupkg", SearchOption.TopDirectoryOnly)
-            .Where(file => !file.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase))
-            .ToArray();
-
-        if (!packageFiles.Any(file => Path.GetFileName(file).StartsWith("Aspire.Hosting.", StringComparison.OrdinalIgnoreCase)))
-        {
-            throw new InvalidOperationException("Local source-built TypeScript E2E tests require packed Aspire.Hosting packages. Run './build.sh --bundle --pack' first.");
-        }
-
-        var localChannelPackagesPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire-local", "packages");
-        Directory.CreateDirectory(localChannelPackagesPath);
-
-        foreach (var packageFile in packageFiles)
-        {
-            File.Copy(packageFile, Path.Combine(localChannelPackagesPath, Path.GetFileName(packageFile)), overwrite: true);
-        }
-
-        var sdkVersion = packageFiles
-            .Select(Path.GetFileName)
-            .FirstOrDefault(fileName => fileName is not null && Regex.IsMatch(fileName, @"^Aspire\.Hosting\.\d+\.\d+\.\d+.*\.nupkg$", RegexOptions.IgnoreCase))
-            ?.Replace("Aspire.Hosting.", string.Empty, StringComparison.OrdinalIgnoreCase)
-            ?.Replace(".nupkg", string.Empty, StringComparison.OrdinalIgnoreCase);
-
-        if (string.IsNullOrEmpty(sdkVersion))
-        {
-            throw new InvalidOperationException("Local source-built TypeScript E2E tests could not determine the Aspire SDK version from packed packages.");
-        }
-
-        return new LocalChannelInfo(localChannelPackagesPath, sdkVersion);
-    }
-
     /// <summary>
     /// Finds the extracted bundle layout directory for SourceBuild mode.
     /// The bundle provides the aspire-managed server and DCP needed for template creation.
@@ -180,6 +132,4 @@ public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
 
         return bundlePath;
     }
-
-    private sealed record LocalChannelInfo(string PackagesPath, string SdkVersion);
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
@@ -103,10 +103,6 @@ public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
     }
 
     /// <summary>
-    /// Copies locally-built NuGet packages to the workspace for SourceBuild mode.
-    /// Returns null for non-SourceBuild modes (CI installs packages via the PR script).
-    /// </summary>
-    /// <summary>
     /// Finds the extracted bundle layout directory for SourceBuild mode.
     /// The bundle provides the aspire-managed server and DCP needed for template creation.
     /// Returns null for non-SourceBuild modes (CI installs the full bundle via the PR script).

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.RegularExpressions;
 using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Tests.Utils;
 using Hex1b.Automation;
@@ -21,8 +22,16 @@ public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
         var workspace = TemporaryWorkspace.Create(output);
+        var localChannel = PrepareLocalChannel(repoRoot, workspace, installMode);
+        var bundlePath = FindLocalBundlePath(repoRoot, installMode);
 
-        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, installMode, output, mountDockerSocket: true, workspace: workspace);
+        var additionalVolumes = new List<string>();
+        if (bundlePath is not null)
+        {
+            additionalVolumes.Add($"{bundlePath}:/opt/aspire-bundle:ro");
+        }
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, installMode, output, mountDockerSocket: true, workspace: workspace, additionalVolumes: additionalVolumes);
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
@@ -31,6 +40,36 @@ public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
 
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliInDockerAsync(installMode, counter);
+
+        // Set up bundle layout for SourceBuild mode so the CLI can find
+        // aspire-managed and DCP relative to the CLI binary location.
+        if (bundlePath is not null)
+        {
+            await auto.TypeAsync("ln -s /opt/aspire-bundle/managed ~/.aspire/managed && ln -s /opt/aspire-bundle/dcp ~/.aspire/dcp");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+        }
+
+        // Set up local channel NuGet packages for SourceBuild mode so the
+        // CLI can resolve Aspire packages during template creation.
+        if (localChannel is not null)
+        {
+            var containerLocalChannelPackagesPath = CliE2ETestHelpers.ToContainerPath(localChannel.PackagesPath, workspace);
+            await auto.TypeAsync($"mkdir -p ~/.aspire/hives/local && rm -rf ~/.aspire/hives/local/packages && ln -s '{containerLocalChannelPackagesPath}' ~/.aspire/hives/local/packages");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Set channel and SDK version globally so aspire new uses the local
+            // channel with the correct prerelease version (dev builds fall back to
+            // the last stable release by default, which won't match local packages).
+            await auto.TypeAsync("aspire config set channel local --global");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            await auto.TypeAsync($"aspire config set sdk.version {localChannel.SdkVersion} --global");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+        }
 
         // Step 1: Create project using aspire new, selecting the Express/React template
         await auto.AspireNewAsync("TsStarterApp", counter, template: AspireTemplate.ExpressReact);
@@ -63,4 +102,84 @@ public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
 
         await pendingRun;
     }
+
+    /// <summary>
+    /// Copies locally-built NuGet packages to the workspace for SourceBuild mode.
+    /// Returns null for non-SourceBuild modes (CI installs packages via the PR script).
+    /// </summary>
+    private static LocalChannelInfo? PrepareLocalChannel(
+        string repoRoot,
+        TemporaryWorkspace workspace,
+        CliE2ETestHelpers.DockerInstallMode installMode)
+    {
+        if (installMode != CliE2ETestHelpers.DockerInstallMode.SourceBuild)
+        {
+            return null;
+        }
+
+        var shippingPackagesDirectory = Path.Combine(repoRoot, "artifacts", "packages", "Debug", "Shipping");
+        if (!Directory.Exists(shippingPackagesDirectory))
+        {
+            throw new InvalidOperationException("Local source-built TypeScript E2E tests require packed Aspire packages. Run './build.sh --bundle --pack' first.");
+        }
+
+        var packageFiles = Directory.EnumerateFiles(shippingPackagesDirectory, "Aspire*.nupkg", SearchOption.TopDirectoryOnly)
+            .Where(file => !file.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        if (!packageFiles.Any(file => Path.GetFileName(file).StartsWith("Aspire.Hosting.", StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidOperationException("Local source-built TypeScript E2E tests require packed Aspire.Hosting packages. Run './build.sh --bundle --pack' first.");
+        }
+
+        var localChannelPackagesPath = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire-local", "packages");
+        Directory.CreateDirectory(localChannelPackagesPath);
+
+        foreach (var packageFile in packageFiles)
+        {
+            File.Copy(packageFile, Path.Combine(localChannelPackagesPath, Path.GetFileName(packageFile)), overwrite: true);
+        }
+
+        var sdkVersion = packageFiles
+            .Select(Path.GetFileName)
+            .FirstOrDefault(fileName => fileName is not null && Regex.IsMatch(fileName, @"^Aspire\.Hosting\.\d+\.\d+\.\d+.*\.nupkg$", RegexOptions.IgnoreCase))
+            ?.Replace("Aspire.Hosting.", string.Empty, StringComparison.OrdinalIgnoreCase)
+            ?.Replace(".nupkg", string.Empty, StringComparison.OrdinalIgnoreCase);
+
+        if (string.IsNullOrEmpty(sdkVersion))
+        {
+            throw new InvalidOperationException("Local source-built TypeScript E2E tests could not determine the Aspire SDK version from packed packages.");
+        }
+
+        return new LocalChannelInfo(localChannelPackagesPath, sdkVersion);
+    }
+
+    /// <summary>
+    /// Finds the extracted bundle layout directory for SourceBuild mode.
+    /// The bundle provides the aspire-managed server and DCP needed for template creation.
+    /// Returns null for non-SourceBuild modes (CI installs the full bundle via the PR script).
+    /// </summary>
+    private static string? FindLocalBundlePath(string repoRoot, CliE2ETestHelpers.DockerInstallMode installMode)
+    {
+        if (installMode != CliE2ETestHelpers.DockerInstallMode.SourceBuild)
+        {
+            return null;
+        }
+
+        var bundlePath = Path.Combine(repoRoot, "artifacts", "bundle", "linux-x64");
+        if (!Directory.Exists(bundlePath))
+        {
+            throw new InvalidOperationException("Local source-built TypeScript E2E tests require the bundle layout. Run './build.sh --bundle' first.");
+        }
+
+        var managedPath = Path.Combine(bundlePath, "managed", "aspire-managed");
+        if (!File.Exists(managedPath))
+        {
+            throw new InvalidOperationException($"Bundle layout is missing aspire-managed at {managedPath}. Run './build.sh --bundle' first.");
+        }
+
+        return bundlePath;
+    }
+
+    private sealed record LocalChannelInfo(string PackagesPath, string SdkVersion);
 }

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1342,7 +1342,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         services.AddSingleton<IAppHostProjectFactory>(new TestTypeScriptStarterProjectFactory((directory, cancellationToken) =>
         {
             buildAndGenerateCalled = true;
-            var config = AspireJsonConfiguration.Load(directory.FullName);
+            var config = AspireConfigFile.Load(directory.FullName);
             channelSeenByProject = config?.Channel;
 
             var modulesDir = Directory.CreateDirectory(Path.Combine(directory.FullName, ".modules"));

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -6,12 +6,24 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Utils;
 using Aspire.TypeSystem;
-using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Tests.Projects;
 
-public class GuestRuntimeTests
+public class GuestRuntimeTests(ITestOutputHelper outputHelper)
 {
+    private readonly ILoggerFactory _loggerFactory = LoggerFactory.Create(builder => builder.AddXunit(outputHelper));
+
+    private GuestRuntime CreateRuntime(
+        RuntimeSpec? spec = null,
+        Func<string, string?>? commandResolver = null)
+    {
+        return new GuestRuntime(
+            spec ?? CreateTestSpec(),
+            _loggerFactory.CreateLogger<GuestRuntime>(),
+            commandResolver: commandResolver);
+    }
+
     private static RuntimeSpec CreateTestSpec(
         CommandSpec? execute = null,
         CommandSpec? watchExecute = null,
@@ -38,7 +50,7 @@ public class GuestRuntimeTests
     [Fact]
     public void Language_ReturnsSpecLanguage()
     {
-        var runtime = new GuestRuntime(CreateTestSpec(), NullLogger.Instance);
+        var runtime = CreateRuntime();
 
         Assert.Equal("test/runtime", runtime.Language);
     }
@@ -46,7 +58,7 @@ public class GuestRuntimeTests
     [Fact]
     public void DisplayName_ReturnsSpecDisplayName()
     {
-        var runtime = new GuestRuntime(CreateTestSpec(), NullLogger.Instance);
+        var runtime = CreateRuntime();
 
         Assert.Equal("Test Runtime", runtime.DisplayName);
     }
@@ -54,7 +66,7 @@ public class GuestRuntimeTests
     [Fact]
     public void CreateDefaultLauncher_ReturnsProcessGuestLauncher()
     {
-        var runtime = new GuestRuntime(CreateTestSpec(), NullLogger.Instance);
+        var runtime = CreateRuntime();
 
         var launcher = runtime.CreateDefaultLauncher();
 
@@ -69,7 +81,7 @@ public class GuestRuntimeTests
             Command = "my-runner",
             Args = ["{appHostFile}"]
         });
-        var runtime = new GuestRuntime(spec, NullLogger.Instance);
+        var runtime = CreateRuntime(spec);
         var launcher = new RecordingLauncher();
         var appHostFile = new FileInfo("/tmp/apphost.ts");
         var directory = new DirectoryInfo("/tmp");
@@ -88,7 +100,7 @@ public class GuestRuntimeTests
             execute: new CommandSpec { Command = "run-cmd", Args = ["{appHostFile}"] },
             watchExecute: new CommandSpec { Command = "watch-cmd", Args = ["--watch", "{appHostFile}"] }
         );
-        var runtime = new GuestRuntime(spec, NullLogger.Instance);
+        var runtime = CreateRuntime(spec);
         var launcher = new RecordingLauncher();
         var appHostFile = new FileInfo("/tmp/apphost.ts");
         var directory = new DirectoryInfo("/tmp");
@@ -103,7 +115,7 @@ public class GuestRuntimeTests
     public async Task RunAsync_WatchModeWithoutWatchSpec_FallsBackToExecute()
     {
         var spec = CreateTestSpec(execute: new CommandSpec { Command = "run-cmd", Args = ["{appHostFile}"] });
-        var runtime = new GuestRuntime(spec, NullLogger.Instance);
+        var runtime = CreateRuntime(spec);
         var launcher = new RecordingLauncher();
         var appHostFile = new FileInfo("/tmp/apphost.ts");
         var directory = new DirectoryInfo("/tmp");
@@ -120,7 +132,7 @@ public class GuestRuntimeTests
             execute: new CommandSpec { Command = "run-cmd", Args = ["{appHostFile}"] },
             publishExecute: new CommandSpec { Command = "publish-cmd", Args = ["{appHostFile}", "{args}"] }
         );
-        var runtime = new GuestRuntime(spec, NullLogger.Instance);
+        var runtime = CreateRuntime(spec);
         var launcher = new RecordingLauncher();
         var appHostFile = new FileInfo("/tmp/apphost.ts");
         var directory = new DirectoryInfo("/tmp");
@@ -135,7 +147,7 @@ public class GuestRuntimeTests
     public async Task PublishAsync_WithoutPublishSpec_FallsBackToExecute()
     {
         var spec = CreateTestSpec(execute: new CommandSpec { Command = "run-cmd", Args = ["{appHostFile}"] });
-        var runtime = new GuestRuntime(spec, NullLogger.Instance);
+        var runtime = CreateRuntime(spec);
         var launcher = new RecordingLauncher();
         var appHostFile = new FileInfo("/tmp/apphost.ts");
         var directory = new DirectoryInfo("/tmp");
@@ -154,7 +166,7 @@ public class GuestRuntimeTests
             Args = ["{appHostFile}"],
             EnvironmentVariables = new Dictionary<string, string> { ["SPEC_VAR"] = "spec_value" }
         });
-        var runtime = new GuestRuntime(spec, NullLogger.Instance);
+        var runtime = CreateRuntime(spec);
         var launcher = new RecordingLauncher();
         var appHostFile = new FileInfo("/tmp/apphost.ts");
         var directory = new DirectoryInfo("/tmp");
@@ -175,7 +187,7 @@ public class GuestRuntimeTests
             Args = ["{appHostFile}"],
             EnvironmentVariables = new Dictionary<string, string> { ["SHARED_VAR"] = "from_spec" }
         });
-        var runtime = new GuestRuntime(spec, NullLogger.Instance);
+        var runtime = CreateRuntime(spec);
         var launcher = new RecordingLauncher();
         var appHostFile = new FileInfo("/tmp/apphost.ts");
         var directory = new DirectoryInfo("/tmp");
@@ -194,7 +206,7 @@ public class GuestRuntimeTests
             Command = "npx",
             Args = ["tsx", "{appHostFile}"]
         });
-        var runtime = new GuestRuntime(spec, NullLogger.Instance);
+        var runtime = CreateRuntime(spec);
         var launcher = new RecordingLauncher();
         var appHostFile = new FileInfo("/home/user/project/apphost.ts");
         var directory = new DirectoryInfo("/home/user/project");
@@ -213,7 +225,7 @@ public class GuestRuntimeTests
             Command = "test-cmd",
             Args = ["--dir", "{appHostDir}"]
         });
-        var runtime = new GuestRuntime(spec, NullLogger.Instance);
+        var runtime = CreateRuntime(spec);
         var launcher = new RecordingLauncher();
         var appHostFile = new FileInfo("/home/user/project/apphost.ts");
         var directory = new DirectoryInfo("/home/user/project");
@@ -231,7 +243,7 @@ public class GuestRuntimeTests
             Command = "test-cmd",
             Args = ["{appHostFile}"]
         });
-        var runtime = new GuestRuntime(spec, NullLogger.Instance);
+        var runtime = CreateRuntime(spec);
         var launcher = new RecordingLauncher();
         var appHostFile = new FileInfo("/tmp/apphost.ts");
         var directory = new DirectoryInfo("/tmp");
@@ -251,7 +263,7 @@ public class GuestRuntimeTests
             Command = "test-cmd",
             Args = ["{args}"]
         });
-        var runtime = new GuestRuntime(spec, NullLogger.Instance);
+        var runtime = CreateRuntime(spec);
         var launcher = new RecordingLauncher();
         var appHostFile = new FileInfo("/tmp/apphost.ts");
         var directory = new DirectoryInfo("/tmp");
@@ -273,7 +285,7 @@ public class GuestRuntimeTests
             Execute = new CommandSpec { Command = "test-cmd", Args = ["{appHostFile}"] },
             ExtensionLaunchCapability = "node"
         };
-        var runtime = new GuestRuntime(spec, NullLogger.Instance);
+        var runtime = CreateRuntime(spec);
 
         Assert.Equal("node", runtime.ExtensionLaunchCapability);
     }
@@ -281,7 +293,7 @@ public class GuestRuntimeTests
     [Fact]
     public void ExtensionLaunchCapability_DefaultsToNull()
     {
-        var runtime = new GuestRuntime(CreateTestSpec(), NullLogger.Instance);
+        var runtime = CreateRuntime();
 
         Assert.Null(runtime.ExtensionLaunchCapability);
     }
@@ -290,7 +302,7 @@ public class GuestRuntimeTests
     public async Task InstallDependenciesAsync_WithNoSpec_ReturnsZero()
     {
         var spec = CreateTestSpec();
-        var runtime = new GuestRuntime(spec, NullLogger.Instance);
+        var runtime = CreateRuntime(spec);
 
         var (exitCode, output) = await runtime.InstallDependenciesAsync(new DirectoryInfo("/tmp"), CancellationToken.None);
 
@@ -301,7 +313,7 @@ public class GuestRuntimeTests
     [Fact]
     public async Task InstallDependenciesAsync_WhenNpmIsMissing_ReturnsNodeInstallMessage()
     {
-        var runtime = new GuestRuntime(
+        var runtime = CreateRuntime(
             new RuntimeSpec
             {
                 Language = KnownLanguageId.TypeScript,
@@ -311,7 +323,6 @@ public class GuestRuntimeTests
                 Execute = new CommandSpec { Command = "npx", Args = ["tsx", "{appHostFile}"] },
                 InstallDependencies = new CommandSpec { Command = "npm", Args = ["install"] }
             },
-            NullLogger.Instance,
             commandResolver: _ => null);
 
         var (exitCode, output) = await runtime.InstallDependenciesAsync(new DirectoryInfo(Path.GetTempPath()), CancellationToken.None);
@@ -329,7 +340,7 @@ public class GuestRuntimeTests
     [Fact]
     public async Task RunAsync_WhenNpxIsMissing_ReturnsNodeInstallMessage()
     {
-        var runtime = new GuestRuntime(
+        var runtime = CreateRuntime(
             new RuntimeSpec
             {
                 Language = KnownLanguageId.TypeScript,
@@ -338,7 +349,6 @@ public class GuestRuntimeTests
                 DetectionPatterns = ["apphost.ts"],
                 Execute = new CommandSpec { Command = "npx", Args = ["tsx", "{appHostFile}"] }
             },
-            NullLogger.Instance,
             commandResolver: _ => null);
 
         var appHostFile = new FileInfo(Path.Combine(Path.GetTempPath(), "apphost.ts"));
@@ -372,7 +382,7 @@ public class GuestRuntimeTests
 
             var launcher = new ProcessGuestLauncher(
                 "test",
-                NullLogger.Instance,
+                _loggerFactory.CreateLogger<ProcessGuestLauncher>(),
                 fileLoggerProvider,
                 commandResolver: cmd => cmd == "dotnet" ? "dotnet" : null);
 
@@ -439,7 +449,7 @@ public class GuestRuntimeTests
                 }
             };
 
-            var runtime = new GuestRuntime(spec, NullLogger.Instance);
+            var runtime = CreateRuntime(spec);
             var launcher = new RecordingLauncher();
             var appHostFile = new FileInfo(Path.Combine(tempDir, "apphost.ts"));
             var directory = new DirectoryInfo(tempDir);
@@ -494,7 +504,7 @@ public class GuestRuntimeTests
                 }
             };
 
-            var runtime = new GuestRuntime(spec, NullLogger.Instance);
+            var runtime = CreateRuntime(spec);
             var launcher = new RecordingLauncher();
             var appHostFile = new FileInfo(Path.Combine(tempDir, "apphost.ts"));
             var directory = new DirectoryInfo(tempDir);
@@ -519,7 +529,7 @@ public class GuestRuntimeTests
             Command = "test-cmd",
             Args = ["{appHostFile}"]
         });
-        var runtime = new GuestRuntime(spec, NullLogger.Instance);
+        var runtime = CreateRuntime(spec);
         var launcher = new RecordingLauncher();
         var appHostFile = new FileInfo("/tmp/apphost.ts");
         var directory = new DirectoryInfo("/tmp");

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -411,6 +411,124 @@ public class GuestRuntimeTests
         }
     }
 
+    [Fact]
+    public async Task RunAsync_CreatesMissingMigrationFiles()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"migration-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var migrationFileName = "tsconfig.apphost.json";
+            var migrationContent = """{ "compilerOptions": { "target": "ES2022" } }""";
+
+            var spec = new RuntimeSpec
+            {
+                Language = "test/runtime",
+                DisplayName = "Test Runtime",
+                CodeGenLanguage = "Test",
+                DetectionPatterns = ["apphost.test"],
+                Execute = new CommandSpec
+                {
+                    Command = "test-cmd",
+                    Args = ["--tsconfig", migrationFileName, "{appHostFile}"]
+                },
+                MigrationFiles = new Dictionary<string, string>
+                {
+                    [migrationFileName] = migrationContent
+                }
+            };
+
+            var runtime = new GuestRuntime(spec, NullLogger.Instance);
+            var launcher = new RecordingLauncher();
+            var appHostFile = new FileInfo(Path.Combine(tempDir, "apphost.ts"));
+            var directory = new DirectoryInfo(tempDir);
+
+            // File should not exist before run
+            var migrationFilePath = Path.Combine(tempDir, migrationFileName);
+            Assert.False(File.Exists(migrationFilePath));
+
+            await runtime.RunAsync(appHostFile, directory, new Dictionary<string, string>(), watchMode: false, launcher, CancellationToken.None);
+
+            // File should be created after run
+            Assert.True(File.Exists(migrationFilePath));
+            var writtenContent = await File.ReadAllTextAsync(migrationFilePath);
+            Assert.Equal(migrationContent, writtenContent);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_DoesNotOverwriteExistingMigrationFiles()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"migration-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var migrationFileName = "tsconfig.apphost.json";
+            var migrationContent = """{ "compilerOptions": { "target": "ES2022" } }""";
+            var existingContent = """{ "compilerOptions": { "target": "ES2020" } }""";
+
+            // Pre-create the file with different content
+            var migrationFilePath = Path.Combine(tempDir, migrationFileName);
+            await File.WriteAllTextAsync(migrationFilePath, existingContent);
+
+            var spec = new RuntimeSpec
+            {
+                Language = "test/runtime",
+                DisplayName = "Test Runtime",
+                CodeGenLanguage = "Test",
+                DetectionPatterns = ["apphost.test"],
+                Execute = new CommandSpec
+                {
+                    Command = "test-cmd",
+                    Args = ["--tsconfig", migrationFileName, "{appHostFile}"]
+                },
+                MigrationFiles = new Dictionary<string, string>
+                {
+                    [migrationFileName] = migrationContent
+                }
+            };
+
+            var runtime = new GuestRuntime(spec, NullLogger.Instance);
+            var launcher = new RecordingLauncher();
+            var appHostFile = new FileInfo(Path.Combine(tempDir, "apphost.ts"));
+            var directory = new DirectoryInfo(tempDir);
+
+            await runtime.RunAsync(appHostFile, directory, new Dictionary<string, string>(), watchMode: false, launcher, CancellationToken.None);
+
+            // File should NOT be overwritten
+            var writtenContent = await File.ReadAllTextAsync(migrationFilePath);
+            Assert.Equal(existingContent, writtenContent);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_NoMigrationFiles_ExecutesNormally()
+    {
+        var spec = CreateTestSpec(execute: new CommandSpec
+        {
+            Command = "test-cmd",
+            Args = ["{appHostFile}"]
+        });
+        var runtime = new GuestRuntime(spec, NullLogger.Instance);
+        var launcher = new RecordingLauncher();
+        var appHostFile = new FileInfo("/tmp/apphost.ts");
+        var directory = new DirectoryInfo("/tmp");
+
+        await runtime.RunAsync(appHostFile, directory, new Dictionary<string, string>(), watchMode: false, launcher, CancellationToken.None);
+
+        Assert.Equal("test-cmd", launcher.LastCommand);
+    }
+
     private sealed class RecordingLauncher : IGuestProcessLauncher
     {
         public string LastCommand { get; private set; } = string.Empty;

--- a/tests/Aspire.Cli.Tests/Scaffolding/PackageJsonMergerTests.cs
+++ b/tests/Aspire.Cli.Tests/Scaffolding/PackageJsonMergerTests.cs
@@ -4,11 +4,15 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Cli.Scaffolding;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Scaffolding;
 
 public class PackageJsonMergerTests
 {
+    private static string MergeJson(string existing, string scaffold) =>
+        PackageJsonMerger.Merge(existing, scaffold, NullLogger.Instance);
+
     private static JsonObject ParseJson(string json) =>
         JsonNode.Parse(json)!.AsObject();
 
@@ -44,7 +48,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
         var scripts = GetScripts(result);
 
         // Existing scripts preserved
@@ -81,7 +85,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
         var scripts = GetScripts(result);
 
         // Existing preserved
@@ -117,7 +121,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
         var scripts = GetScripts(result);
 
         // Existing preserved
@@ -155,7 +159,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
         var scripts = GetScripts(result);
 
         // "start" and "lint" are not taken — convenience aliases added
@@ -192,7 +196,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
         var scripts = GetScripts(result);
 
         // All existing scripts preserved
@@ -235,7 +239,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
         var scripts = GetScripts(result);
 
         // Existing preserved
@@ -283,7 +287,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
 
         // Scaffold is newer — upgraded
         Assert.Equal("^5.0.0", GetDep(result, "dependencies", "express"));
@@ -328,7 +332,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
         var json = ParseJson(result);
 
         // Existing scalars preserved
@@ -355,10 +359,10 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge("", scaffold);
+        var result = MergeJson("", scaffold);
         Assert.Equal(scaffold, result);
 
-        result = PackageJsonMerger.Merge("   ", scaffold);
+        result = MergeJson("   ", scaffold);
         Assert.Equal(scaffold, result);
     }
 
@@ -372,8 +376,48 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge("not valid json {{{", scaffold);
+        var result = MergeJson("not valid json {{{", scaffold);
         Assert.Equal(scaffold, result);
+    }
+
+    [Fact]
+    public void ExistingJsonWithCommentsAndTrailingCommas_MergesSuccessfully()
+    {
+        // Real-world package.json files may contain comments and trailing commas
+        // even though they're not valid per the JSON spec. We should tolerate them.
+        var existing = """
+            {
+              // This is a comment
+              "name": "my-app",
+              "version": "1.0.0",
+              "scripts": {
+                "dev": "vite",
+                "build": "vite build", // trailing comma
+              },
+              "dependencies": {
+                "express": "^4.18.0",
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "scripts": { "aspire:start": "aspire run" },
+              "dependencies": { "vscode-jsonrpc": "^8.2.0" }
+            }
+            """;
+
+        var result = MergeJson(existing, scaffold);
+        var json = ParseJson(result);
+
+        // Existing properties preserved (comments and trailing commas are stripped in output)
+        Assert.Equal("my-app", json["name"]?.GetValue<string>());
+        Assert.Equal("vite", GetScript(result, "dev"));
+        Assert.Equal("^4.18.0", GetDep(result, "dependencies", "express"));
+
+        // Scaffold content merged in
+        Assert.Equal("aspire run", GetScript(result, "aspire:start"));
+        Assert.Equal("^8.2.0", GetDep(result, "dependencies", "vscode-jsonrpc"));
     }
 
     [Fact]
@@ -405,8 +449,8 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var firstMerge = PackageJsonMerger.Merge(existing, scaffold);
-        var secondMerge = PackageJsonMerger.Merge(firstMerge, scaffold);
+        var firstMerge = MergeJson(existing, scaffold);
+        var secondMerge = MergeJson(firstMerge, scaffold);
 
         // Parsing both to compare structurally (avoid whitespace differences)
         var first = ParseJson(firstMerge);
@@ -437,7 +481,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
         var scripts = GetScripts(result);
 
         // All scripts added directly (no existing scripts to conflict)
@@ -494,7 +538,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, staleScaffold);
+        var result = MergeJson(existing, staleScaffold);
         var json = ParseJson(result);
         var scripts = json["scripts"]!.AsObject();
 
@@ -553,7 +597,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, updatedScaffold);
+        var result = MergeJson(existing, updatedScaffold);
         var scripts = GetScripts(result);
 
         // Existing preserved
@@ -603,7 +647,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
 
         // Verify the raw JSON string contains literal &&, ', and | — not unicode escapes
         Assert.Contains("tsc && vite build", result);
@@ -651,7 +695,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
 
         Assert.Contains("eslint apphost.ts && echo 'lint complete'", result);
         Assert.Contains("tsc -p tsconfig.apphost.json && echo 'build done'", result);
@@ -679,7 +723,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
         Assert.Equal("^5.9.3", GetDep(result, "devDependencies", "typescript"));
     }
 
@@ -703,7 +747,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
         Assert.Equal("^6.0.0", GetDep(result, "devDependencies", "typescript"));
     }
 
@@ -727,7 +771,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
 
         // Scaffold is newer (5.9.3 > 5.0.0), upgrades — entire value replaced including range operator
         Assert.Equal("^5.9.3", GetDep(result, "devDependencies", "typescript"));
@@ -753,7 +797,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
 
         // Union ranges are unparseable — existing preserved
         Assert.Equal("^1.0.0 || ^2.0.0", GetDep(result, "dependencies", "some-pkg"));
@@ -779,7 +823,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
 
         // Workspace refs are not parseable as semver — existing preserved
         Assert.Equal("workspace:*", GetDep(result, "dependencies", "shared-lib"));
@@ -805,7 +849,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
 
         Assert.Equal("^4.18.0", GetDep(result, "dependencies", "express"));
         Assert.Equal("^8.2.0", GetDep(result, "dependencies", "vscode-jsonrpc"));
@@ -833,7 +877,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
 
         // Valid scripts still merged, invalid ones skipped
         Assert.Equal("vite", GetScript(result, "dev"));
@@ -862,7 +906,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
 
         // Valid deps merged, non-string ones skipped
         Assert.Equal("^4.18.0", GetDep(result, "dependencies", "express"));
@@ -891,7 +935,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
 
         // Non-string existing dep preserved (upgrade skipped due to type mismatch)
         var weirdPkg = ParseJson(result)["dependencies"]!["weird-pkg"];
@@ -920,7 +964,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
 
         // EnsureObject replaces the array with a proper object containing scaffold deps
         Assert.Equal("^8.2.0", GetDep(result, "dependencies", "vscode-jsonrpc"));
@@ -938,7 +982,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
 
         // Can't merge into an array — returns scaffold as-is
         Assert.Equal("scaffold", ParseJson(result)["name"]?.GetValue<string>());
@@ -963,7 +1007,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
 
         // "*" is unparseable — existing preserved
         Assert.Equal("*", GetDep(result, "dependencies", "some-pkg"));
@@ -988,7 +1032,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
 
         // "latest" is unparseable — existing preserved
         Assert.Equal("latest", GetDep(result, "dependencies", "some-pkg"));
@@ -1013,7 +1057,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
 
         // 5.9.3 release is newer than 5.9.3-beta.1 pre-release
         Assert.Equal("^5.9.3", GetDep(result, "devDependencies", "typescript"));
@@ -1039,7 +1083,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
 
         // engines.node is always overwritten — aspire init enforces Node version for ESLint 10
         var engines = ParseJson(result)["engines"]!.AsObject();
@@ -1067,7 +1111,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
 
         var engines = ParseJson(result)["engines"]!.AsObject();
         // node overwritten by scaffold
@@ -1093,7 +1137,7 @@ public class PackageJsonMergerTests
             }
             """;
 
-        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var result = MergeJson(existing, scaffold);
 
         var engines = ParseJson(result)["engines"]!.AsObject();
         Assert.Equal("^20.19.0 || ^22.13.0 || >=24", engines["node"]?.GetValue<string>());
@@ -1116,7 +1160,7 @@ public class PackageJsonMergerTests
 
         // Array properties in scaffold require explicit merge logic — the generic fallthrough
         // cannot handle them correctly, so we throw to catch this at dev/test time.
-        var ex = Assert.Throws<InvalidOperationException>(() => PackageJsonMerger.Merge(existing, scaffold));
+        var ex = Assert.Throws<InvalidOperationException>(() => MergeJson(existing, scaffold));
         Assert.Contains("files", ex.Message);
         Assert.Contains("PackageJsonMerger", ex.Message);
     }

--- a/tests/Aspire.Cli.Tests/Scaffolding/PackageJsonMergerTests.cs
+++ b/tests/Aspire.Cli.Tests/Scaffolding/PackageJsonMergerTests.cs
@@ -1,0 +1,659 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Aspire.Cli.Scaffolding;
+
+namespace Aspire.Cli.Tests.Scaffolding;
+
+public class PackageJsonMergerTests
+{
+    private static JsonObject ParseJson(string json) =>
+        JsonNode.Parse(json)!.AsObject();
+
+    private static string GetScript(string mergedJson, string scriptName) =>
+        ParseJson(mergedJson)["scripts"]![scriptName]?.GetValue<string>()!;
+
+    private static JsonObject GetScripts(string mergedJson) =>
+        ParseJson(mergedJson)["scripts"]!.AsObject();
+
+    private static string? GetDep(string mergedJson, string section, string packageName) =>
+        ParseJson(mergedJson)[section]?[packageName]?.GetValue<string>();
+
+    [Fact]
+    public void ConflictingScripts_AddedWithAspirePrefix()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "scripts": {
+                "dev": "vite",
+                "build": "vite build"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "scripts": {
+                "dev": "aspire run",
+                "build": "tsc -p tsconfig.apphost.json",
+                "lint": "eslint apphost.ts"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var scripts = GetScripts(result);
+
+        // Existing scripts preserved
+        Assert.Equal("vite", scripts["dev"]?.GetValue<string>());
+        Assert.Equal("vite build", scripts["build"]?.GetValue<string>());
+
+        // Conflicting scaffold scripts get aspire: prefix
+        Assert.Equal("aspire run", scripts["aspire:dev"]?.GetValue<string>());
+        Assert.Equal("tsc -p tsconfig.apphost.json", scripts["aspire:build"]?.GetValue<string>());
+
+        // Non-conflicting scaffold script added directly
+        Assert.Equal("eslint apphost.ts", scripts["lint"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void NonConflictingScripts_AddedDirectly()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "scripts": {
+                "test": "jest"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "scripts": {
+                "dev": "aspire run",
+                "build": "tsc -p tsconfig.apphost.json",
+                "lint": "eslint apphost.ts"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var scripts = GetScripts(result);
+
+        // Existing preserved
+        Assert.Equal("jest", scripts["test"]?.GetValue<string>());
+
+        // All scaffold scripts added directly (no conflicts)
+        Assert.Equal("aspire run", scripts["dev"]?.GetValue<string>());
+        Assert.Equal("tsc -p tsconfig.apphost.json", scripts["build"]?.GetValue<string>());
+        Assert.Equal("eslint apphost.ts", scripts["lint"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void PrefixedScripts_AlwaysAdded()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "scripts": {
+                "dev": "vite",
+                "build": "vite build"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "scripts": {
+                "aspire:start": "aspire run",
+                "aspire:build": "tsc -p tsconfig.apphost.json",
+                "aspire:dev": "tsc --watch -p tsconfig.apphost.json",
+                "aspire:lint": "eslint apphost.ts"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var scripts = GetScripts(result);
+
+        // Existing preserved
+        Assert.Equal("vite", scripts["dev"]?.GetValue<string>());
+        Assert.Equal("vite build", scripts["build"]?.GetValue<string>());
+
+        // All aspire: scripts added
+        Assert.Equal("aspire run", scripts["aspire:start"]?.GetValue<string>());
+        Assert.Equal("tsc -p tsconfig.apphost.json", scripts["aspire:build"]?.GetValue<string>());
+        Assert.Equal("tsc --watch -p tsconfig.apphost.json", scripts["aspire:dev"]?.GetValue<string>());
+        Assert.Equal("eslint apphost.ts", scripts["aspire:lint"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void ConvenienceAliases_AddedForFreeNames()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "scripts": {
+                "dev": "vite",
+                "build": "vite build"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "scripts": {
+                "aspire:start": "aspire run",
+                "aspire:build": "tsc -p tsconfig.apphost.json",
+                "aspire:dev": "tsc --watch -p tsconfig.apphost.json",
+                "aspire:lint": "eslint apphost.ts"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var scripts = GetScripts(result);
+
+        // "start" and "lint" are not taken — convenience aliases added
+        Assert.Equal("npm run aspire:start", scripts["start"]?.GetValue<string>());
+        Assert.Equal("npm run aspire:lint", scripts["lint"]?.GetValue<string>());
+
+        // "dev" and "build" are taken — no alias
+        Assert.Equal("vite", scripts["dev"]?.GetValue<string>());
+        Assert.Equal("vite build", scripts["build"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void NoAliasWhenNameTaken()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "scripts": {
+                "start": "node server.js",
+                "lint": "prettier --check .",
+                "dev": "vite",
+                "build": "vite build"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "scripts": {
+                "aspire:start": "aspire run",
+                "aspire:lint": "eslint apphost.ts",
+                "aspire:build": "tsc -p tsconfig.apphost.json"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var scripts = GetScripts(result);
+
+        // All existing scripts preserved
+        Assert.Equal("node server.js", scripts["start"]?.GetValue<string>());
+        Assert.Equal("prettier --check .", scripts["lint"]?.GetValue<string>());
+        Assert.Equal("vite", scripts["dev"]?.GetValue<string>());
+        Assert.Equal("vite build", scripts["build"]?.GetValue<string>());
+
+        // Aspire scripts added
+        Assert.Equal("aspire run", scripts["aspire:start"]?.GetValue<string>());
+        Assert.Equal("eslint apphost.ts", scripts["aspire:lint"]?.GetValue<string>());
+        Assert.Equal("tsc -p tsconfig.apphost.json", scripts["aspire:build"]?.GetValue<string>());
+
+        // No convenience aliases — all unprefixed names are taken
+        // Verify the existing values weren't overwritten with aliases
+        Assert.Equal("node server.js", scripts["start"]?.GetValue<string>());
+        Assert.Equal("prettier --check .", scripts["lint"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void MixedConflicts_SomeScriptsPrefixedSomeNot()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "scripts": {
+                "dev": "vite",
+                "test": "jest"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "scripts": {
+                "dev": "aspire run",
+                "build": "tsc -p tsconfig.apphost.json",
+                "aspire:lint": "eslint apphost.ts"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var scripts = GetScripts(result);
+
+        // Existing preserved
+        Assert.Equal("vite", scripts["dev"]?.GetValue<string>());
+        Assert.Equal("jest", scripts["test"]?.GetValue<string>());
+
+        // "dev" conflicted → prefixed
+        Assert.Equal("aspire run", scripts["aspire:dev"]?.GetValue<string>());
+
+        // "build" didn't conflict → added directly
+        Assert.Equal("tsc -p tsconfig.apphost.json", scripts["build"]?.GetValue<string>());
+
+        // "aspire:lint" always added + alias since "lint" is free
+        Assert.Equal("eslint apphost.ts", scripts["aspire:lint"]?.GetValue<string>());
+        Assert.Equal("npm run aspire:lint", scripts["lint"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void Dependencies_DeepMerged_ExistingWins()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "dependencies": {
+                "express": "^4.18.0"
+              },
+              "devDependencies": {
+                "typescript": "^5.0.0",
+                "vite": "^5.0.0"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "dependencies": {
+                "vscode-jsonrpc": "^8.2.0",
+                "express": "^5.0.0"
+              },
+              "devDependencies": {
+                "typescript": "^5.9.3",
+                "@types/node": "^22.0.0",
+                "tsx": "^4.21.0"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+
+        // Existing dep versions preserved (deep merge — existing wins)
+        Assert.Equal("^4.18.0", GetDep(result, "dependencies", "express"));
+        Assert.Equal("^5.0.0", GetDep(result, "devDependencies", "typescript"));
+        Assert.Equal("^5.0.0", GetDep(result, "devDependencies", "vite"));
+
+        // New deps added
+        Assert.Equal("^8.2.0", GetDep(result, "dependencies", "vscode-jsonrpc"));
+        Assert.Equal("^22.0.0", GetDep(result, "devDependencies", "@types/node"));
+        Assert.Equal("^4.21.0", GetDep(result, "devDependencies", "tsx"));
+    }
+
+    [Fact]
+    public void PreservesNonScriptProperties()
+    {
+        var existing = """
+            {
+              "name": "my-existing-app",
+              "version": "3.0.0",
+              "description": "My cool app",
+              "private": true,
+              "type": "module",
+              "engines": {
+                "node": ">=18"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "name": "aspire-apphost",
+              "version": "1.0.0",
+              "type": "commonjs",
+              "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+              },
+              "scripts": {
+                "aspire:build": "tsc -p tsconfig.apphost.json"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var json = ParseJson(result);
+
+        // Existing scalars preserved
+        Assert.Equal("my-existing-app", json["name"]?.GetValue<string>());
+        Assert.Equal("3.0.0", json["version"]?.GetValue<string>());
+        Assert.Equal("My cool app", json["description"]?.GetValue<string>());
+        Assert.True(json["private"]?.GetValue<bool>());
+        Assert.Equal("module", json["type"]?.GetValue<string>());
+
+        // Existing engine constraint preserved (deep merge — existing wins)
+        Assert.Equal(">=18", json["engines"]?["node"]?.GetValue<string>());
+
+        // Script from scaffold is added
+        Assert.Equal("tsc -p tsconfig.apphost.json", GetScript(result, "aspire:build"));
+    }
+
+    [Fact]
+    public void EmptyExistingContent_ReturnsScaffold()
+    {
+        var scaffold = """
+            {
+              "name": "aspire-apphost",
+              "scripts": { "dev": "aspire run" }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge("", scaffold);
+        Assert.Equal(scaffold, result);
+
+        result = PackageJsonMerger.Merge("   ", scaffold);
+        Assert.Equal(scaffold, result);
+    }
+
+    [Fact]
+    public void MalformedExistingJson_ReturnsScaffold()
+    {
+        var scaffold = """
+            {
+              "name": "aspire-apphost",
+              "scripts": { "dev": "aspire run" }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge("not valid json {{{", scaffold);
+        Assert.Equal(scaffold, result);
+    }
+
+    [Fact]
+    public void Idempotent_MergingTwiceProducesSameResult()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "scripts": {
+                "dev": "vite",
+                "build": "vite build"
+              },
+              "dependencies": {
+                "express": "^4.18.0"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "scripts": {
+                "aspire:start": "aspire run",
+                "aspire:build": "tsc -p tsconfig.apphost.json",
+                "aspire:lint": "eslint apphost.ts"
+              },
+              "dependencies": {
+                "vscode-jsonrpc": "^8.2.0"
+              }
+            }
+            """;
+
+        var firstMerge = PackageJsonMerger.Merge(existing, scaffold);
+        var secondMerge = PackageJsonMerger.Merge(firstMerge, scaffold);
+
+        // Parsing both to compare structurally (avoid whitespace differences)
+        var first = ParseJson(firstMerge);
+        var second = ParseJson(secondMerge);
+
+        Assert.Equal(
+            first.ToJsonString(new JsonSerializerOptions { WriteIndented = true }),
+            second.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    [Fact]
+    public void NoExistingScripts_ScaffoldScriptsAddedDirectly()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "version": "1.0.0"
+            }
+            """;
+
+        var scaffold = """
+            {
+              "scripts": {
+                "dev": "aspire run",
+                "build": "tsc -p tsconfig.apphost.json",
+                "lint": "eslint apphost.ts"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+        var scripts = GetScripts(result);
+
+        // All scripts added directly (no existing scripts to conflict)
+        Assert.Equal("aspire run", scripts["dev"]?.GetValue<string>());
+        Assert.Equal("tsc -p tsconfig.apphost.json", scripts["build"]?.GetValue<string>());
+        Assert.Equal("eslint apphost.ts", scripts["lint"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void StaleServer_AllScriptsPreservedUnderAspirePrefix()
+    {
+        // Simulates the exact scenario: stale server sends non-prefixed scripts,
+        // brownfield project already has dev/build/lint
+        var existing = """
+            {
+              "name": "vite-project",
+              "version": "1.0.0",
+              "type": "module",
+              "scripts": {
+                "dev": "vite",
+                "build": "vite build",
+                "lint": "eslint . --ext .ts,.tsx",
+                "preview": "vite preview"
+              },
+              "dependencies": {
+                "react": "^18.2.0"
+              },
+              "devDependencies": {
+                "typescript": "^5.2.0",
+                "vite": "^5.0.0"
+              }
+            }
+            """;
+
+        var staleScaffold = """
+            {
+              "name": "aspire-apphost",
+              "version": "1.0.0",
+              "type": "module",
+              "scripts": {
+                "lint": "eslint apphost.ts",
+                "dev": "aspire run",
+                "build": "tsc -p tsconfig.apphost.json",
+                "watch": "tsc --watch -p tsconfig.apphost.json"
+              },
+              "dependencies": {
+                "vscode-jsonrpc": "^8.2.0"
+              },
+              "devDependencies": {
+                "@types/node": "^22.0.0",
+                "tsx": "^4.21.0",
+                "typescript": "^5.9.3"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, staleScaffold);
+        var json = ParseJson(result);
+        var scripts = json["scripts"]!.AsObject();
+
+        // Existing project identity preserved
+        Assert.Equal("vite-project", json["name"]?.GetValue<string>());
+        Assert.Equal("1.0.0", json["version"]?.GetValue<string>());
+
+        // Existing scripts preserved
+        Assert.Equal("vite", scripts["dev"]?.GetValue<string>());
+        Assert.Equal("vite build", scripts["build"]?.GetValue<string>());
+        Assert.Equal("eslint . --ext .ts,.tsx", scripts["lint"]?.GetValue<string>());
+        Assert.Equal("vite preview", scripts["preview"]?.GetValue<string>());
+
+        // Conflicting scaffold scripts added under aspire: prefix
+        Assert.Equal("aspire run", scripts["aspire:dev"]?.GetValue<string>());
+        Assert.Equal("tsc -p tsconfig.apphost.json", scripts["aspire:build"]?.GetValue<string>());
+        Assert.Equal("eslint apphost.ts", scripts["aspire:lint"]?.GetValue<string>());
+
+        // Non-conflicting scaffold script added directly
+        Assert.Equal("tsc --watch -p tsconfig.apphost.json", scripts["watch"]?.GetValue<string>());
+
+        // Existing deps preserved, new deps added
+        Assert.Equal("^18.2.0", GetDep(result, "dependencies", "react"));
+        Assert.Equal("^8.2.0", GetDep(result, "dependencies", "vscode-jsonrpc"));
+        Assert.Equal("^5.2.0", GetDep(result, "devDependencies", "typescript"));
+        Assert.Equal("^5.0.0", GetDep(result, "devDependencies", "vite"));
+        Assert.Equal("^22.0.0", GetDep(result, "devDependencies", "@types/node"));
+        Assert.Equal("^4.21.0", GetDep(result, "devDependencies", "tsx"));
+    }
+
+    [Fact]
+    public void UpdatedServer_AllScriptsAndAliasesPresent()
+    {
+        // Simulates the updated server which already sends aspire: prefixed scripts
+        var existing = """
+            {
+              "name": "vite-project",
+              "scripts": {
+                "dev": "vite",
+                "build": "vite build"
+              }
+            }
+            """;
+
+        var updatedScaffold = """
+            {
+              "scripts": {
+                "aspire:start": "aspire run",
+                "aspire:build": "tsc -p tsconfig.apphost.json",
+                "aspire:dev": "tsc --watch -p tsconfig.apphost.json",
+                "aspire:lint": "eslint apphost.ts"
+              },
+              "dependencies": {
+                "vscode-jsonrpc": "^8.2.0"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, updatedScaffold);
+        var scripts = GetScripts(result);
+
+        // Existing preserved
+        Assert.Equal("vite", scripts["dev"]?.GetValue<string>());
+        Assert.Equal("vite build", scripts["build"]?.GetValue<string>());
+
+        // All aspire: scripts present
+        Assert.Equal("aspire run", scripts["aspire:start"]?.GetValue<string>());
+        Assert.Equal("tsc -p tsconfig.apphost.json", scripts["aspire:build"]?.GetValue<string>());
+        Assert.Equal("tsc --watch -p tsconfig.apphost.json", scripts["aspire:dev"]?.GetValue<string>());
+        Assert.Equal("eslint apphost.ts", scripts["aspire:lint"]?.GetValue<string>());
+
+        // Convenience aliases for free names (start, lint not taken)
+        Assert.Equal("npm run aspire:start", scripts["start"]?.GetValue<string>());
+        Assert.Equal("npm run aspire:lint", scripts["lint"]?.GetValue<string>());
+
+        // No aliases for taken names (dev, build already exist)
+        Assert.Equal("vite", scripts["dev"]?.GetValue<string>());
+        Assert.Equal("vite build", scripts["build"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void ScriptCommands_PreservedWithFullFidelity()
+    {
+        // npm scripts commonly use &&, quotes, pipes, and other shell characters.
+        // The merger must write them back exactly as they were — no unicode escaping.
+        var existing = """
+            {
+              "name": "my-app",
+              "scripts": {
+                "build": "tsc && vite build",
+                "dev": "concurrently \"tsc -w\" \"vite\"",
+                "test": "vitest run && echo 'done'",
+                "lint": "eslint . --ext .ts,.tsx && prettier --check .",
+                "clean": "rm -rf dist && rm -rf node_modules/.cache",
+                "start": "node server.js | tee output.log"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "scripts": {
+                "aspire:build": "tsc -p tsconfig.apphost.json",
+                "aspire:start": "aspire run"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+
+        // Verify the raw JSON string contains literal &&, ', and | — not unicode escapes
+        Assert.Contains("tsc && vite build", result);
+        Assert.Contains("vitest run && echo 'done'", result);
+        Assert.Contains("eslint . --ext .ts,.tsx && prettier --check .", result);
+        Assert.Contains("rm -rf dist && rm -rf node_modules/.cache", result);
+        Assert.Contains("node server.js | tee output.log", result);
+
+        // Quotes inside JSON string values are written as \" (valid JSON) — verify via raw string
+        Assert.Contains("concurrently \\\"tsc -w\\\" \\\"vite\\\"", result);
+
+        // Must not contain unicode-escaped ampersands or single quotes
+        Assert.DoesNotContain("\\u0026", result);
+        Assert.DoesNotContain("\\u0027", result);
+
+        // Also verify the parsed values round-trip correctly
+        var scripts = GetScripts(result);
+        Assert.Equal("tsc && vite build", scripts["build"]?.GetValue<string>());
+        Assert.Equal("concurrently \"tsc -w\" \"vite\"", scripts["dev"]?.GetValue<string>());
+        Assert.Equal("vitest run && echo 'done'", scripts["test"]?.GetValue<string>());
+        Assert.Equal("eslint . --ext .ts,.tsx && prettier --check .", scripts["lint"]?.GetValue<string>());
+        Assert.Equal("rm -rf dist && rm -rf node_modules/.cache", scripts["clean"]?.GetValue<string>());
+        Assert.Equal("node server.js | tee output.log", scripts["start"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void ScaffoldScriptCommands_AlsoPreservedWithFullFidelity()
+    {
+        // Even scaffold-generated commands with special chars must be written faithfully
+        var existing = """
+            {
+              "name": "my-app",
+              "scripts": {
+                "dev": "next dev"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "scripts": {
+                "aspire:lint": "eslint apphost.ts && echo 'lint complete'",
+                "aspire:build": "tsc -p tsconfig.apphost.json && echo 'build done'"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+
+        Assert.Contains("eslint apphost.ts && echo 'lint complete'", result);
+        Assert.Contains("tsc -p tsconfig.apphost.json && echo 'build done'", result);
+        Assert.DoesNotContain("\\u0026", result);
+        Assert.DoesNotContain("\\u0027", result);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Scaffolding/PackageJsonMergerTests.cs
+++ b/tests/Aspire.Cli.Tests/Scaffolding/PackageJsonMergerTests.cs
@@ -254,7 +254,7 @@ public class PackageJsonMergerTests
     }
 
     [Fact]
-    public void Dependencies_DeepMerged_ExistingWins()
+    public void Dependencies_SemverAwareMerge()
     {
         var existing = """
             {
@@ -285,9 +285,11 @@ public class PackageJsonMergerTests
 
         var result = PackageJsonMerger.Merge(existing, scaffold);
 
-        // Existing dep versions preserved (deep merge — existing wins)
-        Assert.Equal("^4.18.0", GetDep(result, "dependencies", "express"));
-        Assert.Equal("^5.0.0", GetDep(result, "devDependencies", "typescript"));
+        // Scaffold is newer — upgraded
+        Assert.Equal("^5.0.0", GetDep(result, "dependencies", "express"));
+        Assert.Equal("^5.9.3", GetDep(result, "devDependencies", "typescript"));
+
+        // Not in scaffold — preserved
         Assert.Equal("^5.0.0", GetDep(result, "devDependencies", "vite"));
 
         // New deps added
@@ -514,10 +516,10 @@ public class PackageJsonMergerTests
         // Non-conflicting scaffold script added directly
         Assert.Equal("tsc --watch -p tsconfig.apphost.json", scripts["watch"]?.GetValue<string>());
 
-        // Existing deps preserved, new deps added
+        // Existing deps preserved, new deps added, older deps upgraded
         Assert.Equal("^18.2.0", GetDep(result, "dependencies", "react"));
         Assert.Equal("^8.2.0", GetDep(result, "dependencies", "vscode-jsonrpc"));
-        Assert.Equal("^5.2.0", GetDep(result, "devDependencies", "typescript"));
+        Assert.Equal("^5.9.3", GetDep(result, "devDependencies", "typescript")); // upgraded from ^5.2.0
         Assert.Equal("^5.0.0", GetDep(result, "devDependencies", "vite"));
         Assert.Equal("^22.0.0", GetDep(result, "devDependencies", "@types/node"));
         Assert.Equal("^4.21.0", GetDep(result, "devDependencies", "tsx"));
@@ -655,5 +657,157 @@ public class PackageJsonMergerTests
         Assert.Contains("tsc -p tsconfig.apphost.json && echo 'build done'", result);
         Assert.DoesNotContain("\\u0026", result);
         Assert.DoesNotContain("\\u0027", result);
+    }
+
+    [Fact]
+    public void Dependencies_ScaffoldNewerVersion_Upgrades()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "devDependencies": {
+                "typescript": "^4.0.0"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "devDependencies": {
+                "typescript": "^5.9.3"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+        Assert.Equal("^5.9.3", GetDep(result, "devDependencies", "typescript"));
+    }
+
+    [Fact]
+    public void Dependencies_ExistingNewerVersion_Preserved()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "devDependencies": {
+                "typescript": "^6.0.0"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "devDependencies": {
+                "typescript": "^5.9.3"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+        Assert.Equal("^6.0.0", GetDep(result, "devDependencies", "typescript"));
+    }
+
+    [Fact]
+    public void Dependencies_TildeRange_Compared()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "devDependencies": {
+                "typescript": "~5.0.0"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "devDependencies": {
+                "typescript": "^5.9.3"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+
+        // Scaffold is newer (5.9.3 > 5.0.0), upgrades — entire value replaced including range operator
+        Assert.Equal("^5.9.3", GetDep(result, "devDependencies", "typescript"));
+    }
+
+    [Fact]
+    public void Dependencies_UnionRange_Preserved()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "dependencies": {
+                "some-pkg": "^1.0.0 || ^2.0.0"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "dependencies": {
+                "some-pkg": "^3.0.0"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+
+        // Union ranges are unparseable — existing preserved
+        Assert.Equal("^1.0.0 || ^2.0.0", GetDep(result, "dependencies", "some-pkg"));
+    }
+
+    [Fact]
+    public void Dependencies_WorkspaceRef_Preserved()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "dependencies": {
+                "shared-lib": "workspace:*"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "dependencies": {
+                "shared-lib": "^1.0.0"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+
+        // Workspace refs are not parseable as semver — existing preserved
+        Assert.Equal("workspace:*", GetDep(result, "dependencies", "shared-lib"));
+    }
+
+    [Fact]
+    public void Dependencies_NewDependency_Added()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "dependencies": {
+                "express": "^4.18.0"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "dependencies": {
+                "vscode-jsonrpc": "^8.2.0"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+
+        Assert.Equal("^4.18.0", GetDep(result, "dependencies", "express"));
+        Assert.Equal("^8.2.0", GetDep(result, "dependencies", "vscode-jsonrpc"));
     }
 }

--- a/tests/Aspire.Cli.Tests/Scaffolding/PackageJsonMergerTests.cs
+++ b/tests/Aspire.Cli.Tests/Scaffolding/PackageJsonMergerTests.cs
@@ -1144,24 +1144,106 @@ public class PackageJsonMergerTests
     }
 
     [Fact]
-    public void ScaffoldWithArrayProperty_ThrowsInvalidOperation()
+    public void ScaffoldWithArrayProperty_PreservesExistingArray()
     {
         var existing = """
             {
-              "name": "my-app"
+              "name": "my-app",
+              "keywords": ["web", "api"]
             }
             """;
 
         var scaffold = """
             {
+              "keywords": ["web", "api"],
               "files": ["dist/**", "README.md"]
             }
             """;
 
-        // Array properties in scaffold require explicit merge logic — the generic fallthrough
-        // cannot handle them correctly, so we throw to catch this at dev/test time.
-        var ex = Assert.Throws<InvalidOperationException>(() => MergeJson(existing, scaffold));
-        Assert.Contains("files", ex.Message);
-        Assert.Contains("PackageJsonMerger", ex.Message);
+        // When both have an array, existing wins (preserved). Scaffold-only arrays are added.
+        var result = MergeJson(existing, scaffold);
+        var doc = JsonNode.Parse(result)!.AsObject();
+
+        var keywords = doc["keywords"]!.AsArray();
+        Assert.Equal(2, keywords.Count);
+        Assert.Equal("web", keywords[0]!.GetValue<string>());
+        Assert.Equal("api", keywords[1]!.GetValue<string>());
+
+        var files = doc["files"]!.AsArray();
+        Assert.Equal(2, files.Count);
+        Assert.Equal("dist/**", files[0]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void BrownfieldNpmInit_MergesSuccessfully()
+    {
+        // Reproduces the real-world scenario where npm init creates a package.json
+        // with keywords/author/license that get echoed through the scaffold.
+        var existing = """
+            {
+              "name": "my-project",
+              "version": "1.0.0",
+              "main": "index.js",
+              "scripts": {
+                "test": "echo \"Error: no test specified\" && exit 1"
+              },
+              "keywords": [],
+              "author": "",
+              "license": "ISC",
+              "description": ""
+            }
+            """;
+
+        var scaffold = """
+            {
+              "name": "my-project",
+              "version": "1.0.0",
+              "type": "module",
+              "main": "index.js",
+              "scripts": {
+                "aspire:start": "aspire run",
+                "aspire:build": "tsc -p tsconfig.apphost.json",
+                "aspire:lint": "eslint apphost.ts"
+              },
+              "keywords": [],
+              "author": "",
+              "license": "ISC",
+              "description": "",
+              "dependencies": {
+                "vscode-jsonrpc": "^8.2.0"
+              },
+              "devDependencies": {
+                "typescript": "^5.9.3",
+                "tsx": "^4.21.0"
+              },
+              "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+              }
+            }
+            """;
+
+        var result = MergeJson(existing, scaffold);
+        var doc = JsonNode.Parse(result)!.AsObject();
+
+        // Original fields preserved
+        Assert.Equal("my-project", doc["name"]!.GetValue<string>());
+        Assert.Equal("ISC", doc["license"]!.GetValue<string>());
+
+        // Array preserved (empty keywords from npm init)
+        Assert.NotNull(doc["keywords"]);
+        Assert.IsAssignableFrom<JsonArray>(doc["keywords"]);
+
+        // Aspire scripts added, existing test script preserved
+        var scripts = doc["scripts"]!.AsObject();
+        Assert.Contains("test", scripts.Select(p => p.Key));
+        Assert.Contains("aspire:start", scripts.Select(p => p.Key));
+        Assert.Contains("aspire:build", scripts.Select(p => p.Key));
+
+        // Dependencies merged
+        Assert.NotNull(doc["dependencies"]?["vscode-jsonrpc"]);
+        Assert.NotNull(doc["devDependencies"]?["typescript"]);
+
+        // Engines set
+        Assert.Contains(">=24", doc["engines"]?["node"]?.GetValue<string>());
     }
 }

--- a/tests/Aspire.Cli.Tests/Scaffolding/PackageJsonMergerTests.cs
+++ b/tests/Aspire.Cli.Tests/Scaffolding/PackageJsonMergerTests.cs
@@ -338,8 +338,8 @@ public class PackageJsonMergerTests
         Assert.True(json["private"]?.GetValue<bool>());
         Assert.Equal("module", json["type"]?.GetValue<string>());
 
-        // Existing engine constraint preserved (deep merge — existing wins)
-        Assert.Equal(">=18", json["engines"]?["node"]?.GetValue<string>());
+        // engines.node overwritten by scaffold (Aspire requires specific Node versions)
+        Assert.Equal("^20.19.0 || ^22.13.0 || >=24", json["engines"]?["node"]?.GetValue<string>());
 
         // Script from scaffold is added
         Assert.Equal("tsc -p tsconfig.apphost.json", GetScript(result, "aspire:build"));
@@ -1017,5 +1017,107 @@ public class PackageJsonMergerTests
 
         // 5.9.3 release is newer than 5.9.3-beta.1 pre-release
         Assert.Equal("^5.9.3", GetDep(result, "devDependencies", "typescript"));
+    }
+
+    [Fact]
+    public void Engines_NodeConstraint_OverwrittenByScaffold()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "engines": {
+                "node": ">=16"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+
+        // engines.node is always overwritten — aspire init enforces Node version for ESLint 10
+        var engines = ParseJson(result)["engines"]!.AsObject();
+        Assert.Equal("^20.19.0 || ^22.13.0 || >=24", engines["node"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void Engines_OtherKeys_Preserved()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "engines": {
+                "node": ">=16",
+                "npm": ">=8"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+
+        var engines = ParseJson(result)["engines"]!.AsObject();
+        // node overwritten by scaffold
+        Assert.Equal("^20.19.0 || ^22.13.0 || >=24", engines["node"]?.GetValue<string>());
+        // npm preserved from existing
+        Assert.Equal(">=8", engines["npm"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void Engines_AddedWhenMissing()
+    {
+        var existing = """
+            {
+              "name": "my-app"
+            }
+            """;
+
+        var scaffold = """
+            {
+              "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+
+        var engines = ParseJson(result)["engines"]!.AsObject();
+        Assert.Equal("^20.19.0 || ^22.13.0 || >=24", engines["node"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void ScaffoldWithArrayProperty_ThrowsInvalidOperation()
+    {
+        var existing = """
+            {
+              "name": "my-app"
+            }
+            """;
+
+        var scaffold = """
+            {
+              "files": ["dist/**", "README.md"]
+            }
+            """;
+
+        // Array properties in scaffold require explicit merge logic — the generic fallthrough
+        // cannot handle them correctly, so we throw to catch this at dev/test time.
+        var ex = Assert.Throws<InvalidOperationException>(() => PackageJsonMerger.Merge(existing, scaffold));
+        Assert.Contains("files", ex.Message);
+        Assert.Contains("PackageJsonMerger", ex.Message);
     }
 }

--- a/tests/Aspire.Cli.Tests/Scaffolding/PackageJsonMergerTests.cs
+++ b/tests/Aspire.Cli.Tests/Scaffolding/PackageJsonMergerTests.cs
@@ -4,7 +4,9 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Cli.Scaffolding;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
 
 namespace Aspire.Cli.Tests.Scaffolding;
 
@@ -1178,7 +1180,7 @@ public class PackageJsonMergerTests
     public void BrownfieldNpmInit_MergesSuccessfully()
     {
         // Reproduces the real-world scenario where npm init creates a package.json
-        // with keywords/author/license that get echoed through the scaffold.
+        // and the scaffold produces only Aspire-desired entries (no echo of existing content).
         var existing = """
             {
               "name": "my-project",
@@ -1196,19 +1198,11 @@ public class PackageJsonMergerTests
 
         var scaffold = """
             {
-              "name": "my-project",
-              "version": "1.0.0",
-              "type": "module",
-              "main": "index.js",
               "scripts": {
                 "aspire:start": "aspire run",
                 "aspire:build": "tsc -p tsconfig.apphost.json",
                 "aspire:lint": "eslint apphost.ts"
               },
-              "keywords": [],
-              "author": "",
-              "license": "ISC",
-              "description": "",
               "dependencies": {
                 "vscode-jsonrpc": "^8.2.0"
               },
@@ -1242,6 +1236,202 @@ public class PackageJsonMergerTests
         // Dependencies merged
         Assert.NotNull(doc["dependencies"]?["vscode-jsonrpc"]);
         Assert.NotNull(doc["devDependencies"]?["typescript"]);
+
+        // Engines set
+        Assert.Contains(">=24", doc["engines"]?["node"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void EnsureObject_LogsWarning_WhenReplacingArrayWithObject()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "dependencies": ["express", "react"]
+            }
+            """;
+
+        var scaffold = """
+            {
+              "dependencies": {
+                "vscode-jsonrpc": "^8.2.0"
+              }
+            }
+            """;
+
+        var sink = new TestSink();
+        var logger = new TestLogger("test", sink, enabled: true);
+
+        PackageJsonMerger.Merge(existing, scaffold, logger);
+
+        var warning = Assert.Single(sink.Writes, w => w.LogLevel == LogLevel.Warning);
+        Assert.Contains("dependencies", warning.Formatter!(warning.State, null)!);
+    }
+
+    [Fact]
+    public void EnsureObject_LogsWarning_WhenReplacingScalarWithObject()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "engines": "node >= 16"
+            }
+            """;
+
+        var scaffold = """
+            {
+              "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+              }
+            }
+            """;
+
+        var sink = new TestSink();
+        var logger = new TestLogger("test", sink, enabled: true);
+
+        PackageJsonMerger.Merge(existing, scaffold, logger);
+
+        var warning = Assert.Single(sink.Writes, w => w.LogLevel == LogLevel.Warning);
+        Assert.Contains("engines", warning.Formatter!(warning.State, null)!);
+    }
+
+    [Fact]
+    public void EnsureObject_DoesNotLogWarning_WhenPropertyIsAlreadyObject()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "dependencies": {
+                "express": "^4.18.0"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "dependencies": {
+                "vscode-jsonrpc": "^8.2.0"
+              }
+            }
+            """;
+
+        var sink = new TestSink();
+        var logger = new TestLogger("test", sink, enabled: true);
+
+        PackageJsonMerger.Merge(existing, scaffold, logger);
+
+        Assert.DoesNotContain(sink.Writes, w => w.LogLevel == LogLevel.Warning);
+    }
+
+    [Fact]
+    public void EnsureObject_DoesNotLogWarning_WhenPropertyIsMissing()
+    {
+        var existing = """
+            {
+              "name": "my-app"
+            }
+            """;
+
+        var scaffold = """
+            {
+              "dependencies": {
+                "vscode-jsonrpc": "^8.2.0"
+              }
+            }
+            """;
+
+        var sink = new TestSink();
+        var logger = new TestLogger("test", sink, enabled: true);
+
+        PackageJsonMerger.Merge(existing, scaffold, logger);
+
+        Assert.DoesNotContain(sink.Writes, w => w.LogLevel == LogLevel.Warning);
+    }
+
+    [Fact]
+    public void BrownfieldViteProject_AspireOnlyScaffold_MergesCorrectly()
+    {
+        // Simulates the full brownfield flow where the scaffold only contains
+        // Aspire-desired content (no echo of existing). This verifies the
+        // double-merge ordering dependency (item 3) is resolved: the merger
+        // does not produce incorrect aspire:-prefixed scripts from existing content.
+        var existing = """
+            {
+              "name": "vite-brownfield",
+              "version": "2.0.0",
+              "type": "module",
+              "scripts": {
+                "dev": "vite",
+                "build": "vite build",
+                "preview": "vite preview"
+              },
+              "dependencies": {
+                "vue": "^3.5.0"
+              },
+              "devDependencies": {
+                "vite": "^7.0.0",
+                "typescript": "^5.0.0"
+              }
+            }
+            """;
+
+        // Scaffold only has Aspire entries — no echo of existing content
+        var scaffold = """
+            {
+              "scripts": {
+                "aspire:start": "aspire run",
+                "aspire:build": "tsc -p tsconfig.apphost.json",
+                "aspire:dev": "tsc --watch -p tsconfig.apphost.json",
+                "aspire:lint": "eslint apphost.ts"
+              },
+              "dependencies": {
+                "vscode-jsonrpc": "^8.2.0"
+              },
+              "devDependencies": {
+                "@types/node": "^22.0.0",
+                "eslint": "^10.0.3",
+                "nodemon": "^3.1.14",
+                "tsx": "^4.21.0",
+                "typescript": "^5.9.3",
+                "typescript-eslint": "^8.57.1"
+              },
+              "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+              }
+            }
+            """;
+
+        var result = MergeJson(existing, scaffold);
+        var doc = JsonNode.Parse(result)!.AsObject();
+
+        // Existing metadata preserved
+        Assert.Equal("vite-brownfield", doc["name"]!.GetValue<string>());
+        Assert.Equal("2.0.0", doc["version"]!.GetValue<string>());
+        Assert.Equal("module", doc["type"]!.GetValue<string>());
+
+        // Existing scripts preserved
+        var scripts = doc["scripts"]!.AsObject();
+        Assert.Equal("vite", scripts["dev"]?.GetValue<string>());
+        Assert.Equal("vite build", scripts["build"]?.GetValue<string>());
+        Assert.Equal("vite preview", scripts["preview"]?.GetValue<string>());
+
+        // Aspire scripts added (no incorrect aspire:dev duplicate from old "dev":"vite")
+        Assert.Equal("aspire run", scripts["aspire:start"]?.GetValue<string>());
+        Assert.Equal("tsc -p tsconfig.apphost.json", scripts["aspire:build"]?.GetValue<string>());
+        Assert.Equal("tsc --watch -p tsconfig.apphost.json", scripts["aspire:dev"]?.GetValue<string>());
+        Assert.Equal("eslint apphost.ts", scripts["aspire:lint"]?.GetValue<string>());
+
+        // No spurious aspire-prefixed duplicates of existing scripts
+        Assert.False(scripts.ContainsKey("aspire:preview"));
+
+        // Existing deps preserved, Aspire deps added
+        Assert.Equal("^3.5.0", GetDep(result, "dependencies", "vue"));
+        Assert.Equal("^8.2.0", GetDep(result, "dependencies", "vscode-jsonrpc"));
+
+        // Existing devDeps: vite preserved, typescript upgraded to Aspire's version (newer)
+        Assert.Equal("^7.0.0", GetDep(result, "devDependencies", "vite"));
+        Assert.Equal("^5.9.3", GetDep(result, "devDependencies", "typescript"));
+        Assert.Equal("^4.21.0", GetDep(result, "devDependencies", "tsx"));
 
         // Engines set
         Assert.Contains(">=24", doc["engines"]?["node"]?.GetValue<string>());

--- a/tests/Aspire.Cli.Tests/Scaffolding/PackageJsonMergerTests.cs
+++ b/tests/Aspire.Cli.Tests/Scaffolding/PackageJsonMergerTests.cs
@@ -810,4 +810,212 @@ public class PackageJsonMergerTests
         Assert.Equal("^4.18.0", GetDep(result, "dependencies", "express"));
         Assert.Equal("^8.2.0", GetDep(result, "dependencies", "vscode-jsonrpc"));
     }
+
+    [Fact]
+    public void NonStringScriptValue_SkippedGracefully()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "scripts": {
+                "dev": "vite"
+              }
+            }
+            """;
+
+        // Scaffold has an array value for a script (unusual but should not crash)
+        var scaffold = """
+            {
+              "scripts": {
+                "aspire:start": "aspire run",
+                "bad-script": [1, 2, 3]
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+
+        // Valid scripts still merged, invalid ones skipped
+        Assert.Equal("vite", GetScript(result, "dev"));
+        Assert.Equal("aspire run", GetScript(result, "aspire:start"));
+        Assert.Null(ParseJson(result)["scripts"]!["bad-script"]);
+    }
+
+    [Fact]
+    public void NonStringDependencyValue_SkippedGracefully()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "dependencies": {
+                "express": "^4.18.0"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "dependencies": {
+                "vscode-jsonrpc": "^8.2.0",
+                "bad-dep": ["1.0.0"]
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+
+        // Valid deps merged, non-string ones skipped
+        Assert.Equal("^4.18.0", GetDep(result, "dependencies", "express"));
+        Assert.Equal("^8.2.0", GetDep(result, "dependencies", "vscode-jsonrpc"));
+        Assert.Null(GetDep(result, "dependencies", "bad-dep"));
+    }
+
+    [Fact]
+    public void NonStringExistingDependency_PreservedNotCrashed()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "dependencies": {
+                "weird-pkg": { "version": "1.0.0", "optional": true }
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "dependencies": {
+                "weird-pkg": "^2.0.0",
+                "vscode-jsonrpc": "^8.2.0"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+
+        // Non-string existing dep preserved (upgrade skipped due to type mismatch)
+        var weirdPkg = ParseJson(result)["dependencies"]!["weird-pkg"];
+        Assert.NotNull(weirdPkg);
+        Assert.True(weirdPkg is JsonObject);
+
+        // New deps still added
+        Assert.Equal("^8.2.0", GetDep(result, "dependencies", "vscode-jsonrpc"));
+    }
+
+    [Fact]
+    public void DependenciesSectionIsArray_HandledGracefully()
+    {
+        var existing = """
+            {
+              "name": "my-app",
+              "dependencies": ["express", "react"]
+            }
+            """;
+
+        var scaffold = """
+            {
+              "dependencies": {
+                "vscode-jsonrpc": "^8.2.0"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+
+        // EnsureObject replaces the array with a proper object containing scaffold deps
+        Assert.Equal("^8.2.0", GetDep(result, "dependencies", "vscode-jsonrpc"));
+    }
+
+    [Fact]
+    public void JsonRootIsArray_ReturnsScaffold()
+    {
+        var existing = """["not", "an", "object"]""";
+
+        var scaffold = """
+            {
+              "name": "scaffold",
+              "scripts": { "dev": "aspire run" }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+
+        // Can't merge into an array — returns scaffold as-is
+        Assert.Equal("scaffold", ParseJson(result)["name"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void WildcardVersion_Preserved()
+    {
+        var existing = """
+            {
+              "dependencies": {
+                "some-pkg": "*"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "dependencies": {
+                "some-pkg": "^2.0.0"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+
+        // "*" is unparseable — existing preserved
+        Assert.Equal("*", GetDep(result, "dependencies", "some-pkg"));
+    }
+
+    [Fact]
+    public void LatestTag_Preserved()
+    {
+        var existing = """
+            {
+              "dependencies": {
+                "some-pkg": "latest"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "dependencies": {
+                "some-pkg": "^2.0.0"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+
+        // "latest" is unparseable — existing preserved
+        Assert.Equal("latest", GetDep(result, "dependencies", "some-pkg"));
+    }
+
+    [Fact]
+    public void PreReleaseVersion_ComparedCorrectly()
+    {
+        var existing = """
+            {
+              "devDependencies": {
+                "typescript": "^5.9.3-beta.1"
+              }
+            }
+            """;
+
+        var scaffold = """
+            {
+              "devDependencies": {
+                "typescript": "^5.9.3"
+              }
+            }
+            """;
+
+        var result = PackageJsonMerger.Merge(existing, scaffold);
+
+        // 5.9.3 release is newer than 5.9.3-beta.1 pre-release
+        Assert.Equal("^5.9.3", GetDep(result, "devDependencies", "typescript"));
+    }
 }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
@@ -100,6 +100,42 @@ public sealed class TypeScriptLanguageSupportTests
     }
 
     [Fact]
+    public void Scaffold_UpgradesExistingDependencies_WhenAspireRequiresNewerVersion()
+    {
+        using var testDirectory = new TestDirectory();
+
+        File.WriteAllText(Path.Combine(testDirectory.Path, "package.json"), """
+            {
+              "dependencies": {
+                "vscode-jsonrpc": "^8.1.0"
+              },
+              "devDependencies": {
+                "@types/node": "^18.0.0",
+                "nodemon": "^3.1.0",
+                "tsx": "^4.18.0",
+                "typescript": "^5.2.0"
+              }
+            }
+            """);
+
+        var files = _languageSupport.Scaffold(new ScaffoldRequest
+        {
+            TargetPath = testDirectory.Path,
+            ProjectName = "Ignored"
+        });
+
+        var packageJson = ParseJson(files["package.json"]);
+        var dependencies = packageJson["dependencies"]!.AsObject();
+        var devDependencies = packageJson["devDependencies"]!.AsObject();
+
+        Assert.Equal("^8.2.0", dependencies["vscode-jsonrpc"]?.GetValue<string>());
+        Assert.Equal("^20.0.0", devDependencies["@types/node"]?.GetValue<string>());
+        Assert.Equal("^3.1.11", devDependencies["nodemon"]?.GetValue<string>());
+        Assert.Equal("^4.19.0", devDependencies["tsx"]?.GetValue<string>());
+        Assert.Equal("^5.3.0", devDependencies["typescript"]?.GetValue<string>());
+    }
+
+    [Fact]
     public void Scaffold_DoesNotEmitRootTsConfig_WhenOneAlreadyExists()
     {
         using var testDirectory = new TestDirectory();
@@ -131,8 +167,8 @@ public sealed class TypeScriptLanguageSupportTests
         var runtimeSpec = _languageSupport.GetRuntimeSpec();
         var watchExecute = Assert.IsType<CommandSpec>(runtimeSpec.WatchExecute);
 
-        Assert.Equal(new[] { "tsx", "--tsconfig", "tsconfig.apphost.json", "{appHostFile}" }, runtimeSpec.Execute.Args);
-        Assert.Contains("npx tsx --tsconfig tsconfig.apphost.json {appHostFile}", watchExecute.Args);
+        Assert.Equal(new[] { "--no-install", "tsx", "--tsconfig", "tsconfig.apphost.json", "{appHostFile}" }, runtimeSpec.Execute.Args);
+        Assert.Contains("npx --no-install tsx --tsconfig tsconfig.apphost.json {appHostFile}", watchExecute.Args);
     }
 
     private static JsonObject ParseJson(string content) => JsonNode.Parse(content)!.AsObject();

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
@@ -1,0 +1,158 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Nodes;
+using Aspire.Hosting.Ats;
+
+namespace Aspire.Hosting.CodeGeneration.TypeScript.Tests;
+
+public sealed class TypeScriptLanguageSupportTests
+{
+    private readonly TypeScriptLanguageSupport _languageSupport = new();
+
+    [Fact]
+    public void Scaffold_CreatesAppHostSpecificScriptsAndTsConfig_ForNewProject()
+    {
+        using var testDirectory = new TestDirectory();
+
+        var files = _languageSupport.Scaffold(new ScaffoldRequest
+        {
+            TargetPath = testDirectory.Path,
+            ProjectName = "BrownfieldApp"
+        });
+
+        Assert.Contains("apphost.ts", files.Keys);
+        Assert.Contains("package.json", files.Keys);
+        Assert.Contains("tsconfig.apphost.json", files.Keys);
+        Assert.DoesNotContain("tsconfig.json", files.Keys);
+
+        var packageJson = ParseJson(files["package.json"]);
+        var scripts = packageJson["scripts"]!.AsObject();
+        var devDependencies = packageJson["devDependencies"]!.AsObject();
+
+        Assert.Equal("brownfieldapp", packageJson["name"]?.GetValue<string>());
+        Assert.Equal("1.0.0", packageJson["version"]?.GetValue<string>());
+        Assert.Equal("module", packageJson["type"]?.GetValue<string>());
+        Assert.Equal("aspire run", scripts["aspire:start"]?.GetValue<string>());
+        Assert.Equal("tsc -p tsconfig.apphost.json", scripts["aspire:build"]?.GetValue<string>());
+        Assert.Equal("tsc --watch -p tsconfig.apphost.json", scripts["aspire:dev"]?.GetValue<string>());
+        Assert.False(scripts.ContainsKey("start"));
+        Assert.False(scripts.ContainsKey("build"));
+        Assert.False(scripts.ContainsKey("dev"));
+        Assert.Equal("^4.19.0", devDependencies["tsx"]?.GetValue<string>());
+        Assert.Equal("^5.3.0", devDependencies["typescript"]?.GetValue<string>());
+
+        var tsConfig = ParseJson(files["tsconfig.apphost.json"]);
+        Assert.Equal("./dist/apphost", tsConfig["compilerOptions"]?["outDir"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void Scaffold_MergesExistingPackageJson_WithoutOverwritingExistingAppValues()
+    {
+        using var testDirectory = new TestDirectory();
+
+        File.WriteAllText(Path.Combine(testDirectory.Path, "package.json"), """
+            {
+              "name": "vite-brownfield",
+              "version": "2.0.0",
+              "scripts": {
+                "dev": "vite",
+                "build": "vite build",
+                "preview": "vite preview",
+                "aspire:start": "custom-start"
+              },
+              "dependencies": {
+                "vscode-jsonrpc": "^9.9.9"
+              },
+              "devDependencies": {
+                "tsx": "^9.9.9",
+                "vite": "^7.0.0"
+              }
+            }
+            """);
+
+        var files = _languageSupport.Scaffold(new ScaffoldRequest
+        {
+            TargetPath = testDirectory.Path,
+            ProjectName = "Ignored"
+        });
+
+        var packageJson = ParseJson(files["package.json"]);
+        var scripts = packageJson["scripts"]!.AsObject();
+        var dependencies = packageJson["dependencies"]!.AsObject();
+        var devDependencies = packageJson["devDependencies"]!.AsObject();
+
+        Assert.Equal("vite-brownfield", packageJson["name"]?.GetValue<string>());
+        Assert.Equal("2.0.0", packageJson["version"]?.GetValue<string>());
+        Assert.Null(packageJson["type"]);
+        Assert.Equal("vite", scripts["dev"]?.GetValue<string>());
+        Assert.Equal("vite build", scripts["build"]?.GetValue<string>());
+        Assert.Equal("vite preview", scripts["preview"]?.GetValue<string>());
+        Assert.Equal("aspire run", scripts["aspire:start"]?.GetValue<string>());
+        Assert.Equal("tsc -p tsconfig.apphost.json", scripts["aspire:build"]?.GetValue<string>());
+        Assert.Equal("tsc --watch -p tsconfig.apphost.json", scripts["aspire:dev"]?.GetValue<string>());
+        Assert.Equal("^9.9.9", dependencies["vscode-jsonrpc"]?.GetValue<string>());
+        Assert.Equal("^9.9.9", devDependencies["tsx"]?.GetValue<string>());
+        Assert.Equal("^7.0.0", devDependencies["vite"]?.GetValue<string>());
+        Assert.Equal("^20.0.0", devDependencies["@types/node"]?.GetValue<string>());
+        Assert.Equal("^3.1.11", devDependencies["nodemon"]?.GetValue<string>());
+        Assert.Equal("^5.3.0", devDependencies["typescript"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void Scaffold_DoesNotEmitRootTsConfig_WhenOneAlreadyExists()
+    {
+        using var testDirectory = new TestDirectory();
+        var existingTsConfigPath = Path.Combine(testDirectory.Path, "tsconfig.json");
+        var existingTsConfig = """
+            {
+              "compilerOptions": {
+                "module": "ESNext"
+              }
+            }
+            """;
+
+        File.WriteAllText(existingTsConfigPath, existingTsConfig);
+
+        var files = _languageSupport.Scaffold(new ScaffoldRequest
+        {
+            TargetPath = testDirectory.Path,
+            ProjectName = "BrownfieldApp"
+        });
+
+        Assert.DoesNotContain("tsconfig.json", files.Keys);
+        Assert.Contains("tsconfig.apphost.json", files.Keys);
+        Assert.Equal(existingTsConfig, File.ReadAllText(existingTsConfigPath));
+    }
+
+    [Fact]
+    public void GetRuntimeSpec_UsesAppHostSpecificTsConfig()
+    {
+        var runtimeSpec = _languageSupport.GetRuntimeSpec();
+        var watchExecute = Assert.IsType<CommandSpec>(runtimeSpec.WatchExecute);
+
+        Assert.Equal(new[] { "tsx", "--tsconfig", "tsconfig.apphost.json", "{appHostFile}" }, runtimeSpec.Execute.Args);
+        Assert.Contains("npx tsx --tsconfig tsconfig.apphost.json {appHostFile}", watchExecute.Args);
+    }
+
+    private static JsonObject ParseJson(string content) => JsonNode.Parse(content)!.AsObject();
+
+    private sealed class TestDirectory : IDisposable
+    {
+        public TestDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aspire-ts-language-support-tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json.Nodes;
-using Aspire.Hosting.Ats;
+using Aspire.TypeSystem;
 
 namespace Aspire.Hosting.CodeGeneration.TypeScript.Tests;
 

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
@@ -48,6 +48,9 @@ public sealed class TypeScriptLanguageSupportTests
         var engines = packageJson["engines"]!.AsObject();
         Assert.Equal("^20.19.0 || ^22.13.0 || >=24", engines["node"]?.GetValue<string>());
 
+        // Verify the raw JSON does not contain unicode escapes for >= (fidelity check)
+        Assert.DoesNotContain("\\u003E", files["package.json"]);
+
         Assert.Contains("eslint.config.mjs", files.Keys);
 
         var tsConfig = ParseJson(files["tsconfig.apphost.json"]);

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
@@ -59,7 +59,7 @@ public sealed class TypeScriptLanguageSupportTests
     }
 
     [Fact]
-    public void Scaffold_MergesExistingPackageJson_WithoutOverwritingExistingAppValues()
+    public void Scaffold_BrownfieldOutput_ContainsOnlyAspireEntries()
     {
         using var testDirectory = new TestDirectory();
 
@@ -94,32 +94,37 @@ public sealed class TypeScriptLanguageSupportTests
         var dependencies = packageJson["dependencies"]!.AsObject();
         var devDependencies = packageJson["devDependencies"]!.AsObject();
 
-        Assert.Equal("vite-brownfield", packageJson["name"]?.GetValue<string>());
-        Assert.Equal("2.0.0", packageJson["version"]?.GetValue<string>());
+        // Scaffold output should NOT echo existing content — the CLI-side
+        // PackageJsonMerger handles combining with the on-disk file.
+        Assert.Null(packageJson["name"]);
+        Assert.Null(packageJson["version"]);
         Assert.Null(packageJson["type"]);
-        Assert.Equal("vite", scripts["dev"]?.GetValue<string>());
-        Assert.Equal("vite build", scripts["build"]?.GetValue<string>());
-        Assert.Equal("vite preview", scripts["preview"]?.GetValue<string>());
+        Assert.Null(packageJson["private"]);
+
+        // Scaffold should only contain Aspire-desired scripts
         Assert.Equal("aspire run", scripts["aspire:start"]?.GetValue<string>());
         Assert.Equal("tsc -p tsconfig.apphost.json", scripts["aspire:build"]?.GetValue<string>());
         Assert.Equal("tsc --watch -p tsconfig.apphost.json", scripts["aspire:dev"]?.GetValue<string>());
-        Assert.Equal("^9.9.9", dependencies["vscode-jsonrpc"]?.GetValue<string>());
-        Assert.Equal("^9.9.9", devDependencies["tsx"]?.GetValue<string>());
-        Assert.Equal("^7.0.0", devDependencies["vite"]?.GetValue<string>());
+        Assert.Equal("eslint apphost.ts", scripts["aspire:lint"]?.GetValue<string>());
+        Assert.False(scripts.ContainsKey("dev"));
+        Assert.False(scripts.ContainsKey("build"));
+        Assert.False(scripts.ContainsKey("preview"));
+
+        // Scaffold should only contain Aspire-desired dependencies (at Aspire's versions)
+        Assert.Equal("^8.2.0", dependencies["vscode-jsonrpc"]?.GetValue<string>());
+        Assert.Equal("^4.21.0", devDependencies["tsx"]?.GetValue<string>());
         Assert.Equal("^22.0.0", devDependencies["@types/node"]?.GetValue<string>());
         Assert.Equal("^3.1.14", devDependencies["nodemon"]?.GetValue<string>());
         Assert.Equal("^5.9.3", devDependencies["typescript"]?.GetValue<string>());
+        Assert.False(devDependencies.ContainsKey("vite"));
 
-        // engines.node is always set — Aspire requires specific Node versions for ESLint 10
+        // engines.node is always set
         var engines = packageJson["engines"]!.AsObject();
         Assert.Equal("^20.19.0 || ^22.13.0 || >=24", engines["node"]?.GetValue<string>());
-
-        // private is NOT forced on brownfield projects — existing project may be intentionally publishable
-        Assert.Null(packageJson["private"]);
     }
 
     [Fact]
-    public void Scaffold_UpgradesExistingDependencies_WhenAspireRequiresNewerVersion()
+    public void Scaffold_AlwaysOutputsAspireVersions_RegardlessOfExistingDependencies()
     {
         using var testDirectory = new TestDirectory();
 
@@ -147,6 +152,8 @@ public sealed class TypeScriptLanguageSupportTests
         var dependencies = packageJson["dependencies"]!.AsObject();
         var devDependencies = packageJson["devDependencies"]!.AsObject();
 
+        // Scaffold always produces Aspire's desired versions — the CLI-side
+        // PackageJsonMerger handles semver comparison with existing on-disk versions.
         Assert.Equal("^8.2.0", dependencies["vscode-jsonrpc"]?.GetValue<string>());
         Assert.Equal("^22.0.0", devDependencies["@types/node"]?.GetValue<string>());
         Assert.Equal("^3.1.14", devDependencies["nodemon"]?.GetValue<string>());

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
@@ -36,11 +36,19 @@ public sealed class TypeScriptLanguageSupportTests
         Assert.Equal("aspire run", scripts["aspire:start"]?.GetValue<string>());
         Assert.Equal("tsc -p tsconfig.apphost.json", scripts["aspire:build"]?.GetValue<string>());
         Assert.Equal("tsc --watch -p tsconfig.apphost.json", scripts["aspire:dev"]?.GetValue<string>());
+        Assert.Equal("eslint apphost.ts", scripts["aspire:lint"]?.GetValue<string>());
         Assert.False(scripts.ContainsKey("start"));
         Assert.False(scripts.ContainsKey("build"));
         Assert.False(scripts.ContainsKey("dev"));
-        Assert.Equal("^4.19.0", devDependencies["tsx"]?.GetValue<string>());
-        Assert.Equal("^5.3.0", devDependencies["typescript"]?.GetValue<string>());
+        Assert.Equal("^4.21.0", devDependencies["tsx"]?.GetValue<string>());
+        Assert.Equal("^5.9.3", devDependencies["typescript"]?.GetValue<string>());
+        Assert.Equal("^10.0.3", devDependencies["eslint"]?.GetValue<string>());
+        Assert.Equal("^8.57.1", devDependencies["typescript-eslint"]?.GetValue<string>());
+
+        var engines = packageJson["engines"]!.AsObject();
+        Assert.Equal("^20.19.0 || ^22.13.0 || >=24", engines["node"]?.GetValue<string>());
+
+        Assert.Contains("eslint.config.mjs", files.Keys);
 
         var tsConfig = ParseJson(files["tsconfig.apphost.json"]);
         Assert.Equal("./dist/apphost", tsConfig["compilerOptions"]?["outDir"]?.GetValue<string>());
@@ -94,9 +102,9 @@ public sealed class TypeScriptLanguageSupportTests
         Assert.Equal("^9.9.9", dependencies["vscode-jsonrpc"]?.GetValue<string>());
         Assert.Equal("^9.9.9", devDependencies["tsx"]?.GetValue<string>());
         Assert.Equal("^7.0.0", devDependencies["vite"]?.GetValue<string>());
-        Assert.Equal("^20.0.0", devDependencies["@types/node"]?.GetValue<string>());
-        Assert.Equal("^3.1.11", devDependencies["nodemon"]?.GetValue<string>());
-        Assert.Equal("^5.3.0", devDependencies["typescript"]?.GetValue<string>());
+        Assert.Equal("^22.0.0", devDependencies["@types/node"]?.GetValue<string>());
+        Assert.Equal("^3.1.14", devDependencies["nodemon"]?.GetValue<string>());
+        Assert.Equal("^5.9.3", devDependencies["typescript"]?.GetValue<string>());
     }
 
     [Fact]
@@ -129,10 +137,10 @@ public sealed class TypeScriptLanguageSupportTests
         var devDependencies = packageJson["devDependencies"]!.AsObject();
 
         Assert.Equal("^8.2.0", dependencies["vscode-jsonrpc"]?.GetValue<string>());
-        Assert.Equal("^20.0.0", devDependencies["@types/node"]?.GetValue<string>());
-        Assert.Equal("^3.1.11", devDependencies["nodemon"]?.GetValue<string>());
-        Assert.Equal("^4.19.0", devDependencies["tsx"]?.GetValue<string>());
-        Assert.Equal("^5.3.0", devDependencies["typescript"]?.GetValue<string>());
+        Assert.Equal("^22.0.0", devDependencies["@types/node"]?.GetValue<string>());
+        Assert.Equal("^3.1.14", devDependencies["nodemon"]?.GetValue<string>());
+        Assert.Equal("^4.21.0", devDependencies["tsx"]?.GetValue<string>());
+        Assert.Equal("^5.9.3", devDependencies["typescript"]?.GetValue<string>());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TypeScriptLanguageSupportTests.cs
@@ -32,6 +32,7 @@ public sealed class TypeScriptLanguageSupportTests
 
         Assert.Equal("brownfieldapp", packageJson["name"]?.GetValue<string>());
         Assert.Equal("1.0.0", packageJson["version"]?.GetValue<string>());
+        Assert.True(packageJson["private"]?.GetValue<bool>());
         Assert.Equal("module", packageJson["type"]?.GetValue<string>());
         Assert.Equal("aspire run", scripts["aspire:start"]?.GetValue<string>());
         Assert.Equal("tsc -p tsconfig.apphost.json", scripts["aspire:build"]?.GetValue<string>());
@@ -108,6 +109,13 @@ public sealed class TypeScriptLanguageSupportTests
         Assert.Equal("^22.0.0", devDependencies["@types/node"]?.GetValue<string>());
         Assert.Equal("^3.1.14", devDependencies["nodemon"]?.GetValue<string>());
         Assert.Equal("^5.9.3", devDependencies["typescript"]?.GetValue<string>());
+
+        // engines.node is always set — Aspire requires specific Node versions for ESLint 10
+        var engines = packageJson["engines"]!.AsObject();
+        Assert.Equal("^20.19.0 || ^22.13.0 || >=24", engines["node"]?.GetValue<string>());
+
+        // private is NOT forced on brownfield projects — existing project may be intentionally publishable
+        Assert.Null(packageJson["private"]);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

This draft PR makes TypeScript `aspire init` safer for brownfield repos that already have a frontend project at the repo root, such as a Vite app created with `npm create vite`.

It updates TypeScript AppHost scaffolding to preserve an existing root `package.json` and `tsconfig.json` instead of overwriting them, adds Aspire-owned scripts under non-conflicting names (`aspire:start`, `aspire:build`, `aspire:dev`), emits `tsconfig.apphost.json` for AppHost-specific compilation, and updates the runtime spec to use that dedicated config.

It also adds focused validation for the scenario:
- unit tests for `TypeScriptLanguageSupport` merge/runtime behavior
- CLI E2E coverage for initializing Aspire into a brownfield Vite-at-root repository
- full repo build validation after the change

Fixes #15122

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
