### PR TITLE
Publish and sign CLI install scripts

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -99,10 +99,11 @@
       <_ExtensionFilesToPublish Include="$(ArtifactsPackagesDir)**\aspire-vscode-*.vsix.zip" />
     </ItemGroup>
 
-    <!-- Generate checksums for aspire-cli packages -->
+    <!-- Generate checksums for aspire-cli packages and install scripts -->
     <ItemGroup>
       <_CliFileToPublish Include="@(_ArchiveFiles)" />
       <GenerateChecksumItems Include="@(_CliFileToPublish)" DestinationPath="%(FullPath).sha512" />
+      <GenerateChecksumItems Include="@(_CliInstallScriptsToPublish)" DestinationPath="$(ArtifactsPackagesDir)\%(Filename)%(Extension).sha512" />
     </ItemGroup>
 
     <GenerateChecksums Items="@(GenerateChecksumItems)" />

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -23,6 +23,8 @@
     <_InstallersToPublish Include="$(ArtifactsDir)**\*.wixpack.zip" Condition="'$(PostBuildSign)' == 'true'" />
     <_InstallerManifestFilesToPublish Include="$(ArtifactsDir)VSSetup\$(Configuration)\Insertion\**\*.zip" />
     <_DashboardFilesToPublish Include="$(DashboardPublishedArtifactsOutputDir)\**\*.zip" />
+    <_CliInstallScriptsToPublish Include="$(RepoRoot)eng\scripts\get-aspire-cli.sh" />
+    <_CliInstallScriptsToPublish Include="$(RepoRoot)eng\scripts\get-aspire-cli.ps1" />
   </ItemGroup>
 
   <Target Name="_PublishBlobItems">
@@ -41,6 +43,8 @@
          The signature file is created by signVsix.proj which runs after publish, so validation happens there. -->
     <Error Condition="@(_ExtensionFilesToPublish->Count()) != 1" Text="Expected exactly 1 VS Code extension VSIX file but found @(_ExtensionFilesToPublish->Count()). Files: @(_ExtensionFilesToPublish, ', ')" />
     <Error Condition="@(_ExtensionManifestFiles->Count()) != 1" Text="Expected exactly 1 VS Code extension manifest file but found @(_ExtensionManifestFiles->Count()). Files: @(_ExtensionManifestFiles, ', ')" />
+    <Error Condition="!Exists('$(RepoRoot)eng\scripts\get-aspire-cli.sh')" Text="Expected CLI install script at $(RepoRoot)eng\scripts\get-aspire-cli.sh." />
+    <Error Condition="!Exists('$(RepoRoot)eng\scripts\get-aspire-cli.ps1')" Text="Expected CLI install script at $(RepoRoot)eng\scripts\get-aspire-cli.ps1." />
 
     <ItemGroup>
       <!-- Extract RID from each archive file -->
@@ -103,6 +107,7 @@
 
     <GenerateChecksums Items="@(GenerateChecksumItems)" />
     <ItemGroup>
+      <_CliFileToPublish Include="@(_CliInstallScriptsToPublish)" />
       <_CliFileToPublish Include="@(GenerateChecksumItems->'%(DestinationPath)')" />
     </ItemGroup>
 

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -59,6 +59,7 @@
     <FileSignInfo Condition="$([System.OperatingSystem]::IsWindows())" Include="aspire.exe" CertificateName="MicrosoftDotNet500" />
     <FileSignInfo Condition="$([System.OperatingSystem]::IsLinux())" Include="aspire" CertificateName="MicrosoftDotNet500" />
     <FileSignInfo Condition="$([System.OperatingSystem]::IsMacOS())" Include="aspire" CertificateName="MacDeveloperHardenWithNotarization" />
+    <FileSignInfo Condition="$([System.OperatingSystem]::IsWindows())" Include="get-aspire-cli.ps1" CertificateName="MicrosoftDotNet500" />
 
     <!-- Sign the manifest catalog on Windows -->
     <FileSignInfo Condition="$([System.OperatingSystem]::IsWindows())" Include="manifest.cat" CertificateName="MicrosoftDotNet500" />
@@ -71,6 +72,7 @@
     <ItemsToSign Include="$(VisualStudioSetupInsertionPath)\**\*.zip" Condition="'$(PostBuildSign)' != 'true'" />
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\aspire-cli-*.zip" />
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\aspire-cli-*.tar.gz" />
+    <ItemsToSign Include="$(RepoRoot)eng\scripts\get-aspire-cli.ps1" Condition="$([System.OperatingSystem]::IsWindows())" />
     <!-- 
       Note: VS Code extension (.vsix) is NOT included here.
       Signing the VSIX changes its hash, breaking manifest integrity verification.


### PR DESCRIPTION
## Description

Publishes the Aspire CLI installer scripts together with the existing CLI artifacts on the release/13.2 branch.

- Publishes `get-aspire-cli.sh` and `get-aspire-cli.ps1` to the blob feed and validates that both scripts exist during publishing.
- Generates `.sha512` checksum files for both install scripts alongside the existing CLI archive checksums.
- Signs `get-aspire-cli.ps1` on Windows only so the PowerShell installer script participates in the existing signing flow without changing non-Windows publishing behavior.

This keeps the installer scripts distributed alongside the CLI archives and brings their checksum and signing behavior in line with the release pipeline expectations.

Dependencies: none.

Validation:
- `./restore.sh`
- `./build.sh --build /p:SkipNativeBuild=true`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
