### PR TITLE
Update dependencies from https://github.com/microsoft/dcp build 0.22.9

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.22.8">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.22.9">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>a835bbc13d2acd225c0f1b9c0431f6dc1f4d7ea4</Sha>
+      <Sha>2d830e7dca49e9b22e0148a1f58ac47141a11daa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.22.8">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.22.9">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>a835bbc13d2acd225c0f1b9c0431f6dc1f4d7ea4</Sha>
+      <Sha>2d830e7dca49e9b22e0148a1f58ac47141a11daa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.22.8">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.22.9">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>a835bbc13d2acd225c0f1b9c0431f6dc1f4d7ea4</Sha>
+      <Sha>2d830e7dca49e9b22e0148a1f58ac47141a11daa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.22.8">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.22.9">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>a835bbc13d2acd225c0f1b9c0431f6dc1f4d7ea4</Sha>
+      <Sha>2d830e7dca49e9b22e0148a1f58ac47141a11daa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.22.8">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-musl-amd64" Version="0.22.9">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>a835bbc13d2acd225c0f1b9c0431f6dc1f4d7ea4</Sha>
+      <Sha>2d830e7dca49e9b22e0148a1f58ac47141a11daa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.22.8">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.22.9">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>a835bbc13d2acd225c0f1b9c0431f6dc1f4d7ea4</Sha>
+      <Sha>2d830e7dca49e9b22e0148a1f58ac47141a11daa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.22.8">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.22.9">
       <Uri>https://github.com/microsoft/dcp</Uri>
-      <Sha>a835bbc13d2acd225c0f1b9c0431f6dc1f4d7ea4</Sha>
+      <Sha>2d830e7dca49e9b22e0148a1f58ac47141a11daa</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.DependencyInjection.AutoActivation" Version="10.2.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,13 +28,13 @@
     <!-- Package versions defined directly in <reporoot>/Directory.Packages.props -->
     <MicrosoftDotnetSdkInternalVersion>8.0.100-rtm.23512.16</MicrosoftDotnetSdkInternalVersion>
     <!-- DCP -->
-    <MicrosoftDeveloperControlPlanedarwinamd64Version>0.22.8</MicrosoftDeveloperControlPlanedarwinamd64Version>
-    <MicrosoftDeveloperControlPlanedarwinarm64Version>0.22.8</MicrosoftDeveloperControlPlanedarwinarm64Version>
-    <MicrosoftDeveloperControlPlanelinuxamd64Version>0.22.8</MicrosoftDeveloperControlPlanelinuxamd64Version>
-    <MicrosoftDeveloperControlPlanelinuxarm64Version>0.22.8</MicrosoftDeveloperControlPlanelinuxarm64Version>
-    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.22.8</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
-    <MicrosoftDeveloperControlPlanewindowsamd64Version>0.22.8</MicrosoftDeveloperControlPlanewindowsamd64Version>
-    <MicrosoftDeveloperControlPlanewindowsarm64Version>0.22.8</MicrosoftDeveloperControlPlanewindowsarm64Version>
+    <MicrosoftDeveloperControlPlanedarwinamd64Version>0.22.9</MicrosoftDeveloperControlPlanedarwinamd64Version>
+    <MicrosoftDeveloperControlPlanedarwinarm64Version>0.22.9</MicrosoftDeveloperControlPlanedarwinarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxamd64Version>0.22.9</MicrosoftDeveloperControlPlanelinuxamd64Version>
+    <MicrosoftDeveloperControlPlanelinuxarm64Version>0.22.9</MicrosoftDeveloperControlPlanelinuxarm64Version>
+    <MicrosoftDeveloperControlPlanelinuxmuslamd64Version>0.22.9</MicrosoftDeveloperControlPlanelinuxmuslamd64Version>
+    <MicrosoftDeveloperControlPlanewindowsamd64Version>0.22.9</MicrosoftDeveloperControlPlanewindowsamd64Version>
+    <MicrosoftDeveloperControlPlanewindowsarm64Version>0.22.9</MicrosoftDeveloperControlPlanewindowsarm64Version>
     <!-- Other -->
     <MicrosoftDotNetRemoteExecutorVersion>11.0.0-beta.25610.3</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetXUnitV3ExtensionsVersion>11.0.0-beta.25610.3</MicrosoftDotNetXUnitV3ExtensionsVersion>


### PR DESCRIPTION
## Description

Update with tweaks to how the DCP certificate is generated. See https://github.com/microsoft/dcp/releases/tag/v0.22.9 for detailed changelog.