### PR TITLE
Export method and ignore delegate

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CommandOptions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandOptions.cs
@@ -48,5 +48,6 @@ public class CommandOptions
     /// <para>A callback that is used to update the command state. The callback is executed when the command's resource snapshot is updated.</para>
     /// <para>If a callback isn't specified, the command is always enabled.</para>
     /// </summary>
+    [AspireExportIgnore]
     public Func<UpdateCommandStateContext, ResourceCommandState>? UpdateState { get; set; }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
@@ -221,6 +221,7 @@ public class ReferenceExpression : IManifestExpressionProvider, IValueProvider, 
     /// Gets the value of the expression. The final string value after evaluating the format string and its parameters.
     /// </summary>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
+    [AspireExport("getValue", Description = "Gets the value of the expression. The final string value after evaluating the format string and its parameters.")]
     public ValueTask<string?> GetValueAsync(CancellationToken cancellationToken)
     {
         return this.GetValueAsync(new(), cancellationToken);

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -4953,7 +4953,14 @@ class ReferenceExpression(HandleWrapperBase):
     def __init__(self, handle: Handle, client: AspireClient):
         super().__init__(handle, client)
 
-    pass
+    def get_value(self, cancellation_token: CancellationToken) -> str:
+        """Gets the value of the expression. The final string value after evaluating the format string and its parameters."""
+        args: Dict[str, Any] = { "context": serialize_value(self._handle) }
+        cancellation_token_id = register_cancellation(cancellation_token, self._client) if cancellation_token is not None else None
+        if cancellation_token_id is not None:
+            args["cancellationToken"] = cancellation_token_id
+        return self._client.invoke_capability("Aspire.Hosting.ApplicationModel/getValue", args)
+
 
 class ReferenceExpressionBuilder(HandleWrapperBase):
     def __init__(self, handle: Handle, client: AspireClient):

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -889,12 +889,18 @@ export class EndpointReference {
     }
 
     /** Gets a conditional expression that resolves to the enabledValue when TLS is enabled on the endpoint, or to the disabledValue otherwise. */
-    async getTlsValue(enabledValue: ReferenceExpression, disabledValue: ReferenceExpression): Promise<ReferenceExpression> {
+    /** @internal */
+    async _getTlsValueInternal(enabledValue: ReferenceExpression, disabledValue: ReferenceExpression): Promise<ReferenceExpression> {
         const rpcArgs: Record<string, unknown> = { context: this._handle, enabledValue, disabledValue };
-        return await this._client.invokeCapability<ReferenceExpression>(
+        const result = await this._client.invokeCapability<ReferenceExpressionHandle>(
             'Aspire.Hosting.ApplicationModel/EndpointReference.getTlsValue',
             rpcArgs
         );
+        return new ReferenceExpression(result, this._client);
+    }
+
+    getTlsValue(enabledValue: ReferenceExpression, disabledValue: ReferenceExpression): ReferenceExpressionPromise {
+        return new ReferenceExpressionPromise(this._getTlsValueInternal(enabledValue, disabledValue));
     }
 
 }
@@ -918,8 +924,8 @@ export class EndpointReferencePromise implements PromiseLike<EndpointReference> 
     }
 
     /** Gets a conditional expression that resolves to the enabledValue when TLS is enabled on the endpoint, or to the disabledValue otherwise. */
-    getTlsValue(enabledValue: ReferenceExpression, disabledValue: ReferenceExpression): Promise<ReferenceExpression> {
-        return this._promise.then(obj => obj.getTlsValue(enabledValue, disabledValue));
+    getTlsValue(enabledValue: ReferenceExpression, disabledValue: ReferenceExpression): ReferenceExpressionPromise {
+        return new ReferenceExpressionPromise(this._promise.then(obj => obj.getTlsValue(enabledValue, disabledValue)));
     }
 
 }
@@ -1371,6 +1377,50 @@ export class ProjectResourceOptions {
 }
 
 // ============================================================================
+// ReferenceExpression
+// ============================================================================
+
+/**
+ * Type class for ReferenceExpression.
+ */
+export class ReferenceExpression {
+    constructor(private _handle: ReferenceExpressionHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    /** Gets the value of the expression. The final string value after evaluating the format string and its parameters. */
+    async getValue(cancellationToken: AbortSignal): Promise<string> {
+        const rpcArgs: Record<string, unknown> = { context: this._handle, cancellationToken };
+        return await this._client.invokeCapability<string>(
+            'Aspire.Hosting.ApplicationModel/getValue',
+            rpcArgs
+        );
+    }
+
+}
+
+/**
+ * Thenable wrapper for ReferenceExpression that enables fluent chaining.
+ */
+export class ReferenceExpressionPromise implements PromiseLike<ReferenceExpression> {
+    constructor(private _promise: Promise<ReferenceExpression>) {}
+
+    then<TResult1 = ReferenceExpression, TResult2 = never>(
+        onfulfilled?: ((value: ReferenceExpression) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    /** Gets the value of the expression. The final string value after evaluating the format string and its parameters. */
+    getValue(cancellationToken: AbortSignal): Promise<string> {
+        return this._promise.then(obj => obj.getValue(cancellationToken));
+    }
+
+}
+
+// ============================================================================
 // ReferenceExpressionBuilder
 // ============================================================================
 
@@ -1443,12 +1493,18 @@ export class ReferenceExpressionBuilder {
     }
 
     /** Builds the reference expression */
-    async build(): Promise<ReferenceExpression> {
+    /** @internal */
+    async _buildInternal(): Promise<ReferenceExpression> {
         const rpcArgs: Record<string, unknown> = { context: this._handle };
-        return await this._client.invokeCapability<ReferenceExpression>(
+        const result = await this._client.invokeCapability<ReferenceExpressionHandle>(
             'Aspire.Hosting.ApplicationModel/build',
             rpcArgs
         );
+        return new ReferenceExpression(result, this._client);
+    }
+
+    build(): ReferenceExpressionPromise {
+        return new ReferenceExpressionPromise(this._buildInternal());
     }
 
 }
@@ -1482,8 +1538,8 @@ export class ReferenceExpressionBuilderPromise implements PromiseLike<ReferenceE
     }
 
     /** Builds the reference expression */
-    build(): Promise<ReferenceExpression> {
-        return this._promise.then(obj => obj.build());
+    build(): ReferenceExpressionPromise {
+        return new ReferenceExpressionPromise(this._promise.then(obj => obj.build()));
     }
 
 }
@@ -22796,6 +22852,7 @@ registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineConfigura
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineStep', (handle, client) => new PipelineStep(handle as PipelineStepHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineStepContext', (handle, client) => new PipelineStepContext(handle as PipelineStepContextHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ProjectResourceOptions', (handle, client) => new ProjectResourceOptions(handle as ProjectResourceOptionsHandle, client));
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ReferenceExpression', (handle, client) => new ReferenceExpression(handle as ReferenceExpressionHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ReferenceExpressionBuilder', (handle, client) => new ReferenceExpressionBuilder(handle as ReferenceExpressionBuilderHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ResourceUrlsCallbackContext', (handle, client) => new ResourceUrlsCallbackContext(handle as ResourceUrlsCallbackContextHandle, client));
 registerHandleWrapper('Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes.TestCallbackContext', (handle, client) => new TestCallbackContext(handle as TestCallbackContextHandle, client));


### PR DESCRIPTION
## Description

- Exports the reference expression's `GetValueAsync` API.
- Ignores the `CommandOptions.UpdateState` delegate in the DTO.

Fixes #14778

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
