### PR TITLE
Extension: support aspire.config.json alongside legacy .aspire/settings.json

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -280,6 +280,10 @@
     ],
     "jsonValidation": [
       {
+        "fileMatch": "aspire.config.json",
+        "url": "./schemas/aspire-config.schema.json"
+      },
+      {
         "fileMatch": ".aspire/settings.json",
         "url": "./schemas/aspire-settings.schema.json"
       },

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -20,7 +20,7 @@
 	"command.settings": "Extension settings",
 	"command.openLocalSettings": "Open local Aspire settings",
 	"command.openGlobalSettings": "Open global Aspire settings",
-  "configuration.aspire.enableSettingsFileCreationPromptOnStartup": "Enable apphost discovery on extension activation and prompt to setup .aspire/settings.json.appHostPath if it does not exist in the workspace.",
+  "configuration.aspire.enableSettingsFileCreationPromptOnStartup": "Enable apphost discovery on extension activation and prompt to set up aspire.config.json appHost.path if it does not exist in the workspace.",
   "configuration.aspire.aspireCliExecutablePath": "The path to the Aspire CLI executable. If not set, the extension will attempt to use 'aspire' from the system PATH.",
   "configuration.aspire.enableAspireCliDebugLogging": "Enable console debug logging for Aspire CLI commands executed by the extension.",
   "configuration.aspire.enableAspireDcpDebugLogging": "Enable Developer Control Plane (DCP) debug logging for Aspire applications. Logs will be stored in the workspace's .aspire/dcp/logs-{debugSessionId} folder.",

--- a/extension/schemas/aspire-config.schema.json
+++ b/extension/schemas/aspire-config.schema.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/aspire-config.json",
+  "type": "object",
+  "title": "Aspire Configuration",
+  "description": "Aspire CLI configuration file (aspire.config.json). Consolidates apphost location, launch profiles, and CLI configuration.",
+  "properties": {
+    "$schema": {
+      "description": "The JSON Schema URL for this configuration file.",
+      "type": "string"
+    },
+    "appHost": {
+      "description": "AppHost entry point configuration.",
+      "type": "object",
+      "properties": {
+        "path": {
+          "description": "Relative path to the AppHost entry point file (e.g., \"apphost.ts\", \"apphost.cs\").",
+          "type": "string"
+        },
+        "language": {
+          "description": "Language identifier (e.g., \"typescript/nodejs\", \"python\").",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "sdk": {
+      "description": "Aspire SDK version configuration.",
+      "type": "object",
+      "properties": {
+        "version": {
+          "description": "The Aspire SDK version used for this project. Determines the version of Aspire.Hosting packages to use.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "channel": {
+      "description": "The Aspire channel to use for package resolution (e.g., \"stable\", \"preview\", \"staging\").",
+      "type": "string"
+    },
+    "features": {
+      "description": "Feature flags for enabling/disabling experimental or optional features.",
+      "type": "object",
+      "properties": {
+        "defaultWatchEnabled": {
+          "anyOf": [
+            { "type": "boolean" },
+            { "type": "string", "enum": ["true", "false"] }
+          ],
+          "description": "Enable or disable watch mode by default when running Aspire applications for automatic restarts on file changes",
+          "default": false
+        },
+        "execCommandEnabled": {
+          "anyOf": [
+            { "type": "boolean" },
+            { "type": "string", "enum": ["true", "false"] }
+          ],
+          "description": "Enable or disable the 'aspire exec' command for executing commands inside running resources",
+          "default": false
+        },
+        "experimentalPolyglot:go": {
+          "anyOf": [
+            { "type": "boolean" },
+            { "type": "string", "enum": ["true", "false"] }
+          ],
+          "description": "Enable or disable experimental Go language support for polyglot Aspire applications",
+          "default": false
+        },
+        "experimentalPolyglot:java": {
+          "anyOf": [
+            { "type": "boolean" },
+            { "type": "string", "enum": ["true", "false"] }
+          ],
+          "description": "Enable or disable experimental Java language support for polyglot Aspire applications",
+          "default": false
+        },
+        "experimentalPolyglot:python": {
+          "anyOf": [
+            { "type": "boolean" },
+            { "type": "string", "enum": ["true", "false"] }
+          ],
+          "description": "Enable or disable experimental Python language support for polyglot Aspire applications",
+          "default": false
+        },
+        "experimentalPolyglot:rust": {
+          "anyOf": [
+            { "type": "boolean" },
+            { "type": "string", "enum": ["true", "false"] }
+          ],
+          "description": "Enable or disable experimental Rust language support for polyglot Aspire applications",
+          "default": false
+        },
+        "showAllTemplates": {
+          "anyOf": [
+            { "type": "boolean" },
+            { "type": "string", "enum": ["true", "false"] }
+          ],
+          "description": "Show all available templates including experimental ones in 'aspire new' and 'aspire init' commands",
+          "default": false
+        },
+        "showDeprecatedPackages": {
+          "anyOf": [
+            { "type": "boolean" },
+            { "type": "string", "enum": ["true", "false"] }
+          ],
+          "description": "Show or hide deprecated packages in 'aspire add' search results",
+          "default": false
+        },
+        "stagingChannelEnabled": {
+          "anyOf": [
+            { "type": "boolean" },
+            { "type": "string", "enum": ["true", "false"] }
+          ],
+          "description": "Enable or disable access to the staging channel for early access to preview features and packages",
+          "default": false
+        },
+        "updateNotificationsEnabled": {
+          "anyOf": [
+            { "type": "boolean" },
+            { "type": "string", "enum": ["true", "false"] }
+          ],
+          "description": "Check if update notifications are disabled and set version check environment variable",
+          "default": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "profiles": {
+      "description": "Launch profiles (ports, environment variables). Replaces apphost.run.json.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "applicationUrl": {
+            "description": "Application URLs (e.g., \"https://localhost:17000;http://localhost:15000\").",
+            "type": "string"
+          },
+          "environmentVariables": {
+            "description": "Environment variables for this profile.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "packages": {
+      "description": "Package name to version mapping for non-first-class languages.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "description": "Package version"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/extension/src/commands/openSettings.ts
+++ b/extension/src/commands/openSettings.ts
@@ -9,7 +9,7 @@ import { getConfigInfo } from '../utils/configInfoProvider';
  */
 
 /**
- * Opens the local Aspire settings file (.aspire/settings.json) in the current workspace.
+ * Opens the local Aspire configuration file (aspire.config.json or legacy .aspire/settings.json) in the current workspace.
  * Creates the file with an empty JSON object if it doesn't exist.
  */
 export async function openLocalSettingsCommand(terminalProvider: AspireTerminalProvider): Promise<void> {
@@ -26,7 +26,7 @@ export async function openLocalSettingsCommand(terminalProvider: AspireTerminalP
 }
 
 /**
- * Opens the global Aspire settings file (~/.aspire/globalsettings.json).
+ * Opens the global Aspire configuration file (aspire.config.json or legacy globalsettings.json).
  * Creates the file with an empty JSON object if it doesn't exist.
  */
 export async function openGlobalSettingsCommand(terminalProvider: AspireTerminalProvider): Promise<void> {

--- a/extension/src/editor/AspireEditorCommandProvider.ts
+++ b/extension/src/editor/AspireEditorCommandProvider.ts
@@ -6,31 +6,31 @@ import { AspireCommandType } from '../dcp/types';
 
 export class AspireEditorCommandProvider implements vscode.Disposable {
     private _workspaceAppHostPath: string | null = null;
-    private _workspaceSettingsJsonWatchers: Map<vscode.WorkspaceFolder, vscode.Disposable> = new Map();
+    private _workspaceConfigWatchers: Map<vscode.WorkspaceFolder, vscode.Disposable> = new Map();
     private _disposables: vscode.Disposable[] = [];
 
     constructor() {
-        // if .aspire/settings.json exists, we only need to watch one folder
+        // Watch for both aspire.config.json and legacy .aspire/settings.json
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file('/'));
         if (workspaceFolder) {
-            this._workspaceSettingsJsonWatchers.set(workspaceFolder, this.watchWorkspaceForAppHostPathChanges(workspaceFolder, this.onChangeAppHostPath.bind(this)));
+            this._workspaceConfigWatchers.set(workspaceFolder, this.watchWorkspaceForAppHostPathChanges(workspaceFolder, this.onChangeAppHostPath.bind(this)));
         }
         else {
             vscode.workspace.workspaceFolders?.forEach(folder => {
-                this._workspaceSettingsJsonWatchers.set(folder, this.watchWorkspaceForAppHostPathChanges(folder, this.onChangeAppHostPath.bind(this)));
+                this._workspaceConfigWatchers.set(folder, this.watchWorkspaceForAppHostPathChanges(folder, this.onChangeAppHostPath.bind(this)));
             });
         }
 
         // As additional workspace folders are added/removed, we need to watch/unwatch them too
         this._disposables.push(vscode.workspace.onDidChangeWorkspaceFolders(event => {
             event.added.forEach(folder => {
-                this._workspaceSettingsJsonWatchers.set(folder, this.watchWorkspaceForAppHostPathChanges(folder, this.onChangeAppHostPath.bind(this)));
+                this._workspaceConfigWatchers.set(folder, this.watchWorkspaceForAppHostPathChanges(folder, this.onChangeAppHostPath.bind(this)));
             });
             event.removed.forEach(folder => {
-                const disposable = this._workspaceSettingsJsonWatchers.get(folder);
+                const disposable = this._workspaceConfigWatchers.get(folder);
                 if (disposable) {
                     disposable.dispose();
-                    this._workspaceSettingsJsonWatchers.delete(folder);
+                    this._workspaceConfigWatchers.delete(folder);
                 }
             });
         }));
@@ -101,32 +101,80 @@ export class AspireEditorCommandProvider implements vscode.Disposable {
     }
 
     private watchWorkspaceForAppHostPathChanges(workspaceFolder: vscode.WorkspaceFolder, onChangeAppHostPath: (newPath: string | null) => void): vscode.Disposable {
-        const watcher = vscode.workspace.createFileSystemWatcher(
+        // Watch both new aspire.config.json and legacy .aspire/settings.json
+        const configWatcher = vscode.workspace.createFileSystemWatcher(
+            new vscode.RelativePattern(workspaceFolder, 'aspire.config.json')
+        );
+        const legacyWatcher = vscode.workspace.createFileSystemWatcher(
             new vscode.RelativePattern(workspaceFolder, '.aspire/settings.json')
         );
 
-        watcher.onDidCreate(async uri => readJsonAndInvokeCallback(uri));
-        watcher.onDidChange(uri => readJsonAndInvokeCallback(uri));
-        watcher.onDidDelete(uri => onChangeAppHostPath(null));
+        configWatcher.onDidCreate(async uri => readJsonAndInvokeCallback(uri));
+        configWatcher.onDidChange(uri => readJsonAndInvokeCallback(uri));
+        configWatcher.onDidDelete(() => {
+            // Fall back to legacy file if it exists
+            const legacyUri = vscode.Uri.joinPath(workspaceFolder.uri, '.aspire', 'settings.json');
+            vscode.workspace.fs.stat(legacyUri).then(
+                () => readJsonAndInvokeCallback(legacyUri),
+                () => onChangeAppHostPath(null)
+            );
+        });
 
-        // Read the initial value if the file exists
-        const settingsFileUri = vscode.Uri.joinPath(workspaceFolder.uri, '.aspire', 'settings.json');
-        vscode.workspace.fs.stat(settingsFileUri).then(
-            () => readJsonAndInvokeCallback(settingsFileUri),
-            () => onChangeAppHostPath(null) // File does not exist
+        legacyWatcher.onDidCreate(async uri => {
+            // Only use legacy if new config doesn't exist
+            const configUri = vscode.Uri.joinPath(workspaceFolder.uri, 'aspire.config.json');
+            vscode.workspace.fs.stat(configUri).then(
+                () => { /* new config exists, ignore legacy */ },
+                () => readJsonAndInvokeCallback(uri)
+            );
+        });
+        legacyWatcher.onDidChange(uri => {
+            const configUri = vscode.Uri.joinPath(workspaceFolder.uri, 'aspire.config.json');
+            vscode.workspace.fs.stat(configUri).then(
+                () => { /* new config exists, ignore legacy */ },
+                () => readJsonAndInvokeCallback(uri)
+            );
+        });
+        legacyWatcher.onDidDelete(() => onChangeAppHostPath(null));
+
+        // Read the initial value, preferring aspire.config.json over legacy
+        const configFileUri = vscode.Uri.joinPath(workspaceFolder.uri, 'aspire.config.json');
+        const legacyFileUri = vscode.Uri.joinPath(workspaceFolder.uri, '.aspire', 'settings.json');
+        vscode.workspace.fs.stat(configFileUri).then(
+            () => readJsonAndInvokeCallback(configFileUri),
+            () => vscode.workspace.fs.stat(legacyFileUri).then(
+                () => readJsonAndInvokeCallback(legacyFileUri),
+                () => onChangeAppHostPath(null)
+            )
         );
 
-        return watcher;
+        return {
+            dispose: () => {
+                configWatcher.dispose();
+                legacyWatcher.dispose();
+            }
+        };
 
         async function readJsonAndInvokeCallback(uri: vscode.Uri) {
             try {
                 const json = JSON.parse(await vscode.workspace.fs.readFile(uri).then(buffer => buffer.toString()));
-                if (!json.appHostPath) {
+                const isNewFormat = uri.fsPath.endsWith('aspire.config.json');
+
+                // Extract appHost path from either format
+                const rawPath = isNewFormat ? json.appHost?.path : json.appHostPath;
+                if (!rawPath) {
                     onChangeAppHostPath(null);
                 }
+                else if (path.isAbsolute(rawPath)) {
+                    onChangeAppHostPath(rawPath);
+                }
                 else {
-                    const appHostPath = path.isAbsolute(json.appHostPath) ? json.appHostPath : path.join(workspaceFolder.uri.fsPath, ".aspire",json.appHostPath);
-                    onChangeAppHostPath(appHostPath);
+                    // New format: paths are relative to project root (where aspire.config.json lives)
+                    // Legacy format: paths are relative to .aspire/ directory
+                    const baseDir = isNewFormat
+                        ? workspaceFolder.uri.fsPath
+                        : path.join(workspaceFolder.uri.fsPath, '.aspire');
+                    onChangeAppHostPath(path.join(baseDir, rawPath));
                 }
             }
             catch {
@@ -187,6 +235,6 @@ export class AspireEditorCommandProvider implements vscode.Disposable {
 
     dispose() {
         this._disposables.forEach(disposable => disposable.dispose());
-        this._workspaceSettingsJsonWatchers.forEach(disposable => disposable.dispose());
+        this._workspaceConfigWatchers.forEach(disposable => disposable.dispose());
     }
 }

--- a/extension/src/utils/cliTypes.ts
+++ b/extension/src/utils/cliTypes.ts
@@ -2,3 +2,23 @@ export interface AspireSettingsFile {
     appHostPath?: string;
     [key: string]: any;
 }
+
+/**
+ * Represents the new aspire.config.json configuration file format.
+ */
+export interface AspireConfigFile {
+    appHost?: {
+        path?: string;
+        language?: string;
+    };
+    sdk?: {
+        version?: string;
+    };
+    channel?: string;
+    features?: Record<string, boolean>;
+    profiles?: Record<string, {
+        applicationUrl?: string;
+        environmentVariables?: Record<string, string>;
+    }>;
+    packages?: Record<string, string>;
+}

--- a/extension/src/utils/workspace.ts
+++ b/extension/src/utils/workspace.ts
@@ -4,10 +4,15 @@ import path from 'path';
 import { spawnCliProcess } from '../debugger/languages/cli';
 import { AspireTerminalProvider } from './AspireTerminalProvider';
 import { ChildProcessWithoutNullStreams } from 'child_process';
-import { AspireSettingsFile } from './cliTypes';
+import { AspireSettingsFile, AspireConfigFile } from './cliTypes';
 import { extensionLogOutputChannel } from './logging';
 import { EnvironmentVariables } from './environment';
 import { resolveCliPath } from './cliPath';
+
+/**
+ * The filename for the new consolidated configuration file.
+ */
+const aspireConfigFileName = 'aspire.config.json';
 
 /**
  * Common file patterns to exclude from workspace file searches.
@@ -53,14 +58,49 @@ export function getCommonExcludeGlob(): string {
 }
 
 /**
- * Searches for Aspire settings.json files in the workspace, excluding common build output
- * and dependency directories.
- * @returns An array of URIs pointing to found settings.json files
+ * Searches for Aspire configuration files in the workspace, excluding common build output
+ * and dependency directories. Looks for both the new aspire.config.json and legacy .aspire/settings.json.
+ * @returns An array of URIs pointing to found configuration files
+ */
+export async function findAspireConfigFiles(): Promise<vscode.Uri[]> {
+    const excludePattern = getCommonExcludeGlob();
+    const [configFiles, legacyFiles] = await Promise.all([
+        vscode.workspace.findFiles(`**/${aspireConfigFileName}`, excludePattern),
+        vscode.workspace.findFiles('**/.aspire/settings.json', excludePattern),
+    ]);
+    // Prefer aspire.config.json; include legacy files only for directories without the new format
+    const configDirs = new Set(configFiles.map(uri => path.dirname(uri.fsPath)));
+    const dedupedLegacy = legacyFiles.filter(uri => !configDirs.has(path.dirname(path.dirname(uri.fsPath))));
+    return [...configFiles, ...dedupedLegacy];
+}
+
+/**
+ * @deprecated Use findAspireConfigFiles instead. Kept for backward compatibility.
  */
 export async function findAspireSettingsFiles(): Promise<vscode.Uri[]> {
-    const searchSubpath = '**/.aspire/settings.json';
-    const excludePattern = getCommonExcludeGlob();
-    return vscode.workspace.findFiles(searchSubpath, excludePattern);
+    return findAspireConfigFiles();
+}
+
+/**
+ * Extracts the appHost path from a parsed configuration file, handling both new and legacy formats.
+ */
+function getAppHostPathFromConfig(json: any): string | undefined {
+    // New format: aspire.config.json with nested appHost.path
+    if (json.appHost?.path) {
+        return json.appHost.path;
+    }
+    // Legacy format: .aspire/settings.json with flat appHostPath
+    if (json.appHostPath) {
+        return json.appHostPath;
+    }
+    return undefined;
+}
+
+/**
+ * Returns whether the given URI points to a new-format aspire.config.json file.
+ */
+function isAspireConfigFile(uri: vscode.Uri): boolean {
+    return path.basename(uri.fsPath) === aspireConfigFileName;
 }
 
 export function isWorkspaceOpen(showErrorMessage: boolean = true): boolean {
@@ -127,34 +167,36 @@ export async function checkForExistingAppHostPathInWorkspace(terminalProvider: A
 
     extensionLogOutputChannel.info(`Checking AppHost settings in workspace: ${rootFolder.name}`);
 
-    // Search for settings.json files in any .aspire directory anywhere in the workspace
-    const settingsFiles = await findAspireSettingsFiles();
-    const settingsFileExists = settingsFiles.length > 0;
+    // Search for configuration files (aspire.config.json and legacy .aspire/settings.json)
+    const configFiles = await findAspireConfigFiles();
+    const configFileExists = configFiles.length > 0;
 
-    if (settingsFileExists) {
-        extensionLogOutputChannel.info(`Found existing Aspire settings file at: ${settingsFiles.map(f => f.fsPath).join(', ')}`);
-        for (const file of settingsFiles) {
-            const settingsFileContent = await vscode.workspace.fs.readFile(file);
-            const settings = JSON.parse(settingsFileContent.toString());
-            if (settings.appHostPath) {
-                extensionLogOutputChannel.info(`AppHost path already configured in file ${file.fsPath}: ${settings.appHostPath}`);
+    if (configFileExists) {
+        extensionLogOutputChannel.info(`Found existing Aspire config file at: ${configFiles.map(f => f.fsPath).join(', ')}`);
+        for (const file of configFiles) {
+            const fileContent = await vscode.workspace.fs.readFile(file);
+            const config = JSON.parse(fileContent.toString());
+            const appHostPath = getAppHostPathFromConfig(config);
+            if (appHostPath) {
+                extensionLogOutputChannel.info(`AppHost path already configured in file ${file.fsPath}: ${appHostPath}`);
                 return null;
             }
         }
 
-        extensionLogOutputChannel.info('Settings file(s) exist but no appHostPath is set');
-        if (settingsFiles.length > 1) {
-            // Multiple settings files exist, so don't prompt
-            extensionLogOutputChannel.warn(`Multiple Aspire settings files found (${settingsFiles.length}). Not prompting to choose between them.`);
+        extensionLogOutputChannel.info('Config file(s) exist but no appHost path is set');
+        if (configFiles.length > 1) {
+            // Multiple config files exist, so don't prompt
+            extensionLogOutputChannel.warn(`Multiple Aspire config files found (${configFiles.length}). Not prompting to choose between them.`);
             return null;
         }
     }
     else {
-        extensionLogOutputChannel.info('No Aspire settings file found, will create if AppHost is selected');
-        settingsFiles.push(vscode.Uri.file(path.join(rootFolder.uri.fsPath, '.aspire', 'settings.json')));
+        extensionLogOutputChannel.info('No Aspire config file found, will create if AppHost is selected');
+        // New projects get aspire.config.json at the workspace root
+        configFiles.push(vscode.Uri.file(path.join(rootFolder.uri.fsPath, aspireConfigFileName)));
     }
 
-    const settingsFile = settingsFiles[0];
+    const configFile = configFiles[0];
     extensionLogOutputChannel.info('Searching for AppHost projects using CLI command: aspire extension get-apphosts');
 
     let proc: ChildProcessWithoutNullStreams;
@@ -189,7 +231,7 @@ export async function checkForExistingAppHostPathInWorkspace(terminalProvider: A
             workingDirectory: rootFolder.uri.fsPath
         });
     })
-        .then(result => promptToAddAppHostPathToSettingsFile(result, settingsFileExists, settingsFile, rootFolder, setEnableSettingsFileCreationPromptOnStartup))
+        .then(result => promptToAddAppHostPathToConfigFile(result, configFileExists, configFile, rootFolder, setEnableSettingsFileCreationPromptOnStartup))
         .catch(error => {
             extensionLogOutputChannel.error(`Failed to retrieve AppHost projects: ${error}`);
         })
@@ -202,7 +244,7 @@ export async function checkForExistingAppHostPathInWorkspace(terminalProvider: A
     };
 }
 
-async function promptToAddAppHostPathToSettingsFile(result: AppHostProjectSearchResult, settingsFileExists: boolean, settingsFileLocation: vscode.Uri, rootFolder: vscode.WorkspaceFolder, setEnableSettingsFileCreationPromptOnStartup: (value: boolean) => Promise<void>): Promise<void> {
+async function promptToAddAppHostPathToConfigFile(result: AppHostProjectSearchResult, configFileExists: boolean, configFileLocation: vscode.Uri, rootFolder: vscode.WorkspaceFolder, setEnableSettingsFileCreationPromptOnStartup: (value: boolean) => Promise<void>): Promise<void> {
     if (!result.selected_project_file && result.all_project_file_candidates.length === 0) {
         extensionLogOutputChannel.info('No AppHost projects found in workspace');
         return;
@@ -247,26 +289,49 @@ async function promptToAddAppHostPathToSettingsFile(result: AppHostProjectSearch
         return;
     }
 
-    // make appHostToUse relative to the settings file location
-    appHostToUse = path.relative(path.dirname(settingsFileLocation.fsPath), appHostToUse);
+    // Make appHostToUse relative to the config file location
+    appHostToUse = path.relative(path.dirname(configFileLocation.fsPath), appHostToUse);
 
-    let aspireSettingsFile: AspireSettingsFile;
-    if (settingsFileExists) {
-        extensionLogOutputChannel.info('Updating existing Aspire settings file');
-        const settingsFileContent = await vscode.workspace.fs.readFile(settingsFileLocation);
-        aspireSettingsFile = JSON.parse(settingsFileContent.toString());
+    const useNewFormat = isAspireConfigFile(configFileLocation);
+
+    if (useNewFormat) {
+        // Write/update aspire.config.json with nested appHost.path
+        let aspireConfig: AspireConfigFile;
+        if (configFileExists) {
+            extensionLogOutputChannel.info('Updating existing aspire.config.json');
+            const fileContent = await vscode.workspace.fs.readFile(configFileLocation);
+            aspireConfig = JSON.parse(fileContent.toString());
+        }
+        else {
+            extensionLogOutputChannel.info('Creating new aspire.config.json');
+            aspireConfig = {};
+        }
+
+        aspireConfig.appHost = { ...aspireConfig.appHost, path: appHostToUse };
+
+        const updatedContent = Buffer.from(JSON.stringify(aspireConfig, null, 4), 'utf8');
+        await vscode.workspace.fs.writeFile(configFileLocation, updatedContent);
     }
     else {
-        extensionLogOutputChannel.info('Creating new Aspire settings file');
-        aspireSettingsFile = {};
+        // Write/update legacy .aspire/settings.json with flat appHostPath
+        let aspireSettingsFile: AspireSettingsFile;
+        if (configFileExists) {
+            extensionLogOutputChannel.info('Updating existing Aspire settings file');
+            const fileContent = await vscode.workspace.fs.readFile(configFileLocation);
+            aspireSettingsFile = JSON.parse(fileContent.toString());
+        }
+        else {
+            extensionLogOutputChannel.info('Creating new Aspire settings file');
+            aspireSettingsFile = {};
+        }
+
+        aspireSettingsFile.appHostPath = appHostToUse;
+
+        const updatedContent = Buffer.from(JSON.stringify(aspireSettingsFile, null, 4), 'utf8');
+        await vscode.workspace.fs.writeFile(configFileLocation, updatedContent);
     }
 
-    aspireSettingsFile.appHostPath = appHostToUse;
-
-    const updatedSettingsFileContent = Buffer.from(JSON.stringify(aspireSettingsFile, null, 4), 'utf8');
-    await vscode.workspace.fs.writeFile(settingsFileLocation, updatedSettingsFileContent);
-
-    extensionLogOutputChannel.info(`Successfully set appHostPath to: ${appHostToUse} in ${settingsFileLocation.fsPath}`);
+    extensionLogOutputChannel.info(`Successfully set appHost path to: ${appHostToUse} in ${configFileLocation.fsPath}`);
 }
 
 /**

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -92,9 +92,9 @@ internal sealed class AddCommand : BaseCommand
 
             var source = parseResult.GetValue(s_sourceOption);
 
-            // For non-.NET projects, read the channel from settings.json if available.
-            // Unlike .NET projects which have a nuget.config, polyglot apphosts store
-            // the channel in .aspire/settings.json during the build process.
+            // For non-.NET projects, read the channel from the local Aspire configuration if available.
+            // Unlike .NET projects which have a nuget.config, polyglot apphosts persist the channel
+            // in aspire.config.json (or the legacy settings.json during migration).
             string? configuredChannel = null;
             if (project.LanguageId != KnownLanguageId.CSharp)
             {
@@ -102,8 +102,8 @@ internal sealed class AddCommand : BaseCommand
                 var isProjectReferenceMode = AspireRepositoryDetector.DetectRepositoryRoot(appHostDirectory) is not null;
                 if (!isProjectReferenceMode)
                 {
-                    var settings = AspireJsonConfiguration.Load(appHostDirectory);
-                    configuredChannel = settings?.Channel;
+                    configuredChannel = AspireConfigFile.Load(appHostDirectory)?.Channel
+                        ?? AspireJsonConfiguration.Load(appHostDirectory)?.Channel;
                 }
             }
 

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -585,7 +585,11 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
 
         // Create the apphost project using the scaffolding service
         var context = new ScaffoldContext(language, workingDirectory, ProjectName: null);
-        await _scaffoldingService.ScaffoldAsync(context, cancellationToken);
+        var scaffolded = await _scaffoldingService.ScaffoldAsync(context, cancellationToken);
+        if (!scaffolded)
+        {
+            return ExitCodeConstants.FailedToCreateNewProject;
+        }
 
         InteractionService.DisplaySuccess($"Created {appHostFileName}");
         InteractionService.DisplayMessage(KnownEmojis.Information, $"Run 'aspire run' to start your AppHost.");

--- a/src/Aspire.Cli/Configuration/AspireConfigFile.cs
+++ b/src/Aspire.Cli/Configuration/AspireConfigFile.cs
@@ -90,6 +90,22 @@ internal sealed class AspireConfigFile
     }
 
     /// <summary>
+    /// Converts this AspireConfigFile back to an AspireJsonConfiguration for compatibility with existing code.
+    /// </summary>
+    public AspireJsonConfiguration ToLegacyConfiguration()
+    {
+        return new AspireJsonConfiguration
+        {
+            AppHostPath = AppHost?.Path,
+            Language = AppHost?.Language,
+            SdkVersion = Sdk?.Version,
+            Channel = Channel,
+            Features = Features,
+            Packages = Packages
+        };
+    }
+
+    /// <summary>
     /// Creates from a legacy AspireJsonConfiguration + apphost.run.json.
     /// </summary>
     public static AspireConfigFile FromLegacy(AspireJsonConfiguration? settings, Dictionary<string, AspireConfigProfile>? profiles)

--- a/src/Aspire.Cli/Configuration/AspireConfigFile.cs
+++ b/src/Aspire.Cli/Configuration/AspireConfigFile.cs
@@ -1,0 +1,169 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Aspire.Cli.Configuration;
+
+/// <summary>
+/// Represents the aspire.config.json configuration file.
+/// Consolidates apphost location, launch settings, and CLI config into one file.
+/// </summary>
+internal sealed class AspireConfigFile
+{
+    public const string FileName = "aspire.config.json";
+
+    /// <summary>
+    /// The JSON Schema URL for this configuration file.
+    /// </summary>
+    [JsonPropertyName("$schema")]
+    public string? Schema { get; set; }
+
+    /// <summary>
+    /// AppHost entry point configuration.
+    /// </summary>
+    [JsonPropertyName("appHost")]
+    public AspireConfigAppHost? AppHost { get; set; }
+
+    /// <summary>
+    /// Aspire SDK version configuration.
+    /// </summary>
+    [JsonPropertyName("sdk")]
+    public AspireConfigSdk? Sdk { get; set; }
+
+    /// <summary>
+    /// Aspire channel for package resolution.
+    /// </summary>
+    [JsonPropertyName("channel")]
+    public string? Channel { get; set; }
+
+    /// <summary>
+    /// Feature flags.
+    /// </summary>
+    [JsonPropertyName("features")]
+    public Dictionary<string, bool>? Features { get; set; }
+
+    /// <summary>
+    /// Launch profiles (ports, env vars). Replaces apphost.run.json.
+    /// </summary>
+    [JsonPropertyName("profiles")]
+    public Dictionary<string, AspireConfigProfile>? Profiles { get; set; }
+
+    /// <summary>
+    /// Package references for non-first-class languages.
+    /// </summary>
+    [JsonPropertyName("packages")]
+    public Dictionary<string, string>? Packages { get; set; }
+
+    /// <summary>
+    /// Loads aspire.config.json from the specified directory.
+    /// </summary>
+    public static AspireConfigFile? Load(string directory)
+    {
+        var filePath = Path.Combine(directory, FileName);
+        if (!File.Exists(filePath))
+        {
+            return null;
+        }
+
+        var json = File.ReadAllText(filePath);
+        return JsonSerializer.Deserialize(json, JsonSourceGenerationContext.Default.AspireConfigFile);
+    }
+
+    /// <summary>
+    /// Saves aspire.config.json to the specified directory.
+    /// </summary>
+    public void Save(string directory)
+    {
+        var filePath = Path.Combine(directory, FileName);
+        var json = JsonSerializer.Serialize(this, JsonSourceGenerationContext.Default.AspireConfigFile);
+        File.WriteAllText(filePath, json);
+    }
+
+    /// <summary>
+    /// Checks if aspire.config.json exists in the specified directory.
+    /// </summary>
+    public static bool Exists(string directory)
+    {
+        return File.Exists(Path.Combine(directory, FileName));
+    }
+
+    /// <summary>
+    /// Creates from a legacy AspireJsonConfiguration + apphost.run.json.
+    /// </summary>
+    public static AspireConfigFile FromLegacy(AspireJsonConfiguration? settings, Dictionary<string, AspireConfigProfile>? profiles)
+    {
+        var config = new AspireConfigFile();
+
+        if (settings is not null)
+        {
+            config.AppHost = new AspireConfigAppHost
+            {
+                Path = settings.AppHostPath,
+                Language = settings.Language
+            };
+
+            if (!string.IsNullOrEmpty(settings.SdkVersion))
+            {
+                config.Sdk = new AspireConfigSdk { Version = settings.SdkVersion };
+            }
+
+            config.Channel = settings.Channel;
+            config.Features = settings.Features;
+            config.Packages = settings.Packages;
+        }
+
+        config.Profiles = profiles;
+
+        return config;
+    }
+}
+
+/// <summary>
+/// AppHost entry point configuration within aspire.config.json.
+/// </summary>
+internal sealed class AspireConfigAppHost
+{
+    /// <summary>
+    /// Relative path to the AppHost entry point file.
+    /// </summary>
+    [JsonPropertyName("path")]
+    public string? Path { get; set; }
+
+    /// <summary>
+    /// Language identifier (e.g., "typescript/nodejs", "python").
+    /// </summary>
+    [JsonPropertyName("language")]
+    public string? Language { get; set; }
+}
+
+/// <summary>
+/// SDK version configuration within aspire.config.json.
+/// </summary>
+internal sealed class AspireConfigSdk
+{
+    /// <summary>
+    /// The Aspire SDK version.
+    /// </summary>
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
+}
+
+/// <summary>
+/// Launch profile within aspire.config.json.
+/// </summary>
+internal sealed class AspireConfigProfile
+{
+    /// <summary>
+    /// Application URLs (e.g., "https://localhost:17000;http://localhost:15000").
+    /// </summary>
+    [JsonPropertyName("applicationUrl")]
+    public string? ApplicationUrl { get; set; }
+
+    /// <summary>
+    /// Environment variables for this profile.
+    /// </summary>
+    [JsonPropertyName("environmentVariables")]
+    public Dictionary<string, string>? EnvironmentVariables { get; set; }
+}

--- a/src/Aspire.Cli/Configuration/ConfigurationService.cs
+++ b/src/Aspire.Cli/Configuration/ConfigurationService.cs
@@ -96,18 +96,25 @@ internal sealed class ConfigurationService(IConfiguration configuration, CliExec
         // Walk up the directory tree to find existing settings file
         while (searchDirectory is not null)
         {
-            var settingsFilePath = ConfigurationHelper.BuildPathToSettingsJsonFile(searchDirectory.FullName);
-
-            if (File.Exists(settingsFilePath))
+            // Prefer aspire.config.json (new format)
+            var newSettingsPath = Path.Combine(searchDirectory.FullName, AspireConfigFile.FileName);
+            if (File.Exists(newSettingsPath))
             {
-                return settingsFilePath;
+                return newSettingsPath;
+            }
+
+            // Fall back to .aspire/settings.json (legacy)
+            var legacySettingsPath = ConfigurationHelper.BuildPathToSettingsJsonFile(searchDirectory.FullName);
+            if (File.Exists(legacySettingsPath))
+            {
+                return legacySettingsPath;
             }
 
             searchDirectory = searchDirectory.Parent;
         }
 
-        // If no existing settings file found, create one in current directory
-        return ConfigurationHelper.BuildPathToSettingsJsonFile(executionContext.WorkingDirectory.FullName);
+        // If no existing settings file found, default to aspire.config.json in current directory
+        return Path.Combine(executionContext.WorkingDirectory.FullName, AspireConfigFile.FileName);
     }
 
     public async Task<Dictionary<string, string>> GetAllConfigurationAsync(CancellationToken cancellationToken = default)

--- a/src/Aspire.Cli/JsonSourceGenerationContext.cs
+++ b/src/Aspire.Cli/JsonSourceGenerationContext.cs
@@ -24,6 +24,7 @@ namespace Aspire.Cli;
 [JsonSerializable(typeof(DoctorCheckSummary))]
 [JsonSerializable(typeof(ContainerVersionJson))]
 [JsonSerializable(typeof(AspireJsonConfiguration))]
+[JsonSerializable(typeof(AspireConfigFile))]
 [JsonSerializable(typeof(List<DevCertInfo>))]
 [JsonSerializable(typeof(ConfigInfo))]
 [JsonSerializable(typeof(FeatureInfo))]

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -124,8 +124,24 @@ public class Program
     private static string GetGlobalSettingsPath()
     {
         var usersAspirePath = GetUsersAspirePath();
-        var globalSettingsPath = Path.Combine(usersAspirePath, "globalsettings.json");
-        return globalSettingsPath;
+        var newPath = Path.Combine(usersAspirePath, Configuration.AspireConfigFile.FileName);
+
+        // Migrate legacy globalsettings.json → aspire.config.json on first access
+        var legacyPath = Path.Combine(usersAspirePath, "globalsettings.json");
+        if (!File.Exists(newPath) && File.Exists(legacyPath))
+        {
+            try
+            {
+                File.Move(legacyPath, newPath);
+            }
+            catch
+            {
+                // If move fails, fall back to legacy
+                return legacyPath;
+            }
+        }
+
+        return newPath;
     }
 
     internal static async Task<IHost> BuildApplicationAsync(string[] args, Dictionary<string, string?>? configurationValues = null)

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -550,8 +550,14 @@ internal sealed class GuestAppHostProject : IAppHostProject
 
     private Dictionary<string, string>? ReadLaunchSettingsEnvironmentVariables(DirectoryInfo directory)
     {
-        // For guest apphosts, look for apphost.run.json
-        // similar to how .NET single-file apphosts use apphost.run.json
+        // Check aspire.config.json first for launch profiles
+        var aspireConfig = AspireConfigFile.Load(directory.FullName);
+        if (aspireConfig?.Profiles is { Count: > 0 })
+        {
+            return ReadProfileFromAspireConfig(aspireConfig);
+        }
+
+        // Fall back to apphost.run.json / launchSettings.json
         var apphostRunPath = Path.Combine(directory.FullName, "apphost.run.json");
         var launchSettingsPath = Path.Combine(directory.FullName, "Properties", "launchSettings.json");
 
@@ -559,7 +565,7 @@ internal sealed class GuestAppHostProject : IAppHostProject
 
         if (!File.Exists(configPath))
         {
-            _logger.LogDebug("No apphost.run.json or launchSettings.json found in {Path}", directory.FullName);
+            _logger.LogDebug("No aspire.config.json, apphost.run.json, or launchSettings.json found in {Path}", directory.FullName);
             return null;
         }
 
@@ -628,6 +634,49 @@ internal sealed class GuestAppHostProject : IAppHostProject
             _logger.LogWarning(ex, "Failed to read launchSettings.json");
             return null;
         }
+    }
+
+    private Dictionary<string, string>? ReadProfileFromAspireConfig(AspireConfigFile aspireConfig)
+    {
+        AspireConfigProfile? profile;
+
+        // Prefer 'https' profile, then fall back to first
+        if (aspireConfig.Profiles!.TryGetValue("https", out var httpsProfile))
+        {
+            profile = httpsProfile;
+        }
+        else
+        {
+            profile = aspireConfig.Profiles.Values.FirstOrDefault();
+        }
+
+        if (profile is null)
+        {
+            return null;
+        }
+
+        var result = new Dictionary<string, string>();
+
+        if (!string.IsNullOrEmpty(profile.ApplicationUrl))
+        {
+            result["ASPNETCORE_URLS"] = profile.ApplicationUrl;
+        }
+
+        if (profile.EnvironmentVariables is not null)
+        {
+            foreach (var kvp in profile.EnvironmentVariables)
+            {
+                result[kvp.Key] = kvp.Value;
+            }
+        }
+
+        if (result.Count == 0)
+        {
+            return null;
+        }
+
+        _logger.LogDebug("Read {Count} environment variables from aspire.config.json", result.Count);
+        return result;
     }
 
     /// <inheritdoc />

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -161,7 +161,131 @@ internal sealed class GuestAppHostProject : IAppHostProject
     private AspireJsonConfiguration LoadConfiguration(DirectoryInfo directory)
     {
         var effectiveSdkVersion = GetEffectiveSdkVersion();
-        return AspireJsonConfiguration.LoadOrCreate(directory.FullName, effectiveSdkVersion);
+
+        // If aspire.config.json exists, load from it
+        if (AspireConfigFile.Exists(directory.FullName))
+        {
+            var aspireConfig = AspireConfigFile.Load(directory.FullName);
+            if (aspireConfig is not null)
+            {
+                var config = aspireConfig.ToLegacyConfiguration();
+                config.SdkVersion ??= effectiveSdkVersion;
+                return config;
+            }
+        }
+
+        // If .aspire/settings.json exists but aspire.config.json doesn't, migrate
+        var legacyConfig = AspireJsonConfiguration.Load(directory.FullName);
+        if (legacyConfig is not null)
+        {
+            // Read apphost.run.json profiles if it exists
+            Dictionary<string, AspireConfigProfile>? profiles = null;
+            var apphostRunPath = Path.Combine(directory.FullName, "apphost.run.json");
+            if (File.Exists(apphostRunPath))
+            {
+                profiles = ReadApphostRunProfiles(apphostRunPath);
+            }
+
+            // Merge into AspireConfigFile
+            var aspireConfig = AspireConfigFile.FromLegacy(legacyConfig, profiles);
+            aspireConfig.Save(directory.FullName);
+
+            // Delete legacy files
+            var settingsPath = AspireJsonConfiguration.GetFilePath(directory.FullName);
+            if (File.Exists(settingsPath))
+            {
+                File.Delete(settingsPath);
+            }
+            if (File.Exists(apphostRunPath))
+            {
+                File.Delete(apphostRunPath);
+            }
+
+            // Delete .aspire/ directory if empty
+            var aspireFolder = Path.Combine(directory.FullName, AspireJsonConfiguration.SettingsFolder);
+            if (Directory.Exists(aspireFolder) && !Directory.EnumerateFileSystemEntries(aspireFolder).Any())
+            {
+                Directory.Delete(aspireFolder);
+            }
+
+            _interactionService.DisplayMessage(KnownEmojis.FileCabinet, "Migrated configuration to aspire.config.json");
+
+            legacyConfig.SdkVersion ??= effectiveSdkVersion;
+            return legacyConfig;
+        }
+
+        // Neither exists — create new
+        var newConfig = new AspireJsonConfiguration();
+        newConfig.SdkVersion ??= effectiveSdkVersion;
+        return newConfig;
+    }
+
+    private static Dictionary<string, AspireConfigProfile>? ReadApphostRunProfiles(string apphostRunPath)
+    {
+        try
+        {
+            var json = File.ReadAllText(apphostRunPath);
+            using var doc = JsonDocument.Parse(json);
+
+            if (!doc.RootElement.TryGetProperty("profiles", out var profilesElement))
+            {
+                return null;
+            }
+
+            var profiles = new Dictionary<string, AspireConfigProfile>();
+            foreach (var prop in profilesElement.EnumerateObject())
+            {
+                var profile = new AspireConfigProfile();
+
+                if (prop.Value.TryGetProperty("applicationUrl", out var appUrl) &&
+                    appUrl.ValueKind == JsonValueKind.String)
+                {
+                    profile.ApplicationUrl = appUrl.GetString();
+                }
+
+                if (prop.Value.TryGetProperty("environmentVariables", out var envVars))
+                {
+                    profile.EnvironmentVariables = new Dictionary<string, string>();
+                    foreach (var envProp in envVars.EnumerateObject())
+                    {
+                        if (envProp.Value.ValueKind == JsonValueKind.String)
+                        {
+                            profile.EnvironmentVariables[envProp.Name] = envProp.Value.GetString()!;
+                        }
+                    }
+                }
+
+                profiles[prop.Name] = profile;
+            }
+
+            return profiles.Count > 0 ? profiles : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void SaveConfiguration(AspireJsonConfiguration config, DirectoryInfo directory)
+    {
+        if (AspireConfigFile.Exists(directory.FullName))
+        {
+            // Write to aspire.config.json
+            var aspireConfig = AspireConfigFile.Load(directory.FullName) ?? new AspireConfigFile();
+            aspireConfig.AppHost ??= new AspireConfigAppHost();
+            aspireConfig.AppHost.Path = config.AppHostPath;
+            aspireConfig.AppHost.Language = config.Language;
+            aspireConfig.Sdk = !string.IsNullOrEmpty(config.SdkVersion) ? new AspireConfigSdk { Version = config.SdkVersion } : aspireConfig.Sdk;
+            aspireConfig.Channel = config.Channel ?? aspireConfig.Channel;
+            aspireConfig.Packages = config.Packages ?? aspireConfig.Packages;
+            aspireConfig.Features = config.Features ?? aspireConfig.Features;
+            aspireConfig.Save(directory.FullName);
+        }
+        else
+        {
+            // Legacy path
+            config.Save(directory.FullName);
+        }
     }
 
     private string GetPrepareSdkVersion(AspireJsonConfiguration config)
@@ -323,11 +447,11 @@ internal sealed class GuestAppHostProject : IAppHostProject
                     return (Success: true, Output: prepareOutput, Error: (string?)null, ChannelName: channelName, NeedsCodeGen: needsCodeGen);
                 }, emoji: KnownEmojis.Gear);
 
-            // Save the channel to settings.json if available (config already has SdkVersion)
+            // Save the channel to settings if available (config already has SdkVersion)
             if (buildResult.ChannelName is not null)
             {
                 config.Channel = buildResult.ChannelName;
-                config.Save(directory.FullName);
+                SaveConfiguration(config, directory);
             }
 
             if (!buildResult.Success)
@@ -942,9 +1066,9 @@ internal sealed class GuestAppHostProject : IAppHostProject
         // Load config - source of truth for SDK version and packages
         var config = LoadConfiguration(directory);
 
-        // Update .aspire/settings.json with the new package
+        // Update configuration with the new package
         config.AddOrUpdatePackage(context.PackageId, context.PackageVersion);
-        config.Save(directory.FullName);
+        SaveConfiguration(config, directory);
 
         // Build and regenerate SDK code with the new package
         return await BuildAndGenerateSdkAsync(directory, cancellationToken);
@@ -1055,7 +1179,7 @@ internal sealed class GuestAppHostProject : IAppHostProject
         {
             config.AddOrUpdatePackage(packageId, newVersion);
         }
-        config.Save(directory.FullName);
+        SaveConfiguration(config, directory);
 
         // Rebuild and regenerate SDK code with updated packages
         _interactionService.DisplayEmptyLine();

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -94,9 +94,9 @@ internal sealed class GuestAppHostProject : IAppHostProject
     /// </summary>
     private string GetEffectiveSdkVersion()
     {
-        // IConfiguration merges settings from parent directories and global settings
-        // The key "sdkVersion" is the flattened key from settings.json
-        var configuredVersion = _configuration["sdkVersion"];
+        // IConfiguration merges settings from parent directories and global settings.
+        // Prefer the new nested sdk:version key and fall back to the legacy sdkVersion key.
+        var configuredVersion = _configuration["sdk:version"] ?? _configuration["sdkVersion"];
         if (!string.IsNullOrEmpty(configuredVersion))
         {
             _logger.LogDebug("Using SDK version from configuration: {Version}", configuredVersion);

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -268,24 +268,15 @@ internal sealed class GuestAppHostProject : IAppHostProject
 
     private static void SaveConfiguration(AspireJsonConfiguration config, DirectoryInfo directory)
     {
-        if (AspireConfigFile.Exists(directory.FullName))
-        {
-            // Write to aspire.config.json
-            var aspireConfig = AspireConfigFile.Load(directory.FullName) ?? new AspireConfigFile();
-            aspireConfig.AppHost ??= new AspireConfigAppHost();
-            aspireConfig.AppHost.Path = config.AppHostPath;
-            aspireConfig.AppHost.Language = config.Language;
-            aspireConfig.Sdk = !string.IsNullOrEmpty(config.SdkVersion) ? new AspireConfigSdk { Version = config.SdkVersion } : aspireConfig.Sdk;
-            aspireConfig.Channel = config.Channel ?? aspireConfig.Channel;
-            aspireConfig.Packages = config.Packages ?? aspireConfig.Packages;
-            aspireConfig.Features = config.Features ?? aspireConfig.Features;
-            aspireConfig.Save(directory.FullName);
-        }
-        else
-        {
-            // Legacy path
-            config.Save(directory.FullName);
-        }
+        var aspireConfig = AspireConfigFile.Load(directory.FullName) ?? new AspireConfigFile();
+        aspireConfig.AppHost ??= new AspireConfigAppHost();
+        aspireConfig.AppHost.Path = config.AppHostPath;
+        aspireConfig.AppHost.Language = config.Language;
+        aspireConfig.Sdk = !string.IsNullOrEmpty(config.SdkVersion) ? new AspireConfigSdk { Version = config.SdkVersion } : aspireConfig.Sdk;
+        aspireConfig.Channel = config.Channel ?? aspireConfig.Channel;
+        aspireConfig.Packages = config.Packages ?? aspireConfig.Packages;
+        aspireConfig.Features = config.Features ?? aspireConfig.Features;
+        aspireConfig.Save(directory.FullName);
     }
 
     private string GetPrepareSdkVersion(AspireJsonConfiguration config)

--- a/src/Aspire.Cli/Projects/LanguageService.cs
+++ b/src/Aspire.Cli/Projects/LanguageService.cs
@@ -11,7 +11,7 @@ namespace Aspire.Cli.Projects;
 /// </summary>
 internal sealed class LanguageService : ILanguageService
 {
-    private const string LanguageConfigKey = "language";
+    private const string LanguageConfigKey = "appHost.language";
 
     private readonly IConfigurationService _configurationService;
     private readonly IInteractionService _interactionService;
@@ -131,7 +131,7 @@ internal sealed class LanguageService : ILanguageService
         if (saveSelection)
         {
             await SetLanguageAsync(selectedLanguage.LanguageId, isGlobal: false, cancellationToken);
-            _interactionService.DisplayMessage(KnownEmojis.CheckMark, $"Language preference saved to local settings: {selectedProject.DisplayName}");
+            _interactionService.DisplayMessage(KnownEmojis.CheckMark, $"Language preference saved to local configuration: {selectedProject.DisplayName}");
         }
 
         return selectedProject;

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -158,6 +158,29 @@ internal sealed class ProjectLocator(
 
         while (true)
         {
+            // Check aspire.config.json first
+            var aspireConfig = AspireConfigFile.Load(searchDirectory.FullName);
+            if (aspireConfig?.AppHost?.Path is { } configAppHostPath)
+            {
+                var qualifiedPath = Path.IsPathRooted(configAppHostPath)
+                    ? configAppHostPath
+                    : Path.Combine(searchDirectory.FullName, configAppHostPath);
+                qualifiedPath = PathNormalizer.NormalizePathForCurrentPlatform(qualifiedPath);
+                var appHostFile = new FileInfo(qualifiedPath);
+
+                if (appHostFile.Exists)
+                {
+                    return appHostFile;
+                }
+                else
+                {
+                    var configFilePath = Path.Combine(searchDirectory.FullName, AspireConfigFile.FileName);
+                    interactionService.DisplayMessage(KnownEmojis.Warning, string.Format(CultureInfo.CurrentCulture, ErrorStrings.AppHostWasSpecifiedButDoesntExist, configFilePath, qualifiedPath));
+                    return null;
+                }
+            }
+
+            // Fall back to .aspire/settings.json
             var settingsFile = new FileInfo(ConfigurationHelper.BuildPathToSettingsJsonFile(searchDirectory.FullName));
 
             if (settingsFile.Exists)

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -368,33 +368,138 @@ internal sealed class ProjectLocator(
 
     private async Task CreateSettingsFileAsync(FileInfo projectFile, CancellationToken cancellationToken)
     {
-        var settingsFilePath = ConfigurationHelper.BuildPathToSettingsJsonFile(executionContext.WorkingDirectory.FullName);
-        var settingsFile = new FileInfo(settingsFilePath);
+        var settingsFile = await GetOrCreateLocalAspireConfigFileAsync(cancellationToken);
 
         logger.LogDebug("Creating settings file at {SettingsFilePath}", settingsFile.FullName);
 
         var relativePathToProjectFile = Path.GetRelativePath(settingsFile.Directory!.FullName, projectFile.FullName).Replace(Path.DirectorySeparatorChar, '/');
 
-        // Use the configuration writer to set the appHostPath, which will merge with any existing settings
-        await configurationService.SetConfigurationAsync("appHostPath", relativePathToProjectFile, isGlobal: false, cancellationToken);
+        // Use the configuration writer to set the AppHost path, which will merge with any existing settings.
+        await configurationService.SetConfigurationAsync("appHost.path", relativePathToProjectFile, isGlobal: false, cancellationToken);
 
-        // For polyglot projects, also set language and inherit SDK version from parent/global config
+        // For polyglot projects, also set language and inherit SDK version from parent/global config.
         var language = languageDiscovery.GetLanguageByFile(projectFile);
         if (language is not null && !language.LanguageId.Value.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase))
         {
-            await configurationService.SetConfigurationAsync("language", language.LanguageId.Value, isGlobal: false, cancellationToken);
+            await configurationService.SetConfigurationAsync("appHost.language", language.LanguageId.Value, isGlobal: false, cancellationToken);
 
-            // Inherit SDK version from parent/global config if available
-            var inheritedSdkVersion = await configurationService.GetConfigurationAsync("sdkVersion", cancellationToken);
+            // Inherit SDK version from parent/global config if available.
+            var inheritedSdkVersion = await configurationService.GetConfigurationAsync("sdk.version", cancellationToken)
+                ?? await configurationService.GetConfigurationAsync("sdkVersion", cancellationToken);
             if (!string.IsNullOrEmpty(inheritedSdkVersion))
             {
-                await configurationService.SetConfigurationAsync("sdkVersion", inheritedSdkVersion, isGlobal: false, cancellationToken);
+                await configurationService.SetConfigurationAsync("sdk.version", inheritedSdkVersion, isGlobal: false, cancellationToken);
                 logger.LogDebug("Set SDK version {Version} in settings file (inherited from parent config)", inheritedSdkVersion);
             }
         }
 
         var relativeSettingsFilePath = Path.GetRelativePath(executionContext.WorkingDirectory.FullName, settingsFile.FullName).Replace(Path.DirectorySeparatorChar, '/');
         interactionService.DisplayMessage(KnownEmojis.FileCabinet, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.CreatedSettingsFile, $"[bold]'{relativeSettingsFilePath.EscapeMarkup()}'[/]"), allowMarkup: true);
+    }
+
+    private async Task<FileInfo> GetOrCreateLocalAspireConfigFileAsync(CancellationToken cancellationToken)
+    {
+        var settingsFile = new FileInfo(configurationService.GetSettingsFilePath(isGlobal: false));
+
+        if (string.Equals(settingsFile.Name, AspireConfigFile.FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return settingsFile;
+        }
+
+        var legacySettingsRootDirectory = GetLegacySettingsRootDirectory(settingsFile);
+        if (legacySettingsRootDirectory is null)
+        {
+            return new FileInfo(Path.Combine(executionContext.WorkingDirectory.FullName, AspireConfigFile.FileName));
+        }
+
+        var aspireConfigFile = new FileInfo(Path.Combine(legacySettingsRootDirectory.FullName, AspireConfigFile.FileName));
+        if (!aspireConfigFile.Exists)
+        {
+            await MigrateLegacySettingsAsync(legacySettingsRootDirectory, cancellationToken);
+        }
+
+        return aspireConfigFile;
+    }
+
+    private async Task MigrateLegacySettingsAsync(DirectoryInfo settingsRootDirectory, CancellationToken cancellationToken)
+    {
+        logger.LogDebug("Migrating legacy settings to {SettingsFilePath}", Path.Combine(settingsRootDirectory.FullName, AspireConfigFile.FileName));
+
+        var legacyConfig = AspireJsonConfiguration.Load(settingsRootDirectory.FullName);
+        var profiles = ReadApphostRunProfiles(Path.Combine(settingsRootDirectory.FullName, "apphost.run.json"));
+        var aspireConfig = AspireConfigFile.FromLegacy(legacyConfig, profiles);
+
+        await File.WriteAllTextAsync(
+            Path.Combine(settingsRootDirectory.FullName, AspireConfigFile.FileName),
+            JsonSerializer.Serialize(aspireConfig, JsonSourceGenerationContext.Default.AspireConfigFile),
+            cancellationToken);
+    }
+
+    private static DirectoryInfo? GetLegacySettingsRootDirectory(FileInfo settingsFile)
+    {
+        if (!string.Equals(settingsFile.Name, AspireJsonConfiguration.FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var settingsDirectory = settingsFile.Directory;
+        if (settingsDirectory is null || !string.Equals(settingsDirectory.Name, AspireJsonConfiguration.SettingsFolder, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return settingsDirectory.Parent;
+    }
+
+    private static Dictionary<string, AspireConfigProfile>? ReadApphostRunProfiles(string apphostRunPath)
+    {
+        try
+        {
+            if (!File.Exists(apphostRunPath))
+            {
+                return null;
+            }
+
+            var json = File.ReadAllText(apphostRunPath);
+            using var doc = JsonDocument.Parse(json);
+
+            if (!doc.RootElement.TryGetProperty("profiles", out var profilesElement))
+            {
+                return null;
+            }
+
+            var profiles = new Dictionary<string, AspireConfigProfile>();
+            foreach (var prop in profilesElement.EnumerateObject())
+            {
+                var profile = new AspireConfigProfile();
+
+                if (prop.Value.TryGetProperty("applicationUrl", out var appUrl) &&
+                    appUrl.ValueKind == JsonValueKind.String)
+                {
+                    profile.ApplicationUrl = appUrl.GetString();
+                }
+
+                if (prop.Value.TryGetProperty("environmentVariables", out var envVars))
+                {
+                    profile.EnvironmentVariables = new Dictionary<string, string>();
+                    foreach (var envProp in envVars.EnumerateObject())
+                    {
+                        if (envProp.Value.ValueKind == JsonValueKind.String)
+                        {
+                            profile.EnvironmentVariables[envProp.Name] = envProp.Value.GetString()!;
+                        }
+                    }
+                }
+
+                profiles[prop.Name] = profile;
+            }
+
+            return profiles.Count > 0 ? profiles : null;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
 }

--- a/src/Aspire.Cli/Scaffolding/IScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/IScaffoldingService.cs
@@ -26,5 +26,6 @@ internal interface IScaffoldingService
     /// </summary>
     /// <param name="context">The scaffolding context.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task ScaffoldAsync(ScaffoldContext context, CancellationToken cancellationToken);
+    /// <returns><see langword="true"/> when scaffolding succeeds; otherwise, <see langword="false"/>.</returns>
+    Task<bool> ScaffoldAsync(ScaffoldContext context, CancellationToken cancellationToken);
 }

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -131,7 +131,17 @@ internal sealed class ScaffoldingService : IScaffoldingService
                 language,
                 cancellationToken);
 
-            // Save channel and language to settings.json
+            // Save channel and language to aspire.config.json (new format)
+            var aspireConfigFile = AspireConfigFile.FromLegacy(config, profiles: null);
+            if (prepareResult.ChannelName is not null)
+            {
+                aspireConfigFile.Channel = prepareResult.ChannelName;
+            }
+            aspireConfigFile.AppHost ??= new AspireConfigAppHost();
+            aspireConfigFile.AppHost.Language = language.LanguageId;
+            aspireConfigFile.Save(directory.FullName);
+
+            // Also save legacy settings.json for backward compatibility
             if (prepareResult.ChannelName is not null)
             {
                 config.Channel = prepareResult.ChannelName;

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -183,15 +183,6 @@ internal sealed class ScaffoldingService : IScaffoldingService
             aspireConfigFile.AppHost ??= new AspireConfigAppHost();
             aspireConfigFile.AppHost.Language = language.LanguageId;
             aspireConfigFile.Save(directory.FullName);
-
-            // Also save legacy settings.json for backward compatibility
-            if (prepareResult.ChannelName is not null)
-            {
-                config.Channel = prepareResult.ChannelName;
-            }
-
-            config.Language = language.LanguageId;
-            config.Save(directory.FullName);
         }
         finally
         {

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -40,17 +40,17 @@ internal sealed class ScaffoldingService : IScaffoldingService
     }
 
     /// <inheritdoc />
-    public async Task ScaffoldAsync(ScaffoldContext context, CancellationToken cancellationToken)
+    public async Task<bool> ScaffoldAsync(ScaffoldContext context, CancellationToken cancellationToken)
     {
         if (context.Language.LanguageId.Value.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase))
         {
             throw new NotSupportedException("C# projects should be created using the template system via NewCommand.");
         }
 
-        await ScaffoldGuestLanguageAsync(context, cancellationToken);
+        return await ScaffoldGuestLanguageAsync(context, cancellationToken);
     }
 
-    private async Task ScaffoldGuestLanguageAsync(ScaffoldContext context, CancellationToken cancellationToken)
+    private async Task<bool> ScaffoldGuestLanguageAsync(ScaffoldContext context, CancellationToken cancellationToken)
     {
         var directory = context.TargetDirectory;
         var language = context.Language;
@@ -82,7 +82,7 @@ internal sealed class ScaffoldingService : IScaffoldingService
                 _interactionService.DisplayLines(prepareResult.Output.GetLines());
             }
             _interactionService.DisplayError("Failed to build AppHost server.");
-            return;
+            return false;
         }
 
         // Step 2: Start the server temporarily for scaffolding and code generation
@@ -121,7 +121,7 @@ internal sealed class ScaffoldingService : IScaffoldingService
                 emoji: KnownEmojis.Package);
             if (installResult != 0)
             {
-                return;
+                return false;
             }
 
             // Step 6: Generate SDK code via RPC
@@ -181,8 +181,10 @@ internal sealed class ScaffoldingService : IScaffoldingService
                 aspireConfigFile.Channel = prepareResult.ChannelName;
             }
             aspireConfigFile.AppHost ??= new AspireConfigAppHost();
+            aspireConfigFile.AppHost.Path ??= language.AppHostFileName;
             aspireConfigFile.AppHost.Language = language.LanguageId;
             aspireConfigFile.Save(directory.FullName);
+            return true;
         }
         finally
         {

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
@@ -137,20 +137,35 @@ internal sealed partial class CliTemplateFactory
 
     private async Task ApplyLocalhostTldToScaffoldedRunProfileAsync(string outputPath, string projectName, CancellationToken cancellationToken)
     {
-        var appHostRunProfilePath = Path.Combine(outputPath, "apphost.run.json");
-        if (!File.Exists(appHostRunProfilePath))
+        var hostName = $"{projectName.ToLowerInvariant()}.dev.localhost";
+
+        // Check aspire.config.json first
+        var aspireConfigPath = Path.Combine(outputPath, Configuration.AspireConfigFile.FileName);
+        if (File.Exists(aspireConfigPath))
         {
-            _logger.LogDebug("Skipping localhost TLD update because '{RunProfilePath}' was not found.", appHostRunProfilePath);
+            var content = await File.ReadAllTextAsync(aspireConfigPath, cancellationToken);
+            var updatedContent = content.Replace("://localhost", $"://{hostName}", StringComparison.Ordinal);
+            if (!string.Equals(content, updatedContent, StringComparison.Ordinal))
+            {
+                await File.WriteAllTextAsync(aspireConfigPath, updatedContent, cancellationToken);
+            }
             return;
         }
 
-        var hostName = $"{projectName.ToLowerInvariant()}.dev.localhost";
-        var content = await File.ReadAllTextAsync(appHostRunProfilePath, cancellationToken);
-        var updatedContent = content.Replace("://localhost", $"://{hostName}", StringComparison.Ordinal);
-
-        if (!string.Equals(content, updatedContent, StringComparison.Ordinal))
+        // Fall back to apphost.run.json
+        var appHostRunProfilePath = Path.Combine(outputPath, "apphost.run.json");
+        if (!File.Exists(appHostRunProfilePath))
         {
-            await File.WriteAllTextAsync(appHostRunProfilePath, updatedContent, cancellationToken);
+            _logger.LogDebug("Skipping localhost TLD update because neither aspire.config.json nor apphost.run.json was found in '{OutputPath}'.", outputPath);
+            return;
+        }
+
+        var runContent = await File.ReadAllTextAsync(appHostRunProfilePath, cancellationToken);
+        var updatedRunContent = runContent.Replace("://localhost", $"://{hostName}", StringComparison.Ordinal);
+
+        if (!string.Equals(runContent, updatedRunContent, StringComparison.Ordinal))
+        {
+            await File.WriteAllTextAsync(appHostRunProfilePath, updatedRunContent, cancellationToken);
         }
     }
 

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
@@ -139,33 +139,18 @@ internal sealed partial class CliTemplateFactory
     {
         var hostName = $"{projectName.ToLowerInvariant()}.dev.localhost";
 
-        // Check aspire.config.json first
         var aspireConfigPath = Path.Combine(outputPath, Configuration.AspireConfigFile.FileName);
-        if (File.Exists(aspireConfigPath))
+        if (!File.Exists(aspireConfigPath))
         {
-            var content = await File.ReadAllTextAsync(aspireConfigPath, cancellationToken);
-            var updatedContent = content.Replace("://localhost", $"://{hostName}", StringComparison.Ordinal);
-            if (!string.Equals(content, updatedContent, StringComparison.Ordinal))
-            {
-                await File.WriteAllTextAsync(aspireConfigPath, updatedContent, cancellationToken);
-            }
+            _logger.LogDebug("Skipping localhost TLD update because aspire.config.json was not found in '{OutputPath}'.", outputPath);
             return;
         }
 
-        // Fall back to apphost.run.json
-        var appHostRunProfilePath = Path.Combine(outputPath, "apphost.run.json");
-        if (!File.Exists(appHostRunProfilePath))
+        var content = await File.ReadAllTextAsync(aspireConfigPath, cancellationToken);
+        var updatedContent = content.Replace("://localhost", $"://{hostName}", StringComparison.Ordinal);
+        if (!string.Equals(content, updatedContent, StringComparison.Ordinal))
         {
-            _logger.LogDebug("Skipping localhost TLD update because neither aspire.config.json nor apphost.run.json was found in '{OutputPath}'.", outputPath);
-            return;
-        }
-
-        var runContent = await File.ReadAllTextAsync(appHostRunProfilePath, cancellationToken);
-        var updatedRunContent = runContent.Replace("://localhost", $"://{hostName}", StringComparison.Ordinal);
-
-        if (!string.Equals(runContent, updatedRunContent, StringComparison.Ordinal))
-        {
-            await File.WriteAllTextAsync(appHostRunProfilePath, updatedRunContent, cancellationToken);
+            await File.WriteAllTextAsync(aspireConfigPath, updatedContent, cancellationToken);
         }
     }
 

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
@@ -75,7 +75,10 @@ internal sealed partial class CliTemplateFactory
                     {
                         _logger.LogDebug("Using scaffolding service for language '{LanguageDisplayName}' in '{OutputPath}'.", language.DisplayName, outputPath);
                         var context = new ScaffoldContext(language, new DirectoryInfo(outputPath), projectName);
-                        await _scaffoldingService.ScaffoldAsync(context, cancellationToken);
+                        if (!await _scaffoldingService.ScaffoldAsync(context, cancellationToken))
+                        {
+                            return new TemplateResult(ExitCodeConstants.FailedToCreateNewProject);
+                        }
 
                         if (useLocalhostTld)
                         {

--- a/src/Aspire.Cli/Templating/Templates/empty-apphost/aspire.config.json
+++ b/src/Aspire.Cli/Templating/Templates/empty-apphost/aspire.config.json
@@ -1,4 +1,7 @@
 {
+  "appHost": {
+    "path": "apphost.cs"
+  },
   "profiles": {
     "https": {
       "applicationUrl": "https://{{hostName}}:{{httpsPort}};http://{{hostName}}:{{httpPort}}",

--- a/src/Aspire.Cli/Templating/Templates/empty-apphost/aspire.config.json
+++ b/src/Aspire.Cli/Templating/Templates/empty-apphost/aspire.config.json
@@ -1,23 +1,22 @@
 {
-  "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
     "https": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
       "applicationUrl": "https://{{hostName}}:{{httpsPort}};http://{{hostName}}:{{httpPort}}",
       "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://{{hostName}}:{{otlpHttpsPort}}",
+        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "https://{{hostName}}:{{mcpHttpsPort}}",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://{{hostName}}:{{resourceHttpsPort}}"
       }
     },
     "http": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
       "applicationUrl": "http://{{hostName}}:{{httpPort}}",
       "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://{{hostName}}:{{otlpHttpPort}}",
+        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "http://{{hostName}}:{{mcpHttpPort}}",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://{{hostName}}:{{resourceHttpPort}}",
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/.aspire/settings.json
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/.aspire/settings.json
@@ -1,7 +1,0 @@
-{
-  "appHostPath": "../apphost.ts",
-  "language": "typescript/nodejs",
-  "packages": {
-    "Aspire.Hosting.JavaScript": "{{aspireVersion}}"
-  }
-}

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/aspire.config.json
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/aspire.config.json
@@ -1,29 +1,23 @@
 {
-  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "appHost": {
+    "path": "apphost.ts",
+    "language": "typescript/nodejs"
+  },
+  "packages": {
+    "Aspire.Hosting.JavaScript": "{{aspireVersion}}"
+  },
   "profiles": {
     "https": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
       "applicationUrl": "https://{{hostName}}:{{httpsPort}};http://{{hostName}}:{{httpPort}}",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://{{hostName}}:{{otlpHttpsPort}}",
-        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "https://{{hostName}}:{{mcpHttpsPort}}",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://{{hostName}}:{{resourceHttpsPort}}"
       }
     },
     "http": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
       "applicationUrl": "http://{{hostName}}:{{httpPort}}",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://{{hostName}}:{{otlpHttpPort}}",
-        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "http://{{hostName}}:{{mcpHttpPort}}",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://{{hostName}}:{{resourceHttpPort}}",
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }

--- a/src/Aspire.Cli/Utils/ConfigurationHelper.cs
+++ b/src/Aspire.Cli/Utils/ConfigurationHelper.cs
@@ -13,16 +13,24 @@ internal static class ConfigurationHelper
     {
         var currentDirectory = workingDirectory;
 
-        // Find the nearest local settings file
+        // Find the nearest local settings file (prefer aspire.config.json, fall back to .aspire/settings.json)
         FileInfo? localSettingsFile = null;
 
         while (currentDirectory is not null)
         {
-            var settingsFilePath = BuildPathToSettingsJsonFile(currentDirectory.FullName);
-
-            if (File.Exists(settingsFilePath))
+            // Check for aspire.config.json first (new format)
+            var newSettingsPath = Path.Combine(currentDirectory.FullName, "aspire.config.json");
+            if (File.Exists(newSettingsPath))
             {
-                localSettingsFile = new FileInfo(settingsFilePath);
+                localSettingsFile = new FileInfo(newSettingsPath);
+                break;
+            }
+
+            // Fall back to .aspire/settings.json (legacy format)
+            var legacySettingsPath = BuildPathToSettingsJsonFile(currentDirectory.FullName);
+            if (File.Exists(legacySettingsPath))
+            {
+                localSettingsFile = new FileInfo(legacySettingsPath);
                 break;
             }
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
@@ -679,7 +679,10 @@ internal static class CliE2ETestHelpers
                     .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30))
                     .Type("export PATH=~/.aspire/bin:$PATH")
                     .Enter()
-                    .WaitForSuccessPrompt(counter);
+                    .WaitForSuccessPrompt(counter)
+                    .Type("aspire config set channel daily --global")
+                    .Enter()
+                    .WaitForSuccessPrompt(counter, TimeSpan.FromSeconds(30));
 
             case DockerInstallMode.GaRelease:
                 // Install the latest GA release using the script baked into the container image.

--- a/tests/Aspire.Cli.EndToEnd.Tests/ProjectReferenceTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ProjectReferenceTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Tests.Utils;
 using Hex1b.Automation;
@@ -12,7 +13,7 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// <summary>
 /// End-to-end test for polyglot project reference support.
 /// Creates a .NET hosting integration project and a TypeScript AppHost that references it
-/// via settings.json, then verifies the integration is discovered, code-generated, and functional.
+/// via <c>aspire.config.json</c>, then verifies the integration is discovered, code-generated, and functional.
 /// </summary>
 public sealed class ProjectReferenceTests(ITestOutputHelper output)
 {
@@ -48,23 +49,23 @@ public sealed class ProjectReferenceTests(ITestOutputHelper output)
 
         sequenceBuilder.InstallAspireCliInDocker(installMode, counter);
 
-        // Step 1: Create a TypeScript AppHost (so we get the sdkVersion in settings.json)
+        // Step 1: Create a TypeScript AppHost (so we get the SDK version in aspire.config.json)
         sequenceBuilder
             .Type("aspire init --language typescript --non-interactive")
             .Enter()
             .WaitUntil(s => waitingForAppHostCreated.Search(s).Count > 0, TimeSpan.FromMinutes(2))
             .WaitForSuccessPrompt(counter);
 
-        // Step 2: Create the integration project, update settings.json, and modify apphost.ts
+        // Step 2: Create the integration project, update aspire.config.json, and modify apphost.ts
         sequenceBuilder.ExecuteCallback(() =>
         {
             var workDir = workspace.WorkspaceRoot.FullName;
 
-            // Read the sdkVersion from the settings.json that aspire init created
-            var settingsPath = Path.Combine(workDir, ".aspire", "settings.json");
-            var settingsJson = File.ReadAllText(settingsPath);
-            using var doc = JsonDocument.Parse(settingsJson);
-            var sdkVersion = doc.RootElement.GetProperty("sdkVersion").GetString()!;
+            // Read the SDK version from the aspire.config.json that aspire init created.
+            var configPath = Path.Combine(workDir, "aspire.config.json");
+            var configJson = File.ReadAllText(configPath);
+            using var doc = JsonDocument.Parse(configJson);
+            var sdkVersion = doc.RootElement.GetProperty("sdk").GetProperty("version").GetString()!;
 
             // Create the .NET hosting integration project
             var integrationDir = Path.Combine(workDir, "MyIntegration");
@@ -129,20 +130,15 @@ public sealed class ProjectReferenceTests(ITestOutputHelper output)
                 }
                 """);
 
-            // Update settings.json to add the project reference
-            using var settingsDoc = JsonDocument.Parse(settingsJson);
-            var settings = new Dictionary<string, object>();
-            foreach (var prop in settingsDoc.RootElement.EnumerateObject())
-            {
-                settings[prop.Name] = prop.Value.Clone();
-            }
-            settings["packages"] = new Dictionary<string, string>
-            {
-                ["MyIntegration"] = "./MyIntegration/MyIntegration.csproj"
-            };
+            // Update aspire.config.json to add the project reference.
+            var config = JsonNode.Parse(configJson)?.AsObject()
+                ?? throw new InvalidOperationException("Expected aspire.config.json to contain a JSON object.");
+            var packages = config["packages"] as JsonObject ?? new JsonObject();
+            packages["MyIntegration"] = "./MyIntegration/MyIntegration.csproj";
+            config["packages"] = packages;
 
-            var updatedJson = JsonSerializer.Serialize(settings, new JsonSerializerOptions { WriteIndented = true });
-            File.WriteAllText(settingsPath, updatedJson);
+            var updatedJson = config.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(configPath, updatedJson);
 
             // Delete the generated .modules folder to force re-codegen with the new integration
             var modulesDir = Path.Combine(workDir, ".modules");

--- a/tests/Aspire.Cli.EndToEnd.Tests/StagingChannelTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StagingChannelTests.cs
@@ -58,13 +58,13 @@ public sealed class StagingChannelTests(ITestOutputHelper output)
             .Enter()
             .WaitForSuccessPrompt(counter);
 
-        // Step 2: Verify the settings were persisted in the global settings file
+        // Step 2: Verify the settings were persisted in the global config file
         var settingsFilePattern = new CellPatternSearcher()
             .Find("stagingPinToCliVersion");
 
         sequenceBuilder
             .ClearScreen(counter)
-            .Type("cat ~/.aspire/globalsettings.json")
+            .Type("cat ~/.aspire/aspire.config.json")
             .Enter()
             .WaitUntil(s => settingsFilePattern.Search(s).Count > 0, TimeSpan.FromSeconds(10))
             .WaitForSuccessPrompt(counter);

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
@@ -39,7 +39,7 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
 
         // Pattern for aspire add completion
         var waitingForPackageAdded = new CellPatternSearcher()
-            .Find("The package Aspire.Hosting.JavaScript::");
+            .Find("The package Aspire.Hosting.");
 
         // Pattern for aspire run ready
         var waitForCtrlCMessage = new CellPatternSearcher()

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1068,7 +1068,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(0, exitCode);
         Assert.True(localhostPrompted);
 
-        var runProfilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.run.json");
+        var runProfilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json");
         Assert.True(File.Exists(runProfilePath));
         var runProfile = await File.ReadAllTextAsync(runProfilePath);
         Assert.Contains("testapp.dev.localhost", runProfile);

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1242,8 +1242,12 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             ScaffoldAsyncCallback = async (context, cancellationToken) =>
             {
                 scaffoldingInvoked = true;
-                await File.WriteAllTextAsync(Path.Combine(context.TargetDirectory.FullName, "apphost.run.json"), """
+                await File.WriteAllTextAsync(Path.Combine(context.TargetDirectory.FullName, "aspire.config.json"), """
                     {
+                      "appHost": {
+                        "path": "apphost.ts",
+                        "language": "typescript/nodejs"
+                      },
                       "profiles": {
                         "https": {
                           "applicationUrl": "https://localhost:1234;http://localhost:5678",
@@ -1267,10 +1271,10 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.True(scaffoldingInvoked);
         Assert.True(localhostPrompted);
 
-        var runProfilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.run.json");
-        var runProfile = await File.ReadAllTextAsync(runProfilePath);
-        Assert.Contains("testapp.dev.localhost", runProfile);
-        Assert.DoesNotContain("://localhost", runProfile);
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json");
+        var configContent = await File.ReadAllTextAsync(configPath);
+        Assert.Contains("testapp.dev.localhost", configContent);
+        Assert.DoesNotContain("://localhost", configContent);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -890,7 +890,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             {
                 scaffoldedLanguageId = context.Language.LanguageId.Value;
                 File.WriteAllText(Path.Combine(context.TargetDirectory.FullName, "apphost.ts"), "// test apphost");
-                return Task.CompletedTask;
+                return Task.FromResult(true);
             }
         });
 
@@ -1107,7 +1107,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             ScaffoldAsyncCallback = (context, cancellationToken) =>
             {
                 scaffoldingInvoked = true;
-                return Task.CompletedTask;
+                return Task.FromResult(true);
             }
         });
 
@@ -1163,7 +1163,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
             ScaffoldAsyncCallback = (context, cancellationToken) =>
             {
                 capturedTargetDirectory = context.TargetDirectory.FullName;
-                return Task.CompletedTask;
+                return Task.FromResult(true);
             }
         });
 
@@ -1259,6 +1259,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                       }
                     }
                     """, cancellationToken);
+                return true;
             }
         });
 
@@ -1498,15 +1499,15 @@ internal sealed class NewCommandTestFakeNuGetPackageCache : INuGetPackageCache
 
 internal sealed class TestScaffoldingService : IScaffoldingService
 {
-    public Func<ScaffoldContext, CancellationToken, Task>? ScaffoldAsyncCallback { get; set; }
+    public Func<ScaffoldContext, CancellationToken, Task<bool>>? ScaffoldAsyncCallback { get; set; }
 
-    public Task ScaffoldAsync(ScaffoldContext context, CancellationToken cancellationToken)
+    public Task<bool> ScaffoldAsync(ScaffoldContext context, CancellationToken cancellationToken)
     {
         if (ScaffoldAsyncCallback is not null)
         {
             return ScaffoldAsyncCallback(context, cancellationToken);
         }
 
-        return Task.CompletedTask;
+        return Task.FromResult(true);
     }
 }

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.AspNetCore.InternalTesting;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
@@ -305,16 +304,16 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
 
         await locator.UseOrFindAppHostProjectFileAsync(null, createSettingsFile: true, CancellationToken.None).DefaultTimeout();
 
-        var settingsFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "settings.json"));
+        var settingsFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName));
         Assert.True(settingsFile.Exists, "Settings file should exist.");
 
         var settingsJson = await File.ReadAllTextAsync(settingsFile.FullName);
-        var settings = JsonSerializer.Deserialize<CliSettings>(settingsJson);
+        var settings = JsonSerializer.Deserialize<AspireConfigFile>(settingsJson);
 
         Assert.NotNull(settings);
-        Assert.NotNull(settings!.AppHostPath);
-        Assert.DoesNotContain('\\', settings.AppHostPath); // Ensure no backslashes
-        Assert.Contains('/', settings.AppHostPath); // Ensure forward slashes
+        Assert.NotNull(settings!.AppHost?.Path);
+        Assert.DoesNotContain('\\', settings.AppHost.Path); // Ensure no backslashes
+        Assert.Contains('/', settings.AppHost.Path); // Ensure forward slashes
     }
 
     [Fact]
@@ -615,13 +614,7 @@ builder.Build().Run();");
         Assert.True(result.FullName == csprojFile.FullName || result.FullName == appHostFile.FullName);
     }
 
-    private sealed class CliSettings
-    {
-        [JsonPropertyName("appHostPath")]
-        public string? AppHostPath { get; set; }
-    }
-
-    private sealed class TestConfigurationService : IConfigurationService
+    private sealed class TestConfigurationService(CliExecutionContext executionContext) : IConfigurationService
     {
         public Task SetConfigurationAsync(string key, string value, bool isGlobal = false, CancellationToken cancellationToken = default)
         {
@@ -658,7 +651,9 @@ builder.Build().Run();");
 
         public string GetSettingsFilePath(bool isGlobal)
         {
-            return string.Empty;
+            return isGlobal
+                ? Path.Combine(executionContext.HomeDirectory.FullName, ".aspire", AspireConfigFile.FileName)
+                : Path.Combine(executionContext.WorkingDirectory.FullName, AspireConfigFile.FileName);
         }
     }
 
@@ -1038,11 +1033,10 @@ builder.Build().Run();");
             logger,
             executionContext,
             interactionService ?? new TestInteractionService(),
-            configurationService ?? new TestConfigurationService(),
+            configurationService ?? new TestConfigurationService(executionContext),
             projectFactory ?? new TestAppHostProjectFactory(),
             languageDiscovery ?? new TestLanguageDiscovery(),
             sdkInstaller ?? new TestDotNetSdkInstaller(),
             telemetry ?? TestTelemetryHelper.CreateInitializedTelemetry());
     }
 }
-


### PR DESCRIPTION
## Summary

Updates the VS Code extension to support the new `aspire.config.json` format introduced by the CLI config consolidation in #14985.

The extension now handles **both** `aspire.config.json` (new) and `.aspire/settings.json` (legacy), preferring the new format when both exist. This ensures a smooth transition as the CLI auto-migrates legacy files.

## Changes

### New files
- **`extension/schemas/aspire-config.schema.json`** — JSON schema for IntelliSense and validation of `aspire.config.json`

### Modified files
- **`extension/src/utils/cliTypes.ts`** — Added `AspireConfigFile` interface with the new nested config structure (`appHost.path`, `sdk.version`, `profiles`, etc.)
- **`extension/package.json`** — Added `jsonValidation` entry for `aspire.config.json`
- **`extension/package.nls.json`** — Updated setting description to reference `aspire.config.json appHost.path`
- **`extension/src/utils/workspace.ts`** — Major update:
  - New `findAspireConfigFiles()` discovers both config formats, deduplicates (prefers new format)
  - New `getAppHostPathFromConfig()` extracts appHost path from either format
  - New `isAspireConfigFile()` helper
  - `checkForExistingAppHostPathInWorkspace()` creates `aspire.config.json` for new projects
  - `promptToAddAppHostPathToConfigFile()` writes correct format based on file type
- **`extension/src/editor/AspireEditorCommandProvider.ts`** — File watchers now monitor both `aspire.config.json` and `.aspire/settings.json`:
  - Correct path resolution per format (new: relative to project root, legacy: relative to `.aspire/`)
  - Falls back to legacy file when new config is deleted
  - Ignores legacy changes when new config exists
- **`extension/src/commands/openSettings.ts`** — Updated comments to reference new config file

## Testing

Manual testing needed:
1. Open workspace with `aspire.config.json` → extension discovers apphost path
2. Open workspace with `.aspire/settings.json` → legacy path still works
3. Delete `aspire.config.json` → falls back to `.aspire/settings.json`
4. Create new project → creates `aspire.config.json` (not `.aspire/settings.json`)
5. IntelliSense works in `aspire.config.json` files