### PR TITLE
feat: Expose `ReferenceExpression` get value and enhance server value resolution

### DIFF
--- a/playground/TypeScriptAppHost/.modules/aspire.ts
+++ b/playground/TypeScriptAppHost/.modules/aspire.ts
@@ -8,6 +8,7 @@ import {
     AspireClient as AspireClientRpc,
     Handle,
     MarshalledHandle,
+    AppHostUsageError,
     CapabilityError,
     registerCallback,
     wrapIfHandle,
@@ -239,6 +240,7 @@ export enum EndpointProperty {
     Scheme = "Scheme",
     TargetPort = "TargetPort",
     HostAndPort = "HostAndPort",
+    TlsEnabled = "TlsEnabled",
 }
 
 /** Enum type for IconVariant */
@@ -876,6 +878,16 @@ export class EndpointReference {
         },
     };
 
+    /** Gets the TlsEnabled property */
+    tlsEnabled = {
+        get: async (): Promise<boolean> => {
+            return await this._client.invokeCapability<boolean>(
+                'Aspire.Hosting.ApplicationModel/EndpointReference.tlsEnabled',
+                { context: this._handle }
+            );
+        },
+    };
+
     /** Gets the Port property */
     port = {
         get: async (): Promise<number> => {
@@ -937,6 +949,15 @@ export class EndpointReference {
         );
     }
 
+    /** Gets a conditional expression that resolves to the enabledValue when TLS is enabled on the endpoint, or to the disabledValue otherwise. */
+    async getTlsValue(enabledValue: ReferenceExpression, disabledValue: ReferenceExpression): Promise<ReferenceExpression> {
+        const rpcArgs: Record<string, unknown> = { context: this._handle, enabledValue, disabledValue };
+        return await this._client.invokeCapability<ReferenceExpression>(
+            'Aspire.Hosting.ApplicationModel/EndpointReference.getTlsValue',
+            rpcArgs
+        );
+    }
+
 }
 
 /**
@@ -955,6 +976,11 @@ export class EndpointReferencePromise implements PromiseLike<EndpointReference> 
     /** Gets the URL of the endpoint asynchronously */
     getValueAsync(options?: GetValueAsyncOptions): Promise<string> {
         return this._promise.then(obj => obj.getValueAsync(options));
+    }
+
+    /** Gets a conditional expression that resolves to the enabledValue when TLS is enabled on the endpoint, or to the disabledValue otherwise. */
+    getTlsValue(enabledValue: ReferenceExpression, disabledValue: ReferenceExpression): Promise<ReferenceExpression> {
+        return this._promise.then(obj => obj.getTlsValue(enabledValue, disabledValue));
     }
 
 }
@@ -3203,36 +3229,6 @@ export class ConnectionStringResource extends ResourceBuilderBase<ConnectionStri
     }
 
     /** @internal */
-    private async _withRemoteImageNameInternal(remoteImageName: string): Promise<ConnectionStringResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageName };
-        const result = await this._client.invokeCapability<ConnectionStringResourceHandle>(
-            'Aspire.Hosting/withRemoteImageName',
-            rpcArgs
-        );
-        return new ConnectionStringResource(result, this._client);
-    }
-
-    /** Sets the remote image name for publishing */
-    withRemoteImageName(remoteImageName: string): ConnectionStringResourcePromise {
-        return new ConnectionStringResourcePromise(this._withRemoteImageNameInternal(remoteImageName));
-    }
-
-    /** @internal */
-    private async _withRemoteImageTagInternal(remoteImageTag: string): Promise<ConnectionStringResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageTag };
-        const result = await this._client.invokeCapability<ConnectionStringResourceHandle>(
-            'Aspire.Hosting/withRemoteImageTag',
-            rpcArgs
-        );
-        return new ConnectionStringResource(result, this._client);
-    }
-
-    /** Sets the remote image tag for publishing */
-    withRemoteImageTag(remoteImageTag: string): ConnectionStringResourcePromise {
-        return new ConnectionStringResourcePromise(this._withRemoteImageTagInternal(remoteImageTag));
-    }
-
-    /** @internal */
     private async _withPipelineStepFactoryInternal(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, dependsOn?: string[], requiredBy?: string[], tags?: string[], description?: string): Promise<ConnectionStringResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as PipelineStepContextHandle;
@@ -3439,16 +3435,6 @@ export class ConnectionStringResourcePromise implements PromiseLike<ConnectionSt
     /** Excludes the resource from MCP server exposure */
     excludeFromMcp(): ConnectionStringResourcePromise {
         return new ConnectionStringResourcePromise(this._promise.then(obj => obj.excludeFromMcp()));
-    }
-
-    /** Sets the remote image name for publishing */
-    withRemoteImageName(remoteImageName: string): ConnectionStringResourcePromise {
-        return new ConnectionStringResourcePromise(this._promise.then(obj => obj.withRemoteImageName(remoteImageName)));
-    }
-
-    /** Sets the remote image tag for publishing */
-    withRemoteImageTag(remoteImageTag: string): ConnectionStringResourcePromise {
-        return new ConnectionStringResourcePromise(this._promise.then(obj => obj.withRemoteImageTag(remoteImageTag)));
     }
 
     /** Adds a pipeline step to the resource */
@@ -3756,36 +3742,6 @@ export class ContainerRegistryResource extends ResourceBuilderBase<ContainerRegi
     }
 
     /** @internal */
-    private async _withRemoteImageNameInternal(remoteImageName: string): Promise<ContainerRegistryResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageName };
-        const result = await this._client.invokeCapability<ContainerRegistryResourceHandle>(
-            'Aspire.Hosting/withRemoteImageName',
-            rpcArgs
-        );
-        return new ContainerRegistryResource(result, this._client);
-    }
-
-    /** Sets the remote image name for publishing */
-    withRemoteImageName(remoteImageName: string): ContainerRegistryResourcePromise {
-        return new ContainerRegistryResourcePromise(this._withRemoteImageNameInternal(remoteImageName));
-    }
-
-    /** @internal */
-    private async _withRemoteImageTagInternal(remoteImageTag: string): Promise<ContainerRegistryResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageTag };
-        const result = await this._client.invokeCapability<ContainerRegistryResourceHandle>(
-            'Aspire.Hosting/withRemoteImageTag',
-            rpcArgs
-        );
-        return new ContainerRegistryResource(result, this._client);
-    }
-
-    /** Sets the remote image tag for publishing */
-    withRemoteImageTag(remoteImageTag: string): ContainerRegistryResourcePromise {
-        return new ContainerRegistryResourcePromise(this._withRemoteImageTagInternal(remoteImageTag));
-    }
-
-    /** @internal */
     private async _withPipelineStepFactoryInternal(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, dependsOn?: string[], requiredBy?: string[], tags?: string[], description?: string): Promise<ContainerRegistryResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as PipelineStepContextHandle;
@@ -3957,16 +3913,6 @@ export class ContainerRegistryResourcePromise implements PromiseLike<ContainerRe
     /** Excludes the resource from MCP server exposure */
     excludeFromMcp(): ContainerRegistryResourcePromise {
         return new ContainerRegistryResourcePromise(this._promise.then(obj => obj.excludeFromMcp()));
-    }
-
-    /** Sets the remote image name for publishing */
-    withRemoteImageName(remoteImageName: string): ContainerRegistryResourcePromise {
-        return new ContainerRegistryResourcePromise(this._promise.then(obj => obj.withRemoteImageName(remoteImageName)));
-    }
-
-    /** Sets the remote image tag for publishing */
-    withRemoteImageTag(remoteImageTag: string): ContainerRegistryResourcePromise {
-        return new ContainerRegistryResourcePromise(this._promise.then(obj => obj.withRemoteImageTag(remoteImageTag)));
     }
 
     /** Adds a pipeline step to the resource */
@@ -8975,36 +8921,6 @@ export class DockerComposeEnvironmentResource extends ResourceBuilderBase<Docker
     }
 
     /** @internal */
-    private async _withRemoteImageNameInternal(remoteImageName: string): Promise<DockerComposeEnvironmentResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageName };
-        const result = await this._client.invokeCapability<DockerComposeEnvironmentResourceHandle>(
-            'Aspire.Hosting/withRemoteImageName',
-            rpcArgs
-        );
-        return new DockerComposeEnvironmentResource(result, this._client);
-    }
-
-    /** Sets the remote image name for publishing */
-    withRemoteImageName(remoteImageName: string): DockerComposeEnvironmentResourcePromise {
-        return new DockerComposeEnvironmentResourcePromise(this._withRemoteImageNameInternal(remoteImageName));
-    }
-
-    /** @internal */
-    private async _withRemoteImageTagInternal(remoteImageTag: string): Promise<DockerComposeEnvironmentResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageTag };
-        const result = await this._client.invokeCapability<DockerComposeEnvironmentResourceHandle>(
-            'Aspire.Hosting/withRemoteImageTag',
-            rpcArgs
-        );
-        return new DockerComposeEnvironmentResource(result, this._client);
-    }
-
-    /** Sets the remote image tag for publishing */
-    withRemoteImageTag(remoteImageTag: string): DockerComposeEnvironmentResourcePromise {
-        return new DockerComposeEnvironmentResourcePromise(this._withRemoteImageTagInternal(remoteImageTag));
-    }
-
-    /** @internal */
     private async _withPipelineStepFactoryInternal(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, dependsOn?: string[], requiredBy?: string[], tags?: string[], description?: string): Promise<DockerComposeEnvironmentResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as PipelineStepContextHandle;
@@ -9233,16 +9149,6 @@ export class DockerComposeEnvironmentResourcePromise implements PromiseLike<Dock
     /** Excludes the resource from MCP server exposure */
     excludeFromMcp(): DockerComposeEnvironmentResourcePromise {
         return new DockerComposeEnvironmentResourcePromise(this._promise.then(obj => obj.excludeFromMcp()));
-    }
-
-    /** Sets the remote image name for publishing */
-    withRemoteImageName(remoteImageName: string): DockerComposeEnvironmentResourcePromise {
-        return new DockerComposeEnvironmentResourcePromise(this._promise.then(obj => obj.withRemoteImageName(remoteImageName)));
-    }
-
-    /** Sets the remote image tag for publishing */
-    withRemoteImageTag(remoteImageTag: string): DockerComposeEnvironmentResourcePromise {
-        return new DockerComposeEnvironmentResourcePromise(this._promise.then(obj => obj.withRemoteImageTag(remoteImageTag)));
     }
 
     /** Adds a pipeline step to the resource */
@@ -9586,36 +9492,6 @@ export class DockerComposeServiceResource extends ResourceBuilderBase<DockerComp
     }
 
     /** @internal */
-    private async _withRemoteImageNameInternal(remoteImageName: string): Promise<DockerComposeServiceResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageName };
-        const result = await this._client.invokeCapability<DockerComposeServiceResourceHandle>(
-            'Aspire.Hosting/withRemoteImageName',
-            rpcArgs
-        );
-        return new DockerComposeServiceResource(result, this._client);
-    }
-
-    /** Sets the remote image name for publishing */
-    withRemoteImageName(remoteImageName: string): DockerComposeServiceResourcePromise {
-        return new DockerComposeServiceResourcePromise(this._withRemoteImageNameInternal(remoteImageName));
-    }
-
-    /** @internal */
-    private async _withRemoteImageTagInternal(remoteImageTag: string): Promise<DockerComposeServiceResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageTag };
-        const result = await this._client.invokeCapability<DockerComposeServiceResourceHandle>(
-            'Aspire.Hosting/withRemoteImageTag',
-            rpcArgs
-        );
-        return new DockerComposeServiceResource(result, this._client);
-    }
-
-    /** Sets the remote image tag for publishing */
-    withRemoteImageTag(remoteImageTag: string): DockerComposeServiceResourcePromise {
-        return new DockerComposeServiceResourcePromise(this._withRemoteImageTagInternal(remoteImageTag));
-    }
-
-    /** @internal */
     private async _withPipelineStepFactoryInternal(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, dependsOn?: string[], requiredBy?: string[], tags?: string[], description?: string): Promise<DockerComposeServiceResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as PipelineStepContextHandle;
@@ -9787,16 +9663,6 @@ export class DockerComposeServiceResourcePromise implements PromiseLike<DockerCo
     /** Excludes the resource from MCP server exposure */
     excludeFromMcp(): DockerComposeServiceResourcePromise {
         return new DockerComposeServiceResourcePromise(this._promise.then(obj => obj.excludeFromMcp()));
-    }
-
-    /** Sets the remote image name for publishing */
-    withRemoteImageName(remoteImageName: string): DockerComposeServiceResourcePromise {
-        return new DockerComposeServiceResourcePromise(this._promise.then(obj => obj.withRemoteImageName(remoteImageName)));
-    }
-
-    /** Sets the remote image tag for publishing */
-    withRemoteImageTag(remoteImageTag: string): DockerComposeServiceResourcePromise {
-        return new DockerComposeServiceResourcePromise(this._promise.then(obj => obj.withRemoteImageTag(remoteImageTag)));
     }
 
     /** Adds a pipeline step to the resource */
@@ -13074,36 +12940,6 @@ export class ExternalServiceResource extends ResourceBuilderBase<ExternalService
     }
 
     /** @internal */
-    private async _withRemoteImageNameInternal(remoteImageName: string): Promise<ExternalServiceResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageName };
-        const result = await this._client.invokeCapability<ExternalServiceResourceHandle>(
-            'Aspire.Hosting/withRemoteImageName',
-            rpcArgs
-        );
-        return new ExternalServiceResource(result, this._client);
-    }
-
-    /** Sets the remote image name for publishing */
-    withRemoteImageName(remoteImageName: string): ExternalServiceResourcePromise {
-        return new ExternalServiceResourcePromise(this._withRemoteImageNameInternal(remoteImageName));
-    }
-
-    /** @internal */
-    private async _withRemoteImageTagInternal(remoteImageTag: string): Promise<ExternalServiceResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageTag };
-        const result = await this._client.invokeCapability<ExternalServiceResourceHandle>(
-            'Aspire.Hosting/withRemoteImageTag',
-            rpcArgs
-        );
-        return new ExternalServiceResource(result, this._client);
-    }
-
-    /** Sets the remote image tag for publishing */
-    withRemoteImageTag(remoteImageTag: string): ExternalServiceResourcePromise {
-        return new ExternalServiceResourcePromise(this._withRemoteImageTagInternal(remoteImageTag));
-    }
-
-    /** @internal */
     private async _withPipelineStepFactoryInternal(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, dependsOn?: string[], requiredBy?: string[], tags?: string[], description?: string): Promise<ExternalServiceResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as PipelineStepContextHandle;
@@ -13280,16 +13116,6 @@ export class ExternalServiceResourcePromise implements PromiseLike<ExternalServi
     /** Excludes the resource from MCP server exposure */
     excludeFromMcp(): ExternalServiceResourcePromise {
         return new ExternalServiceResourcePromise(this._promise.then(obj => obj.excludeFromMcp()));
-    }
-
-    /** Sets the remote image name for publishing */
-    withRemoteImageName(remoteImageName: string): ExternalServiceResourcePromise {
-        return new ExternalServiceResourcePromise(this._promise.then(obj => obj.withRemoteImageName(remoteImageName)));
-    }
-
-    /** Sets the remote image tag for publishing */
-    withRemoteImageTag(remoteImageTag: string): ExternalServiceResourcePromise {
-        return new ExternalServiceResourcePromise(this._promise.then(obj => obj.withRemoteImageTag(remoteImageTag)));
     }
 
     /** Adds a pipeline step to the resource */
@@ -16824,36 +16650,6 @@ export class ParameterResource extends ResourceBuilderBase<ParameterResourceHand
     }
 
     /** @internal */
-    private async _withRemoteImageNameInternal(remoteImageName: string): Promise<ParameterResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageName };
-        const result = await this._client.invokeCapability<ParameterResourceHandle>(
-            'Aspire.Hosting/withRemoteImageName',
-            rpcArgs
-        );
-        return new ParameterResource(result, this._client);
-    }
-
-    /** Sets the remote image name for publishing */
-    withRemoteImageName(remoteImageName: string): ParameterResourcePromise {
-        return new ParameterResourcePromise(this._withRemoteImageNameInternal(remoteImageName));
-    }
-
-    /** @internal */
-    private async _withRemoteImageTagInternal(remoteImageTag: string): Promise<ParameterResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageTag };
-        const result = await this._client.invokeCapability<ParameterResourceHandle>(
-            'Aspire.Hosting/withRemoteImageTag',
-            rpcArgs
-        );
-        return new ParameterResource(result, this._client);
-    }
-
-    /** Sets the remote image tag for publishing */
-    withRemoteImageTag(remoteImageTag: string): ParameterResourcePromise {
-        return new ParameterResourcePromise(this._withRemoteImageTagInternal(remoteImageTag));
-    }
-
-    /** @internal */
     private async _withPipelineStepFactoryInternal(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, dependsOn?: string[], requiredBy?: string[], tags?: string[], description?: string): Promise<ParameterResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as PipelineStepContextHandle;
@@ -17030,16 +16826,6 @@ export class ParameterResourcePromise implements PromiseLike<ParameterResource> 
     /** Excludes the resource from MCP server exposure */
     excludeFromMcp(): ParameterResourcePromise {
         return new ParameterResourcePromise(this._promise.then(obj => obj.excludeFromMcp()));
-    }
-
-    /** Sets the remote image name for publishing */
-    withRemoteImageName(remoteImageName: string): ParameterResourcePromise {
-        return new ParameterResourcePromise(this._promise.then(obj => obj.withRemoteImageName(remoteImageName)));
-    }
-
-    /** Sets the remote image tag for publishing */
-    withRemoteImageTag(remoteImageTag: string): ParameterResourcePromise {
-        return new ParameterResourcePromise(this._promise.then(obj => obj.withRemoteImageTag(remoteImageTag)));
     }
 
     /** Adds a pipeline step to the resource */
@@ -20972,36 +20758,6 @@ export class PostgresDatabaseResource extends ResourceBuilderBase<PostgresDataba
     }
 
     /** @internal */
-    private async _withRemoteImageNameInternal(remoteImageName: string): Promise<PostgresDatabaseResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageName };
-        const result = await this._client.invokeCapability<PostgresDatabaseResourceHandle>(
-            'Aspire.Hosting/withRemoteImageName',
-            rpcArgs
-        );
-        return new PostgresDatabaseResource(result, this._client);
-    }
-
-    /** Sets the remote image name for publishing */
-    withRemoteImageName(remoteImageName: string): PostgresDatabaseResourcePromise {
-        return new PostgresDatabaseResourcePromise(this._withRemoteImageNameInternal(remoteImageName));
-    }
-
-    /** @internal */
-    private async _withRemoteImageTagInternal(remoteImageTag: string): Promise<PostgresDatabaseResource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageTag };
-        const result = await this._client.invokeCapability<PostgresDatabaseResourceHandle>(
-            'Aspire.Hosting/withRemoteImageTag',
-            rpcArgs
-        );
-        return new PostgresDatabaseResource(result, this._client);
-    }
-
-    /** Sets the remote image tag for publishing */
-    withRemoteImageTag(remoteImageTag: string): PostgresDatabaseResourcePromise {
-        return new PostgresDatabaseResourcePromise(this._withRemoteImageTagInternal(remoteImageTag));
-    }
-
-    /** @internal */
     private async _withPipelineStepFactoryInternal(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, dependsOn?: string[], requiredBy?: string[], tags?: string[], description?: string): Promise<PostgresDatabaseResource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as PipelineStepContextHandle;
@@ -21222,16 +20978,6 @@ export class PostgresDatabaseResourcePromise implements PromiseLike<PostgresData
     /** Excludes the resource from MCP server exposure */
     excludeFromMcp(): PostgresDatabaseResourcePromise {
         return new PostgresDatabaseResourcePromise(this._promise.then(obj => obj.excludeFromMcp()));
-    }
-
-    /** Sets the remote image name for publishing */
-    withRemoteImageName(remoteImageName: string): PostgresDatabaseResourcePromise {
-        return new PostgresDatabaseResourcePromise(this._promise.then(obj => obj.withRemoteImageName(remoteImageName)));
-    }
-
-    /** Sets the remote image tag for publishing */
-    withRemoteImageTag(remoteImageTag: string): PostgresDatabaseResourcePromise {
-        return new PostgresDatabaseResourcePromise(this._promise.then(obj => obj.withRemoteImageTag(remoteImageTag)));
     }
 
     /** Adds a pipeline step to the resource */
@@ -30152,12 +29898,6 @@ export class RedisResource extends ResourceBuilderBase<RedisResourceHandle> {
                 { context: this._handle }
             );
         },
-        set: async (value: boolean): Promise<void> => {
-            await this._client.invokeCapability<void>(
-                'Aspire.Hosting.ApplicationModel/RedisResource.setTlsEnabled',
-                { context: this._handle, value }
-            );
-        }
     };
 
     /** Gets the ConnectionStringExpression property */
@@ -33890,6 +33630,36 @@ export class ComputeResource extends ResourceBuilderBase<IComputeResourceHandle>
     }
 
     /** @internal */
+    private async _withRemoteImageNameInternal(remoteImageName: string): Promise<ComputeResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageName };
+        const result = await this._client.invokeCapability<IComputeResourceHandle>(
+            'Aspire.Hosting/withRemoteImageName',
+            rpcArgs
+        );
+        return new ComputeResource(result, this._client);
+    }
+
+    /** Sets the remote image name for publishing */
+    withRemoteImageName(remoteImageName: string): ComputeResourcePromise {
+        return new ComputeResourcePromise(this._withRemoteImageNameInternal(remoteImageName));
+    }
+
+    /** @internal */
+    private async _withRemoteImageTagInternal(remoteImageTag: string): Promise<ComputeResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageTag };
+        const result = await this._client.invokeCapability<IComputeResourceHandle>(
+            'Aspire.Hosting/withRemoteImageTag',
+            rpcArgs
+        );
+        return new ComputeResource(result, this._client);
+    }
+
+    /** Sets the remote image tag for publishing */
+    withRemoteImageTag(remoteImageTag: string): ComputeResourcePromise {
+        return new ComputeResourcePromise(this._withRemoteImageTagInternal(remoteImageTag));
+    }
+
+    /** @internal */
     private async _publishAsDockerComposeServiceInternal(configure: (arg1: DockerComposeServiceResource, arg2: Service) => Promise<void>): Promise<ComputeResource> {
         const configureId = registerCallback(async (argsData: unknown) => {
             const args = argsData as { p0: unknown, p1: unknown };
@@ -33927,6 +33697,16 @@ export class ComputeResourcePromise implements PromiseLike<ComputeResource> {
         onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
     ): PromiseLike<TResult1 | TResult2> {
         return this._promise.then(onfulfilled, onrejected);
+    }
+
+    /** Sets the remote image name for publishing */
+    withRemoteImageName(remoteImageName: string): ComputeResourcePromise {
+        return new ComputeResourcePromise(this._promise.then(obj => obj.withRemoteImageName(remoteImageName)));
+    }
+
+    /** Sets the remote image tag for publishing */
+    withRemoteImageTag(remoteImageTag: string): ComputeResourcePromise {
+        return new ComputeResourcePromise(this._promise.then(obj => obj.withRemoteImageTag(remoteImageTag)));
     }
 
     /** Publishes the resource as a Docker Compose service with custom service configuration */
@@ -34267,36 +34047,6 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    private async _withRemoteImageNameInternal(remoteImageName: string): Promise<Resource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageName };
-        const result = await this._client.invokeCapability<IResourceHandle>(
-            'Aspire.Hosting/withRemoteImageName',
-            rpcArgs
-        );
-        return new Resource(result, this._client);
-    }
-
-    /** Sets the remote image name for publishing */
-    withRemoteImageName(remoteImageName: string): ResourcePromise {
-        return new ResourcePromise(this._withRemoteImageNameInternal(remoteImageName));
-    }
-
-    /** @internal */
-    private async _withRemoteImageTagInternal(remoteImageTag: string): Promise<Resource> {
-        const rpcArgs: Record<string, unknown> = { builder: this._handle, remoteImageTag };
-        const result = await this._client.invokeCapability<IResourceHandle>(
-            'Aspire.Hosting/withRemoteImageTag',
-            rpcArgs
-        );
-        return new Resource(result, this._client);
-    }
-
-    /** Sets the remote image tag for publishing */
-    withRemoteImageTag(remoteImageTag: string): ResourcePromise {
-        return new ResourcePromise(this._withRemoteImageTagInternal(remoteImageTag));
-    }
-
-    /** @internal */
     private async _withPipelineStepFactoryInternal(stepName: string, callback: (arg: PipelineStepContext) => Promise<void>, dependsOn?: string[], requiredBy?: string[], tags?: string[], description?: string): Promise<Resource> {
         const callbackId = registerCallback(async (argData: unknown) => {
             const argHandle = wrapIfHandle(argData) as PipelineStepContextHandle;
@@ -34468,16 +34218,6 @@ export class ResourcePromise implements PromiseLike<Resource> {
     /** Excludes the resource from MCP server exposure */
     excludeFromMcp(): ResourcePromise {
         return new ResourcePromise(this._promise.then(obj => obj.excludeFromMcp()));
-    }
-
-    /** Sets the remote image name for publishing */
-    withRemoteImageName(remoteImageName: string): ResourcePromise {
-        return new ResourcePromise(this._promise.then(obj => obj.withRemoteImageName(remoteImageName)));
-    }
-
-    /** Sets the remote image tag for publishing */
-    withRemoteImageTag(remoteImageTag: string): ResourcePromise {
-        return new ResourcePromise(this._promise.then(obj => obj.withRemoteImageTag(remoteImageTag)));
     }
 
     /** Adds a pipeline step to the resource */
@@ -35668,7 +35408,7 @@ export async function createBuilder(options?: CreateBuilderOptions): Promise<Dis
 }
 
 // Re-export commonly used types
-export { Handle, CapabilityError, registerCallback } from './transport.js';
+export { Handle, AppHostUsageError, CapabilityError, registerCallback } from './transport.js';
 export { refExpr, ReferenceExpression } from './base.js';
 
 // ============================================================================
@@ -35682,7 +35422,9 @@ export { refExpr, ReferenceExpression } from './base.js';
 process.on('unhandledRejection', (reason: unknown) => {
     const error = reason instanceof Error ? reason : new Error(String(reason));
 
-    if (reason instanceof CapabilityError) {
+    if (reason instanceof AppHostUsageError) {
+        console.error(`\n❌ AppHost Error: ${error.message}`);
+    } else if (reason instanceof CapabilityError) {
         console.error(`\n❌ Capability Error: ${error.message}`);
         console.error(`   Code: ${(reason as CapabilityError).code}`);
         if ((reason as CapabilityError).capability) {
@@ -35699,8 +35441,12 @@ process.on('unhandledRejection', (reason: unknown) => {
 });
 
 process.on('uncaughtException', (error: Error) => {
-    console.error(`\n❌ Uncaught Exception: ${error.message}`);
-    if (error.stack) {
+    if (error instanceof AppHostUsageError) {
+        console.error(`\n❌ AppHost Error: ${error.message}`);
+    } else {
+        console.error(`\n❌ Uncaught Exception: ${error.message}`);
+    }
+    if (!(error instanceof AppHostUsageError) && error.stack) {
         console.error(error.stack);
     }
     process.exit(1);

--- a/playground/TypeScriptAppHost/.modules/base.ts
+++ b/playground/TypeScriptAppHost/.modules/base.ts
@@ -170,7 +170,7 @@ export class ReferenceExpression {
             const rpcArgs: Record<string, unknown> = { context: this._handle };
             if (cancellationTokenId !== undefined) rpcArgs.cancellationToken = cancellationTokenId;
             return await this._client.invokeCapability<string | null>(
-                'Aspire.Hosting.ApplicationModel/getValueAsync',
+                'Aspire.Hosting.ApplicationModel/getValue',
                 rpcArgs
             );
         } finally {

--- a/playground/TypeScriptAppHost/.modules/base.ts
+++ b/playground/TypeScriptAppHost/.modules/base.ts
@@ -1,5 +1,5 @@
 // aspire.ts - Core Aspire types: base classes, ReferenceExpression
-import { Handle, AspireClient, MarshalledHandle } from './transport.js';
+import { Handle, AspireClient, MarshalledHandle, registerCancellation, registerHandleWrapper, unregisterCancellation } from './transport.js';
 
 // Re-export transport types for convenience
 export { Handle, AspireClient, CapabilityError, registerCallback, unregisterCallback, registerCancellation, unregisterCancellation } from './transport.js';
@@ -43,20 +43,44 @@ export class ReferenceExpression {
     private readonly _format?: string;
     private readonly _valueProviders?: unknown[];
 
+    // Conditional mode fields
+    private readonly _condition?: unknown;
+    private readonly _whenTrue?: ReferenceExpression;
+    private readonly _whenFalse?: ReferenceExpression;
+    private readonly _matchValue?: string;
+
     // Handle mode fields (when wrapping a server-returned handle)
     private readonly _handle?: Handle;
     private readonly _client?: AspireClient;
 
     constructor(format: string, valueProviders: unknown[]);
     constructor(handle: Handle, client: AspireClient);
-    constructor(handleOrFormat: Handle | string, clientOrValueProviders: AspireClient | unknown[]) {
-        if (typeof handleOrFormat === 'string') {
-            this._format = handleOrFormat;
-            this._valueProviders = clientOrValueProviders as unknown[];
+    constructor(condition: unknown, matchValue: string, whenTrue: ReferenceExpression, whenFalse: ReferenceExpression);
+    constructor(
+        handleOrFormatOrCondition: Handle | string | unknown,
+        clientOrValueProvidersOrMatchValue: AspireClient | unknown[] | string,
+        whenTrueOrWhenFalse?: ReferenceExpression,
+        whenFalse?: ReferenceExpression
+    ) {
+        if (typeof handleOrFormatOrCondition === 'string') {
+            this._format = handleOrFormatOrCondition;
+            this._valueProviders = clientOrValueProvidersOrMatchValue as unknown[];
+        } else if (handleOrFormatOrCondition instanceof Handle) {
+            this._handle = handleOrFormatOrCondition;
+            this._client = clientOrValueProvidersOrMatchValue as AspireClient;
         } else {
-            this._handle = handleOrFormat;
-            this._client = clientOrValueProviders as AspireClient;
+            this._condition = handleOrFormatOrCondition;
+            this._matchValue = (clientOrValueProvidersOrMatchValue as string) ?? 'True';
+            this._whenTrue = whenTrueOrWhenFalse;
+            this._whenFalse = whenFalse;
         }
+    }
+
+    /**
+     * Gets whether this reference expression is conditional.
+     */
+    get isConditional(): boolean {
+        return this._condition !== undefined;
     }
 
     /**
@@ -83,13 +107,43 @@ export class ReferenceExpression {
     }
 
     /**
+     * Creates a conditional reference expression from its constituent parts.
+     *
+     * @param condition - A value provider whose result is compared to matchValue
+     * @param whenTrue - The expression to use when the condition matches
+     * @param whenFalse - The expression to use when the condition does not match
+     * @param matchValue - The value to compare the condition against (defaults to "True")
+     * @returns A ReferenceExpression instance in conditional mode
+     */
+    static createConditional(
+        condition: unknown,
+        matchValue: string,
+        whenTrue: ReferenceExpression,
+        whenFalse: ReferenceExpression
+    ): ReferenceExpression {
+        return new ReferenceExpression(condition, matchValue, whenTrue, whenFalse);
+    }
+
+    /**
      * Serializes the reference expression for JSON-RPC transport.
-     * In template-literal mode, uses the $expr format.
+     * In expression mode, uses the $expr format with format + valueProviders.
+     * In conditional mode, uses the $expr format with condition + whenTrue + whenFalse.
      * In handle mode, delegates to the handle's serialization.
      */
-    toJSON(): { $expr: { format: string; valueProviders?: unknown[] } } | MarshalledHandle {
+    toJSON(): { $expr: { format: string; valueProviders?: unknown[] } | { condition: unknown; whenTrue: unknown; whenFalse: unknown; matchValue: string } } | MarshalledHandle {
         if (this._handle) {
             return this._handle.toJSON();
+        }
+
+        if (this.isConditional) {
+            return {
+                $expr: {
+                    condition: this._condition instanceof Handle ? this._condition.toJSON() : this._condition,
+                    whenTrue: this._whenTrue!.toJSON(),
+                    whenFalse: this._whenFalse!.toJSON(),
+                    matchValue: this._matchValue!
+                }
+            };
         }
 
         return {
@@ -101,15 +155,46 @@ export class ReferenceExpression {
     }
 
     /**
+     * Resolves the expression to its string value on the server.
+     * Only available on server-returned ReferenceExpression instances (handle mode).
+     *
+     * @param cancellationToken - Optional AbortSignal for cancellation support
+     * @returns The resolved string value, or null if the expression resolves to null
+     */
+    async getValue(cancellationToken?: AbortSignal): Promise<string | null> {
+        if (!this._handle || !this._client) {
+            throw new Error('getValue is only available on server-returned ReferenceExpression instances');
+        }
+        const cancellationTokenId = registerCancellation(cancellationToken);
+        try {
+            const rpcArgs: Record<string, unknown> = { context: this._handle };
+            if (cancellationTokenId !== undefined) rpcArgs.cancellationToken = cancellationTokenId;
+            return await this._client.invokeCapability<string | null>(
+                'Aspire.Hosting.ApplicationModel/getValueAsync',
+                rpcArgs
+            );
+        } finally {
+            unregisterCancellation(cancellationTokenId);
+        }
+    }
+
+    /**
      * String representation for debugging.
      */
     toString(): string {
         if (this._handle) {
             return `ReferenceExpression(handle)`;
         }
+        if (this.isConditional) {
+            return `ReferenceExpression(conditional)`;
+        }
         return `ReferenceExpression(${this._format})`;
     }
 }
+
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ReferenceExpression', (handle, client) =>
+    new ReferenceExpression(handle, client)
+);
 
 /**
  * Extracts a value for use in reference expressions.

--- a/playground/TypeScriptAppHost/.modules/transport.ts
+++ b/playground/TypeScriptAppHost/.modules/transport.ts
@@ -213,6 +213,75 @@ export class CapabilityError extends Error {
     }
 }
 
+/**
+ * Error thrown when the AppHost script uses the generated SDK incorrectly.
+ */
+export class AppHostUsageError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'AppHostUsageError';
+    }
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+    return (
+        value !== null &&
+        (typeof value === 'object' || typeof value === 'function') &&
+        'then' in value &&
+        typeof (value as { then?: unknown }).then === 'function'
+    );
+}
+
+function validateCapabilityArgs(
+    capabilityId: string,
+    args?: Record<string, unknown>
+): void {
+    if (!args) {
+        return;
+    }
+
+    const seen = new Set<object>();
+
+    const validateValue = (value: unknown, path: string): void => {
+        if (value === null || value === undefined) {
+            return;
+        }
+
+        if (isPromiseLike(value)) {
+            throw new AppHostUsageError(
+                `Argument '${path}' passed to capability '${capabilityId}' is a Promise-like value. ` +
+                `This usually means an async builder call was not awaited. ` +
+                `Did you forget 'await' on a call like builder.addPostgres(...) or resource.addDatabase(...)?`
+            );
+        }
+
+        if (typeof value !== 'object') {
+            return;
+        }
+
+        if (seen.has(value)) {
+            return;
+        }
+
+        seen.add(value);
+
+        if (Array.isArray(value)) {
+            for (let i = 0; i < value.length; i++) {
+                validateValue(value[i], `${path}[${i}]`);
+            }
+            return;
+        }
+
+        for (const [key, nestedValue] of Object.entries(value)) {
+            validateValue(nestedValue, `${path}.${key}`);
+        }
+    };
+
+    for (const [key, value] of Object.entries(args)) {
+        validateValue(value, key);
+    }
+}
+
 // ============================================================================
 // Callback Registry
 // ============================================================================
@@ -532,6 +601,8 @@ export class AspireClient {
         if (!this.connection) {
             throw new Error('Not connected to AppHost');
         }
+
+        validateCapabilityArgs(capabilityId, args);
 
         // Ref counting: The vscode-jsonrpc socket keeps Node's event loop alive.
         // We ref() during RPC calls so the process doesn't exit mid-call, and

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
@@ -2490,6 +2490,13 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
                 continue;
             }
 
+            // ReferenceExpression is implemented manually in base.ts, including its handle wrapper
+            // registration, so it must not also generate a duplicate wrapper class in aspire.ts.
+            if (targetTypeId == AtsConstants.ReferenceExpressionTypeId)
+            {
+                continue;
+            }
+
             // Use expanded types if available, otherwise fall back to the original target
             var expandedTypes = cap.ExpandedTargetTypes;
             if (expandedTypes is { Count: > 0 })

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/base.ts
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/base.ts
@@ -1,5 +1,5 @@
 // aspire.ts - Core Aspire types: base classes, ReferenceExpression
-import { Handle, AspireClient, MarshalledHandle } from './transport.js';
+import { Handle, AspireClient, MarshalledHandle, registerCancellation, registerHandleWrapper, unregisterCancellation } from './transport.js';
 
 // Re-export transport types for convenience
 export { Handle, AspireClient, CapabilityError, registerCallback, unregisterCallback, registerCancellation, unregisterCancellation } from './transport.js';
@@ -155,6 +155,30 @@ export class ReferenceExpression {
     }
 
     /**
+     * Resolves the expression to its string value on the server.
+     * Only available on server-returned ReferenceExpression instances (handle mode).
+     *
+     * @param cancellationToken - Optional AbortSignal for cancellation support
+     * @returns The resolved string value, or null if the expression resolves to null
+     */
+    async getValue(cancellationToken?: AbortSignal): Promise<string | null> {
+        if (!this._handle || !this._client) {
+            throw new Error('getValue is only available on server-returned ReferenceExpression instances');
+        }
+        const cancellationTokenId = registerCancellation(cancellationToken);
+        try {
+            const rpcArgs: Record<string, unknown> = { context: this._handle };
+            if (cancellationTokenId !== undefined) rpcArgs.cancellationToken = cancellationTokenId;
+            return await this._client.invokeCapability<string | null>(
+                'Aspire.Hosting.ApplicationModel/getValueAsync',
+                rpcArgs
+            );
+        } finally {
+            unregisterCancellation(cancellationTokenId);
+        }
+    }
+
+    /**
      * String representation for debugging.
      */
     toString(): string {
@@ -167,6 +191,10 @@ export class ReferenceExpression {
         return `ReferenceExpression(${this._format})`;
     }
 }
+
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ReferenceExpression', (handle, client) =>
+    new ReferenceExpression(handle, client)
+);
 
 /**
  * Extracts a value for use in reference expressions.

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/base.ts
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/base.ts
@@ -170,7 +170,7 @@ export class ReferenceExpression {
             const rpcArgs: Record<string, unknown> = { context: this._handle };
             if (cancellationTokenId !== undefined) rpcArgs.cancellationToken = cancellationTokenId;
             return await this._client.invokeCapability<string | null>(
-                'Aspire.Hosting.ApplicationModel/getValueAsync',
+                'Aspire.Hosting.ApplicationModel/getValue',
                 rpcArgs
             );
         } finally {

--- a/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
@@ -459,12 +459,22 @@ internal sealed class CapabilityDispatcher
 
     private static async Task<object?> InvokeMethodAsync(MethodInfo method, object? target, object?[] methodArgs, bool runSyncOnBackgroundThread)
     {
-        if (runSyncOnBackgroundThread && !typeof(Task).IsAssignableFrom(method.ReturnType))
+        if (runSyncOnBackgroundThread && !IsAsyncReturnType(method.ReturnType))
         {
             return await Task.Run(() => InvokeMethodCore(method, target, methodArgs)).ConfigureAwait(false);
         }
 
         return InvokeMethodCore(method, target, methodArgs);
+    }
+
+    private static bool IsAsyncReturnType(Type returnType)
+    {
+        if (typeof(Task).IsAssignableFrom(returnType) || returnType == typeof(ValueTask))
+        {
+            return true;
+        }
+
+        return returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(ValueTask<>);
     }
 
     private static async Task<object?> UnwrapAsyncResultAsync(object? result, Type returnType)

--- a/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
@@ -309,29 +309,7 @@ internal sealed class CapabilityDispatcher
             object? result;
             result = await InvokeMethodAsync(methodToInvoke, invokeTarget, methodArgs, capability.RunSyncOnBackgroundThread).ConfigureAwait(false);
 
-            // Handle async methods - await instead of blocking
-            if (result is Task task)
-            {
-                try
-                {
-                    await task.ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    throw new InvalidOperationException(ex.Message, ex);
-                }
-
-                var taskType = task.GetType();
-                if (taskType.IsGenericType)
-                {
-                    var resultProperty = taskType.GetProperty("Result");
-                    result = resultProperty?.GetValue(task);
-                }
-                else
-                {
-                    result = null;
-                }
-            }
+            result = await UnwrapAsyncResultAsync(result, methodToInvoke.ReturnType).ConfigureAwait(false);
 
             return _marshaller.MarshalToJson(result, capability.ReturnType);
         };
@@ -393,31 +371,7 @@ internal sealed class CapabilityDispatcher
             object? result;
             result = await InvokeMethodAsync(methodToInvoke, target: null, methodArgs, capability.RunSyncOnBackgroundThread).ConfigureAwait(false);
 
-            // Handle async methods - await instead of blocking
-            if (result is Task task)
-            {
-                try
-                {
-                    await task.ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    // Rethrow the exception - it will be caught by the outer handler
-                    // and converted to a CapabilityException
-                    throw new InvalidOperationException(ex.Message, ex);
-                }
-
-                var taskType = task.GetType();
-                if (taskType.IsGenericType)
-                {
-                    var resultProperty = taskType.GetProperty("Result");
-                    result = resultProperty?.GetValue(task);
-                }
-                else
-                {
-                    result = null;
-                }
-            }
+            result = await UnwrapAsyncResultAsync(result, methodToInvoke.ReturnType).ConfigureAwait(false);
 
             return _marshaller.MarshalToJson(result, capability.ReturnType);
         };
@@ -511,6 +465,53 @@ internal sealed class CapabilityDispatcher
         }
 
         return InvokeMethodCore(method, target, methodArgs);
+    }
+
+    private static async Task<object?> UnwrapAsyncResultAsync(object? result, Type returnType)
+    {
+        try
+        {
+            if (result is Task task)
+            {
+                await task.ConfigureAwait(false);
+                return GetAsyncResultValue(task);
+            }
+
+            if (returnType == typeof(ValueTask) && result is ValueTask valueTask)
+            {
+                await valueTask.ConfigureAwait(false);
+                return null;
+            }
+
+            if (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(ValueTask<>))
+            {
+                var asTask = returnType.GetMethod(nameof(ValueTask<int>.AsTask), BindingFlags.Instance | BindingFlags.Public)
+                    ?? throw new InvalidOperationException($"Unable to await ValueTask result for return type '{returnType}'.");
+                var boxedTask = asTask.Invoke(result, null) as Task
+                    ?? throw new InvalidOperationException($"Unable to convert ValueTask result for return type '{returnType}' to Task.");
+
+                await boxedTask.ConfigureAwait(false);
+                return GetAsyncResultValue(boxedTask);
+            }
+
+            return result;
+        }
+        catch (Exception ex) when (ex is not InvalidOperationException)
+        {
+            throw new InvalidOperationException(ex.Message, ex);
+        }
+    }
+
+    private static object? GetAsyncResultValue(Task task)
+    {
+        var taskType = task.GetType();
+        if (!taskType.IsGenericType)
+        {
+            return null;
+        }
+
+        var resultProperty = taskType.GetProperty("Result");
+        return resultProperty?.GetValue(task);
     }
 
     private static object? InvokeMethodCore(MethodInfo method, object? target, object?[] methodArgs)

--- a/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
@@ -221,7 +221,7 @@ public class ReferenceExpression : IManifestExpressionProvider, IValueProvider, 
     /// Gets the value of the expression. The final string value after evaluating the format string and its parameters.
     /// </summary>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
-    [AspireExport("getValueAsync", Description = "Gets the resolved string value of the reference expression asynchronously")]
+    [AspireExport("getValue", Description = "Gets the resolved string value of the reference expression asynchronously")]
     public ValueTask<string?> GetValueAsync(CancellationToken cancellationToken)
     {
         return this.GetValueAsync(new(), cancellationToken);

--- a/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
@@ -221,6 +221,7 @@ public class ReferenceExpression : IManifestExpressionProvider, IValueProvider, 
     /// Gets the value of the expression. The final string value after evaluating the format string and its parameters.
     /// </summary>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
+    [AspireExport("getValueAsync", Description = "Gets the resolved string value of the reference expression asynchronously")]
     public ValueTask<string?> GetValueAsync(CancellationToken cancellationToken)
     {
         return this.GetValueAsync(new(), cancellationToken);

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -4953,7 +4953,14 @@ class ReferenceExpression(HandleWrapperBase):
     def __init__(self, handle: Handle, client: AspireClient):
         super().__init__(handle, client)
 
-    pass
+    def get_value(self, cancellation_token: CancellationToken) -> str:
+        """Gets the resolved string value of the reference expression asynchronously"""
+        args: Dict[str, Any] = { "context": serialize_value(self._handle) }
+        cancellation_token_id = register_cancellation(cancellation_token, self._client) if cancellation_token is not None else None
+        if cancellation_token_id is not None:
+            args["cancellationToken"] = cancellation_token_id
+        return self._client.invoke_capability("Aspire.Hosting.ApplicationModel/getValue", args)
+
 
 class ReferenceExpressionBuilder(HandleWrapperBase):
     def __init__(self, handle: Handle, client: AspireClient):

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
@@ -51,6 +51,17 @@ public class AtsTypeScriptCodeGeneratorTests
     }
 
     [Fact]
+    public void GenerateDistributedApplication_WithHostingTypes_KeepsReferenceExpressionInBaseTs()
+    {
+        var atsContext = CreateContextFromBothAssemblies();
+
+        var files = _generator.GenerateDistributedApplication(atsContext);
+
+        Assert.DoesNotContain("export class ReferenceExpression {", files["aspire.ts"]);
+        Assert.Contains("registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ReferenceExpression'", files["base.ts"]);
+    }
+
+    [Fact]
     public void GenerateDistributedApplication_WithTestTypes_IncludesCapabilities()
     {
         // Arrange
@@ -962,6 +973,19 @@ public class AtsTypeScriptCodeGeneratorTests
         var getValueAsync = capabilities.First(c =>
             c.CapabilityId == "Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestResourceContext.getValueAsync");
 
+        Assert.Equal(AtsCapabilityKind.InstanceMethod, getValueAsync.CapabilityKind);
+    }
+
+    [Fact]
+    public void Scanner_ReferenceExpressionGetValueAsync_IsExported()
+    {
+        var capabilities = ScanCapabilitiesFromHostingAssembly();
+
+        var getValueAsync = capabilities.FirstOrDefault(c =>
+            c.CapabilityId == "Aspire.Hosting.ApplicationModel/getValueAsync" &&
+            c.TargetTypeId == AtsConstants.ReferenceExpressionTypeId);
+
+        Assert.NotNull(getValueAsync);
         Assert.Equal(AtsCapabilityKind.InstanceMethod, getValueAsync.CapabilityKind);
     }
 

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
@@ -982,7 +982,7 @@ public class AtsTypeScriptCodeGeneratorTests
         var capabilities = ScanCapabilitiesFromHostingAssembly();
 
         var getValueAsync = capabilities.FirstOrDefault(c =>
-            c.CapabilityId == "Aspire.Hosting.ApplicationModel/getValueAsync" &&
+            c.CapabilityId == "Aspire.Hosting.ApplicationModel/getValue" &&
             c.TargetTypeId == AtsConstants.ReferenceExpressionTypeId);
 
         Assert.NotNull(getValueAsync);

--- a/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
@@ -711,6 +711,31 @@ public class CapabilityDispatcherTests
     }
 
     [Fact]
+    public void Invoke_ValueTaskCapabilityWithBackgroundThreadOptIn_RunsInline()
+    {
+        var dispatcher = CreateDispatcher(typeof(TestCapabilitiesWithBackgroundThreadDispatch).Assembly);
+        var callerThreadId = Environment.CurrentManagedThreadId;
+
+        var result = dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/valueTaskBackgroundThreadProbe", null);
+
+        Assert.NotNull(result);
+        Assert.Equal(callerThreadId, result.GetValue<int>());
+    }
+
+    [Fact]
+    public void Invoke_NonGenericValueTaskCapabilityWithBackgroundThreadOptIn_RunsInline()
+    {
+        var dispatcher = CreateDispatcher(typeof(TestCapabilitiesWithBackgroundThreadDispatch).Assembly);
+        var callerThreadId = Environment.CurrentManagedThreadId;
+
+        TestCapabilitiesWithBackgroundThreadDispatch.ResetLastObservedThreadId();
+
+        dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/nonGenericValueTaskBackgroundThreadProbe", null);
+
+        Assert.Equal(callerThreadId, TestCapabilitiesWithBackgroundThreadDispatch.LastObservedThreadId);
+    }
+
+    [Fact]
     public void Invoke_MethodWithoutCallbackFactory_ThrowsForCallbackParameter()
     {
         var handles = new HandleRegistry();
@@ -1538,6 +1563,13 @@ internal static class TestCapabilitiesWithCallback
 
 internal static class TestCapabilitiesWithBackgroundThreadDispatch
 {
+    public static int LastObservedThreadId { get; private set; }
+
+    public static void ResetLastObservedThreadId()
+    {
+        LastObservedThreadId = 0;
+    }
+
     [AspireExport("syncInlineThreadProbe", Description = "Captures the current thread for inline sync invocation")]
     public static int SyncInlineThreadProbe()
     {
@@ -1548,6 +1580,19 @@ internal static class TestCapabilitiesWithBackgroundThreadDispatch
     public static int SyncBackgroundThreadProbe()
     {
         return Environment.CurrentManagedThreadId;
+    }
+
+    [AspireExport("valueTaskBackgroundThreadProbe", Description = "Captures the current thread for ValueTask<T> invocation", RunSyncOnBackgroundThread = true)]
+    public static ValueTask<int> ValueTaskBackgroundThreadProbe()
+    {
+        return ValueTask.FromResult(Environment.CurrentManagedThreadId);
+    }
+
+    [AspireExport("nonGenericValueTaskBackgroundThreadProbe", Description = "Captures the current thread for ValueTask invocation", RunSyncOnBackgroundThread = true)]
+    public static ValueTask NonGenericValueTaskBackgroundThreadProbe()
+    {
+        LastObservedThreadId = Environment.CurrentManagedThreadId;
+        return ValueTask.CompletedTask;
     }
 }
 

--- a/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
@@ -544,6 +544,38 @@ public class CapabilityDispatcherTests
     }
 
     [Fact]
+    public void Invoke_ValueTaskInstanceMethod()
+    {
+        var handles = new HandleRegistry();
+        var dispatcher = new CapabilityDispatcher(handles, CreateTestMarshaller(handles), [typeof(TestTypeWithMethods).Assembly]);
+
+        var context = new TestTypeWithMethods();
+        var handleId = handles.Register(context, "Aspire.Hosting.RemoteHost.Tests/Aspire.Hosting.RemoteHost.Tests.TestTypeWithMethods");
+        var args = new JsonObject
+        {
+            ["context"] = new JsonObject { ["$handle"] = handleId },
+            ["input"] = "value-task"
+        };
+
+        var result = dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/TestTypeWithMethods.processValueTaskAsync", args);
+
+        Assert.NotNull(result);
+        Assert.Equal("VALUE-TASK", result.GetValue<string>());
+    }
+
+    [Fact]
+    public void Invoke_StaticValueTaskMethod()
+    {
+        var dispatcher = CreateDispatcher(typeof(TestCapabilities).Assembly);
+        var args = new JsonObject { ["value"] = "value-task" };
+
+        var result = dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/asyncValueTaskWithResult", args);
+
+        Assert.NotNull(result);
+        Assert.Equal("VALUE-TASK", result.GetValue<string>());
+    }
+
+    [Fact]
     public void Constructor_SkipsNonPublicMethods()
     {
         var dispatcher = CreateDispatcher(typeof(TestTypeWithMethods).Assembly);
@@ -1351,6 +1383,13 @@ internal static class TestCapabilities
         return value.ToUpperInvariant();
     }
 
+    [AspireExport("asyncValueTaskWithResult", Description = "Async method returning ValueTask<T>")]
+    public static async ValueTask<string> AsyncValueTaskWithResult(string value)
+    {
+        await Task.Delay(1);
+        return value.ToUpperInvariant();
+    }
+
     [AspireExport("asyncThrows", Description = "Async method that throws")]
     public static async Task<string> AsyncThrows(string value)
     {
@@ -1433,6 +1472,12 @@ internal sealed class TestTypeWithMethods
     }
 
     public async Task<string> ProcessAsync(string input)
+    {
+        await Task.Delay(1);
+        return input.ToUpperInvariant();
+    }
+
+    public async ValueTask<string> ProcessValueTaskAsync(string input)
     {
         await Task.Delay(1);
         return input.ToUpperInvariant();


### PR DESCRIPTION
Expose `ReferenceExpression` get value and enhance server value resolution

- Implemented `getValue` method to resolve the expression's value on the server, including cancellation support.
- Improved async method handling in `CapabilityDispatcher` to support `ValueTask` / `ValueTask<T>`.
- Registered handle wrapper for `ReferenceExpression` in `base.ts` to avoid duplication in generated SDK.
- Added tests for `ReferenceExpression` and `ValueTask` methods to ensure correct functionality and exports.

Fixes #14772

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
