### PR TITLE
Prevent RID-specific Aspire.Hosting analyzer builds

### DIFF
--- a/playground/Directory.Build.targets
+++ b/playground/Directory.Build.targets
@@ -18,7 +18,8 @@
                       PrivateAssets="all"
                       ReferenceOutputAssembly="false"
                       OutputItemType="Analyzer"
-                      SetTargetFramework="TargetFramework=netstandard2.0" />
+                      SetTargetFramework="TargetFramework=netstandard2.0"
+                      GlobalPropertiesToRemove="RuntimeIdentifier;PlatformTarget;SelfContained" />
   </ItemGroup>
 
   <!-- Import only when in-repo. For the out-of-repo case a parent Directory.Build.targets does the import -->

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -23,7 +23,8 @@
                     PrivateAssets="all"
                     ReferenceOutputAssembly="false"
                     OutputItemType="Analyzer"
-                    SetTargetFramework="TargetFramework=netstandard2.0" />
+                    SetTargetFramework="TargetFramework=netstandard2.0"
+                    GlobalPropertiesToRemove="RuntimeIdentifier;PlatformTarget;SelfContained" />
   </ItemGroup>
   <!-- Used by Aspire.Workload.Testing.targets -->
   <Target Name="GetPackageName" Returns="@(PackageName)">


### PR DESCRIPTION
## Description

This change prevents `RuntimeIdentifier`-specific properties from flowing into `Aspire.Hosting.Analyzers` when it is referenced as a Roslyn analyzer from in-repo Aspire hosting projects.

On arm64 macOS builds targeting `osx-x64`, that property flow caused the analyzer to be built as an x64-specific assembly under `artifacts/bin/Aspire.Hosting.Analyzers/Release/netstandard2.0/osx-x64/`, which Roslyn then failed to load with `CS8034` due to an architecture mismatch.

The fix removes `RuntimeIdentifier`, `PlatformTarget`, and `SelfContained` from the analyzer `ProjectReference` metadata in the two in-repo analyzer injection points so the analyzer remains architecture-neutral while the consuming project still builds for the requested RID.

Fixes # (issue)

Validation:
- `./.dotnet/dotnet publish src/Aspire.Managed/Aspire.Managed.csproj -c Release -r osx-x64 --self-contained /p:GenerateDocumentationFile=false /p:EnforceCodeStyleInBuild=false -v:minimal`
- `./.dotnet/dotnet build src/Aspire.Hosting.RemoteHost/Aspire.Hosting.RemoteHost.csproj -c Release -r osx-x64 /p:GenerateDocumentationFile=false /p:EnforceCodeStyleInBuild=false -v:diag`
- Confirmed `Aspire.Hosting.Analyzers` now builds to `artifacts/bin/Aspire.Hosting.Analyzers/Release/netstandard2.0/Aspire.Hosting.Analyzers.dll` instead of an RID-specific output when referenced as an analyzer.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
