### PR TITLE
Fix deployment E2E tests: replace blind timer with explicit WaitUntil for aspire init prompts

### DIFF
--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
@@ -66,9 +66,6 @@ public sealed class AcaCompactNamingDeploymentTests(ITestOutputHelper output)
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            var waitingForInitComplete = new CellPatternSearcher()
-                .Find("Aspire initialization complete");
-
             var waitingForVersionSelectionPrompt = new CellPatternSearcher()
                 .Find("(based on NuGet.config)");
 
@@ -91,13 +88,7 @@ public sealed class AcaCompactNamingDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost
             output.WriteLine("Step 3: Creating single-file AppHost...");
-            sequenceBuilder.Type("aspire init --language csharp")
-                .Enter()
-                .Wait(TimeSpan.FromSeconds(5))
-                .Enter()
-                .WaitUntil(s => waitingForInitComplete.Search(s).Count > 0, TimeSpan.FromMinutes(2))
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
+            sequenceBuilder.RunAspireInit(counter);
 
             // Step 4: Add required packages
             output.WriteLine("Step 4: Adding Azure Container Apps package...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
@@ -88,7 +88,7 @@ public sealed class AcaCompactNamingDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost
             output.WriteLine("Step 3: Creating single-file AppHost...");
-            sequenceBuilder.RunAspireInit(counter);
+            sequenceBuilder.AspireInit(counter);
 
             // Step 4: Add required packages
             output.WriteLine("Step 4: Adding Azure Container Apps package...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaDeploymentErrorOutputTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaDeploymentErrorOutputTests.cs
@@ -69,9 +69,6 @@ public sealed class AcaDeploymentErrorOutputTests(ITestOutputHelper output)
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            var waitingForInitComplete = new CellPatternSearcher()
-                .Find("Aspire initialization complete");
-
             var waitingForVersionSelectionPrompt = new CellPatternSearcher()
                 .Find("(based on NuGet.config)");
 
@@ -94,13 +91,7 @@ public sealed class AcaDeploymentErrorOutputTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost
             output.WriteLine("Step 3: Creating single-file AppHost...");
-            sequenceBuilder.Type("aspire init --language csharp")
-                .Enter()
-                .Wait(TimeSpan.FromSeconds(5))
-                .Enter()
-                .WaitUntil(s => waitingForInitComplete.Search(s).Count > 0, TimeSpan.FromMinutes(2))
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
+            sequenceBuilder.RunAspireInit(counter);
 
             // Step 4: Add Azure Container Apps package
             output.WriteLine("Step 4: Adding Azure Container Apps package...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaDeploymentErrorOutputTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaDeploymentErrorOutputTests.cs
@@ -91,7 +91,7 @@ public sealed class AcaDeploymentErrorOutputTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost
             output.WriteLine("Step 3: Creating single-file AppHost...");
-            sequenceBuilder.RunAspireInit(counter);
+            sequenceBuilder.AspireInit(counter);
 
             // Step 4: Add Azure Container Apps package
             output.WriteLine("Step 4: Adding Azure Container Apps package...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureAppConfigDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureAppConfigDeploymentTests.cs
@@ -63,10 +63,6 @@ public sealed class AzureAppConfigDeploymentTests(ITestOutputHelper output)
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            // Pattern searchers for aspire init
-            var waitingForInitComplete = new CellPatternSearcher()
-                .Find("Aspire initialization complete");
-
             // Pattern searchers for aspire add prompts
             // Integration selection prompt appears when multiple packages match the search term
             var waitingForIntegrationSelectionPrompt = new CellPatternSearcher()
@@ -96,15 +92,7 @@ public sealed class AzureAppConfigDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.Type("aspire init --language csharp")
-                .Enter()
-                // NuGet.config prompt may or may not appear depending on environment.
-                // Wait a moment then press Enter to dismiss if present, then wait for completion.
-                .Wait(TimeSpan.FromSeconds(5))
-                .Enter()  // Dismiss NuGet.config prompt if present (no-op if already auto-accepted)
-                .WaitUntil(s => waitingForInitComplete.Search(s).Count > 0, TimeSpan.FromMinutes(2))
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
+            sequenceBuilder.RunAspireInit(counter);
 
             // Step 4a: Add Aspire.Hosting.Azure.ContainerApps package (for managed identity support)
             // This command triggers TWO prompts in sequence:

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureAppConfigDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureAppConfigDeploymentTests.cs
@@ -92,7 +92,7 @@ public sealed class AzureAppConfigDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.RunAspireInit(counter);
+            sequenceBuilder.AspireInit(counter);
 
             // Step 4a: Add Aspire.Hosting.Azure.ContainerApps package (for managed identity support)
             // This command triggers TWO prompts in sequence:

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureContainerRegistryDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureContainerRegistryDeploymentTests.cs
@@ -63,10 +63,6 @@ public sealed class AzureContainerRegistryDeploymentTests(ITestOutputHelper outp
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            // Pattern searchers for aspire init
-            var waitingForInitComplete = new CellPatternSearcher()
-                .Find("Aspire initialization complete");
-
             // Pattern searchers for aspire add prompts
             var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
                 .Find("(based on NuGet.config)");
@@ -91,15 +87,7 @@ public sealed class AzureContainerRegistryDeploymentTests(ITestOutputHelper outp
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.Type("aspire init --language csharp")
-                .Enter()
-                // NuGet.config prompt may or may not appear depending on environment.
-                // Wait a moment then press Enter to dismiss if present, then wait for completion.
-                .Wait(TimeSpan.FromSeconds(5))
-                .Enter()  // Dismiss NuGet.config prompt if present (no-op if already auto-accepted)
-                .WaitUntil(s => waitingForInitComplete.Search(s).Count > 0, TimeSpan.FromMinutes(2))
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
+            sequenceBuilder.RunAspireInit(counter);
 
             // Step 4: Add Aspire.Hosting.Azure.ContainerRegistry package
             output.WriteLine("Step 4: Adding Azure Container Registry hosting package...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureContainerRegistryDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureContainerRegistryDeploymentTests.cs
@@ -87,7 +87,7 @@ public sealed class AzureContainerRegistryDeploymentTests(ITestOutputHelper outp
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.RunAspireInit(counter);
+            sequenceBuilder.AspireInit(counter);
 
             // Step 4: Add Aspire.Hosting.Azure.ContainerRegistry package
             output.WriteLine("Step 4: Adding Azure Container Registry hosting package...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureEventHubsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureEventHubsDeploymentTests.cs
@@ -92,7 +92,7 @@ public sealed class AzureEventHubsDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.RunAspireInit(counter);
+            sequenceBuilder.AspireInit(counter);
 
             // Step 4a: Add Aspire.Hosting.Azure.ContainerApps package (for managed identity support)
             // This command triggers TWO prompts in sequence:

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureEventHubsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureEventHubsDeploymentTests.cs
@@ -63,10 +63,6 @@ public sealed class AzureEventHubsDeploymentTests(ITestOutputHelper output)
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            // Pattern searchers for aspire init
-            var waitingForInitComplete = new CellPatternSearcher()
-                .Find("Aspire initialization complete");
-
             // Pattern searchers for aspire add prompts
             // Integration selection prompt appears when multiple packages match the search term
             var waitingForIntegrationSelectionPrompt = new CellPatternSearcher()
@@ -96,15 +92,7 @@ public sealed class AzureEventHubsDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.Type("aspire init --language csharp")
-                .Enter()
-                // NuGet.config prompt may or may not appear depending on environment.
-                // Wait a moment then press Enter to dismiss if present, then wait for completion.
-                .Wait(TimeSpan.FromSeconds(5))
-                .Enter()  // Dismiss NuGet.config prompt if present (no-op if already auto-accepted)
-                .WaitUntil(s => waitingForInitComplete.Search(s).Count > 0, TimeSpan.FromMinutes(2))
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
+            sequenceBuilder.RunAspireInit(counter);
 
             // Step 4a: Add Aspire.Hosting.Azure.ContainerApps package (for managed identity support)
             // This command triggers TWO prompts in sequence:

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureKeyVaultDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureKeyVaultDeploymentTests.cs
@@ -63,10 +63,6 @@ public sealed class AzureKeyVaultDeploymentTests(ITestOutputHelper output)
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            // Pattern searchers for aspire init
-            var waitingForInitComplete = new CellPatternSearcher()
-                .Find("Aspire initialization complete");
-
             // Pattern searchers for aspire add prompts
             // Integration selection prompt appears when multiple packages match the search term
             var waitingForIntegrationSelectionPrompt = new CellPatternSearcher()
@@ -96,15 +92,7 @@ public sealed class AzureKeyVaultDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.Type("aspire init --language csharp")
-                .Enter()
-                // NuGet.config prompt may or may not appear depending on environment.
-                // Wait a moment then press Enter to dismiss if present, then wait for completion.
-                .Wait(TimeSpan.FromSeconds(5))
-                .Enter()  // Dismiss NuGet.config prompt if present (no-op if already auto-accepted)
-                .WaitUntil(s => waitingForInitComplete.Search(s).Count > 0, TimeSpan.FromMinutes(2))
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
+            sequenceBuilder.RunAspireInit(counter);
 
             // Step 4a: Add Aspire.Hosting.Azure.ContainerApps package (for managed identity support)
             // This command triggers TWO prompts in sequence:

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureKeyVaultDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureKeyVaultDeploymentTests.cs
@@ -92,7 +92,7 @@ public sealed class AzureKeyVaultDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.RunAspireInit(counter);
+            sequenceBuilder.AspireInit(counter);
 
             // Step 4a: Add Aspire.Hosting.Azure.ContainerApps package (for managed identity support)
             // This command triggers TWO prompts in sequence:

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureLogAnalyticsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureLogAnalyticsDeploymentTests.cs
@@ -63,10 +63,6 @@ public sealed class AzureLogAnalyticsDeploymentTests(ITestOutputHelper output)
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            // Pattern searchers for aspire init
-            var waitingForInitComplete = new CellPatternSearcher()
-                .Find("Aspire initialization complete");
-
             // Pattern searchers for aspire add prompts
             var waitingForAddVersionSelectionPrompt = new CellPatternSearcher()
                 .Find("(based on NuGet.config)");
@@ -91,15 +87,7 @@ public sealed class AzureLogAnalyticsDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.Type("aspire init --language csharp")
-                .Enter()
-                // NuGet.config prompt may or may not appear depending on environment.
-                // Wait a moment then press Enter to dismiss if present, then wait for completion.
-                .Wait(TimeSpan.FromSeconds(5))
-                .Enter()  // Dismiss NuGet.config prompt if present (no-op if already auto-accepted)
-                .WaitUntil(s => waitingForInitComplete.Search(s).Count > 0, TimeSpan.FromMinutes(2))
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
+            sequenceBuilder.RunAspireInit(counter);
 
             // Step 4: Add Aspire.Hosting.Azure.OperationalInsights package
             output.WriteLine("Step 4: Adding Azure Log Analytics hosting package...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureLogAnalyticsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureLogAnalyticsDeploymentTests.cs
@@ -87,7 +87,7 @@ public sealed class AzureLogAnalyticsDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.RunAspireInit(counter);
+            sequenceBuilder.AspireInit(counter);
 
             // Step 4: Add Aspire.Hosting.Azure.OperationalInsights package
             output.WriteLine("Step 4: Adding Azure Log Analytics hosting package...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureServiceBusDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureServiceBusDeploymentTests.cs
@@ -92,7 +92,7 @@ public sealed class AzureServiceBusDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.RunAspireInit(counter);
+            sequenceBuilder.AspireInit(counter);
 
             // Step 4a: Add Aspire.Hosting.Azure.ContainerApps package (for managed identity support)
             // This command triggers TWO prompts in sequence:

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureServiceBusDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureServiceBusDeploymentTests.cs
@@ -63,10 +63,6 @@ public sealed class AzureServiceBusDeploymentTests(ITestOutputHelper output)
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            // Pattern searchers for aspire init
-            var waitingForInitComplete = new CellPatternSearcher()
-                .Find("Aspire initialization complete");
-
             // Pattern searchers for aspire add prompts
             // Integration selection prompt appears when multiple packages match the search term
             var waitingForIntegrationSelectionPrompt = new CellPatternSearcher()
@@ -96,15 +92,7 @@ public sealed class AzureServiceBusDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.Type("aspire init --language csharp")
-                .Enter()
-                // NuGet.config prompt may or may not appear depending on environment.
-                // Wait a moment then press Enter to dismiss if present, then wait for completion.
-                .Wait(TimeSpan.FromSeconds(5))
-                .Enter()  // Dismiss NuGet.config prompt if present (no-op if already auto-accepted)
-                .WaitUntil(s => waitingForInitComplete.Search(s).Count > 0, TimeSpan.FromMinutes(2))
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
+            sequenceBuilder.RunAspireInit(counter);
 
             // Step 4a: Add Aspire.Hosting.Azure.ContainerApps package (for managed identity support)
             // This command triggers TWO prompts in sequence:

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureStorageDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureStorageDeploymentTests.cs
@@ -63,10 +63,6 @@ public sealed class AzureStorageDeploymentTests(ITestOutputHelper output)
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            // Pattern searchers for aspire init
-            var waitingForInitComplete = new CellPatternSearcher()
-                .Find("Aspire initialization complete");
-
             // Pattern searchers for aspire add prompts
             // Integration selection prompt appears when multiple packages match the search term
             var waitingForIntegrationSelectionPrompt = new CellPatternSearcher()
@@ -96,15 +92,7 @@ public sealed class AzureStorageDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.Type("aspire init --language csharp")
-                .Enter()
-                // NuGet.config prompt may or may not appear depending on environment.
-                // Wait a moment then press Enter to dismiss if present, then wait for completion.
-                .Wait(TimeSpan.FromSeconds(5))
-                .Enter()  // Dismiss NuGet.config prompt if present (no-op if already auto-accepted)
-                .WaitUntil(s => waitingForInitComplete.Search(s).Count > 0, TimeSpan.FromMinutes(2))
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
+            sequenceBuilder.RunAspireInit(counter);
 
             // Step 4a: Add Aspire.Hosting.Azure.ContainerApps package (for managed identity support)
             // This command triggers TWO prompts in sequence:

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureStorageDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureStorageDeploymentTests.cs
@@ -92,7 +92,7 @@ public sealed class AzureStorageDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.RunAspireInit(counter);
+            sequenceBuilder.AspireInit(counter);
 
             // Step 4a: Add Aspire.Hosting.Azure.ContainerApps package (for managed identity support)
             // This command triggers TWO prompts in sequence:

--- a/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentE2ETestHelpers.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentE2ETestHelpers.cs
@@ -175,23 +175,28 @@ internal static class DeploymentE2ETestHelpers
     }
 
     /// <summary>
-    /// Runs <c>aspire init</c> and handles the NuGet.config and agent init prompts.
-    /// The agent init prompt is declined so the command exits cleanly.
+    /// Runs <c>aspire init --language csharp</c> and handles the NuGet.config and agent init prompts.
+    /// Explicitly waits for the NuGet.config prompt (or init completion) rather than using a blind timer,
+    /// then declines the agent init prompt so the command exits cleanly.
     /// </summary>
     internal static Hex1bTerminalInputSequenceBuilder RunAspireInit(
         this Hex1bTerminalInputSequenceBuilder builder,
         SequenceCounter counter)
     {
+        var waitingForNuGetConfigPrompt = new CellPatternSearcher()
+            .Find("NuGet.config");
+
         var waitingForInitComplete = new CellPatternSearcher()
             .Find("Aspire initialization complete");
 
         return builder
-            .Type("aspire init")
+            .Type("aspire init --language csharp")
             .Enter()
             // NuGet.config prompt may or may not appear depending on environment.
-            // Wait a moment then press Enter to dismiss if present.
-            .Wait(TimeSpan.FromSeconds(5))
-            .Enter()
+            // Wait for either the NuGet.config prompt or init completion.
+            .WaitUntil(s => waitingForNuGetConfigPrompt.Search(s).Count > 0
+                || waitingForInitComplete.Search(s).Count > 0, TimeSpan.FromMinutes(2))
+            .Enter()  // Dismiss NuGet.config prompt if present
             .WaitUntil(s => waitingForInitComplete.Search(s).Count > 0, TimeSpan.FromMinutes(2))
             .DeclineAgentInitPrompt()
             .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));

--- a/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentE2ETestHelpers.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/Helpers/DeploymentE2ETestHelpers.cs
@@ -174,32 +174,4 @@ internal static class DeploymentE2ETestHelpers
             .WaitForSuccessPrompt(counter);
     }
 
-    /// <summary>
-    /// Runs <c>aspire init --language csharp</c> and handles the NuGet.config and agent init prompts.
-    /// Explicitly waits for the NuGet.config prompt (or init completion) rather than using a blind timer,
-    /// then declines the agent init prompt so the command exits cleanly.
-    /// </summary>
-    internal static Hex1bTerminalInputSequenceBuilder RunAspireInit(
-        this Hex1bTerminalInputSequenceBuilder builder,
-        SequenceCounter counter)
-    {
-        var waitingForNuGetConfigPrompt = new CellPatternSearcher()
-            .Find("NuGet.config");
-
-        var waitingForInitComplete = new CellPatternSearcher()
-            .Find("Aspire initialization complete");
-
-        return builder
-            .Type("aspire init --language csharp")
-            .Enter()
-            // NuGet.config prompt may or may not appear depending on environment.
-            // Wait for either the NuGet.config prompt or init completion.
-            .WaitUntil(s => waitingForNuGetConfigPrompt.Search(s).Count > 0
-                || waitingForInitComplete.Search(s).Count > 0, TimeSpan.FromMinutes(2))
-            .Enter()  // Dismiss NuGet.config prompt if present
-            .WaitUntil(s => waitingForInitComplete.Search(s).Count > 0, TimeSpan.FromMinutes(2))
-            .DeclineAgentInitPrompt()
-            .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
-    }
-
 }

--- a/tests/Aspire.Deployment.EndToEnd.Tests/VnetKeyVaultInfraDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/VnetKeyVaultInfraDeploymentTests.cs
@@ -82,7 +82,7 @@ public sealed class VnetKeyVaultInfraDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.RunAspireInit(counter);
+            sequenceBuilder.AspireInit(counter);
 
             // Step 4a: Add Aspire.Hosting.Azure.AppContainers
             output.WriteLine("Step 4a: Adding Azure Container Apps hosting package...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/VnetKeyVaultInfraDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/VnetKeyVaultInfraDeploymentTests.cs
@@ -61,9 +61,6 @@ public sealed class VnetKeyVaultInfraDeploymentTests(ITestOutputHelper output)
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            var waitingForInitComplete = new CellPatternSearcher()
-                .Find("Aspire initialization complete");
-
             var waitingForVersionSelectionPrompt = new CellPatternSearcher()
                 .Find("(based on NuGet.config)");
 
@@ -85,13 +82,7 @@ public sealed class VnetKeyVaultInfraDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.Type("aspire init --language csharp")
-                .Enter()
-                .Wait(TimeSpan.FromSeconds(5))
-                .Enter()
-                .WaitUntil(s => waitingForInitComplete.Search(s).Count > 0, TimeSpan.FromMinutes(2))
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
+            sequenceBuilder.RunAspireInit(counter);
 
             // Step 4a: Add Aspire.Hosting.Azure.AppContainers
             output.WriteLine("Step 4a: Adding Azure Container Apps hosting package...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/VnetSqlServerInfraDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/VnetSqlServerInfraDeploymentTests.cs
@@ -82,7 +82,7 @@ public sealed class VnetSqlServerInfraDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.RunAspireInit(counter);
+            sequenceBuilder.AspireInit(counter);
 
             // Step 4a: Add Aspire.Hosting.Azure.AppContainers
             output.WriteLine("Step 4a: Adding Azure Container Apps hosting package...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/VnetSqlServerInfraDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/VnetSqlServerInfraDeploymentTests.cs
@@ -61,9 +61,6 @@ public sealed class VnetSqlServerInfraDeploymentTests(ITestOutputHelper output)
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            var waitingForInitComplete = new CellPatternSearcher()
-                .Find("Aspire initialization complete");
-
             var waitingForVersionSelectionPrompt = new CellPatternSearcher()
                 .Find("(based on NuGet.config)");
 
@@ -85,13 +82,7 @@ public sealed class VnetSqlServerInfraDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.Type("aspire init --language csharp")
-                .Enter()
-                .Wait(TimeSpan.FromSeconds(5))
-                .Enter()
-                .WaitUntil(s => waitingForInitComplete.Search(s).Count > 0, TimeSpan.FromMinutes(2))
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
+            sequenceBuilder.RunAspireInit(counter);
 
             // Step 4a: Add Aspire.Hosting.Azure.AppContainers
             output.WriteLine("Step 4a: Adding Azure Container Apps hosting package...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/VnetStorageBlobInfraDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/VnetStorageBlobInfraDeploymentTests.cs
@@ -61,9 +61,6 @@ public sealed class VnetStorageBlobInfraDeploymentTests(ITestOutputHelper output
             using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
             var pendingRun = terminal.RunAsync(cancellationToken);
 
-            var waitingForInitComplete = new CellPatternSearcher()
-                .Find("Aspire initialization complete");
-
             var waitingForVersionSelectionPrompt = new CellPatternSearcher()
                 .Find("(based on NuGet.config)");
 
@@ -86,13 +83,7 @@ public sealed class VnetStorageBlobInfraDeploymentTests(ITestOutputHelper output
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.Type("aspire init --language csharp")
-                .Enter()
-                .Wait(TimeSpan.FromSeconds(5))
-                .Enter()
-                .WaitUntil(s => waitingForInitComplete.Search(s).Count > 0, TimeSpan.FromMinutes(2))
-                .DeclineAgentInitPrompt()
-                .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
+            sequenceBuilder.RunAspireInit(counter);
 
             // Step 4a: Add Aspire.Hosting.Azure.AppContainers
             output.WriteLine("Step 4a: Adding Azure Container Apps hosting package...");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/VnetStorageBlobInfraDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/VnetStorageBlobInfraDeploymentTests.cs
@@ -83,7 +83,7 @@ public sealed class VnetStorageBlobInfraDeploymentTests(ITestOutputHelper output
 
             // Step 3: Create single-file AppHost using aspire init
             output.WriteLine("Step 3: Creating single-file AppHost with aspire init...");
-            sequenceBuilder.RunAspireInit(counter);
+            sequenceBuilder.AspireInit(counter);
 
             // Step 4a: Add Aspire.Hosting.Azure.AppContainers
             output.WriteLine("Step 4a: Adding Azure Container Apps hosting package...");

--- a/tests/Shared/Hex1bTestHelpers.cs
+++ b/tests/Shared/Hex1bTestHelpers.cs
@@ -499,6 +499,34 @@ internal static class Hex1bTestHelpers
     }
 
     /// <summary>
+    /// Runs <c>aspire init --language csharp</c> and handles the NuGet.config and agent init prompts.
+    /// Explicitly waits for the NuGet.config prompt (or init completion) rather than using a blind timer,
+    /// then declines the agent init prompt so the command exits cleanly.
+    /// </summary>
+    internal static Hex1bTerminalInputSequenceBuilder AspireInit(
+        this Hex1bTerminalInputSequenceBuilder builder,
+        SequenceCounter counter)
+    {
+        var waitingForNuGetConfigPrompt = new CellPatternSearcher()
+            .Find("NuGet.config");
+
+        var waitingForInitComplete = new CellPatternSearcher()
+            .Find("Aspire initialization complete");
+
+        return builder
+            .Type("aspire init --language csharp")
+            .Enter()
+            // NuGet.config prompt may or may not appear depending on environment.
+            // Wait for either the NuGet.config prompt or init completion.
+            .WaitUntil(s => waitingForNuGetConfigPrompt.Search(s).Count > 0
+                || waitingForInitComplete.Search(s).Count > 0, TimeSpan.FromMinutes(2))
+            .Enter()  // Dismiss NuGet.config prompt if present
+            .WaitUntil(s => waitingForInitComplete.Search(s).Count > 0, TimeSpan.FromMinutes(2))
+            .DeclineAgentInitPrompt()
+            .WaitForSuccessPrompt(counter, TimeSpan.FromMinutes(2));
+    }
+
+    /// <summary>
     /// Installs the Aspire CLI Bundle from a specific pull request's artifacts.
     /// The bundle is a self-contained distribution that includes:
     /// - Native AOT Aspire CLI


### PR DESCRIPTION
## Description

Fix 12 deployment E2E tests that are failing nightly due to a timing issue with `aspire init` prompt handling.

**Root cause:** The blind 5-second `Wait` + `Enter` pattern to dismiss the NuGet.config prompt is unreliable. The language preference save and template setup now take longer than 5 seconds, so the `Enter` fires before the NuGet.config prompt appears, leaving the terminal stuck on the prompt and timing out waiting for "Aspire initialization complete".

**Fix:**
- Updated `RunAspireInit` helper to use `aspire init --language csharp` and explicitly `WaitUntil` the NuGet.config prompt (or init completion) appears, instead of a blind 5-second timer
- Replaced inline `aspire init` sequences in all 12 failing tests with the shared `RunAspireInit` helper, reducing code duplication
- Added `stopOnFail: false` to `xunit.runner.json` so all tests in a class run even if one fails

**Failing run:** https://github.com/dotnet/aspire/actions/runs/22935754279

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
