### PR TITLE
Clean up RemoteHost project now that it is included in the Aspire.Managed

### DIFF
--- a/Aspire.slnx
+++ b/Aspire.slnx
@@ -383,6 +383,7 @@
     <Project Path="src/Aspire.Hosting.CodeGeneration.Java/Aspire.Hosting.CodeGeneration.Java.csproj" />
     <Project Path="src/Aspire.Hosting.CodeGeneration.Rust/Aspire.Hosting.CodeGeneration.Rust.csproj" />
     <Project Path="src/Aspire.Hosting.RemoteHost/Aspire.Hosting.RemoteHost.csproj" />
+    <Project Path="src/Aspire.Managed/Aspire.Managed.csproj" />
   </Folder>
   <Folder Name="/Testing/">
     <Project Path="src/Aspire.Hosting.Testing/Aspire.Hosting.Testing.csproj" />

--- a/src/Aspire.Hosting.RemoteHost/Aspire.Hosting.RemoteHost.csproj
+++ b/src/Aspire.Hosting.RemoteHost/Aspire.Hosting.RemoteHost.csproj
@@ -1,36 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <AssemblyName>aspire-server</AssemblyName>
-    <Description>Remote host server for polyglot Aspire AppHosts.</Description>
-    <PackageTags>aspire hosting polyglot</PackageTags>
-
-    <!-- This is included in the Aspire bundle layout -->
-    <IsPackable>true</IsPackable>
-    <!-- New package, no baseline to compare against yet -->
-    <EnablePackageValidation>false</EnablePackageValidation>
-
-    <!-- Framework-dependent deployment - uses the bundled runtime -->
-    <SelfContained>false</SelfContained>
-    <PublishSingleFile>false</PublishSingleFile>
-
-    <!-- Suppress IL3000 for single-file - code handles Assembly.Location returning empty -->
-    <NoWarn>$(NoWarn);IL3000</NoWarn>
-
-    <!-- Allow running on newer .NET versions -->
-    <RollForward>Major</RollForward>
-
-    <!-- Minimize size by not including unnecessary metadata -->
-    <DebugType>none</DebugType>
-    <DebugSymbols>false</DebugSymbols>
-
-    <!-- Skip Aspire workload checks - this is internal tooling -->
-    <SkipValidateAspireHostProjectResources>true</SkipValidateAspireHostProjectResources>
-    <SkipAddAspireDefaultReferences>true</SkipAddAspireDefaultReferences>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.RemoteHost/Program.cs
+++ b/src/Aspire.Hosting.RemoteHost/Program.cs
@@ -1,8 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-// This is the entry point for the pre-built AppHost server used in bundle mode.
-// It runs the RemoteHostServer which listens on a Unix socket for JSON-RPC
-// connections from polyglot app hosts (TypeScript, Python, etc.)
-
-await Aspire.Hosting.RemoteHost.RemoteHostServer.RunAsync(args).ConfigureAwait(false);


### PR DESCRIPTION
These settings are no longer needed.

They also make debugging harder than it should be.