### PR TITLE
Change dashboard API to default to off

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -200,7 +200,7 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
     private bool ShouldShowUnsecuredApiMessage()
     {
         // Only show warning if API is enabled and unsecured
-        return Options.CurrentValue.Api.Enabled == true &&
+        return Options.CurrentValue.Api.Enabled.GetValueOrDefault() &&
                Options.CurrentValue.Api.AuthMode == ApiAuthMode.Unsecured;
     }
 

--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -150,7 +150,7 @@ public sealed class ApiOptions
     /// <summary>
     /// Gets or sets whether the Telemetry HTTP API is enabled.
     /// When false, the /api/telemetry/* endpoints are not registered.
-    /// Defaults to true.
+    /// Defaults to false.
     /// </summary>
     public bool? Enabled { get; set; }
 

--- a/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
@@ -87,7 +87,7 @@ public sealed class PostConfigureDashboardOptions : IPostConfigureOptions<Dashbo
 
         options.AI.Disabled = _configuration.GetBool(DashboardConfigNames.DashboardAIDisabledName.ConfigKey);
 
-        options.Api.Enabled ??= _configuration.GetBool(DashboardConfigNames.DashboardApiEnabledEnvName.ConfigKey);
+        options.Api.Enabled ??= _configuration.GetBool(DashboardConfigNames.DashboardAspireApiEnabledName.ConfigKey);
 
         // Normalize API keys: Api is canonical, falls back to Mcp if not set.
         // Api -> Mcp fallback only (not bidirectional).

--- a/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
@@ -87,7 +87,7 @@ public sealed class PostConfigureDashboardOptions : IPostConfigureOptions<Dashbo
 
         options.AI.Disabled = _configuration.GetBool(DashboardConfigNames.DashboardAIDisabledName.ConfigKey);
 
-        options.Api.Enabled ??= _configuration.GetBool(DashboardConfigNames.DashboardEnableApiName.ConfigKey);
+        options.Api.Enabled ??= _configuration.GetBool(DashboardConfigNames.DashboardApiEnabledEnvName.ConfigKey);
 
         // Normalize API keys: Api is canonical, falls back to Mcp if not set.
         // Api -> Mcp fallback only (not bidirectional).

--- a/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
@@ -87,6 +87,8 @@ public sealed class PostConfigureDashboardOptions : IPostConfigureOptions<Dashbo
 
         options.AI.Disabled = _configuration.GetBool(DashboardConfigNames.DashboardAIDisabledName.ConfigKey);
 
+        options.Api.Enabled ??= _configuration.GetBool(DashboardConfigNames.DashboardEnableApiName.ConfigKey);
+
         // Normalize API keys: Api is canonical, falls back to Mcp if not set.
         // Api -> Mcp fallback only (not bidirectional).
         if (string.IsNullOrEmpty(options.Mcp.PrimaryApiKey) && !string.IsNullOrEmpty(options.Api.PrimaryApiKey))

--- a/src/Aspire.Dashboard/DashboardEndpointsBuilder.cs
+++ b/src/Aspire.Dashboard/DashboardEndpointsBuilder.cs
@@ -108,8 +108,8 @@ public static class DashboardEndpointsBuilder
 
     public static void MapTelemetryApi(this IEndpointRouteBuilder endpoints, DashboardOptions dashboardOptions)
     {
-        // Check if API is disabled (defaults to enabled if not specified)
-        if (dashboardOptions.Api.Enabled == false)
+        // Check if API is enabled (defaults to disabled if not specified)
+        if (!dashboardOptions.Api.Enabled.GetValueOrDefault())
         {
             return;
         }

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -413,7 +413,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 
             // Only show API security warning if API is enabled and unsecured
             // API runs on the frontend endpoint (no separate accessor needed)
-            if (_dashboardOptionsMonitor.CurrentValue.Api.Enabled == true &&
+            if (_dashboardOptionsMonitor.CurrentValue.Api.Enabled.GetValueOrDefault() &&
                 _dashboardOptionsMonitor.CurrentValue.Api.AuthMode == ApiAuthMode.Unsecured)
             {
                 _logger.LogWarning("Dashboard API is unsecured. Untrusted apps can access sensitive telemetry data.");

--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -639,6 +639,9 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
             context.EnvironmentVariables[DashboardConfigNames.DashboardApiAuthModeName.EnvVarName] = "Unsecured";
         }
 
+        // Enable dashboard API
+        context.EnvironmentVariables[DashboardConfigNames.DashboardEnableApiName.EnvVarName] = "true";
+
         // Configure dashboard to show CLI MCP instructions when running with an AppHost (not in standalone mode)
         context.EnvironmentVariables[DashboardConfigNames.DashboardMcpUseCliMcpName.EnvVarName] = "true";
 

--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -640,7 +640,7 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
         }
 
         // Enable dashboard API
-        context.EnvironmentVariables[DashboardConfigNames.DashboardEnableApiName.EnvVarName] = "true";
+        context.EnvironmentVariables[DashboardConfigNames.DashboardApiEnabledEnvName.EnvVarName] = "true";
 
         // Configure dashboard to show CLI MCP instructions when running with an AppHost (not in standalone mode)
         context.EnvironmentVariables[DashboardConfigNames.DashboardMcpUseCliMcpName.EnvVarName] = "true";

--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -640,7 +640,7 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
         }
 
         // Enable dashboard API
-        context.EnvironmentVariables[DashboardConfigNames.DashboardApiEnabledEnvName.EnvVarName] = "true";
+        context.EnvironmentVariables[DashboardConfigNames.DashboardAspireApiEnabledName.EnvVarName] = "true";
 
         // Configure dashboard to show CLI MCP instructions when running with an AppHost (not in standalone mode)
         context.EnvironmentVariables[DashboardConfigNames.DashboardMcpUseCliMcpName.EnvVarName] = "true";

--- a/src/Shared/DashboardConfigNames.cs
+++ b/src/Shared/DashboardConfigNames.cs
@@ -14,7 +14,7 @@ internal static class DashboardConfigNames
     public static readonly ConfigName DashboardConfigFilePathName = new(KnownConfigNames.DashboardConfigFilePath);
     public static readonly ConfigName DashboardFileConfigDirectoryName = new(KnownConfigNames.DashboardFileConfigDirectory);
     public static readonly ConfigName DashboardAIDisabledName = new(KnownConfigNames.DashboardAIDisabled);
-    public static readonly ConfigName DashboardEnableApiName = new(KnownConfigNames.DashboardEnableApi);
+    public static readonly ConfigName DashboardApiEnabledEnvName = new(KnownConfigNames.DashboardApiEnabled);
     public static readonly ConfigName ResourceServiceUrlName = new(KnownConfigNames.ResourceServiceEndpointUrl);
     public static readonly ConfigName ForwardedHeaders = new(KnownConfigNames.DashboardForwardedHeadersEnabled);
 

--- a/src/Shared/DashboardConfigNames.cs
+++ b/src/Shared/DashboardConfigNames.cs
@@ -14,7 +14,7 @@ internal static class DashboardConfigNames
     public static readonly ConfigName DashboardConfigFilePathName = new(KnownConfigNames.DashboardConfigFilePath);
     public static readonly ConfigName DashboardFileConfigDirectoryName = new(KnownConfigNames.DashboardFileConfigDirectory);
     public static readonly ConfigName DashboardAIDisabledName = new(KnownConfigNames.DashboardAIDisabled);
-    public static readonly ConfigName DashboardApiEnabledEnvName = new(KnownConfigNames.DashboardApiEnabled);
+    public static readonly ConfigName DashboardAspireApiEnabledName = new(KnownConfigNames.DashboardApiEnabled);
     public static readonly ConfigName ResourceServiceUrlName = new(KnownConfigNames.ResourceServiceEndpointUrl);
     public static readonly ConfigName ForwardedHeaders = new(KnownConfigNames.DashboardForwardedHeadersEnabled);
 

--- a/src/Shared/DashboardConfigNames.cs
+++ b/src/Shared/DashboardConfigNames.cs
@@ -14,6 +14,7 @@ internal static class DashboardConfigNames
     public static readonly ConfigName DashboardConfigFilePathName = new(KnownConfigNames.DashboardConfigFilePath);
     public static readonly ConfigName DashboardFileConfigDirectoryName = new(KnownConfigNames.DashboardFileConfigDirectory);
     public static readonly ConfigName DashboardAIDisabledName = new(KnownConfigNames.DashboardAIDisabled);
+    public static readonly ConfigName DashboardEnableApiName = new(KnownConfigNames.DashboardEnableApi);
     public static readonly ConfigName ResourceServiceUrlName = new(KnownConfigNames.ResourceServiceEndpointUrl);
     public static readonly ConfigName ForwardedHeaders = new(KnownConfigNames.DashboardForwardedHeadersEnabled);
 

--- a/src/Shared/KnownConfigNames.cs
+++ b/src/Shared/KnownConfigNames.cs
@@ -18,7 +18,7 @@ internal static class KnownConfigNames
     public const string DashboardConfigFilePath = "ASPIRE_DASHBOARD_CONFIG_FILE_PATH";
     public const string DashboardFileConfigDirectory = "ASPIRE_DASHBOARD_FILE_CONFIG_DIRECTORY";
     public const string DashboardAIDisabled = "ASPIRE_DASHBOARD_AI_DISABLED";
-    public const string DashboardEnableApi = "ASPIRE_DASHBOARD_ENABLE_API";
+    public const string DashboardApiEnabled = "ASPIRE_DASHBOARD_API_ENABLED";
     public const string DashboardForwardedHeadersEnabled = "ASPIRE_DASHBOARD_FORWARDEDHEADERS_ENABLED";
 
     public const string ShowDashboardResources = "ASPIRE_SHOW_DASHBOARD_RESOURCES";

--- a/src/Shared/KnownConfigNames.cs
+++ b/src/Shared/KnownConfigNames.cs
@@ -18,6 +18,7 @@ internal static class KnownConfigNames
     public const string DashboardConfigFilePath = "ASPIRE_DASHBOARD_CONFIG_FILE_PATH";
     public const string DashboardFileConfigDirectory = "ASPIRE_DASHBOARD_FILE_CONFIG_DIRECTORY";
     public const string DashboardAIDisabled = "ASPIRE_DASHBOARD_AI_DISABLED";
+    public const string DashboardEnableApi = "ASPIRE_DASHBOARD_ENABLE_API";
     public const string DashboardForwardedHeadersEnabled = "ASPIRE_DASHBOARD_FORWARDEDHEADERS_ENABLED";
 
     public const string ShowDashboardResources = "ASPIRE_SHOW_DASHBOARD_RESOURCES";

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -213,6 +213,11 @@ public class FrontendBrowserTokenAuthTests
             },
             w =>
             {
+                Assert.Equal("Dashboard API is unsecured. Untrusted apps can access sensitive telemetry data.", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
+                Assert.Equal(LogLevel.Warning, w.LogLevel);
+            },
+            w =>
+            {
                 Assert.Equal("Login to the dashboard at {DashboardLoginUrl}", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
 
                 var uri = new Uri((string)LogTestHelpers.GetValue(w, "DashboardLoginUrl")!, UriKind.Absolute);

--- a/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
@@ -64,6 +64,7 @@ public static class IntegrationTestHelpers
             [DashboardConfigNames.DashboardMcpUrlName.ConfigKey] = "http://127.0.0.1:0",
             [DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey] = nameof(OtlpAuthMode.Unsecured),
             [DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = nameof(FrontendAuthMode.Unsecured),
+            [DashboardConfigNames.DashboardApiEnabledName.ConfigKey] = "true",
             // Allow the requirement of HTTPS communication with the OpenIdConnect authority to be relaxed during tests.
             ["Authentication:Schemes:OpenIdConnect:RequireHttpsMetadata"] = "false"
         };

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -725,6 +725,11 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
             {
                 Assert.Equal("MCP server is unsecured. Untrusted apps can access sensitive information.", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
                 Assert.Equal(LogLevel.Warning, w.LogLevel);
+            },
+            w =>
+            {
+                Assert.Equal("Dashboard API is unsecured. Untrusted apps can access sensitive telemetry data.", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
+                Assert.Equal(LogLevel.Warning, w.LogLevel);
             });
     }
 
@@ -764,6 +769,11 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
             w =>
             {
                 Assert.Equal("MCP server is unsecured. Untrusted apps can access sensitive information.", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
+                Assert.Equal(LogLevel.Warning, w.LogLevel);
+            },
+            w =>
+            {
+                Assert.Equal("Dashboard API is unsecured. Untrusted apps can access sensitive telemetry data.", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
                 Assert.Equal(LogLevel.Warning, w.LogLevel);
             });
     }
@@ -931,6 +941,11 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
             w =>
             {
                 Assert.Equal("MCP server is unsecured. Untrusted apps can access sensitive information.", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
+                Assert.Equal(LogLevel.Warning, w.LogLevel);
+            },
+            w =>
+            {
+                Assert.Equal("Dashboard API is unsecured. Untrusted apps can access sensitive telemetry data.", LogTestHelpers.GetValue(w, "{OriginalFormat}"));
                 Assert.Equal(LogLevel.Warning, w.LogLevel);
             });
     }

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -790,6 +790,53 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         Assert.DoesNotContain(l, w => LogTestHelpers.GetValue(w, "{OriginalFormat}")?.ToString()?.Contains("MCP server is unsecured") == true);
     }
 
+    [Theory]
+    [InlineData(null, HttpStatusCode.NotFound)]
+    [InlineData(true, HttpStatusCode.OK)]
+    [InlineData(false, HttpStatusCode.NotFound)]
+    public async Task ApiEnabled_ReturnsExpectedStatusAndWarning(bool? enabled, HttpStatusCode expectedStatusCode)
+    {
+        const string ApiUnsecuredWarning = "Dashboard API is unsecured. Untrusted apps can access sensitive telemetry data.";
+
+        // Arrange
+        var testSink = new TestSink();
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper,
+            additionalConfiguration: config =>
+            {
+                if (enabled is not null)
+                {
+                    config[DashboardConfigNames.DashboardApiEnabledName.ConfigKey] = enabled.Value.ToString();
+                }
+                else
+                {
+                    config.Remove(DashboardConfigNames.DashboardApiEnabledName.ConfigKey);
+                }
+            },
+            testSink: testSink);
+        await app.StartAsync().DefaultTimeout();
+
+        using var httpClient = IntegrationTestHelpers.CreateHttpClient($"http://{app.FrontendSingleEndPointAccessor().EndPoint}");
+
+        // Act
+        var response = await httpClient.GetAsync("/api/telemetry/spans").DefaultTimeout();
+
+        // Assert
+        Assert.Equal(expectedStatusCode, response.StatusCode);
+
+        var warnings = testSink.Writes
+            .Where(w => w.LoggerName == typeof(DashboardWebApplication).FullName && w.LogLevel >= LogLevel.Warning)
+            .ToList();
+
+        if (enabled == true)
+        {
+            Assert.Contains(warnings, w => LogTestHelpers.GetValue(w, "{OriginalFormat}")?.ToString() == ApiUnsecuredWarning);
+        }
+        else
+        {
+            Assert.DoesNotContain(warnings, w => LogTestHelpers.GetValue(w, "{OriginalFormat}")?.ToString() == ApiUnsecuredWarning);
+        }
+    }
+
     [Fact]
     public async Task LogOutput_LocalhostAddress_LocalhostInLogOutput()
     {

--- a/tests/Aspire.Dashboard.Tests/Integration/TelemetryApiTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/TelemetryApiTests.cs
@@ -182,25 +182,6 @@ public class TelemetryApiTests
     }
 
     [Fact]
-    public async Task GetSpans_ApiDisabled_Returns404()
-    {
-        // Arrange - disable the Telemetry API explicitly
-        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, config =>
-        {
-            config[DashboardConfigNames.DashboardApiEnabledName.ConfigKey] = "false";
-        });
-        await app.StartAsync().DefaultTimeout();
-
-        using var httpClient = IntegrationTestHelpers.CreateHttpClient($"http://{app.FrontendSingleEndPointAccessor().EndPoint}");
-
-        // Act
-        var response = await httpClient.GetAsync("/api/telemetry/spans").DefaultTimeout();
-
-        // Assert
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-    }
-
-    [Fact]
     public async Task GetLogs_UnsecuredMode_Returns200()
     {
         // Arrange

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
@@ -121,7 +121,7 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
         Assert.Collection(config,
             e =>
             {
-                Assert.Equal(KnownConfigNames.DashboardEnableApi, e.Key);
+                Assert.Equal(KnownConfigNames.DashboardApiEnabled, e.Key);
                 Assert.Equal("true", e.Value);
             },
             e =>

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
@@ -121,6 +121,11 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
         Assert.Collection(config,
             e =>
             {
+                Assert.Equal(KnownConfigNames.DashboardEnableApi, e.Key);
+                Assert.Equal("true", e.Value);
+            },
+            e =>
+            {
                 Assert.Equal(KnownConfigNames.DashboardMcpEndpointUrl, e.Key);
                 Assert.Equal("http://localhost:5004", e.Value);
             },


### PR DESCRIPTION
## Description

Change the dashboard Telemetry API to default to **disabled** (`false`) instead of enabled.

Previously, the `Api.Enabled` option defaulted to `true` when not explicitly configured. This change flips the default so the API endpoints (`/api/telemetry/*`) are not registered unless the user explicitly opts in by setting `Api.Enabled = true`.

Key changes:
- Updated `ApiOptions.Enabled` default from `true` to `false` in documentation and behavior.
- Changed null-coalescing logic to use `GetValueOrDefault()` (which returns `false` for `null`) instead of `== false`/`== true` checks.
- Updated integration test helpers to explicitly enable the API so existing tests continue to pass.
- Added a new `ApiEnabled_ReturnsExpectedStatusAndWarning` theory test covering `null`, `true`, and `false` scenarios.
- Removed the now-redundant `GetSpans_ApiDisabled_Returns404` test (covered by the new theory).

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
