### PR TITLE
Increase dashboard gRPC max receive message size

### DIFF
--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -170,7 +170,8 @@ internal sealed class DashboardClient : IDashboardClient
                     HttpHandler = httpHandler,
                     ServiceConfig = new() { MethodConfigs = { methodConfig } },
                     LoggerFactory = _loggerFactory,
-                    ThrowOperationCanceledOnCancellation = true
+                    ThrowOperationCanceledOnCancellation = true,
+                    MaxReceiveMessageSize = 16 * 1024 * 1024 // 16 MB
                 });
 
             X509CertificateCollection GetFileCertificate()


### PR DESCRIPTION
## Description

Increase the gRPC max receive message size on the Dashboard's `DashboardClient` from the default 4 MB to 16 MB.

When an app model has many resources, the resource watch stream can produce messages that exceed the default 4 MB gRPC limit, causing `ResourceExhausted` errors:

```
Grpc.Core.RpcException: Status(StatusCode="ResourceExhausted", Detail="Received message exceeds the maximum configured message size.")
```

This sets `MaxReceiveMessageSize` on the `GrpcChannelOptions` to 16 MB to accommodate larger payloads.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
