### PR TITLE
Strip build metadata from CLI banner version display

### DIFF
--- a/src/Aspire.Cli/Interaction/BannerService.cs
+++ b/src/Aspire.Cli/Interaction/BannerService.cs
@@ -51,6 +51,14 @@ internal sealed class BannerService : IBannerService
     public async Task DisplayBannerAsync(CancellationToken cancellationToken = default)
     {
         var cliVersion = VersionHelper.GetDefaultTemplateVersion();
+
+        // Strip build metadata (everything after '+') for display purposes.
+        var plusIndex = cliVersion.IndexOf('+', StringComparison.Ordinal);
+        if (plusIndex >= 0)
+        {
+            cliVersion = cliVersion[..plusIndex];
+        }
+
         var aspireWidth = s_aspireLines[0].TrimEnd().Length;
         var welcomeText = RootCommandStrings.BannerWelcomeText;
         var versionText = string.Format(CultureInfo.CurrentCulture, RootCommandStrings.BannerVersionFormat, cliVersion);


### PR DESCRIPTION
## Description

Strip build metadata (everything after `+`) from the CLI version string displayed in the banner. Previously, the full version including build metadata (e.g. `9.3.0-preview.1.12345+abcdef`) was shown, which is noisy and not useful for users. Now only the SemVer portion is displayed (e.g. `9.3.0-preview.1.12345`).

---

I don't know if this will be a problem in release version, but it triggered me when viewing banner in daily/PR builds. Note: `--version` still prints the full value

Before:
<img width="1032" height="288" alt="image" src="https://github.com/user-attachments/assets/105a3c07-f40f-46b5-bcff-b023c5e76542" />

After:
<img width="601" height="284" alt="image" src="https://github.com/user-attachments/assets/634087f1-5ca6-4a60-9e0f-376ed73f0a54" />


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
