### PR TITLE
vs code extension file-based app fixes

### DIFF
--- a/extension/src/debugger/languages/dotnet.ts
+++ b/extension/src/debugger/languages/dotnet.ts
@@ -56,60 +56,6 @@ class DotNetService implements IDotNetService {
     }
 
     async buildDotNetProject(projectFile: string): Promise<void> {
-        const isDevKitEnabled = await this.getAndActivateDevKit();
-        if (isDevKitEnabled) {
-            this.writeToDebugConsole(lookingForDevkitBuildTask, 'stdout', true);
-
-            const tasks = await vscode.tasks.fetchTasks();
-            const buildTask = tasks.find(t => t.source === "dotnet" && t.name?.includes('build'));
-
-            // The build task may not be registered if there are is no solution in the workspace or if there are no C# projects
-            // with .csproj files.
-            if (buildTask) {
-                // Modify the task to target the specific project
-                const projectName = path.basename(projectFile, '.csproj');
-
-                // Create a modified task definition with just the project file
-                const modifiedDefinition = {
-                    ...buildTask.definition,
-                    file: projectFile  // This will make it build the specific project directly
-                };
-
-                // Create a new task with the modified definition
-                const modifiedTask = new vscode.Task(
-                    modifiedDefinition,
-                    buildTask.scope || vscode.TaskScope.Workspace,
-                    `build ${projectName}`,
-                    buildTask.source,
-                    buildTask.execution,
-                    buildTask.problemMatchers
-                );
-
-                extensionLogOutputChannel.info(`Executing build task: ${modifiedTask.name} for project: ${projectFile}`);
-                await vscode.tasks.executeTask(modifiedTask);
-
-                let disposable: vscode.Disposable = { dispose: () => {} };
-                return new Promise<void>((resolve, reject) => {
-                    disposable = vscode.tasks.onDidEndTaskProcess(async e => {
-                        if (e.execution.task === modifiedTask) {
-                            if (e.exitCode !== 0) {
-                                reject(new Error(buildFailedWithExitCode(e.exitCode ?? 'unknown')));
-                            }
-                            else {
-                                return resolve();
-                            }
-                        }
-                    });
-                }).finally(() => disposable.dispose());
-            }
-            else {
-                this.writeToDebugConsole(noCsharpBuildTask, 'stdout', true);
-            }
-        }
-        else {
-            this.writeToDebugConsole(csharpDevKitNotInstalled, 'stdout', true);
-        }
-
         return new Promise<void>((resolve, reject) => {
             extensionLogOutputChannel.info(`Building .NET project: ${projectFile} using dotnet CLI`);
 

--- a/extension/src/debugger/languages/dotnet.ts
+++ b/extension/src/debugger/languages/dotnet.ts
@@ -325,10 +325,9 @@ export function createProjectDebuggerExtension(dotNetServiceProducer: (debugSess
                 const runApiOutput = await dotNetService.getDotNetRunApiOutput(projectPath);
                 const runApiConfig = getRunApiConfigFromOutput(runApiOutput);
 
-                // Build if the executable doesn't exist or forceBuild is requested
-                if ((!(await doesFileExist(runApiConfig.executablePath)) || launchOptions.forceBuild)) {
-                    await dotNetService.buildDotNetProject(projectPath);
-                }
+                // There may be an older cached version of the file-based app, so we
+                // should force a build.
+                await dotNetService.buildDotNetProject(projectPath);
 
                 debugConfiguration.program = runApiConfig.executablePath;
 

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1383,6 +1383,8 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                     {
                         var projectLaunchConfiguration = new ProjectLaunchConfiguration();
                         projectLaunchConfiguration.ProjectPath = projectMetadata.ProjectPath;
+                        projectLaunchConfiguration.Mode = _configuration[KnownConfigNames.DebugSessionRunMode]
+                            ?? (Debugger.IsAttached ? ExecutableLaunchMode.Debug : ExecutableLaunchMode.NoDebug);
 
                         projectLaunchConfiguration.DisableLaunchProfile = project.TryGetLastAnnotation<ExcludeLaunchProfileAnnotation>(out _);
                         // Use the effective launch profile which has fallback logic

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -1421,6 +1421,39 @@ public class DcpExecutorTests
         Assert.Equal("http", plc.LaunchProfile);
     }
 
+    [Theory]
+    [InlineData("Debug", ExecutableLaunchMode.Debug)]
+    [InlineData("NoDebug", ExecutableLaunchMode.NoDebug)]
+    public async Task ProjectLaunchConfiguration_RespectsDebugSessionRunMode(string runMode, string expectedMode)
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        builder.AddProject<Projects.ServiceA>("proj", launchProfileName: "http");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var kubernetes = new TestKubernetesService();
+        var configBuilder = new ConfigurationBuilder();
+        configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = "http://localhost",
+            ["AppHost:BrowserToken"] = "token",
+            ["AppHost:OtlpApiKey"] = "otlp-key",
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+            [KnownConfigNames.DebugSessionRunMode] = runMode
+        });
+        var configuration = configBuilder.Build();
+
+        var executor = CreateAppExecutor(model, configuration: configuration, kubernetesService: kubernetes);
+
+        await executor.RunApplicationAsync();
+
+        var exe = Assert.Single(kubernetes.CreatedResources.OfType<Executable>());
+        Assert.True(exe.TryGetProjectLaunchConfiguration(out var plc));
+        Assert.NotNull(plc);
+        Assert.Equal(expectedMode, plc!.Mode);
+    }
+
     [Fact]
     public async Task ProjectLaunchConfiguration_Disabled_WhenLaunchProfileExcluded_InDebugSession()
     {


### PR DESCRIPTION
## Description

Discovered during dogfooding. File-based apps should be built before launch, as we aren't using dotnet run to launch them (which will handle build). Also, for polyglot apphosts, to debug file-based apps we need `KnownConfigNames.DebugSessionRunMode` to be respected (NoDebug is currently set based on whether a debugger is attached, which is not true for the apphost server).

Removes C# dev kit build of dotnet projects and just uses the dotnet CLI. We had agreed to make this change before, it just never happened.

Fixes #15161 and fixes #15162

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [X] No
