### PR TITLE
Automatically restore TypeScript starter SDK artifacts

### DIFF
--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -25,7 +25,7 @@ namespace Aspire.Cli.Projects;
 /// Handler for guest (non-.NET) AppHost projects.
 /// Supports any language registered via <see cref="ILanguageDiscovery"/>.
 /// </summary>
-internal sealed class GuestAppHostProject : IAppHostProject
+internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGenerator
 {
     private const string GeneratedFolderName = ".modules";
 
@@ -242,6 +242,11 @@ internal sealed class GuestAppHostProject : IAppHostProject
                 }
             }
         }
+    }
+
+    Task<bool> IGuestAppHostSdkGenerator.BuildAndGenerateSdkAsync(DirectoryInfo directory, CancellationToken cancellationToken)
+    {
+        return BuildAndGenerateSdkAsync(directory, cancellationToken);
     }
 
     // ═══════════════════════════════════════════════════════════════

--- a/src/Aspire.Cli/Projects/IGuestAppHostSdkGenerator.cs
+++ b/src/Aspire.Cli/Projects/IGuestAppHostSdkGenerator.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Projects;
+
+/// <summary>
+/// Generates SDK artifacts for a guest AppHost project.
+/// </summary>
+internal interface IGuestAppHostSdkGenerator
+{
+    /// <summary>
+    /// Builds any required server components and generates guest SDK artifacts.
+    /// </summary>
+    /// <param name="directory">The AppHost project directory.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns><see langword="true"/> if SDK generation succeeded; otherwise, <see langword="false"/>.</returns>
+    Task<bool> BuildAndGenerateSdkAsync(DirectoryInfo directory, CancellationToken cancellationToken);
+}

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
@@ -3,8 +3,8 @@
 
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
-using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 
@@ -61,23 +61,7 @@ internal sealed partial class CliTemplateFactory
                     _logger.LogDebug("Copying embedded TypeScript starter template files to '{OutputPath}'.", outputPath);
                     await CopyTemplateTreeToDiskAsync("ts-starter", outputPath, ApplyAllTokens, cancellationToken);
 
-                    if (!CommandPathResolver.TryResolveCommand("npm", out var npmPath, out var errorMessage))
-                    {
-                        _interactionService.DisplayError(errorMessage!);
-                        return new TemplateResult(ExitCodeConstants.InvalidCommand);
-                    }
-
-                    // Run npm install in the output directory (non-fatal — package may not be published yet)
-                    _logger.LogDebug("Running npm install for TypeScript starter in '{OutputPath}'.", outputPath);
-                    var npmInstallResult = await RunProcessAsync(npmPath!, "install", outputPath, cancellationToken);
-                    if (npmInstallResult.ExitCode != 0)
-                    {
-                        _interactionService.DisplaySubtleMessage("npm install had warnings or errors. You may need to run 'npm install' manually after dependencies are available.");
-                        DisplayProcessOutput(npmInstallResult, treatStandardErrorAsError: false);
-                    }
-
-                    // Write channel to settings.json if available so that aspire add
-                    // knows which channel to use for package resolution
+                    // Write channel to settings.json before restore so package resolution uses the selected channel.
                     if (!string.IsNullOrEmpty(inputs.Channel))
                     {
                         var config = AspireJsonConfiguration.Load(outputPath);
@@ -86,6 +70,21 @@ internal sealed partial class CliTemplateFactory
                             config.Channel = inputs.Channel;
                             config.Save(outputPath);
                         }
+                    }
+
+                    var appHostProject = _projectFactory.TryGetProject(new FileInfo(Path.Combine(outputPath, "apphost.ts")));
+                    if (appHostProject is not IGuestAppHostSdkGenerator guestProject)
+                    {
+                        _interactionService.DisplayError("Automatic 'aspire restore' failed for the new TypeScript starter project.");
+                        return new TemplateResult(ExitCodeConstants.FailedToBuildArtifacts, outputPath);
+                    }
+
+                    _logger.LogDebug("Generating SDK code for TypeScript starter in '{OutputPath}'.", outputPath);
+                    var restoreSucceeded = await guestProject.BuildAndGenerateSdkAsync(new DirectoryInfo(outputPath), cancellationToken);
+                    if (!restoreSucceeded)
+                    {
+                        _interactionService.DisplayError("Automatic 'aspire restore' failed for the new TypeScript starter project.");
+                        return new TemplateResult(ExitCodeConstants.FailedToBuildArtifacts, outputPath);
                     }
 
                     return new TemplateResult(ExitCodeConstants.Success, outputPath);

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
@@ -75,7 +75,7 @@ internal sealed partial class CliTemplateFactory
                     var appHostProject = _projectFactory.TryGetProject(new FileInfo(Path.Combine(outputPath, "apphost.ts")));
                     if (appHostProject is not IGuestAppHostSdkGenerator guestProject)
                     {
-                        _interactionService.DisplayError("Automatic 'aspire restore' failed for the new TypeScript starter project.");
+                        _interactionService.DisplayError("Automatic 'aspire restore' is unavailable for the new TypeScript starter project because no TypeScript AppHost SDK generator was found.");
                         return new TemplateResult(ExitCodeConstants.FailedToBuildArtifacts, outputPath);
                     }
 
@@ -83,7 +83,7 @@ internal sealed partial class CliTemplateFactory
                     var restoreSucceeded = await guestProject.BuildAndGenerateSdkAsync(new DirectoryInfo(outputPath), cancellationToken);
                     if (!restoreSucceeded)
                     {
-                        _interactionService.DisplayError("Automatic 'aspire restore' failed for the new TypeScript starter project.");
+                        _interactionService.DisplayError("Automatic 'aspire restore' failed for the new TypeScript starter project. Run 'aspire restore' in the project directory for more details.");
                         return new TemplateResult(ExitCodeConstants.FailedToBuildArtifacts, outputPath);
                     }
 

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
-using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using Aspire.Cli.Commands;
@@ -39,6 +38,7 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
     };
 
     private readonly ILanguageDiscovery _languageDiscovery;
+    private readonly IAppHostProjectFactory _projectFactory;
     private readonly IScaffoldingService _scaffoldingService;
     private readonly INewCommandPrompter _prompter;
     private readonly CliExecutionContext _executionContext;
@@ -49,6 +49,7 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
 
     public CliTemplateFactory(
         ILanguageDiscovery languageDiscovery,
+        IAppHostProjectFactory projectFactory,
         IScaffoldingService scaffoldingService,
         INewCommandPrompter prompter,
         CliExecutionContext executionContext,
@@ -58,6 +59,7 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
         ILogger<CliTemplateFactory> logger)
     {
         _languageDiscovery = languageDiscovery;
+        _projectFactory = projectFactory;
         _scaffoldingService = scaffoldingService;
         _prompter = prompter;
         _executionContext = executionContext;
@@ -208,76 +210,6 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
             }
         }
     }
-
-    private void DisplayProcessOutput(ProcessExecutionResult result, bool treatStandardErrorAsError)
-    {
-        if (!string.IsNullOrWhiteSpace(result.StandardOutput))
-        {
-            _interactionService.DisplaySubtleMessage(result.StandardOutput.TrimEnd());
-        }
-
-        if (!string.IsNullOrWhiteSpace(result.StandardError))
-        {
-            var message = result.StandardError.TrimEnd();
-            if (treatStandardErrorAsError)
-            {
-                _interactionService.DisplayError(message);
-            }
-            else
-            {
-                _interactionService.DisplaySubtleMessage(message);
-            }
-        }
-    }
-
-    private static async Task<ProcessExecutionResult> RunProcessAsync(string fileName, string arguments, string workingDirectory, CancellationToken cancellationToken)
-    {
-        var startInfo = new ProcessStartInfo(fileName, arguments)
-        {
-            RedirectStandardInput = true,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-            WorkingDirectory = workingDirectory
-        };
-
-        using var process = new Process { StartInfo = startInfo };
-        process.Start();
-        process.StandardInput.Close(); // Prevent hanging on prompts
-
-        // Drain output streams to prevent deadlocks
-        var outputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
-        var errorTask = process.StandardError.ReadToEndAsync(cancellationToken);
-
-        try
-        {
-            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-            await Task.WhenAll(outputTask, errorTask).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            try
-            {
-                if (!process.HasExited)
-                {
-                    process.Kill(entireProcessTree: true);
-                }
-            }
-            catch (InvalidOperationException)
-            {
-            }
-
-            throw;
-        }
-
-        return new ProcessExecutionResult(
-            process.ExitCode,
-            await outputTask.ConfigureAwait(false),
-            await errorTask.ConfigureAwait(false));
-    }
-
-    private sealed record ProcessExecutionResult(int ExitCode, string StandardOutput, string StandardError);
 
     private void DisplayPostCreationInstructions(string outputPath)
     {

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptStarterTemplateTests.cs
@@ -39,6 +39,24 @@ public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
         // Step 1: Create project using aspire new, selecting the Express/React template
         sequenceBuilder.AspireNew("TsStarterApp", counter, template: AspireTemplate.ExpressReact);
 
+        // Step 1.5: Verify starter creation also restored the generated TypeScript SDK.
+        sequenceBuilder.ExecuteCallback(() =>
+        {
+            var projectRoot = Path.Combine(workspace.WorkspaceRoot.FullName, "TsStarterApp");
+            var modulesDir = Path.Combine(projectRoot, ".modules");
+
+            if (!Directory.Exists(modulesDir))
+            {
+                throw new InvalidOperationException($".modules directory was not created at {modulesDir}");
+            }
+
+            var aspireModulePath = Path.Combine(modulesDir, "aspire.ts");
+            if (!File.Exists(aspireModulePath))
+            {
+                throw new InvalidOperationException($"Expected generated file not found: {aspireModulePath}");
+            }
+        });
+
         // Step 2: Navigate into the project and start it in background with JSON output
         sequenceBuilder
             .Type("cd TsStarterApp")

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -4,6 +4,7 @@
 using Aspire.Cli.Utils;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Commands;
+using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.NuGet;
 using Aspire.Cli.Packaging;
@@ -1274,6 +1275,80 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task NewCommandWithTypeScriptStarterGeneratesSdkArtifacts()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var buildAndGenerateCalled = false;
+        string? channelSeenByProject = null;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner
+            {
+                SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, runnerOptions, cancellationToken) =>
+                {
+                    var package = new NuGetPackage
+                    {
+                        Id = "Aspire.ProjectTemplates",
+                        Source = "nuget",
+                        Version = "9.2.0"
+                    };
+
+                    return (0, new NuGetPackage[] { package });
+                }
+            };
+
+            options.PackagingServiceFactory = _ => new NewCommandTestPackagingService
+            {
+                GetChannelsAsyncCallback = cancellationToken =>
+                {
+                    var dailyCache = new NewCommandTestFakeNuGetPackageCache
+                    {
+                        GetTemplatePackagesAsyncCallback = (dir, prerelease, nugetConfig, ct) =>
+                        {
+                            var package = new NuGetPackage
+                            {
+                                Id = "Aspire.ProjectTemplates",
+                                Source = "nuget",
+                                Version = "9.2.0"
+                            };
+
+                            return Task.FromResult<IEnumerable<NuGetPackage>>([package]);
+                        }
+                    };
+
+                    var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [], dailyCache);
+                    return Task.FromResult<IEnumerable<PackageChannel>>([dailyChannel]);
+                }
+            };
+        });
+
+        services.AddSingleton<IAppHostProjectFactory>(new TestTypeScriptStarterProjectFactory((directory, cancellationToken) =>
+        {
+            buildAndGenerateCalled = true;
+            var config = AspireJsonConfiguration.Load(directory.FullName);
+            channelSeenByProject = config?.Channel;
+
+            var modulesDir = Directory.CreateDirectory(Path.Combine(directory.FullName, ".modules"));
+            File.WriteAllText(Path.Combine(modulesDir.FullName, "aspire.ts"), "// generated sdk");
+
+            return Task.FromResult(true);
+        }));
+
+        var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("new aspire-ts-starter --name TestApp --output . --channel daily --localhost-tld false");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+        Assert.True(buildAndGenerateCalled);
+        Assert.Equal("daily", channelSeenByProject);
+        Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, ".modules", "aspire.ts")));
+    }
+
+    [Fact]
     public async Task NewCommandNonInteractiveDoesNotPrompt()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -1504,5 +1579,96 @@ internal sealed class TestScaffoldingService : IScaffoldingService
         }
 
         return Task.CompletedTask;
+    }
+}
+
+internal sealed class TestTypeScriptStarterProjectFactory(Func<DirectoryInfo, CancellationToken, Task<bool>> buildAndGenerateSdkAsync) : IAppHostProjectFactory
+{
+    private readonly TestTypeScriptStarterProject _project = new(buildAndGenerateSdkAsync);
+
+    public IAppHostProject GetProject(LanguageInfo language)
+    {
+        return _project;
+    }
+
+    public IAppHostProject? TryGetProject(FileInfo appHostFile)
+    {
+        return appHostFile.Name.Equals("apphost.ts", StringComparison.OrdinalIgnoreCase) ? _project : null;
+    }
+
+    public IAppHostProject GetProject(FileInfo appHostFile)
+    {
+        return TryGetProject(appHostFile) ?? throw new NotSupportedException($"No handler available for AppHost file '{appHostFile.Name}'.");
+    }
+}
+
+internal sealed class TestTypeScriptStarterProject(Func<DirectoryInfo, CancellationToken, Task<bool>> buildAndGenerateSdkAsync) : IAppHostProject, IGuestAppHostSdkGenerator
+{
+    public bool IsUnsupported { get; set; }
+
+    public string LanguageId => KnownLanguageId.TypeScript;
+
+    public string DisplayName => "TypeScript (Node.js)";
+
+    public string? AppHostFileName => "apphost.ts";
+
+    public Task<string[]> GetDetectionPatternsAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult<string[]>(["apphost.ts"]);
+    }
+
+    public bool CanHandle(FileInfo appHostFile)
+    {
+        return appHostFile.Name.Equals("apphost.ts", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public bool IsUsingProjectReferences(FileInfo appHostFile)
+    {
+        return false;
+    }
+
+    public Task<int> RunAsync(AppHostProjectContext context, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<int> PublishAsync(PublishContext context, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<AppHostValidationResult> ValidateAppHostAsync(FileInfo appHostFile, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new AppHostValidationResult(IsValid: CanHandle(appHostFile)));
+    }
+
+    public Task<bool> AddPackageAsync(AddPackageContext context, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<UpdatePackagesResult> UpdatePackagesAsync(UpdatePackagesContext context, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<RunningInstanceResult> FindAndStopRunningInstanceAsync(FileInfo appHostFile, DirectoryInfo homeDirectory, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(RunningInstanceResult.NoRunningInstance);
+    }
+
+    public Task<string?> GetUserSecretsIdAsync(FileInfo appHostFile, bool autoInit, CancellationToken cancellationToken)
+    {
+        return Task.FromResult<string?>(null);
+    }
+
+    public Task<IReadOnlyList<(string PackageId, string Version)>> GetPackageReferencesAsync(FileInfo appHostFile, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> BuildAndGenerateSdkAsync(DirectoryInfo directory, CancellationToken cancellationToken)
+    {
+        return buildAndGenerateSdkAsync(directory, cancellationToken);
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1349,6 +1349,69 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task NewCommandWithTypeScriptStarterReturnsFailedToBuildArtifactsWhenSdkGenerationFails()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var interactionService = new TestInteractionService();
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.DotNetCliRunnerFactory = _ => new TestDotNetCliRunner
+            {
+                SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, runnerOptions, cancellationToken) =>
+                {
+                    var package = new NuGetPackage
+                    {
+                        Id = "Aspire.ProjectTemplates",
+                        Source = "nuget",
+                        Version = "9.2.0"
+                    };
+
+                    return (0, new NuGetPackage[] { package });
+                }
+            };
+
+            options.PackagingServiceFactory = _ => new NewCommandTestPackagingService
+            {
+                GetChannelsAsyncCallback = cancellationToken =>
+                {
+                    var dailyCache = new NewCommandTestFakeNuGetPackageCache
+                    {
+                        GetTemplatePackagesAsyncCallback = (dir, prerelease, nugetConfig, ct) =>
+                        {
+                            var package = new NuGetPackage
+                            {
+                                Id = "Aspire.ProjectTemplates",
+                                Source = "nuget",
+                                Version = "9.2.0"
+                            };
+
+                            return Task.FromResult<IEnumerable<NuGetPackage>>([package]);
+                        }
+                    };
+
+                    var dailyChannel = PackageChannel.CreateExplicitChannel("daily", PackageChannelQuality.Both, [], dailyCache);
+                    return Task.FromResult<IEnumerable<PackageChannel>>([dailyChannel]);
+                }
+            };
+        });
+
+        services.AddSingleton<IInteractionService>(interactionService);
+        services.AddSingleton<IAppHostProjectFactory>(new TestTypeScriptStarterProjectFactory((directory, cancellationToken) => Task.FromResult(false)));
+
+        var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("new aspire-ts-starter --name TestApp --output . --channel daily --localhost-tld false");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.FailedToBuildArtifacts, exitCode);
+        Assert.Single(interactionService.DisplayedErrors);
+        Assert.Equal("Automatic 'aspire restore' failed for the new TypeScript starter project. Run 'aspire restore' in the project directory for more details.", interactionService.DisplayedErrors[0]);
+    }
+
+    [Fact]
     public async Task NewCommandNonInteractiveDoesNotPrompt()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -1588,6 +1651,13 @@ internal sealed class TestTypeScriptStarterProjectFactory(Func<DirectoryInfo, Ca
 
     public IAppHostProject GetProject(LanguageInfo language)
     {
+        ArgumentNullException.ThrowIfNull(language);
+
+        if (!string.Equals(language.LanguageId, KnownLanguageId.TypeScript, StringComparison.Ordinal))
+        {
+            throw new NotSupportedException($"No handler available for language '{language.LanguageId}'.");
+        }
+
         return _project;
     }
 

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -480,7 +480,8 @@ internal sealed class CliServiceCollectionTestOptions
         var cliTemplateLogger = serviceProvider.GetRequiredService<ILogger<CliTemplateFactory>>();
         var templateNuGetConfigService = new TemplateNuGetConfigService(interactionService, executionContext, packagingService, configurationService);
         var dotNetFactory = new DotNetTemplateFactory(interactionService, runner, certificateService, packagingService, prompter, templateVersionPrompter, executionContext, sdkInstaller, features, configurationService, telemetry, hostEnvironment, templateNuGetConfigService);
-        var cliFactory = new CliTemplateFactory(languageDiscovery, scaffoldingService, prompter, executionContext, interactionService, hostEnvironment, templateNuGetConfigService, cliTemplateLogger);
+        var projectFactory = serviceProvider.GetRequiredService<IAppHostProjectFactory>();
+        var cliFactory = new CliTemplateFactory(languageDiscovery, projectFactory, scaffoldingService, prompter, executionContext, interactionService, hostEnvironment, templateNuGetConfigService, cliTemplateLogger);
         return new TemplateProvider([dotNetFactory, cliFactory]);
     };
 


### PR DESCRIPTION
## Description

Automatically restore TypeScript starter projects as part of `aspire new` so the generated `.modules` SDK is available immediately after creation.

Fixes #15169

This change updates the TypeScript starter template finalization flow to use the guest AppHost restore/code generation pipeline directly instead of spawning a nested CLI process. That keeps the restore behavior aligned with the existing guest project infrastructure, avoids the hanging child-process path seen in automation, and ensures the selected channel is written before restore/package resolution runs.

The implementation also keeps the generated project behavior correct by letting `aspire restore` own guest dependency installation and SDK generation rather than layering an extra template-specific `npm install` step on top. For validation, the change adds focused CLI-level coverage for the TypeScript starter restore path and updates the existing scenario assertion to verify the generated `.modules/aspire.ts` artifact without assuming emitted `.js` files.

Validation:
- `dotnet test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj -- --filter-method "*.NewCommandWithTypeScriptStarterGeneratesSdkArtifacts" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj -- --filter-class "*.NewCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj -- --filter-class "*.TypeScriptStarterTemplateTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` still fails locally in Docker terminal setup before the starter assertions run (`the input device is not a TTY` / container-ready timeout), so that scenario was not revalidated end-to-end on this machine.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
