### PR TITLE
Change Analyzer references to be consistent

### DIFF
--- a/eng/pipelines/azure-pipelines-unofficial.yml
+++ b/eng/pipelines/azure-pipelines-unofficial.yml
@@ -45,7 +45,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: NetCore1ESPool-Internal
-        image: windows.vs2022preview.amd64
+        image: windows.vs2026preview.scout.amd64
         os: windows
     containers:
       linux_x64:
@@ -135,7 +135,7 @@ extends:
 
             pool:
               name: NetCore1ESPool-Internal
-              image: windows.vs2022preview.amd64
+              image: windows.vs2026preview.scout.amd64
               os: windows
 
             variables:

--- a/eng/pipelines/azure-pipelines-unofficial.yml
+++ b/eng/pipelines/azure-pipelines-unofficial.yml
@@ -162,6 +162,40 @@ extends:
                   script: |
                     Get-ChildItem -Path "$(Build.SourcesDirectory)\artifacts\packages" -File -Recurse | Select-Object FullName, @{Name="Size(MB)";Expression={[math]::Round($_.Length/1MB,2)}} | Format-Table -AutoSize
 
+              - task: NodeTool@0
+                displayName: 🟣Install node.js
+                inputs:
+                  versionSpec: '20.x'
+
+              - task: npmAuthenticate@0
+                displayName: 🟣NPM authenticate
+                inputs:
+                  workingFile: $(Build.SourcesDirectory)\.npmrc
+
+              - task: PowerShell@2
+                displayName: 🟣Set .npmrc environment
+                inputs:
+                  targetType: 'inline'
+                  script: Write-Host "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$(Build.SourcesDirectory)\.npmrc"
+
+              - task: PowerShell@2
+                displayName: 🟣Install yarn
+                inputs:
+                  targetType: 'inline'
+                  script: |
+                    npm install -g yarn@1.22.22
+                    yarn --version
+                  workingDirectory: '$(Build.SourcesDirectory)'
+
+              - task: PowerShell@2
+                displayName: 🟣Install vsce
+                inputs:
+                  targetType: 'inline'
+                  script: |
+                    npm install -g @vscode/vsce@3.7.1
+                    vsce --version
+                  workingDirectory: '$(Build.SourcesDirectory)'
+
               - template: /eng/pipelines/templates/BuildAndTest.yml
                 parameters:
                   dotnetScript: $(Build.SourcesDirectory)/dotnet.cmd

--- a/src/Aspire.Hosting.AppHost/Aspire.Hosting.AppHost.csproj
+++ b/src/Aspire.Hosting.AppHost/Aspire.Hosting.AppHost.csproj
@@ -7,6 +7,7 @@
     <IsPackable>true</IsPackable>
     <PackageTags>aspire hosting</PackageTags>
     <Description>Core library and MSBuild logic for Aspire AppHost projects.</Description>
+    <SkipAspireIntegrationAnalyzersReference>true</SkipAspireIntegrationAnalyzersReference>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Aspire.Hosting.RemoteHost/Aspire.Hosting.RemoteHost.csproj
+++ b/src/Aspire.Hosting.RemoteHost/Aspire.Hosting.RemoteHost.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <SkipAspireIntegrationAnalyzersReference>true</SkipAspireIntegrationAnalyzersReference>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -142,18 +142,17 @@
     <InternalsVisibleTo Include="Aspire.Hosting.CodeGeneration.Rust.Tests" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Reference the analyzer to ensure it's built but don't reference its output -->
+    <ProjectReference Include="..\Aspire.Hosting.Integration.Analyzers\Aspire.Hosting.Integration.Analyzers.csproj" ReferenceOutputAssembly="false" Private="true" />
+  </ItemGroup>
+
   <!-- Include the integration analyzer in the package -->
   <PropertyGroup>
     <BeforePack>$(BeforePack);IncludeIntegrationAnalyzerInPackage</BeforePack>
   </PropertyGroup>
   <Target Name="IncludeIntegrationAnalyzerInPackage">
-    <MSBuild Projects="..\Aspire.Hosting.Integration.Analyzers\Aspire.Hosting.Integration.Analyzers.csproj"
-             Targets="Build"
-             Properties="Configuration=$(Configuration);Platform=$(Platform)" />
-
-    <MSBuild Projects="..\Aspire.Hosting.Integration.Analyzers\Aspire.Hosting.Integration.Analyzers.csproj"
-             Targets="GetTargetPath"
-             Properties="Configuration=$(Configuration);Platform=$(Platform)">
+    <MSBuild Projects="..\Aspire.Hosting.Integration.Analyzers\Aspire.Hosting.Integration.Analyzers.csproj" Targets="GetTargetPath">
       <Output TaskParameter="TargetOutputs" PropertyName="AspireIntegrationAnalyzerFile" />
     </MSBuild>
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -3,6 +3,7 @@
     <DisablePackageBaselineValidation Condition="'$(DisablePackageBaselineValidation)' == '' And '$(SuppressFinalPackageVersion)' == 'true'">true</DisablePackageBaselineValidation>
     <!-- If the project is packable, we generate its API surface in a separate file to be used by the API review process. -->
     <GenAPITargetPath Condition="'$(IsPackable)' == 'true'">$(MSBuildProjectDirectory)/api/$(AssemblyName).cs</GenAPITargetPath>
+    <SkipAspireIntegrationAnalyzersReference Condition="'$(SkipAspireIntegrationAnalyzersReference)' == '' And '$(IsRoslynComponent)' == 'true'">true</SkipAspireIntegrationAnalyzersReference>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,21 +16,15 @@
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
 
-   <ItemGroup Condition="
-             $([System.String]::Copy('$(MSBuildProjectName)').StartsWith('Aspire.Hosting.'))
-             and
-             '$(MSBuildProjectName)' != 'Aspire.Hosting.Analyzers'
-             and
-             '$(MSBuildProjectName)' != 'Aspire.Hosting.AppHost'
-             and
-             '$(MSBuildProjectName)' != 'Aspire.Hosting.Integration.Analyzers'">
+  <ItemGroup Condition="$([System.String]::Copy('$(MSBuildProjectName)').StartsWith('Aspire.Hosting.'))
+                        and
+                        '$(SkipAspireIntegrationAnalyzersReference)' != 'true'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)\Aspire.Hosting.Integration.Analyzers\Aspire.Hosting.Integration.Analyzers.csproj"
                     PrivateAssets="all"
                     ReferenceOutputAssembly="false"
-                    OutputItemType="Analyzer"
-                    SetTargetFramework="TargetFramework=netstandard2.0"
-                    GlobalPropertiesToRemove="RuntimeIdentifier;PlatformTarget;SelfContained" />
+                    OutputItemType="Analyzer" />
   </ItemGroup>
+
   <!-- Used by Aspire.Workload.Testing.targets -->
   <Target Name="GetPackageName" Returns="@(PackageName)">
     <ItemGroup>


### PR DESCRIPTION
We have 2 analyzers, but we build and pack them differently. We should use the same pattern.
