### PR TITLE
Exclude playground and tests from CodeQL scanning

### DIFF
--- a/.CodeQL.yml
+++ b/.CodeQL.yml
@@ -1,0 +1,10 @@
+# This file configures CodeQL scanning path exclusions.
+# For more information, see:
+# https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/troubleshooting/bugs/generated-library-code
+
+path_classifiers:
+  refs:
+    # The playground and tests directories are not product code,
+    # so they don't need to be scanned by CodeQL.
+    - playground/**
+    - tests/**


### PR DESCRIPTION
## Description

Add a `.CodeQL.yml` configuration file to exclude the `playground/` and `tests/` directories from CodeQL scanning. These directories contain sample and test code, not product code, so they don't need to be analyzed by CodeQL. This uses the `path_classifiers` mechanism to mark them as reference code.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
