### PR TITLE
Show error message in Aspire panel when CLI does not support describe

### DIFF
--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -229,9 +229,6 @@
     <trans-unit id="aspire-vscode.strings.openAspireDashboard">
       <source xml:lang="en">Launch Aspire Dashboard</source>
     </trans-unit>
-    <trans-unit id="aspire-vscode.strings.settingsLabel">
-      <source xml:lang="en">Settings</source>
-    </trans-unit>
     <trans-unit id="configuration.aspire.dashboardBrowser.debugChrome">
       <source xml:lang="en">Launch Chrome as a debug session (auto-closes when debugging ends).</source>
     </trans-unit>
@@ -392,7 +389,7 @@
       <source xml:lang="en">The Aspire CLI creates, runs, and manages your applications. Install it using the commands in the panel, then verify your installation.&#10;&#10;[Verify installation](command:aspire-vscode.verifyCliInstalled)</source>
     </trans-unit>
     <trans-unit id="views.runningAppHosts.errorWelcome">
-      <source xml:lang="en">The Aspire CLI is not installed or does not support this feature. Install or update the Aspire CLI to get started.&#10;[Update Aspire CLI](command:aspire-vscode.updateSelf)&#10;[Refresh](command:aspire-vscode.refreshRunningAppHosts)</source>
+      <source xml:lang="en">The Aspire CLI is not installed or does not support this feature. Install or update the Aspire CLI and restart VS Code to get started.&#10;[Update Aspire CLI](command:aspire-vscode.updateSelf)&#10;[Refresh](command:aspire-vscode.refreshRunningAppHosts)</source>
     </trans-unit>
     <trans-unit id="walkthrough.getStarted.dashboard.description">
       <source xml:lang="en">The Aspire Dashboard shows your resources, endpoints, logs, traces, and metrics — all in one place.&#10;&#10;[Open dashboard](command:aspire-vscode.openDashboard)</source>

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -118,7 +118,7 @@
   "viewsContainers.aspirePanel.title": "Aspire",
   "views.runningAppHosts.name": "Running AppHosts",
   "views.runningAppHosts.welcome": "No running Aspire apphost detected in this workspace.\n[Refresh](command:aspire-vscode.refreshRunningAppHosts)",
-  "views.runningAppHosts.errorWelcome": "The Aspire CLI is not installed or does not support this feature. Install or update the Aspire CLI to get started.\n[Update Aspire CLI](command:aspire-vscode.updateSelf)\n[Refresh](command:aspire-vscode.refreshRunningAppHosts)",
+  "views.runningAppHosts.errorWelcome": "The Aspire CLI is not installed or does not support this feature. Install or update the Aspire CLI and restart VS Code to get started.\n[Update Aspire CLI](command:aspire-vscode.updateSelf)\n[Refresh](command:aspire-vscode.refreshRunningAppHosts)",
   "command.refreshRunningAppHosts": "Refresh running apphosts",
   "command.openDashboard": "Open Dashboard",
   "command.stopAppHost": "Stop",

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -270,10 +270,11 @@ export class AppHostDataRepository {
                     this._describeProcess = undefined;
 
                     if (!this._disposed && !this._describeRestarting) {
-                        if (!this._describeReceivedData) {
-                            // The process exited without ever producing valid data.
+                        if (!this._describeReceivedData && code !== 0) {
+                            // The process exited with a non-zero code without ever producing valid data.
                             // This likely means the CLI does not support the describe command.
                             extensionLogOutputChannel.warn('aspire describe --follow exited without producing data; the installed Aspire CLI may not support this feature.');
+                            this._workspaceResources.clear();
                             this._setError(errorFetchingAppHosts(`exit code ${code}`));
                             this._updateWorkspaceContext();
                         } else {

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -65,6 +65,7 @@ export class AppHostDataRepository {
     private _describeRestarting = false;
     private _describeRestartDelay = 5000;
     private _describeRestartTimer: ReturnType<typeof setTimeout> | undefined;
+    private _describeReceivedData = false;
 
     // ── Global mode state (ps polling) ──
     private _appHosts: AppHostDisplayInfo[] = [];
@@ -145,6 +146,7 @@ export class AppHostDataRepository {
     refresh(): void {
         this._stopDescribeWatch();
         this._workspaceResources.clear();
+        this._setError(undefined);
         this._updateWorkspaceContext();
         this._describeRestartDelay = 5000;
         this._startDescribeWatch();
@@ -257,6 +259,7 @@ export class AppHostDataRepository {
 
             extensionLogOutputChannel.info('Starting aspire describe --follow for workspace resources');
 
+            this._describeReceivedData = false;
             this._describeProcess = spawnCliProcess(this._terminalProvider, cliPath, args, {
                 noExtensionVariables: true,
                 lineCallback: (line) => {
@@ -267,20 +270,28 @@ export class AppHostDataRepository {
                     this._describeProcess = undefined;
 
                     if (!this._disposed && !this._describeRestarting) {
-                        this._workspaceResources.clear();
-                        this._setError(undefined);
-                        this._updateWorkspaceContext();
+                        if (!this._describeReceivedData) {
+                            // The process exited without ever producing valid data.
+                            // This likely means the CLI does not support the describe command.
+                            extensionLogOutputChannel.warn('aspire describe --follow exited without producing data; the installed Aspire CLI may not support this feature.');
+                            this._setError(errorFetchingAppHosts(`exit code ${code}`));
+                            this._updateWorkspaceContext();
+                        } else {
+                            this._workspaceResources.clear();
+                            this._setError(undefined);
+                            this._updateWorkspaceContext();
 
-                        // Auto-restart with exponential backoff
-                        const delay = this._describeRestartDelay;
-                        this._describeRestartDelay = Math.min(this._describeRestartDelay * 2, this._getPollingIntervalMs());
-                        extensionLogOutputChannel.info(`Restarting describe --follow in ${delay}ms`);
-                        this._describeRestartTimer = setTimeout(() => {
-                            this._describeRestartTimer = undefined;
-                            if (!this._disposed) {
-                                this._startDescribeWatch();
-                            }
-                        }, delay);
+                            // Auto-restart with exponential backoff
+                            const delay = this._describeRestartDelay;
+                            this._describeRestartDelay = Math.min(this._describeRestartDelay * 2, this._getPollingIntervalMs());
+                            extensionLogOutputChannel.info(`Restarting describe --follow in ${delay}ms`);
+                            this._describeRestartTimer = setTimeout(() => {
+                                this._describeRestartTimer = undefined;
+                                if (!this._disposed) {
+                                    this._startDescribeWatch();
+                                }
+                            }, delay);
+                        }
                     }
                     this._describeRestarting = false;
                 },
@@ -320,6 +331,7 @@ export class AppHostDataRepository {
             const resource: ResourceJson = JSON.parse(trimmed);
             if (resource.name) {
                 this._workspaceResources.set(resource.name, resource);
+                this._describeReceivedData = true;
                 this._setError(undefined);
                 this._describeRestartDelay = 5000; // Reset backoff on successful data
                 this._updateWorkspaceContext();


### PR DESCRIPTION
## Description

When `aspire describe --follow` exits without producing valid NDJSON data (e.g., because the installed Aspire CLI is too old and doesn't support the `describe` command), the extension now shows the existing `errorWelcome` view in the Aspire panel. This informs the user that their CLI version doesn't support this feature and provides buttons to update the CLI or refresh.

Previously, the exit callback would silently retry with exponential backoff forever, never surfacing the error to the user.

### Changes

- **`AppHostDataRepository.ts`**: Added a `_describeReceivedData` flag that tracks whether the describe process ever produced valid data. On exit:
  - If no data was received → set error state (triggers `errorWelcome` view)
  - If data was received → clear error and retry with backoff (existing behavior)
  - On `refresh()` → clear error state immediately so the error page dismisses before re-attempting
- **`package.nls.json`**: Updated error message to mention restarting VS Code after updating the CLI.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
