### PR TITLE
Fix Analyzers build race condition and sync unofficial pipeline

### DIFF
--- a/eng/pipelines/azure-pipelines-unofficial.yml
+++ b/eng/pipelines/azure-pipelines-unofficial.yml
@@ -45,7 +45,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: NetCore1ESPool-Internal
-        image: windows.vs2022preview.amd64
+        image: windows.vs2026preview.scout.amd64
         os: windows
     containers:
       linux_x64:
@@ -135,7 +135,7 @@ extends:
 
             pool:
               name: NetCore1ESPool-Internal
-              image: windows.vs2022preview.amd64
+              image: windows.vs2026preview.scout.amd64
               os: windows
 
             variables:

--- a/eng/pipelines/azure-pipelines-unofficial.yml
+++ b/eng/pipelines/azure-pipelines-unofficial.yml
@@ -162,6 +162,40 @@ extends:
                   script: |
                     Get-ChildItem -Path "$(Build.SourcesDirectory)\artifacts\packages" -File -Recurse | Select-Object FullName, @{Name="Size(MB)";Expression={[math]::Round($_.Length/1MB,2)}} | Format-Table -AutoSize
 
+              - task: NodeTool@0
+                displayName: 🟣Install node.js
+                inputs:
+                  versionSpec: '20.x'
+
+              - task: npmAuthenticate@0
+                displayName: 🟣NPM authenticate
+                inputs:
+                  workingFile: $(Build.SourcesDirectory)\.npmrc
+
+              - task: PowerShell@2
+                displayName: 🟣Set .npmrc environment
+                inputs:
+                  targetType: 'inline'
+                  script: Write-Host "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$(Build.SourcesDirectory)\.npmrc"
+
+              - task: PowerShell@2
+                displayName: 🟣Install yarn
+                inputs:
+                  targetType: 'inline'
+                  script: |
+                    npm install -g yarn@1.22.22
+                    yarn --version
+                  workingDirectory: '$(Build.SourcesDirectory)'
+
+              - task: PowerShell@2
+                displayName: 🟣Install vsce
+                inputs:
+                  targetType: 'inline'
+                  script: |
+                    npm install -g @vscode/vsce@3.7.1
+                    vsce --version
+                  workingDirectory: '$(Build.SourcesDirectory)'
+
               - template: /eng/pipelines/templates/BuildAndTest.yml
                 parameters:
                   dotnetScript: $(Build.SourcesDirectory)/dotnet.cmd

--- a/src/Aspire.Hosting.AppHost/Aspire.Hosting.AppHost.csproj
+++ b/src/Aspire.Hosting.AppHost/Aspire.Hosting.AppHost.csproj
@@ -35,7 +35,9 @@
 
   <ItemGroup>
     <!-- Reference the analyzer to ensure it's built but don't reference its output -->
-    <ProjectReference Include="..\Aspire.Hosting.Analyzers\Aspire.Hosting.Analyzers.csproj" ReferenceOutputAssembly="false" Private="true" />
+    <ProjectReference Include="..\Aspire.Hosting.Analyzers\Aspire.Hosting.Analyzers.csproj" ReferenceOutputAssembly="false" Private="true"
+                    SetTargetFramework="TargetFramework=netstandard2.0"
+                    GlobalPropertiesToRemove="RuntimeIdentifier;PlatformTarget;SelfContained" />
     <!-- Reference the tasks project to ensure it's built/restored but don't reference its output -->
     <ProjectReference Include="..\Aspire.Hosting.Tasks\Aspire.Hosting.Tasks.csproj" ReferenceOutputAssembly="false" Private="true" />
   </ItemGroup>
@@ -45,7 +47,9 @@
     <BeforePack>$(BeforePack);IncludeAnalyzerInPackage;IncludeTasksInPackage</BeforePack>
   </PropertyGroup>
   <Target Name="IncludeAnalyzerInPackage">
-    <MSBuild Projects="..\Aspire.Hosting.Analyzers\Aspire.Hosting.Analyzers.csproj" Targets="GetTargetPath">
+    <MSBuild Projects="..\Aspire.Hosting.Analyzers\Aspire.Hosting.Analyzers.csproj" Targets="GetTargetPath"
+            Properties="TargetFramework=netstandard2.0"
+            RemoveProperties="RuntimeIdentifier;PlatformTarget;SelfContained">
       <Output TaskParameter="TargetOutputs" PropertyName="AspireHostingAnalyzerFile" />
     </MSBuild>
 


### PR DESCRIPTION
## Summary

This PR fixes the intermittent `MSB3026`/`CS2012` file-locking errors on `Aspire.Hosting.Analyzers.dll` that have been causing the `dotnet-aspire` official pipeline to fail on the `release/13.2` branch.

## Root Cause

The `Aspire.Hosting.AppHost.csproj` had a direct `ProjectReference` to `Aspire.Hosting.Analyzers` **without** `SetTargetFramework` or `GlobalPropertiesToRemove`. Since `src/Directory.Build.targets` also injects an analyzer reference **with** those attributes into all `Aspire.Hosting.*` projects, MSBuild saw two different global-property configurations and created two parallel build nodes targeting the same output path. When both nodes tried to write `Aspire.Hosting.Analyzers.dll` simultaneously, `Pdb2Pdb` would hold a file lock causing the second node to fail.

## Changes

1. **`src/Aspire.Hosting.AppHost/Aspire.Hosting.AppHost.csproj`**: Added `SetTargetFramework` and `GlobalPropertiesToRemove` to the direct `ProjectReference`, and `Properties`/`RemoveProperties` to the `MSBuild` task call — aligning them with the injected reference from `Directory.Build.targets` so MSBuild deduplicates into a single node.

2. **`eng/pipelines/azure-pipelines-unofficial.yml`**: Synced with the official pipeline:
   - Updated VM image from `windows.vs2022preview.amd64` (no longer exists) to `windows.vs2026preview.scout.amd64`
   - Added Node.js, yarn, and vsce install steps that the official pipeline already has

## Validation

- Reproduced the race locally with the CI build command, confirmed it fails consistently before the fix
- Ran 5 clean build iterations after the fix — **0 file-locking errors across all 5 runs**
- Queued an unofficial pipeline run to validate end-to-end

@radical This is an attempt to fix the race conditions we've been seeing in the `dotnet-aspire` official builds on `release/13.2`. The Analyzers DLL file-locking error has been hitting 3 out of the last 5 builds.