### PR TITLE
[release/13.2] aspire doctor certificates check updates

### DIFF
--- a/src/Aspire.Cli/Certificates/CertificateGeneration/CertificateManager.cs
+++ b/src/Aspire.Cli/Certificates/CertificateGeneration/CertificateManager.cs
@@ -24,8 +24,10 @@ internal abstract class CertificateManager
     // This is the minimum version of the certificate that will be considered valid by runtime components built using this version of the library.
     // Increment this only when making breaking changes to the certificate or during major runtime version increments. Must always be less than or equal to CurrentAspNetCoreCertificateVersion.
     // This determines the minimum version of the tooling required to generate a certificate that will be considered valid by the runtime.
-    // Version 4 was introduced in SDK 10.0.100 and runtime 10.0.0.
-    internal const int CurrentMinimumAspNetCoreCertificateVersion = 4;
+    // Version 6 was introduced in SDK 10.0.102 and runtime 10.0.2.
+    // This is an intentional change from the aspnetcore logic to prefer keeping users up-to-date on the latest certificate version in order
+    // to ensure maximum compatibility with Aspire features.
+    internal const int CurrentMinimumAspNetCoreCertificateVersion = 6;
 
     // OID used for HTTPS certs
     internal const string AspNetHttpsOid = "1.3.6.1.4.1.311.84.1.1";

--- a/src/Aspire.Cli/Certificates/CertificateGeneration/CertificateManager.cs
+++ b/src/Aspire.Cli/Certificates/CertificateGeneration/CertificateManager.cs
@@ -24,10 +24,8 @@ internal abstract class CertificateManager
     // This is the minimum version of the certificate that will be considered valid by runtime components built using this version of the library.
     // Increment this only when making breaking changes to the certificate or during major runtime version increments. Must always be less than or equal to CurrentAspNetCoreCertificateVersion.
     // This determines the minimum version of the tooling required to generate a certificate that will be considered valid by the runtime.
-    // Version 6 was introduced in SDK 10.0.102 and runtime 10.0.2.
-    // This is an intentional change from the aspnetcore logic to prefer keeping users up-to-date on the latest certificate version in order
-    // to ensure maximum compatibility with Aspire features.
-    internal const int CurrentMinimumAspNetCoreCertificateVersion = 6;
+    // Version 4 was introduced in SDK 10.0.100 and runtime 10.0.0.
+    internal const int CurrentMinimumAspNetCoreCertificateVersion = 4;
 
     // OID used for HTTPS certs
     internal const string AspNetHttpsOid = "1.3.6.1.4.1.311.84.1.1";

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
@@ -276,7 +276,7 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Older certificate versions (&lt; v{0}) may not support container trust scenarios..
+        ///   Looks up a localized string similar to Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios..
         /// </summary>
         public static string DevCertsOldVersionDetailsFormat {
             get {

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
@@ -133,7 +133,7 @@
     <value>HTTPS development certificate has an older version ({0})</value>
   </data>
   <data name="DevCertsOldVersionDetailsFormat" xml:space="preserve">
-    <value>Older certificate versions (&lt; v{0}) may not support container trust scenarios.</value>
+    <value>Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</value>
   </data>
   <data name="DevCertsTrustLabelFull" xml:space="preserve">
     <value>[trusted]</value>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionDetailsFormat">
-        <source>Older certificate versions (&lt; v{0}) may not support container trust scenarios.</source>
-        <target state="new">Older certificate versions (&lt; v{0}) may not support container trust scenarios.</target>
+        <source>Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</source>
+        <target state="new">Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</target>
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionMessageFormat">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionDetailsFormat">
-        <source>Older certificate versions (&lt; v{0}) may not support container trust scenarios.</source>
-        <target state="new">Older certificate versions (&lt; v{0}) may not support container trust scenarios.</target>
+        <source>Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</source>
+        <target state="new">Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</target>
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionMessageFormat">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionDetailsFormat">
-        <source>Older certificate versions (&lt; v{0}) may not support container trust scenarios.</source>
-        <target state="new">Older certificate versions (&lt; v{0}) may not support container trust scenarios.</target>
+        <source>Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</source>
+        <target state="new">Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</target>
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionMessageFormat">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionDetailsFormat">
-        <source>Older certificate versions (&lt; v{0}) may not support container trust scenarios.</source>
-        <target state="new">Older certificate versions (&lt; v{0}) may not support container trust scenarios.</target>
+        <source>Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</source>
+        <target state="new">Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</target>
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionMessageFormat">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionDetailsFormat">
-        <source>Older certificate versions (&lt; v{0}) may not support container trust scenarios.</source>
-        <target state="new">Older certificate versions (&lt; v{0}) may not support container trust scenarios.</target>
+        <source>Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</source>
+        <target state="new">Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</target>
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionMessageFormat">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionDetailsFormat">
-        <source>Older certificate versions (&lt; v{0}) may not support container trust scenarios.</source>
-        <target state="new">Older certificate versions (&lt; v{0}) may not support container trust scenarios.</target>
+        <source>Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</source>
+        <target state="new">Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</target>
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionMessageFormat">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionDetailsFormat">
-        <source>Older certificate versions (&lt; v{0}) may not support container trust scenarios.</source>
-        <target state="new">Older certificate versions (&lt; v{0}) may not support container trust scenarios.</target>
+        <source>Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</source>
+        <target state="new">Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</target>
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionMessageFormat">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionDetailsFormat">
-        <source>Older certificate versions (&lt; v{0}) may not support container trust scenarios.</source>
-        <target state="new">Older certificate versions (&lt; v{0}) may not support container trust scenarios.</target>
+        <source>Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</source>
+        <target state="new">Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</target>
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionMessageFormat">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionDetailsFormat">
-        <source>Older certificate versions (&lt; v{0}) may not support container trust scenarios.</source>
-        <target state="new">Older certificate versions (&lt; v{0}) may not support container trust scenarios.</target>
+        <source>Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</source>
+        <target state="new">Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</target>
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionMessageFormat">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionDetailsFormat">
-        <source>Older certificate versions (&lt; v{0}) may not support container trust scenarios.</source>
-        <target state="new">Older certificate versions (&lt; v{0}) may not support container trust scenarios.</target>
+        <source>Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</source>
+        <target state="new">Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</target>
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionMessageFormat">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionDetailsFormat">
-        <source>Older certificate versions (&lt; v{0}) may not support container trust scenarios.</source>
-        <target state="new">Older certificate versions (&lt; v{0}) may not support container trust scenarios.</target>
+        <source>Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</source>
+        <target state="new">Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</target>
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionMessageFormat">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionDetailsFormat">
-        <source>Older certificate versions (&lt; v{0}) may not support container trust scenarios.</source>
-        <target state="new">Older certificate versions (&lt; v{0}) may not support container trust scenarios.</target>
+        <source>Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</source>
+        <target state="new">Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</target>
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionMessageFormat">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionDetailsFormat">
-        <source>Older certificate versions (&lt; v{0}) may not support container trust scenarios.</source>
-        <target state="new">Older certificate versions (&lt; v{0}) may not support container trust scenarios.</target>
+        <source>Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</source>
+        <target state="new">Older certificate versions (&lt; v{0}) may not support all certificate trust scenarios.</target>
         <note />
       </trans-unit>
       <trans-unit id="DevCertsOldVersionMessageFormat">

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -5,7 +5,6 @@ using System.Globalization;
 using System.Text.Json.Nodes;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Resources;
-using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.Certificates.Generation;
 using Microsoft.Extensions.Logging;
 
@@ -74,7 +73,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
 
         // Check for old certificate versions among trusted certificates
         var oldTrustedVersions = certInfos
-            .Where(c => c.TrustLevel != CertificateManager.TrustLevel.None && c.Version < X509Certificate2Extensions.MinimumCertificateVersionSupportingContainerTrust)
+            .Where(c => c.TrustLevel != CertificateManager.TrustLevel.None && c.Version < CertificateManager.CurrentAspNetCoreCertificateVersion)
             .Select(c => c.Version)
             .ToList();
 
@@ -191,7 +190,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
                 Name = "dev-certs-version",
                 Status = EnvironmentCheckStatus.Warning,
                 Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOldVersionMessageFormat, versions),
-                Details = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOldVersionDetailsFormat, X509Certificate2Extensions.MinimumCertificateVersionSupportingContainerTrust),
+                Details = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOldVersionDetailsFormat, CertificateManager.CurrentMinimumAspNetCoreCertificateVersion),
                 Fix = s_cleanAndTrustFixCommand,
                 Link = "https://aka.ms/aspire-prerequisites#dev-certs"
             });

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -146,7 +146,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
                 Name = "dev-certs",
                 Status = EnvironmentCheckStatus.Warning,
                 Message = DoctorCommandStrings.DevCertsNotTrustedMessage,
-                Details = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsNotTrustedDetailsFormat, cert.Thumbprint),
+                Details = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsNotTrustedDetailsFormat, cert.Thumbprint ?? "unknown"),
                 Fix = s_trustFixCommand,
                 Link = "https://aka.ms/aspire-prerequisites#dev-certs",
                 Metadata = metadata
@@ -210,7 +210,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         {
             var certNode = new JsonObject
             {
-                ["thumbprint"] = cert.Thumbprint,
+                ["thumbprint"] = cert.Thumbprint ?? "unknown",
                 ["version"] = cert.Version,
                 ["trustLevel"] = cert.TrustLevel.ToString().ToLowerInvariant(),
                 ["notBefore"] = cert.ValidityNotBefore.ToString("o", CultureInfo.InvariantCulture),

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -1,10 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Globalization;
-using System.Runtime.InteropServices;
-using System.Security.Cryptography.X509Certificates;
+using System.Text.Json.Nodes;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Resources;
 using Aspire.Hosting.Utils;
@@ -16,9 +14,8 @@ namespace Aspire.Cli.Utils.EnvironmentChecker;
 /// <summary>
 /// Checks if the dotnet dev-certs HTTPS certificate is trusted and detects multiple certificates.
 /// </summary>
-internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger) : IEnvironmentCheck
+internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateToolRunner certificateToolRunner) : IEnvironmentCheck
 {
-    private const string SslCertDirEnvVar = "SSL_CERT_DIR";
     private const string DevCertsOpenSslCertDirEnvVar = "DOTNET_DEV_CERTS_OPENSSL_CERTIFICATE_DIRECTORY";
 
     public int Order => 35; // After SDK check (30), before container checks (40+)
@@ -30,8 +27,8 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger) : IEnvironmen
     {
         try
         {
-            var certInfos = GetCertificateInfos();
-            var results = EvaluateCertificateResults(certInfos);
+            var trustResult = certificateToolRunner.CheckHttpCertificate();
+            var results = EvaluateCertificateResults(trustResult.Certificates);
 
             return Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>(results);
         }
@@ -52,10 +49,10 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger) : IEnvironmen
     /// <summary>
     /// Evaluates certificate information and produces the appropriate check results.
     /// </summary>
-    /// <param name="certInfos">Pre-computed certificate information including trust level, thumbprint, and version.</param>
+    /// <param name="certInfos">Certificate information from <see cref="ICertificateToolRunner.CheckHttpCertificate"/>.</param>
     /// <returns>The list of environment check results.</returns>
     internal static List<EnvironmentCheckResult> EvaluateCertificateResults(
-        List<CertificateInfo> certInfos)
+        IReadOnlyList<DevCertInfo> certInfos)
     {
         if (certInfos.Count == 0)
         {
@@ -81,6 +78,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger) : IEnvironmen
             .Select(c => c.Version)
             .ToList();
 
+        var metadata = BuildCertificateMetadata(certInfos);
         var results = new List<EnvironmentCheckResult>();
 
         // Check for multiple dev certificates (in My store)
@@ -94,7 +92,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger) : IEnvironmen
                     CertificateManager.TrustLevel.Partial => $" {DoctorCommandStrings.DevCertsTrustLabelPartial}",
                     _ => ""
                 };
-                return $"v{c.Version} ({c.Thumbprint[..8]}...){trustLabel}";
+                return $"v{c.Version} ({c.Thumbprint?[..8]}...){trustLabel}";
             }));
 
             if (trustedCount == 0)
@@ -107,7 +105,8 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger) : IEnvironmen
                     Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsMultipleNoneTrustedMessageFormat, certInfos.Count),
                     Details = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsMultipleNoneTrustedDetailsFormat, certDetails),
                     Fix = s_cleanAndTrustFixCommand,
-                    Link = "https://aka.ms/aspire-prerequisites#dev-certs"
+                    Link = "https://aka.ms/aspire-prerequisites#dev-certs",
+                    Metadata = metadata
                 });
             }
             else if (trustedCount < certInfos.Count)
@@ -120,7 +119,8 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger) : IEnvironmen
                     Message = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsMultipleSomeUntrustedMessageFormat, certInfos.Count),
                     Details = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsMultipleSomeUntrustedDetailsFormat, certDetails),
                     Fix = s_cleanAndTrustFixCommand,
-                    Link = "https://aka.ms/aspire-prerequisites#dev-certs"
+                    Link = "https://aka.ms/aspire-prerequisites#dev-certs",
+                    Metadata = metadata
                 });
             }
             // else: all certificates are trusted — no warning needed
@@ -131,7 +131,8 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger) : IEnvironmen
                     Category = "environment",
                     Name = "dev-certs",
                     Status = EnvironmentCheckStatus.Pass,
-                    Message = DoctorCommandStrings.DevCertsTrustedMessage
+                    Message = DoctorCommandStrings.DevCertsTrustedMessage,
+                    Metadata = metadata
                 });
             }
         }
@@ -147,7 +148,8 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger) : IEnvironmen
                 Message = DoctorCommandStrings.DevCertsNotTrustedMessage,
                 Details = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsNotTrustedDetailsFormat, cert.Thumbprint),
                 Fix = s_trustFixCommand,
-                Link = "https://aka.ms/aspire-prerequisites#dev-certs"
+                Link = "https://aka.ms/aspire-prerequisites#dev-certs",
+                Metadata = metadata
             });
         }
         else if (partiallyTrustedCount > 0 && fullyTrustedCount == 0)
@@ -162,7 +164,8 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger) : IEnvironmen
                 Message = DoctorCommandStrings.DevCertsPartiallyTrustedMessage,
                 Details = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsPartiallyTrustedDetailsFormat, devCertsTrustPath),
                 Fix = string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsPartiallyTrustedFixFormat, BuildSslCertDirFixCommand(devCertsTrustPath)),
-                Link = "https://aka.ms/aspire-prerequisites#dev-certs"
+                Link = "https://aka.ms/aspire-prerequisites#dev-certs",
+                Metadata = metadata
             });
         }
         else
@@ -173,7 +176,8 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger) : IEnvironmen
                 Category = "environment",
                 Name = "dev-certs",
                 Status = EnvironmentCheckStatus.Pass,
-                Message = DoctorCommandStrings.DevCertsTrustedMessage
+                Message = DoctorCommandStrings.DevCertsTrustedMessage,
+                Metadata = metadata
             });
         }
 
@@ -197,88 +201,28 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger) : IEnvironmen
     }
 
     /// <summary>
-    /// Loads developer certificates and builds pre-computed certificate information.
-    /// Used by <see cref="CheckAsync"/>.
+    /// Builds structured metadata from certificate information for JSON output.
     /// </summary>
-    private List<CertificateInfo> GetCertificateInfos()
+    private static JsonObject BuildCertificateMetadata(IReadOnlyList<DevCertInfo> certInfos)
     {
-        var devCertificates = GetDeveloperCertificates();
-        try
+        var certificatesArray = new JsonArray();
+        foreach (var cert in certInfos)
         {
-            return devCertificates.Select(c =>
+            var certNode = new JsonObject
             {
-                var trustLevel = GetCertificateTrustLevel(c);
-                return new CertificateInfo(trustLevel, c.Thumbprint, c.GetCertificateVersion());
-            }).ToList();
+                ["thumbprint"] = cert.Thumbprint,
+                ["version"] = cert.Version,
+                ["trustLevel"] = cert.TrustLevel.ToString().ToLowerInvariant(),
+                ["notBefore"] = cert.ValidityNotBefore.ToString("o", CultureInfo.InvariantCulture),
+                ["notAfter"] = cert.ValidityNotAfter.ToString("o", CultureInfo.InvariantCulture)
+            };
+            certificatesArray.Add((JsonNode)certNode);
         }
-        finally
+
+        return new JsonObject
         {
-            foreach (var cert in devCertificates)
-            {
-                cert.Dispose();
-            }
-        }
-    }
-
-    /// <summary>
-    /// Gets all ASP.NET Core development certificates from the CurrentUser/My store.
-    /// </summary>
-    private List<X509Certificate2> GetDeveloperCertificates()
-    {
-        var devCerts = new List<X509Certificate2>();
-
-        try
-        {
-            using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
-            store.Open(OpenFlags.ReadOnly);
-
-            var now = DateTimeOffset.Now;
-            foreach (var cert in store.Certificates)
-            {
-                // Check if it's an ASP.NET Core development certificate and is currently valid
-                if (cert.IsAspNetCoreDevelopmentCertificate() &&
-                    cert.NotBefore <= now && now <= cert.NotAfter)
-                {
-                    // Create a new instance to avoid keeping references to store certificates
-                    devCerts.Add(new X509Certificate2(cert));
-                }
-
-                // Dispose the certificate from the store enumeration
-                cert.Dispose();
-            }
-        }
-        catch (Exception ex)
-        {
-            logger.LogDebug(ex, "Error reading certificates from CurrentUser/My store");
-        }
-
-        return devCerts;
-    }
-
-    /// <summary>
-    /// Gets the trust level of a certificate.
-    /// </summary>
-    private CertificateManager.TrustLevel GetCertificateTrustLevel(X509Certificate2 certificate)
-    {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            // On macOS, use 'security verify-cert' to check trust (same as dotnet dev-certs)
-            return IsCertificateTrustedOnMacOS(certificate) ? CertificateManager.TrustLevel.Full : CertificateManager.TrustLevel.None;
-        }
-
-        // Check if the certificate exists in the Root stores
-        if (!IsCertificateInRootStore(certificate))
-        {
-            return CertificateManager.TrustLevel.None;
-        }
-
-        // On Linux, check if SSL_CERT_DIR is configured properly
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !IsSslCertDirConfigured())
-        {
-            return CertificateManager.TrustLevel.Partial;
-        }
-
-        return CertificateManager.TrustLevel.Full;
+            ["certificates"] = certificatesArray
+        };
     }
 
     /// <summary>
@@ -290,23 +234,6 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger) : IEnvironmen
         return !string.IsNullOrEmpty(overridePath)
             ? overridePath
             : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspnet", "dev-certs", "trust");
-    }
-
-    /// <summary>
-    /// Checks if SSL_CERT_DIR is configured to include the dev-certs trust path.
-    /// </summary>
-    private static bool IsSslCertDirConfigured()
-    {
-        var devCertsTrustPath = GetDevCertsTrustPath();
-        var currentSslCertDir = Environment.GetEnvironmentVariable(SslCertDirEnvVar);
-
-        if (string.IsNullOrEmpty(currentSslCertDir))
-        {
-            return false;
-        }
-
-        var paths = currentSslCertDir.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
-        return paths.Any(p => string.Equals(p.TrimEnd(Path.DirectorySeparatorChar), devCertsTrustPath.TrimEnd(Path.DirectorySeparatorChar), StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>
@@ -335,106 +262,4 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger) : IEnvironmen
 
         return $"export SSL_CERT_DIR=\"$SSL_CERT_DIR:{devCertsTrustPath}\"";
     }
-
-    /// <summary>
-    /// Checks if a certificate is trusted on macOS using the security command.
-    /// </summary>
-    /// <remarks>
-    /// This logic is based on ASP.NET Core's MacOSCertificateManager.GetTrustLevel method:
-    /// https://github.com/dotnet/aspnetcore/blob/main/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
-    /// It uses 'security verify-cert' to check trust, which is the same approach used by 'dotnet dev-certs https --trust'.
-    /// </remarks>
-    private bool IsCertificateTrustedOnMacOS(X509Certificate2 certificate)
-    {
-        DirectoryInfo? tempDir = null;
-        try
-        {
-            // Create a temporary directory for the certificate file
-            tempDir = Directory.CreateTempSubdirectory("aspire-cert-");
-            var tempCertPath = Path.Combine(tempDir.FullName, $"{certificate.Thumbprint}.pem");
-            var pemData = certificate.ExportCertificatePem();
-            File.WriteAllText(tempCertPath, pemData);
-
-            // Use 'security verify-cert' to check trust
-            var processInfo = new ProcessStartInfo
-            {
-                FileName = "security",
-                Arguments = $"verify-cert -c \"{tempCertPath}\" -p basic -p ssl",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-
-            using var process = Process.Start(processInfo);
-            if (process is null)
-            {
-                logger.LogDebug("Failed to start security verify-cert process");
-                return false;
-            }
-
-            process.WaitForExit(TimeSpan.FromSeconds(10));
-            return process.ExitCode == 0;
-        }
-        catch (Exception ex)
-        {
-            logger.LogDebug(ex, "Error checking certificate trust on macOS");
-            return false;
-        }
-        finally
-        {
-            if (tempDir != null)
-            {
-                try { tempDir.Delete(recursive: true); } catch { }
-            }
-        }
-    }
-
-    /// <summary>
-    /// Checks if a certificate exists in the trusted Root stores.
-    /// </summary>
-    private bool IsCertificateInRootStore(X509Certificate2 certificate)
-    {
-        var storeLocations = new[]
-        {
-            (StoreName.Root, StoreLocation.CurrentUser),
-            (StoreName.Root, StoreLocation.LocalMachine)
-        };
-
-        foreach (var (storeName, storeLocation) in storeLocations)
-        {
-            try
-            {
-                using var store = new X509Store(storeName, storeLocation);
-                store.Open(OpenFlags.ReadOnly);
-
-                foreach (var cert in store.Certificates)
-                {
-                    try
-                    {
-                        if (string.Equals(cert.Thumbprint, certificate.Thumbprint, StringComparison.OrdinalIgnoreCase))
-                        {
-                            return true;
-                        }
-                    }
-                    finally
-                    {
-                        // Dispose certificates from the store enumeration
-                        cert.Dispose();
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                logger.LogDebug(ex, "Error reading certificates from {StoreName}/{StoreLocation}", storeName, storeLocation);
-            }
-        }
-
-        return false;
-    }
 }
-
-/// <summary>
-/// Pre-computed certificate information for evaluation without accessing the certificate store.
-/// </summary>
-internal sealed record CertificateInfo(CertificateManager.TrustLevel TrustLevel, string Thumbprint, int Version);

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/EnvironmentCheckResult.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/EnvironmentCheckResult.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace Aspire.Cli.Utils.EnvironmentChecker;
@@ -56,6 +57,17 @@ internal sealed class EnvironmentCheckResult
     [JsonPropertyName("details")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Details { get; init; }
+
+    /// <summary>
+    /// Gets optional structured metadata for programmatic consumption.
+    /// </summary>
+    /// <remarks>
+    /// This property allows individual checks to attach arbitrary structured data
+    /// to the JSON output. It is omitted from non-JSON output and when null.
+    /// </remarks>
+    [JsonPropertyName("metadata")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public JsonObject? Metadata { get; init; }
 }
 
 /// <summary>

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckFixRecommendationTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckFixRecommendationTests.cs
@@ -24,9 +24,9 @@ public class DevCertsCheckFixRecommendationTests
     [Fact]
     public void EvaluateCertificateResults_SingleUntrustedCert_RecommendsTrust()
     {
-        var certInfos = new List<CertificateInfo>
+        var certInfos = new List<DevCertInfo>
         {
-            new(CertificateManager.TrustLevel.None, "AABB1234", 4)
+            CreateDevCertInfo(CertificateManager.TrustLevel.None, "AABB1234", 4)
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certInfos);
@@ -41,9 +41,9 @@ public class DevCertsCheckFixRecommendationTests
     [Fact]
     public void EvaluateCertificateResults_SingleFullyTrustedCert_ReportsPass()
     {
-        var certInfos = new List<CertificateInfo>
+        var certInfos = new List<DevCertInfo>
         {
-            new(CertificateManager.TrustLevel.Full, "AABB1234", 4)
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AABB1234", 4)
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certInfos);
@@ -56,10 +56,10 @@ public class DevCertsCheckFixRecommendationTests
     [Fact]
     public void EvaluateCertificateResults_MultipleCerts_SomeUntrusted_RecommendsCleanAndTrust()
     {
-        var certInfos = new List<CertificateInfo>
+        var certInfos = new List<DevCertInfo>
         {
-            new(CertificateManager.TrustLevel.Full, "AABB1234", 4),
-            new(CertificateManager.TrustLevel.None, "CCDD5678", 4)
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AABB1234", 4),
+            CreateDevCertInfo(CertificateManager.TrustLevel.None, "CCDD5678", 4)
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certInfos);
@@ -74,10 +74,10 @@ public class DevCertsCheckFixRecommendationTests
     [Fact]
     public void EvaluateCertificateResults_MultipleCerts_NoneUntrusted_RecommendsCleanAndTrust()
     {
-        var certInfos = new List<CertificateInfo>
+        var certInfos = new List<DevCertInfo>
         {
-            new(CertificateManager.TrustLevel.None, "AABB1234", 4),
-            new(CertificateManager.TrustLevel.None, "CCDD5678", 4)
+            CreateDevCertInfo(CertificateManager.TrustLevel.None, "AABB1234", 4),
+            CreateDevCertInfo(CertificateManager.TrustLevel.None, "CCDD5678", 4)
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certInfos);
@@ -92,9 +92,9 @@ public class DevCertsCheckFixRecommendationTests
     [Fact]
     public void EvaluateCertificateResults_OldVersionCert_RecommendsCleanAndTrust()
     {
-        var certInfos = new List<CertificateInfo>
+        var certInfos = new List<DevCertInfo>
         {
-            new(CertificateManager.TrustLevel.Full, "AABB1234", 1)
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AABB1234", 1)
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certInfos);
@@ -111,9 +111,9 @@ public class DevCertsCheckFixRecommendationTests
     [Fact]
     public void EvaluateCertificateResults_PartiallyTrustedCert_RecommendsSslCertDir()
     {
-        var certInfos = new List<CertificateInfo>
+        var certInfos = new List<DevCertInfo>
         {
-            new(CertificateManager.TrustLevel.Partial, "AABB1234", 4)
+            CreateDevCertInfo(CertificateManager.TrustLevel.Partial, "AABB1234", 4)
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certInfos);
@@ -128,16 +128,32 @@ public class DevCertsCheckFixRecommendationTests
     [Fact]
     public void EvaluateCertificateResults_MultipleAllTrusted_ReportsPass()
     {
-        var certInfos = new List<CertificateInfo>
+        var certInfos = new List<DevCertInfo>
         {
-            new(CertificateManager.TrustLevel.Full, "AABB1234", 4),
-            new(CertificateManager.TrustLevel.Full, "CCDD5678", 4)
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AABB1234", 4),
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "CCDD5678", 4)
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certInfos);
 
         var result = Assert.Single(results);
         Assert.Equal(EnvironmentCheckStatus.Pass, result.Status);
+    }
+
+    private static DevCertInfo CreateDevCertInfo(CertificateManager.TrustLevel trustLevel, string thumbprint, int version)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new DevCertInfo
+        {
+            TrustLevel = trustLevel,
+            Thumbprint = thumbprint,
+            Version = version,
+            ValidityNotBefore = now.AddDays(-30),
+            ValidityNotAfter = now.AddDays(335),
+            Subject = "CN=localhost",
+            IsHttpsDevelopmentCertificate = true,
+            IsExportable = true
+        };
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckFixRecommendationTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckFixRecommendationTests.cs
@@ -9,6 +9,8 @@ namespace Aspire.Cli.Tests.Utils;
 
 public class DevCertsCheckFixRecommendationTests
 {
+    private const int MinVersion = CertificateManager.CurrentAspNetCoreCertificateVersion;
+
     [Fact]
     public void EvaluateCertificateResults_NoCertificates_RecommendsTrust()
     {
@@ -26,7 +28,7 @@ public class DevCertsCheckFixRecommendationTests
     {
         var certInfos = new List<DevCertInfo>
         {
-            CreateDevCertInfo(CertificateManager.TrustLevel.None, "AABB1234", 4)
+            CreateDevCertInfo(CertificateManager.TrustLevel.None, "AABB1234", MinVersion)
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certInfos);
@@ -43,7 +45,7 @@ public class DevCertsCheckFixRecommendationTests
     {
         var certInfos = new List<DevCertInfo>
         {
-            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AABB1234", 4)
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AABB1234", MinVersion)
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certInfos);
@@ -58,8 +60,8 @@ public class DevCertsCheckFixRecommendationTests
     {
         var certInfos = new List<DevCertInfo>
         {
-            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AABB1234", 4),
-            CreateDevCertInfo(CertificateManager.TrustLevel.None, "CCDD5678", 4)
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AABB1234", MinVersion),
+            CreateDevCertInfo(CertificateManager.TrustLevel.None, "CCDD5678", MinVersion)
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certInfos);
@@ -76,8 +78,8 @@ public class DevCertsCheckFixRecommendationTests
     {
         var certInfos = new List<DevCertInfo>
         {
-            CreateDevCertInfo(CertificateManager.TrustLevel.None, "AABB1234", 4),
-            CreateDevCertInfo(CertificateManager.TrustLevel.None, "CCDD5678", 4)
+            CreateDevCertInfo(CertificateManager.TrustLevel.None, "AABB1234", MinVersion),
+            CreateDevCertInfo(CertificateManager.TrustLevel.None, "CCDD5678", MinVersion)
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certInfos);
@@ -113,7 +115,7 @@ public class DevCertsCheckFixRecommendationTests
     {
         var certInfos = new List<DevCertInfo>
         {
-            CreateDevCertInfo(CertificateManager.TrustLevel.Partial, "AABB1234", 4)
+            CreateDevCertInfo(CertificateManager.TrustLevel.Partial, "AABB1234", MinVersion)
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certInfos);
@@ -130,8 +132,8 @@ public class DevCertsCheckFixRecommendationTests
     {
         var certInfos = new List<DevCertInfo>
         {
-            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AABB1234", 4),
-            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "CCDD5678", 4)
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AABB1234", MinVersion),
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "CCDD5678", MinVersion)
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certInfos);

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Cli.Certificates;
 using Aspire.Cli.Utils.EnvironmentChecker;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.Certificates.Generation;
@@ -10,6 +11,22 @@ namespace Aspire.Cli.Tests.Utils;
 public class DevCertsCheckTests
 {
     private const int MinVersion = X509Certificate2Extensions.MinimumCertificateVersionSupportingContainerTrust;
+
+    private static DevCertInfo CreateDevCertInfo(CertificateManager.TrustLevel trustLevel, string thumbprint, int version)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new DevCertInfo
+        {
+            TrustLevel = trustLevel,
+            Thumbprint = thumbprint,
+            Version = version,
+            ValidityNotBefore = now.AddDays(-30),
+            ValidityNotAfter = now.AddDays(335),
+            Subject = "CN=localhost",
+            IsHttpsDevelopmentCertificate = true,
+            IsExportable = true
+        };
+    }
 
     [Fact]
     public void EvaluateCertificateResults_NoCertificates_ReturnsWarning()
@@ -25,10 +42,10 @@ public class DevCertsCheckTests
     [Fact]
     public void EvaluateCertificateResults_MultipleCerts_AllTrusted_ReturnsPass()
     {
-        var certs = new List<CertificateInfo>
+        var certs = new List<DevCertInfo>
         {
-            new(CertificateManager.TrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
-            new(CertificateManager.TrustLevel.Full, "CCCC3333DDDD4444", MinVersion),
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "CCCC3333DDDD4444", MinVersion),
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
@@ -41,10 +58,10 @@ public class DevCertsCheckTests
     [Fact]
     public void EvaluateCertificateResults_MultipleCerts_NoneTrusted_ReturnsWarning()
     {
-        var certs = new List<CertificateInfo>
+        var certs = new List<DevCertInfo>
         {
-            new(CertificateManager.TrustLevel.None, "AAAA1111BBBB2222", MinVersion),
-            new(CertificateManager.TrustLevel.None, "CCCC3333DDDD4444", MinVersion),
+            CreateDevCertInfo(CertificateManager.TrustLevel.None, "AAAA1111BBBB2222", MinVersion),
+            CreateDevCertInfo(CertificateManager.TrustLevel.None, "CCCC3333DDDD4444", MinVersion),
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
@@ -57,10 +74,10 @@ public class DevCertsCheckTests
     [Fact]
     public void EvaluateCertificateResults_MultipleCerts_SomeUntrusted_ReturnsWarning()
     {
-        var certs = new List<CertificateInfo>
+        var certs = new List<DevCertInfo>
         {
-            new(CertificateManager.TrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
-            new(CertificateManager.TrustLevel.None, "CCCC3333DDDD4444", MinVersion),
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
+            CreateDevCertInfo(CertificateManager.TrustLevel.None, "CCCC3333DDDD4444", MinVersion),
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
@@ -73,9 +90,9 @@ public class DevCertsCheckTests
     [Fact]
     public void EvaluateCertificateResults_SingleCert_Trusted_ReturnsPass()
     {
-        var certs = new List<CertificateInfo>
+        var certs = new List<DevCertInfo>
         {
-            new(CertificateManager.TrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
@@ -88,9 +105,9 @@ public class DevCertsCheckTests
     [Fact]
     public void EvaluateCertificateResults_SingleCert_Untrusted_ReturnsWarning()
     {
-        var certs = new List<CertificateInfo>
+        var certs = new List<DevCertInfo>
         {
-            new(CertificateManager.TrustLevel.None, "AAAA1111BBBB2222", MinVersion),
+            CreateDevCertInfo(CertificateManager.TrustLevel.None, "AAAA1111BBBB2222", MinVersion),
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
@@ -103,9 +120,9 @@ public class DevCertsCheckTests
     [Fact]
     public void EvaluateCertificateResults_SingleCert_PartiallyTrusted_ReturnsWarning()
     {
-        var certs = new List<CertificateInfo>
+        var certs = new List<DevCertInfo>
         {
-            new(CertificateManager.TrustLevel.Partial, "AAAA1111BBBB2222", MinVersion),
+            CreateDevCertInfo(CertificateManager.TrustLevel.Partial, "AAAA1111BBBB2222", MinVersion),
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
@@ -118,9 +135,9 @@ public class DevCertsCheckTests
     [Fact]
     public void EvaluateCertificateResults_OldTrustedCert_ReturnsVersionWarning()
     {
-        var certs = new List<CertificateInfo>
+        var certs = new List<DevCertInfo>
         {
-            new(CertificateManager.TrustLevel.Full, "AAAA1111BBBB2222", MinVersion - 1),
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AAAA1111BBBB2222", MinVersion - 1),
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
@@ -134,10 +151,10 @@ public class DevCertsCheckTests
     [Fact]
     public void EvaluateCertificateResults_MultipleCerts_AllTrusted_NoVersionWarning()
     {
-        var certs = new List<CertificateInfo>
+        var certs = new List<DevCertInfo>
         {
-            new(CertificateManager.TrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
-            new(CertificateManager.TrustLevel.Full, "CCCC3333DDDD4444", MinVersion + 1),
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "CCCC3333DDDD4444", MinVersion + 1),
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
@@ -152,10 +169,10 @@ public class DevCertsCheckTests
     public void EvaluateCertificateResults_MultipleCerts_AllPartiallyTrusted_ReturnsPass()
     {
         // Partially trusted counts as trusted (not None), so all certs are "trusted"
-        var certs = new List<CertificateInfo>
+        var certs = new List<DevCertInfo>
         {
-            new(CertificateManager.TrustLevel.Partial, "AAAA1111BBBB2222", MinVersion),
-            new(CertificateManager.TrustLevel.Partial, "CCCC3333DDDD4444", MinVersion),
+            CreateDevCertInfo(CertificateManager.TrustLevel.Partial, "AAAA1111BBBB2222", MinVersion),
+            CreateDevCertInfo(CertificateManager.TrustLevel.Partial, "CCCC3333DDDD4444", MinVersion),
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
@@ -168,11 +185,11 @@ public class DevCertsCheckTests
     [Fact]
     public void EvaluateCertificateResults_ThreeCerts_TwoTrustedOneNot_ReturnsWarning()
     {
-        var certs = new List<CertificateInfo>
+        var certs = new List<DevCertInfo>
         {
-            new(CertificateManager.TrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
-            new(CertificateManager.TrustLevel.Full, "CCCC3333DDDD4444", MinVersion),
-            new(CertificateManager.TrustLevel.None, "EEEE5555FFFF6666", MinVersion),
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "CCCC3333DDDD4444", MinVersion),
+            CreateDevCertInfo(CertificateManager.TrustLevel.None, "EEEE5555FFFF6666", MinVersion),
         };
 
         var results = DevCertsCheck.EvaluateCertificateResults(certs);
@@ -180,5 +197,39 @@ public class DevCertsCheckTests
         var devCertsResult = Assert.Single(results, r => r.Name == "dev-certs");
         Assert.Equal(EnvironmentCheckStatus.Warning, devCertsResult.Status);
         Assert.Contains("3 certificates", devCertsResult.Message);
+    }
+
+    [Fact]
+    public void EvaluateCertificateResults_PassResult_IncludesMetadata()
+    {
+        var certs = new List<DevCertInfo>
+        {
+            CreateDevCertInfo(CertificateManager.TrustLevel.Full, "AAAA1111BBBB2222", MinVersion),
+        };
+
+        var results = DevCertsCheck.EvaluateCertificateResults(certs);
+
+        var devCertsResult = Assert.Single(results, r => r.Name == "dev-certs");
+        Assert.NotNull(devCertsResult.Metadata);
+        Assert.True(devCertsResult.Metadata.ContainsKey("certificates"));
+
+        var certificates = devCertsResult.Metadata["certificates"]!.AsArray();
+        Assert.Single(certificates);
+
+        var certNode = certificates[0]!.AsObject();
+        Assert.Equal("AAAA1111BBBB2222", certNode["thumbprint"]!.GetValue<string>());
+        Assert.Equal(MinVersion, certNode["version"]!.GetValue<int>());
+        Assert.Equal("full", certNode["trustLevel"]!.GetValue<string>());
+        Assert.NotNull(certNode["notBefore"]);
+        Assert.NotNull(certNode["notAfter"]);
+    }
+
+    [Fact]
+    public void EvaluateCertificateResults_NoCertificates_DoesNotIncludeMetadata()
+    {
+        var results = DevCertsCheck.EvaluateCertificateResults([]);
+
+        var devCertsResult = Assert.Single(results);
+        Assert.Null(devCertsResult.Metadata);
     }
 }

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
@@ -3,14 +3,13 @@
 
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Utils.EnvironmentChecker;
-using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.Certificates.Generation;
 
 namespace Aspire.Cli.Tests.Utils;
 
 public class DevCertsCheckTests
 {
-    private const int MinVersion = X509Certificate2Extensions.MinimumCertificateVersionSupportingContainerTrust;
+    private const int MinVersion = CertificateManager.CurrentAspNetCoreCertificateVersion;
 
     private static DevCertInfo CreateDevCertInfo(CertificateManager.TrustLevel trustLevel, string thumbprint, int version)
     {


### PR DESCRIPTION
## Description

- Updates `aspire doctor` to use our fork of the aspnetcore certificate logic for more consistency with the new `aspire certs` commands.
- Treats the latest dev cert version (6) as the minimum version for Aspire specific checks (prefer encouraging users to update to the latest certificate).
- Adds additional certificate metadata to `aspire doctor --format json` output detailing the certificates found, version, trust level, etc.

Sample `aspire doctor --format json` output:
```json
{
  "checks": [
    {
      "category": "sdk",
      "name": "dotnet-sdk",
      "status": "pass",
      "message": ".NET 10.0.200 installed (arm64)"
    },
    {
      "category": "environment",
      "name": "dev-certs",
      "status": "pass",
      "message": "HTTPS development certificate is trusted",
      "metadata": {
        "certificates": [
          {
            "thumbprint": "BAF1DBC82142C479B1119513BE99D582354DCF9C",
            "version": 6,
            "trustLevel": "full",
            "notBefore": "2026-03-12T10:26:33.0000000-07:00",
            "notAfter": "2027-03-12T09:26:33.0000000-08:00"
          }
        ]
      }
    },
    {
      "category": "container",
      "name": "container-runtime",
      "status": "pass",
      "message": "Podman detected and running (version 5.7.1)"
    }
  ],
  "summary": {
    "passed": 3,
    "warnings": 0,
    "failed": 0
  }
}
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
