### PR TITLE
[CI] Fix the auto-rerun workflow missing some PRs

### DIFF
--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -2,7 +2,6 @@
 const failureConclusions = new Set(['failure', 'cancelled', 'timed_out', 'startup_failure']);
 const ignoredJobs = new Set(['Final Results', 'Tests / Final Test Results']);
 const defaultMaxRetryableJobs = 5;
-const defaultMaxLogInspections = defaultMaxRetryableJobs;
 
 const retryableWithAnnotationStepPatterns = [
     /^Set up job$/i,
@@ -147,7 +146,36 @@ function matchesWorkflowRunHead(pullRequest, workflowRun, headOwner, headBranch)
         || pullRequestHeadSha === workflowHeadSha;
 }
 
-async function getAssociatedPullRequestNumbers({ github, owner, repo, workflowRun }) {
+async function listPullRequestsByHead({ github, owner, repo, head, warn }) {
+    const pullRequests = [];
+
+    try {
+        for (let page = 1; ; page++) {
+            const response = await github.request('GET /repos/{owner}/{repo}/pulls', {
+                owner,
+                repo,
+                state: 'all',
+                head,
+                per_page: 100,
+                page,
+            });
+
+            pullRequests.push(...(response.data || []));
+
+            if (!response.headers?.link || !response.headers.link.includes('rel="next"')) {
+                return pullRequests;
+            }
+        }
+    }
+    catch (error) {
+        if (typeof warn === 'function') {
+            warn(`Failed to resolve pull requests for head '${head}': ${error.message}`);
+        }
+        return [];
+    }
+}
+
+async function getAssociatedPullRequestNumbers({ github, owner, repo, workflowRun, warn }) {
     const pullRequestNumbers = getPullRequestNumbers(workflowRun);
     if (pullRequestNumbers.length > 0) {
         return pullRequestNumbers;
@@ -160,15 +188,15 @@ async function getAssociatedPullRequestNumbers({ github, owner, repo, workflowRu
         return [];
     }
 
-    const response = await github.request('GET /repos/{owner}/{repo}/pulls', {
+    const responseData = await listPullRequestsByHead({
+        github,
         owner,
         repo,
-        state: 'all',
         head: `${headOwner}:${headBranch}`,
-        per_page: 100,
+        warn,
     });
 
-    const matchingPullRequests = (response.data || [])
+    const matchingPullRequests = responseData
         .filter(pullRequest => matchesWorkflowRunHead(pullRequest, workflowRun, headOwner, headBranch));
     const fallbackPullRequestNumbers = [...new Set(matchingPullRequests
         .map(pullRequest => pullRequest.number)
@@ -244,8 +272,19 @@ function formatMatchedPatternForMarkdown(matchedPattern) {
         return '';
     }
 
-    const safePattern = String(matchedPattern).replace(/`/g, '\\`');
-    return ` Matched pattern: \`${safePattern}\`.`;
+    const patternText = String(matchedPattern);
+    let maxBacktickRun = 0;
+    const backtickRunRegex = /`+/g;
+    let match;
+
+    while ((match = backtickRunRegex.exec(patternText)) !== null) {
+        if (match[0].length > maxBacktickRun) {
+            maxBacktickRun = match[0].length;
+        }
+    }
+
+    const fence = '`'.repeat(maxBacktickRun + 1);
+    return ` Matched pattern: ${fence}${patternText}${fence}.`;
 }
 
 function findInfrastructureNetworkLogOverridePattern(jobLogText) {
@@ -387,16 +426,15 @@ async function analyzeFailedJobs({
     jobs,
     getAnnotationsForJob,
     getJobLogTextForJob,
-    maxLogInspections = defaultMaxLogInspections,
+    maxRetryableJobs = defaultMaxRetryableJobs,
 }) {
-    const normalizedMaxLogInspections =
-        Number.isInteger(maxLogInspections) && maxLogInspections >= 0
-            ? maxLogInspections
-            : defaultMaxLogInspections;
+    const normalizedMaxRetryableJobs =
+        Number.isInteger(maxRetryableJobs) && maxRetryableJobs >= 0
+            ? maxRetryableJobs
+            : defaultMaxRetryableJobs;
     const failedJobs = (jobs || []).filter(job => failureConclusions.has(job.conclusion) && !ignoredJobs.has(job.name));
     const retryableJobs = [];
     const skippedJobs = [];
-    let logInspectionCount = 0;
 
     for (const job of failedJobs) {
         const failedSteps = getFailedSteps(job);
@@ -413,16 +451,16 @@ async function analyzeFailedJobs({
             !classification.retryable &&
             getJobLogTextForJob &&
             canUseInfrastructureNetworkLogOverride(failedSteps) &&
-            logInspectionCount < normalizedMaxLogInspections;
+            normalizedMaxRetryableJobs > 0 &&
+            retryableJobs.length <= normalizedMaxRetryableJobs;
 
         if (shouldInspectLogs) {
-            logInspectionCount += 1;
-            const matchedInfrastructureNetworkLogOverridePattern =
-                findInfrastructureNetworkLogOverridePattern(await getJobLogTextForJob(job));
+            const jobLogText = await getJobLogTextForJob(job);
+            const matchedInfrastructureNetworkLogOverridePattern = findInfrastructureNetworkLogOverridePattern(jobLogText);
             classification = classifyFailedJob(
                 job,
                 annotations,
-                '',
+                jobLogText,
                 { matchedInfrastructureNetworkLogOverridePattern }
             );
         }
@@ -768,11 +806,13 @@ module.exports = {
     classifyFailedJob,
     computeRerunEligibility,
     defaultMaxRetryableJobs,
+    formatMatchedPatternForMarkdown,
     findInfrastructureNetworkLogOverridePattern,
     getAssociatedPullRequestNumbers,
     getCheckRunIdForJob,
     getOpenPullRequestNumbers,
     getLatestRunAttempt,
+    listPullRequestsByHead,
     rerunMatchedJobs,
     writeAnalysisSummary,
 };

--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -114,6 +114,68 @@ function parseCheckRunId(checkRunUrl) {
     return Number.isInteger(checkRunId) && checkRunId > 0 ? checkRunId : null;
 }
 
+function getPullRequestNumbers(workflowRun) {
+    return [...new Set((workflowRun?.pull_requests || [])
+        .map(pullRequest => pullRequest.number)
+        .filter(Number.isInteger))];
+}
+
+function getHeadRepositoryOwnerLogin(workflowRun) {
+    return workflowRun?.head_repository?.owner?.login ?? workflowRun?.head_repository?.owner?.name ?? null;
+}
+
+function matchesWorkflowRunHead(pullRequest, workflowRun, headOwner, headBranch) {
+    const pullRequestHead = pullRequest?.head;
+    const pullRequestHeadOwner = pullRequestHead?.repo?.owner?.login ?? pullRequestHead?.user?.login ?? null;
+
+    if (typeof pullRequestHeadOwner !== 'string' || pullRequestHeadOwner.toLowerCase() !== headOwner.toLowerCase()) {
+        return false;
+    }
+
+    if (pullRequestHead?.ref !== headBranch) {
+        return false;
+    }
+
+    const workflowHeadSha = workflowRun?.head_sha;
+    const pullRequestHeadSha = pullRequestHead?.sha;
+
+    return typeof workflowHeadSha !== 'string'
+        || workflowHeadSha.length === 0
+        || typeof pullRequestHeadSha !== 'string'
+        || pullRequestHeadSha.length === 0
+        || pullRequestHeadSha === workflowHeadSha;
+}
+
+async function getAssociatedPullRequestNumbers({ github, owner, repo, workflowRun }) {
+    const pullRequestNumbers = getPullRequestNumbers(workflowRun);
+    if (pullRequestNumbers.length > 0) {
+        return pullRequestNumbers;
+    }
+
+    const headOwner = getHeadRepositoryOwnerLogin(workflowRun);
+    const headBranch = workflowRun?.head_branch;
+
+    if (typeof headOwner !== 'string' || headOwner.length === 0 || typeof headBranch !== 'string' || headBranch.length === 0) {
+        return [];
+    }
+
+    const response = await github.request('GET /repos/{owner}/{repo}/pulls', {
+        owner,
+        repo,
+        state: 'all',
+        head: `${headOwner}:${headBranch}`,
+        per_page: 100,
+    });
+
+    const matchingPullRequests = (response.data || [])
+        .filter(pullRequest => matchesWorkflowRunHead(pullRequest, workflowRun, headOwner, headBranch));
+    const fallbackPullRequestNumbers = [...new Set(matchingPullRequests
+        .map(pullRequest => pullRequest.number)
+        .filter(Number.isInteger))];
+
+    return fallbackPullRequestNumbers.length === 1 ? fallbackPullRequestNumbers : [];
+}
+
 async function getCheckRunIdForJob({ job, getJobForWorkflowRun }) {
     const checkRunIdFromJob = parseCheckRunId(job?.check_run_url);
     if (checkRunIdFromJob) {
@@ -672,6 +734,7 @@ module.exports = {
     classifyFailedJob,
     computeRerunEligibility,
     defaultMaxRetryableJobs,
+    getAssociatedPullRequestNumbers,
     getCheckRunIdForJob,
     getOpenPullRequestNumbers,
     getLatestRunAttempt,

--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -2,6 +2,7 @@
 const failureConclusions = new Set(['failure', 'cancelled', 'timed_out', 'startup_failure']);
 const ignoredJobs = new Set(['Final Results', 'Tests / Final Test Results']);
 const defaultMaxRetryableJobs = 5;
+const defaultMaxLogInspections = defaultMaxRetryableJobs;
 
 const retryableWithAnnotationStepPatterns = [
     /^Set up job$/i,
@@ -238,9 +239,22 @@ function isSingleFailedStep(failedSteps) {
     return failedSteps.length === 1;
 }
 
-function getInfrastructureNetworkLogOverrideReason(failedStepText, matchedPattern) {
-    const patternText = matchedPattern ? ` Matched pattern: ${matchedPattern}.` : '';
-    return `Failed step '${failedStepText}' will be retried because the job log shows a likely transient infrastructure network failure.${patternText}`;
+function formatMatchedPatternForMarkdown(matchedPattern) {
+    if (!matchedPattern) {
+        return '';
+    }
+
+    const safePattern = String(matchedPattern).replace(/`/g, '\\`');
+    return ` Matched pattern: \`${safePattern}\`.`;
+}
+
+function findInfrastructureNetworkLogOverridePattern(jobLogText) {
+    return findMatchingPattern(jobLogText, infrastructureNetworkFailureLogOverridePatterns);
+}
+
+function getInfrastructureNetworkLogOverrideReason(failedSteps, failedStepText, matchedPattern) {
+    const patternText = formatMatchedPatternForMarkdown(matchedPattern);
+    return `${formatFailedStepLabel(failedSteps, failedStepText)} will be retried because the job log shows a likely transient infrastructure network failure.${patternText}`;
 }
 
 function getOutsideRetryRulesReason(failedSteps, failedStepText) {
@@ -273,17 +287,22 @@ function getNoRetryMatchReason({
         return 'The job annotations did not show a retry-safe transient infrastructure failure.';
     }
 
-    return 'No retry-safe transient infrastructure signal was found in the job annotations or logs.';
+    return 'No retry-safe transient infrastructure signal was found in the available job diagnostics.';
 }
 
-function classifyFailedJob(job, annotationsOrText, jobLogText = '') {
+function classifyFailedJob(job, annotationsOrText, jobLogText = '', options = {}) {
+    const {
+        matchedInfrastructureNetworkLogOverridePattern: preMatchedInfrastructureNetworkLogOverridePattern,
+    } = options;
     const failedSteps = getFailedSteps(job);
     const failedStepText = failedSteps.join(' | ');
     const { hasRetryableStep, hasIgnoredFailureStep, shouldInspectAnnotations } = getFailureStepSignals(failedSteps);
     const hasTestExecutionFailureStep = failedSteps.some(step => matchesAny(step, testExecutionFailureStepPatterns));
     const matchedInfrastructureNetworkLogOverridePattern =
         !hasTestExecutionFailureStep
-            ? findMatchingPattern(jobLogText, infrastructureNetworkFailureLogOverridePatterns)
+            ? preMatchedInfrastructureNetworkLogOverridePattern === undefined
+                ? findInfrastructureNetworkLogOverridePattern(jobLogText)
+                : preMatchedInfrastructureNetworkLogOverridePattern
             : null;
     const matchesInfrastructureNetworkLogOverride = matchedInfrastructureNetworkLogOverridePattern !== null;
 
@@ -292,7 +311,7 @@ function classifyFailedJob(job, annotationsOrText, jobLogText = '') {
             return {
                 retryable: true,
                 failedSteps,
-                reason: getInfrastructureNetworkLogOverrideReason(failedStepText, matchedInfrastructureNetworkLogOverridePattern),
+                reason: getInfrastructureNetworkLogOverrideReason(failedSteps, failedStepText, matchedInfrastructureNetworkLogOverridePattern),
             };
         }
 
@@ -346,7 +365,7 @@ function classifyFailedJob(job, annotationsOrText, jobLogText = '') {
         return {
             retryable: true,
             failedSteps,
-            reason: getInfrastructureNetworkLogOverrideReason(failedStepText, matchedInfrastructureNetworkLogOverridePattern),
+            reason: getInfrastructureNetworkLogOverrideReason(failedSteps, failedStepText, matchedInfrastructureNetworkLogOverridePattern),
         };
     }
 
@@ -364,10 +383,20 @@ function classifyFailedJob(job, annotationsOrText, jobLogText = '') {
     };
 }
 
-async function analyzeFailedJobs({ jobs, getAnnotationsForJob, getJobLogTextForJob }) {
+async function analyzeFailedJobs({
+    jobs,
+    getAnnotationsForJob,
+    getJobLogTextForJob,
+    maxLogInspections = defaultMaxLogInspections,
+}) {
+    const normalizedMaxLogInspections =
+        Number.isInteger(maxLogInspections) && maxLogInspections >= 0
+            ? maxLogInspections
+            : defaultMaxLogInspections;
     const failedJobs = (jobs || []).filter(job => failureConclusions.has(job.conclusion) && !ignoredJobs.has(job.name));
     const retryableJobs = [];
     const skippedJobs = [];
+    let logInspectionCount = 0;
 
     for (const job of failedJobs) {
         const failedSteps = getFailedSteps(job);
@@ -383,13 +412,18 @@ async function analyzeFailedJobs({ jobs, getAnnotationsForJob, getJobLogTextForJ
         const shouldInspectLogs =
             !classification.retryable &&
             getJobLogTextForJob &&
-            canUseInfrastructureNetworkLogOverride(failedSteps);
+            canUseInfrastructureNetworkLogOverride(failedSteps) &&
+            logInspectionCount < normalizedMaxLogInspections;
 
         if (shouldInspectLogs) {
+            logInspectionCount += 1;
+            const matchedInfrastructureNetworkLogOverridePattern =
+                findInfrastructureNetworkLogOverridePattern(await getJobLogTextForJob(job));
             classification = classifyFailedJob(
                 job,
                 annotations,
-                await getJobLogTextForJob(job)
+                '',
+                { matchedInfrastructureNetworkLogOverridePattern }
             );
         }
 
@@ -734,6 +768,7 @@ module.exports = {
     classifyFailedJob,
     computeRerunEligibility,
     defaultMaxRetryableJobs,
+    findInfrastructureNetworkLogOverridePattern,
     getAssociatedPullRequestNumbers,
     getCheckRunIdForJob,
     getOpenPullRequestNumbers,

--- a/.github/workflows/auto-rerun-transient-ci-failures.js
+++ b/.github/workflows/auto-rerun-transient-ci-failures.js
@@ -484,8 +484,12 @@ async function analyzeFailedJobs({
     return { failedJobs, retryableJobs, skippedJobs };
 }
 
-function computeRerunEligibility({ dryRun, retryableCount, maxRetryableJobs = defaultMaxRetryableJobs }) {
-    return !dryRun && retryableCount > 0 && retryableCount <= maxRetryableJobs;
+function computeRerunEligibility({ retryableCount, maxRetryableJobs = defaultMaxRetryableJobs }) {
+    return retryableCount > 0 && retryableCount <= maxRetryableJobs;
+}
+
+function computeRerunExecutionEligibility({ dryRun, retryableCount, maxRetryableJobs = defaultMaxRetryableJobs }) {
+    return !dryRun && computeRerunEligibility({ retryableCount, maxRetryableJobs });
 }
 
 function buildSummaryReference(url, text) {
@@ -548,14 +552,14 @@ async function writeAnalysisSummary({
     );
     const outcome = rerunEligible ? 'Rerun eligible' : 'Rerun skipped';
     const outcomeDetails = rerunEligible
-        ? `Matched ${retryableJobs.length} retry-safe job${retryableJobs.length === 1 ? '' : 's'} for rerun.`
+        ? dryRun
+            ? `Matched ${retryableJobs.length} retry-safe job${retryableJobs.length === 1 ? '' : 's'} that would be rerun if dry run were disabled.`
+            : `Matched ${retryableJobs.length} retry-safe job${retryableJobs.length === 1 ? '' : 's'} for rerun.`
         : retryableJobs.length === 0
             ? 'No retry-safe jobs were found in the analyzed run.'
-            : dryRun
-                ? 'Dry run is enabled, so no rerun requests will be sent.'
-                : retryableJobs.length > maxRetryableJobs
-                    ? `Matched ${retryableJobs.length} jobs, which exceeds the cap of ${maxRetryableJobs}.`
-                    : 'The analyzed run did not satisfy the workflow safety rails for reruns.';
+            : retryableJobs.length > maxRetryableJobs
+                ? `Matched ${retryableJobs.length} jobs, which exceeds the cap of ${maxRetryableJobs}.`
+                : 'The analyzed run did not satisfy the workflow safety rails for reruns.';
     const summaryRows = [
         [{ data: 'Category', header: true }, { data: 'Count', header: true }],
         ['Outcome', outcome],
@@ -805,6 +809,7 @@ module.exports = {
     buildPullRequestCommentBody,
     classifyFailedJob,
     computeRerunEligibility,
+    computeRerunExecutionEligibility,
     defaultMaxRetryableJobs,
     formatMatchedPatternForMarkdown,
     findInfrastructureNetworkLogOverridePattern,

--- a/.github/workflows/auto-rerun-transient-ci-failures.yml
+++ b/.github/workflows/auto-rerun-transient-ci-failures.yml
@@ -70,6 +70,7 @@ jobs:
             const repo = context.repo.repo;
             const isWorkflowDispatch = context.eventName === 'workflow_dispatch';
             const maxRetryableJobs = rerunWorkflow.defaultMaxRetryableJobs;
+            const maxJobLogInspectionBytes = 256 * 1024;
 
             async function paginate(route, parameters, selectItems) {
               const items = [];
@@ -178,7 +179,7 @@ jobs:
                   throw new Error(`HTTP ${response.status}`);
                 }
 
-                return await response.text();
+                return (await response.text()).slice(-maxJobLogInspectionBytes);
               }
               catch (error) {
                 core.warning(`Failed to fetch logs for job ${jobId}: ${error.message}`);
@@ -226,6 +227,7 @@ jobs:
               jobs,
               getAnnotationsForJob: async job => listAnnotations(job),
               getJobLogTextForJob: async job => getJobLogText(job.id),
+              maxLogInspections: maxRetryableJobs,
             });
 
             core.setOutput('retryable_jobs', JSON.stringify(retryableJobs.map(job => ({

--- a/.github/workflows/auto-rerun-transient-ci-failures.yml
+++ b/.github/workflows/auto-rerun-transient-ci-failures.yml
@@ -50,6 +50,7 @@ jobs:
       retryable_count: ${{ steps.analyze.outputs.retryable_count }}
       skipped_count: ${{ steps.analyze.outputs.skipped_count }}
       rerun_eligible: ${{ steps.analyze.outputs.rerun_eligible }}
+      rerun_execution_eligible: ${{ steps.analyze.outputs.rerun_execution_eligible }}
       dry_run: ${{ steps.analyze.outputs.dry_run }}
       max_retryable_jobs: ${{ steps.analyze.outputs.max_retryable_jobs }}
     steps:
@@ -201,6 +202,7 @@ jobs:
             core.setOutput('retryable_count', '0');
             core.setOutput('skipped_count', '0');
             core.setOutput('rerun_eligible', 'false');
+            core.setOutput('rerun_execution_eligible', 'false');
 
             if (workflowRun.name && workflowRun.name !== 'CI') {
               console.log(`Workflow run ${workflowRun.id} is '${workflowRun.name}', not 'CI'. Skipping.`);
@@ -241,11 +243,16 @@ jobs:
             core.setOutput('skipped_count', String(skippedJobs.length));
 
             const rerunEligible = rerunWorkflow.computeRerunEligibility({
+              retryableCount: retryableJobs.length,
+              maxRetryableJobs,
+            });
+            const rerunExecutionEligible = rerunWorkflow.computeRerunExecutionEligibility({
               dryRun,
               retryableCount: retryableJobs.length,
               maxRetryableJobs,
             });
             core.setOutput('rerun_eligible', String(rerunEligible));
+            core.setOutput('rerun_execution_eligible', String(rerunExecutionEligible));
 
             await rerunWorkflow.writeAnalysisSummary({
               summary: core.summary,
@@ -267,7 +274,7 @@ jobs:
   rerun-transient-failures:
     name: Rerun transient CI failures
     needs: [analyze-transient-failures]
-    if: ${{ needs.analyze-transient-failures.outputs.rerun_eligible == 'true' }}
+    if: ${{ needs.analyze-transient-failures.outputs.rerun_execution_eligible == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/auto-rerun-transient-ci-failures.yml
+++ b/.github/workflows/auto-rerun-transient-ci-failures.yml
@@ -212,6 +212,7 @@ jobs:
               owner,
               repo,
               workflowRun,
+              warn: message => core.warning(message),
             });
             core.setOutput('pull_request_numbers', JSON.stringify(pullRequestNumbers));
 
@@ -227,7 +228,7 @@ jobs:
               jobs,
               getAnnotationsForJob: async job => listAnnotations(job),
               getJobLogTextForJob: async job => getJobLogText(job.id),
-              maxLogInspections: maxRetryableJobs,
+              maxRetryableJobs,
             });
 
             core.setOutput('retryable_jobs', JSON.stringify(retryableJobs.map(job => ({

--- a/.github/workflows/auto-rerun-transient-ci-failures.yml
+++ b/.github/workflows/auto-rerun-transient-ci-failures.yml
@@ -206,13 +206,16 @@ jobs:
               return;
             }
 
-            const pullRequestNumbers = [...new Set((workflowRun.pull_requests || [])
-              .map(pullRequest => pullRequest.number)
-              .filter(Number.isInteger))];
+            const pullRequestNumbers = await rerunWorkflow.getAssociatedPullRequestNumbers({
+              github,
+              owner,
+              repo,
+              workflowRun,
+            });
             core.setOutput('pull_request_numbers', JSON.stringify(pullRequestNumbers));
 
             if (pullRequestNumbers.length === 0) {
-              console.log('No pull request is associated with this workflow run. Skipping.');
+              console.log('No associated pull request could be resolved for this workflow run. Skipping.');
               return;
             }
 

--- a/docs/ci/auto-rerun-transient-ci-failures.md
+++ b/docs/ci/auto-rerun-transient-ci-failures.md
@@ -8,7 +8,7 @@ The workflow analyzes failed `CI` pull request runs, identifies retry-safe trans
 
 GitHub's job-rerun API also reruns downstream dependent jobs, so the workflow targets only the matched jobs when issuing rerun requests, but the resulting rerun attempt can include dependents that GitHub schedules automatically.
 
-When GitHub's `workflow_run` payload omits `pull_requests` for a failed PR run, the workflow falls back to resolving the source pull request from the CI run's `head_repository.owner.login` and `head_branch`. The fallback proceeds only when that lookup yields exactly one matching pull request, so ambiguous branch reuse still results in a skip.
+When GitHub's `workflow_run` payload omits `pull_requests` for a failed PR run, the workflow falls back to resolving the source pull request from the CI run's `head_repository.owner.login` and `head_branch`. The fallback proceeds only when that lookup yields exactly one matching pull request, so ambiguous branch reuse still results in a skip. When the `workflow_run` payload also includes a `head_sha`, the fallback further filters candidate pull requests to those whose head SHA matches that value, which can also cause the lookup to skip if the branch still matches but the pull request head has advanced since the analyzed run.
 
 It is intentionally conservative:
 

--- a/docs/ci/auto-rerun-transient-ci-failures.md
+++ b/docs/ci/auto-rerun-transient-ci-failures.md
@@ -31,6 +31,7 @@ It is intentionally conservative:
 
 - `workflow_dispatch` can inspect any `CI` workflow run by ID and request reruns when the same retry-safety rules are satisfied.
 - `workflow_dispatch` also exposes an optional `dry_run` input so manual runs can produce the analysis summary without sending rerun requests.
+- Dry-run summaries still report whether the analyzed run would be eligible to rerun if dry run were disabled; the execution gate remains suppressed separately.
 - Automatic rerun requires at least one retryable job.
 - Automatic rerun is suppressed when matched jobs exceed the configured cap.
 - Before issuing reruns, the workflow confirms that at least one associated pull request is still open.

--- a/docs/ci/auto-rerun-transient-ci-failures.md
+++ b/docs/ci/auto-rerun-transient-ci-failures.md
@@ -8,6 +8,8 @@ The workflow analyzes failed `CI` pull request runs, identifies retry-safe trans
 
 GitHub's job-rerun API also reruns downstream dependent jobs, so the workflow targets only the matched jobs when issuing rerun requests, but the resulting rerun attempt can include dependents that GitHub schedules automatically.
 
+When GitHub's `workflow_run` payload omits `pull_requests` for a failed PR run, the workflow falls back to resolving the source pull request from the CI run's `head_repository.owner.login` and `head_branch`. The fallback proceeds only when that lookup yields exactly one matching pull request, so ambiguous branch reuse still results in a skip.
+
 It is intentionally conservative:
 
 - it does not rerun every failed job in a run

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -311,6 +311,144 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task GetAssociatedPullRequestNumbersPrefersWorkflowRunPayloadWhenPresent()
+    {
+        AssociatedPullRequestNumbersResult result = await InvokeHarnessAsync<AssociatedPullRequestNumbersResult>(
+            "getAssociatedPullRequestNumbers",
+            new
+            {
+                workflowRun = new
+                {
+                    pull_requests = new[]
+                    {
+                        new { number = 15110 },
+                        new { number = 15110 },
+                        new { number = 15111 }
+                    }
+                }
+            });
+
+        Assert.Equal([15110, 15111], result.PullRequestNumbers);
+        Assert.Empty(result.Requests);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task GetAssociatedPullRequestNumbersFallsBackToHeadLookupWhenPayloadOmitsPullRequests()
+    {
+        AssociatedPullRequestNumbersResult result = await InvokeHarnessAsync<AssociatedPullRequestNumbersResult>(
+            "getAssociatedPullRequestNumbers",
+            new
+            {
+                workflowRun = new
+                {
+                    head_branch = "conditional-test-runs",
+                    head_sha = "5ccc5540dcc68f57dbe10ff941d1f39bab9f9336",
+                    head_repository = new
+                    {
+                        owner = new
+                        {
+                            login = "radical"
+                        }
+                    }
+                },
+                pullRequestsByHead = new Dictionary<string, object[]>
+                {
+                    ["radical:conditional-test-runs"] =
+                    [
+                        new
+                        {
+                            number = 13832,
+                            head = new
+                            {
+                                @ref = "conditional-test-runs",
+                                sha = "5ccc5540dcc68f57dbe10ff941d1f39bab9f9336",
+                                repo = new
+                                {
+                                    owner = new
+                                    {
+                                        login = "radical"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            });
+
+        Assert.Equal([13832], result.PullRequestNumbers);
+
+        RequestRecord request = Assert.Single(result.Requests);
+        Assert.Equal("GET /repos/{owner}/{repo}/pulls", request.Route);
+        Assert.Equal("radical:conditional-test-runs", request.Payload.GetProperty("head").GetString());
+        Assert.Equal("all", request.Payload.GetProperty("state").GetString());
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task GetAssociatedPullRequestNumbersRejectsAmbiguousFallbackMatches()
+    {
+        AssociatedPullRequestNumbersResult result = await InvokeHarnessAsync<AssociatedPullRequestNumbersResult>(
+            "getAssociatedPullRequestNumbers",
+            new
+            {
+                workflowRun = new
+                {
+                    head_branch = "conditional-test-runs",
+                    head_repository = new
+                    {
+                        owner = new
+                        {
+                            login = "radical"
+                        }
+                    }
+                },
+                pullRequestsByHead = new Dictionary<string, object[]>
+                {
+                    ["radical:conditional-test-runs"] =
+                    [
+                        new
+                        {
+                            number = 13832,
+                            head = new
+                            {
+                                @ref = "conditional-test-runs",
+                                sha = "first-sha",
+                                repo = new
+                                {
+                                    owner = new
+                                    {
+                                        login = "radical"
+                                    }
+                                }
+                            }
+                        },
+                        new
+                        {
+                            number = 15177,
+                            head = new
+                            {
+                                @ref = "conditional-test-runs",
+                                sha = "second-sha",
+                                repo = new
+                                {
+                                    owner = new
+                                    {
+                                        login = "radical"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            });
+
+        Assert.Empty(result.PullRequestNumbers);
+        Assert.Single(result.Requests);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task ComputeRerunEligibilityDisablesRerunsWhenDryRunIsEnabled()
     {
         bool rerunEligible = await InvokeHarnessAsync<bool>(
@@ -430,6 +568,7 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         Assert.Contains("MANUAL_DRY_RUN", workflowText);
         Assert.Contains("function parseManualDryRun()", workflowText);
         Assert.Contains("const dryRun = parseManualDryRun();", workflowText);
+        Assert.Contains("getAssociatedPullRequestNumbers", workflowText);
     }
 
     [Fact]
@@ -726,6 +865,12 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         public AnalyzedJob[] FailedJobs { get; init; } = [];
         public AnalyzedJob[] RetryableJobs { get; init; } = [];
         public AnalyzedJob[] SkippedJobs { get; init; } = [];
+    }
+
+    private sealed class AssociatedPullRequestNumbersResult
+    {
+        public int[] PullRequestNumbers { get; init; } = [];
+        public RequestRecord[] Requests { get; init; } = [];
     }
 
     private sealed class AnalyzedJob

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -176,7 +176,7 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
         Assert.Single(result.RetryableJobs);
         Assert.Equal(
-            "Failed step 'Build test project' will be retried because the job log shows a likely transient infrastructure network failure. Matched pattern: /Unable to load the service index for source https:\\/\\/(?:pkgs\\.dev\\.azure\\.com\\/dnceng|dnceng\\.pkgs\\.visualstudio\\.com)\\/public\\/_packaging\\//i.",
+            "Failed step 'Build test project' will be retried because the job log shows a likely transient infrastructure network failure. Matched pattern: `/Unable to load the service index for source https:\\/\\/(?:pkgs\\.dev\\.azure\\.com\\/dnceng|dnceng\\.pkgs\\.visualstudio\\.com)\\/public\\/_packaging\\//i`.",
             result.RetryableJobs[0].Reason);
     }
 
@@ -197,7 +197,7 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
         Assert.Single(result.RetryableJobs);
         Assert.Equal(
-            $"Failed step '{failedStep}' will be retried because the job log shows a likely transient infrastructure network failure. Matched pattern: /Unable to load the service index for source https:\\/\\/(?:pkgs\\.dev\\.azure\\.com\\/dnceng|dnceng\\.pkgs\\.visualstudio\\.com)\\/public\\/_packaging\\//i.",
+            $"Failed step '{failedStep}' will be retried because the job log shows a likely transient infrastructure network failure. Matched pattern: `/Unable to load the service index for source https:\\/\\/(?:pkgs\\.dev\\.azure\\.com\\/dnceng|dnceng\\.pkgs\\.visualstudio\\.com)\\/public\\/_packaging\\//i`.",
             result.RetryableJobs[0].Reason);
     }
 
@@ -214,7 +214,24 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
         Assert.Single(result.RetryableJobs);
         Assert.Equal(
-            "Failed step 'Run ./.github/actions/enumerate-tests' will be retried because the job log shows a likely transient infrastructure network failure. Matched pattern: /Unable to load the service index for source https:\\/\\/(?:pkgs\\.dev\\.azure\\.com\\/dnceng|dnceng\\.pkgs\\.visualstudio\\.com)\\/public\\/_packaging\\//i.",
+            "Failed step 'Run ./.github/actions/enumerate-tests' will be retried because the job log shows a likely transient infrastructure network failure. Matched pattern: `/Unable to load the service index for source https:\\/\\/(?:pkgs\\.dev\\.azure\\.com\\/dnceng|dnceng\\.pkgs\\.visualstudio\\.com)\\/public\\/_packaging\\//i`.",
+            result.RetryableJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task UsesPluralFailedStepLabelWhenMultipleFailedStepsShareALogBasedOverride()
+    {
+        WorkflowJob job = CreateJob(failedSteps: ["Build test project", "Check validation results"]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(
+            job,
+            "Process completed with exit code 1.",
+            "error : Unable to load the service index for source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json.");
+
+        Assert.Single(result.RetryableJobs);
+        Assert.Equal(
+            "Failed steps 'Build test project | Check validation results' will be retried because the job log shows a likely transient infrastructure network failure. Matched pattern: `/Unable to load the service index for source https:\\/\\/(?:pkgs\\.dev\\.azure\\.com\\/dnceng|dnceng\\.pkgs\\.visualstudio\\.com)\\/public\\/_packaging\\//i`.",
             result.RetryableJobs[0].Reason);
     }
 
@@ -252,6 +269,49 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         Assert.Equal(
             "Failed step 'Build test project' is only retried when the job shows a high-confidence infrastructure override, and none was found.",
             result.SkippedJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task UsesAvailableDiagnosticsMessageWhenNoSignalsWereInspectedFromFailedStepsOrLogs()
+    {
+        WorkflowJob job = CreateJob(failedSteps: []);
+
+        AnalyzeFailedJobsResult result = await AnalyzeSingleJobAsync(job, string.Empty);
+
+        Assert.Empty(result.RetryableJobs);
+        Assert.Single(result.SkippedJobs);
+        Assert.Equal(
+            "No retry-safe transient infrastructure signal was found in the available job diagnostics.",
+            result.SkippedJobs[0].Reason);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task CapsLogInspectionCountToAvoidFetchingEveryFailedJobLog()
+    {
+        WorkflowJob firstJob = CreateJob(id: 1, failedSteps: ["Build test project"]);
+        WorkflowJob secondJob = CreateJob(id: 2, failedSteps: ["Build test project"]);
+
+        AnalyzeFailedJobsResult result = await AnalyzeJobsAsync(
+            [firstJob, secondJob],
+            new Dictionary<string, string>
+            {
+                ["1"] = "Process completed with exit code 1.",
+                ["2"] = "Process completed with exit code 1."
+            },
+            new Dictionary<string, string>
+            {
+                ["1"] = "error : Unable to load the service index for source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json.",
+                ["2"] = "error : Unable to load the service index for source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json."
+            },
+            maxLogInspections: 1);
+
+        Assert.Single(result.LogRequestJobIds);
+        Assert.Equal(1, result.LogRequestJobIds[0]);
+        Assert.Single(result.RetryableJobs);
+        Assert.Single(result.SkippedJobs);
+        Assert.Equal(2, result.SkippedJobs[0].Id);
     }
 
     [Fact]
@@ -762,29 +822,68 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         Assert.Contains("All associated pull requests are closed. No jobs were rerun.", skippedRaw.Text);
     }
 
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task RerunMatchedJobsDoesNotFabricateCommentLinksWhenGitHubDoesNotReturnACommentUrl()
+    {
+        RerunMatchedJobsResult result = await InvokeHarnessAsync<RerunMatchedJobsResult>(
+            "rerunMatchedJobs",
+            new
+            {
+                owner = "dotnet",
+                repo = "aspire",
+                retryableJobs = new[]
+                {
+                    new RetryableJobInput
+                    {
+                        Id = 11,
+                        Name = "Tests / One",
+                        HtmlUrl = "https://github.com/dotnet/aspire/actions/runs/123/job/11",
+                        Reason = "Reason one"
+                    }
+                },
+                pullRequestNumbers = new[] { 15110 },
+                issueStatesByNumber = new Dictionary<string, string>
+                {
+                    ["15110"] = "open"
+                },
+                latestRunAttempt = 2,
+                sourceRunId = 123,
+                sourceRunAttempt = 1,
+                sourceRunUrl = "https://github.com/dotnet/aspire/actions/runs/123"
+            });
+
+        Assert.Contains(result.Events, e => e.Type == "raw" && e.Text == "Pull request comments:");
+        Assert.DoesNotContain(result.Events, e => e.Type == "link" && e.Text == "PR #15110 comment");
+        Assert.Contains(result.Events, e => e.Type == "raw" && e.Text == "PR #15110 comment");
+    }
+
     private async Task<AnalyzeFailedJobsResult> AnalyzeSingleJobAsync(WorkflowJob job, string annotationsOrText, string jobLogText = "")
     {
-        Dictionary<string, string> annotationTextByJobId = new()
-        {
-            [job.Id.ToString()] = annotationsOrText
-        };
-
         Dictionary<string, string>? jobLogTextByJobId = string.IsNullOrEmpty(jobLogText)
             ? null
-            : new Dictionary<string, string>
-            {
-                [job.Id.ToString()] = jobLogText
-            };
+            : new Dictionary<string, string> { [job.Id.ToString()] = jobLogText };
 
-        return await InvokeHarnessAsync<AnalyzeFailedJobsResult>(
+        return await AnalyzeJobsAsync(
+            [job],
+            new Dictionary<string, string> { [job.Id.ToString()] = annotationsOrText },
+            jobLogTextByJobId);
+    }
+
+    private Task<AnalyzeFailedJobsResult> AnalyzeJobsAsync(
+        WorkflowJob[] jobs,
+        Dictionary<string, string> annotationTextByJobId,
+        Dictionary<string, string>? jobLogTextByJobId = null,
+        int? maxLogInspections = null)
+        => InvokeHarnessAsync<AnalyzeFailedJobsResult>(
             "analyzeFailedJobs",
             new AnalyzeFailedJobsRequest
             {
-                Jobs = [job],
+                Jobs = jobs,
                 AnnotationTextByJobId = annotationTextByJobId,
-                JobLogTextByJobId = jobLogTextByJobId
+                JobLogTextByJobId = jobLogTextByJobId,
+                MaxLogInspections = maxLogInspections
             });
-    }
 
     private async Task<T> InvokeHarnessAsync<T>(string operation, object payload)
     {
@@ -858,6 +957,7 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         public WorkflowJob[] Jobs { get; init; } = [];
         public Dictionary<string, string> AnnotationTextByJobId { get; init; } = [];
         public Dictionary<string, string>? JobLogTextByJobId { get; init; }
+        public int? MaxLogInspections { get; init; }
     }
 
     private sealed class AnalyzeFailedJobsResult
@@ -865,6 +965,7 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         public AnalyzedJob[] FailedJobs { get; init; } = [];
         public AnalyzedJob[] RetryableJobs { get; init; } = [];
         public AnalyzedJob[] SkippedJobs { get; init; } = [];
+        public int[] LogRequestJobIds { get; init; } = [];
     }
 
     private sealed class AssociatedPullRequestNumbersResult

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -620,7 +620,7 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
-    public async Task ComputeRerunEligibilityDisablesRerunsWhenDryRunIsEnabled()
+    public async Task ComputeRerunEligibilityStillReportsSafeCandidatesDuringDryRun()
     {
         bool rerunEligible = await InvokeHarnessAsync<bool>(
             "computeRerunEligibility",
@@ -630,7 +630,22 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
                 retryableCount = 1
             });
 
-        Assert.False(rerunEligible);
+        Assert.True(rerunEligible);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task ComputeRerunExecutionEligibilityDisablesRerunsWhenDryRunIsEnabled()
+    {
+        bool rerunExecutionEligible = await InvokeHarnessAsync<bool>(
+            "computeRerunExecutionEligibility",
+            new
+            {
+                dryRun = true,
+                retryableCount = 1
+            });
+
+        Assert.False(rerunExecutionEligible);
     }
 
     [Fact]
@@ -735,10 +750,12 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         Assert.Contains("dry_run:", workflowText);
         Assert.Contains("default: false", workflowText);
         Assert.Contains("github.event.workflow_run.run_attempt == 1", workflowText);
-        Assert.Contains("needs.analyze-transient-failures.outputs.rerun_eligible == 'true'", workflowText);
+        Assert.Contains("rerun_execution_eligible", workflowText);
+        Assert.Contains("needs.analyze-transient-failures.outputs.rerun_execution_eligible == 'true'", workflowText);
         Assert.Contains("MANUAL_DRY_RUN", workflowText);
         Assert.Contains("function parseManualDryRun()", workflowText);
         Assert.Contains("const dryRun = parseManualDryRun();", workflowText);
+        Assert.Contains("computeRerunExecutionEligibility", workflowText);
         Assert.Contains("getAssociatedPullRequestNumbers", workflowText);
     }
 
@@ -773,6 +790,38 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
         SummaryEvent rawEvent = Assert.Single(result.Events, e => e.Type == "raw" && e.Text == "Matched 1 retry-safe job for rerun.");
         Assert.Equal("Matched 1 retry-safe job for rerun.", rawEvent.Text);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task WriteAnalysisSummaryShowsWouldRerunDuringDryRun()
+    {
+        SummaryResult result = await InvokeHarnessAsync<SummaryResult>(
+            "writeAnalysisSummary",
+            new
+            {
+                failedJobs = new[]
+                {
+                    new SummaryJob { Id = 11, Name = "Tests / One", Reason = "Reason one" }
+                },
+                retryableJobs = new[]
+                {
+                    new SummaryJob { Id = 11, Name = "Tests / One", Reason = "Reason one" }
+                },
+                skippedJobs = Array.Empty<SummaryJob>(),
+                dryRun = true,
+                rerunEligible = true,
+                sourceRunAttempt = 1,
+                sourceRunUrl = "https://github.com/dotnet/aspire/actions/runs/123"
+            });
+
+        SummaryEvent headingEvent = Assert.Single(result.Events, e => e.Type == "heading" && e.Level == 1);
+        Assert.Equal("Rerun eligible", headingEvent.Text);
+
+        SummaryEvent rawEvent = Assert.Single(
+            result.Events,
+            e => e.Type == "raw" && e.Text == "Matched 1 retry-safe job that would be rerun if dry run were disabled.");
+        Assert.Equal("Matched 1 retry-safe job that would be rerun if dry run were disabled.", rawEvent.Text);
     }
 
     [Fact]

--- a/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/AutoRerunTransientCiFailuresTests.cs
@@ -237,6 +237,20 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task UsesLongerMarkdownFenceWhenMatchedPatternContainsBackticks()
+    {
+        string result = await InvokeHarnessAsync<string>(
+            "formatMatchedPatternForMarkdown",
+            new
+            {
+                matchedPattern = "/foo`bar/i"
+            });
+
+        Assert.Equal(" Matched pattern: ``/foo`bar/i``.", result);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task DoesNotApplyBroadNetworkOverrideWhenTestExecutionFailed()
     {
         WorkflowJob job = CreateJob(failedSteps: ["Run tests (Windows)"]);
@@ -288,7 +302,7 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
-    public async Task CapsLogInspectionCountToAvoidFetchingEveryFailedJobLog()
+    public async Task ContinuesInspectingLaterLogsWhenEarlierCandidatesAreNotRetryable()
     {
         WorkflowJob firstJob = CreateJob(id: 1, failedSteps: ["Build test project"]);
         WorkflowJob secondJob = CreateJob(id: 2, failedSteps: ["Build test project"]);
@@ -302,16 +316,17 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
             },
             new Dictionary<string, string>
             {
-                ["1"] = "error : Unable to load the service index for source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json.",
+                ["1"] = "error MSB4236: The SDK specified could not be found.",
                 ["2"] = "error : Unable to load the service index for source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json."
             },
-            maxLogInspections: 1);
+            maxRetryableJobs: 1);
 
-        Assert.Single(result.LogRequestJobIds);
-        Assert.Equal(1, result.LogRequestJobIds[0]);
+        Assert.Equal([1, 2], result.LogRequestJobIds);
         Assert.Single(result.RetryableJobs);
+        Assert.Equal(2, result.RetryableJobs[0].Id);
+        Assert.Equal(1, result.LogRequestJobIds[0]);
         Assert.Single(result.SkippedJobs);
-        Assert.Equal(2, result.SkippedJobs[0].Id);
+        Assert.Equal(1, result.SkippedJobs[0].Id);
     }
 
     [Fact]
@@ -446,6 +461,76 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
 
     [Fact]
     [RequiresTools(["node"])]
+    public async Task GetAssociatedPullRequestNumbersPaginatesFallbackLookupUntilItFindsTheMatchingSha()
+    {
+        AssociatedPullRequestNumbersResult result = await InvokeHarnessAsync<AssociatedPullRequestNumbersResult>(
+            "getAssociatedPullRequestNumbers",
+            new
+            {
+                workflowRun = new
+                {
+                    head_branch = "conditional-test-runs",
+                    head_sha = "wanted-sha",
+                    head_repository = new
+                    {
+                        owner = new
+                        {
+                            login = "radical"
+                        }
+                    }
+                },
+                pullRequestsByHeadPages = new Dictionary<string, object[][]>
+                {
+                    ["radical:conditional-test-runs"] =
+                    [
+                        [
+                            new
+                            {
+                                number = 11111,
+                                head = new
+                                {
+                                    @ref = "conditional-test-runs",
+                                    sha = "old-sha",
+                                    repo = new
+                                    {
+                                        owner = new
+                                        {
+                                            login = "radical"
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        [
+                            new
+                            {
+                                number = 13832,
+                                head = new
+                                {
+                                    @ref = "conditional-test-runs",
+                                    sha = "wanted-sha",
+                                    repo = new
+                                    {
+                                        owner = new
+                                        {
+                                            login = "radical"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    ]
+                }
+            });
+
+        Assert.Equal([13832], result.PullRequestNumbers);
+        Assert.Equal(2, result.Requests.Length);
+        Assert.Equal(1, result.Requests[0].Payload.GetProperty("page").GetInt32());
+        Assert.Equal(2, result.Requests[1].Payload.GetProperty("page").GetInt32());
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
     public async Task GetAssociatedPullRequestNumbersRejectsAmbiguousFallbackMatches()
     {
         AssociatedPullRequestNumbersResult result = await InvokeHarnessAsync<AssociatedPullRequestNumbersResult>(
@@ -501,6 +586,32 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
                         }
                     ]
                 }
+            });
+
+        Assert.Empty(result.PullRequestNumbers);
+        Assert.Single(result.Requests);
+    }
+
+    [Fact]
+    [RequiresTools(["node"])]
+    public async Task GetAssociatedPullRequestNumbersReturnsEmptyWhenFallbackLookupFails()
+    {
+        AssociatedPullRequestNumbersResult result = await InvokeHarnessAsync<AssociatedPullRequestNumbersResult>(
+            "getAssociatedPullRequestNumbers",
+            new
+            {
+                workflowRun = new
+                {
+                    head_branch = "conditional-test-runs",
+                    head_repository = new
+                    {
+                        owner = new
+                        {
+                            login = "radical"
+                        }
+                    }
+                },
+                failPullRequestLookup = "HTTP 502"
             });
 
         Assert.Empty(result.PullRequestNumbers);
@@ -874,7 +985,7 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         WorkflowJob[] jobs,
         Dictionary<string, string> annotationTextByJobId,
         Dictionary<string, string>? jobLogTextByJobId = null,
-        int? maxLogInspections = null)
+        int? maxRetryableJobs = null)
         => InvokeHarnessAsync<AnalyzeFailedJobsResult>(
             "analyzeFailedJobs",
             new AnalyzeFailedJobsRequest
@@ -882,7 +993,7 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
                 Jobs = jobs,
                 AnnotationTextByJobId = annotationTextByJobId,
                 JobLogTextByJobId = jobLogTextByJobId,
-                MaxLogInspections = maxLogInspections
+                MaxRetryableJobs = maxRetryableJobs
             });
 
     private async Task<T> InvokeHarnessAsync<T>(string operation, object payload)
@@ -957,7 +1068,7 @@ public sealed class AutoRerunTransientCiFailuresTests : IDisposable
         public WorkflowJob[] Jobs { get; init; } = [];
         public Dictionary<string, string> AnnotationTextByJobId { get; init; } = [];
         public Dictionary<string, string>? JobLogTextByJobId { get; init; }
-        public int? MaxLogInspections { get; init; }
+        public int? MaxRetryableJobs { get; init; }
     }
 
     private sealed class AnalyzeFailedJobsResult

--- a/tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js
@@ -63,6 +63,19 @@ async function dispatch(operation, payload) {
                 getJobForWorkflowRun: payload.workflowJob ? async () => payload.workflowJob : undefined,
             });
 
+        case 'getAssociatedPullRequestNumbers': {
+            const requests = [];
+            const github = createGitHubRecorder(payload, requests);
+            const pullRequestNumbers = await rerunWorkflow.getAssociatedPullRequestNumbers({
+                github,
+                owner: payload.owner ?? 'dotnet',
+                repo: payload.repo ?? 'aspire',
+                workflowRun: payload.workflowRun,
+            });
+
+            return { pullRequestNumbers, requests };
+        }
+
         case 'computeRerunEligibility':
             return rerunWorkflow.computeRerunEligibility(payload);
 
@@ -121,6 +134,10 @@ function createGitHubRecorder(payload, requests) {
                 };
             }
 
+            if (route === 'GET /repos/{owner}/{repo}/pulls') {
+                const pullRequests = payload.pullRequestsByHead?.[requestPayload.head] ?? [];
+                return { data: pullRequests };
+            }
             if (route === 'POST /repos/{owner}/{repo}/issues/{issue_number}/comments') {
                 const issueNumber = String(requestPayload.issue_number);
                 const htmlUrl = payload.commentHtmlUrlByNumber?.[issueNumber]

--- a/tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js
@@ -91,6 +91,9 @@ async function dispatch(operation, payload) {
         case 'computeRerunEligibility':
             return rerunWorkflow.computeRerunEligibility(payload);
 
+        case 'computeRerunExecutionEligibility':
+            return rerunWorkflow.computeRerunExecutionEligibility(payload);
+
         case 'writeAnalysisSummary': {
             const summary = new SummaryRecorder();
             await rerunWorkflow.writeAnalysisSummary({

--- a/tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js
@@ -60,11 +60,14 @@ async function dispatch(operation, payload) {
                         logRequestJobIds.push(job.id);
                         return payload.jobLogTextByJobId?.[String(job.id)] ?? '';
                     },
-                    maxLogInspections: payload.maxLogInspections,
+                    maxRetryableJobs: payload.maxRetryableJobs,
                 });
 
                 return { ...result, logRequestJobIds };
             }
+
+        case 'formatMatchedPatternForMarkdown':
+            return rerunWorkflow.formatMatchedPatternForMarkdown(payload.matchedPattern);
 
         case 'getCheckRunIdForJob':
             return rerunWorkflow.getCheckRunIdForJob({
@@ -144,8 +147,23 @@ function createGitHubRecorder(payload, requests) {
             }
 
             if (route === 'GET /repos/{owner}/{repo}/pulls') {
-                const pullRequests = payload.pullRequestsByHead?.[requestPayload.head] ?? [];
-                return { data: pullRequests };
+                if (payload.failPullRequestLookup) {
+                    throw new Error(payload.failPullRequestLookup);
+                }
+
+                const page = Number(requestPayload.page ?? 1);
+                const pullRequestPages = payload.pullRequestsByHeadPages?.[requestPayload.head];
+                const pullRequests = pullRequestPages
+                    ? pullRequestPages[page - 1] ?? []
+                    : payload.pullRequestsByHead?.[requestPayload.head] ?? [];
+                const hasNextPage = Array.isArray(pullRequestPages) && page < pullRequestPages.length;
+
+                return {
+                    data: pullRequests,
+                    headers: {
+                        link: hasNextPage ? '<https://api.github.com/next>; rel="next"' : '',
+                    },
+                };
             }
             if (route === 'POST /repos/{owner}/{repo}/issues/{issue_number}/comments') {
                 const issueNumber = String(requestPayload.issue_number);

--- a/tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js
+++ b/tests/Infrastructure.Tests/WorkflowScripts/auto-rerun-transient-ci-failures.harness.js
@@ -51,11 +51,20 @@ async function main() {
 async function dispatch(operation, payload) {
     switch (operation) {
         case 'analyzeFailedJobs':
-            return rerunWorkflow.analyzeFailedJobs({
-                jobs: payload.jobs ?? [],
-                getAnnotationsForJob: async job => payload.annotationTextByJobId?.[String(job.id)] ?? '',
-                getJobLogTextForJob: async job => payload.jobLogTextByJobId?.[String(job.id)] ?? '',
-            });
+            {
+                const logRequestJobIds = [];
+                const result = await rerunWorkflow.analyzeFailedJobs({
+                    jobs: payload.jobs ?? [],
+                    getAnnotationsForJob: async job => payload.annotationTextByJobId?.[String(job.id)] ?? '',
+                    getJobLogTextForJob: async job => {
+                        logRequestJobIds.push(job.id);
+                        return payload.jobLogTextByJobId?.[String(job.id)] ?? '';
+                    },
+                    maxLogInspections: payload.maxLogInspections,
+                });
+
+                return { ...result, logRequestJobIds };
+            }
 
         case 'getCheckRunIdForJob':
             return rerunWorkflow.getCheckRunIdForJob({
@@ -140,8 +149,7 @@ function createGitHubRecorder(payload, requests) {
             }
             if (route === 'POST /repos/{owner}/{repo}/issues/{issue_number}/comments') {
                 const issueNumber = String(requestPayload.issue_number);
-                const htmlUrl = payload.commentHtmlUrlByNumber?.[issueNumber]
-                    ?? `https://github.com/${requestPayload.owner}/${requestPayload.repo}/pull/${issueNumber}#issuecomment-${issueNumber}`;
+                const htmlUrl = payload.commentHtmlUrlByNumber?.[issueNumber] ?? null;
 
                 return {
                     data: {


### PR DESCRIPTION
## Description

This PR fixes the transient CI rerun workflow when a failed `CI` workflow run does not carry an associated pull request in `workflow_run.pull_requests`.

The main fix is a fallback PR lookup path that resolves the source pull request from the workflow run's head repository owner and head branch, and further narrows the match with `head_sha` when available. This lets the rerun workflow continue analyzing PR runs that previously logged `No associated pull request could be resolved for this workflow run. Skipping.` even though they were triggered by a pull request.

This update also includes a few follow-up fixes and refinements that came out of testing the workflow end to end:

- keep the fallback lookup conservative by requiring exactly one matching pull request after owner/branch/SHA filtering
- improve retry reason formatting and markdown rendering in workflow summaries and PR comments
- bound job log inspection to the relevant tail and avoid overstating when annotations or logs were inspected
- keep dry-run behavior inspection-only while still reporting whether the analyzed run would have been eligible to rerun if dry run were disabled
- update the workflow harness, focused infrastructure tests, and behavior documentation together so the workflow contract stays aligned

### Validation

- `dotnet test tests/Infrastructure.Tests/Infrastructure.Tests.csproj -- --filter-class "*.AutoRerunTransientCiFailuresTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- manual `workflow_dispatch` dry-run checks against representative failed `CI` runs, including runs that previously lacked associated PR metadata

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
