### PR TITLE
Fix StringComparers to StringComparisons

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
@@ -658,7 +658,7 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
 
     private void RemoveAllSelectionsForResource(string resourceName)
     {
-        _selectedRows.RemoveWhere(r => StringComparers.ResourceName.Equals(r.ResourceName, resourceName));
+        _selectedRows.RemoveWhere(r => string.Equals(r.ResourceName, resourceName, StringComparisons.ResourceName));
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -79,7 +79,7 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
 
     private void OnLanguageChanged()
     {
-        if (_selectedUiCulture is null || StringComparers.CultureName.Equals(CultureInfo.CurrentUICulture.Name, _selectedUiCulture.Name))
+        if (_selectedUiCulture is null || string.Equals(CultureInfo.CurrentUICulture.Name, _selectedUiCulture.Name, StringComparisons.CultureName))
         {
             return;
         }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
@@ -19,7 +19,7 @@
     }
     @if (Resource.Properties.TryGetValue(KnownProperties.Container.Lifetime, out var value) &&
         value.Value.HasStringValue &&
-        StringComparer.Ordinal.Equals(value.Value.StringValue, KnownContainerLifetimes.Persistent))
+        string.Equals(value.Value.StringValue, KnownContainerLifetimes.Persistent, StringComparison.Ordinal))
     {
         <FluentIcon Icon="Icons.Regular.Size16.Pin" Title="@Loc[nameof(Columns.PersistentContainerIconTooltip)]"
             Color="Color.Neutral" Class="persistent-container-icon" />

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -209,14 +209,14 @@ public sealed class ResourceViewModelNameComparer : IComparer<ResourceViewModel>
         // Use display name by itself first.
         // This is to avoid the problem of using the full name where one resource is called "database" and another is called "database-admin".
         // The full names could end up "database-xyz" and "database-admin-xyz", which would put resources out of order.
-        var displayNameResult = StringComparers.ResourceName.Compare(x.DisplayName, y.DisplayName);
+        var displayNameResult = string.Compare(x.DisplayName, y.DisplayName, StringComparisons.ResourceName);
         if (displayNameResult != 0)
         {
             return displayNameResult;
         }
 
         // Display names are the same so compare with full names.
-        return StringComparers.ResourceName.Compare(x.Name, y.Name);
+        return string.Compare(x.Name, y.Name, StringComparisons.ResourceName);
     }
 }
 

--- a/src/Aspire.Dashboard/Model/ResourceViewModelExtensions.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModelExtensions.cs
@@ -31,29 +31,29 @@ internal static class ResourceViewModelExtensions
 
     public static bool IsContainer(this ResourceViewModel resource)
     {
-        return StringComparers.ResourceType.Equals(resource.ResourceType, KnownResourceTypes.Container);
+        return string.Equals(resource.ResourceType, KnownResourceTypes.Container, StringComparisons.ResourceType);
     }
 
     public static bool IsProject(this ResourceViewModel resource)
     {
-        return StringComparers.ResourceType.Equals(resource.ResourceType, KnownResourceTypes.Project);
+        return string.Equals(resource.ResourceType, KnownResourceTypes.Project, StringComparisons.ResourceType);
     }
 
     public static bool IsTool(this ResourceViewModel resource)
     {
-        return StringComparers.ResourceType.Equals(resource.ResourceType, KnownResourceTypes.Tool);
+        return string.Equals(resource.ResourceType, KnownResourceTypes.Tool, StringComparisons.ResourceType);
     }
 
     public static bool IsExecutable(this ResourceViewModel resource, bool allowSubtypes)
     {
-        if (StringComparers.ResourceType.Equals(resource.ResourceType, KnownResourceTypes.Executable))
+        if (string.Equals(resource.ResourceType, KnownResourceTypes.Executable, StringComparisons.ResourceType))
         {
             return true;
         }
 
         if (allowSubtypes)
         {
-            return StringComparers.ResourceType.Equals(resource.ResourceType, KnownResourceTypes.Project);
+            return string.Equals(resource.ResourceType, KnownResourceTypes.Project, StringComparisons.ResourceType);
         }
 
         return false;

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
@@ -32,7 +32,6 @@ public static partial class DevTunnelsResourceBuilderExtensions
     /// <remarks>
     /// Dev tunnels can be used to expose local endpoints to the public internet via a secure tunnel. By default,
     /// the tunnel requires authentication, but anonymous access can be enabled via <see cref="WithAnonymousAccess(IResourceBuilder{DevTunnelResource})"/>.
-    /// This overload is not available in polyglot app hosts. Use <see cref="AddDevTunnelForPolyglot"/> instead.
     /// </remarks>
     /// <example>
     /// The following example shows how to create a dev tunnel resource that exposes all endpoints on a web application project and enable anonymous access:
@@ -45,7 +44,7 @@ public static partial class DevTunnelsResourceBuilderExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
-    [AspireExportIgnore(Reason = "Use the dedicated polyglot overload instead.")]
+    [AspireExport("addDevTunnel", Description = "Adds a Dev Tunnel resource to the distributed application model.")]
     public static IResourceBuilder<DevTunnelResource> AddDevTunnel(
         this IDistributedApplicationBuilder builder,
         [ResourceName] string name,
@@ -234,21 +233,6 @@ public static partial class DevTunnelsResourceBuilderExtensions
         return rb;
     }
 
-    [AspireExport("addDevTunnel", Description = "Adds a Dev Tunnel resource to the distributed application model.")]
-    internal static IResourceBuilder<DevTunnelResource> AddDevTunnelForPolyglot(
-        this IDistributedApplicationBuilder builder,
-        [ResourceName] string name,
-        string? tunnelId = null,
-        bool allowAnonymous = false,
-        string? description = null,
-        string[]? labels = null)
-        => AddDevTunnel(builder, name, tunnelId, new DevTunnelOptions
-        {
-            AllowAnonymous = allowAnonymous,
-            Description = description,
-            Labels = labels is null ? null : [.. labels]
-        });
-
     /// <summary>
     /// Adds ports on the dev tunnel for all endpoints found on the referenced resource and sets whether anonymous access is allowed.
     /// </summary>
@@ -405,7 +389,7 @@ public static partial class DevTunnelsResourceBuilderExtensions
         ArgumentNullException.ThrowIfNull(endpointName);
 
         var portResource = tunnelBuilder.Resource.Ports
-            .FirstOrDefault(p => p.TargetEndpoint.Resource == resource && StringComparers.EndpointAnnotationName.Equals(p.TargetEndpoint.EndpointName, endpointName));
+            .FirstOrDefault(p => p.TargetEndpoint.Resource == resource && string.Equals(p.TargetEndpoint.EndpointName, endpointName, StringComparisons.EndpointAnnotationName));
 
         if (portResource is null)
         {
@@ -429,7 +413,7 @@ public static partial class DevTunnelsResourceBuilderExtensions
 
         var portResource = tunnelBuilder.Resource.Ports
             .FirstOrDefault(p => p.TargetEndpoint.Resource == targetEndpointReference.Resource
-                && StringComparers.EndpointAnnotationName.Equals(p.TargetEndpoint.EndpointName, targetEndpointReference.EndpointName));
+                && string.Equals(p.TargetEndpoint.EndpointName, targetEndpointReference.EndpointName, StringComparisons.EndpointAnnotationName));
 
         if (portResource is null)
         {
@@ -541,7 +525,7 @@ public static partial class DevTunnelsResourceBuilderExtensions
         }
 
         if (targetEndpoint.Resource.Annotations.OfType<EndpointAnnotation>()
-            .SingleOrDefault(a => StringComparers.EndpointAnnotationName.Equals(a.Name, targetEndpoint.EndpointName)) is { } targetEndpointAnnotation)
+            .SingleOrDefault(a => string.Equals(a.Name, targetEndpoint.EndpointName, StringComparisons.EndpointAnnotationName)) is { } targetEndpointAnnotation)
         {
             // The target endpoint already exists so let's ensure it's target is localhost
             if (!EndpointHostHelpers.IsLocalhostOrLocalhostTld(targetEndpointAnnotation.TargetHost))

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelResourceBuilderExtensions.cs
@@ -32,6 +32,7 @@ public static partial class DevTunnelsResourceBuilderExtensions
     /// <remarks>
     /// Dev tunnels can be used to expose local endpoints to the public internet via a secure tunnel. By default,
     /// the tunnel requires authentication, but anonymous access can be enabled via <see cref="WithAnonymousAccess(IResourceBuilder{DevTunnelResource})"/>.
+    /// This overload is not available in polyglot app hosts. Use <see cref="AddDevTunnelForPolyglot"/> instead.
     /// </remarks>
     /// <example>
     /// The following example shows how to create a dev tunnel resource that exposes all endpoints on a web application project and enable anonymous access:
@@ -44,7 +45,7 @@ public static partial class DevTunnelsResourceBuilderExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
-    [AspireExport("addDevTunnel", Description = "Adds a Dev Tunnel resource to the distributed application model.")]
+    [AspireExportIgnore(Reason = "Use the dedicated polyglot overload instead.")]
     public static IResourceBuilder<DevTunnelResource> AddDevTunnel(
         this IDistributedApplicationBuilder builder,
         [ResourceName] string name,
@@ -232,6 +233,21 @@ public static partial class DevTunnelsResourceBuilderExtensions
 
         return rb;
     }
+
+    [AspireExport("addDevTunnel", Description = "Adds a Dev Tunnel resource to the distributed application model.")]
+    internal static IResourceBuilder<DevTunnelResource> AddDevTunnelForPolyglot(
+        this IDistributedApplicationBuilder builder,
+        [ResourceName] string name,
+        string? tunnelId = null,
+        bool allowAnonymous = false,
+        string? description = null,
+        string[]? labels = null)
+        => AddDevTunnel(builder, name, tunnelId, new DevTunnelOptions
+        {
+            AllowAnonymous = allowAnonymous,
+            Description = description,
+            Labels = labels is null ? null : [.. labels]
+        });
 
     /// <summary>
     /// Adds ports on the dev tunnel for all endpoints found on the referenced resource and sets whether anonymous access is allowed.

--- a/src/Aspire.Hosting.Redis/Aspire.Hosting.Redis.csproj
+++ b/src/Aspire.Hosting.Redis/Aspire.Hosting.Redis.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.Redis" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -249,7 +249,7 @@ public static class RedisBuilderExtensions
                     var endpoint = redisInstance.PrimaryEndpoint;
                     if (redisInstance.TryGetEndpoints(out var endpoints))
                     {
-                        var secondaryEndpoint = endpoints.FirstOrDefault(ep => StringComparer.OrdinalIgnoreCase.Equals(ep.Name, RedisResource.SecondaryEndpointName));
+                        var secondaryEndpoint = endpoints.FirstOrDefault(ep => string.Equals(ep.Name, RedisResource.SecondaryEndpointName, StringComparisons.EndpointAnnotationName));
                         if (secondaryEndpoint is not null)
                         {
                             endpoint = new EndpointReference(redisInstance, secondaryEndpoint);

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -53,14 +53,12 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
     /// <summary>
     /// Gets a value indicating whether the endpoint uses HTTP scheme.
     /// </summary>
-    public bool IsHttp => StringComparers.EndpointAnnotationUriScheme.Equals(Scheme, "http");
+    public bool IsHttp => string.Equals(Scheme, "http", StringComparisons.EndpointAnnotationUriScheme);
 
     /// <summary>
-    ///
-    /// </summary> <summary>
     /// Gets a value indicating whether the endpoint uses HTTPS scheme.
     /// </summary>
-    public bool IsHttps => StringComparers.EndpointAnnotationUriScheme.Equals(Scheme, "https");
+    public bool IsHttps => string.Equals(Scheme, "https", StringComparisons.EndpointAnnotationUriScheme);
 
     /// <summary>
     /// Gets a value indicating whether TLS is enabled for this endpoint.
@@ -192,7 +190,7 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
         }
 
         _endpointAnnotation ??= Resource.Annotations.OfType<EndpointAnnotation>()
-            .SingleOrDefault(a => StringComparers.EndpointAnnotationName.Equals(a.Name, EndpointName));
+            .SingleOrDefault(a => string.Equals(a.Name, EndpointName, StringComparisons.EndpointAnnotationName));
         return _endpointAnnotation;
     }
 
@@ -206,7 +204,7 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
 
         foreach (var nes in endpointAnnotation.AllAllocatedEndpoints)
         {
-            if (StringComparers.NetworkID.Equals(nes.NetworkID, _contextNetworkID ?? KnownNetworkIdentifiers.LocalhostNetwork))
+            if (string.Equals(nes.NetworkID.Value, (_contextNetworkID ?? KnownNetworkIdentifiers.LocalhostNetwork).Value, StringComparisons.NetworkID))
             {
                 if (!nes.Snapshot.IsValueSet)
                 {

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -702,7 +702,7 @@ public static class ResourceExtensions
     public static EndpointReference GetEndpoint(this IResourceWithEndpoints resource, string endpointName)
     {
         var endpoint = resource.TryGetEndpoints(out var endpoints) ?
-            endpoints.FirstOrDefault(e => StringComparers.EndpointAnnotationName.Equals(e.Name, endpointName)) :
+            endpoints.FirstOrDefault(e => string.Equals(e.Name, endpointName, StringComparisons.EndpointAnnotationName)) :
             null;
         if (endpoint is null)
         {
@@ -725,7 +725,7 @@ public static class ResourceExtensions
     {
 
         var endpoint = resource.TryGetEndpoints(out var endpoints) ?
-            endpoints.FirstOrDefault(e => StringComparers.EndpointAnnotationName.Equals(e.Name, endpointName)) :
+            endpoints.FirstOrDefault(e => string.Equals(e.Name, endpointName, StringComparisons.EndpointAnnotationName)) :
             null;
         if (endpoint is null)
         {

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -235,7 +235,7 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
         ArgumentNullException.ThrowIfNull(request);
 
         var appModel = serviceProvider.GetService<DistributedApplicationModel>();
-        if (appModel is not null && !appModel.Resources.Any(r => StringComparers.ResourceName.Equals(r.Name, request.ResourceName)))
+        if (appModel is not null && !appModel.Resources.Any(r => string.Equals(r.Name, request.ResourceName, StringComparisons.ResourceName)))
         {
             return new WaitForResourceResponse
             {
@@ -378,7 +378,7 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
         }
 
         // Find the dashboard resource
-        if (appModel.Resources.SingleOrDefault(r => StringComparers.ResourceName.Equals(r.Name, KnownResourceNames.AspireDashboard)) is not IResourceWithEndpoints dashboardResource)
+        if (appModel.Resources.SingleOrDefault(r => string.Equals(r.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName)) is not IResourceWithEndpoints dashboardResource)
         {
             logger.LogDebug("Dashboard resource not found in application model.");
             return null;
@@ -446,7 +446,7 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
         foreach (var resource in appModel.Resources)
         {
             // Skip the dashboard resource
-            if (StringComparers.ResourceName.Equals(resource.Name, KnownResourceNames.AspireDashboard))
+            if (string.Equals(resource.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName))
             {
                 continue;
             }
@@ -486,7 +486,7 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
         await foreach (var resourceEvent in resourceEvents.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
             // Skip the dashboard resource
-            if (StringComparers.ResourceName.Equals(resourceEvent.Resource.Name, KnownResourceNames.AspireDashboard))
+            if (string.Equals(resourceEvent.Resource.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName))
             {
                 continue;
             }
@@ -661,7 +661,7 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
 
         if (resourceName is not null)
         {
-            var resource = appModel.Resources.FirstOrDefault(r => StringComparers.ResourceName.Equals(r.Name, resourceName));
+            var resource = appModel.Resources.FirstOrDefault(r => string.Equals(r.Name, resourceName, StringComparisons.ResourceName));
             if (resource is null)
             {
                 logger.LogWarning("Resource '{ResourceName}' not found. No logs will be returned.", resourceName);
@@ -675,7 +675,7 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
             foreach (var resource in appModel.Resources)
             {
                 // Skip the dashboard
-                if (StringComparers.ResourceName.Equals(resource.Name, KnownResourceNames.AspireDashboard))
+                if (string.Equals(resource.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName))
                 {
                     continue;
                 }

--- a/src/Aspire.Hosting/Backchannel/DashboardUrlsHelper.cs
+++ b/src/Aspire.Hosting/Backchannel/DashboardUrlsHelper.cs
@@ -57,7 +57,7 @@ internal static class DashboardUrlsHelper
         // Find the dashboard resource and get all endpoints
         var appModel = serviceProvider.GetService<DistributedApplicationModel>();
         var dashboardResource = appModel?.Resources.SingleOrDefault(
-            r => StringComparers.ResourceName.Equals(r.Name, KnownResourceNames.AspireDashboard)) as IResourceWithEndpoints;
+            r => string.Equals(r.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName)) as IResourceWithEndpoints;
 
         string? apiBaseUrl = null;
         string? mcpBaseUrl = null;

--- a/src/Aspire.Hosting/BuiltInDistributedApplicationEventSubscriptionHandlers.cs
+++ b/src/Aspire.Hosting/BuiltInDistributedApplicationEventSubscriptionHandlers.cs
@@ -45,7 +45,7 @@ internal static class BuiltInDistributedApplicationEventSubscriptionHandlers
     public static Task ExcludeDashboardFromManifestAsync(BeforeStartEvent beforeStartEvent, CancellationToken _)
     {
         // When developing locally, exclude the dashboard from the manifest. This only affects our playground projects in practice.
-        if (beforeStartEvent.Model.Resources.SingleOrDefault(r => StringComparers.ResourceName.Equals(r.Name, KnownResourceNames.AspireDashboard)) is { } dashboardResource)
+        if (beforeStartEvent.Model.Resources.SingleOrDefault(r => string.Equals(r.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName)) is { } dashboardResource)
         {
             dashboardResource.Annotations.Add(ManifestPublishingCallbackAnnotation.Ignore);
         }

--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -67,7 +67,7 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
     {
         Debug.Assert(executionContext.IsRunMode, "Dashboard resource should only be added in run mode");
 
-        if (@event.Model.Resources.SingleOrDefault(r => StringComparers.ResourceName.Equals(r.Name, KnownResourceNames.AspireDashboard)) is { } dashboardResource)
+        if (@event.Model.Resources.SingleOrDefault(r => string.Equals(r.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName)) is { } dashboardResource)
         {
             ConfigureAspireDashboardResource(dashboardResource);
 
@@ -802,7 +802,7 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
             {
                 // Track all dashboard resources and start watching their logs.
                 // TODO: In the future when resources can restart, we should handle purging the taskCache.
-                if (StringComparers.ResourceName.Equals(notification.Resource.Name, KnownResourceNames.AspireDashboard) && !dashboardResourceTasks.ContainsKey(notification.ResourceId))
+                if (string.Equals(notification.Resource.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName) && !dashboardResourceTasks.ContainsKey(notification.ResourceId))
                 {
                     dashboardResourceTasks[notification.ResourceId] = WatchResourceLogsAsync(notification.ResourceId, loggerCache, defaultDashboardLogger, resourceLoggerService, loggerFactory, cancellationToken);
                 }

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1014,7 +1014,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                 ))
                 .Where(ts =>
                     ts.Service is not null &&
-                    StringComparers.ResourceName.Equals(ts.ResourceName, appResource.ModelResource.Name) &&
+                    string.Equals(ts.ResourceName, appResource.ModelResource.Name, StringComparisons.ResourceName) &&
                     !string.IsNullOrEmpty(ts.EndpointName) &&
                     !string.IsNullOrEmpty(ts.ContainerNetworkName)
                 );
@@ -1033,9 +1033,9 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                     }
 
                     var serverSvc = _appResources.OfType<ServiceWithModelResource>().FirstOrDefault(swr =>
-                         StringComparers.ResourceName.Equals(swr.ModelResource.Name, ts.ResourceName) &&
-                         StringComparers.EndpointAnnotationName.Equals(swr.EndpointAnnotation.Name, endpoint.Name)
-                     );
+                        string.Equals(swr.ModelResource.Name, ts.ResourceName, StringComparisons.ResourceName) &&
+                        string.Equals(swr.EndpointAnnotation.Name, endpoint.Name, StringComparisons.EndpointAnnotationName)
+                    );
                     if (serverSvc is null)
                     {
                         // Should never happen -- we should have created a Service for every endpoint exposed from a resource.
@@ -1225,8 +1225,8 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                 // Address and port will be set automatically by DCP.
 
                 var serverSvc = _appResources.OfType<ServiceWithModelResource>().FirstOrDefault(swr =>
-                    StringComparers.ResourceName.Equals(swr.ModelResource.Name, re.Resource.Name) &&
-                    StringComparers.EndpointAnnotationName.Equals(swr.EndpointAnnotation.Name, endpoint.Name)
+                    string.Equals(swr.ModelResource.Name, re.Resource.Name, StringComparisons.ResourceName) &&
+                    string.Equals(swr.EndpointAnnotation.Name, endpoint.Name, StringComparisons.EndpointAnnotationName)
                 );
                 if (serverSvc is null)
                 {
@@ -2939,7 +2939,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         endpoint = null;
         if (resource.TryGetAnnotationsOfType<EndpointAnnotation>(out var endpoints))
         {
-            endpoint = endpoints.FirstOrDefault(e => StringComparers.EndpointAnnotationName.Equals(e.Name, endpointName));
+            endpoint = endpoints.FirstOrDefault(e => string.Equals(e.Name, endpointName, StringComparisons.EndpointAnnotationName));
         }
         return endpoint is not null;
     }

--- a/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
+++ b/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
@@ -230,8 +230,8 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
             }
 
             if (checkReportSnapshot.Status != value.Status
-                || !StringComparers.HealthReportPropertyValue.Equals(checkReportSnapshot.Description, value.Description)
-                || !StringComparers.HealthReportPropertyValue.Equals(checkReportSnapshot.ExceptionText, value.Exception?.ToString()))
+                || !string.Equals(checkReportSnapshot.Description, value.Description, StringComparisons.HealthReportPropertyValue)
+                || !string.Equals(checkReportSnapshot.ExceptionText, value.Exception?.ToString(), StringComparisons.HealthReportPropertyValue))
             {
                 return true;
             }

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -912,8 +912,7 @@ public static class ResourceBuilderExtensions
 
         var endpoint = builder.Resource.Annotations
             .OfType<EndpointAnnotation>()
-            .Where(ea => StringComparers.EndpointAnnotationName.Equals(ea.Name, endpointName))
-            .SingleOrDefault();
+            .SingleOrDefault(ea => string.Equals(ea.Name, endpointName, StringComparisons.EndpointAnnotationName));
 
         if (endpoint != null)
         {

--- a/src/Shared/Model/ResourceSourceViewModel.cs
+++ b/src/Shared/Model/ResourceSourceViewModel.cs
@@ -10,14 +10,14 @@ internal record ResourceSource(string Value, string OriginalValue)
     public static ResourceSource? GetSourceModel(string? resourceType, IReadOnlyDictionary<string, string?> properties)
     {
         // NOTE project and tools are also executables, so check for those first
-        if (StringComparers.ResourceType.Equals(resourceType, KnownResourceTypes.Project) &&
+        if (string.Equals(resourceType, KnownResourceTypes.Project, StringComparisons.ResourceType) &&
             properties.TryGetValue(KnownProperties.Project.Path, out var projectPath) &&
             !string.IsNullOrEmpty(projectPath))
         {
             return new ResourceSource(Path.GetFileName(projectPath), projectPath);
         }
 
-        if (StringComparers.ResourceType.Equals(resourceType, KnownResourceTypes.Tool) &&
+        if (string.Equals(resourceType, KnownResourceTypes.Tool, StringComparisons.ResourceType) &&
             properties.TryGetValue(KnownProperties.Tool.Package, out var toolPackage) &&
             !string.IsNullOrEmpty(toolPackage))
         {


### PR DESCRIPTION
## Description

Use StringComparions in string comparisons. Only use comparers with dictionaries and other APIs that expect that type.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
