### PR TITLE
Clarify YarpSslProtocol rationale

### DIFF
--- a/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpClusterConfigDtos.cs
+++ b/src/Aspire.Hosting.Yarp/ConfigurationBuilder/YarpClusterConfigDtos.cs
@@ -258,6 +258,7 @@ internal sealed class YarpPassiveHealthCheckConfig
 
 /// <summary>
 /// Specifies the SSL protocols to enable for a YARP cluster.
+/// This enum exists because <see cref="System.Security.Authentication.SslProtocols"/> includes obsolete members and values that YARP does not accept.
 /// </summary>
 internal enum YarpSslProtocol
 {


### PR DESCRIPTION
## Description

Add an XML documentation note to `YarpSslProtocol` explaining that the enum exists because `System.Security.Authentication.SslProtocols` contains obsolete members and values that YARP does not accept.

Validation:
- `./restore.sh`
- `./dotnet.sh build src/Aspire.Hosting.Yarp/Aspire.Hosting.Yarp.csproj /p:SkipNativeBuild=true`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
