### PR TITLE
Update Sigstore and Tuf packages to 0.4.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -131,8 +131,8 @@
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <PackageVersion Include="StreamJsonRpc" Version="2.22.23" />
     <PackageVersion Include="Semver" Version="3.0.0" />
-    <PackageVersion Include="Sigstore" Version="0.3.0" />
-    <PackageVersion Include="Tuf" Version="0.3.0" />
+    <PackageVersion Include="Sigstore" Version="0.4.0" />
+    <PackageVersion Include="Tuf" Version="0.4.0" />
     <PackageVersion Include="Microsoft.DevTunnels.Connections" Version="1.3.12" />
     <!-- Open Telemetry -->
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="$(AzureMonitorOpenTelemetryExporterVersion)" />


### PR DESCRIPTION
## Description

Update `Sigstore` and `Tuf` NuGet packages from 0.3.0 to 0.4.0 (latest stable).

Both packages are consumed by `Aspire.Cli` for sigstore attestation verification.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
