### PR TITLE
Fix duplicate deployment tests in CI matrix

### DIFF
--- a/tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj
@@ -12,9 +12,10 @@
     <!-- Disable strong name signing because Hex1b package is not signed -->
     <SignAssembly>false</SignAssembly>
 
-    <!-- Deployment tests run on Linux via deployment-tests.yml (excluded from tests.yml via OnlyDeploymentTests) -->
+    <!-- Deployment tests run on Linux only via deployment-tests.yml (excluded from tests.yml via OnlyDeploymentTests) -->
     <RunOnGithubActionsWindows>false</RunOnGithubActionsWindows>
     <RunOnGithubActionsLinux>true</RunOnGithubActionsLinux>
+    <RunOnGithubActionsMacOS>false</RunOnGithubActionsMacOS>
 
     <!-- Do not run tests in Helix - use GitHub Actions matrix strategy instead -->
     <RunOnAzdoHelixWindows>false</RunOnAzdoHelixWindows>


### PR DESCRIPTION
## Description

Fix duplicate deployment tests appearing in the `/deployment-test` PR comment.

**Root cause:** The deployment test project (`Aspire.Deployment.EndToEnd.Tests.csproj`) set `RunOnGithubActionsWindows=false` and `RunOnGithubActionsLinux=true`, but did not set `RunOnGithubActionsMacOS=false`. Since the default for macOS is `true` (in `eng/Testing.props`), the test matrix expansion (`expand-test-matrix-github.ps1`) generated two entries per test class — one for Linux and one for macOS. Since `deployment-tests.yml` hardcodes `runs-on: 8-core-ubuntu-latest`, both copies ran on Ubuntu, causing each test to appear twice in the `/deployment-test` comment (showing ~half passed and ~half failed even when all tests actually pass).

**Fix:** Add `<RunOnGithubActionsMacOS>false</RunOnGithubActionsMacOS>` so each test class generates exactly one matrix entry (Linux only), matching the workflow's intent.

**Example of the problem:** https://github.com/dotnet/aspire/pull/15028#issuecomment-4050890248

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
