### PR TITLE
Fix aspire mcp command description — only init/start are deprecated

### DIFF
--- a/src/Aspire.Cli/Resources/McpCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/McpCommandStrings.Designer.cs
@@ -61,7 +61,7 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Manage MCP (Model Context Protocol) server. (deprecated, use &apos;agent&apos;).
+        ///   Looks up a localized string similar to Interact with MCP (Model Context Protocol) tools exposed by Aspire resources..
         /// </summary>
         internal static string Description {
             get {

--- a/src/Aspire.Cli/Resources/McpCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/McpCommandStrings.resx
@@ -61,7 +61,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description" xml:space="preserve">
-    <value>Manage MCP (Model Context Protocol) server. (deprecated, use 'agent')</value>
+    <value>Interact with MCP (Model Context Protocol) tools exposed by Aspire resources.</value>
   </data>
   <data name="StartCommand_Description" xml:space="preserve">
     <value>Start the MCP (Model Context Protocol) server. (deprecated, use 'agent mcp')</value>

--- a/src/Aspire.Cli/Resources/xlf/McpCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/McpCommandStrings.cs.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage MCP (Model Context Protocol) server. (deprecated, use 'agent')</source>
-        <target state="translated">Spravujte server MCP (Model Context Protocol). (zastaralé, použijte „agent“)</target>
+        <source>Interact with MCP (Model Context Protocol) tools exposed by Aspire resources.</source>
+        <target state="needs-review-translation">Spravujte server MCP (Model Context Protocol). (zastaralé, použijte „agent“)</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_AdditionalOptionsSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/McpCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/McpCommandStrings.de.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage MCP (Model Context Protocol) server. (deprecated, use 'agent')</source>
-        <target state="translated">Verwalten Sie den MCP-Server (Model Context Protocol). (Veraltet, stattdessen „agent“ verwenden)</target>
+        <source>Interact with MCP (Model Context Protocol) tools exposed by Aspire resources.</source>
+        <target state="needs-review-translation">Verwalten Sie den MCP-Server (Model Context Protocol). (Veraltet, stattdessen „agent“ verwenden)</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_AdditionalOptionsSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/McpCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/McpCommandStrings.es.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage MCP (Model Context Protocol) server. (deprecated, use 'agent')</source>
-        <target state="translated">Administrar el servidor MCP (protocolo de contexto de modelo). (en desuso, use ''agent'')</target>
+        <source>Interact with MCP (Model Context Protocol) tools exposed by Aspire resources.</source>
+        <target state="needs-review-translation">Administrar el servidor MCP (protocolo de contexto de modelo). (en desuso, use ''agent'')</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_AdditionalOptionsSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/McpCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/McpCommandStrings.fr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage MCP (Model Context Protocol) server. (deprecated, use 'agent')</source>
-        <target state="translated">Gérez le serveur MCP (Model Context Protocol). (obsolète, utilisez « agent »)</target>
+        <source>Interact with MCP (Model Context Protocol) tools exposed by Aspire resources.</source>
+        <target state="needs-review-translation">Gérez le serveur MCP (Model Context Protocol). (obsolète, utilisez « agent »)</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_AdditionalOptionsSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/McpCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/McpCommandStrings.it.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage MCP (Model Context Protocol) server. (deprecated, use 'agent')</source>
-        <target state="translated">Consente di gestire il server MCP (Model Context Protocol). (deprecato, usare "agent")</target>
+        <source>Interact with MCP (Model Context Protocol) tools exposed by Aspire resources.</source>
+        <target state="needs-review-translation">Consente di gestire il server MCP (Model Context Protocol). (deprecato, usare "agent")</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_AdditionalOptionsSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/McpCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/McpCommandStrings.ja.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage MCP (Model Context Protocol) server. (deprecated, use 'agent')</source>
-        <target state="translated">MCP (モデル コンテキスト プロトコル) サーバーを管理します。(非推奨です。'agent' を使用してください)</target>
+        <source>Interact with MCP (Model Context Protocol) tools exposed by Aspire resources.</source>
+        <target state="needs-review-translation">MCP (モデル コンテキスト プロトコル) サーバーを管理します。(非推奨です。'agent' を使用してください)</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_AdditionalOptionsSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/McpCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/McpCommandStrings.ko.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage MCP (Model Context Protocol) server. (deprecated, use 'agent')</source>
-        <target state="translated">MCP(모델 컨텍스트 프로토콜) 서버를 관리합니다. (더 이상 사용되지 않음, 'agent' 사용)</target>
+        <source>Interact with MCP (Model Context Protocol) tools exposed by Aspire resources.</source>
+        <target state="needs-review-translation">MCP(모델 컨텍스트 프로토콜) 서버를 관리합니다. (더 이상 사용되지 않음, 'agent' 사용)</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_AdditionalOptionsSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/McpCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/McpCommandStrings.pl.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage MCP (Model Context Protocol) server. (deprecated, use 'agent')</source>
-        <target state="translated">Zarządzaj serwerem MCP (Model Context Protocol). (przestarzałe, użyj polecenia „agent”)</target>
+        <source>Interact with MCP (Model Context Protocol) tools exposed by Aspire resources.</source>
+        <target state="needs-review-translation">Zarządzaj serwerem MCP (Model Context Protocol). (przestarzałe, użyj polecenia „agent”)</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_AdditionalOptionsSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/McpCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/McpCommandStrings.pt-BR.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage MCP (Model Context Protocol) server. (deprecated, use 'agent')</source>
-        <target state="translated">Gerencie o servidor MCP (Protocolo de Contexto de Modelo). (obsoleto, usar "agent")</target>
+        <source>Interact with MCP (Model Context Protocol) tools exposed by Aspire resources.</source>
+        <target state="needs-review-translation">Gerencie o servidor MCP (Protocolo de Contexto de Modelo). (obsoleto, usar "agent")</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_AdditionalOptionsSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/McpCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/McpCommandStrings.ru.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage MCP (Model Context Protocol) server. (deprecated, use 'agent')</source>
-        <target state="translated">Управление сервером MCP. (не рекомендуется, используйте "agent"")</target>
+        <source>Interact with MCP (Model Context Protocol) tools exposed by Aspire resources.</source>
+        <target state="needs-review-translation">Управление сервером MCP. (не рекомендуется, используйте "agent"")</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_AdditionalOptionsSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/McpCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/McpCommandStrings.tr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage MCP (Model Context Protocol) server. (deprecated, use 'agent')</source>
-        <target state="translated">MCP (Model Bağlam Protokolü) sunucusunu yönetin. (kullanım dışı, 'agent' kullanın)</target>
+        <source>Interact with MCP (Model Context Protocol) tools exposed by Aspire resources.</source>
+        <target state="needs-review-translation">MCP (Model Bağlam Protokolü) sunucusunu yönetin. (kullanım dışı, 'agent' kullanın)</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_AdditionalOptionsSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/McpCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/McpCommandStrings.zh-Hans.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage MCP (Model Context Protocol) server. (deprecated, use 'agent')</source>
-        <target state="translated">管理 MCP (模型上下文协议)服务器。(已弃用，请使用 "agent")</target>
+        <source>Interact with MCP (Model Context Protocol) tools exposed by Aspire resources.</source>
+        <target state="needs-review-translation">管理 MCP (模型上下文协议)服务器。(已弃用，请使用 "agent")</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_AdditionalOptionsSelectPrompt">

--- a/src/Aspire.Cli/Resources/xlf/McpCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/McpCommandStrings.zh-Hant.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Description">
-        <source>Manage MCP (Model Context Protocol) server. (deprecated, use 'agent')</source>
-        <target state="translated">管理 MCP (模型內容通訊協定) 伺服器。(已棄用，請使用 'agent')</target>
+        <source>Interact with MCP (Model Context Protocol) tools exposed by Aspire resources.</source>
+        <target state="needs-review-translation">管理 MCP (模型內容通訊協定) 伺服器。(已棄用，請使用 'agent')</target>
         <note />
       </trans-unit>
       <trans-unit id="InitCommand_AdditionalOptionsSelectPrompt">


### PR DESCRIPTION
## Description

Fix the `aspire mcp` command description which incorrectly stated the entire command was deprecated. Only the `mcp init` and `mcp start` subcommands are deprecated (hidden, redirected to `aspire agent init` and `aspire agent mcp`). The active subcommands `mcp tools` and `mcp call` are not deprecated.

Updated the description from:
> "Manage MCP (Model Context Protocol) server. (deprecated, use 'agent')"

To:
> "Interact with MCP (Model Context Protocol) tools exposed by Aspire resources."

Updated the resx, Designer.cs, and all xlf localization files.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
