### PR TITLE
Fix IOException crash when CLI is invoked via iex/Invoke-Expression

### DIFF
--- a/src/Aspire.Cli/Utils/CliHostEnvironment.cs
+++ b/src/Aspire.Cli/Utils/CliHostEnvironment.cs
@@ -150,6 +150,30 @@ internal sealed class CliHostEnvironment : ICliHostEnvironment
             return false;
         }
 
+        // Verify the console handles are valid. Returning false here is safe —
+        // all consumers gracefully degrade to plain text output (no spinners,
+        // no banner, no progress bars) so the command still works.
+        return HasValidConsoleHandles();
+    }
+
+    private static bool HasValidConsoleHandles()
+    {
+        // On Windows, processes spawned without a console (e.g., via PowerShell's
+        // Invoke-Expression) have invalid output handles. Probing CursorVisible
+        // is a reliable way to detect this — it fails fast if there's no console,
+        // and it exercises the same handle that interactive UI components need.
+        if (OperatingSystem.IsWindows())
+        {
+            try
+            {
+                _ = Console.CursorVisible;
+            }
+            catch (IOException)
+            {
+                return false;
+            }
+        }
+
         return true;
     }
 

--- a/tests/Aspire.Cli.Tests/TestHelpers.cs
+++ b/tests/Aspire.Cli.Tests/TestHelpers.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Utils;
-using Microsoft.Extensions.Configuration;
 
 namespace Aspire.Cli.Tests;
 
@@ -10,13 +9,18 @@ internal static class TestHelpers
 {
     public static ICliHostEnvironment CreateInteractiveHostEnvironment()
     {
-        var configuration = new ConfigurationBuilder().Build();
-        return new CliHostEnvironment(configuration, nonInteractive: false);
+        return new TestCliHostEnvironment(supportsInteractiveInput: true, supportsInteractiveOutput: true, supportsAnsi: true);
     }
 
     public static ICliHostEnvironment CreateNonInteractiveHostEnvironment()
     {
-        var configuration = new ConfigurationBuilder().Build();
-        return new CliHostEnvironment(configuration, nonInteractive: true);
+        return new TestCliHostEnvironment(supportsInteractiveInput: false, supportsInteractiveOutput: false, supportsAnsi: false);
+    }
+
+    private sealed class TestCliHostEnvironment(bool supportsInteractiveInput, bool supportsInteractiveOutput, bool supportsAnsi) : ICliHostEnvironment
+    {
+        public bool SupportsInteractiveInput => supportsInteractiveInput;
+        public bool SupportsInteractiveOutput => supportsInteractiveOutput;
+        public bool SupportsAnsi => supportsAnsi;
     }
 }

--- a/tests/Aspire.Cli.Tests/Utils/CliHostEnvironmentTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliHostEnvironmentTests.cs
@@ -22,7 +22,7 @@ public class CliHostEnvironmentTests
     }
 
     [Fact]
-    public void SupportsInteractiveOutput_ReturnsTrue_WhenNoConfigSet()
+    public void SupportsInteractiveOutput_DependsOnConsoleHandles_WhenNoConfigSet()
     {
         // Arrange
         var configuration = new ConfigurationBuilder().Build();
@@ -30,8 +30,10 @@ public class CliHostEnvironmentTests
         // Act
         var env = new CliHostEnvironment(configuration, nonInteractive: false);
 
-        // Assert
-        Assert.True(env.SupportsInteractiveOutput);
+        // Assert — result depends on whether the test host has valid console handles
+        // (true in a real terminal, false in redirected/CI environments).
+        // The important contract: it should NOT throw.
+        _ = env.SupportsInteractiveOutput;
     }
 
     [Theory]


### PR DESCRIPTION
## Description

Fix `System.IO.IOException: The handle is invalid` crash when the Aspire CLI is invoked via `iex` (Invoke-Expression) during installation.

The install script runs `aspire config set` after installing the CLI. On first run, the CLI tries to display an animated banner using Spectre.Console's `LiveDisplay`, which internally accesses `Console.CursorVisible`. When invoked via `iex`, the process has no valid console handle, causing the IOException.

**Fix:** Add `HasValidConsoleHandles()` to `DetectInteractiveOutput()` in `CliHostEnvironment.cs`. On Windows, it probes `Console.CursorVisible` — the exact property that crashes — during environment setup. If the handle is invalid, `SupportsInteractiveOutput` returns `false` and no interactive UI (banner, spinners, LiveDisplay) is attempted. Commands like `config set` execute normally.

This is Windows-only — Linux doesn't use Win32 console handles and handles this scenario gracefully via ANSI escape sequences.

Fixes #15203

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
