### PR TITLE
Convert WaitCommandTests to Hex1bTerminalAutomator imperative API

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -97,9 +97,9 @@
     <PackageVersion Include="Grpc.AspNetCore" Version="2.76.0" />
     <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.78.0" />
-    <PackageVersion Include="Hex1b" Version="0.105.0" />
-    <PackageVersion Include="Hex1b.McpServer" Version="0.105.0" />
-    <PackageVersion Include="Hex1b.Tool" Version="0.105.0" />
+    <PackageVersion Include="Hex1b" Version="0.116.0" />
+    <PackageVersion Include="Hex1b.McpServer" Version="0.116.0" />
+    <PackageVersion Include="Hex1b.Tool" Version="0.116.0" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="KubernetesClient" Version="18.0.13" />
     <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />

--- a/tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj
@@ -54,6 +54,7 @@
   <ItemGroup>
       <Compile Include="$(TestsSharedDir)TemporaryRepo.cs" Link="shared\TemporaryRepo.cs" />
       <Compile Include="$(TestsSharedDir)Hex1bTestHelpers.cs" Link="shared\Hex1bTestHelpers.cs" />
+      <Compile Include="$(TestsSharedDir)Hex1bAutomatorTestHelpers.cs" Link="shared\Hex1bAutomatorTestHelpers.cs" />
       <Compile Include="..\Aspire.Hosting.Tests\Utils\MSBuildUtils.cs" Link="Utils\MSBuildUtils.cs" />
   </ItemGroup>
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+
+namespace Aspire.Cli.EndToEnd.Tests.Helpers;
+
+/// <summary>
+/// Extension methods for <see cref="Hex1bTerminalAutomator"/> providing Docker E2E test helpers.
+/// These parallel the <see cref="Hex1bTerminalInputSequenceBuilder"/>-based methods in <see cref="CliE2ETestHelpers"/>.
+/// </summary>
+internal static class CliE2EAutomatorHelpers
+{
+    /// <summary>
+    /// Prepares the Docker environment by setting up prompt counting, umask, and environment variables.
+    /// </summary>
+    internal static async Task PrepareDockerEnvironmentAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        TemporaryWorkspace? workspace = null)
+    {
+        // Wait for container to be ready (root prompt)
+        await auto.WaitUntilAsync(
+            s => new CellPatternSearcher().Find("# ").Search(s).Count > 0,
+            timeout: TimeSpan.FromSeconds(60),
+            description: "Docker container root prompt (# )");
+
+        await auto.WaitAsync(500);
+
+        // Set up the prompt counting mechanism
+        const string promptSetup = "CMDCOUNT=0; PROMPT_COMMAND='s=$?;((CMDCOUNT++));PS1=\"[$CMDCOUNT $([ $s -eq 0 ] && echo OK || echo ERR:$s)] \\$ \"'";
+        await auto.TypeAsync(promptSetup);
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Set permissive umask
+        await auto.TypeAsync("umask 000");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Set environment variables
+        await auto.TypeAsync("export ASPIRE_PLAYGROUND=true TERM=xterm DOTNET_CLI_TELEMETRY_OPTOUT=true DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true DOTNET_GENERATE_ASPNET_CERTIFICATE=false");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        if (workspace is not null)
+        {
+            await auto.TypeAsync($"cd /workspace/{workspace.WorkspaceRoot.Name}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+        }
+    }
+
+    /// <summary>
+    /// Installs the Aspire CLI inside a Docker container based on the detected install mode.
+    /// </summary>
+    internal static async Task InstallAspireCliInDockerAsync(
+        this Hex1bTerminalAutomator auto,
+        CliE2ETestHelpers.DockerInstallMode installMode,
+        SequenceCounter counter)
+    {
+        switch (installMode)
+        {
+            case CliE2ETestHelpers.DockerInstallMode.SourceBuild:
+                await auto.TypeAsync("mkdir -p ~/.aspire/bin && cp /opt/aspire-cli/aspire ~/.aspire/bin/aspire && chmod +x ~/.aspire/bin/aspire");
+                await auto.EnterAsync();
+                await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+                await auto.TypeAsync("export PATH=~/.aspire/bin:$PATH");
+                await auto.EnterAsync();
+                await auto.WaitForSuccessPromptAsync(counter);
+                break;
+
+            case CliE2ETestHelpers.DockerInstallMode.GaRelease:
+                await auto.TypeAsync("/opt/aspire-scripts/get-aspire-cli.sh");
+                await auto.EnterAsync();
+                await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromSeconds(120));
+                await auto.TypeAsync("export PATH=~/.aspire/bin:$PATH");
+                await auto.EnterAsync();
+                await auto.WaitForSuccessPromptAsync(counter);
+                break;
+
+            case CliE2ETestHelpers.DockerInstallMode.PullRequest:
+                var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
+                await auto.TypeAsync($"/opt/aspire-scripts/get-aspire-cli-pr.sh {prNumber}");
+                await auto.EnterAsync();
+                await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromSeconds(300));
+                await auto.TypeAsync("export PATH=~/.aspire/bin:~/.aspire:$PATH");
+                await auto.EnterAsync();
+                await auto.WaitForSuccessPromptAsync(counter);
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(installMode));
+        }
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -8,7 +8,7 @@ namespace Aspire.Cli.EndToEnd.Tests.Helpers;
 
 /// <summary>
 /// Extension methods for <see cref="Hex1bTerminalAutomator"/> providing Docker E2E test helpers.
-/// These parallel the <see cref="Hex1bTerminalInputSequenceBuilder"/>-based methods in <see cref="CliE2ETestHelpers"/>.
+/// These parallel the <see cref="Hex1b.Automation.Hex1bTerminalInputSequenceBuilder"/>-based methods in <see cref="CliE2ETestHelpers"/>.
 /// </summary>
 internal static class CliE2EAutomatorHelpers
 {

--- a/tests/Aspire.Cli.EndToEnd.Tests/WaitCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/WaitCommandTests.cs
@@ -28,57 +28,54 @@ public sealed class WaitCommandTests(ITestOutputHelper output)
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
-        // Pattern searchers for start/wait/stop commands
-        var waitForAppHostStartedSuccessfully = new CellPatternSearcher()
-            .Find("AppHost started successfully.");
-
-        var waitForResourceUp = new CellPatternSearcher()
-            .Find("is up (running).");
-
-        var waitForAppHostStoppedSuccessfully = new CellPatternSearcher()
-            .Find("AppHost stopped successfully.");
-
         var counter = new SequenceCounter();
-        var sequenceBuilder = new Hex1bTerminalInputSequenceBuilder();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
 
-        sequenceBuilder.PrepareDockerEnvironment(counter, workspace);
+        // Prepare Docker environment (prompt counting, umask, env vars)
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
 
-        sequenceBuilder.InstallAspireCliInDocker(installMode, counter);
+        // Install the Aspire CLI
+        await auto.InstallAspireCliInDockerAsync(installMode, counter);
 
         // Create a new project using aspire new
-        sequenceBuilder.AspireNew("AspireWaitApp", counter);
+        await auto.AspireNewAsync("AspireWaitApp", counter);
 
         // Navigate to the AppHost directory
-        sequenceBuilder.Type("cd AspireWaitApp/AspireWaitApp.AppHost")
-            .Enter()
-            .WaitForSuccessPrompt(counter);
+        await auto.TypeAsync("cd AspireWaitApp/AspireWaitApp.AppHost");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
 
         // Start the AppHost in the background using aspire start
-        sequenceBuilder.Type("aspire start")
-            .Enter()
-            .WaitUntil(s => waitForAppHostStartedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(3))
-            .WaitForSuccessPrompt(counter);
+        await auto.TypeAsync("aspire start");
+        await auto.EnterAsync();
+        await auto.WaitUntilAsync(
+            s => new CellPatternSearcher().Find("AppHost started successfully.").Search(s).Count > 0,
+            timeout: TimeSpan.FromMinutes(3),
+            description: "AppHost started successfully");
+        await auto.WaitForSuccessPromptAsync(counter);
 
         // Wait for the webfrontend resource to be up (running).
         // Use a longer timeout in Docker-in-Docker where container startup is slower.
-        sequenceBuilder.Type("aspire wait webfrontend --status up --timeout 300")
-            .Enter()
-            .WaitUntil(s => waitForResourceUp.Search(s).Count > 0, TimeSpan.FromMinutes(6))
-            .WaitForSuccessPrompt(counter);
+        await auto.TypeAsync("aspire wait webfrontend --status up --timeout 300");
+        await auto.EnterAsync();
+        await auto.WaitUntilAsync(
+            s => new CellPatternSearcher().Find("is up (running).").Search(s).Count > 0,
+            timeout: TimeSpan.FromMinutes(6),
+            description: "webfrontend resource is up (running)");
+        await auto.WaitForSuccessPromptAsync(counter);
 
         // Stop the AppHost using aspire stop
-        sequenceBuilder.Type("aspire stop")
-            .Enter()
-            .WaitUntil(s => waitForAppHostStoppedSuccessfully.Search(s).Count > 0, TimeSpan.FromMinutes(1))
-            .WaitForSuccessPrompt(counter);
+        await auto.TypeAsync("aspire stop");
+        await auto.EnterAsync();
+        await auto.WaitUntilAsync(
+            s => new CellPatternSearcher().Find("AppHost stopped successfully.").Search(s).Count > 0,
+            timeout: TimeSpan.FromMinutes(1),
+            description: "AppHost stopped successfully");
+        await auto.WaitForSuccessPromptAsync(counter);
 
         // Exit the shell
-        sequenceBuilder.Type("exit")
-            .Enter();
-
-        var sequence = sequenceBuilder.Build();
-
-        await sequence.ApplyAsync(terminal, TestContext.Current.CancellationToken);
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
 
         await pendingRun;
     }

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -1,0 +1,306 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Hex1b.Automation;
+
+namespace Aspire.Tests.Shared;
+
+/// <summary>
+/// Extension methods for <see cref="Hex1bTerminalAutomator"/> providing Aspire-specific
+/// shell prompt detection and common CLI interaction patterns.
+/// </summary>
+internal static class Hex1bAutomatorTestHelpers
+{
+    /// <summary>
+    /// Waits for a shell success prompt matching the current sequence counter value,
+    /// then increments the counter. Looks for the pattern: [N OK] $
+    /// </summary>
+    internal static async Task WaitForSuccessPromptAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        TimeSpan? timeout = null)
+    {
+        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(500);
+
+        await auto.WaitUntilAsync(snapshot =>
+        {
+            var successPromptSearcher = new CellPatternSearcher()
+                .FindPattern(counter.Value.ToString())
+                .RightText(" OK] $ ");
+
+            return successPromptSearcher.Search(snapshot).Count > 0;
+        }, timeout: effectiveTimeout, description: $"success prompt [{counter.Value} OK] $");
+
+        counter.Increment();
+    }
+
+    /// <summary>
+    /// Waits for any prompt (success or error) matching the current sequence counter.
+    /// </summary>
+    internal static async Task WaitForAnyPromptAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        TimeSpan? timeout = null)
+    {
+        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(500);
+
+        await auto.WaitUntilAsync(snapshot =>
+        {
+            var successSearcher = new CellPatternSearcher()
+                .FindPattern(counter.Value.ToString())
+                .RightText(" OK] $ ");
+            var errorSearcher = new CellPatternSearcher()
+                .FindPattern(counter.Value.ToString())
+                .RightText(" ERR:");
+
+            return successSearcher.Search(snapshot).Count > 0 || errorSearcher.Search(snapshot).Count > 0;
+        }, timeout: effectiveTimeout, description: $"any prompt [{counter.Value} OK/ERR] $");
+
+        counter.Increment();
+    }
+
+    /// <summary>
+    /// Waits for an error prompt matching the current sequence counter and expected exit code.
+    /// </summary>
+    internal static async Task WaitForErrorPromptAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        int exitCode = 1,
+        TimeSpan? timeout = null)
+    {
+        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(500);
+
+        await auto.WaitUntilAsync(snapshot =>
+        {
+            var errorPromptSearcher = new CellPatternSearcher()
+                .FindPattern(counter.Value.ToString())
+                .RightText($" ERR:{exitCode}] $ ");
+
+            return errorPromptSearcher.Search(snapshot).Count > 0;
+        }, timeout: effectiveTimeout, description: $"error prompt [{counter.Value} ERR:{exitCode}] $");
+
+        counter.Increment();
+    }
+
+    /// <summary>
+    /// Waits for a successful command prompt, but fails fast if an error prompt is detected.
+    /// </summary>
+    internal static async Task WaitForSuccessPromptFailFastAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        TimeSpan? timeout = null)
+    {
+        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(500);
+        var sawError = false;
+
+        await auto.WaitUntilAsync(snapshot =>
+        {
+            var successSearcher = new CellPatternSearcher()
+                .FindPattern(counter.Value.ToString())
+                .RightText(" OK] $ ");
+
+            if (successSearcher.Search(snapshot).Count > 0)
+            {
+                return true;
+            }
+
+            var errorSearcher = new CellPatternSearcher()
+                .FindPattern(counter.Value.ToString())
+                .RightText(" ERR:");
+
+            if (errorSearcher.Search(snapshot).Count > 0)
+            {
+                sawError = true;
+                return true;
+            }
+
+            return false;
+        }, timeout: effectiveTimeout, description: $"success prompt [{counter.Value} OK] $ (fail-fast on error)");
+
+        if (sawError)
+        {
+            throw new InvalidOperationException(
+                $"Command failed with non-zero exit code (detected ERR prompt at sequence {counter.Value}). Check the terminal recording for details.");
+        }
+
+        counter.Increment();
+    }
+
+    /// <summary>
+    /// Handles the agent init confirmation prompt that appears after aspire init/new,
+    /// then waits for the shell success prompt. Supports CLI versions with and without agent init chaining.
+    /// </summary>
+    internal static async Task DeclineAgentInitPromptAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        TimeSpan? timeout = null)
+    {
+        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(500);
+
+        var agentInitPrompt = new CellPatternSearcher()
+            .Find("configure AI agent environments");
+
+        var agentInitFound = false;
+
+        // Wait for either the agent init prompt (new CLI) or the success prompt (old CLI).
+        await auto.WaitUntilAsync(s =>
+        {
+            if (agentInitPrompt.Search(s).Count > 0)
+            {
+                agentInitFound = true;
+                return true;
+            }
+            var successSearcher = new CellPatternSearcher()
+                .FindPattern(counter.Value.ToString())
+                .RightText(" OK] $ ");
+            return successSearcher.Search(s).Count > 0;
+        }, timeout: effectiveTimeout, description: $"agent init prompt or success prompt [{counter.Value} OK] $");
+
+        await auto.WaitAsync(500);
+
+        // Type 'n' + Enter unconditionally:
+        // - Agent init: declines the prompt, CLI exits, success prompt appears
+        // - No agent init: 'n' runs at bash (command not found), produces error prompt
+        await auto.TypeAsync("n");
+        await auto.EnterAsync();
+
+        // Wait for the aspire command's success prompt
+        await auto.WaitUntilAsync(s =>
+        {
+            var successSearcher = new CellPatternSearcher()
+                .FindPattern(counter.Value.ToString())
+                .RightText(" OK] $ ");
+            return successSearcher.Search(s).Count > 0;
+        }, timeout: effectiveTimeout, description: $"success prompt [{counter.Value} OK] $ after agent init");
+
+        // Increment counter correctly for both cases
+        if (!agentInitFound)
+        {
+            counter.Increment();
+        }
+        counter.Increment();
+    }
+
+    /// <summary>
+    /// Runs <c>aspire new</c> interactively, selecting the specified template and responding to all prompts.
+    /// </summary>
+    internal static async Task AspireNewAsync(
+        this Hex1bTerminalAutomator auto,
+        string projectName,
+        SequenceCounter counter,
+        AspireTemplate template = AspireTemplate.Starter,
+        bool useRedisCache = true)
+    {
+        var templateTimeout = TimeSpan.FromSeconds(60);
+
+        // Step 1: Type aspire new and wait for the template list
+        await auto.TypeAsync("aspire new");
+        await auto.EnterAsync();
+        await auto.WaitUntilAsync(
+            s => new CellPatternSearcher().Find("> Starter App").Search(s).Count > 0,
+            timeout: templateTimeout,
+            description: "template selection list (> Starter App)");
+
+        // Step 2: Navigate to and select the desired template
+        switch (template)
+        {
+            case AspireTemplate.Starter:
+                await auto.EnterAsync(); // First option, no navigation needed
+                break;
+
+            case AspireTemplate.JsReact:
+                await auto.DownAsync();
+                await auto.WaitUntilAsync(
+                    s => new CellPatternSearcher().Find("> Starter App (ASP.NET Core/React)").Search(s).Count > 0,
+                    timeout: TimeSpan.FromSeconds(5),
+                    description: "JS React template selected");
+                await auto.EnterAsync();
+                break;
+
+            case AspireTemplate.ExpressReact:
+                await auto.DownAsync();
+                await auto.DownAsync();
+                await auto.WaitUntilAsync(
+                    s => new CellPatternSearcher().Find("> Starter App (Express/React)").Search(s).Count > 0,
+                    timeout: TimeSpan.FromSeconds(5),
+                    description: "Express React template selected");
+                await auto.EnterAsync();
+                break;
+
+            case AspireTemplate.PythonReact:
+                await auto.DownAsync();
+                await auto.DownAsync();
+                await auto.DownAsync();
+                await auto.WaitUntilAsync(
+                    s => new CellPatternSearcher().Find("> Starter App (FastAPI/React)").Search(s).Count > 0,
+                    timeout: TimeSpan.FromSeconds(5),
+                    description: "Python React template selected");
+                await auto.EnterAsync();
+                break;
+
+            case AspireTemplate.EmptyAppHost:
+                await auto.DownAsync();
+                await auto.DownAsync();
+                await auto.DownAsync();
+                await auto.DownAsync();
+                await auto.WaitUntilAsync(
+                    s => new CellPatternSearcher().Find("> Empty AppHost").Search(s).Count > 0,
+                    timeout: TimeSpan.FromSeconds(5),
+                    description: "Empty AppHost template selected");
+                await auto.EnterAsync();
+                await auto.EnterAsync(); // Select C# language
+                break;
+        }
+
+        // Step 3: Enter project name
+        await auto.WaitUntilAsync(
+            s => new CellPatternSearcher().Find("Enter the project name").Search(s).Count > 0,
+            timeout: TimeSpan.FromSeconds(10),
+            description: "project name prompt");
+        await auto.TypeAsync(projectName);
+        await auto.EnterAsync();
+
+        // Step 4: Accept default output path
+        await auto.WaitUntilAsync(
+            s => new CellPatternSearcher().Find("Enter the output path").Search(s).Count > 0,
+            timeout: TimeSpan.FromSeconds(10),
+            description: "output path prompt");
+        await auto.EnterAsync();
+
+        // Step 5: URLs prompt (all templates have this)
+        await auto.WaitUntilAsync(
+            s => new CellPatternSearcher().Find("Use *.dev.localhost URLs").Search(s).Count > 0,
+            timeout: TimeSpan.FromSeconds(10),
+            description: "URLs prompt");
+        await auto.EnterAsync(); // Accept default "No"
+
+        // Step 6: Redis prompt (only Starter, JsReact, PythonReact)
+        if (template is AspireTemplate.Starter or AspireTemplate.JsReact or AspireTemplate.PythonReact)
+        {
+            await auto.WaitUntilAsync(
+                s => new CellPatternSearcher().Find("Use Redis Cache").Search(s).Count > 0,
+                timeout: TimeSpan.FromSeconds(10),
+                description: "Redis cache prompt");
+
+            if (!useRedisCache)
+            {
+                await auto.DownAsync(); // Default is "Yes", navigate to "No"
+            }
+
+            await auto.EnterAsync();
+        }
+
+        // Step 7: Test project prompt (only Starter)
+        if (template is AspireTemplate.Starter)
+        {
+            await auto.WaitUntilAsync(
+                s => new CellPatternSearcher().Find("Do you want to create a test project?").Search(s).Count > 0,
+                timeout: TimeSpan.FromSeconds(10),
+                description: "test project prompt");
+            await auto.EnterAsync(); // Accept default "No"
+        }
+
+        // Step 8: Decline the agent init prompt and wait for success
+        await auto.DeclineAgentInitPromptAsync(counter);
+    }
+}


### PR DESCRIPTION
## Summary

Demonstrates the new `Hex1bTerminalAutomator` imperative testing API by converting `WaitCommandTests` from the declarative `Hex1bTerminalInputSequenceBuilder` pattern.

## Motivation

The `Hex1bTerminalInputSequenceBuilder` (build-then-apply) pattern makes it difficult to debug failures in long E2E sequences — the exception doesn't pinpoint which step failed. The new `Hex1bTerminalAutomator` executes each step immediately and records a breadcrumb trail. On failure, `Hex1bAutomationException` includes:
- Full step history with timings and source locations
- Terminal snapshot at the point of failure
- Caller file/line via `[CallerFilePath]`/`[CallerLineNumber]`

## Changes

### Package Updates
- `NuGet.config`: Added `hex1b-gh-packages` feed for PR packages
- `Directory.Packages.props`: Updated Hex1b packages to `0.116.0-pr.243` (from [mitchdenny/hex1b#243](https://github.com/mitchdenny/hex1b/pull/243))

### New Files
- `tests/Shared/Hex1bAutomatorTestHelpers.cs` — Automator extension methods:
  - `WaitForSuccessPromptAsync`, `WaitForAnyPromptAsync`, `WaitForErrorPromptAsync`
  - `WaitForSuccessPromptFailFastAsync`, `DeclineAgentInitPromptAsync`
  - `AspireNewAsync` (full template wizard automation)
  - Each step includes descriptive names like `success prompt [3 OK] $` for diagnostics
- `tests/.../Helpers/CliE2EAutomatorHelpers.cs` — Docker-specific extensions:
  - `PrepareDockerEnvironmentAsync`, `InstallAspireCliInDockerAsync`

### Converted Test
- `WaitCommandTests.cs` — Rewritten from builder pattern to imperative automator

## Before / After

**Before** (declarative):
```csharp
sequenceBuilder.Type("aspire start")
    .Enter()
    .WaitUntil(s => waitForStarted.Search(s).Count > 0, TimeSpan.FromMinutes(3))
    .WaitForSuccessPrompt(counter);
// ... 20 more chained calls ...
var sequence = sequenceBuilder.Build();
await sequence.ApplyAsync(terminal, ct);
```

**After** (imperative):
```csharp
await auto.TypeAsync("aspire start");
await auto.EnterAsync();
await auto.WaitUntilAsync(
    s => new CellPatternSearcher().Find("AppHost started successfully.").Search(s).Count > 0,
    timeout: TimeSpan.FromMinutes(3),
    description: "AppHost started successfully");
await auto.WaitForSuccessPromptAsync(counter);
```

Each `await` executes immediately. If it fails, the exception shows exactly which step, with the full history of what succeeded before it.