### PR TITLE
Fix deployment test PR comment to use unified table

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -456,12 +456,24 @@ jobs:
           for zipfile in recordings/*.zip; do
             if [ -f "$zipfile" ]; then
               echo "Extracting $zipfile..."
-              unzip -o "$zipfile" -d "recordings/extracted_$(basename "$zipfile" .zip)" || true
+              # Artifact zip name: deployment-test-recordings-{shortname}.zip
+              ARTIFACT_NAME=$(basename "$zipfile" .zip)
+              SHORTNAME=${ARTIFACT_NAME#deployment-test-recordings-}
+              EXTRACT_DIR="recordings/extracted_${ARTIFACT_NAME}"
+              unzip -o "$zipfile" -d "$EXTRACT_DIR" || true
+
+              # Rename .cast files to use the shortname (matching the job/test name)
+              CAST_INDEX=0
+              while IFS= read -r -d '' castfile; do
+                if [ $CAST_INDEX -eq 0 ]; then
+                  cp "$castfile" "cast_files/${SHORTNAME}.cast"
+                else
+                  cp "$castfile" "cast_files/${SHORTNAME}-${CAST_INDEX}.cast"
+                fi
+                CAST_INDEX=$((CAST_INDEX + 1))
+              done < <(find "$EXTRACT_DIR" -name "*.cast" -print0)
             fi
           done
-
-          # Find and copy all .cast files
-          find recordings -name "*.cast" -exec cp {} cast_files/ \; 2>/dev/null || true
 
           echo "Found recordings:"
           ls -la cast_files/ || echo "No .cast files found"
@@ -500,86 +512,88 @@ jobs:
             STATUS="unknown"
           fi
 
-          # Build the comment header
-          COMMENT_BODY="${EMOJI} **Deployment E2E Tests ${STATUS}**
-
-          **Summary:** ${PASSED_COUNT} passed, ${FAILED_COUNT} failed, ${CANCELLED_COUNT} cancelled
-
-          [View workflow run](${RUN_URL})"
-
-          # Add passed tests section if any
-          if [ "$PASSED_COUNT" -gt 0 ]; then
-            PASSED_LIST=$(echo "$PASSED_TESTS" | jq -r '.[]' | while read test; do echo "- ✅ ${test}"; done)
-            COMMENT_BODY="${COMMENT_BODY}
-
-          ### Passed Tests
-          ${PASSED_LIST}"
-          fi
-
-          # Add failed tests section if any
-          if [ "$FAILED_COUNT" -gt 0 ]; then
-            FAILED_LIST=$(echo "$FAILED_TESTS" | jq -r '.[]' | while read test; do echo "- ❌ ${test}"; done)
-            COMMENT_BODY="${COMMENT_BODY}
-
-          ### Failed Tests
-          ${FAILED_LIST}"
-          fi
-
-          # Add cancelled tests section if any
-          if [ "$CANCELLED_COUNT" -gt 0 ]; then
-            CANCELLED_LIST=$(echo "$CANCELLED_TESTS" | jq -r '.[]' | while read test; do echo "- ⚠️ ${test}"; done)
-            COMMENT_BODY="${COMMENT_BODY}
-
-          ### Cancelled Tests
-          ${CANCELLED_LIST}"
-          fi
-
-          # Check for recordings and upload them
+          # Upload recordings first so we can include links in the unified table
           RECORDINGS_DIR="cast_files"
+          declare -A RECORDING_URLS
 
           if [ -d "$RECORDINGS_DIR" ] && compgen -G "$RECORDINGS_DIR"/*.cast > /dev/null; then
-            # Install asciinema
             pip install --quiet asciinema
 
-            RECORDING_TABLE="
-
-          ### 🎬 Terminal Recordings
-
-          | Test | Recording |
-          |------|-----------|"
-
             UPLOAD_COUNT=0
-
             for castfile in "$RECORDINGS_DIR"/*.cast; do
               if [ -f "$castfile" ]; then
                 filename=$(basename "$castfile" .cast)
                 echo "Uploading $castfile..."
 
-                # Upload to asciinema and capture URL
                 UPLOAD_OUTPUT=$(asciinema upload "$castfile" 2>&1) || true
                 ASCIINEMA_URL=$(echo "$UPLOAD_OUTPUT" | grep -oP 'https://asciinema\.org/a/[a-zA-Z0-9_-]+' | head -1) || true
 
                 if [ -n "$ASCIINEMA_URL" ]; then
-                  RECORDING_TABLE="${RECORDING_TABLE}
-          | ${filename} | [▶️ View Recording](${ASCIINEMA_URL}) |"
+                  RECORDING_URLS["$filename"]="$ASCIINEMA_URL"
                   echo "Uploaded: $ASCIINEMA_URL"
                   UPLOAD_COUNT=$((UPLOAD_COUNT + 1))
                 else
-                  RECORDING_TABLE="${RECORDING_TABLE}
-          | ${filename} | ❌ Upload failed |"
+                  RECORDING_URLS["$filename"]="FAILED"
                   echo "Failed to upload $castfile"
                 fi
               fi
             done
-
-            if [ $UPLOAD_COUNT -gt 0 ]; then
-              COMMENT_BODY="${COMMENT_BODY}${RECORDING_TABLE}"
-            fi
-
             echo "Uploaded $UPLOAD_COUNT recordings"
           else
             echo "No recordings found in $RECORDINGS_DIR"
           fi
+
+          # Build the comment with a single unified table
+          COMMENT_BODY="${EMOJI} **Deployment E2E Tests ${STATUS}**
+
+          **Summary:** ${PASSED_COUNT} passed, ${FAILED_COUNT} failed, ${CANCELLED_COUNT} cancelled
+
+          [View workflow run](${RUN_URL})
+
+          | Test | Result | Recording |
+          |------|--------|-----------|"
+
+          # Add passed tests
+          while IFS= read -r test; do
+            RECORDING_LINK=""
+            if [ -n "${RECORDING_URLS[$test]+x}" ]; then
+              if [ "${RECORDING_URLS[$test]}" = "FAILED" ]; then
+                RECORDING_LINK="❌ Upload failed"
+              else
+                RECORDING_LINK="[▶️ View Recording](${RECORDING_URLS[$test]})"
+              fi
+            fi
+            COMMENT_BODY="${COMMENT_BODY}
+          | ${test} | ✅ Passed | ${RECORDING_LINK} |"
+          done < <(echo "$PASSED_TESTS" | jq -r '.[]')
+
+          # Add failed tests
+          while IFS= read -r test; do
+            RECORDING_LINK=""
+            if [ -n "${RECORDING_URLS[$test]+x}" ]; then
+              if [ "${RECORDING_URLS[$test]}" = "FAILED" ]; then
+                RECORDING_LINK="❌ Upload failed"
+              else
+                RECORDING_LINK="[▶️ View Recording](${RECORDING_URLS[$test]})"
+              fi
+            fi
+            COMMENT_BODY="${COMMENT_BODY}
+          | ${test} | ❌ Failed | ${RECORDING_LINK} |"
+          done < <(echo "$FAILED_TESTS" | jq -r '.[]')
+
+          # Add cancelled tests
+          while IFS= read -r test; do
+            RECORDING_LINK=""
+            if [ -n "${RECORDING_URLS[$test]+x}" ]; then
+              if [ "${RECORDING_URLS[$test]}" = "FAILED" ]; then
+                RECORDING_LINK="❌ Upload failed"
+              else
+                RECORDING_LINK="[▶️ View Recording](${RECORDING_URLS[$test]})"
+              fi
+            fi
+            COMMENT_BODY="${COMMENT_BODY}
+          | ${test} | ⚠️ Cancelled | ${RECORDING_LINK} |"
+          done < <(echo "$CANCELLED_TESTS" | jq -r '.[]')
 
           # Post the comment
           gh pr comment "${PR_NUMBER}" --repo "${{ github.repository }}" --body "$COMMENT_BODY"


### PR DESCRIPTION
## Summary

Fixes the deployment test PR comment so test names are consistent and easier to scan.

**Before:** Three separate sections with mismatched names:
- "Passed Tests" / "Failed Tests" lists used job shortnames (class names like `Deployment.EndToEnd-AcaStarterDeploymentTests`)
- "Terminal Recordings" table used `.cast` filenames (method names like `DeployStarterTemplateToAzureContainerAppsCore`)

**After:** A single unified table with Test, Result, and Recording columns — all using consistent shortnames.

### Changes

- **Extraction step**: Rename `.cast` files to match the artifact shortname (which matches the job name) instead of using method names
- **Comment step**: Replace the three separate sections (Passed, Failed, Recordings) with a single table combining Test, Result, and Recording columns
- Upload recordings first into an associative array, then build the unified table referencing them by shortname

### Example output

| Test | Result | Recording |
|------|--------|-----------|
| Deployment.EndToEnd-AcaStarterDeploymentTests | ✅ Passed | [▶️ View Recording](https://asciinema.org/a/example) |
| Deployment.EndToEnd-TypeScriptExpressDeploymentTests | ❌ Failed | [▶️ View Recording](https://asciinema.org/a/example2) |

See https://github.com/dotnet/aspire/pull/15208#issuecomment-4055623831 for an example of the old format with mismatched names.