### PR TITLE
Make aspire new templates language-specific

### DIFF
--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -8,7 +8,6 @@ using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.NuGet;
 using Aspire.Cli.Packaging;
-using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Templating;
@@ -53,7 +52,6 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
     };
 
     private readonly Option<string?> _channelOption;
-    private readonly Option<AppHostLanguage?> _languageOption;
 
     /// <summary>
     /// NewCommand prefetches both template and CLI package metadata.
@@ -103,13 +101,6 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         };
         Options.Add(_channelOption);
 
-        _languageOption = new Option<AppHostLanguage?>("--language")
-        {
-            Description = NewCommandStrings.LanguageOptionDescription,
-            Recursive = true
-        };
-        Options.Add(_languageOption);
-
         // Register template definitions as subcommands synchronously.
         // This uses GetTemplates() which returns template definitions without
         // performing any async I/O (e.g. SDK availability checks). Runtime
@@ -123,105 +114,9 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         }
     }
 
-    private string? ParseExplicitLanguageId(ParseResult parseResult)
+    private static ITemplate[] GetTemplatesForPrompt(ITemplate[] availableTemplates)
     {
-        return parseResult.GetValue(_languageOption) switch
-        {
-            AppHostLanguage.CSharp => KnownLanguageId.CSharp,
-            AppHostLanguage.TypeScript => KnownLanguageId.TypeScript,
-            null => null,
-            _ => null
-        };
-    }
-
-    private static string NormalizeLanguageId(string languageId)
-    {
-        return languageId.Equals(KnownLanguageId.TypeScriptAlias, StringComparison.OrdinalIgnoreCase)
-            ? KnownLanguageId.TypeScript
-            : languageId;
-    }
-
-    private static string GetLanguageDisplayName(string languageId)
-    {
-        return NormalizeLanguageId(languageId) switch
-        {
-            KnownLanguageId.CSharp => KnownLanguageId.CSharpDisplayName,
-            KnownLanguageId.TypeScript => "TypeScript (Node.js)",
-            _ => languageId
-        };
-    }
-
-    private async Task<string> PromptForAppHostLanguageAsync(IReadOnlyList<string> selectableLanguages, CancellationToken cancellationToken)
-    {
-        var choices = selectableLanguages
-            .Select(NormalizeLanguageId)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .Select(static languageId => (LanguageId: languageId, DisplayName: GetLanguageDisplayName(languageId)))
-            .ToArray();
-
-        var selected = await InteractionService.PromptForSelectionAsync(
-            "Which language would you like to use?",
-            choices,
-            choice => choice.DisplayName.EscapeMarkup(),
-            cancellationToken);
-
-        return selected.LanguageId;
-    }
-
-    private async Task<(bool Success, string? LanguageId)> ResolveSelectedLanguageAsync(ITemplate template, ParseResult parseResult, CancellationToken cancellationToken)
-    {
-        var explicitLanguageId = ParseExplicitLanguageId(parseResult);
-
-        if (template.SelectableAppHostLanguages.Count == 0)
-        {
-            if (!string.IsNullOrWhiteSpace(explicitLanguageId) && !template.SupportsLanguage(explicitLanguageId))
-            {
-                InteractionService.DisplayError($"Template '{template.Name}' does not support language '{explicitLanguageId}'.");
-                return (false, null);
-            }
-
-            return (true, explicitLanguageId);
-        }
-
-        if (!string.IsNullOrWhiteSpace(explicitLanguageId))
-        {
-            var normalizedExplicitLanguageId = NormalizeLanguageId(explicitLanguageId);
-            if (!template.SelectableAppHostLanguages.Any(l => l.Equals(normalizedExplicitLanguageId, StringComparison.OrdinalIgnoreCase)))
-            {
-                InteractionService.DisplayError($"Template '{template.Name}' does not support language '{explicitLanguageId}'.");
-                return (false, null);
-            }
-
-            await _configurationService.SetConfigurationAsync("language", normalizedExplicitLanguageId, isGlobal: false, cancellationToken);
-            return (true, normalizedExplicitLanguageId);
-        }
-
-        var configuredLanguageId = await _configurationService.GetConfigurationAsync("language", cancellationToken);
-        if (!string.IsNullOrWhiteSpace(configuredLanguageId))
-        {
-            var normalizedConfiguredLanguageId = NormalizeLanguageId(configuredLanguageId);
-            if (template.SelectableAppHostLanguages.Any(l => l.Equals(normalizedConfiguredLanguageId, StringComparison.OrdinalIgnoreCase)))
-            {
-                return (true, normalizedConfiguredLanguageId);
-            }
-        }
-
-        var selectedLanguageId = await PromptForAppHostLanguageAsync(template.SelectableAppHostLanguages, cancellationToken);
-        await _configurationService.SetConfigurationAsync("language", selectedLanguageId, isGlobal: false, cancellationToken);
-        return (true, selectedLanguageId);
-    }
-
-    private ITemplate[] GetTemplatesForPrompt(ITemplate[] availableTemplates, ParseResult parseResult)
-    {
-        var explicitLanguageId = ParseExplicitLanguageId(parseResult);
         var templatesForPrompt = availableTemplates.ToList();
-
-        if (!string.IsNullOrWhiteSpace(explicitLanguageId))
-        {
-            templatesForPrompt = templatesForPrompt
-                .Where(t => t.SupportsLanguage(explicitLanguageId))
-                .ToList();
-        }
 
         // Sort templates alphabetically by description, keeping empty templates at the end
         templatesForPrompt.Sort((a, b) =>
@@ -257,7 +152,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             return null;
         }
 
-        var templatesForPrompt = GetTemplatesForPrompt(availableTemplates, parseResult);
+        var templatesForPrompt = GetTemplatesForPrompt(availableTemplates);
         if (templatesForPrompt.Length == 0)
         {
             InteractionService.DisplayError("No templates are available for the current environment.");
@@ -349,12 +244,6 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             return ExitCodeConstants.InvalidCommand;
         }
 
-        var (languageResolutionSuccess, selectedLanguageId) = await ResolveSelectedLanguageAsync(template, parseResult, cancellationToken);
-        if (!languageResolutionSuccess)
-        {
-            return ExitCodeConstants.InvalidCommand;
-        }
-
         var version = parseResult.GetValue(s_versionOption);
         string? resolvedChannelName = null;
         if (ShouldResolveCliTemplateVersion(template) &&
@@ -378,7 +267,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             Source = parseResult.GetValue(s_sourceOption),
             Version = version,
             Channel = parseResult.GetValue(_channelOption) ?? resolvedChannelName,
-            Language = selectedLanguageId
+            Language = template.LanguageId
         };
         var templateResult = await template.ApplyTemplateAsync(inputs, parseResult, cancellationToken);
         if (templateResult.OutputPath is not null && ExtensionHelper.IsExtensionHost(InteractionService, out var extensionInteractionService, out _))
@@ -393,12 +282,6 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
     private static bool ShouldResolveCliTemplateVersion(ITemplate template)
     {
         return template.Runtime is TemplateRuntime.Cli;
-    }
-
-    private enum AppHostLanguage
-    {
-        CSharp,
-        TypeScript
     }
 }
 

--- a/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.Designer.cs
@@ -88,6 +88,15 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Empty (C# AppHost, dotnet template).
+        /// </summary>
+        public static string AspireEmptyDotNetTemplate_Description {
+            get {
+                return ResourceManager.GetString("AspireEmptyDotNetTemplate_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to MSTest.
         /// </summary>
         public static string AspireMSTest_Description {

--- a/src/Aspire.Cli/Resources/TemplatingStrings.resx
+++ b/src/Aspire.Cli/Resources/TemplatingStrings.resx
@@ -129,6 +129,9 @@
   <data name="AspireEmpty_Description" xml:space="preserve">
     <value>AppHost and service defaults</value>
   </data>
+  <data name="AspireEmptyDotNetTemplate_Description" xml:space="preserve">
+    <value>Empty (C# AppHost, dotnet template)</value>
+  </data>
   <data name="AspireAppHost_Description" xml:space="preserve">
     <value>AppHost</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">AppHost</target>
         <note />
       </trans-unit>
+      <trans-unit id="AspireEmptyDotNetTemplate_Description">
+        <source>Empty (C# AppHost, dotnet template)</source>
+        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireEmpty_Description">
         <source>AppHost and service defaults</source>
         <target state="translated">AppHost a výchozí nastavení služby</target>
@@ -221,6 +226,7 @@
         <source>Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</source>
         <target state="new">Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</target>
         <note>{0} is the relative path to the project directory</note>
-      </trans-unit>    </body>
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.cs.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="AspireEmptyDotNetTemplate_Description">
         <source>Empty (C# AppHost, dotnet template)</source>
-        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <target state="new">Empty (C# AppHost, dotnet template)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">AppHost</target>
         <note />
       </trans-unit>
+      <trans-unit id="AspireEmptyDotNetTemplate_Description">
+        <source>Empty (C# AppHost, dotnet template)</source>
+        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireEmpty_Description">
         <source>AppHost and service defaults</source>
         <target state="translated">AppHost und Dienststandardwerte</target>
@@ -221,6 +226,7 @@
         <source>Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</source>
         <target state="new">Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</target>
         <note>{0} is the relative path to the project directory</note>
-      </trans-unit>    </body>
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.de.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="AspireEmptyDotNetTemplate_Description">
         <source>Empty (C# AppHost, dotnet template)</source>
-        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <target state="new">Empty (C# AppHost, dotnet template)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="AspireEmptyDotNetTemplate_Description">
         <source>Empty (C# AppHost, dotnet template)</source>
-        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <target state="new">Empty (C# AppHost, dotnet template)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">AppHost</target>
         <note />
       </trans-unit>
+      <trans-unit id="AspireEmptyDotNetTemplate_Description">
+        <source>Empty (C# AppHost, dotnet template)</source>
+        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireEmpty_Description">
         <source>AppHost and service defaults</source>
         <target state="translated">AppHost y servicios predeterminados</target>
@@ -221,6 +226,7 @@
         <source>Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</source>
         <target state="new">Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</target>
         <note>{0} is the relative path to the project directory</note>
-      </trans-unit>    </body>
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">AppHost</target>
         <note />
       </trans-unit>
+      <trans-unit id="AspireEmptyDotNetTemplate_Description">
+        <source>Empty (C# AppHost, dotnet template)</source>
+        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireEmpty_Description">
         <source>AppHost and service defaults</source>
         <target state="translated">AppHost et les paramètres par défaut du service</target>
@@ -221,6 +226,7 @@
         <source>Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</source>
         <target state="new">Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</target>
         <note>{0} is the relative path to the project directory</note>
-      </trans-unit>    </body>
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.fr.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="AspireEmptyDotNetTemplate_Description">
         <source>Empty (C# AppHost, dotnet template)</source>
-        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <target state="new">Empty (C# AppHost, dotnet template)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">AppHost</target>
         <note />
       </trans-unit>
+      <trans-unit id="AspireEmptyDotNetTemplate_Description">
+        <source>Empty (C# AppHost, dotnet template)</source>
+        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireEmpty_Description">
         <source>AppHost and service defaults</source>
         <target state="translated">Impostazioni predefinite di AppHost e del servizio</target>
@@ -221,6 +226,7 @@
         <source>Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</source>
         <target state="new">Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</target>
         <note>{0} is the relative path to the project directory</note>
-      </trans-unit>    </body>
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.it.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="AspireEmptyDotNetTemplate_Description">
         <source>Empty (C# AppHost, dotnet template)</source>
-        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <target state="new">Empty (C# AppHost, dotnet template)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="AspireEmptyDotNetTemplate_Description">
         <source>Empty (C# AppHost, dotnet template)</source>
-        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <target state="new">Empty (C# AppHost, dotnet template)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">AppHost</target>
         <note />
       </trans-unit>
+      <trans-unit id="AspireEmptyDotNetTemplate_Description">
+        <source>Empty (C# AppHost, dotnet template)</source>
+        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireEmpty_Description">
         <source>AppHost and service defaults</source>
         <target state="translated">AppHost およびサービスの既定値</target>
@@ -221,6 +226,7 @@
         <source>Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</source>
         <target state="new">Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</target>
         <note>{0} is the relative path to the project directory</note>
-      </trans-unit>    </body>
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="AspireEmptyDotNetTemplate_Description">
         <source>Empty (C# AppHost, dotnet template)</source>
-        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <target state="new">Empty (C# AppHost, dotnet template)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">AppHost</target>
         <note />
       </trans-unit>
+      <trans-unit id="AspireEmptyDotNetTemplate_Description">
+        <source>Empty (C# AppHost, dotnet template)</source>
+        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireEmpty_Description">
         <source>AppHost and service defaults</source>
         <target state="translated">AppHost 및 서비스 기본값</target>
@@ -221,6 +226,7 @@
         <source>Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</source>
         <target state="new">Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</target>
         <note>{0} is the relative path to the project directory</note>
-      </trans-unit>    </body>
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="AspireEmptyDotNetTemplate_Description">
         <source>Empty (C# AppHost, dotnet template)</source>
-        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <target state="new">Empty (C# AppHost, dotnet template)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">AppHost</target>
         <note />
       </trans-unit>
+      <trans-unit id="AspireEmptyDotNetTemplate_Description">
+        <source>Empty (C# AppHost, dotnet template)</source>
+        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireEmpty_Description">
         <source>AppHost and service defaults</source>
         <target state="translated">AppHost i ustawienia domyślne usługi</target>
@@ -221,6 +226,7 @@
         <source>Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</source>
         <target state="new">Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</target>
         <note>{0} is the relative path to the project directory</note>
-      </trans-unit>    </body>
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">AppHost</target>
         <note />
       </trans-unit>
+      <trans-unit id="AspireEmptyDotNetTemplate_Description">
+        <source>Empty (C# AppHost, dotnet template)</source>
+        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireEmpty_Description">
         <source>AppHost and service defaults</source>
         <target state="translated">AppHost e padrões de serviço</target>
@@ -221,6 +226,7 @@
         <source>Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</source>
         <target state="new">Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</target>
         <note>{0} is the relative path to the project directory</note>
-      </trans-unit>    </body>
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.pt-BR.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="AspireEmptyDotNetTemplate_Description">
         <source>Empty (C# AppHost, dotnet template)</source>
-        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <target state="new">Empty (C# AppHost, dotnet template)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="AspireEmptyDotNetTemplate_Description">
         <source>Empty (C# AppHost, dotnet template)</source>
-        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <target state="new">Empty (C# AppHost, dotnet template)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">AppHost</target>
         <note />
       </trans-unit>
+      <trans-unit id="AspireEmptyDotNetTemplate_Description">
+        <source>Empty (C# AppHost, dotnet template)</source>
+        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireEmpty_Description">
         <source>AppHost and service defaults</source>
         <target state="translated">AppHost и службы по умолчанию</target>
@@ -221,6 +226,7 @@
         <source>Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</source>
         <target state="new">Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</target>
         <note>{0} is the relative path to the project directory</note>
-      </trans-unit>    </body>
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">AppHost</target>
         <note />
       </trans-unit>
+      <trans-unit id="AspireEmptyDotNetTemplate_Description">
+        <source>Empty (C# AppHost, dotnet template)</source>
+        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireEmpty_Description">
         <source>AppHost and service defaults</source>
         <target state="translated">AppHost ve hizmet varsayılanları</target>
@@ -221,6 +226,7 @@
         <source>Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</source>
         <target state="new">Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</target>
         <note>{0} is the relative path to the project directory</note>
-      </trans-unit>    </body>
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.tr.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="AspireEmptyDotNetTemplate_Description">
         <source>Empty (C# AppHost, dotnet template)</source>
-        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <target state="new">Empty (C# AppHost, dotnet template)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">AppHost</target>
         <note />
       </trans-unit>
+      <trans-unit id="AspireEmptyDotNetTemplate_Description">
+        <source>Empty (C# AppHost, dotnet template)</source>
+        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireEmpty_Description">
         <source>AppHost and service defaults</source>
         <target state="translated">AppHost 和服务默认值</target>
@@ -221,6 +226,7 @@
         <source>Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</source>
         <target state="new">Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</target>
         <note>{0} is the relative path to the project directory</note>
-      </trans-unit>    </body>
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hans.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="AspireEmptyDotNetTemplate_Description">
         <source>Empty (C# AppHost, dotnet template)</source>
-        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <target state="new">Empty (C# AppHost, dotnet template)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="AspireEmptyDotNetTemplate_Description">
         <source>Empty (C# AppHost, dotnet template)</source>
-        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <target state="new">Empty (C# AppHost, dotnet template)</target>
         <note />
       </trans-unit>
       <trans-unit id="AspireEmpty_Description">

--- a/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/TemplatingStrings.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">AppHost</target>
         <note />
       </trans-unit>
+      <trans-unit id="AspireEmptyDotNetTemplate_Description">
+        <source>Empty (C# AppHost, dotnet template)</source>
+        <target state="translated">Empty (C# AppHost, dotnet template)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AspireEmpty_Description">
         <source>AppHost and service defaults</source>
         <target state="translated">AppHost 和服務預設值</target>
@@ -221,6 +226,7 @@
         <source>Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</source>
         <target state="new">Run 'cd "{0}"' and then 'aspire run' to start your AppHost.</target>
         <note>{0} is the relative path to the project directory</note>
-      </trans-unit>    </body>
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Aspire.Cli/Templating/CallbackTemplate.cs
+++ b/src/Aspire.Cli/Templating/CallbackTemplate.cs
@@ -12,8 +12,7 @@ internal class CallbackTemplate(
     Action<Command> applyOptionsCallback,
     Func<CallbackTemplate, TemplateInputs, ParseResult, CancellationToken, Task<TemplateResult>> applyTemplateCallback,
     TemplateRuntime runtime = TemplateRuntime.DotNet,
-    Func<string, bool>? supportsLanguageCallback = null,
-    IReadOnlyList<string>? selectableAppHostLanguages = null,
+    string? languageId = null,
     bool isEmpty = false) : ITemplate
 {
     public string Name => name;
@@ -26,12 +25,7 @@ internal class CallbackTemplate(
 
     public Func<string, string> PathDeriver => pathDeriverCallback;
 
-    public bool SupportsLanguage(string languageId)
-    {
-        return supportsLanguageCallback?.Invoke(languageId) ?? true;
-    }
-
-    public IReadOnlyList<string> SelectableAppHostLanguages { get; } = selectableAppHostLanguages ?? [];
+    public string? LanguageId => languageId;
 
     public void ApplyOptions(Command command)
     {

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.EmptyTemplate.cs
@@ -107,7 +107,7 @@ internal sealed partial class CliTemplateFactory
     {
         var localhostTldOptionSpecified = parseResult.Tokens.Any(token =>
             string.Equals(token.Value, "--localhost-tld", StringComparisons.CliInputOrOutput));
-        var useLocalhostTld = parseResult.GetValue(s_localhostTldOption);
+        var useLocalhostTld = parseResult.GetValue(_localhostTldOption);
         if (!localhostTldOptionSpecified)
         {
             if (!_hostEnvironment.SupportsInteractiveInput)

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.cs
@@ -32,7 +32,7 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
         ".otf"
     ];
 
-    private static readonly Option<bool?> s_localhostTldOption = new("--localhost-tld")
+    private readonly Option<bool?> _localhostTldOption = new("--localhost-tld")
     {
         Description = TemplatingStrings.UseLocalhostTld_Description
     };
@@ -92,25 +92,29 @@ internal sealed partial class CliTemplateFactory : ITemplateFactory
                 KnownTemplateId.TypeScriptStarter,
                 "Starter App (Express/React)",
                 projectName => $"./{projectName}",
-                static cmd => AddOptionIfMissing(cmd, s_localhostTldOption),
+                cmd => AddOptionIfMissing(cmd, _localhostTldOption),
                 ApplyTypeScriptStarterTemplateAsync,
                 runtime: TemplateRuntime.Cli,
-                supportsLanguageCallback: static languageId =>
-                    languageId.Equals(KnownLanguageId.TypeScript, StringComparison.OrdinalIgnoreCase) ||
-                    languageId.Equals(KnownLanguageId.TypeScriptAlias, StringComparison.OrdinalIgnoreCase)),
+                languageId: KnownLanguageId.TypeScript),
 
             new CallbackTemplate(
-                KnownTemplateId.EmptyAppHost,
-                "Empty AppHost",
+                KnownTemplateId.CSharpEmptyAppHost,
+                "Empty (C# AppHost)",
                 projectName => $"./{projectName}",
-                static cmd => AddOptionIfMissing(cmd, s_localhostTldOption),
+                cmd => AddOptionIfMissing(cmd, _localhostTldOption),
                 ApplyEmptyAppHostTemplateAsync,
                 runtime: TemplateRuntime.Cli,
-                supportsLanguageCallback: static languageId =>
-                    languageId.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase) ||
-                    languageId.Equals(KnownLanguageId.TypeScript, StringComparison.OrdinalIgnoreCase) ||
-                    languageId.Equals(KnownLanguageId.TypeScriptAlias, StringComparison.OrdinalIgnoreCase),
-                selectableAppHostLanguages: [KnownLanguageId.CSharp, KnownLanguageId.TypeScript],
+                languageId: KnownLanguageId.CSharp,
+                isEmpty: true),
+
+            new CallbackTemplate(
+                KnownTemplateId.TypeScriptEmptyAppHost,
+                "Empty (TypeScript AppHost)",
+                projectName => $"./{projectName}",
+                cmd => AddOptionIfMissing(cmd, _localhostTldOption),
+                ApplyEmptyAppHostTemplateAsync,
+                runtime: TemplateRuntime.Cli,
+                languageId: KnownLanguageId.TypeScript,
                 isEmpty: true)
         ];
     }

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -173,7 +173,7 @@ internal class DotNetTemplateFactory(
         {
             yield return new CallbackTemplate(
                 KnownTemplateId.DotNetEmptyAppHost,
-                "Empty (C# AppHost, dotnet template)",
+                TemplatingStrings.AspireEmptyDotNetTemplate_Description,
                 projectName => $"./{projectName}",
                 ApplyDevLocalhostTldOption,
                 ApplyTemplateWithNoExtraArgsAsync,

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -56,9 +56,9 @@ internal class DotNetTemplateFactory(
         Description = TemplatingStrings.EnterXUnitVersion_Description
     };
 
-    private static bool SupportsCSharpAppHost(string languageId)
+    private static bool SupportsOnlyCSharp(string? languageId)
     {
-        return languageId.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase);
+        return string.Equals(languageId, KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase);
     }
 
     public IEnumerable<ITemplate> GetTemplates()
@@ -149,7 +149,7 @@ internal class DotNetTemplateFactory(
             nonInteractive
                 ? ApplyTemplateWithNoExtraArgsAsync
                 : (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireStarterOptionsAsync, ct),
-            supportsLanguageCallback: SupportsCSharpAppHost
+            supportsLanguageCallback: SupportsOnlyCSharp
             );
 
         yield return new CallbackTemplate(
@@ -160,7 +160,7 @@ internal class DotNetTemplateFactory(
             nonInteractive
                 ? ApplyTemplateWithNoExtraArgsAsync
                 : (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireJsFrontendStarterOptionsAsync, ct),
-            supportsLanguageCallback: SupportsCSharpAppHost
+            supportsLanguageCallback: SupportsOnlyCSharp
             );
 
         yield return new CallbackTemplate(
@@ -171,7 +171,7 @@ internal class DotNetTemplateFactory(
             nonInteractive
                 ? ApplySingleFileTemplateWithNoExtraArgsAsync
                 : (template, inputs, parseResult, ct) => ApplySingleFileTemplate(template, inputs, parseResult, PromptForExtraAspirePythonStarterOptionsAsync, ct),
-            supportsLanguageCallback: SupportsCSharpAppHost
+            supportsLanguageCallback: SupportsOnlyCSharp
             );
 
         if (showAllTemplates)
@@ -182,7 +182,7 @@ internal class DotNetTemplateFactory(
                 projectName => $"./{projectName}",
                 ApplyDevLocalhostTldOption,
                 ApplyTemplateWithNoExtraArgsAsync,
-                supportsLanguageCallback: SupportsCSharpAppHost
+                supportsLanguageCallback: SupportsOnlyCSharp
                 );
 
             yield return new CallbackTemplate(
@@ -191,7 +191,7 @@ internal class DotNetTemplateFactory(
                 projectName => $"./{projectName}",
                 ApplyDevLocalhostTldOption,
                 ApplyTemplateWithNoExtraArgsAsync,
-                supportsLanguageCallback: SupportsCSharpAppHost
+                supportsLanguageCallback: SupportsOnlyCSharp
                 );
 
             yield return new CallbackTemplate(
@@ -200,7 +200,7 @@ internal class DotNetTemplateFactory(
                 projectName => $"./{projectName}",
                 _ => { },
                 ApplyTemplateWithNoExtraArgsAsync,
-                supportsLanguageCallback: SupportsCSharpAppHost
+                supportsLanguageCallback: SupportsOnlyCSharp
                 );
         }
 
@@ -211,7 +211,7 @@ internal class DotNetTemplateFactory(
             projectName => $"./{projectName}",
             _ => { },
             ApplyTemplateWithNoExtraArgsAsync,
-            supportsLanguageCallback: SupportsCSharpAppHost
+            supportsLanguageCallback: SupportsOnlyCSharp
             );
 
         // Folded into the last yielded template.
@@ -221,7 +221,7 @@ internal class DotNetTemplateFactory(
             projectName => $"./{projectName}",
             _ => { },
             ApplyTemplateWithNoExtraArgsAsync,
-            supportsLanguageCallback: SupportsCSharpAppHost
+            supportsLanguageCallback: SupportsOnlyCSharp
             );
 
         // Folded into the last yielded template.
@@ -233,7 +233,7 @@ internal class DotNetTemplateFactory(
             nonInteractive
                 ? ApplyTemplateWithNoExtraArgsAsync
                 : (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireXUnitOptionsAsync, ct),
-            supportsLanguageCallback: SupportsCSharpAppHost
+            supportsLanguageCallback: SupportsOnlyCSharp
             );
 
         // Prepends a test framework selection step then calls the
@@ -255,7 +255,7 @@ internal class DotNetTemplateFactory(
                     var testCallbackTemplate = (CallbackTemplate)testTemplate;
                     return await testCallbackTemplate.ApplyTemplateAsync(inputs, parseResult, ct);
                 },
-                supportsLanguageCallback: SupportsCSharpAppHost);
+                supportsLanguageCallback: SupportsOnlyCSharp);
         }
     }
 
@@ -269,7 +269,7 @@ internal class DotNetTemplateFactory(
             nonInteractive
                 ? ApplySingleFileTemplateWithNoExtraArgsAsync
                 : (template, inputs, parseResult, ct) => ApplySingleFileTemplate(template, inputs, parseResult, PromptForExtraAspireSingleFileOptionsAsync, ct),
-            supportsLanguageCallback: SupportsCSharpAppHost,
+            supportsLanguageCallback: SupportsOnlyCSharp,
             isEmpty: true
             );
     }

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -254,7 +254,8 @@ internal class DotNetTemplateFactory(
 
                     var testCallbackTemplate = (CallbackTemplate)testTemplate;
                     return await testCallbackTemplate.ApplyTemplateAsync(inputs, parseResult, ct);
-                });
+                },
+                supportsLanguageCallback: SupportsCSharpAppHost);
         }
     }
 

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -37,29 +37,24 @@ internal class DotNetTemplateFactory(
     : ITemplateFactory
 {
     // Template-specific options
-    private static readonly Option<bool?> s_localhostTldOption = new("--localhost-tld")
+    private readonly Option<bool?> _localhostTldOption = new("--localhost-tld")
     {
         Description = TemplatingStrings.UseLocalhostTld_Description,
         DefaultValueFactory = _ => false
     };
-    private static readonly Option<bool?> s_useRedisCacheOption = new("--use-redis-cache")
+    private readonly Option<bool?> _useRedisCacheOption = new("--use-redis-cache")
     {
         Description = TemplatingStrings.UseRedisCache_Description,
         DefaultValueFactory = _ => false
     };
-    private static readonly Option<string?> s_testFrameworkOption = new("--test-framework")
+    private readonly Option<string?> _testFrameworkOption = new("--test-framework")
     {
         Description = TemplatingStrings.PromptForTFMOptions_Description
     };
-    private static readonly Option<string?> s_xunitVersionOption = new("--xunit-version")
+    private readonly Option<string?> _xunitVersionOption = new("--xunit-version")
     {
         Description = TemplatingStrings.EnterXUnitVersion_Description
     };
-
-    private static bool SupportsOnlyCSharp(string? languageId)
-    {
-        return string.Equals(languageId, KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase);
-    }
 
     public IEnumerable<ITemplate> GetTemplates()
     {
@@ -149,7 +144,7 @@ internal class DotNetTemplateFactory(
             nonInteractive
                 ? ApplyTemplateWithNoExtraArgsAsync
                 : (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireStarterOptionsAsync, ct),
-            supportsLanguageCallback: SupportsOnlyCSharp
+            languageId: KnownLanguageId.CSharp
             );
 
         yield return new CallbackTemplate(
@@ -160,7 +155,7 @@ internal class DotNetTemplateFactory(
             nonInteractive
                 ? ApplyTemplateWithNoExtraArgsAsync
                 : (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireJsFrontendStarterOptionsAsync, ct),
-            supportsLanguageCallback: SupportsOnlyCSharp
+            languageId: KnownLanguageId.CSharp
             );
 
         yield return new CallbackTemplate(
@@ -171,18 +166,19 @@ internal class DotNetTemplateFactory(
             nonInteractive
                 ? ApplySingleFileTemplateWithNoExtraArgsAsync
                 : (template, inputs, parseResult, ct) => ApplySingleFileTemplate(template, inputs, parseResult, PromptForExtraAspirePythonStarterOptionsAsync, ct),
-            supportsLanguageCallback: SupportsOnlyCSharp
+            languageId: KnownLanguageId.CSharp
             );
 
         if (showAllTemplates)
         {
             yield return new CallbackTemplate(
-                "aspire",
-                TemplatingStrings.AspireEmpty_Description,
+                KnownTemplateId.DotNetEmptyAppHost,
+                "Empty (C# AppHost, dotnet template)",
                 projectName => $"./{projectName}",
                 ApplyDevLocalhostTldOption,
                 ApplyTemplateWithNoExtraArgsAsync,
-                supportsLanguageCallback: SupportsOnlyCSharp
+                languageId: KnownLanguageId.CSharp,
+                isEmpty: true
                 );
 
             yield return new CallbackTemplate(
@@ -191,7 +187,7 @@ internal class DotNetTemplateFactory(
                 projectName => $"./{projectName}",
                 ApplyDevLocalhostTldOption,
                 ApplyTemplateWithNoExtraArgsAsync,
-                supportsLanguageCallback: SupportsOnlyCSharp
+                languageId: KnownLanguageId.CSharp
                 );
 
             yield return new CallbackTemplate(
@@ -200,7 +196,7 @@ internal class DotNetTemplateFactory(
                 projectName => $"./{projectName}",
                 _ => { },
                 ApplyTemplateWithNoExtraArgsAsync,
-                supportsLanguageCallback: SupportsOnlyCSharp
+                languageId: KnownLanguageId.CSharp
                 );
         }
 
@@ -211,7 +207,7 @@ internal class DotNetTemplateFactory(
             projectName => $"./{projectName}",
             _ => { },
             ApplyTemplateWithNoExtraArgsAsync,
-            supportsLanguageCallback: SupportsOnlyCSharp
+            languageId: KnownLanguageId.CSharp
             );
 
         // Folded into the last yielded template.
@@ -221,7 +217,7 @@ internal class DotNetTemplateFactory(
             projectName => $"./{projectName}",
             _ => { },
             ApplyTemplateWithNoExtraArgsAsync,
-            supportsLanguageCallback: SupportsOnlyCSharp
+            languageId: KnownLanguageId.CSharp
             );
 
         // Folded into the last yielded template.
@@ -233,7 +229,7 @@ internal class DotNetTemplateFactory(
             nonInteractive
                 ? ApplyTemplateWithNoExtraArgsAsync
                 : (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireXUnitOptionsAsync, ct),
-            supportsLanguageCallback: SupportsOnlyCSharp
+            languageId: KnownLanguageId.CSharp
             );
 
         // Prepends a test framework selection step then calls the
@@ -255,7 +251,7 @@ internal class DotNetTemplateFactory(
                     var testCallbackTemplate = (CallbackTemplate)testTemplate;
                     return await testCallbackTemplate.ApplyTemplateAsync(inputs, parseResult, ct);
                 },
-                supportsLanguageCallback: SupportsOnlyCSharp);
+                languageId: KnownLanguageId.CSharp);
         }
     }
 
@@ -269,7 +265,7 @@ internal class DotNetTemplateFactory(
             nonInteractive
                 ? ApplySingleFileTemplateWithNoExtraArgsAsync
                 : (template, inputs, parseResult, ct) => ApplySingleFileTemplate(template, inputs, parseResult, PromptForExtraAspireSingleFileOptionsAsync, ct),
-            supportsLanguageCallback: SupportsOnlyCSharp,
+            languageId: KnownLanguageId.CSharp,
             isEmpty: true
             );
     }
@@ -325,7 +321,7 @@ internal class DotNetTemplateFactory(
 
     private async Task PromptForDevLocalhostTldOptionAsync(ParseResult result, List<string> extraArgs, CancellationToken cancellationToken)
     {
-        var useLocalhostTld = result.GetValue(s_localhostTldOption);
+        var useLocalhostTld = result.GetValue(_localhostTldOption);
         if (!useLocalhostTld.HasValue)
         {
             useLocalhostTld = await interactionService.PromptForSelectionAsync(TemplatingStrings.UseLocalhostTld_Prompt, [TemplatingStrings.No, TemplatingStrings.Yes], choice => choice, cancellationToken) switch
@@ -345,7 +341,7 @@ internal class DotNetTemplateFactory(
 
     private async Task PromptForRedisCacheOptionAsync(ParseResult result, List<string> extraArgs, CancellationToken cancellationToken)
     {
-        var useRedisCache = result.GetValue(s_useRedisCacheOption);
+        var useRedisCache = result.GetValue(_useRedisCacheOption);
         if (!useRedisCache.HasValue)
         {
             useRedisCache = await interactionService.PromptForSelectionAsync(TemplatingStrings.UseRedisCache_Prompt, [TemplatingStrings.Yes, TemplatingStrings.No], choice => choice, cancellationToken) switch
@@ -365,7 +361,7 @@ internal class DotNetTemplateFactory(
 
     private async Task PromptForTestFrameworkOptionsAsync(ParseResult result, List<string> extraArgs, CancellationToken cancellationToken)
     {
-        var testFramework = result.GetValue(s_testFrameworkOption);
+        var testFramework = result.GetValue(_testFrameworkOption);
 
         if (testFramework is null)
         {
@@ -406,7 +402,7 @@ internal class DotNetTemplateFactory(
 
     private async Task PromptForXUnitVersionOptionsAsync(ParseResult result, List<string> extraArgs, CancellationToken cancellationToken)
     {
-        var xunitVersion = result.GetValue(s_xunitVersionOption);
+        var xunitVersion = result.GetValue(_xunitVersionOption);
         if (string.IsNullOrEmpty(xunitVersion))
         {
             xunitVersion = await interactionService.PromptForSelectionAsync(
@@ -420,25 +416,25 @@ internal class DotNetTemplateFactory(
         extraArgs.Add(xunitVersion);
     }
 
-    private static void ApplyExtraAspireStarterOptions(Command command)
+    private void ApplyExtraAspireStarterOptions(Command command)
     {
         ApplyDevLocalhostTldOption(command);
 
-        AddOptionIfMissing(command, s_useRedisCacheOption);
-        AddOptionIfMissing(command, s_testFrameworkOption);
-        AddOptionIfMissing(command, s_xunitVersionOption);
+        AddOptionIfMissing(command, _useRedisCacheOption);
+        AddOptionIfMissing(command, _testFrameworkOption);
+        AddOptionIfMissing(command, _xunitVersionOption);
     }
 
-    private static void ApplyExtraAspireJsFrontendStarterOptions(Command command)
+    private void ApplyExtraAspireJsFrontendStarterOptions(Command command)
     {
         ApplyDevLocalhostTldOption(command);
 
-        AddOptionIfMissing(command, s_useRedisCacheOption);
+        AddOptionIfMissing(command, _useRedisCacheOption);
     }
 
-    private static void ApplyDevLocalhostTldOption(Command command)
+    private void ApplyDevLocalhostTldOption(Command command)
     {
-        AddOptionIfMissing(command, s_localhostTldOption);
+        AddOptionIfMissing(command, _localhostTldOption);
     }
 
     private static void AddOptionIfMissing(Command command, Option option)

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -10,6 +10,7 @@ using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Packaging;
+using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
@@ -54,6 +55,11 @@ internal class DotNetTemplateFactory(
     {
         Description = TemplatingStrings.EnterXUnitVersion_Description
     };
+
+    private static bool SupportsCSharpAppHost(string languageId)
+    {
+        return languageId.Equals(KnownLanguageId.CSharp, StringComparison.OrdinalIgnoreCase);
+    }
 
     public IEnumerable<ITemplate> GetTemplates()
     {
@@ -142,7 +148,8 @@ internal class DotNetTemplateFactory(
             ApplyExtraAspireStarterOptions,
             nonInteractive
                 ? ApplyTemplateWithNoExtraArgsAsync
-                : (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireStarterOptionsAsync, ct)
+                : (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireStarterOptionsAsync, ct),
+            supportsLanguageCallback: SupportsCSharpAppHost
             );
 
         yield return new CallbackTemplate(
@@ -152,7 +159,8 @@ internal class DotNetTemplateFactory(
             ApplyExtraAspireJsFrontendStarterOptions,
             nonInteractive
                 ? ApplyTemplateWithNoExtraArgsAsync
-                : (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireJsFrontendStarterOptionsAsync, ct)
+                : (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireJsFrontendStarterOptionsAsync, ct),
+            supportsLanguageCallback: SupportsCSharpAppHost
             );
 
         yield return new CallbackTemplate(
@@ -162,7 +170,8 @@ internal class DotNetTemplateFactory(
             ApplyDevLocalhostTldOption,
             nonInteractive
                 ? ApplySingleFileTemplateWithNoExtraArgsAsync
-                : (template, inputs, parseResult, ct) => ApplySingleFileTemplate(template, inputs, parseResult, PromptForExtraAspirePythonStarterOptionsAsync, ct)
+                : (template, inputs, parseResult, ct) => ApplySingleFileTemplate(template, inputs, parseResult, PromptForExtraAspirePythonStarterOptionsAsync, ct),
+            supportsLanguageCallback: SupportsCSharpAppHost
             );
 
         if (showAllTemplates)
@@ -172,7 +181,8 @@ internal class DotNetTemplateFactory(
                 TemplatingStrings.AspireEmpty_Description,
                 projectName => $"./{projectName}",
                 ApplyDevLocalhostTldOption,
-                ApplyTemplateWithNoExtraArgsAsync
+                ApplyTemplateWithNoExtraArgsAsync,
+                supportsLanguageCallback: SupportsCSharpAppHost
                 );
 
             yield return new CallbackTemplate(
@@ -180,7 +190,8 @@ internal class DotNetTemplateFactory(
                 TemplatingStrings.AspireAppHost_Description,
                 projectName => $"./{projectName}",
                 ApplyDevLocalhostTldOption,
-                ApplyTemplateWithNoExtraArgsAsync
+                ApplyTemplateWithNoExtraArgsAsync,
+                supportsLanguageCallback: SupportsCSharpAppHost
                 );
 
             yield return new CallbackTemplate(
@@ -188,7 +199,8 @@ internal class DotNetTemplateFactory(
                 TemplatingStrings.AspireServiceDefaults_Description,
                 projectName => $"./{projectName}",
                 _ => { },
-                ApplyTemplateWithNoExtraArgsAsync
+                ApplyTemplateWithNoExtraArgsAsync,
+                supportsLanguageCallback: SupportsCSharpAppHost
                 );
         }
 
@@ -198,7 +210,8 @@ internal class DotNetTemplateFactory(
             TemplatingStrings.AspireMSTest_Description,
             projectName => $"./{projectName}",
             _ => { },
-            ApplyTemplateWithNoExtraArgsAsync
+            ApplyTemplateWithNoExtraArgsAsync,
+            supportsLanguageCallback: SupportsCSharpAppHost
             );
 
         // Folded into the last yielded template.
@@ -207,7 +220,8 @@ internal class DotNetTemplateFactory(
             TemplatingStrings.AspireNUnit_Description,
             projectName => $"./{projectName}",
             _ => { },
-            ApplyTemplateWithNoExtraArgsAsync
+            ApplyTemplateWithNoExtraArgsAsync,
+            supportsLanguageCallback: SupportsCSharpAppHost
             );
 
         // Folded into the last yielded template.
@@ -218,7 +232,8 @@ internal class DotNetTemplateFactory(
             _ => { },
             nonInteractive
                 ? ApplyTemplateWithNoExtraArgsAsync
-                : (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireXUnitOptionsAsync, ct)
+                : (template, inputs, parseResult, ct) => ApplyTemplateAsync(template, inputs, parseResult, PromptForExtraAspireXUnitOptionsAsync, ct),
+            supportsLanguageCallback: SupportsCSharpAppHost
             );
 
         // Prepends a test framework selection step then calls the
@@ -253,6 +268,7 @@ internal class DotNetTemplateFactory(
             nonInteractive
                 ? ApplySingleFileTemplateWithNoExtraArgsAsync
                 : (template, inputs, parseResult, ct) => ApplySingleFileTemplate(template, inputs, parseResult, PromptForExtraAspireSingleFileOptionsAsync, ct),
+            supportsLanguageCallback: SupportsCSharpAppHost,
             isEmpty: true
             );
     }

--- a/src/Aspire.Cli/Templating/ITemplate.cs
+++ b/src/Aspire.Cli/Templating/ITemplate.cs
@@ -36,16 +36,9 @@ internal interface ITemplate
     Func<string, string> PathDeriver { get; }
 
     /// <summary>
-    /// Determines whether this template is available for the selected language.
+    /// Gets the AppHost language identifier associated with this template.
     /// </summary>
-    /// <param name="languageId">The selected language identifier.</param>
-    /// <returns><see langword="true"/> if the template is available; otherwise <see langword="false"/>.</returns>
-    bool SupportsLanguage(string languageId);
-
-    /// <summary>
-    /// Gets the AppHost languages that this template can prompt for.
-    /// </summary>
-    IReadOnlyList<string> SelectableAppHostLanguages { get; }
+    string? LanguageId { get; }
 
     /// <summary>
     /// Applies template-specific command options.

--- a/src/Aspire.Cli/Templating/KnownTemplateId.cs
+++ b/src/Aspire.Cli/Templating/KnownTemplateId.cs
@@ -9,9 +9,19 @@ namespace Aspire.Cli.Templating;
 internal static class KnownTemplateId
 {
     /// <summary>
-    /// The template ID for the empty AppHost template.
+    /// The template ID for the CLI C# empty AppHost template.
     /// </summary>
-    public const string EmptyAppHost = "aspire-empty";
+    public const string CSharpEmptyAppHost = "aspire-empty";
+
+    /// <summary>
+    /// The template ID for the CLI TypeScript empty AppHost template.
+    /// </summary>
+    public const string TypeScriptEmptyAppHost = "aspire-ts-empty";
+
+    /// <summary>
+    /// The template ID for the dotnet empty AppHost template.
+    /// </summary>
+    public const string DotNetEmptyAppHost = "aspire";
 
     /// <summary>
     /// The template ID for the TypeScript starter template.

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -904,6 +904,10 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(KnownLanguageId.TypeScript, scaffoldedLanguageId);
         Assert.NotNull(promptedTemplateNames);
         Assert.Contains("aspire-empty", promptedTemplateNames);
+        Assert.Contains("aspire-ts-starter", promptedTemplateNames);
+        Assert.DoesNotContain("aspire-starter", promptedTemplateNames);
+        Assert.DoesNotContain("aspire-ts-cs-starter", promptedTemplateNames);
+        Assert.DoesNotContain("aspire-py-starter", promptedTemplateNames);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts")));
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -50,6 +50,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var command = provider.GetRequiredService<NewCommand>();
         Assert.NotEmpty(command.Subcommands);
+        Assert.Contains(command.Subcommands, subcommand => subcommand.Name == KnownTemplateId.CSharpEmptyAppHost && subcommand.Description == "Empty (C# AppHost)");
+        Assert.Contains(command.Subcommands, subcommand => subcommand.Name == KnownTemplateId.TypeScriptEmptyAppHost && subcommand.Description == "Empty (TypeScript AppHost)");
     }
 
     [Fact]
@@ -61,6 +63,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var command = provider.GetRequiredService<NewCommand>();
         Assert.NotEmpty(command.Subcommands);
+        Assert.DoesNotContain(command.Options, option => option.Aliases.Contains("--language", StringComparer.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -842,11 +845,11 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task NewCommandWithLanguageOptionAndNoTemplateCanCreateCliEmptyTemplate()
+    public async Task NewCommandWithoutTemplateCanCreateTypeScriptEmptyTemplate()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var scaffoldedLanguageId = string.Empty;
-        string[]? promptedTemplateNames = null;
+        (string Name, string Description)[]? promptedTemplates = null;
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
@@ -877,8 +880,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 var prompter = new TestNewCommandPrompter(interactionService);
                 prompter.PromptForTemplateCallback = templates =>
                 {
-                    promptedTemplateNames = templates.Select(t => t.Name).ToArray();
-                    return templates.Single(t => t.Name.Equals("aspire-empty", StringComparison.OrdinalIgnoreCase));
+                    promptedTemplates = templates.Select(t => (t.Name, t.Description)).ToArray();
+                    return templates.Single(t => t.Name.Equals(KnownTemplateId.TypeScriptEmptyAppHost, StringComparison.OrdinalIgnoreCase));
                 };
 
                 return prompter;
@@ -897,103 +900,55 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new --language typescript --name TestApp --output .");
+        var result = command.Parse("new --name TestApp --output .");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(0, exitCode);
         Assert.Equal(KnownLanguageId.TypeScript, scaffoldedLanguageId);
-        Assert.NotNull(promptedTemplateNames);
-        Assert.Contains("aspire-empty", promptedTemplateNames);
-        Assert.Contains("aspire-ts-starter", promptedTemplateNames);
-        Assert.DoesNotContain("aspire-starter", promptedTemplateNames);
-        Assert.DoesNotContain("aspire-ts-cs-starter", promptedTemplateNames);
-        Assert.DoesNotContain("aspire-py-starter", promptedTemplateNames);
+        Assert.NotNull(promptedTemplates);
+        Assert.Contains((KnownTemplateId.CSharpEmptyAppHost, "Empty (C# AppHost)"), promptedTemplates);
+        Assert.Contains((KnownTemplateId.TypeScriptEmptyAppHost, "Empty (TypeScript AppHost)"), promptedTemplates);
+        Assert.Contains((KnownTemplateId.TypeScriptStarter, "Starter App (Express/React)"), promptedTemplates);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts")));
     }
 
     [Fact]
-    public async Task NewCommandWithLanguageOptionAndShowAllTemplatesFiltersOutAspireTest()
+    public void NewCommandTemplateSubcommandsListTechnicalNamesForNonInteractiveFlows()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        string[]? promptedTemplateNames = null;
-
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
             options.FeatureFlagsFactory = _ => new NewCommandTestFeatures(showAllTemplates: true);
-            options.InteractionServiceFactory = _ => new TestInteractionService
-            {
-                PromptForSelectionCallback = (promptText, choices, choiceFormatter, cancellationToken) => choices.Cast<object>().First()
-            };
-            options.DotNetCliRunnerFactory = (sp) =>
-            {
-                var runner = new TestDotNetCliRunner();
-                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, dotnetOptions, cancellationToken) =>
-                {
-                    var package = new NuGetPackage()
-                    {
-                        Id = "Aspire.ProjectTemplates",
-                        Source = "nuget",
-                        Version = "9.2.0"
-                    };
-
-                    return (0, new NuGetPackage[] { package });
-                };
-
-                return runner;
-            };
-            options.NewCommandPrompterFactory = (sp) =>
-            {
-                var interactionService = sp.GetRequiredService<IInteractionService>();
-                var prompter = new TestNewCommandPrompter(interactionService);
-                prompter.PromptForTemplateCallback = templates =>
-                {
-                    promptedTemplateNames = templates.Select(t => t.Name).ToArray();
-                    return templates.Single(t => t.Name.Equals("aspire-empty", StringComparison.OrdinalIgnoreCase));
-                };
-
-                return prompter;
-            };
-        });
-
-        services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
-        {
-            ScaffoldAsyncCallback = (context, cancellationToken) =>
-            {
-                File.WriteAllText(Path.Combine(context.TargetDirectory.FullName, "apphost.ts"), "// test apphost");
-                return Task.CompletedTask;
-            }
         });
 
         var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new --language typescript --name TestApp --output .");
 
-        var exitCode = await result.InvokeAsync().DefaultTimeout();
-        Assert.Equal(0, exitCode);
-        Assert.NotNull(promptedTemplateNames);
-        Assert.DoesNotContain("aspire-test", promptedTemplateNames);
+        Assert.Contains(command.Subcommands, subcommand => subcommand.Name == "aspire-test");
+        Assert.Contains(command.Subcommands, subcommand => subcommand.Name == KnownTemplateId.DotNetEmptyAppHost && subcommand.Description == "Empty (C# AppHost, dotnet template)");
+        Assert.Contains(command.Subcommands, subcommand => subcommand.Name == KnownTemplateId.CSharpEmptyAppHost && subcommand.Description == "Empty (C# AppHost)");
+        Assert.Contains(command.Subcommands, subcommand => subcommand.Name == KnownTemplateId.TypeScriptEmptyAppHost && subcommand.Description == "Empty (TypeScript AppHost)");
     }
 
     [Fact]
-    public async Task NewCommandWithLanguageOptionFiltersOutTypeScriptStarterForCSharp()
+    public async Task NewCommandWithoutTemplatePromptsWithDistinctLanguageSpecificEmptyDescriptions()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        string[]? promptedTemplateNames = null;
+        string[]? promptedTemplateDescriptions = null;
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            options.InteractionServiceFactory = _ => new TestInteractionService
-            {
-                PromptForSelectionCallback = (promptText, choices, choiceFormatter, cancellationToken) => choices.Cast<object>().First()
-            };
             options.NewCommandPrompterFactory = (sp) =>
             {
                 var interactionService = sp.GetRequiredService<IInteractionService>();
                 var prompter = new TestNewCommandPrompter(interactionService);
                 prompter.PromptForTemplateCallback = templates =>
                 {
-                    promptedTemplateNames = templates.Select(t => t.Name).ToArray();
-                    return templates.Single(t => t.Name.Equals("aspire-empty", StringComparison.OrdinalIgnoreCase));
+                    promptedTemplateDescriptions = templates
+                        .Where(t => t.Name is KnownTemplateId.CSharpEmptyAppHost or KnownTemplateId.TypeScriptEmptyAppHost)
+                        .Select(t => t.Description)
+                        .ToArray();
+                    return templates.Single(t => t.Name.Equals(KnownTemplateId.CSharpEmptyAppHost, StringComparison.OrdinalIgnoreCase));
                 };
 
                 return prompter;
@@ -1019,34 +974,22 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new --language csharp --name TestApp --output .");
+        var result = command.Parse("new --name TestApp --output .");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(0, exitCode);
-        Assert.NotNull(promptedTemplateNames);
-        Assert.DoesNotContain("aspire-ts-starter", promptedTemplateNames);
+        Assert.NotNull(promptedTemplateDescriptions);
+        Assert.Contains("Empty (C# AppHost)", promptedTemplateDescriptions);
+        Assert.Contains("Empty (TypeScript AppHost)", promptedTemplateDescriptions);
     }
 
     [Fact]
-    public async Task NewCommandWithExplicitTemplateAndPolyglotEnabledDoesNotPromptForLanguageSelection()
+    public async Task NewCommandWithExplicitCSharpEmptyTemplateCreatesCSharpAppHost()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var languageSelectionRequested = false;
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
-            options.LanguageServiceFactory = (sp) =>
-            {
-                return new TestLanguageService
-                {
-                    GetOrPromptForProjectAsyncCallback = (explicitLanguageId, saveSelection, cancellationToken) =>
-                    {
-                        languageSelectionRequested = true;
-                        throw new InvalidOperationException("Language selection should not be requested for template subcommands without --language.");
-                    }
-                };
-            };
-
             options.DotNetCliRunnerFactory = (sp) =>
             {
                 var runner = new TestDotNetCliRunner();
@@ -1068,11 +1011,10 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new aspire-empty --language csharp --name TestApp --output . --localhost-tld false");
+        var result = command.Parse("new aspire-empty --name TestApp --output . --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(0, exitCode);
-        Assert.False(languageSelectionRequested);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs")));
     }
 
@@ -1130,7 +1072,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new --language csharp --name TestApp --output .");
+        var result = command.Parse("new aspire-empty --name TestApp --output .");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(0, exitCode);
@@ -1144,7 +1086,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task NewCommandWithEmptyTemplateAndExplicitTypeScriptLanguageUsesScaffolding()
+    public async Task NewCommandWithTypeScriptEmptyTemplateUsesScaffolding()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var scaffoldingInvoked = false;
@@ -1181,7 +1123,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("new --language typescript aspire-empty --name TestApp --output . --localhost-tld false");
+        var result = command.Parse("new aspire-ts-empty --name TestApp --output . --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(0, exitCode);
@@ -1238,7 +1180,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
         // Do not pass --output so the default "./TestApp" path is used via the prompter
-        var result = command.Parse("new --language typescript aspire-empty --name TestApp --localhost-tld false");
+        var result = command.Parse("new aspire-ts-empty --name TestApp --localhost-tld false");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(0, exitCode);
@@ -1282,7 +1224,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 var interactionService = sp.GetRequiredService<IInteractionService>();
                 var prompter = new TestNewCommandPrompter(interactionService);
                 prompter.PromptForTemplateCallback = templates =>
-                    templates.Single(t => t.Name.Equals("aspire-empty", StringComparison.OrdinalIgnoreCase));
+                    templates.Single(t => t.Name.Equals("aspire-ts-empty", StringComparison.OrdinalIgnoreCase));
 
                 return prompter;
             };
@@ -1328,7 +1270,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new --language typescript --name TestApp --output .");
+        var result = command.Parse("new aspire-ts-empty --name TestApp --output .");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(0, exitCode);
@@ -1515,7 +1457,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var provider = services.BuildServiceProvider();
 
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse("new aspire-empty --language csharp --name TestApp --output .");
+        var result = command.Parse("new aspire-empty --name TestApp --output .");
 
         // Before the fix, this would throw InvalidOperationException with
         // "Interactive input is not supported in this environment" because

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -912,6 +912,69 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task NewCommandWithLanguageOptionAndShowAllTemplatesFiltersOutAspireTest()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        string[]? promptedTemplateNames = null;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.FeatureFlagsFactory = _ => new NewCommandTestFeatures(showAllTemplates: true);
+            options.InteractionServiceFactory = _ => new TestInteractionService
+            {
+                PromptForSelectionCallback = (promptText, choices, choiceFormatter, cancellationToken) => choices.Cast<object>().First()
+            };
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, dotnetOptions, cancellationToken) =>
+                {
+                    var package = new NuGetPackage()
+                    {
+                        Id = "Aspire.ProjectTemplates",
+                        Source = "nuget",
+                        Version = "9.2.0"
+                    };
+
+                    return (0, new NuGetPackage[] { package });
+                };
+
+                return runner;
+            };
+            options.NewCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                var prompter = new TestNewCommandPrompter(interactionService);
+                prompter.PromptForTemplateCallback = templates =>
+                {
+                    promptedTemplateNames = templates.Select(t => t.Name).ToArray();
+                    return templates.Single(t => t.Name.Equals("aspire-empty", StringComparison.OrdinalIgnoreCase));
+                };
+
+                return prompter;
+            };
+        });
+
+        services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
+        {
+            ScaffoldAsyncCallback = (context, cancellationToken) =>
+            {
+                File.WriteAllText(Path.Combine(context.TargetDirectory.FullName, "apphost.ts"), "// test apphost");
+                return Task.CompletedTask;
+            }
+        });
+
+        var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new --language typescript --name TestApp --output .");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(promptedTemplateNames);
+        Assert.DoesNotContain("aspire-test", promptedTemplateNames);
+    }
+
+    [Fact]
     public async Task NewCommandWithLanguageOptionFiltersOutTypeScriptStarterForCSharp()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -1646,6 +1709,18 @@ internal sealed class TestScaffoldingService : IScaffoldingService
         }
 
         return Task.CompletedTask;
+    }
+}
+
+internal sealed class NewCommandTestFeatures(bool showAllTemplates = false) : IFeatures
+{
+    public bool IsFeatureEnabled(string featureFlag, bool defaultValue)
+    {
+        return featureFlag switch
+        {
+            "showAllTemplates" => showAllTemplates,
+            _ => defaultValue
+        };
     }
 }
 

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -305,7 +305,7 @@ public class DotNetTemplateFactoryTests
         // Assert
         var templateNames = templates.Select(t => t.Name).ToList();
         Assert.Contains("aspire-starter", templateNames);
-        Assert.DoesNotContain("aspire", templateNames);
+        Assert.DoesNotContain(KnownTemplateId.DotNetEmptyAppHost, templateNames);
         Assert.DoesNotContain("aspire-apphost", templateNames);
         Assert.DoesNotContain("aspire-servicedefaults", templateNames);
         Assert.DoesNotContain("aspire-test", templateNames);

--- a/tests/Shared/Hex1bTestHelpers.cs
+++ b/tests/Shared/Hex1bTestHelpers.cs
@@ -52,8 +52,8 @@ internal enum AspireTemplate
     PythonReact,
 
     /// <summary>
-    /// Empty AppHost — 5th option.
-    /// Prompts: template, language (C#), project name, output path, URLs. No Redis or test project prompt.
+    /// Empty (C# AppHost) — 5th option.
+    /// Prompts: template, project name, output path, URLs. No language, Redis, or test project prompt.
     /// </summary>
     EmptyAppHost,
 }
@@ -445,14 +445,13 @@ internal static class Hex1bTestHelpers
 
             case AspireTemplate.EmptyAppHost:
                 var emptyAppHostSelected = new CellPatternSearcher()
-                    .Find("> Empty AppHost");
+                    .Find("> Empty (C# AppHost)");
                 builder.Key(Hex1bKey.DownArrow)
                     .Key(Hex1bKey.DownArrow)
                     .Key(Hex1bKey.DownArrow)
                     .Key(Hex1bKey.DownArrow)
                     .WaitUntil(s => emptyAppHostSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
-                    .Enter()
-                    .Enter(); // Select C# language
+                    .Enter();
                 break;
         }
 


### PR DESCRIPTION
## Description

This change makes `aspire new` template selection language-specific instead of selecting a template first and then resolving the AppHost language separately.

It updates the `new` flow to:
- remove `--language` from `aspire new`
- stop prompting `Which language would you like to use?` in `aspire new`
- split the empty AppHost experience into language-specific templates:
  - `aspire-empty` -> `Empty (C# AppHost)`
  - `aspire-ts-empty` -> `Empty (TypeScript AppHost)`
- derive `TemplateInputs.Language` directly from the selected template
- keep the raw dotnet `aspire` template as a separate show-all entry
- preserve technical template names for non-interactive flows and update tests accordingly
- align the shared Hex1b E2E helper with the renamed empty C# template and the removed language prompt
- move the show-all dotnet empty template label into `TemplatingStrings` and add the new English entry to every localized XLF file for now

This PR intentionally does **not** change `aspire init`, which still has its own language-selection flow.

## Validation

- `./dotnet.sh test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `./dotnet.sh test tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj -- --filter-method "*.CreateEmptyAppHostProject" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` (targeted E2E project compile / focused execution check)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No