### PR TITLE
Fix guest AppHost secret store resolution

### DIFF
--- a/src/Aspire.Cli/Commands/SecretCommand.cs
+++ b/src/Aspire.Cli/Commands/SecretCommand.cs
@@ -24,6 +24,7 @@ internal sealed class SecretCommand : BaseCommand
         SecretSetCommand setCommand,
         SecretGetCommand getCommand,
         SecretListCommand listCommand,
+        SecretPathCommand pathCommand,
         SecretDeleteCommand deleteCommand,
         IInteractionService interactionService,
         IFeatures features,
@@ -35,6 +36,7 @@ internal sealed class SecretCommand : BaseCommand
         Subcommands.Add(getCommand);
         Subcommands.Add(setCommand);
         Subcommands.Add(listCommand);
+        Subcommands.Add(pathCommand);
         Subcommands.Add(deleteCommand);
     }
 

--- a/src/Aspire.Cli/Commands/SecretPathCommand.cs
+++ b/src/Aspire.Cli/Commands/SecretPathCommand.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Resources;
+using Aspire.Cli.Secrets;
+using Aspire.Cli.Telemetry;
+using Aspire.Cli.Utils;
+
+namespace Aspire.Cli.Commands;
+
+/// <summary>
+/// Shows the user secrets file path for an AppHost project.
+/// </summary>
+internal sealed class SecretPathCommand : BaseCommand
+{
+    private readonly SecretStoreResolver _secretStoreResolver;
+
+    public SecretPathCommand(
+        IInteractionService interactionService,
+        SecretStoreResolver secretStoreResolver,
+        IFeatures features,
+        ICliUpdateNotifier updateNotifier,
+        CliExecutionContext executionContext,
+        AspireCliTelemetry telemetry)
+        : base("path", SecretCommandStrings.PathDescription, features, updateNotifier, executionContext, interactionService, telemetry)
+    {
+        _secretStoreResolver = secretStoreResolver;
+
+        Options.Add(SecretCommand.s_appHostOption);
+    }
+
+    protected override async Task<int> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    {
+        var projectFile = parseResult.GetValue(SecretCommand.s_appHostOption);
+
+        var result = await _secretStoreResolver.ResolveAsync(projectFile, autoInit: false, cancellationToken);
+        if (result is null)
+        {
+            InteractionService.DisplayError(SecretCommandStrings.CouldNotFindAppHost);
+            return ExitCodeConstants.FailedToFindProject;
+        }
+
+        InteractionService.DisplayPlainText(result.Store.FilePath);
+        return ExitCodeConstants.Success;
+    }
+}

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -409,6 +409,7 @@ public class Program
         builder.Services.AddTransient<SecretSetCommand>();
         builder.Services.AddTransient<SecretGetCommand>();
         builder.Services.AddTransient<SecretListCommand>();
+        builder.Services.AddTransient<SecretPathCommand>();
         builder.Services.AddTransient<SecretDeleteCommand>();
         builder.Services.AddTransient<SecretStoreResolver>();
         builder.Services.AddTransient<SdkCommand>();

--- a/src/Aspire.Cli/Resources/SecretCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/SecretCommandStrings.Designer.cs
@@ -11,6 +11,7 @@ internal static class SecretCommandStrings
     internal static string SetDescription => s_resourceManager.GetString("SetDescription", System.Globalization.CultureInfo.CurrentUICulture) ?? "Set a secret value.";
     internal static string GetDescription => s_resourceManager.GetString("GetDescription", System.Globalization.CultureInfo.CurrentUICulture) ?? "Get a secret value.";
     internal static string ListDescription => s_resourceManager.GetString("ListDescription", System.Globalization.CultureInfo.CurrentUICulture) ?? "List all secrets.";
+    internal static string PathDescription => s_resourceManager.GetString("PathDescription", System.Globalization.CultureInfo.CurrentUICulture) ?? "Show the secrets file path.";
     internal static string DeleteDescription => s_resourceManager.GetString("DeleteDescription", System.Globalization.CultureInfo.CurrentUICulture) ?? "Delete a secret.";
     internal static string KeyArgumentDescription => s_resourceManager.GetString("KeyArgumentDescription", System.Globalization.CultureInfo.CurrentUICulture) ?? "The secret key.";
     internal static string KeyRetrieveArgumentDescription => s_resourceManager.GetString("KeyRetrieveArgumentDescription", System.Globalization.CultureInfo.CurrentUICulture) ?? "The secret key to retrieve.";

--- a/src/Aspire.Cli/Resources/SecretCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/SecretCommandStrings.resx
@@ -51,6 +51,9 @@
   <data name="ListDescription" xml:space="preserve">
     <value>List all secrets.</value>
   </data>
+  <data name="PathDescription" xml:space="preserve">
+    <value>Show the secrets file path.</value>
+  </data>
   <data name="DeleteDescription" xml:space="preserve">
     <value>Delete a secret.</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.cs.xlf
@@ -52,6 +52,11 @@
         <target state="new">No secrets configured.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PathDescription">
+        <source>Show the secrets file path.</source>
+        <target state="new">Show the secrets file path.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecretDeleteSuccess">
         <source>Secret '{0}' deleted successfully.</source>
         <target state="new">Secret '{0}' deleted successfully.</target>

--- a/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.de.xlf
@@ -52,6 +52,11 @@
         <target state="new">No secrets configured.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PathDescription">
+        <source>Show the secrets file path.</source>
+        <target state="new">Show the secrets file path.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecretDeleteSuccess">
         <source>Secret '{0}' deleted successfully.</source>
         <target state="new">Secret '{0}' deleted successfully.</target>

--- a/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.es.xlf
@@ -52,6 +52,11 @@
         <target state="new">No secrets configured.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PathDescription">
+        <source>Show the secrets file path.</source>
+        <target state="new">Show the secrets file path.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecretDeleteSuccess">
         <source>Secret '{0}' deleted successfully.</source>
         <target state="new">Secret '{0}' deleted successfully.</target>

--- a/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.fr.xlf
@@ -52,6 +52,11 @@
         <target state="new">No secrets configured.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PathDescription">
+        <source>Show the secrets file path.</source>
+        <target state="new">Show the secrets file path.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecretDeleteSuccess">
         <source>Secret '{0}' deleted successfully.</source>
         <target state="new">Secret '{0}' deleted successfully.</target>

--- a/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.it.xlf
@@ -52,6 +52,11 @@
         <target state="new">No secrets configured.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PathDescription">
+        <source>Show the secrets file path.</source>
+        <target state="new">Show the secrets file path.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecretDeleteSuccess">
         <source>Secret '{0}' deleted successfully.</source>
         <target state="new">Secret '{0}' deleted successfully.</target>

--- a/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.ja.xlf
@@ -52,6 +52,11 @@
         <target state="new">No secrets configured.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PathDescription">
+        <source>Show the secrets file path.</source>
+        <target state="new">Show the secrets file path.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecretDeleteSuccess">
         <source>Secret '{0}' deleted successfully.</source>
         <target state="new">Secret '{0}' deleted successfully.</target>

--- a/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.ko.xlf
@@ -52,6 +52,11 @@
         <target state="new">No secrets configured.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PathDescription">
+        <source>Show the secrets file path.</source>
+        <target state="new">Show the secrets file path.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecretDeleteSuccess">
         <source>Secret '{0}' deleted successfully.</source>
         <target state="new">Secret '{0}' deleted successfully.</target>

--- a/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.pl.xlf
@@ -52,6 +52,11 @@
         <target state="new">No secrets configured.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PathDescription">
+        <source>Show the secrets file path.</source>
+        <target state="new">Show the secrets file path.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecretDeleteSuccess">
         <source>Secret '{0}' deleted successfully.</source>
         <target state="new">Secret '{0}' deleted successfully.</target>

--- a/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.pt-BR.xlf
@@ -52,6 +52,11 @@
         <target state="new">No secrets configured.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PathDescription">
+        <source>Show the secrets file path.</source>
+        <target state="new">Show the secrets file path.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecretDeleteSuccess">
         <source>Secret '{0}' deleted successfully.</source>
         <target state="new">Secret '{0}' deleted successfully.</target>

--- a/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.ru.xlf
@@ -52,6 +52,11 @@
         <target state="new">No secrets configured.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PathDescription">
+        <source>Show the secrets file path.</source>
+        <target state="new">Show the secrets file path.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecretDeleteSuccess">
         <source>Secret '{0}' deleted successfully.</source>
         <target state="new">Secret '{0}' deleted successfully.</target>

--- a/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.tr.xlf
@@ -52,6 +52,11 @@
         <target state="new">No secrets configured.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PathDescription">
+        <source>Show the secrets file path.</source>
+        <target state="new">Show the secrets file path.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecretDeleteSuccess">
         <source>Secret '{0}' deleted successfully.</source>
         <target state="new">Secret '{0}' deleted successfully.</target>

--- a/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.zh-Hans.xlf
@@ -52,6 +52,11 @@
         <target state="new">No secrets configured.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PathDescription">
+        <source>Show the secrets file path.</source>
+        <target state="new">Show the secrets file path.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecretDeleteSuccess">
         <source>Secret '{0}' deleted successfully.</source>
         <target state="new">Secret '{0}' deleted successfully.</target>

--- a/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/SecretCommandStrings.zh-Hant.xlf
@@ -52,6 +52,11 @@
         <target state="new">No secrets configured.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PathDescription">
+        <source>Show the secrets file path.</source>
+        <target state="new">Show the secrets file path.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SecretDeleteSuccess">
         <source>Secret '{0}' deleted successfully.</source>
         <target state="new">Secret '{0}' deleted successfully.</target>

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -29,6 +29,7 @@ using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Pipelines.Internal;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.UserSecrets;
+using Aspire.Shared.UserSecrets;
 using Microsoft.Extensions.Configuration.UserSecrets;
 using Aspire.Hosting.VersionChecking;
 using Microsoft.Extensions.Configuration;
@@ -187,19 +188,9 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         LogBuilderConstructing(options, innerBuilderOptions);
         _innerBuilder = new HostApplicationBuilder(innerBuilderOptions);
 
-        // Resolve the effective UserSecretsId: assembly attribute for .NET, env var for polyglot
-        var userSecretsId = AppHostAssembly?.GetCustomAttribute<UserSecretsIdAttribute>()?.UserSecretsId
-            ?? _innerBuilder.Configuration[KnownConfigNames.AspireUserSecretsId];
-
-        // For polyglot AppHosts (no assembly attribute), add user secrets early so they have the
-        // same precedence as the default AddUserSecrets called by HostApplicationBuilder for .NET projects.
-        // Only add in Development environment, matching the behavior of the default AddUserSecrets.
-        if (!string.IsNullOrEmpty(userSecretsId) &&
-            AppHostAssembly?.GetCustomAttribute<UserSecretsIdAttribute>() is null &&
-            _innerBuilder.Environment.IsDevelopment())
-        {
-            _innerBuilder.Configuration.AddUserSecrets(userSecretsId);
-        }
+        var configuredUserSecretsId = _innerBuilder.Configuration[KnownConfigNames.AspireUserSecretsId];
+        var userSecretsId = ResolveUserSecretsId(AppHostAssembly, _innerBuilder.Configuration);
+        AddConfiguredUserSecrets(_innerBuilder.Configuration, AppHostAssembly, configuredUserSecretsId, _innerBuilder.Environment.IsDevelopment());
 
         _innerBuilder.Services.AddSingleton(TimeProvider.System);
 
@@ -787,6 +778,66 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         return builder;
     }
 
+    internal static string? ResolveUserSecretsId(Assembly? appHostAssembly, IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        // An explicitly configured value should win over any assembly-level UserSecretsId so guest AppHosts can
+        // direct secrets to their synthetic store instead of the generated server project's store.
+        var configuredUserSecretsId = configuration[KnownConfigNames.AspireUserSecretsId];
+        var assemblyUserSecretsId = appHostAssembly?.GetCustomAttribute<UserSecretsIdAttribute>()?.UserSecretsId;
+        return string.IsNullOrWhiteSpace(configuredUserSecretsId) ? assemblyUserSecretsId : configuredUserSecretsId;
+    }
+
+    internal static void AddConfiguredUserSecrets(IConfigurationManager configuration, Assembly? appHostAssembly, string? configuredUserSecretsId, bool isDevelopment)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        // Add explicitly configured user secrets early so they have the same precedence as the default AddUserSecrets
+        // called by HostApplicationBuilder for .NET projects, and can replace any assembly-level store when needed.
+        // Only add in Development environment, matching the behavior of the default AddUserSecrets.
+        if (!string.IsNullOrWhiteSpace(configuredUserSecretsId) && isDevelopment)
+        {
+            RemoveUserSecretsSource(configuration, appHostAssembly?.GetCustomAttribute<UserSecretsIdAttribute>()?.UserSecretsId);
+            configuration.AddUserSecrets(configuredUserSecretsId);
+        }
+    }
+
+    internal static void RemoveUserSecretsSource(IConfigurationManager configuration, string? userSecretsId)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        if (string.IsNullOrWhiteSpace(userSecretsId))
+        {
+            return;
+        }
+
+        var userSecretsFilePath = Path.GetFullPath(UserSecretsPathHelper.GetSecretsPathFromSecretsId(userSecretsId));
+
+        for (var i = configuration.Sources.Count - 1; i >= 0; i--)
+        {
+            if (configuration.Sources[i] is not FileConfigurationSource fileSource)
+            {
+                continue;
+            }
+
+            if (fileSource.Path is null)
+            {
+                continue;
+            }
+
+            var filePath = fileSource.FileProvider?.GetFileInfo(fileSource.Path).PhysicalPath;
+
+            if (filePath is not null && PathsEqual(filePath, userSecretsFilePath))
+            {
+                configuration.Sources.RemoveAt(i);
+            }
+        }
+    }
+
+    private static bool PathsEqual(string left, string right) =>
+        string.Equals(Path.GetFullPath(left), Path.GetFullPath(right), OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+
     private static DiagnosticListener LogBuilderConstructing(DistributedApplicationOptions appBuilderOptions, HostApplicationBuilderSettings hostBuilderOptions)
     {
         var diagnosticListener = new DiagnosticListener(HostingDiagnosticListenerName);
@@ -879,4 +930,3 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
     private static string? GetMetadataValue(IEnumerable<AssemblyMetadataAttribute>? assemblyMetadata, string key) =>
         assemblyMetadata?.FirstOrDefault(a => string.Equals(a.Key, key, StringComparison.OrdinalIgnoreCase))?.Value;
 }
-

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -798,6 +798,8 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         // Only add in Development environment, matching the behavior of the default AddUserSecrets.
         if (!string.IsNullOrWhiteSpace(configuredUserSecretsId) && isDevelopment)
         {
+            // Remove only the file-backed source for the assembly-derived user-secrets ID so the configured
+            // user-secrets store replaces that single source without affecting other configuration providers.
             RemoveUserSecretsSource(configuration, appHostAssembly?.GetCustomAttribute<UserSecretsIdAttribute>()?.UserSecretsId);
             configuration.AddUserSecrets(configuredUserSecretsId);
         }

--- a/src/Aspire.Hosting/Resources/InteractionStrings.resx
+++ b/src/Aspire.Hosting/Resources/InteractionStrings.resx
@@ -143,7 +143,7 @@
     <value>Save to user secrets</value>
   </data>
   <data name="ParametersInputsRememberDescriptionNotConfigured" xml:space="preserve">
-    <value>Requires a `UserSecretsId` to be configured in the AppHost project file. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</value>
+    <value>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</value>
   </data>
   <data name="ParametersInputsTitle" xml:space="preserve">
     <value>Set unresolved parameters</value>

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.cs.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.cs.xlf
@@ -127,8 +127,8 @@ Hodnota je aktuálně uložena v [tajných klíčích uživatele](https://learn.
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
-        <source>Requires a `UserSecretsId` to be configured in the AppHost project file. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
-        <target state="needs-review-translation">Vyžaduje konfiguraci UserSecretsId v souboru projektu AppHost. Konfiguraci provedete spuštěním příkazu dotnet user-secrets init v adresáři AppHost.</target>
+        <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
+        <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.de.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.de.xlf
@@ -127,8 +127,8 @@ Der Wert wird derzeit in [Benutzergeheimnissen](https://learn.microsoft.com/aspn
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
-        <source>Requires a `UserSecretsId` to be configured in the AppHost project file. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
-        <target state="needs-review-translation">Erfordert die Konfiguration von „UserSecretsId“ in der AppHost-Projektdatei. Führen Sie „dotnet user-secrets init“ im Verzeichnis „AppHost“ aus, um die Konfiguration durchzuführen.</target>
+        <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
+        <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.es.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.es.xlf
@@ -127,8 +127,8 @@ El valor se guarda actualmente en [secretos de usuario](https://learn.microsoft.
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
-        <source>Requires a `UserSecretsId` to be configured in the AppHost project file. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
-        <target state="needs-review-translation">Requiere que se configure un "UserSecretsId" en el archivo de proyecto AppHost. Ejecute "dotnet user-secrets init" en el directorio AppHost que se va a configurar.</target>
+        <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
+        <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.fr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.fr.xlf
@@ -127,8 +127,8 @@ La valeur est actuellement enregistrée dans [secrets utilisateur](https://learn
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
-        <source>Requires a `UserSecretsId` to be configured in the AppHost project file. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
-        <target state="needs-review-translation">Nécessite la configuration d’un UserSecretsId dans le fichier projet AppHost. Exécutez « dotnet user-secrets init » dans le répertoire AppHost à configurer.</target>
+        <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
+        <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.it.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.it.xlf
@@ -127,8 +127,8 @@ Il valore è attualmente salvato nei [segreti utente](https://learn.microsoft.co
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
-        <source>Requires a `UserSecretsId` to be configured in the AppHost project file. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
-        <target state="needs-review-translation">È necessario configurare un 'UserSecretsId' nel file di progetto AppHost. Eseguire 'dotnet user-secrets init' nella directory AppHost per configurarlo.</target>
+        <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
+        <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ja.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ja.xlf
@@ -127,8 +127,8 @@ The value is currently saved in [user secrets](https://aka.ms/aspire/user-secret
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
-        <source>Requires a `UserSecretsId` to be configured in the AppHost project file. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
-        <target state="needs-review-translation">AppHost プロジェクト ファイルで 'UserSecretsId' を構成する必要があります。AppHost ディレクトリで 'dotnet user-secrets init' を実行して構成します。</target>
+        <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
+        <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ko.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ko.xlf
@@ -127,8 +127,8 @@ The value is currently saved in [user secrets](https://aka.ms/aspire/user-secret
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
-        <source>Requires a `UserSecretsId` to be configured in the AppHost project file. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
-        <target state="needs-review-translation">AppHost 프로젝트 파일에서 `UserSecretsId`를 구성해야 합니다. AppHost 디렉터리에서 `dotnet user-secrets init`을 실행하여 구성합니다.</target>
+        <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
+        <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pl.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pl.xlf
@@ -127,8 +127,8 @@ Wartość jest obecnie zapisana we [wpisach tajnych użytkownika](https://learn.
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
-        <source>Requires a `UserSecretsId` to be configured in the AppHost project file. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
-        <target state="needs-review-translation">Wymaga skonfigurowania parametru „UserSecretsId” w pliku projektu AppHost. W katalogu AppHost uruchom „dotnet user-secrets init”, aby to skonfigurować.</target>
+        <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
+        <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pt-BR.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.pt-BR.xlf
@@ -127,8 +127,8 @@ O valor está atualmente salvo em [segredos do usuário](https://learn.microsof
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
-        <source>Requires a `UserSecretsId` to be configured in the AppHost project file. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
-        <target state="needs-review-translation">É necessário que um `UserSecretsId` seja configurado no arquivo de projeto AppHost. Execute `dotnet user-secrets init` no diretório AppHost para configurar.</target>
+        <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
+        <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ru.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.ru.xlf
@@ -127,8 +127,8 @@ The value is currently saved in [user secrets](https://aka.ms/aspire/user-secret
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
-        <source>Requires a `UserSecretsId` to be configured in the AppHost project file. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
-        <target state="needs-review-translation">Требуется настроить UserSecretsId в файле проекта AppHost. Для настройки выполните команду "dotnet user-secrets init" в каталоге AppHost.</target>
+        <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
+        <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.tr.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.tr.xlf
@@ -127,8 +127,8 @@ Değer şu anda [kullanıcı gizli dizinleri](https://learn.microsoft.com/aspnet
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
-        <source>Requires a `UserSecretsId` to be configured in the AppHost project file. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
-        <target state="needs-review-translation">AppHost proje dosyasında bir `UserSecretsId` yapılandırılması gerekir. Yapılandırmak için AppHost dizininde `dotnet user-secrets init` komutunu çalıştırın.</target>
+        <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
+        <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hans.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hans.xlf
@@ -127,8 +127,8 @@ The value is currently saved in [user secrets](https://aka.ms/aspire/user-secret
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
-        <source>Requires a `UserSecretsId` to be configured in the AppHost project file. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
-        <target state="needs-review-translation">要求在 AppHost 项目文件中配置 `UserSecretsId`。在 AppHost 目录中运行 `dotnet user-secrets init` 进行配置。</target>
+        <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
+        <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">

--- a/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hant.xlf
+++ b/src/Aspire.Hosting/Resources/xlf/InteractionStrings.zh-Hant.xlf
@@ -127,8 +127,8 @@ The value is currently saved in [user secrets](https://aka.ms/aspire/user-secret
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberDescriptionNotConfigured">
-        <source>Requires a `UserSecretsId` to be configured in the AppHost project file. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
-        <target state="needs-review-translation">需要在 AppHost 專案檔中設定 `UserSecretsId`。在 AppHost 目錄中執行 `dotnet user-secrets init` 以設定。</target>
+        <source>Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</source>
+        <target state="new">Requires user secrets to be configured for the AppHost. Run `aspire secret set &lt;key&gt; &lt;value&gt;` to initialize user secrets, or see [user secrets](https://aka.ms/aspire/user-secrets) for more information.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParametersInputsRememberLabel">

--- a/tests/Aspire.Cli.Tests/Commands/SecretCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SecretCommandTests.cs
@@ -1,0 +1,122 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Commands;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Tests.Utils;
+using Aspire.Shared.UserSecrets;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Aspire.Cli.Tests.Commands;
+
+public class SecretCommandTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task SecretPathCommand_PrintsSecretsPath_ForDotNetAppHost()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "AppHost.csproj"));
+        var userSecretsId = Guid.NewGuid().ToString("N");
+        var expectedPath = UserSecretsPathHelper.GetSecretsPathFromSecretsId(userSecretsId);
+
+        await File.WriteAllTextAsync(appHostFile.FullName, "<Project />");
+
+        var command = CreateRootCommand(
+            workspace,
+            outputWriter,
+            appHostFile,
+            userSecretsId);
+
+        var result = command.Parse($"secret path --apphost \"{appHostFile.FullName}\"");
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Contains(expectedPath, outputWriter.Logs);
+    }
+
+    [Fact]
+    public async Task SecretPathCommand_PrintsSecretsPath_ForGuestAppHost()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var appHostFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.ts"));
+        var userSecretsId = UserSecretsPathHelper.ComputeSyntheticUserSecretsId(appHostFile.FullName);
+        var expectedPath = UserSecretsPathHelper.GetSecretsPathFromSecretsId(userSecretsId);
+
+        await File.WriteAllTextAsync(appHostFile.FullName, "export {};");
+
+        var command = CreateRootCommand(
+            workspace,
+            outputWriter,
+            appHostFile,
+            userSecretsId);
+
+        var result = command.Parse($"secret path --apphost \"{appHostFile.FullName}\"");
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.Contains(expectedPath, outputWriter.Logs);
+    }
+
+    private RootCommand CreateRootCommand(
+        TemporaryWorkspace workspace,
+        TestOutputTextWriter outputWriter,
+        FileInfo appHostFile,
+        string userSecretsId)
+    {
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = outputWriter;
+            options.DisableAnsi = true;
+            options.ProjectLocatorFactory = _ => new TestProjectLocator(appHostFile);
+        });
+
+        services.Replace(ServiceDescriptor.Singleton<IAppHostProjectFactory>(
+            new TestAppHostProjectFactory(new TestAppHostProject(userSecretsId))));
+
+        return services.BuildServiceProvider().GetRequiredService<RootCommand>();
+    }
+
+    private sealed class TestProjectLocator(FileInfo appHostFile) : IProjectLocator
+    {
+        public Task<FileInfo?> GetAppHostFromSettingsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<FileInfo?>(appHostFile);
+
+        public Task<FileInfo?> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, bool createSettingsFile, CancellationToken cancellationToken)
+            => Task.FromResult<FileInfo?>(projectFile ?? appHostFile);
+
+        public Task<AppHostProjectSearchResult> UseOrFindAppHostProjectFileAsync(FileInfo? projectFile, MultipleAppHostProjectsFoundBehavior multipleAppHostProjectsFoundBehavior, bool createSettingsFile, CancellationToken cancellationToken = default)
+            => Task.FromResult(new AppHostProjectSearchResult(projectFile ?? appHostFile, [projectFile ?? appHostFile]));
+    }
+
+    private sealed class TestAppHostProjectFactory(IAppHostProject project) : IAppHostProjectFactory
+    {
+        public IAppHostProject GetProject(LanguageInfo language) => project;
+
+        public IAppHostProject? TryGetProject(FileInfo appHostFile) => project;
+
+        public IAppHostProject GetProject(FileInfo appHostFile) => project;
+    }
+
+    private sealed class TestAppHostProject(string userSecretsId) : IAppHostProject
+    {
+        public bool IsUnsupported { get; set; }
+        public string LanguageId => "test";
+        public string DisplayName => "Test";
+        public string? AppHostFileName => null;
+
+        public Task<bool> AddPackageAsync(AddPackageContext context, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public bool CanHandle(FileInfo appHostFile) => true;
+        public Task<RunningInstanceResult> FindAndStopRunningInstanceAsync(FileInfo appHostFile, DirectoryInfo homeDirectory, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<string[]> GetDetectionPatternsAsync(CancellationToken cancellationToken = default) => Task.FromResult<string[]>([]);
+        public Task<string?> GetUserSecretsIdAsync(FileInfo appHostFile, bool autoInit, CancellationToken cancellationToken) => Task.FromResult<string?>(userSecretsId);
+        public bool IsUsingProjectReferences(FileInfo appHostFile) => false;
+        public Task<int> PublishAsync(PublishContext context, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<int> RunAsync(AppHostProjectContext context, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<UpdatePackagesResult> UpdatePackagesAsync(UpdatePackagesContext context, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<AppHostValidationResult> ValidateAppHostAsync(FileInfo appHostFile, CancellationToken cancellationToken) => throw new NotSupportedException();
+    }
+}

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -214,6 +214,7 @@ internal static class CliTestHelper
         services.AddTransient<SecretSetCommand>();
         services.AddTransient<SecretGetCommand>();
         services.AddTransient<SecretListCommand>();
+        services.AddTransient<SecretPathCommand>();
         services.AddTransient<SecretDeleteCommand>();
         services.AddTransient<SecretStoreResolver>();
 #if DEBUG

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderTests.cs
@@ -1,14 +1,20 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREUSERSECRETS001
+
 #pragma warning disable ASPIREPIPELINES001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
+using System.Reflection;
+using System.Reflection.Emit;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Dcp;
 using Aspire.Hosting.Devcontainers;
 using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Pipelines;
+using Aspire.Shared.UserSecrets;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.UserSecrets;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -17,6 +23,8 @@ namespace Aspire.Hosting.Tests;
 [Trait("Partition", "5")]
 public class DistributedApplicationBuilderTests
 {
+    private static readonly ConstructorInfo s_userSecretsIdAttrCtor = typeof(UserSecretsIdAttribute).GetConstructor([typeof(string)])!;
+
     [Theory]
     [InlineData(new string[0], DistributedApplicationOperation.Run)]
     [InlineData(new string[] { "--publisher", "manifest" }, DistributedApplicationOperation.Publish)]
@@ -109,6 +117,93 @@ public class DistributedApplicationBuilderTests
         Assert.False(string.IsNullOrEmpty(config["AppHost:ResourceService:ApiKey"]));
     }
 
+    [Fact]
+    public void PolyglotAppHostUsesAspireUserSecretsIdForUserSecretsManager()
+    {
+        var userSecretsId = Guid.NewGuid().ToString("N");
+        var userSecretsPath = UserSecretsPathHelper.GetSecretsPathFromSecretsId(userSecretsId);
+
+        if (File.Exists(userSecretsPath))
+        {
+            File.Delete(userSecretsPath);
+        }
+
+        var appBuilder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            Args = [$"{KnownConfigNames.AspireUserSecretsId}={userSecretsId}"],
+            DisableDashboard = true,
+        });
+
+        Assert.True(appBuilder.UserSecretsManager.IsAvailable);
+        Assert.Equal(userSecretsPath, appBuilder.UserSecretsManager.FilePath);
+    }
+
+    [Fact]
+    public void AspireUserSecretsIdOverridesAppHostAssemblyUserSecretsId()
+    {
+        var assemblyUserSecretsId = Guid.NewGuid().ToString("N");
+        var configuredUserSecretsId = Guid.NewGuid().ToString("N");
+        var assemblyUserSecretsPath = UserSecretsPathHelper.GetSecretsPathFromSecretsId(assemblyUserSecretsId);
+        var configuredUserSecretsPath = UserSecretsPathHelper.GetSecretsPathFromSecretsId(configuredUserSecretsId);
+
+        DeleteUserSecretsFile(assemblyUserSecretsPath);
+        DeleteUserSecretsFile(configuredUserSecretsPath);
+
+        File.WriteAllText(assemblyUserSecretsPath, """
+            {
+              "AssemblyOnly": "assembly-only",
+              "Probe": "assembly"
+            }
+            """);
+
+        File.WriteAllText(configuredUserSecretsPath, """
+            {
+              "ConfiguredOnly": "configured-only",
+              "Probe": "configured"
+            }
+            """);
+
+        var testAssembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName($"TestAssembly{Guid.NewGuid():N}"),
+            AssemblyBuilderAccess.RunAndCollect,
+            [new CustomAttributeBuilder(s_userSecretsIdAttrCtor, [assemblyUserSecretsId])]);
+
+        try
+        {
+            var configuration = new ConfigurationManager();
+            configuration.AddUserSecrets(testAssembly);
+            configuration[KnownConfigNames.AspireUserSecretsId] = configuredUserSecretsId;
+
+            Assert.Equal(configuredUserSecretsId, DistributedApplicationBuilder.ResolveUserSecretsId(testAssembly, configuration));
+
+            DistributedApplicationBuilder.AddConfiguredUserSecrets(configuration, testAssembly, configuredUserSecretsId, isDevelopment: true);
+
+            Assert.Null(configuration["AssemblyOnly"]);
+            Assert.Equal("configured-only", configuration["ConfiguredOnly"]);
+            Assert.Equal("configured", configuration["Probe"]);
+        }
+        finally
+        {
+            DeleteUserSecretsFile(assemblyUserSecretsPath);
+            DeleteUserSecretsFile(configuredUserSecretsPath);
+        }
+    }
+
+    [Fact]
+    public void EmptyAspireUserSecretsIdFallsBackToAppHostAssemblyUserSecretsId()
+    {
+        var assemblyUserSecretsId = Guid.NewGuid().ToString("N");
+        var testAssembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName($"TestAssembly{Guid.NewGuid():N}"),
+            AssemblyBuilderAccess.RunAndCollect,
+            [new CustomAttributeBuilder(s_userSecretsIdAttrCtor, [assemblyUserSecretsId])]);
+
+        var configuration = new ConfigurationManager();
+        configuration[KnownConfigNames.AspireUserSecretsId] = "";
+
+        Assert.Equal(assemblyUserSecretsId, DistributedApplicationBuilder.ResolveUserSecretsId(testAssembly, configuration));
+    }
+
     [Theory]
     [InlineData(KnownConfigNames.DashboardUnsecuredAllowAnonymous)]
     [InlineData(KnownConfigNames.Legacy.DashboardUnsecuredAllowAnonymous)]
@@ -120,6 +215,20 @@ public class DistributedApplicationBuilderTests
         var config = app.Services.GetRequiredService<IConfiguration>();
         Assert.Equal(nameof(ResourceServiceAuthMode.Unsecured), config["AppHost:ResourceService:AuthMode"]);
         Assert.True(string.IsNullOrEmpty(config["AppHost:ResourceService:ApiKey"]));
+    }
+
+    private static void DeleteUserSecretsFile(string userSecretsPath)
+    {
+        if (File.Exists(userSecretsPath))
+        {
+            File.Delete(userSecretsPath);
+        }
+
+        var directory = Path.GetDirectoryName(userSecretsPath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Fixes guest/polyglot AppHost user secrets handling on `release/13.2` and adds a CLI command to show the resolved secrets file path.

- adds `aspire secret path` to print the user secrets file used for a given AppHost
- updates `DistributedApplicationBuilder` so an explicit `ASPIRE_USER_SECRETS_ID` fully replaces the generated server project's user-secrets store, while empty values still fall back to the assembly user secrets ID
- updates the save-to-user-secrets interaction text to be AppHost-generic and refreshes the corresponding XLF entries for translators
- adds focused CLI and hosting tests for the new command and the guest AppHost secrets precedence behavior

Fixes #14788

Validation:
- `./dotnet.sh test tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj -v quiet -- --filter-method "*.PolyglotAppHostUsesAspireUserSecretsIdForUserSecretsManager" --filter-method "*.AspireUserSecretsIdOverridesAppHostAssemblyUserSecretsId" --filter-method "*.EmptyAspireUserSecretsIdFallsBackToAppHostAssemblyUserSecretsId" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `./dotnet.sh test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj -v quiet -- --filter-method "*.SecretPath*" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- manual verification with temporary TypeScript AppHosts running persistent SQL Server and RabbitMQ resources across two runs to confirm container reuse and inspect the resolved secret store behavior

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
