### PR TITLE
Remove dependency on SemVer

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -130,7 +130,6 @@
     <PackageVersion Include="System.IO.Hashing" Version="10.0.3" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <PackageVersion Include="StreamJsonRpc" Version="2.22.23" />
-    <PackageVersion Include="Semver" Version="3.0.0" />
     <PackageVersion Include="Sigstore" Version="0.4.0" />
     <PackageVersion Include="Tuf" Version="0.4.0" />
     <PackageVersion Include="Microsoft.DevTunnels.Connections" Version="1.3.12" />

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -56,7 +56,6 @@
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
-    <PackageReference Include="Semver" />
     <PackageReference Include="Sigstore" />
     <PackageReference Include="Tuf" />
     <PackageReference Include="ModelContextProtocol" />
@@ -123,6 +122,7 @@
     <Compile Include="$(SharedDir)ConsoleLogs\SharedAIHelpers.cs" Link="ConsoleLogs\SharedAIHelpers.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\TimestampParser.cs" Link="ConsoleLogs\TimestampParser.cs" />
     <Compile Include="$(SharedDir)ConsoleLogs\UrlParser.cs" Link="ConsoleLogs\UrlParser.cs" />
+    <Compile Include="$(VendoringDir)SemVer\**\*.cs" LinkBase="SemVer" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -53,6 +53,7 @@
     <Compile Include="$(SharedDir)UserSecrets\UserSecretsPathHelper.cs" Link="UserSecrets\UserSecretsPathHelper.cs" />
     <Compile Include="$(SharedDir)X509Certificate2Extensions.cs" Link="Utils\X509Certificate2Extensions.cs" />
     <Compile Include="$(SharedDir)PasswordGenerator.cs" Link="Utils\PasswordGenerator.cs" />
+    <Compile Include="$(VendoringDir)SemVer\**\*.cs" LinkBase="SemVer" />
   </ItemGroup>
 
   <ItemGroup>
@@ -63,7 +64,6 @@
     <PackageReference Include="Polly.Core" />
     <PackageReference Include="JsonPatch.Net" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" />
-    <PackageReference Include="Semver" />
     <PackageReference Include="System.IO.Hashing" />
     <PackageReference Include="StreamJsonRpc" />
   </ItemGroup>

--- a/src/Vendoring/SemVer/.editorconfig
+++ b/src/Vendoring/SemVer/.editorconfig
@@ -1,0 +1,51 @@
+root = true
+
+[*.{cs,vb}]
+
+# Vendored third-party code (MIT License - Jeff Walker, Max Hauser)
+# Suppress all .NET analyzer diagnostics
+dotnet_analyzer_diagnostic.severity = none
+
+# Suppress IDE style enforcement for vendored code
+csharp_prefer_braces = false:none
+dotnet_diagnostic.IDE0011.severity = none
+dotnet_diagnostic.IDE0016.severity = none
+dotnet_diagnostic.IDE0018.severity = none
+dotnet_diagnostic.IDE0019.severity = none
+dotnet_diagnostic.IDE0020.severity = none
+dotnet_diagnostic.IDE0028.severity = none
+dotnet_diagnostic.IDE0031.severity = none
+dotnet_diagnostic.IDE0034.severity = none
+dotnet_diagnostic.IDE0036.severity = none
+dotnet_diagnostic.IDE0040.severity = none
+dotnet_diagnostic.IDE0044.severity = none
+dotnet_diagnostic.IDE0046.severity = none
+dotnet_diagnostic.IDE0047.severity = none
+dotnet_diagnostic.IDE0048.severity = none
+dotnet_diagnostic.IDE0049.severity = none
+dotnet_diagnostic.IDE0055.severity = none
+dotnet_diagnostic.IDE0057.severity = none
+dotnet_diagnostic.IDE0060.severity = none
+dotnet_diagnostic.IDE0063.severity = none
+dotnet_diagnostic.IDE0065.severity = none
+dotnet_diagnostic.IDE0066.severity = none
+dotnet_diagnostic.IDE0071.severity = none
+dotnet_diagnostic.IDE0073.severity = none
+dotnet_diagnostic.IDE0074.severity = none
+dotnet_diagnostic.IDE0078.severity = none
+dotnet_diagnostic.IDE0090.severity = none
+dotnet_diagnostic.IDE0130.severity = none
+dotnet_diagnostic.IDE0161.severity = none
+dotnet_diagnostic.IDE0180.severity = none
+dotnet_diagnostic.IDE0200.severity = none
+dotnet_diagnostic.IDE0230.severity = none
+dotnet_diagnostic.IDE0250.severity = none
+dotnet_diagnostic.IDE0251.severity = none
+dotnet_diagnostic.IDE0260.severity = none
+dotnet_diagnostic.IDE0270.severity = none
+dotnet_diagnostic.IDE0290.severity = none
+dotnet_diagnostic.IDE0300.severity = none
+dotnet_diagnostic.IDE0301.severity = none
+dotnet_diagnostic.IDE1006.severity = none
+dotnet_diagnostic.IDE0005.severity = none
+dotnet_diagnostic.CS1591.severity = none

--- a/src/Vendoring/SemVer/Comparers/ISemVersionComparer.cs
+++ b/src/Vendoring/SemVer/Comparers/ISemVersionComparer.cs
@@ -1,0 +1,20 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Semver.Comparers;
+
+/// <summary>
+/// An interface that combines equality and order comparison for the <see cref="SemVersion"/>
+/// class.
+/// </summary>
+/// <remarks>
+/// <para>This interface provides a type for the <see cref="SemVersion.PrecedenceComparer"/> and
+/// <see cref="SemVersion.SortOrderComparer"/> so that separate properties aren't needed for the
+/// <see cref="IEqualityComparer{T}"/> and <see cref="IComparer{T}"/> of <see cref="SemVersion"/>.
+/// </para>
+/// <para>Consumers of this library should not implement this interface. Doing so may expose your
+/// code to breaking changes in a future release.</para>
+/// </remarks>
+public interface ISemVersionComparer : IEqualityComparer<SemVersion?>, IEqualityComparer, IComparer<SemVersion?>, IComparer
+{
+}

--- a/src/Vendoring/SemVer/Comparers/PrecedenceComparer.cs
+++ b/src/Vendoring/SemVer/Comparers/PrecedenceComparer.cs
@@ -1,0 +1,59 @@
+using System;
+
+namespace Semver.Comparers;
+
+internal sealed class PrecedenceComparer : SemVersionComparer
+{
+    #region Singleton
+    public static readonly ISemVersionComparer Instance = new PrecedenceComparer();
+
+    private PrecedenceComparer() { }
+    #endregion
+
+    public override bool Equals(SemVersion? x, SemVersion? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x is null || y is null) return false;
+
+        return x.Major == y.Major && x.Minor == y.Minor && x.Patch == y.Patch
+               && x.Prerelease == y.Prerelease;
+    }
+
+    public override int GetHashCode(SemVersion? v)
+        => v is null ? 0 : HashCode.Combine(v.Major, v.Minor, v.Patch, v.Prerelease);
+
+    public override int Compare(SemVersion? x, SemVersion? y)
+    {
+        if (ReferenceEquals(x, y)) return 0; // covers both null case
+        if (x is null) return -1;
+        if (y is null) return 1;
+
+        var comparison = x.Major.CompareTo(y.Major);
+        if (comparison != 0) return comparison;
+
+        comparison = x.Minor.CompareTo(y.Minor);
+        if (comparison != 0) return comparison;
+
+        comparison = x.Patch.CompareTo(y.Patch);
+        if (comparison != 0) return comparison;
+
+        // Release are higher precedence than prerelease
+        var xIsRelease = x.IsRelease;
+        var yIsRelease = y.IsRelease;
+        if (xIsRelease && yIsRelease) return 0;
+        if (xIsRelease) return 1;
+        if (yIsRelease) return -1;
+
+        var xPrereleaseIdentifiers = x.PrereleaseIdentifiers;
+        var yPrereleaseIdentifiers = y.PrereleaseIdentifiers;
+
+        var minLength = Math.Min(xPrereleaseIdentifiers.Count, yPrereleaseIdentifiers.Count);
+        for (int i = 0; i < minLength; i++)
+        {
+            comparison = xPrereleaseIdentifiers[i].CompareTo(yPrereleaseIdentifiers[i]);
+            if (comparison != 0) return comparison;
+        }
+
+        return xPrereleaseIdentifiers.Count.CompareTo(yPrereleaseIdentifiers.Count);
+    }
+}

--- a/src/Vendoring/SemVer/Comparers/SemVersionComparer.cs
+++ b/src/Vendoring/SemVer/Comparers/SemVersionComparer.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections;
+
+namespace Semver.Comparers;
+
+internal abstract class SemVersionComparer : ISemVersionComparer
+{
+    bool IEqualityComparer.Equals(object? x, object? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x == null || y == null) return false;
+        if (x is SemVersion v1 && y is SemVersion v2) return Equals(v1, v2);
+        throw new ArgumentException(InvalidTypeMessage);
+    }
+
+    public abstract bool Equals(SemVersion? x, SemVersion? y);
+
+    int IEqualityComparer.GetHashCode(object? obj)
+    {
+        if (obj is null) return 0;
+        if (obj is SemVersion v) return GetHashCode(v);
+        throw new ArgumentException(InvalidTypeMessage);
+    }
+
+    public abstract int GetHashCode(SemVersion? v);
+
+    int IComparer.Compare(object? x, object? y)
+    {
+        if (x is null) return y is null ? 0 : -1;
+        if (y is null) return 1;
+        if (x is SemVersion v1 && y is SemVersion v2) return Compare(v1, v2);
+        throw new ArgumentException(InvalidTypeMessage);
+    }
+
+    public abstract int Compare(SemVersion? x, SemVersion? y);
+
+    private const string InvalidTypeMessage = $"Type of argument is not {nameof(SemVersion)}.";
+}

--- a/src/Vendoring/SemVer/Comparers/SortOrderComparer.cs
+++ b/src/Vendoring/SemVer/Comparers/SortOrderComparer.cs
@@ -1,0 +1,48 @@
+using System;
+using Semver.Utility;
+
+namespace Semver.Comparers;
+
+internal sealed class SortOrderComparer : SemVersionComparer
+{
+    #region Singleton
+    public static readonly ISemVersionComparer Instance = new SortOrderComparer();
+
+    private SortOrderComparer() { }
+    #endregion
+
+    public override bool Equals(SemVersion? x, SemVersion? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x is null || y is null) return false;
+
+        return x.Major == y.Major && x.Minor == y.Minor && x.Patch == y.Patch
+               && x.Prerelease == y.Prerelease
+               && x.Metadata == y.Metadata;
+    }
+
+    public override int GetHashCode(SemVersion? v)
+        => v is null ? 0 : HashCode.Combine(v.Major, v.Minor, v.Patch, v.Prerelease, v.Metadata);
+
+    public override int Compare(SemVersion? x, SemVersion? y)
+    {
+        if (ReferenceEquals(x, y)) return 0; // covers both null case
+
+        var comparison = PrecedenceComparer.Instance.Compare(x!, y!);
+        if (comparison != 0) return comparison;
+
+        DebugChecks.IsNotNull(x, nameof(x));
+        DebugChecks.IsNotNull(y, nameof(y));
+
+        var xMetadataIdentifiers = x.MetadataIdentifiers;
+        var yMetadataIdentifiers = y.MetadataIdentifiers;
+        var minLength = Math.Min(xMetadataIdentifiers.Count, yMetadataIdentifiers.Count);
+        for (int i = 0; i < minLength; i++)
+        {
+            comparison = xMetadataIdentifiers[i].CompareTo(yMetadataIdentifiers[i]);
+            if (comparison != 0) return comparison;
+        }
+
+        return xMetadataIdentifiers.Count.CompareTo(yMetadataIdentifiers.Count);
+    }
+}

--- a/src/Vendoring/SemVer/Comparers/UnbrokenSemVersionRangeComparer.cs
+++ b/src/Vendoring/SemVer/Comparers/UnbrokenSemVersionRangeComparer.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+
+namespace Semver.Comparers;
+
+/// <summary>
+/// Compare <see cref="UnbrokenSemVersionRange"/> by the left bound and then by the reversed
+/// right bound. Thus, wider ranges sort before narrower ones. Finally, sort ranges including
+/// prerelease before those not including prerelease.
+/// </summary>
+/// <remarks>This order is important to the removal of fully contained ranges from
+/// <see cref="SemVersionRange"/> since it sorts the ranges and then checks earlier ranges to
+/// see if they contain later ranges. Thus, more inclusive ranges need to come first so that
+/// the ranges they contain will be removed. Note that the <see cref="SemVersionRange"/> API
+/// will never expose this order exactly because contained ranges will not be included in the
+/// final <see cref="SemVersionRange"/>.</remarks>
+internal sealed class UnbrokenSemVersionRangeComparer : Comparer<UnbrokenSemVersionRange?>
+{
+    #region Singleton
+    public static readonly UnbrokenSemVersionRangeComparer Instance = new();
+
+    private UnbrokenSemVersionRangeComparer() { }
+    #endregion
+
+    public override int Compare(UnbrokenSemVersionRange? x, UnbrokenSemVersionRange? y)
+    {
+        if (ReferenceEquals(x, y)) return 0; // covers both null case
+        if (x is null) return -1;
+        if (y is null) return 1;
+
+        var comparison = x.LeftBound.CompareTo(y.LeftBound);
+        if (comparison != 0) return comparison;
+        comparison = -x.RightBound.CompareTo(y.RightBound);
+        if (comparison != 0) return comparison;
+        return -x.IncludeAllPrerelease.CompareTo(y.IncludeAllPrerelease);
+    }
+}

--- a/src/Vendoring/SemVer/License.txt
+++ b/src/Vendoring/SemVer/License.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2013-2024 Jeff Walker, Max Hauser
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Vendoring/SemVer/MetadataIdentifier.cs
+++ b/src/Vendoring/SemVer/MetadataIdentifier.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Runtime.CompilerServices;
+using Semver.Utility;
+
+namespace Semver;
+
+/// <summary>
+/// An individual metadata identifier for a semantic version.
+/// </summary>
+/// <remarks>
+/// <para>The metadata for a semantic version is composed of dot ('<c>.</c>') separated identifiers.
+/// A valid identifier is a non-empty string of ASCII alphanumeric and hyphen characters
+/// (<c>[0-9A-Za-z-]</c>). Metadata identifiers are compared lexically in ASCII sort order.</para>
+///
+/// <para>Because <see cref="MetadataIdentifier"/> is a struct, the default value is a
+/// <see cref="MetadataIdentifier"/> with a <see langword="null"/> value. However, the
+/// <see cref="Semver"/> namespace types do not accept and will not return such a
+/// <see cref="MetadataIdentifier"/>.</para>
+/// </remarks>
+public readonly struct MetadataIdentifier : IEquatable<MetadataIdentifier>, IComparable<MetadataIdentifier>, IComparable
+{
+    /// <summary>
+    /// The string value of the metadata identifier.
+    /// </summary>
+    /// <value>The string value of this metadata identifier or <see langword="null"/> if this is
+    /// a default <see cref="MetadataIdentifier"/>.</value>
+    public string Value { get; }
+
+    /// <summary>
+    /// Constructs a <see cref="MetadataIdentifier"/> without checking that any of the invariants
+    /// hold. Used by the parser for performance.
+    /// </summary>
+    /// <remarks>This is a create method rather than a constructor to clearly indicate uses
+    /// of it. The other constructors have not been hidden behind create methods because only
+    /// constructors are visible to the package users. So they see a class consistently
+    /// using constructors without any create methods.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static MetadataIdentifier CreateUnsafe(string value)
+    {
+        DebugChecks.IsNotNull(value, nameof(value));
+        DebugChecks.IsNotEmpty(value, nameof(value));
+#if DEBUG
+            if (!value.IsAlphanumericOrHyphens())
+                throw new ArgumentException($"DEBUG: A metadata identifier can contain only ASCII alphanumeric characters and hyphens '{value}'.", nameof(value));
+#endif
+        return new MetadataIdentifier(value, UnsafeOverload.Marker);
+    }
+
+    /// <summary>
+    /// Private constructor used by <see cref="CreateUnsafe"/>.
+    /// </summary>
+    /// <param name="value">The value for the identifier. Not validated.</param>
+    /// <param name="_">Unused parameter that differentiates this from the
+    /// constructor that performs validation.</param>
+    private MetadataIdentifier(string value, UnsafeOverload _)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// Constructs a valid <see cref="MetadataIdentifier"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The <paramref name="value"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">The <paramref name="value"/> is empty or contains invalid characters
+    /// (i.e. characters that are not ASCII alphanumerics or hyphens).</exception>
+    public MetadataIdentifier(string value)
+        : this(value, nameof(value))
+    {
+    }
+
+    /// <summary>
+    /// Constructs a valid <see cref="MetadataIdentifier"/>.
+    /// </summary>
+    /// <remarks>
+    /// Internal constructor allows changing the parameter name to enable methods using this
+    /// as part of their metadata identifier validation to match the parameter name to their
+    /// parameter name.
+    /// </remarks>
+    internal MetadataIdentifier(string value, string paramName)
+    {
+        if (value is null)
+            throw new ArgumentNullException(paramName);
+        if (value.Length == 0)
+            throw new ArgumentException("Metadata identifier cannot be empty.", paramName);
+        if (!value.IsAlphanumericOrHyphens())
+            throw new ArgumentException($"A metadata identifier can contain only ASCII alphanumeric characters and hyphens '{value}'.", paramName);
+
+        Value = value;
+    }
+
+    #region Equality
+    /// <summary>
+    /// Determines whether two identifiers are equal.
+    /// </summary>
+    /// <returns><see langword="true"/> if <paramref name="value"/> is equal to this identifier;
+    /// otherwise <see langword="false"/>.</returns>
+    public bool Equals(MetadataIdentifier value) => Value == value.Value;
+
+    /// <summary>Determines whether the given object is equal to this identifier.</summary>
+    /// <returns><see langword="true"/> if <paramref name="value"/> is equal to this identifier;
+    /// otherwise <see langword="false"/>.</returns>
+    public override bool Equals(object? value)
+        => value is MetadataIdentifier other && Equals(other);
+
+    /// <summary>Gets a hash code for this identifier.</summary>
+    /// <returns>A hash code for this identifier.</returns>
+    public override int GetHashCode() => HashCode.Combine(Value);
+
+    /// <summary>
+    /// Determines whether two identifiers are equal.
+    /// </summary>
+    /// <returns><see langword="true"/> if the value of <paramref name="left"/> is the same as
+    /// the value of <paramref name="right"/>; otherwise <see langword="false"/>.</returns>
+    public static bool operator ==(MetadataIdentifier left, MetadataIdentifier right)
+        => left.Value == right.Value;
+
+    /// <summary>
+    /// Determines whether two identifiers are <em>not</em> equal.
+    /// </summary>
+    /// <returns><see langword="true"/> if the value of <paramref name="left"/> is different
+    /// from the value of <paramref name="right"/>; otherwise <see langword="false"/>.</returns>
+    public static bool operator !=(MetadataIdentifier left, MetadataIdentifier right)
+        => left.Value != right.Value;
+    #endregion
+
+    #region Comparison
+    /// <summary>
+    /// Compares two identifiers and indicates whether this instance precedes, follows, or is
+    /// equal to the other in sort order.
+    /// </summary>
+    /// <returns>
+    /// An integer that indicates whether this instance precedes, follows, or is equal to
+    /// <paramref name="value"/> in sort order.
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>Value</term>
+    ///         <description>Condition</description>
+    ///     </listheader>
+    ///     <item>
+    ///          <term>-1</term>
+    ///          <description>This instance precedes <paramref name="value"/>.</description>
+    ///     </item>
+    ///     <item>
+    ///          <term>0</term>
+    ///          <description>This instance is equal to <paramref name="value"/>.</description>
+    ///     </item>
+    ///     <item>
+    ///          <term>1</term>
+    ///          <description>This instance follows <paramref name="value"/>.</description>
+    ///     </item>
+    /// </list>
+    /// </returns>
+    /// <remarks>Identifiers are compared lexically in ASCII sort order. Invalid identifiers are
+    /// compared via an ordinal string comparison.</remarks>
+    public int CompareTo(MetadataIdentifier value)
+        => IdentifierString.Compare(Value, value.Value);
+
+    /// <summary>
+    /// Compares this identifier to an <see cref="Object"/> and indicates whether this instance
+    /// precedes, follows, or is equal to the object in sort order.
+    /// </summary>
+    /// <returns>
+    /// An integer that indicates whether this instance precedes, follows, or is equal to
+    /// <paramref name="value"/> in sort order.
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>Value</term>
+    ///         <description>Condition</description>
+    ///     </listheader>
+    ///     <item>
+    ///          <term>-1</term>
+    ///          <description>This instance precedes <paramref name="value"/>.</description>
+    ///     </item>
+    ///     <item>
+    ///          <term>0</term>
+    ///          <description>This instance is equal to <paramref name="value"/>.</description>
+    ///     </item>
+    ///     <item>
+    ///          <term>1</term>
+    ///          <description>This instance follows <paramref name="value"/> or <paramref name="value"/>
+    ///                         is <see langword="null"/>.</description>
+    ///     </item>
+    /// </list>
+    /// </returns>
+    /// <exception cref="ArgumentException"><paramref name="value"/> is not a <see cref="MetadataIdentifier"/>.</exception>
+    /// <remarks>Identifiers are compared lexically in ASCII sort order. Invalid identifiers are
+    /// compared via an ordinal string comparison.</remarks>
+    public int CompareTo(object? value)
+    {
+        if (value is null) return 1;
+        return value is MetadataIdentifier other
+            ? IdentifierString.Compare(Value, other.Value)
+            : throw new ArgumentException($"Object must be of type {nameof(MetadataIdentifier)}.", nameof(value));
+    }
+    #endregion
+
+    /// <summary>
+    /// Converts this identifier into an equivalent string value.
+    /// </summary>
+    /// <returns>The string value of this identifier or <see langword="null"/> if this is
+    /// a default <see cref="MetadataIdentifier"/>.</returns>
+    public static implicit operator string(MetadataIdentifier metadataIdentifier)
+        => metadataIdentifier.Value;
+
+    /// <summary>
+    /// Converts this identifier into an equivalent string value.
+    /// </summary>
+    /// <returns>The string value of this identifier or <see langword="null"/> if this is
+    /// a default <see cref="MetadataIdentifier"/></returns>
+    public override string ToString() => Value;
+}

--- a/src/Vendoring/SemVer/Parsing/GeneralRangeParser.cs
+++ b/src/Vendoring/SemVer/Parsing/GeneralRangeParser.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Primitives;
+using Semver.Utility;
+
+namespace Semver.Parsing;
+
+internal static class GeneralRangeParser
+{
+    public static int CountSplitOnOrOperator(string range)
+    {
+        DebugChecks.IsNotNull(range, nameof(range));
+
+        int count = 1; // Always one more item than there are separators
+        bool possiblyInSeparator = false;
+        // Use `for` instead of `foreach` to ensure performance
+        for (int i = 0; i < range.Length; i++)
+        {
+            var isSeparatorChar = range[i] == '|';
+            if (possiblyInSeparator && isSeparatorChar)
+            {
+                count++;
+                possiblyInSeparator = false;
+            }
+            else
+                possiblyInSeparator = isSeparatorChar;
+        }
+
+        return count;
+    }
+
+    public static IEnumerable<StringSegment> SplitOnOrOperator(string range)
+    {
+        DebugChecks.IsNotNull(range, nameof(range));
+
+        var possiblyInSeparator = false;
+        int start = 0;
+        // Use `for` instead of `foreach` to ensure performance
+        for (int i = 0; i < range.Length; i++)
+        {
+            var isSeparatorChar = range[i] == '|';
+            if (possiblyInSeparator && isSeparatorChar)
+            {
+                possiblyInSeparator = false;
+                yield return range.Slice(start, i - 1 - start);
+                start = i + 1;
+            }
+            else
+                possiblyInSeparator = isSeparatorChar;
+        }
+
+        // The final segment from the last separator to the end of the string
+        yield return range.Slice(start, range.Length - start);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsPossibleOperatorChar(char c, SemVersionRangeOptions rangeOptions)
+        => c == '=' || c == '<' || c == '>' || c == '~' || c == '^'
+           || (char.IsPunctuation(c) && !char.IsWhiteSpace(c) && c != '*')
+           || (char.IsSymbol(c) && (c != '+' || !rangeOptions.HasOption(SemVersionRangeOptions.AllowMetadata)));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsPossibleVersionChar(char c, SemVersionRangeOptions rangeOptions)
+        => !char.IsWhiteSpace(c)
+           && (!IsPossibleOperatorChar(c, rangeOptions) || c == '-' || c == '.'
+               || (c == '+' && rangeOptions.HasOption(SemVersionRangeOptions.AllowMetadata)));
+
+    /// <summary>
+    /// Parse optional spaces from the beginning of the segment.
+    /// </summary>
+    public static Exception? ParseOptionalSpaces(ref StringSegment segment, Exception? ex)
+    {
+        segment = segment.TrimStartSpaces();
+
+        if (segment.Length > 0 && char.IsWhiteSpace(segment[0]))
+            return ex ?? RangeError.InvalidWhitespace(segment.Offset, segment.Buffer!);
+        return null;
+    }
+
+    /// <summary>
+    /// Parse optional whitespace from the beginning of the segment.
+    /// </summary>
+    public static void ParseOptionalWhitespace(ref StringSegment segment)
+        => segment = segment.TrimStart();
+
+    /// <summary>
+    /// Parse a version number from the beginning of the segment.
+    /// </summary>
+    public static Exception? ParseVersion(
+        ref StringSegment segment,
+        SemVersionRangeOptions rangeOptions,
+        SemVersionParsingOptions parseOptions,
+        Exception? ex,
+        int maxLength,
+        out SemVersion? semver,
+        out WildcardVersion wildcardVersion)
+    {
+        // The SemVersionParser assumes there is nothing following the version number. To reuse
+        // its parsing, the appropriate end must be found.
+        var end = 0;
+        while (end < segment.Length && IsPossibleVersionChar(segment[end], rangeOptions)) end++;
+        var version = segment.Subsegment(0, end);
+        segment = segment.Subsegment(end);
+
+        var exception = SemVersionParser.Parse(version, rangeOptions.ToStyles(), parseOptions, ex,
+            maxLength, out semver, out wildcardVersion);
+        if (exception != null) return exception;
+        DebugChecks.IsNotNull(semver, nameof(semver));
+
+        // Trim off metadata if it was allowed
+        if (semver.MetadataIdentifiers.Count > 0)
+            semver = semver.WithoutMetadata();
+        return null;
+    }
+}

--- a/src/Vendoring/SemVer/Parsing/NpmRangeParser.cs
+++ b/src/Vendoring/SemVer/Parsing/NpmRangeParser.cs
@@ -1,0 +1,502 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Microsoft.Extensions.Primitives;
+using Semver.Ranges;
+using Semver.Utility;
+
+namespace Semver.Parsing;
+
+internal static class NpmRangeParser
+{
+    private const SemVersionRangeOptions StandardRangeOptions
+        = SemVersionRangeOptions.AllowLowerV
+          | SemVersionRangeOptions.AllowMetadata
+          | SemVersionRangeOptions.OptionalMinorPatch;
+
+    public static Exception? Parse(
+        string? range,
+        bool includeAllPrerelease,
+        Exception? ex,
+        int maxLength,
+        out SemVersionRange? semverRange)
+    {
+        var options = StandardRangeOptions;
+        if (includeAllPrerelease)
+            options |= SemVersionRangeOptions.IncludeAllPrerelease;
+        return Parse(range, options, ex, maxLength, out semverRange);
+    }
+
+    private static Exception? Parse(
+        string? range,
+        SemVersionRangeOptions rangeOptions,
+        Exception? ex,
+        int maxLength,
+        out SemVersionRange? semverRange)
+    {
+        DebugChecks.IsValid(rangeOptions, nameof(rangeOptions));
+        DebugChecks.IsValidMaxLength(maxLength, nameof(maxLength));
+
+        // Assign null once, so it doesn't have to be done any time parse fails
+        semverRange = null;
+
+        // Note: this method relies on the fact that the null coalescing operator `??`
+        // is short-circuiting to avoid constructing exceptions and exception messages
+        // when a non-null exception is passed in.
+
+        if (range is null) return ex ?? new ArgumentNullException(nameof(range));
+        if (range.Length > maxLength) return ex ?? RangeError.TooLong(range, maxLength);
+
+        var unbrokenRanges = new List<UnbrokenSemVersionRange>(GeneralRangeParser.CountSplitOnOrOperator(range));
+        foreach (var segment in GeneralRangeParser.SplitOnOrOperator(range))
+        {
+            var exception = ParseUnbrokenRange(segment, rangeOptions, ex, maxLength, out var unbrokenRange);
+            if (exception is not null) return exception;
+            DebugChecks.IsNotNull(unbrokenRange, nameof(unbrokenRange));
+
+            unbrokenRanges.Add(unbrokenRange);
+        }
+
+        semverRange = SemVersionRange.Create(unbrokenRanges);
+        return null;
+    }
+
+    private static Exception? ParseUnbrokenRange(
+        StringSegment segment,
+        SemVersionRangeOptions rangeOptions,
+        Exception? ex,
+        int maxLength,
+        out UnbrokenSemVersionRange? unbrokenRange)
+    {
+        // Assign null once, so it doesn't have to be done any time parse fails
+        unbrokenRange = null;
+
+        var includeAllPrerelease = rangeOptions.HasOption(SemVersionRangeOptions.IncludeAllPrerelease);
+
+        var start = LeftBoundedRange.Unbounded;
+        var end = RightBoundedRange.Unbounded;
+
+        // Try to split before removing leading whitespace because of invalid ranges like ' - 2.0.0'
+        if (TrySplitOnHyphenRangeSeparator(segment, out var segment1, out var segment2))
+        {
+            var exception = ParseHyphenRange(segment1, segment2, rangeOptions, includeAllPrerelease, ex,
+                maxLength, ref start, ref end);
+            if (exception != null) return exception;
+        }
+        else
+        {
+            // Parse off leading whitespace
+            GeneralRangeParser.ParseOptionalWhitespace(ref segment);
+
+            // Handle empty string ranges
+            if (segment.IsEmpty())
+            {
+                unbrokenRange = includeAllPrerelease
+                    ? UnbrokenSemVersionRange.All
+                    : UnbrokenSemVersionRange.AllRelease;
+                return null;
+            }
+
+            while (!segment.IsEmpty())
+            {
+                var exception = ParseComparison(ref segment, rangeOptions, includeAllPrerelease, ex, maxLength,
+                    ref start, ref end);
+                if (exception != null) return exception;
+            }
+        }
+
+        unbrokenRange = UnbrokenSemVersionRange.Create(start, end, includeAllPrerelease);
+        return null;
+    }
+
+    private static bool TrySplitOnHyphenRangeSeparator(
+        StringSegment segment,
+        out StringSegment segment1,
+        out StringSegment segment2)
+    {
+        var searchLength = segment.Length - 1;
+        int start = 1;
+        int i;
+        while (start < segment.Length && (i = segment.IndexOf('-', start, searchLength - start)) >= 0)
+        {
+            var indexBefore = i - 1;
+            var indexAfter = i + 1;
+
+            if (char.IsWhiteSpace(segment[indexBefore]) && char.IsWhiteSpace(segment[indexAfter]))
+            {
+                // Split in two before and after the whitespace around the hyphen
+                segment1 = segment.Subsegment(0, indexBefore);
+                segment2 = segment.Subsegment(indexAfter + 1);
+                return true;
+            }
+
+            start = indexAfter;
+        }
+        // No hyphen, just don't split but have to set the out params to something
+        segment1 = segment2 = segment;
+        return false;
+    }
+
+    private static Exception? ParseHyphenRange(
+        StringSegment beforeHyphenSegment,
+        StringSegment afterHyphenSegment,
+        SemVersionRangeOptions rangeOptions,
+        bool includeAllPrerelease,
+        Exception? ex,
+        int maxLength,
+        ref LeftBoundedRange leftBound,
+        ref RightBoundedRange rightBound)
+    {
+        var exception = ParseHyphenSegment(beforeHyphenSegment, rangeOptions, ex, maxLength,
+            out var semver1, out var wildcardVersion1);
+        if (exception != null) return exception;
+        DebugChecks.IsNotNull(semver1, nameof(semver1));
+
+        exception = ParseHyphenSegment(afterHyphenSegment, rangeOptions, ex, maxLength,
+            out var semver2, out var wildcardVersion2);
+        if (exception != null) return exception;
+        DebugChecks.IsNotNull(semver2, nameof(semver2));
+
+        WildcardLowerBound(includeAllPrerelease, ref leftBound, semver1, wildcardVersion1);
+        WildcardUpperBound(ref rightBound, semver2, wildcardVersion2);
+        return null;
+    }
+
+    private static Exception? ParseHyphenSegment(
+        StringSegment segment,
+        SemVersionRangeOptions rangeOptions,
+        Exception? ex,
+        int maxLength,
+        out SemVersion? semver,
+        out WildcardVersion wildcardVersion)
+    {
+        // Assign null once, so it doesn't have to be done any time parse fails
+        semver = null;
+        wildcardVersion = WildcardVersion.None;
+
+        // Parse off leading whitespace from before hyphen segment
+        GeneralRangeParser.ParseOptionalWhitespace(ref segment);
+
+        // Check for missing version number
+        if (segment.Length == 0)
+            return ex ?? RangeError.MissingVersionInHyphenRange(segment.Buffer!);
+
+        // Check for invalid chars, like an operator, before the version
+        if (!GeneralRangeParser.IsPossibleVersionChar(segment[0], rangeOptions))
+            return ex ?? RangeError.UnexpectedInHyphenRange(segment[0].ToString());
+
+        // Now parse the actual version number
+        var exception = ParseNpmVersion(ref segment, rangeOptions, ex, maxLength,
+            out semver, out wildcardVersion);
+        if (exception != null) return exception;
+
+        // Parse off trailing whitespace from before hyphen segment
+        GeneralRangeParser.ParseOptionalWhitespace(ref segment);
+
+        if (segment.Length != 0) return ex ?? RangeError.UnexpectedInHyphenRange(segment.ToString());
+
+        return null;
+    }
+
+    /// <summary>
+    /// Parse a comparison from the beginning of the segment.
+    /// </summary>
+    /// <remarks>
+    /// Must have leading whitespace removed. Will consume trailing whitespace.
+    /// </remarks>
+    private static Exception? ParseComparison(
+        ref StringSegment segment,
+        SemVersionRangeOptions rangeOptions,
+        bool includeAllPrerelease,
+        Exception? ex,
+        int maxLength,
+        ref LeftBoundedRange leftBound,
+        ref RightBoundedRange rightBound)
+    {
+        DebugChecks.IsNotEmpty(segment, nameof(segment));
+
+        var exception = ParseOperator(ref segment, ex, out var @operator);
+        if (exception != null) return exception;
+
+        GeneralRangeParser.ParseOptionalWhitespace(ref segment);
+
+        exception = ParseNpmVersion(ref segment, rangeOptions, ex, maxLength,
+                        out var semver, out var wildcardVersion);
+        if (exception != null) return exception;
+        DebugChecks.IsNotNull(semver, nameof(semver));
+
+        GeneralRangeParser.ParseOptionalWhitespace(ref segment);
+
+        switch (@operator)
+        {
+            case StandardOperator.GreaterThan:
+                GreaterThan(includeAllPrerelease, ref leftBound, ref rightBound, semver, wildcardVersion);
+                return null;
+            case StandardOperator.GreaterThanOrEqual:
+                WildcardLowerBound(includeAllPrerelease, ref leftBound, semver, wildcardVersion);
+                return null;
+            case StandardOperator.LessThan:
+                LessThan(ref rightBound, semver, wildcardVersion);
+                return null;
+            case StandardOperator.LessThanOrEqual:
+                WildcardUpperBound(ref rightBound, semver, wildcardVersion);
+                return null;
+            case StandardOperator.Caret:
+                if (wildcardVersion == WildcardVersion.MajorMinorPatchWildcard)
+                    // No further bound is places on the left and right bounds
+                    return null;
+                WildcardLowerBound(includeAllPrerelease, ref leftBound, semver, wildcardVersion);
+                BigInteger major = BigInteger.Zero, minor = BigInteger.Zero, patch = BigInteger.Zero;
+                if (semver.Major != 0 || wildcardVersion == WildcardVersion.MinorPatchWildcard)
+                    major = semver.Major + BigInteger.One;
+                else if (semver.Minor != 0 || wildcardVersion == WildcardVersion.PatchWildcard)
+                    minor = semver.Minor + BigInteger.One;
+                else
+                    patch = semver.Patch + BigInteger.One;
+
+                rightBound = rightBound.Min(new RightBoundedRange(new SemVersion(
+                                major, minor, patch,
+                                "0", PrereleaseIdentifiers.Zero,
+                                "", ReadOnlyList<MetadataIdentifier>.Empty), false));
+                return null;
+            case StandardOperator.Tilde:
+                if (wildcardVersion == WildcardVersion.MajorMinorPatchWildcard)
+                    // No further bound is places on the left and right bounds
+                    return null;
+                WildcardLowerBound(includeAllPrerelease, ref leftBound, semver, wildcardVersion);
+                if (wildcardVersion == WildcardVersion.MinorPatchWildcard)
+                {
+                    rightBound = rightBound.Min(new RightBoundedRange(
+                        new SemVersion(semver.Major + BigInteger.One, BigInteger.Zero, BigInteger.Zero, "0", PrereleaseIdentifiers.Zero, "",
+                            ReadOnlyList<MetadataIdentifier>.Empty), false));
+                }
+                else
+                {
+                    rightBound = rightBound.Min(new RightBoundedRange(
+                        semver.With(minor: semver.Minor + BigInteger.One, patch: BigInteger.Zero, prerelease: PrereleaseIdentifiers.Zero),
+                        false));
+                }
+                return null;
+            case StandardOperator.Equals:
+            case StandardOperator.None: // implied =
+                WildcardLowerBound(includeAllPrerelease, ref leftBound, semver, wildcardVersion);
+                WildcardUpperBound(ref rightBound, semver, wildcardVersion);
+                return null;
+            default:
+                // dotcover disable next line
+                throw Unreachable.InvalidEnum(@operator);
+        }
+    }
+
+    public static Exception? ParseNpmVersion(
+        ref StringSegment segment,
+        SemVersionRangeOptions rangeOptions,
+        Exception? ex,
+        int maxLength,
+        out SemVersion? semver,
+        out WildcardVersion wildcardVersion)
+    {
+        var exception = GeneralRangeParser.ParseVersion(ref segment, rangeOptions, ParsingOptions, ex, maxLength,
+            out semver, out wildcardVersion);
+        if (exception != null) return exception;
+        DebugChecks.IsNotNull(semver, nameof(semver));
+        if (wildcardVersion != WildcardVersion.None && semver.IsPrerelease)
+            return ex ?? RangeError.PrereleaseNotSupportedWithWildcardVersion(segment.Buffer!);
+        // Remove the metadata the npm ranges allow (note we always allow metadata even though
+        // npm rejects it for partial versions)
+        semver = semver.WithoutMetadata();
+        return null;
+    }
+
+    /// <summary>
+    /// The greater than operator taking into account the wildcard.
+    /// </summary>
+    private static void GreaterThan(
+        bool includeAllPrerelease,
+        ref LeftBoundedRange leftBound,
+        ref RightBoundedRange rightBound,
+        SemVersion semver,
+        WildcardVersion wildcardVersion)
+    {
+        DebugChecks.IsNotWildcardVersionWithPrerelease(wildcardVersion, semver);
+
+        bool inclusive;
+        switch (wildcardVersion)
+        {
+            case WildcardVersion.MajorMinorPatchWildcard:
+                // No version matches
+                rightBound = new RightBoundedRange(SemVersion.Min, false);
+                return;
+            case WildcardVersion.MinorPatchWildcard:
+            {
+                var prereleaseString = includeAllPrerelease ? "0" : "";
+                var prerelease = includeAllPrerelease ? PrereleaseIdentifiers.Zero : ReadOnlyList<PrereleaseIdentifier>.Empty;
+                semver = new SemVersion(semver.Major + BigInteger.One, BigInteger.Zero, BigInteger.Zero, prereleaseString, prerelease,
+                    "", ReadOnlyList<MetadataIdentifier>.Empty);
+                inclusive = true;
+                break;
+            }
+            case WildcardVersion.PatchWildcard:
+            {
+                var prereleaseString = includeAllPrerelease ? "0" : "";
+                var prerelease = includeAllPrerelease ? PrereleaseIdentifiers.Zero : ReadOnlyList<PrereleaseIdentifier>.Empty;
+                semver = new SemVersion(semver.Major, semver.Minor + BigInteger.One, BigInteger.Zero, prereleaseString, prerelease,
+                    "", ReadOnlyList<MetadataIdentifier>.Empty);
+                inclusive = true;
+                break;
+            }
+            case WildcardVersion.None:
+                inclusive = false;
+                break;
+            default:
+                // dotcover disable next line
+                throw Unreachable.InvalidEnum(wildcardVersion);
+        }
+        leftBound = leftBound.Max(new LeftBoundedRange(semver, inclusive));
+    }
+
+    /// <summary>
+    /// The less than operator taking into account the wildcard.
+    /// </summary>
+    private static void LessThan(
+        ref RightBoundedRange rightBound,
+        SemVersion semver,
+        WildcardVersion wildcardVersion)
+    {
+        DebugChecks.IsNotWildcardVersionWithPrerelease(wildcardVersion, semver);
+
+        switch (wildcardVersion)
+        {
+            case WildcardVersion.MajorMinorPatchWildcard:
+            case WildcardVersion.MinorPatchWildcard:
+            case WildcardVersion.PatchWildcard:
+                // Wildcard places already filled with zeros
+                semver = semver.WithPrerelease(PrereleaseIdentifier.Zero);
+                break;
+            case WildcardVersion.None:
+                // No changes to version
+                break;
+            default:
+                // dotcover disable next line
+                throw Unreachable.InvalidEnum(wildcardVersion);
+        }
+
+        rightBound = rightBound.Min(new RightBoundedRange(semver, false));
+    }
+
+    private static void WildcardLowerBound(
+        bool includeAllPrerelease,
+        ref LeftBoundedRange leftBound,
+        SemVersion semver,
+        WildcardVersion wildcardVersion)
+    {
+        DebugChecks.IsNotWildcardVersionWithPrerelease(wildcardVersion, semver);
+
+        switch (wildcardVersion)
+        {
+            case WildcardVersion.MajorMinorPatchWildcard:
+                // No further bound placed
+                return;
+            case WildcardVersion.MinorPatchWildcard:
+            case WildcardVersion.PatchWildcard:
+                if (includeAllPrerelease)
+                    semver = semver.WithPrerelease(PrereleaseIdentifier.Zero);
+                break;
+            case WildcardVersion.None:
+                // No changes to version
+                break;
+            default:
+                // dotcover disable next line
+                throw Unreachable.InvalidEnum(wildcardVersion);
+        }
+
+        leftBound = leftBound.Max(new LeftBoundedRange(semver, true));
+    }
+
+    private static void WildcardUpperBound(
+        ref RightBoundedRange rightBound,
+        SemVersion semver,
+        WildcardVersion wildcardVersion)
+    {
+        DebugChecks.IsNotWildcardVersionWithPrerelease(wildcardVersion, semver);
+
+        switch (wildcardVersion)
+        {
+            case WildcardVersion.None:
+                rightBound = rightBound.Min(new RightBoundedRange(semver, true));
+                return;
+            case WildcardVersion.MajorMinorPatchWildcard:
+                // No further bounds placed
+                return;
+            case WildcardVersion.MinorPatchWildcard:
+                rightBound = rightBound.Min(new RightBoundedRange(
+                    new SemVersion(semver.Major + BigInteger.One, BigInteger.Zero, BigInteger.Zero, "0", PrereleaseIdentifiers.Zero, "",
+                        ReadOnlyList<MetadataIdentifier>.Empty), false));
+                return;
+            case WildcardVersion.PatchWildcard:
+                rightBound = rightBound.Min(new RightBoundedRange(
+                    new SemVersion(semver.Major, semver.Minor + BigInteger.One, BigInteger.Zero, "0", PrereleaseIdentifiers.Zero, "",
+                        ReadOnlyList<MetadataIdentifier>.Empty), false));
+                return;
+            default:
+                // dotcover disable next line
+                throw Unreachable.InvalidEnum(wildcardVersion);
+        }
+    }
+
+    private static Exception? ParseOperator(
+        ref StringSegment segment, Exception? ex, out StandardOperator @operator)
+    {
+        var end = 0;
+        while (end < segment.Length && GeneralRangeParser.IsPossibleOperatorChar(segment[end], SemVersionRangeOptions.AllowMetadata)) end++;
+        var opSegment = segment.Subsegment(0, end);
+        segment = segment.Subsegment(end);
+
+        if (opSegment.Length == 0)
+        {
+            @operator = StandardOperator.None;
+            return null;
+        }
+
+        // Assign invalid once, so it doesn't have to be done any time parse fails
+        @operator = 0;
+        if (opSegment.Length > 2
+            || (opSegment.Length == 2
+                && opSegment[1] != '='
+                && !(opSegment[0] == '~' && opSegment[1] == '>')))
+            return ex ?? RangeError.InvalidOperator(opSegment);
+
+        var firstChar = opSegment[0];
+        var isOrEqual = opSegment.Length == 2 && opSegment[1] == '=';
+        switch (firstChar)
+        {
+            case '=' when !isOrEqual:
+                @operator = StandardOperator.Equals;
+                return null;
+            case '<' when isOrEqual:
+                @operator = StandardOperator.LessThanOrEqual;
+                return null;
+            case '<':
+                @operator = StandardOperator.LessThan;
+                return null;
+            case '>' when isOrEqual:
+                @operator = StandardOperator.GreaterThanOrEqual;
+                return null;
+            case '>':
+                @operator = StandardOperator.GreaterThan;
+                return null;
+            case '~' when !isOrEqual:
+                // '~>' operator is allowed by check for invalid above and matched by this
+                @operator = StandardOperator.Tilde;
+                return null;
+            case '^' when !isOrEqual:
+                @operator = StandardOperator.Caret;
+                return null;
+            default:
+                return ex ?? RangeError.InvalidOperator(opSegment);
+        }
+    }
+
+    private static readonly SemVersionParsingOptions ParsingOptions
+        = new(true, false, true, c => c is 'x' or 'X' or '*');
+}

--- a/src/Vendoring/SemVer/Parsing/PrereleaseIdentifiers.cs
+++ b/src/Vendoring/SemVer/Parsing/PrereleaseIdentifiers.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Semver.Parsing;
+
+internal static class PrereleaseIdentifiers
+{
+    public static readonly IReadOnlyList<PrereleaseIdentifier> Zero
+        = new List<PrereleaseIdentifier>(1) { PrereleaseIdentifier.Zero }.AsReadOnly();
+}

--- a/src/Vendoring/SemVer/Parsing/RangeError.cs
+++ b/src/Vendoring/SemVer/Parsing/RangeError.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Primitives;
+using Semver.Utility;
+
+namespace Semver.Parsing;
+
+internal static class RangeError
+{
+    private const string TooLongMessage = "Exceeded maximum length of {1} for '{0}'.";
+    private const string InvalidOperatorMessage = "Invalid operator '{0}'.";
+    private const string InvalidWhitespaceMessage
+        = "Invalid whitespace character at {0} in '{1}'. Only the ASCII space character is allowed.";
+    private const string MissingComparisonMessage
+        = "Range is missing a comparison or limit at {0} in '{1}'.";
+    private const string WildcardWithOperatorMessage
+        = "Operator is combined with wildcards in '{0}'.";
+    private const string PrereleaseWithWildcardVersionMessage
+        = "A wildcard major, minor, or patch is combined with a prerelease version in '{0}'.";
+    private const string UnexpectedInHyphenRangeMessage
+        = "Unexpected characters in hyphen range '{0}'.";
+    private const string MissingVersionInHyphenRangeMessage
+        = "Missing a version number in hyphen range in '{0}'.";
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static FormatException TooLong(string range, int maxLength)
+        => NewFormatException(TooLongMessage, range.LimitLength(), maxLength);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Exception InvalidOperator(StringSegment @operator)
+        => NewFormatException(InvalidOperatorMessage, @operator.ToStringLimitLength());
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Exception InvalidWhitespace(int position, string range)
+        => NewFormatException(InvalidWhitespaceMessage, position, range.LimitLength());
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Exception MissingComparison(int position, string range)
+        => NewFormatException(MissingComparisonMessage, position, range.LimitLength());
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Exception WildcardNotSupportedWithOperator(string range)
+        => NewFormatException(WildcardWithOperatorMessage, range.LimitLength());
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Exception PrereleaseNotSupportedWithWildcardVersion(string range)
+        => NewFormatException(PrereleaseWithWildcardVersionMessage, range.LimitLength());
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Exception UnexpectedInHyphenRange(string unexpected)
+        => NewFormatException(UnexpectedInHyphenRangeMessage, unexpected);
+
+    public static Exception MissingVersionInHyphenRange(string range)
+        => NewFormatException(MissingVersionInHyphenRangeMessage, range.LimitLength());
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static FormatException NewFormatException(string messageTemplate, params object[] args)
+        => new(string.Format(CultureInfo.InvariantCulture, messageTemplate, args));
+}

--- a/src/Vendoring/SemVer/Parsing/SemVersionParser.cs
+++ b/src/Vendoring/SemVer/Parsing/SemVersionParser.cs
@@ -1,0 +1,458 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Primitives;
+using Semver.Utility;
+
+namespace Semver.Parsing;
+
+/// <summary>
+/// Parsing for <see cref="SemVersion"/>
+/// </summary>
+/// <remarks>The new parsing code was complex enough that is made sense to break out into its
+/// own class.</remarks>
+internal static class SemVersionParser
+{
+    private const string LeadingWhitespaceMessage = "Version '{0}' has leading whitespace.";
+    private const string TrailingWhitespaceMessage = "Version '{0}' has trailing whitespace.";
+    private const string EmptyVersionMessage = "Empty string is not a valid version.";
+    private const string TooLongVersionMessage = "Exceeded maximum length of {1} for '{0}'.";
+    private const string AllWhitespaceVersionMessage = "Whitespace is not a valid version.";
+    private const string LeadingLowerVMessage = "Leading 'v' in '{0}'.";
+    private const string LeadingUpperVMessage = "Leading 'V' in '{0}'.";
+    private const string LeadingZeroInMajorMinorOrPatchMessage = "{1} version has leading zero in '{0}'.";
+    private const string EmptyMajorMinorOrPatchMessage = "{1} version missing in '{0}'.";
+    private const string FourthVersionNumberMessage = "Fourth version number in '{0}'.";
+    private const string PrereleasePrefixedByDotMessage = "The prerelease identfiers should be prefixed by '-' instead of '.' in '{0}'.";
+    private const string MissingPrereleaseIdentifierMessage = "Missing prerelease identifier in '{0}'.";
+    private const string LeadingZeroInPrereleaseMessage = "Leading zero in prerelease identifier in version '{0}'.";
+    private const string InvalidCharacterInPrereleaseMessage = "Invalid character '{1}' in prerelease identifier in '{0}'.";
+    private const string MissingMetadataIdentifierMessage = "Missing metadata identifier in '{0}'.";
+    private const string InvalidCharacterInMajorMinorOrPatchMessage = "{1} version contains invalid character '{2}' in '{0}'.";
+    private const string InvalidCharacterInMetadataMessage = "Invalid character '{1}' in metadata identifier in '{0}'.";
+    private const string InvalidWildcardInMajorMinorOrPatchMessage = "{1} version is a wildcard and should contain only 1 character in '{0}'.";
+    private const string MinorOrPatchMustBeWildcardVersionMessage = "{1} version should be a wildcard because the preceding version is a wildcard in '{0}'.";
+    private const string InvalidWildcardInPrereleaseMessage = "Prerelease version is a wildcard and should contain only 1 character in '{0}'.";
+    private const string PrereleaseWildcardMustBeLastMessage = "Prerelease identifier follows wildcard prerelease identifier in '{0}'.";
+    private const string MajorMinorOrPatchParsingFailedMessage = "{1} version '{2}' failed to parse in '{0}'.";
+    private const string PrereleaseParsingFailedMessage = "Prerelease identifier '{1}' failed to parse in '{0}'.";
+
+    /// <summary>
+    /// The internal method that all parsing is based on. Because this is called by both
+    /// <see cref="SemVersion.Parse(string, SemVersionStyles, int)"/> and
+    /// <see cref="SemVersion.TryParse(string, SemVersionStyles, out SemVersion, int)"/>
+    /// it does not throw exceptions, but instead returns the exception that should be thrown
+    /// by the parse method. For performance when used from try parse, all exception construction
+    /// and message formatting can be avoided by passing in an exception which will be returned
+    /// when parsing fails.
+    /// </summary>
+    /// <remarks>This does not validate the <paramref name="style"/> or <paramref name="maxLength"/>
+    /// parameter values. That must be done in the calling method.</remarks>
+    public static Exception? Parse(
+        string? version,
+        SemVersionStyles style,
+        Exception? ex,
+        int maxLength,
+        out SemVersion? semver)
+    {
+        DebugChecks.IsValid(style, nameof(style));
+        DebugChecks.IsValidMaxLength(maxLength, nameof(maxLength));
+
+        if (version != null)
+            return Parse(version, style, SemVersionParsingOptions.None, ex, maxLength, out semver, out _);
+        semver = null;
+        return ex ?? new ArgumentNullException(nameof(version));
+    }
+
+    /// <summary>
+    /// An internal method that is used when parsing versions from ranges. Because this is
+    /// called by both
+    /// <see cref="SemVersionRange.Parse(string,SemVersionRangeOptions,int)"/> and
+    /// <see cref="SemVersionRange.TryParse(string,SemVersionRangeOptions,out SemVersionRange,int)"/>
+    /// it does not throw exceptions, but instead returns the exception that should be thrown
+    /// by the parse method. For performance when used from try parse, all exception construction
+    /// and message formatting can be avoided by passing in an exception which will be returned
+    /// when parsing fails.
+    /// </summary>
+    /// <remarks>This does not validate the <paramref name="style"/> or <paramref name="maxLength"/>
+    /// parameter values. That must be done in the calling method.</remarks>
+    public static Exception? Parse(
+        StringSegment version,
+        SemVersionStyles style,
+        SemVersionParsingOptions options,
+        Exception? ex,
+        int maxLength,
+        out SemVersion? semver,
+        out WildcardVersion wildcardVersion)
+    {
+        DebugChecks.IsValid(style, nameof(style));
+        DebugChecks.IsValidMaxLength(maxLength, nameof(maxLength));
+
+        // Assign once so it doesn't have to be done any time parse fails
+        semver = null;
+        wildcardVersion = WildcardVersion.None;
+
+        // Note: this method relies on the fact that the null coalescing operator `??`
+        // is short-circuiting to avoid constructing exceptions and exception messages
+        // when a non-null exception is passed in.
+
+        if (version.Length == 0) return ex ?? new FormatException(EmptyVersionMessage);
+
+        if (version.Length > maxLength)
+            return ex ?? NewFormatException(TooLongVersionMessage, version.ToStringLimitLength(), maxLength);
+
+        // This code does two things to help provide good error messages:
+        // 1. It breaks the version number into segments and then parses those segments
+        // 2. It parses an element first, then checks the flags for whether it should be allowed
+
+        var mainSegment = version;
+
+        var parseEx = ParseLeadingWhitespace(version, ref mainSegment, style, ex);
+        if (parseEx != null) return parseEx;
+
+        // Take of trailing whitespace and remember that there was trailing whitespace
+        var lengthWithTrailingWhitespace = mainSegment.Length;
+        mainSegment = mainSegment.TrimEnd();
+        var hasTrailingWhitespace = lengthWithTrailingWhitespace > mainSegment.Length;
+
+        // Now break the version number down into segments.
+        mainSegment.SplitBeforeFirst('+', out mainSegment, out var metadataSegment);
+        mainSegment.SplitBeforeFirst('-', out var majorMinorPatchSegment, out var prereleaseSegment);
+
+        parseEx = ParseLeadingV(version, ref majorMinorPatchSegment, style, ex);
+        if (parseEx != null) return parseEx;
+
+        // Are leading zeros allowed
+        var allowLeadingZeros = style.HasStyle(SemVersionStyles.AllowLeadingZeros);
+
+        BigInteger major, minor, patch;
+        using (var versionNumbers = majorMinorPatchSegment.Split('.').GetEnumerator())
+        {
+            const bool majorIsOptional = false;
+            const bool majorIsWildcardRequired = false;
+            parseEx = ParseVersionNumber("Major", version, versionNumbers, allowLeadingZeros,
+                majorIsOptional, majorIsWildcardRequired, options, ex, out major, out var majorIsWildcard);
+            if (parseEx != null) return parseEx;
+            if (majorIsWildcard) wildcardVersion |= WildcardVersion.MajorMinorPatchWildcard;
+
+            var minorIsOptional = style.HasStyle(SemVersionStyles.OptionalMinorPatch) || majorIsWildcard;
+            parseEx = ParseVersionNumber("Minor", version, versionNumbers, allowLeadingZeros,
+                minorIsOptional, majorIsWildcard, options, ex, out minor, out var minorIsWildcard);
+            if (parseEx != null) return parseEx;
+            if (minorIsWildcard) wildcardVersion |= WildcardVersion.MinorPatchWildcard;
+
+            var patchIsOptional = style.HasStyle(SemVersionStyles.OptionalPatch) || majorIsWildcard || minorIsWildcard;
+            parseEx = ParseVersionNumber("Patch", version, versionNumbers, allowLeadingZeros,
+                patchIsOptional, minorIsWildcard, options, ex, out patch, out var patchIsWildcard);
+            if (parseEx != null) return parseEx;
+            if (patchIsWildcard) wildcardVersion |= WildcardVersion.PatchWildcard;
+
+            // Handle fourth version number
+            if (versionNumbers.MoveNext())
+            {
+                var fourthSegment = versionNumbers.Current;
+                // If it is ".\d" then we'll assume they were trying to have a fourth version number
+                if (fourthSegment.Length > 0 && fourthSegment[0].IsDigit())
+                    return ex ?? NewFormatException(FourthVersionNumberMessage, version.ToStringLimitLength());
+
+                // Otherwise, assume they used "." instead of "-" to start the prerelease
+                return ex ?? NewFormatException(PrereleasePrefixedByDotMessage, version.ToStringLimitLength());
+            }
+        }
+
+        // Parse prerelease version
+        string? prerelease;
+        IReadOnlyList<PrereleaseIdentifier> prereleaseIdentifiers;
+        if (prereleaseSegment.Length > 0)
+        {
+            prereleaseSegment = prereleaseSegment.Subsegment(1);
+            parseEx = ParsePrerelease(version, prereleaseSegment, allowLeadingZeros, options, ex,
+                        out prerelease, out prereleaseIdentifiers, out var prereleaseIsWildcard);
+            if (parseEx != null) return parseEx;
+            DebugChecks.IsNotNull(prerelease, nameof(prerelease));
+            if (prereleaseIsWildcard) wildcardVersion |= WildcardVersion.PrereleaseWildcard;
+        }
+        else
+        {
+            prerelease = "";
+            prereleaseIdentifiers = ReadOnlyList<PrereleaseIdentifier>.Empty;
+        }
+
+        // Parse metadata
+        string metadata;
+        IReadOnlyList<MetadataIdentifier> metadataIdentifiers;
+        if (metadataSegment.Length > 0)
+        {
+            metadataSegment = metadataSegment.Subsegment(1);
+            parseEx = ParseMetadata(version, metadataSegment, ex, out metadata, out metadataIdentifiers);
+            if (parseEx != null) return parseEx;
+        }
+        else
+        {
+            metadata = "";
+            metadataIdentifiers = ReadOnlyList<MetadataIdentifier>.Empty;
+        }
+
+        // Error if trailing whitespace not allowed
+        if (hasTrailingWhitespace && !style.HasStyle(SemVersionStyles.AllowTrailingWhitespace))
+            return ex ?? NewFormatException(TrailingWhitespaceMessage, version.ToStringLimitLength());
+
+        semver = new SemVersion(major, minor, patch,
+            prerelease, prereleaseIdentifiers, metadata, metadataIdentifiers);
+        return null;
+    }
+
+    private static Exception? ParseLeadingWhitespace(
+        StringSegment version,
+        ref StringSegment segment,
+        SemVersionStyles style,
+        Exception? ex)
+    {
+        var oldLength = segment.Length;
+
+        // Skip leading whitespace
+        segment = segment.TrimStart();
+
+        // Error if all whitespace
+        if (segment.Length == 0)
+            return ex ?? new FormatException(AllWhitespaceVersionMessage);
+
+        // Error if leading whitespace not allowed
+        if (oldLength > segment.Length && !style.HasStyle(SemVersionStyles.AllowLeadingWhitespace))
+            return ex ?? NewFormatException(LeadingWhitespaceMessage, version.ToStringLimitLength());
+
+        return null;
+    }
+
+    private static Exception? ParseLeadingV(
+        StringSegment version,
+        ref StringSegment segment,
+        SemVersionStyles style,
+        Exception? ex)
+    {
+        if (segment.IsEmpty()) return null;
+
+        var leadChar = segment[0];
+        switch (leadChar)
+        {
+            case 'v' when style.HasStyle(SemVersionStyles.AllowLowerV):
+                segment = segment.Subsegment(1);
+                break;
+            case 'v':
+                return ex ?? NewFormatException(LeadingLowerVMessage, version.ToStringLimitLength());
+            case 'V' when style.HasStyle(SemVersionStyles.AllowUpperV):
+                segment = segment.Subsegment(1);
+                break;
+            case 'V':
+                return ex ?? NewFormatException(LeadingUpperVMessage, version.ToStringLimitLength());
+        }
+
+        return null;
+    }
+
+    private static Exception? ParseVersionNumber(
+        string kind, // i.e. Major, Minor, or Patch
+        StringSegment version,
+        IEnumerator<StringSegment> versionNumbers,
+        bool allowLeadingZeros,
+        bool optional,
+        bool wildcardRequired,
+        SemVersionParsingOptions options,
+        Exception? ex,
+        out BigInteger number,
+        out bool isWildcard)
+    {
+        if (versionNumbers.MoveNext())
+            return ParseVersionNumber(kind, version, versionNumbers.Current, allowLeadingZeros,
+                wildcardRequired, options, ex, out number, out isWildcard);
+
+        number = 0;
+        isWildcard = options.MissingVersionsAreWildcards;
+        if (!optional)
+            return ex ?? NewFormatException(EmptyMajorMinorOrPatchMessage, version.ToStringLimitLength(), kind);
+
+        return null;
+    }
+
+    private static Exception? ParseVersionNumber(
+        string kind, // i.e. Major, Minor, or Patch
+        StringSegment version,
+        StringSegment segment,
+        bool allowLeadingZeros,
+        bool wildcardRequired,
+        SemVersionParsingOptions options,
+        Exception? ex,
+        out BigInteger number,
+        out bool isWildcard)
+    {
+        // Assign once so it doesn't have to be done any time parse fails
+        number = BigInteger.Zero;
+
+        if (segment.Length == 0)
+        {
+            isWildcard = false;
+            return ex ?? NewFormatException(EmptyMajorMinorOrPatchMessage, version.ToStringLimitLength(), kind);
+        }
+
+        if (options.AllowWildcardMajorMinorPatch && segment.Length > 0 && options.IsWildcard(segment[0]))
+        {
+            isWildcard = true;
+            if (segment.Length > 1)
+                return ex ?? NewFormatException(InvalidWildcardInMajorMinorOrPatchMessage,
+                    version.ToStringLimitLength(), kind);
+
+            return null;
+        }
+
+        isWildcard = false;
+
+        if (wildcardRequired)
+            return ex ?? NewFormatException(MinorOrPatchMustBeWildcardVersionMessage,
+                version.ToStringLimitLength(), kind);
+
+        var lengthWithLeadingZeros = segment.Length;
+
+        // Skip leading zeros
+        segment = segment.TrimLeadingZeros();
+
+        // Scan for digits
+        var i = 0;
+        while (i < segment.Length && segment[i].IsDigit()) i += 1;
+
+        // If there are unprocessed characters, then it is an invalid char for this segment
+        if (i < segment.Length)
+            return ex ?? NewFormatException(InvalidCharacterInMajorMinorOrPatchMessage,
+                version.ToStringLimitLength(),
+                kind, segment[i]);
+
+        if (!allowLeadingZeros && lengthWithLeadingZeros > segment.Length)
+            return ex ?? NewFormatException(LeadingZeroInMajorMinorOrPatchMessage,
+                version.ToStringLimitLength(), kind);
+
+        var numberString = segment.ToString();
+        if (!BigInteger.TryParse(numberString, NumberStyles.None, CultureInfo.InvariantCulture, out number))
+            // Parsing validated this as a string of digits possibly proceeded by zero so this
+            // failure shouldn't be possible.
+            return ex ?? new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
+                MajorMinorOrPatchParsingFailedMessage, version.ToStringLimitLength(), kind, numberString));
+
+        return null;
+    }
+
+    private static Exception? ParsePrerelease(
+        StringSegment version,
+        StringSegment segment,
+        bool allowLeadingZero,
+        SemVersionParsingOptions options,
+        Exception? ex,
+        out string? prerelease,
+        out IReadOnlyList<PrereleaseIdentifier> prereleaseIdentifiers,
+        out bool isWildcard)
+    {
+        prerelease = null;
+        var identifiers = new List<PrereleaseIdentifier>(segment.SplitCount('.'));
+        prereleaseIdentifiers = identifiers.AsReadOnly();
+        isWildcard = false;
+
+        bool hasLeadingZeros = false;
+        foreach (var identifier in segment.Split('.'))
+        {
+            // Identifier after wildcard
+            if (isWildcard)
+                return ex ?? NewFormatException(PrereleaseWildcardMustBeLastMessage, version.ToStringLimitLength());
+
+            // Empty identifiers not allowed
+            if (identifier.Length == 0)
+                return ex ?? NewFormatException(MissingPrereleaseIdentifierMessage, version.ToStringLimitLength());
+
+            var isNumeric = true;
+
+            for (int i = 0; i < identifier.Length; i++)
+            {
+                var c = identifier[i];
+                if (c.IsAlphaOrHyphen())
+                    isNumeric = false;
+                else if (options.AllowWildcardPrerelease && options.IsWildcard(c))
+                    isWildcard = true;
+                else if (!c.IsDigit())
+                    return ex ?? NewFormatException(InvalidCharacterInPrereleaseMessage,
+                        version.ToStringLimitLength(), c);
+            }
+
+            if (isWildcard)
+            {
+                if (identifier.Length > 1) return ex ?? NewFormatException(InvalidWildcardInPrereleaseMessage, version.ToStringLimitLength());
+                isWildcard = true;
+                continue; // continue to make sure there aren't more identifiers
+            }
+
+            if (!isNumeric)
+                identifiers.Add(PrereleaseIdentifier.CreateUnsafe(identifier.ToString(), null));
+            else
+            {
+                string identifierString;
+                if (identifier[0] == '0' && identifier.Length > 1)
+                {
+                    if (!allowLeadingZero)
+                        return ex ?? NewFormatException(LeadingZeroInPrereleaseMessage,
+                            version.ToStringLimitLength());
+                    hasLeadingZeros = true;
+                    identifierString = identifier.TrimLeadingZeros().ToString();
+                }
+                else
+                    identifierString = identifier.ToString();
+
+                if (!BigInteger.TryParse(identifierString, NumberStyles.None, null, out var numericValue))
+                    // Parsing validated this as a string of digits possibly proceeded by zero
+                    // so this failure shouldn't be possible.
+                    return ex ?? new FormatException(string.Format(CultureInfo.InvariantCulture,
+                        PrereleaseParsingFailedMessage, version.ToStringLimitLength(), identifier));
+
+                identifiers.Add(PrereleaseIdentifier.CreateUnsafe(identifierString, numericValue));
+            }
+        }
+
+        // If there are leading zeros or a wildcard, reconstruct the string from the identifiers,
+        // otherwise just take a substring.
+        prerelease = hasLeadingZeros || isWildcard
+                        ? string.Join(".", identifiers) : segment.ToString();
+
+        return null;
+    }
+
+    private static Exception? ParseMetadata(
+        StringSegment version,
+        StringSegment segment,
+        Exception? ex,
+        out string metadata,
+        out IReadOnlyList<MetadataIdentifier> metadataIdentifiers)
+    {
+        metadata = segment.ToString();
+        var identifiers = new List<MetadataIdentifier>(segment.SplitCount('.'));
+        metadataIdentifiers = identifiers.AsReadOnly();
+        foreach (var identifier in segment.Split('.'))
+        {
+            // Empty identifiers not allowed
+            if (identifier.Length == 0)
+                return ex ?? NewFormatException(MissingMetadataIdentifierMessage, version.ToStringLimitLength());
+
+            for (int i = 0; i < identifier.Length; i++)
+            {
+                var c = identifier[i];
+                if (!c.IsAlphaOrHyphen() && !c.IsDigit())
+                    return ex ?? NewFormatException(InvalidCharacterInMetadataMessage,
+                        version.ToStringLimitLength(), c);
+            }
+
+            identifiers.Add(MetadataIdentifier.CreateUnsafe(identifier.ToString()));
+        }
+
+        return null;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static FormatException NewFormatException(string messageTemplate, params object[] args)
+        => new(string.Format(CultureInfo.InvariantCulture, messageTemplate, args));
+}

--- a/src/Vendoring/SemVer/Parsing/SemVersionParsingOptions.cs
+++ b/src/Vendoring/SemVer/Parsing/SemVersionParsingOptions.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace Semver.Parsing;
+
+/// <summary>
+/// Options beyond the <see cref="SemVersionStyles"/> for version parsing used by range parsing.
+/// </summary>
+internal class SemVersionParsingOptions
+{
+    /// <summary>
+    /// No special parsing options. Used when parsing versions outside of ranges.
+    /// </summary>
+    public static SemVersionParsingOptions None = new(false, false, false, _ => false);
+
+    public SemVersionParsingOptions(
+        bool allowWildcardMajorMinorPatch,
+        bool allowWildcardPrerelease,
+        bool missingVersionsAreWildcards,
+        Predicate<char> isWildcard)
+    {
+        AllowWildcardMajorMinorPatch = allowWildcardMajorMinorPatch;
+        AllowWildcardPrerelease = allowWildcardPrerelease;
+        MissingVersionsAreWildcards = missingVersionsAreWildcards;
+        IsWildcard = isWildcard;
+    }
+
+    /// <summary>
+    /// Allow wildcards as defined by <see cref="IsWildcard"/> in the major, minor, and patch
+    /// version numbers.
+    /// </summary>
+    public bool AllowWildcardMajorMinorPatch { get; }
+
+    /// <summary>
+    /// Allow a wildcard as defined by <see cref="IsWildcard"/> as the final prerelease identifier.
+    /// </summary>
+    public bool AllowWildcardPrerelease { get; }
+
+    /// <summary>
+    /// Whether missing minor and patch version numbers allowed by the optional minor and patch
+    /// options count as being wildcard version numbers.
+    /// </summary>
+    public bool MissingVersionsAreWildcards { get; }
+
+    /// <summary>
+    /// Determines whether any given character is a wildcard character.
+    /// </summary>
+    public Predicate<char> IsWildcard { get; }
+}

--- a/src/Vendoring/SemVer/Parsing/StandardOperator.cs
+++ b/src/Vendoring/SemVer/Parsing/StandardOperator.cs
@@ -1,0 +1,19 @@
+﻿namespace Semver.Parsing;
+
+internal enum StandardOperator
+{
+    None = 1,
+    Equals,
+    LessThan,
+    LessThanOrEqual,
+    GreaterThan,
+    GreaterThanOrEqual,
+    /// <summary>
+    /// Approximately equivalent to version. Allows patch updates.
+    /// </summary>
+    Tilde,
+    /// <summary>
+    /// Compatible with version. Allows minor and patch updates.
+    /// </summary>
+    Caret,
+}

--- a/src/Vendoring/SemVer/Parsing/StandardRangeParser.cs
+++ b/src/Vendoring/SemVer/Parsing/StandardRangeParser.cs
@@ -1,0 +1,284 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using Microsoft.Extensions.Primitives;
+using Semver.Ranges;
+using Semver.Utility;
+
+namespace Semver.Parsing;
+
+internal static class StandardRangeParser
+{
+    public static Exception? Parse(
+        string? range,
+        SemVersionRangeOptions rangeOptions,
+        Exception? ex,
+        int maxLength,
+        out SemVersionRange? semverRange)
+    {
+        DebugChecks.IsValid(rangeOptions, nameof(rangeOptions));
+        DebugChecks.IsValidMaxLength(maxLength, nameof(maxLength));
+
+        // Assign null once, so it doesn't have to be done any time parse fails
+        semverRange = null;
+
+        // Note: this method relies on the fact that the null coalescing operator `??`
+        // is short-circuiting to avoid constructing exceptions and exception messages
+        // when a non-null exception is passed in.
+
+        if (range is null) return ex ?? new ArgumentNullException(nameof(range));
+        if (range.Length > maxLength) return ex ?? RangeError.TooLong(range, maxLength);
+
+        var unbrokenRanges = new List<UnbrokenSemVersionRange>(GeneralRangeParser.CountSplitOnOrOperator(range));
+        foreach (var segment in GeneralRangeParser.SplitOnOrOperator(range))
+        {
+            var exception = ParseUnbrokenRange(segment, rangeOptions, ex, maxLength, out var unbrokenRange);
+            if (exception is not null) return exception;
+            DebugChecks.IsNotNull(unbrokenRange, nameof(unbrokenRange));
+
+            unbrokenRanges.Add(unbrokenRange);
+        }
+
+        semverRange = SemVersionRange.Create(unbrokenRanges);
+        return null;
+    }
+
+    private static Exception? ParseUnbrokenRange(
+        StringSegment segment,
+        SemVersionRangeOptions rangeOptions,
+        Exception? ex,
+        int maxLength,
+        out UnbrokenSemVersionRange? unbrokenRange)
+    {
+        // Assign null once, so it doesn't have to be done any time parse fails
+        unbrokenRange = null;
+
+        // Parse off leading whitespace
+        var exception = GeneralRangeParser.ParseOptionalSpaces(ref segment, ex);
+        if (exception != null) return exception;
+
+        // Reject empty string ranges
+        if (segment.IsEmpty()) return ex ?? RangeError.MissingComparison(segment.Offset, segment.Buffer!);
+
+        var start = LeftBoundedRange.Unbounded;
+        var end = RightBoundedRange.Unbounded;
+        var includeAllPrerelease = rangeOptions.HasOption(SemVersionRangeOptions.IncludeAllPrerelease);
+        while (!segment.IsEmpty())
+        {
+            exception = ParseComparison(ref segment, rangeOptions, ref includeAllPrerelease, ex, maxLength, ref start, ref end);
+            if (exception != null) return exception;
+        }
+
+        unbrokenRange = UnbrokenSemVersionRange.Create(start, end, includeAllPrerelease);
+        return null;
+    }
+
+    /// <summary>
+    /// Parse a comparison from the beginning of the segment.
+    /// </summary>
+    /// <remarks>
+    /// Must have leading whitespace removed. Will consume trailing whitespace.
+    /// </remarks>
+    private static Exception? ParseComparison(
+        ref StringSegment segment,
+        SemVersionRangeOptions rangeOptions,
+        ref bool includeAllPrerelease,
+        Exception? ex,
+        int maxLength,
+        ref LeftBoundedRange leftBound,
+        ref RightBoundedRange rightBound)
+    {
+        DebugChecks.IsNotEmpty(segment, nameof(segment));
+
+        var exception = ParseOperator(ref segment, ex, out var @operator);
+        if (exception != null) return exception;
+
+        exception = GeneralRangeParser.ParseOptionalSpaces(ref segment, ex);
+        if (exception != null) return exception;
+
+        exception = GeneralRangeParser.ParseVersion(ref segment, rangeOptions, ParsingOptions, ex, maxLength,
+                        out var semver, out var wildcardVersion);
+        if (exception != null) return exception;
+        DebugChecks.IsNotNull(semver, nameof(semver));
+
+        if (@operator != StandardOperator.None && wildcardVersion != WildcardVersion.None)
+            return ex ?? RangeError.WildcardNotSupportedWithOperator(segment.Buffer!);
+
+        exception = GeneralRangeParser.ParseOptionalSpaces(ref segment, ex);
+        if (exception != null) return exception;
+
+        switch (@operator)
+        {
+            case StandardOperator.Equals:
+                leftBound = leftBound.Max(new LeftBoundedRange(semver, true));
+                rightBound = rightBound.Min(new RightBoundedRange(semver, true));
+                return null;
+            case StandardOperator.GreaterThan:
+                leftBound = leftBound.Max(new LeftBoundedRange(semver, false));
+                return null;
+            case StandardOperator.GreaterThanOrEqual:
+                leftBound = leftBound.Max(new LeftBoundedRange(semver, true));
+                return null;
+            case StandardOperator.LessThan:
+                rightBound = rightBound.Min(new RightBoundedRange(semver, false));
+                return null;
+            case StandardOperator.LessThanOrEqual:
+                rightBound = rightBound.Min(new RightBoundedRange(semver, true));
+                return null;
+            case StandardOperator.Caret:
+                leftBound = leftBound.Max(new LeftBoundedRange(semver, true));
+                BigInteger major = BigInteger.Zero, minor = BigInteger.Zero, patch = BigInteger.Zero;
+                if (semver.Major != 0)
+                    major = semver.Major + BigInteger.One;
+                else if (semver.Minor != 0)
+                    minor = semver.Minor + BigInteger.One;
+                else
+                    patch = semver.Patch + BigInteger.One;
+
+                rightBound = rightBound.Min(new RightBoundedRange(new SemVersion(
+                                major, minor, patch,
+                                "0", PrereleaseIdentifiers.Zero,
+                                "", ReadOnlyList<MetadataIdentifier>.Empty), false));
+                return null;
+            case StandardOperator.Tilde:
+                leftBound = leftBound.Max(new LeftBoundedRange(semver, true));
+                rightBound = rightBound.Min(new RightBoundedRange(
+                    semver.With(minor: semver.Minor + BigInteger.One, patch: BigInteger.Zero, prerelease: PrereleaseIdentifiers.Zero),
+                    false));
+                return null;
+            case StandardOperator.None: // implied = (supports wildcard *)
+                var prereleaseWildcard = wildcardVersion.HasOption(WildcardVersion.PrereleaseWildcard);
+                includeAllPrerelease |= prereleaseWildcard;
+                wildcardVersion.RemoveOption(WildcardVersion.PrereleaseWildcard);
+                if (wildcardVersion != WildcardVersion.None && semver.IsPrerelease)
+                    return ex ?? RangeError.PrereleaseNotSupportedWithWildcardVersion(segment.Buffer!);
+                switch (wildcardVersion)
+                {
+                    case WildcardVersion.None:
+                        leftBound = leftBound.Max(WildcardLowerBound(semver, prereleaseWildcard));
+                        PrereleaseWildcardUpperBound(ref rightBound, semver, prereleaseWildcard);
+                        return null;
+                    case WildcardVersion.MajorMinorPatchWildcard:
+                        // No further bound is places on the left and right bounds
+                        return null;
+                    case WildcardVersion.MinorPatchWildcard:
+                        leftBound = leftBound.Max(WildcardLowerBound(semver, prereleaseWildcard));
+                        rightBound = rightBound.Min(new RightBoundedRange(
+                            new SemVersion(semver.Major + BigInteger.One, BigInteger.Zero, BigInteger.Zero,
+                                "0", PrereleaseIdentifiers.Zero,
+                                "", ReadOnlyList<MetadataIdentifier>.Empty), false));
+                        return null;
+                    case WildcardVersion.PatchWildcard:
+                        leftBound = leftBound.Max(WildcardLowerBound(semver, prereleaseWildcard));
+                        rightBound = rightBound.Min(new RightBoundedRange(
+                            new SemVersion(semver.Major, semver.Minor + BigInteger.One, BigInteger.Zero,
+                                "0", PrereleaseIdentifiers.Zero,
+                                "", ReadOnlyList<MetadataIdentifier>.Empty), false));
+                        return null;
+                    default:
+                        // dotcover disable next line
+                        throw Unreachable.InvalidEnum(wildcardVersion);
+                }
+            default:
+                // dotcover disable next line
+                throw Unreachable.InvalidEnum(@operator);
+        }
+    }
+
+    private static LeftBoundedRange WildcardLowerBound(SemVersion semver, bool prereleaseWildcard)
+    {
+        if (prereleaseWildcard)
+            semver = semver.IsPrerelease
+                ? semver.WithPrerelease(semver.PrereleaseIdentifiers.Concat(PrereleaseIdentifiers.Zero))
+                : semver.WithPrerelease(PrereleaseIdentifier.Zero);
+        return new LeftBoundedRange(semver, true);
+    }
+
+    private static void PrereleaseWildcardUpperBound(
+        ref RightBoundedRange rightBound,
+        SemVersion semver,
+        bool prereleaseWildcard)
+    {
+        var inclusive = false;
+        if (prereleaseWildcard)
+        {
+            if (semver.IsPrerelease)
+                semver = new SemVersion(semver.Major, semver.Minor, semver.Patch,
+                    PrereleaseWildcardUpperBoundPrereleaseIdentifiers(semver.PrereleaseIdentifiers));
+            else
+            {
+                semver = new SemVersion(semver.Major, semver.Minor, semver.Patch + BigInteger.One,
+                    "0", PrereleaseIdentifiers.Zero, "", ReadOnlyList<MetadataIdentifier>.Empty);
+            }
+        }
+        else
+            inclusive = true;
+
+        rightBound = rightBound.Min(new RightBoundedRange(semver, inclusive));
+    }
+
+    private static IEnumerable<PrereleaseIdentifier> PrereleaseWildcardUpperBoundPrereleaseIdentifiers(
+        IReadOnlyList<PrereleaseIdentifier> identifiers)
+    {
+        for (int i = 0; i < identifiers.Count - 1; i++)
+            yield return identifiers[i];
+
+        var lastIdentifier = identifiers[^1];
+
+        yield return lastIdentifier.NextIdentifier();
+    }
+
+    private static Exception? ParseOperator(
+        ref StringSegment segment, Exception? ex, out StandardOperator @operator)
+    {
+        var end = 0;
+        while (end < segment.Length && GeneralRangeParser.IsPossibleOperatorChar(segment[end], SemVersionRangeOptions.Strict)) end++;
+        var opSegment = segment.Subsegment(0, end);
+        segment = segment.Subsegment(end);
+
+        if (opSegment.Length == 0)
+        {
+            @operator = StandardOperator.None;
+            return null;
+        }
+
+        // Assign invalid once, so it doesn't have to be done any time parse fails
+        @operator = 0;
+        if (opSegment.Length > 2
+            || (opSegment.Length == 2 && opSegment[1] != '='))
+            return ex ?? RangeError.InvalidOperator(opSegment);
+
+        var firstChar = opSegment[0];
+        var isOrEqual = opSegment.Length == 2; // Already checked for second char != '='
+        switch (firstChar)
+        {
+            case '=' when !isOrEqual:
+                @operator = StandardOperator.Equals;
+                return null;
+            case '<' when isOrEqual:
+                @operator = StandardOperator.LessThanOrEqual;
+                return null;
+            case '<':
+                @operator = StandardOperator.LessThan;
+                return null;
+            case '>' when isOrEqual:
+                @operator = StandardOperator.GreaterThanOrEqual;
+                return null;
+            case '>':
+                @operator = StandardOperator.GreaterThan;
+                return null;
+            case '~' when !isOrEqual:
+                @operator = StandardOperator.Tilde;
+                return null;
+            case '^' when !isOrEqual:
+                @operator = StandardOperator.Caret;
+                return null;
+            default:
+                return ex ?? RangeError.InvalidOperator(opSegment);
+        }
+    }
+
+    private static readonly SemVersionParsingOptions ParsingOptions
+        = new(true, true, false, c => c == '*');
+}

--- a/src/Vendoring/SemVer/Parsing/WildcardVersion.cs
+++ b/src/Vendoring/SemVer/Parsing/WildcardVersion.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Semver.Parsing;
+
+[Flags]
+internal enum WildcardVersion : byte
+{
+    None = 0,
+    MajorWildcard = 1 << 3,
+    MinorWildcard = 1 << 2,
+    PatchWildcard = 1 << 1,
+    PrereleaseWildcard = 1 << 0,
+
+    MinorPatchWildcard = MinorWildcard | PatchWildcard,
+    MajorMinorPatchWildcard = MajorWildcard | MinorPatchWildcard,
+}

--- a/src/Vendoring/SemVer/Parsing/WildcardVersionExtensions.cs
+++ b/src/Vendoring/SemVer/Parsing/WildcardVersionExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace Semver.Parsing;
+
+internal static class WildcardVersionExtensions
+{
+    /// <summary>
+    /// The <see cref="Enum.HasFlag"/> method is surprisingly slow. This provides
+    /// a fast alternative for the <see cref="WildcardVersion"/> enum.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool HasOption(this WildcardVersion wildcards, WildcardVersion flag)
+        => (wildcards & flag) == flag;
+
+    /// <summary>
+    /// Remove a flag from a <see cref="WildcardVersion"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void RemoveOption(this ref WildcardVersion wildcards, WildcardVersion flag)
+        => wildcards &= ~flag;
+}

--- a/src/Vendoring/SemVer/PrereleaseIdentifier.cs
+++ b/src/Vendoring/SemVer/PrereleaseIdentifier.cs
@@ -1,0 +1,332 @@
+using System;
+using System.Globalization;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Semver.Utility;
+
+namespace Semver;
+
+/// <summary>
+/// An individual prerelease identifier for a semantic version.
+/// </summary>
+/// <remarks>
+/// <para>The prerelease portion of a semantic version is composed of dot ('<c>.</c>') separated identifiers.
+/// A prerelease identifier is either an alphanumeric or numeric identifier. A valid numeric
+/// identifier is composed of ASCII digits (<c>[0-9]</c>) without leading zeros. A valid
+/// alphanumeric identifier is a non-empty string of ASCII alphanumeric and hyphen characters
+/// (<c>[0-9A-Za-z-]</c>) with at least one non-digit character. Prerelease identifiers are
+/// compared first by whether they are numeric or alphanumeric. Numeric identifiers have lower
+/// precedence than alphanumeric identifiers. Numeric identifiers are compared to each other
+/// numerically. Alphanumeric identifiers are compared to each other lexically in ASCII sort
+/// order.</para>
+///
+/// <para>Because <see cref="PrereleaseIdentifier"/> is a struct, the default value is a
+/// <see cref="PrereleaseIdentifier"/> with a <see langword="null"/> value. However, the
+/// <see cref="Semver"/> namespace types do not accept and will not return such a
+/// <see cref="PrereleaseIdentifier"/>.</para>
+/// </remarks>
+[StructLayout(LayoutKind.Auto)]
+public readonly struct PrereleaseIdentifier : IEquatable<PrereleaseIdentifier>, IComparable<PrereleaseIdentifier>, IComparable
+{
+    internal static readonly PrereleaseIdentifier Zero = CreateUnsafe("0", BigInteger.Zero);
+    internal static readonly PrereleaseIdentifier Hyphen = CreateUnsafe("-", null);
+
+    /// <summary>
+    /// The string value of the prerelease identifier even if it is a numeric identifier.
+    /// </summary>
+    /// <value>The string value of this prerelease identifier even if it is a numeric identifier
+    /// or <see langword="null"/> if this is a default <see cref="PrereleaseIdentifier"/>.</value>
+    /// <remarks>Invalid numeric prerelease identifiers with leading zeros will have a string
+    /// value including the leading zeros. This can be used to distinguish invalid numeric
+    /// identifiers with different numbers of leading zeros.</remarks>
+    public string Value { get; }
+
+    /// <summary>
+    /// The numeric value of the prerelease identifier if it is a numeric identifier, otherwise
+    /// <see langword="null"/>.
+    /// </summary>
+    /// <value>The numeric value of the prerelease identifier if it is a numeric identifier,
+    /// otherwise <see langword="null"/>.</value>
+    /// <remarks>The numeric value of a prerelease identifier will never be negative.</remarks>
+    public BigInteger? NumericValue { get; }
+
+    /// <summary>
+    /// Construct a <see cref="PrereleaseIdentifier"/> without checking that any of the invariants
+    /// hold. Used by the parser for performance.
+    /// </summary>
+    /// <remarks>This is a create method rather than a constructor to clearly indicate uses
+    /// of it. The other constructors have not been hidden behind create methods because only
+    /// constructors are visible to the package users. So they see a class consistently
+    /// using constructors without any create methods.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static PrereleaseIdentifier CreateUnsafe(string value, BigInteger? numericValue)
+    {
+        DebugChecks.IsNotNull(value, nameof(value));
+#if DEBUG
+        PrereleaseIdentifier expected;
+        try
+        {
+            // Use the standard constructor as a way of validating the input
+            expected = new PrereleaseIdentifier(value);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new ArgumentException("DEBUG: " + ex.Message, ex.ParamName, ex);
+        }
+        catch (Exception ex)
+        {
+            throw new Exception("DEBUG: " + ex.Message, ex);
+        }
+        if (expected.NumericValue != numericValue)
+            throw new ArgumentException($"DEBUG: Numeric value {numericValue} doesn't match string value.", nameof(numericValue));
+#endif
+        return new PrereleaseIdentifier(value, numericValue);
+    }
+
+    /// <summary>
+    /// Private constructor used by <see cref="CreateUnsafe"/>.
+    /// </summary>
+    private PrereleaseIdentifier(string value, BigInteger? numericValue)
+    {
+        Value = value;
+        NumericValue = numericValue;
+    }
+
+    /// <summary>
+    /// Constructs a valid <see cref="PrereleaseIdentifier"/>.
+    /// </summary>
+    /// <param name="value">The string value of this prerelease identifier.</param>
+    /// <param name="allowLeadingZeros">Whether to allow leading zeros in the <paramref name="value"/>
+    /// parameter. If <see langword="true"/>, leading zeros will be allowed on numeric identifiers
+    /// but will be removed.</param>
+    /// <exception cref="ArgumentNullException">The <paramref name="value"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">The <paramref name="value"/> is empty or contains invalid characters
+    /// (i.e. characters that are not ASCII alphanumerics or hyphens) or has leading zeros for
+    /// a numeric identifier when <paramref name="allowLeadingZeros"/> is <see langword="false"/>.</exception>
+    /// <remarks>Because a valid numeric identifier does not have leading zeros, this constructor
+    /// will never create a <see cref="PrereleaseIdentifier"/> with leading zeros even if
+    /// <paramref name="allowLeadingZeros"/> is <see langword="true"/>. Any leading zeros will
+    /// be removed.</remarks>
+    public PrereleaseIdentifier(string value, bool allowLeadingZeros = false)
+        : this(value, allowLeadingZeros, nameof(value))
+    {
+    }
+
+    /// <summary>
+    /// Constructs a valid <see cref="PrereleaseIdentifier"/>.
+    /// </summary>
+    /// <remarks>
+    /// Internal constructor allows changing the parameter name to enable methods using this
+    /// as part of their prerelease identifier validation to match the parameter name to their
+    /// parameter name.
+    /// </remarks>
+    internal PrereleaseIdentifier(string value, bool allowLeadingZeros, string paramName)
+    {
+        if (value is null)
+            throw new ArgumentNullException(paramName);
+        if (value.Length == 0)
+            throw new ArgumentException("Prerelease identifier cannot be empty.", paramName);
+        if (value.IsDigits())
+        {
+            if (value.Length > 1 && value[0] == '0')
+            {
+                if (allowLeadingZeros)
+                    value = value.TrimLeadingZeros();
+                else
+                    throw new ArgumentException($"Leading zeros are not allowed on numeric prerelease identifiers '{value}'.", paramName);
+            }
+
+            NumericValue = BigInteger.Parse(value, NumberStyles.None, CultureInfo.InvariantCulture);
+        }
+        else
+        {
+            if (!value.IsAlphanumericOrHyphens())
+                throw new ArgumentException($"A prerelease identifier can contain only ASCII alphanumeric characters and hyphens '{value}'.", paramName);
+            NumericValue = null;
+        }
+
+        Value = value;
+    }
+
+    /// <summary>
+    /// Construct a valid numeric <see cref="PrereleaseIdentifier"/> from an integer value.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">The <paramref name="value"/> is negative.</exception>
+    /// <param name="value">The non-negative value of this identifier.</param>
+    public PrereleaseIdentifier(BigInteger value)
+    {
+        if (value < 0)
+            throw new ArgumentOutOfRangeException(nameof(value), $"Numeric prerelease identifiers can't be negative: {value}.");
+        Value = value.ToString(CultureInfo.InvariantCulture);
+        NumericValue = value;
+    }
+
+    #region Equality
+    /// <summary>
+    /// Determines whether two identifiers are equal.
+    /// </summary>
+    /// <returns><see langword="true"/> if <paramref name="value"/> is equal to this identifier;
+    /// otherwise <see langword="false"/>.</returns>
+    /// <remarks>Numeric identifiers with leading zeros are considered equal (e.g. '<c>15</c>'
+    /// is equal to '<c>015</c>').</remarks>
+    public bool Equals(PrereleaseIdentifier value)
+    {
+        if (NumericValue is BigInteger numericValue) return numericValue == value.NumericValue;
+        return Value == value.Value;
+    }
+
+    /// <summary>Determines whether the given object is equal to this identifier.</summary>
+    /// <returns><see langword="true"/> if <paramref name="value"/> is equal to this identifier;
+    /// otherwise <see langword="false"/>.</returns>
+    /// <remarks>Numeric identifiers with leading zeros are considered equal (e.g. '<c>15</c>'
+    /// is equal to '<c>015</c>').</remarks>
+    public override bool Equals(object? value)
+        => value is PrereleaseIdentifier other && Equals(other);
+
+    /// <summary>Gets a hash code for this identifier.</summary>
+    /// <returns>A hash code for this identifier.</returns>
+    /// <remarks>Numeric identifiers with leading zeros are have the same hash code (e.g.
+    /// '<c>15</c>' has the same hash code as '<c>015</c>').</remarks>
+    public override int GetHashCode()
+    {
+        if (NumericValue is BigInteger numericValue) return HashCode.Combine(numericValue);
+        return HashCode.Combine(Value);
+    }
+
+    /// <summary>
+    /// Determines whether two identifiers are equal.
+    /// </summary>
+    /// <returns><see langword="true"/> if the value of <paramref name="left"/> is the same as
+    /// the value of <paramref name="right"/>; otherwise <see langword="false"/>.</returns>
+    /// <remarks>Numeric identifiers with leading zeros are considered equal (e.g. '<c>15</c>'
+    /// is equal to '<c>015</c>').</remarks>
+    public static bool operator ==(PrereleaseIdentifier left, PrereleaseIdentifier right)
+        => left.Equals(right);
+
+    /// <summary>
+    /// Determines whether two identifiers are <em>not</em> equal.
+    /// </summary>
+    /// <returns><see langword="true"/> if the value of <paramref name="left"/> is different
+    /// from the value of <paramref name="right"/>; otherwise <see langword="false"/>.</returns>
+    /// <remarks>Numeric identifiers with leading zeros are considered equal (e.g. '<c>15</c>'
+    /// is equal to '<c>015</c>').</remarks>
+    public static bool operator !=(PrereleaseIdentifier left, PrereleaseIdentifier right)
+        => !left.Equals(right);
+    #endregion
+
+    #region Comparison
+    /// <summary>
+    /// Compares two identifiers and indicates whether this instance precedes, follows, or is
+    /// equal to the other in precedence order.
+    /// </summary>
+    /// <returns>
+    /// An integer that indicates whether this instance precedes, follows, or is equal to
+    /// <paramref name="value"/> in precedence order.
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>Value</term>
+    ///         <description>Condition</description>
+    ///     </listheader>
+    ///     <item>
+    ///          <term>-1</term>
+    ///          <description>This instance precedes <paramref name="value"/>.</description>
+    ///     </item>
+    ///     <item>
+    ///          <term>0</term>
+    ///          <description>This instance is equal to <paramref name="value"/>.</description>
+    ///     </item>
+    ///     <item>
+    ///          <term>1</term>
+    ///          <description>This instance follows <paramref name="value"/>.</description>
+    ///     </item>
+    /// </list>
+    /// </returns>
+    /// <remarks>Numeric identifiers have lower precedence than alphanumeric identifiers.
+    /// Numeric identifiers are compared numerically. Numeric identifiers with leading zeros are
+    /// considered equal (e.g. '<c>15</c>' is equal to '<c>015</c>'). Alphanumeric identifiers are
+    /// compared lexically in ASCII sort order. Invalid alphanumeric identifiers are
+    /// compared via an ordinal string comparison.</remarks>
+    public int CompareTo(PrereleaseIdentifier value)
+    {
+        // Handle the fact that numeric identifiers are always less than alphanumeric
+        // and numeric identifiers are compared equal even with leading zeros.
+        if (NumericValue is BigInteger numericValue)
+        {
+            if (value.NumericValue is BigInteger otherNumericValue)
+                return numericValue.CompareTo(otherNumericValue);
+
+            return -1;
+        }
+
+        if (value.NumericValue is not null)
+            return 1;
+
+        return IdentifierString.Compare(Value, value.Value);
+    }
+
+    /// <summary>
+    /// Compares this identifier to an <see cref="Object"/> and indicates whether this instance
+    /// precedes, follows, or is equal to the object in precedence order.
+    /// </summary>
+    /// <returns>
+    /// An integer that indicates whether this instance precedes, follows, or is equal to
+    /// <paramref name="value"/> in precedence order.
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>Value</term>
+    ///         <description>Condition</description>
+    ///     </listheader>
+    ///     <item>
+    ///          <term>-1</term>
+    ///          <description>This instance precedes <paramref name="value"/>.</description>
+    ///     </item>
+    ///     <item>
+    ///          <term>0</term>
+    ///          <description>This instance is equal to <paramref name="value"/>.</description>
+    ///     </item>
+    ///     <item>
+    ///          <term>1</term>
+    ///          <description>This instance follows <paramref name="value"/> or <paramref name="value"/>
+    ///                         is <see langword="null"/>.</description>
+    ///     </item>
+    /// </list>
+    /// </returns>
+    /// <exception cref="ArgumentException"><paramref name="value"/> is not a <see cref="PrereleaseIdentifier"/>.</exception>
+    /// <remarks>Numeric identifiers have lower precedence than alphanumeric identifiers.
+    /// Numeric identifiers are compared numerically. Numeric identifiers with leading zeros are
+    /// considered equal (e.g. '<c>15</c>' is equal to '<c>015</c>'). Alphanumeric identifiers are
+    /// compared lexically in ASCII sort order. Invalid alphanumeric identifiers are
+    /// compared via an ordinal string comparison.</remarks>
+    public int CompareTo(object? value)
+    {
+        if (value is null) return 1;
+        return value is PrereleaseIdentifier other
+            ? CompareTo(other)
+            : throw new ArgumentException($"Object must be of type {nameof(PrereleaseIdentifier)}.", nameof(value));
+    }
+    #endregion
+
+    /// <summary>
+    /// Converts this identifier into an equivalent string value.
+    /// </summary>
+    /// <returns>The string value of this identifier or <see langword="null"/> if this is
+    /// a default <see cref="PrereleaseIdentifier"/></returns>
+    public static implicit operator string(PrereleaseIdentifier prereleaseIdentifier)
+        => prereleaseIdentifier.Value;
+
+    /// <summary>
+    /// Converts this identifier into an equivalent string value.
+    /// </summary>
+    /// <returns>The string value of this identifier or <see langword="null"/> if this is
+    /// a default <see cref="PrereleaseIdentifier"/></returns>
+    public override string ToString() => Value;
+
+    internal PrereleaseIdentifier NextIdentifier()
+    {
+        if (NumericValue is BigInteger numericValue)
+            return new PrereleaseIdentifier(numericValue + BigInteger.One);
+
+        return new PrereleaseIdentifier(Value + "-");
+    }
+}

--- a/src/Vendoring/SemVer/Ranges/LeftBoundedRange.cs
+++ b/src/Vendoring/SemVer/Ranges/LeftBoundedRange.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using Semver.Comparers;
+using Semver.Utility;
+
+namespace Semver.Ranges;
+
+/// <summary>
+/// A range of versions that is bounded only on the left. That is a range defined by some version
+/// <c>x</c> such that <c>x &lt; v</c> or <c>x &lt;= v</c> depending on whether it is inclusive.
+/// A left-bounded range forms the lower limit for a version range.
+/// </summary>
+/// <remarks>An "unbounded" left-bounded range is represented by a lower bound of
+/// <see langword="null"/> since <see langword="null"/> compares as less than all versions.
+/// However, it does not allow such ranges to be inclusive because a range cannot contain null.
+/// The <see cref="SemVersion.Min"/> (i.e. <c>0.0.0-0</c>) cannot be used instead
+/// because it would be inclusive of prerelease.</remarks>
+[StructLayout(LayoutKind.Auto)]
+internal readonly struct LeftBoundedRange : IEquatable<LeftBoundedRange>
+{
+    public static readonly LeftBoundedRange Unbounded = new LeftBoundedRange(null, false);
+
+    public LeftBoundedRange(SemVersion? version, bool inclusive)
+    {
+#if DEBUG
+        // dotcover disable
+        if (version is null && inclusive)
+            throw new ArgumentException("DEBUG: Cannot be inclusive of start without start value.", nameof(inclusive));
+        // dotcover enable
+#endif
+        DebugChecks.NoMetadata(version, nameof(version));
+
+        Version = version;
+        Inclusive = inclusive;
+    }
+
+    public SemVersion? Version { get; }
+
+    [MemberNotNullWhen(true, "Version")]
+    public bool Inclusive { get; }
+
+    public bool IncludesPrerelease => Version?.IsPrerelease == true;
+
+    public bool Contains(SemVersion version)
+    {
+        DebugChecks.IsNotNull(version, nameof(version));
+        var comparison = SemVersion.ComparePrecedence(Version, version);
+        return Inclusive ? comparison <= 0 : comparison < 0;
+    }
+
+    public LeftBoundedRange Min(LeftBoundedRange other)
+        => CompareTo(other) <= 0 ? this : other;
+
+    public LeftBoundedRange Max(LeftBoundedRange other)
+        => CompareTo(other) >= 0 ? this : other;
+
+    #region Equality
+    public bool Equals(LeftBoundedRange other)
+        => Equals(Version, other.Version) && Inclusive == other.Inclusive;
+
+    public override bool Equals(object? obj)
+        => obj is LeftBoundedRange other && Equals(other);
+
+    public override int GetHashCode()
+        => HashCode.Combine(Version, Inclusive);
+
+    public static bool operator ==(LeftBoundedRange left, LeftBoundedRange right)
+        => left.Equals(right);
+
+    public static bool operator !=(LeftBoundedRange left, LeftBoundedRange right)
+        => !left.Equals(right);
+    #endregion
+
+    public int CompareTo(RightBoundedRange other)
+    {
+        if(other.Version is null) return -1;
+        var comparison = PrecedenceComparer.Instance.Compare(Version!, other.Version);
+        if (comparison != 0) return comparison;
+        return Inclusive && other.Inclusive ? 0 : 1;
+    }
+
+    public int CompareTo(LeftBoundedRange other)
+    {
+        var comparison = PrecedenceComparer.Instance.Compare(Version!, other.Version!);
+        if (comparison != 0) return comparison;
+        return -Inclusive.CompareTo(other.Inclusive);
+    }
+
+    public override string ToString() => (Inclusive ? ">=" : ">") + (Version?.ToString() ?? "null");
+}

--- a/src/Vendoring/SemVer/Ranges/RightBoundedRange.cs
+++ b/src/Vendoring/SemVer/Ranges/RightBoundedRange.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using Semver.Comparers;
+using Semver.Utility;
+
+namespace Semver.Ranges;
+
+/// <summary>
+/// A range of versions that is bounded only on the right. That is a range defined by some
+/// version <c>x</c> such that <c>v &lt; x</c> or <c>v &lt;= x</c> depending on whether it is
+/// inclusive. A right-bounded range forms the upper limit for a version range.
+/// </summary>
+/// <remarks>An "unbounded" right-bounded range is represented by an inclusive upper bound of
+/// <see langword="null"/> since there is no maximum <see cref="SemVersion"/>. This requires
+/// special checking for comparison.</remarks>
+[StructLayout(LayoutKind.Auto)]
+internal readonly struct RightBoundedRange : IEquatable<RightBoundedRange>
+{
+    public static readonly RightBoundedRange Unbounded
+        = new RightBoundedRange(null, false);
+
+    public RightBoundedRange(SemVersion? version, bool inclusive)
+    {
+#if DEBUG
+        // dotcover disable
+        if (version is null && inclusive)
+            throw new ArgumentException("DEBUG: Cannot be inclusive of end without end value.",
+                nameof(inclusive));
+        // dotcover enable
+#endif
+        DebugChecks.NoMetadata(version, nameof(version));
+
+        Version = version;
+        Inclusive = inclusive;
+    }
+
+    public SemVersion? Version { get; }
+
+    [MemberNotNullWhen(true, "Version")]
+    public bool Inclusive { get; }
+
+    /// <summary>
+    /// Whether this bound actually includes any prerelease versions.
+    /// </summary>
+    /// <remarks>
+    /// A non-inclusive bound of X.Y.Z-0 doesn't actually include any prerelease versions.
+    /// </remarks>
+    public bool IncludesPrerelease
+        => Version?.IsPrerelease == true && !(!Inclusive && Version.PrereleaseIsZero);
+
+    public bool Contains(SemVersion version)
+    {
+        DebugChecks.IsNotNull(version, nameof(version));
+        if (Version is null) return true;
+        var comparison = SemVersion.ComparePrecedence(version, Version);
+        return Inclusive ? comparison <= 0 : comparison < 0;
+    }
+
+    public RightBoundedRange Min(RightBoundedRange other)
+        => CompareTo(other) <= 0 ? this : other;
+
+    public RightBoundedRange Max(RightBoundedRange other)
+        => CompareTo(other) >= 0 ? this : other;
+
+    #region Equality
+    public bool Equals(RightBoundedRange other)
+        => Equals(Version, other.Version) && Inclusive == other.Inclusive;
+
+    public override bool Equals(object? obj)
+        => obj is RightBoundedRange other && Equals(other);
+
+    public override int GetHashCode()
+        => HashCode.Combine(Version, Inclusive);
+
+    public static bool operator ==(RightBoundedRange left, RightBoundedRange right)
+        => left.Equals(right);
+
+    public static bool operator !=(RightBoundedRange left, RightBoundedRange right)
+        => !left.Equals(right);
+    #endregion
+
+    public int CompareTo(RightBoundedRange other)
+    {
+        switch (Version, other.Version)
+        {
+            case (null,null): return 0;
+            case (null, _): return 1;
+            case (_, null): return -1;
+            default:
+                var comparison = PrecedenceComparer.Instance.Compare(Version!, other.Version!);
+                if (comparison != 0) return comparison;
+                return Inclusive.CompareTo(other.Inclusive);
+        }
+    }
+
+    public override string ToString() => (Inclusive ? "<=" : "<") + (Version?.ToString() ?? "null");
+}

--- a/src/Vendoring/SemVer/SemVersion.cs
+++ b/src/Vendoring/SemVer/SemVersion.cs
@@ -1,0 +1,1416 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.Serialization;
+using System.Security.Permissions;
+using System.Text;
+using Semver.Comparers;
+using Semver.Parsing;
+using Semver.Utility;
+
+namespace Semver;
+
+/// <summary>
+/// A semantic version number. Conforms with v2.0.0 of semantic versioning
+/// (<a href="https://semver.org">semver.org</a>).
+/// </summary>
+[Serializable]
+public sealed class SemVersion : IEquatable<SemVersion>, ISerializable
+{
+    internal static readonly SemVersion Min = new SemVersion(BigInteger.Zero, BigInteger.Zero, BigInteger.Zero, new[] { PrereleaseIdentifier.Zero });
+    internal static readonly SemVersion MinRelease = new SemVersion(BigInteger.Zero, BigInteger.Zero, BigInteger.Zero);
+
+    internal const string InvalidSemVersionStylesMessage = "An invalid SemVersionStyles value was used.";
+    private const string InvalidMajorVersionMessage = "Major version must be greater than or equal to zero.";
+    private const string InvalidMinorVersionMessage = "Minor version must be greater than or equal to zero.";
+    private const string InvalidPatchVersionMessage = "Patch version must be greater than or equal to zero.";
+    private const string PrereleaseIdentifierIsDefaultMessage = "Prerelease identifier cannot be default/null.";
+    private const string MetadataIdentifierIsDefaultMessage = "Metadata identifier cannot be default/null.";
+    private const string InvalidMaxLengthMessage = "Must not be negative.";
+    private const string MajorMinorOrPatchVersionToLargeToConvertMessage =
+        "Version with {0} version of {1} can't be converted to System.Version because it is greater than Int32.MaxValue.";
+    internal const int MaxVersionLength = 1024;
+
+    /// <summary>
+    /// Deserialize a <see cref="SemVersion"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The <paramref name="info"/> parameter is null.</exception>
+    private SemVersion(SerializationInfo info, StreamingContext context)
+    {
+        if (info == null) throw new ArgumentNullException(nameof(info));
+        var semVersion = Parse(info.GetString("SemVersion")!, SemVersionStyles.Strict);
+        Major = semVersion.Major;
+        Minor = semVersion.Minor;
+        Patch = semVersion.Patch;
+        Prerelease = semVersion.Prerelease;
+        PrereleaseIdentifiers = semVersion.PrereleaseIdentifiers;
+        Metadata = semVersion.Metadata;
+        MetadataIdentifiers = semVersion.MetadataIdentifiers;
+    }
+
+    /// <summary>
+    /// Populates a <see cref="SerializationInfo"/> with the data needed to serialize the target object.
+    /// </summary>
+    /// <param name="info">The <see cref="SerializationInfo"/> to populate with data.</param>
+    /// <param name="context">The destination (see <see cref="SerializationInfo"/>) for this serialization.</param>
+#if !NET5_0_OR_GREATER
+    [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
+#endif
+    public void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        if (info == null) throw new ArgumentNullException(nameof(info));
+        info.AddValue("SemVersion", ToString());
+    }
+
+    /// <summary>
+    /// Constructs a new instance of the <see cref="SemVersion" /> class.
+    /// </summary>
+    /// <param name="major">The major version number.</param>
+    /// <exception cref="ArgumentOutOfRangeException">The <paramref name="major"/> version
+    /// number is negative.</exception>
+    // Constructor needed to resolve ambiguity between other overloads with default parameters.
+    public SemVersion(BigInteger major)
+    {
+        if (major < 0) throw new ArgumentOutOfRangeException(nameof(major), InvalidMajorVersionMessage);
+        Major = major;
+        Minor = BigInteger.Zero;
+        Patch = BigInteger.Zero;
+        Prerelease = "";
+        PrereleaseIdentifiers = ReadOnlyList<PrereleaseIdentifier>.Empty;
+        Metadata = "";
+        MetadataIdentifiers = ReadOnlyList<MetadataIdentifier>.Empty;
+    }
+
+    /// <summary>
+    /// Constructs a new instance of the <see cref="SemVersion" /> class.
+    /// </summary>
+    /// <param name="major">The major version number.</param>
+    /// <param name="minor">The minor version number.</param>
+    /// <exception cref="ArgumentOutOfRangeException">The <paramref name="major"/> or
+    /// <paramref name="minor"/> version number is negative.</exception>
+    // Constructor needed to resolve ambiguity between other overloads with default parameters.
+    public SemVersion(BigInteger major, BigInteger minor)
+    {
+        if (major < 0) throw new ArgumentOutOfRangeException(nameof(major), InvalidMajorVersionMessage);
+        if (minor < 0) throw new ArgumentOutOfRangeException(nameof(minor), InvalidMinorVersionMessage);
+        Major = major;
+        Minor = minor;
+        Patch = BigInteger.Zero;
+        Prerelease = "";
+        PrereleaseIdentifiers = ReadOnlyList<PrereleaseIdentifier>.Empty;
+        Metadata = "";
+        MetadataIdentifiers = ReadOnlyList<MetadataIdentifier>.Empty;
+    }
+
+    /// <summary>
+    /// Constructs a new instance of the <see cref="SemVersion" /> class.
+    /// </summary>
+    /// <param name="major">The major version number.</param>
+    /// <param name="minor">The minor version number.</param>
+    /// <param name="patch">The patch version number.</param>
+    /// <exception cref="ArgumentOutOfRangeException">The <paramref name="major"/>,
+    /// <paramref name="minor"/>, or <paramref name="patch"/> version number is negative.</exception>
+    // Constructor needed to resolve ambiguity between other overloads with default parameters.
+    public SemVersion(BigInteger major, BigInteger minor, BigInteger patch)
+    {
+        if (major < 0) throw new ArgumentOutOfRangeException(nameof(major), InvalidMajorVersionMessage);
+        if (minor < 0) throw new ArgumentOutOfRangeException(nameof(minor), InvalidMinorVersionMessage);
+        if (patch < 0) throw new ArgumentOutOfRangeException(nameof(patch), InvalidPatchVersionMessage);
+        Major = major;
+        Minor = minor;
+        Patch = patch;
+        Prerelease = "";
+        PrereleaseIdentifiers = ReadOnlyList<PrereleaseIdentifier>.Empty;
+        Metadata = "";
+        MetadataIdentifiers = ReadOnlyList<MetadataIdentifier>.Empty;
+    }
+
+    /// <summary>
+    /// Constructs a new instance of the <see cref="SemVersion" /> class.
+    /// </summary>
+    /// <param name="major">The major version number.</param>
+    /// <param name="minor">The minor version number.</param>
+    /// <param name="patch">The patch version number.</param>
+    /// <param name="prerelease">The prerelease identifiers.</param>
+    /// <param name="metadata">The build metadata identifiers.</param>
+    /// <exception cref="ArgumentOutOfRangeException">The <paramref name="major"/>,
+    /// <paramref name="minor"/>, or <paramref name="patch"/> version number is negative.</exception>
+    /// <exception cref="ArgumentException">A prerelease or metadata identifier has the default value.</exception>
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+    public SemVersion(BigInteger major, BigInteger minor = default, BigInteger patch = default,
+#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
+        IEnumerable<PrereleaseIdentifier>? prerelease = null,
+        IEnumerable<MetadataIdentifier>? metadata = null)
+    {
+        if (major < 0) throw new ArgumentOutOfRangeException(nameof(major), InvalidMajorVersionMessage);
+        if (minor < 0) throw new ArgumentOutOfRangeException(nameof(minor), InvalidMinorVersionMessage);
+        if (patch < 0) throw new ArgumentOutOfRangeException(nameof(patch), InvalidPatchVersionMessage);
+        IReadOnlyList<PrereleaseIdentifier>? prereleaseIdentifiers;
+        if (prerelease is null)
+            prereleaseIdentifiers = null;
+        else
+        {
+            prereleaseIdentifiers = prerelease.ToReadOnlyList();
+            if (prereleaseIdentifiers.Any(i => i == default))
+                throw new ArgumentException(PrereleaseIdentifierIsDefaultMessage, nameof(prerelease));
+        }
+
+        IReadOnlyList<MetadataIdentifier>? metadataIdentifiers;
+        if (metadata is null)
+            metadataIdentifiers = null;
+        else
+        {
+            metadataIdentifiers = metadata.ToReadOnlyList();
+            if (metadataIdentifiers.Any(i => i == default))
+                throw new ArgumentException(MetadataIdentifierIsDefaultMessage, nameof(metadata));
+        }
+
+        Major = major;
+        Minor = minor;
+        Patch = patch;
+
+        if (prereleaseIdentifiers is null || prereleaseIdentifiers.Count == 0)
+        {
+            Prerelease = "";
+            PrereleaseIdentifiers = ReadOnlyList<PrereleaseIdentifier>.Empty;
+        }
+        else
+        {
+            Prerelease = string.Join(".", prereleaseIdentifiers);
+            PrereleaseIdentifiers = prereleaseIdentifiers;
+        }
+
+        if (metadataIdentifiers is null || metadataIdentifiers.Count == 0)
+        {
+            Metadata = "";
+            MetadataIdentifiers = ReadOnlyList<MetadataIdentifier>.Empty;
+        }
+        else
+        {
+            Metadata = string.Join(".", metadataIdentifiers);
+            MetadataIdentifiers = metadataIdentifiers;
+        }
+    }
+
+    /// <summary>
+    /// Constructs a new instance of the <see cref="SemVersion" /> class.
+    /// </summary>
+    /// <param name="major">The major version number.</param>
+    /// <param name="minor">The minor version number.</param>
+    /// <param name="patch">The patch version number.</param>
+    /// <param name="prerelease">The prerelease identifiers.</param>
+    /// <param name="metadata">The build metadata identifiers.</param>
+    /// <exception cref="ArgumentOutOfRangeException">The <paramref name="major"/>,
+    /// <paramref name="minor"/>, or <paramref name="patch"/> version number is negative.</exception>
+    /// <exception cref="ArgumentNullException">One of the prerelease or metadata identifiers is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">A prerelease identifier is empty or contains invalid
+    /// characters (i.e. characters that are not ASCII alphanumerics or hyphens) or has leading
+    /// zeros for a numeric identifier. Or, a metadata identifier is empty or contains invalid
+    /// characters (i.e. characters that are not ASCII alphanumerics or hyphens).</exception>
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+    public SemVersion(BigInteger major, BigInteger minor = default, BigInteger patch = default,
+#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
+        IEnumerable<string>? prerelease = null,
+        IEnumerable<string>? metadata = null)
+    {
+        if (major < 0) throw new ArgumentOutOfRangeException(nameof(major), InvalidMajorVersionMessage);
+        if (minor < 0) throw new ArgumentOutOfRangeException(nameof(minor), InvalidMinorVersionMessage);
+        if (patch < 0) throw new ArgumentOutOfRangeException(nameof(patch), InvalidPatchVersionMessage);
+        var prereleaseIdentifiers = prerelease?
+                                    .Select(i => new PrereleaseIdentifier(i, allowLeadingZeros: false, nameof(prerelease)))
+                                    .ToReadOnlyList();
+
+        var metadataIdentifiers = metadata?
+                                  .Select(i => new MetadataIdentifier(i, nameof(metadata)))
+                                  .ToReadOnlyList();
+
+        Major = major;
+        Minor = minor;
+        Patch = patch;
+
+        if (prereleaseIdentifiers is null || prereleaseIdentifiers.Count == 0)
+        {
+            Prerelease = "";
+            PrereleaseIdentifiers = ReadOnlyList<PrereleaseIdentifier>.Empty;
+        }
+        else
+        {
+            Prerelease = string.Join(".", prereleaseIdentifiers);
+            PrereleaseIdentifiers = prereleaseIdentifiers;
+        }
+
+        if (metadataIdentifiers is null || metadataIdentifiers.Count == 0)
+        {
+            Metadata = "";
+            MetadataIdentifiers = ReadOnlyList<MetadataIdentifier>.Empty;
+        }
+        else
+        {
+            Metadata = string.Join(".", metadataIdentifiers);
+            MetadataIdentifiers = metadataIdentifiers;
+        }
+    }
+
+    /// <summary>
+    /// Create a new instance of the <see cref="SemVersion" /> class. Parses prerelease
+    /// and metadata identifiers from dot separated strings. If parsing is not needed, use a
+    /// constructor instead.
+    /// </summary>
+    /// <param name="major">The major version number.</param>
+    /// <param name="minor">The minor version number.</param>
+    /// <param name="patch">The patch version number.</param>
+    /// <param name="prerelease">The prerelease portion (e.g. "alpha.5").</param>
+    /// <param name="metadata">The build metadata (e.g. "nightly.232").</param>
+    /// <param name="allowLeadingZeros">Allow leading zeros in numeric prerelease identifiers. Leading
+    /// zeros will be removed.</param>
+    /// <exception cref="ArgumentOutOfRangeException">The <paramref name="major"/>,
+    /// <paramref name="minor"/>, or <paramref name="patch"/> version number is negative.</exception>
+    /// <exception cref="ArgumentException">A prerelease identifier is empty or contains invalid
+    /// characters (i.e. characters that are not ASCII alphanumerics or hyphens) or has leading
+    /// zeros for a numeric identifier when <paramref name="allowLeadingZeros"/> is
+    /// <see langword="false"/>. Or, a metadata identifier is empty or contains invalid
+    /// characters (i.e. characters that are not ASCII alphanumerics or hyphens).</exception>
+    public static SemVersion ParsedFrom(BigInteger major, BigInteger? minor = null, BigInteger? patch = null,
+        string prerelease = "", string metadata = "", bool allowLeadingZeros = false)
+    {
+        var internalMajor = major; //for uniformity
+        var internalMinor = minor ?? BigInteger.Zero;
+        var internalPatch = patch ?? BigInteger.Zero;
+
+        if (internalMajor < 0) throw new ArgumentOutOfRangeException(nameof(major), InvalidMajorVersionMessage);
+        if (internalMinor < 0) throw new ArgumentOutOfRangeException(nameof(minor), InvalidMinorVersionMessage);
+        if (internalPatch < 0) throw new ArgumentOutOfRangeException(nameof(patch), InvalidPatchVersionMessage);
+
+        if (prerelease is null) throw new ArgumentNullException(nameof(prerelease));
+        var prereleaseIdentifiers = prerelease.Length == 0
+            ? ReadOnlyList<PrereleaseIdentifier>.Empty
+            : prerelease.SplitAndMapToReadOnlyList('.',
+                i => new PrereleaseIdentifier(i, allowLeadingZeros, nameof(prerelease)));
+        if (allowLeadingZeros)
+            // Leading zeros may have been removed, need to reconstruct the prerelease string
+            prerelease = string.Join(".", prereleaseIdentifiers);
+
+        if (metadata is null) throw new ArgumentNullException(nameof(metadata));
+        var metadataIdentifiers = metadata.Length == 0
+            ? ReadOnlyList<MetadataIdentifier>.Empty
+            : metadata.SplitAndMapToReadOnlyList('.', i => new MetadataIdentifier(i, nameof(metadata)));
+
+        return new SemVersion(internalMajor, internalMinor, internalPatch,
+            prerelease, prereleaseIdentifiers, metadata, metadataIdentifiers);
+    }
+
+    /// <summary>
+    /// Construct a <see cref="SemVersion"/> from its proper parts.
+    /// </summary>
+    /// <remarks>Parameter validation is not performed. The <paramref name="major"/>,
+    /// <paramref name="minor"/>, and <paramref name="patch"/> version numbers must not be
+    /// negative. The <paramref name="prereleaseIdentifiers"/> and
+    /// <paramref name="metadataIdentifiers"/> must not be <see langword="null"/> or
+    /// contain invalid values and must be immutable. The <paramref name="prerelease"/>
+    /// and <paramref name="metadata"/> must not be null and must be equal to the
+    /// corresponding identifiers.</remarks>
+    internal SemVersion(BigInteger major, BigInteger minor, BigInteger patch,
+        string prerelease, IReadOnlyList<PrereleaseIdentifier> prereleaseIdentifiers,
+        string metadata, IReadOnlyList<MetadataIdentifier> metadataIdentifiers)
+    {
+        DebugChecks.IsValidVersionNumber(major, "Major", nameof(major));
+        DebugChecks.IsValidVersionNumber(minor, "Minor", nameof(minor));
+        DebugChecks.IsValidVersionNumber(patch, "Patch", nameof(patch));
+        DebugChecks.IsNotNull(prerelease, nameof(prerelease));
+        DebugChecks.IsNotNull(prerelease, nameof(prereleaseIdentifiers));
+        DebugChecks.ContainsNoDefaultValues(prereleaseIdentifiers, "Prerelease", nameof(prereleaseIdentifiers));
+        DebugChecks.AreEqualWhenJoinedWithDots(prerelease, nameof(prerelease),
+            prereleaseIdentifiers, nameof(prereleaseIdentifiers));
+        DebugChecks.IsNotNull(metadata, nameof(metadata));
+        DebugChecks.IsNotNull(metadataIdentifiers, nameof(metadataIdentifiers));
+        DebugChecks.ContainsNoDefaultValues(metadataIdentifiers, "Metadata", nameof(metadataIdentifiers));
+        DebugChecks.AreEqualWhenJoinedWithDots(metadata, nameof(metadata),
+            metadataIdentifiers, nameof(metadataIdentifiers));
+
+        Major = major;
+        Minor = minor;
+        Patch = patch;
+        Prerelease = prerelease;
+        PrereleaseIdentifiers = prereleaseIdentifiers;
+        Metadata = metadata;
+        MetadataIdentifiers = metadataIdentifiers;
+    }
+
+    #region System.Version
+    /// <summary>
+    /// Converts a <see cref="Version"/> into the equivalent semantic version.
+    /// </summary>
+    /// <param name="version">The version to be converted to a semantic version.</param>
+    /// <returns>The equivalent semantic version.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="version"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="version"/> has a revision number greater than zero.</exception>
+    /// <remarks>
+    /// <see cref="Version"/> numbers have the form <em>major</em>.<em>minor</em>[.<em>build</em>[.<em>revision</em>]]
+    /// where square brackets ('[' and ']')  indicate optional components. The first three parts
+    /// are converted to the major, minor, and patch version numbers of a semantic version. If the
+    /// build component is not defined (-1), the patch number is assumed to be zero.
+    /// <see cref="Version"/> numbers with a revision greater than zero cannot be converted to
+    /// semantic versions. An <see cref="ArgumentException"/> is thrown when this method is called
+    /// with such a <see cref="Version"/>.
+    /// </remarks>
+    public static SemVersion FromVersion(Version version)
+    {
+        if (version is null) throw new ArgumentNullException(nameof(version));
+        if (version.Revision > 0) throw new ArgumentException("Version with Revision number can't be converted to SemVer.", nameof(version));
+        var patch = version.Build > 0 ? version.Build : 0;
+        return new SemVersion(version.Major, version.Minor, patch);
+    }
+
+    /// <summary>
+    /// Converts this semantic version to a <see cref="Version"/>.
+    /// </summary>
+    /// <returns>The equivalent <see cref="Version"/>.</returns>
+    /// <exception cref="InvalidOperationException">The semantic version is a prerelease version
+    /// or has build metadata or has a major, minor, or patch version number greater than
+    /// <see cref="int.MaxValue"/>.</exception>
+    /// <remarks>
+    /// A semantic version of the form <em>major</em>.<em>minor</em>.<em>patch</em>
+    /// is converted to a <see cref="Version"/> of the form
+    /// <em>major</em>.<em>minor</em>.<em>build</em> where the build number is the
+    /// patch version of the semantic version. Prerelease versions and build metadata
+    /// are not representable in a <see cref="Version"/>. This method throws
+    /// an <see cref="InvalidOperationException"/> if the semantic version is a
+    /// prerelease version or has build metadata.
+    /// </remarks>
+    public Version ToVersion()
+    {
+        if (IsPrerelease) throw new InvalidOperationException("Prerelease version can't be converted to System.Version.");
+        if (Metadata.Length != 0) throw new InvalidOperationException("Version with build metadata can't be converted to System.Version.");
+        if (Major > int.MaxValue)
+            throw new InvalidOperationException(string.Format(MajorMinorOrPatchVersionToLargeToConvertMessage, "major", Major));
+        if (Minor > int.MaxValue)
+            throw new InvalidOperationException(string.Format(MajorMinorOrPatchVersionToLargeToConvertMessage, "minor", Minor));
+        if (Patch > int.MaxValue)
+            throw new InvalidOperationException(string.Format(MajorMinorOrPatchVersionToLargeToConvertMessage, "patch", Patch));
+
+        return new Version((int)Major, (int)Minor, (int)Patch);
+    }
+    #endregion
+
+    /// <summary>
+    /// Converts the string representation of a semantic version to its <see cref="SemVersion"/> equivalent.
+    /// </summary>
+    /// <param name="version">The version string.</param>
+    /// <param name="style">A bitwise combination of enumeration values that indicates the style
+    /// elements that can be present in <paramref name="version"/>. The preferred value to use
+    /// is <see cref="SemVersionStyles.Strict"/>.</param>
+    /// <param name="maxLength">The maximum length of <paramref name="version"/> that should be
+    /// parsed. This prevents attacks using very long version strings.</param>
+    /// <exception cref="ArgumentException"><paramref name="style"/> is not a valid
+    /// <see cref="SemVersionStyles"/> value.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="version"/> is <see langword="null"/>.</exception>
+    /// <exception cref="FormatException">The <paramref name="version"/> is invalid or not in a
+    /// format compliant with <paramref name="style"/>.</exception>
+    public static SemVersion Parse(string version, SemVersionStyles style, int maxLength = MaxVersionLength)
+    {
+        if (!style.IsValid()) throw new ArgumentException(InvalidSemVersionStylesMessage, nameof(style));
+        if (maxLength < 0) throw new ArgumentOutOfRangeException(nameof(maxLength), InvalidMaxLengthMessage);
+        var ex = SemVersionParser.Parse(version, style, null, maxLength, out var semver);
+
+        if (ex is not null)
+            throw ex;
+        DebugChecks.IsNotNull(semver, nameof(semver));
+
+        return semver;
+    }
+
+    public static SemVersion Parse(string version, int maxLength = MaxVersionLength)
+        => Parse(version, SemVersionStyles.Strict, maxLength);
+
+    /// <summary>
+    /// Converts the string representation of a semantic version to its <see cref="SemVersion"/>
+    /// equivalent. The return value indicates whether the conversion succeeded.
+    /// </summary>
+    /// <param name="version">The version string.</param>
+    /// <param name="style">A bitwise combination of enumeration values that indicates the style
+    /// elements that can be present in <paramref name="version"/>. The preferred value to use
+    /// is <see cref="SemVersionStyles.Strict"/>.</param>
+    /// <param name="semver">When this method returns, contains a <see cref="SemVersion"/> instance equivalent
+    /// to the version string passed in, if the version string was valid, or <see langword="null"/> if the
+    /// version string was invalid.</param>
+    /// <param name="maxLength">The maximum length of <paramref name="version"/> that should be
+    /// parsed. This prevents attacks using very long version strings.</param>
+    /// <returns><see langword="false"/> when an invalid version string is passed, otherwise <see langword="true"/>.</returns>
+    /// <exception cref="ArgumentException"><paramref name="style"/> is not a valid
+    /// <see cref="SemVersionStyles"/> value.</exception>
+    public static bool TryParse(string? version, SemVersionStyles style,
+        [NotNullWhen(true)] out SemVersion? semver, int maxLength = MaxVersionLength)
+    {
+        if (!style.IsValid()) throw new ArgumentException(InvalidSemVersionStylesMessage, nameof(style));
+        if (maxLength < 0) throw new ArgumentOutOfRangeException(nameof(maxLength), InvalidMaxLengthMessage);
+        var exception = SemVersionParser.Parse(version, style, VersionParsing.FailedException, maxLength, out semver);
+
+        DebugChecks.IsNotFailedException(exception, nameof(SemVersionParser), nameof(SemVersionParser.Parse));
+
+        return exception is null;
+    }
+
+    public static bool TryParse(string? version, [NotNullWhen(true)] out SemVersion? semver, int maxLength = MaxVersionLength)
+        => TryParse(version, SemVersionStyles.Strict, out semver, maxLength);
+
+    /// <summary>
+    /// Creates a copy of the current instance with multiple changed properties. If changing only
+    /// one property use one of the more specific <c>WithX()</c> methods.
+    /// </summary>
+    /// <param name="major">The value to replace the major version number or <see langword="null"/> to leave it unchanged.</param>
+    /// <param name="minor">The value to replace the minor version number or <see langword="null"/> to leave it unchanged.</param>
+    /// <param name="patch">The value to replace the patch version number or <see langword="null"/> to leave it unchanged.</param>
+    /// <param name="prerelease">The value to replace the prerelease identifiers or <see langword="null"/> to leave it unchanged.</param>
+    /// <param name="metadata">The value to replace the build metadata identifiers or <see langword="null"/> to leave it unchanged.</param>
+    /// <returns>The new version with changed properties.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">The <paramref name="major"/>,
+    /// <paramref name="minor"/>, or <paramref name="patch"/> version number is negative.</exception>
+    /// <exception cref="ArgumentException">A prerelease or metadata identifier has the default value.</exception>
+    /// <remarks>
+    /// The <see cref="With"/> method is intended to be called using named argument syntax, passing only
+    /// those fields to be changed.
+    /// </remarks>
+    /// <example>
+    /// To change the minor and patch versions:
+    /// <code>var modifiedVersion = version.With(minor: 2, patch: 4);</code>
+    /// </example>
+    public SemVersion With(
+        BigInteger? major = null,
+        BigInteger? minor = null,
+        BigInteger? patch = null,
+        IEnumerable<PrereleaseIdentifier>? prerelease = null,
+        IEnumerable<MetadataIdentifier>? metadata = null)
+    {
+        if (major < 0)
+            throw new ArgumentOutOfRangeException(nameof(major), InvalidMajorVersionMessage);
+        if (minor < 0)
+            throw new ArgumentOutOfRangeException(nameof(minor), InvalidMinorVersionMessage);
+        if (patch < 0)
+            throw new ArgumentOutOfRangeException(nameof(patch), InvalidPatchVersionMessage);
+
+        IReadOnlyList<PrereleaseIdentifier>? prereleaseIdentifiers = null;
+        string? prereleaseString = null;
+        if (prerelease != null)
+        {
+            prereleaseIdentifiers = prerelease.ToReadOnlyList();
+            if (prereleaseIdentifiers.Count == 0)
+            {
+                prereleaseIdentifiers = ReadOnlyList<PrereleaseIdentifier>.Empty;
+                prereleaseString = "";
+            }
+            else if (prereleaseIdentifiers.Any(i => i == default))
+                throw new ArgumentException(PrereleaseIdentifierIsDefaultMessage, nameof(prerelease));
+            else
+                prereleaseString = string.Join(".", prereleaseIdentifiers);
+        }
+
+        IReadOnlyList<MetadataIdentifier>? metadataIdentifiers = null;
+        string? metadataString = null;
+        if (metadata != null)
+        {
+            metadataIdentifiers = metadata.ToReadOnlyList();
+            if (metadataIdentifiers.Count == 0)
+            {
+                metadataIdentifiers = ReadOnlyList<MetadataIdentifier>.Empty;
+                metadataString = "";
+            }
+            else if (metadataIdentifiers.Any(i => i == default))
+                throw new ArgumentException(MetadataIdentifierIsDefaultMessage, nameof(metadata));
+            else
+                metadataString = string.Join(".", metadataIdentifiers);
+        }
+
+        return new SemVersion(
+            major ?? Major,
+            minor ?? Minor,
+            patch ?? Patch,
+            prereleaseString ?? Prerelease,
+            prereleaseIdentifiers ?? PrereleaseIdentifiers,
+            metadataString ?? Metadata,
+            metadataIdentifiers ?? MetadataIdentifiers);
+    }
+
+    /// <summary>
+    /// Creates a copy of the current instance with multiple changed properties. Parses prerelease
+    /// and metadata identifiers from dot separated strings. Use <see cref="With"/> instead if
+    /// parsing is not needed. If changing only one property use one of the more specific
+    /// <c>WithX()</c> methods.
+    /// </summary>
+    /// <param name="major">The value to replace the major version number or <see langword="null"/> to leave it unchanged.</param>
+    /// <param name="minor">The value to replace the minor version number or <see langword="null"/> to leave it unchanged.</param>
+    /// <param name="patch">The value to replace the patch version number or <see langword="null"/> to leave it unchanged.</param>
+    /// <param name="prerelease">The value to replace the prerelease identifiers or <see langword="null"/> to leave it unchanged.</param>
+    /// <param name="metadata">The value to replace the build metadata identifiers or <see langword="null"/> to leave it unchanged.</param>
+    /// <param name="allowLeadingZeros">Allow leading zeros in numeric prerelease identifiers. Leading
+    /// zeros will be removed.</param>
+    /// <returns>The new version with changed properties.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">The <paramref name="major"/>,
+    /// <paramref name="minor"/>, or <paramref name="patch"/> version number is negative.</exception>
+    /// <exception cref="ArgumentException">A prerelease identifier is empty or contains invalid
+    /// characters (i.e. characters that are not ASCII alphanumerics or hyphens) or has leading
+    /// zeros for a numeric identifier when <paramref name="allowLeadingZeros"/> is
+    /// <see langword="false"/>. Or, a metadata identifier is empty or contains invalid
+    /// characters (i.e. characters that are not ASCII alphanumerics or hyphens).</exception>
+    /// <remarks>
+    /// The <see cref="WithParsedFrom"/> method is intended to be called using named argument
+    /// syntax, passing only those fields to be changed.
+    /// </remarks>
+    /// <example>
+    /// To change the patch version and prerelease identifiers version:
+    /// <code>var modifiedVersion = version.WithParsedFrom(patch: 4, prerelease: "alpha.5");</code>
+    /// </example>
+    public SemVersion WithParsedFrom(
+        BigInteger? major = null,
+        BigInteger? minor = null,
+        BigInteger? patch = null,
+        string? prerelease = null,
+        string? metadata = null,
+        bool allowLeadingZeros = false)
+    {
+        if (major < 0)
+            throw new ArgumentOutOfRangeException(nameof(major), InvalidMajorVersionMessage);
+        if (minor < 0)
+            throw new ArgumentOutOfRangeException(nameof(minor), InvalidMinorVersionMessage);
+        if (patch < 0)
+            throw new ArgumentOutOfRangeException(nameof(patch), InvalidPatchVersionMessage);
+
+        var prereleaseIdentifiers = prerelease?.SplitAndMapToReadOnlyList('.',
+            i => new PrereleaseIdentifier(i, allowLeadingZeros, nameof(prerelease)));
+        var metadataIdentifiers = metadata?.SplitAndMapToReadOnlyList('.',
+            i => new MetadataIdentifier(i, nameof(metadata)));
+
+        if (allowLeadingZeros && prereleaseIdentifiers != null)
+            // Leading zeros may have been removed, need to reconstruct the prerelease string
+            prerelease = string.Join(".", prereleaseIdentifiers);
+
+        return new SemVersion(
+            major ?? Major,
+            minor ?? Minor,
+            patch ?? Patch,
+            prerelease ?? Prerelease,
+            prereleaseIdentifiers ?? PrereleaseIdentifiers,
+            metadata ?? Metadata,
+            metadataIdentifiers ?? MetadataIdentifiers);
+    }
+
+    #region With... Methods
+    /// <summary>
+    /// Creates a copy of the current instance with a different major version number.
+    /// </summary>
+    /// <param name="major">The value to replace the major version number.</param>
+    /// <returns>The new version with the different major version number.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="major"/> is negative.</exception>
+    public SemVersion WithMajor(BigInteger major)
+    {
+        if (major < 0) throw new ArgumentOutOfRangeException(nameof(major), InvalidMajorVersionMessage);
+        if (Major == major) return this;
+        return new SemVersion(major, Minor, Patch,
+            Prerelease, PrereleaseIdentifiers, Metadata, MetadataIdentifiers);
+    }
+
+    /// <summary>
+    /// Creates a copy of the current instance with a different minor version number.
+    /// </summary>
+    /// <param name="minor">The value to replace the minor version number.</param>
+    /// <returns>The new version with the different minor version number.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="minor"/> is negative.</exception>
+    public SemVersion WithMinor(BigInteger minor)
+    {
+        if (minor < 0) throw new ArgumentOutOfRangeException(nameof(minor), InvalidMinorVersionMessage);
+        if (Minor == minor) return this;
+        return new SemVersion(Major, minor, Patch,
+            Prerelease, PrereleaseIdentifiers, Metadata, MetadataIdentifiers);
+    }
+
+    /// <summary>
+    /// Creates a copy of the current instance with a different patch version number.
+    /// </summary>
+    /// <param name="patch">The value to replace the patch version number.</param>
+    /// <returns>The new version with the different patch version number.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="patch"/> is negative.</exception>
+    public SemVersion WithPatch(BigInteger patch)
+    {
+        if (patch < 0) throw new ArgumentOutOfRangeException(nameof(patch), InvalidPatchVersionMessage);
+        if (Patch == patch) return this;
+        return new SemVersion(Major, Minor, patch,
+            Prerelease, PrereleaseIdentifiers, Metadata, MetadataIdentifiers);
+    }
+
+    /// <summary>
+    /// Creates a copy of the current instance with a different prerelease portion.
+    /// </summary>
+    /// <param name="prerelease">The value to replace the prerelease portion.</param>
+    /// <param name="allowLeadingZeros">Whether to allow leading zeros in the prerelease identifiers.
+    /// If <see langword="true"/>, leading zeros will be allowed on numeric identifiers
+    /// but will be removed.</param>
+    /// <returns>The new version with the different prerelease identifiers.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="prerelease"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">A prerelease identifier is empty or contains invalid
+    /// characters (i.e. characters that are not ASCII alphanumerics or hyphens) or has leading
+    /// zeros for a numeric identifier when <paramref name="allowLeadingZeros"/> is <see langword="false"/>.</exception>
+    /// <remarks>Because a valid numeric identifier does not have leading zeros, this constructor
+    /// will never create a <see cref="PrereleaseIdentifier"/> with leading zeros even if
+    /// <paramref name="allowLeadingZeros"/> is <see langword="true"/>. Any leading zeros will
+    /// be removed.</remarks>
+    public SemVersion WithPrereleaseParsedFrom(string prerelease, bool allowLeadingZeros = false)
+    {
+        if (prerelease is null) throw new ArgumentNullException(nameof(prerelease));
+        if (prerelease.Length == 0) return WithoutPrerelease();
+        var identifiers = prerelease.SplitAndMapToReadOnlyList('.',
+            i => new PrereleaseIdentifier(i, allowLeadingZeros, nameof(prerelease)));
+        if (allowLeadingZeros)
+            // Leading zeros may have been removed, need to reconstruct the prerelease string
+            prerelease = string.Join(".", identifiers);
+        return new SemVersion(Major, Minor, Patch,
+            prerelease, identifiers, Metadata, MetadataIdentifiers);
+    }
+
+    /// <summary>
+    /// Creates a copy of the current instance with different prerelease identifiers.
+    /// </summary>
+    /// <param name="prereleaseIdentifier">The first identifier to replace the existing
+    /// prerelease identifiers.</param>
+    /// <param name="prereleaseIdentifiers">The rest of the identifiers to replace the
+    /// existing prerelease identifiers.</param>
+    /// <returns>The new version with the different prerelease identifiers.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="prereleaseIdentifier"/> or
+    /// <paramref name="prereleaseIdentifiers"/> is <see langword="null"/> or one of the
+    /// prerelease identifiers is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">A prerelease identifier is empty or contains invalid
+    /// characters (i.e. characters that are not ASCII alphanumerics or hyphens) or has leading
+    /// zeros for a numeric identifier.</exception>
+    public SemVersion WithPrerelease(string prereleaseIdentifier, params string[] prereleaseIdentifiers)
+    {
+        if (prereleaseIdentifier is null) throw new ArgumentNullException(nameof(prereleaseIdentifier));
+        if (prereleaseIdentifiers is null) throw new ArgumentNullException(nameof(prereleaseIdentifiers));
+        var identifiers = prereleaseIdentifiers
+                          .Prepend(prereleaseIdentifier)
+                          .Select(i => new PrereleaseIdentifier(i, allowLeadingZeros: false, nameof(prereleaseIdentifiers)))
+                          .ToReadOnlyList();
+        return new SemVersion(Major, Minor, Patch,
+            string.Join(".", identifiers), identifiers, Metadata, MetadataIdentifiers);
+    }
+
+    /// <summary>
+    /// Creates a copy of the current instance with different prerelease identifiers.
+    /// </summary>
+    /// <param name="prereleaseIdentifiers">The identifiers to replace the prerelease identifiers.</param>
+    /// <returns>The new version with the different prerelease identifiers.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="prereleaseIdentifiers"/> is
+    /// <see langword="null"/> or one of the prerelease identifiers is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">A prerelease identifier is empty or contains invalid
+    /// characters (i.e. characters that are not ASCII alphanumerics or hyphens) or has leading
+    /// zeros for a numeric identifier.</exception>
+    public SemVersion WithPrerelease(IEnumerable<string> prereleaseIdentifiers)
+    {
+        if (prereleaseIdentifiers is null) throw new ArgumentNullException(nameof(prereleaseIdentifiers));
+        var identifiers = prereleaseIdentifiers
+                          .Select(i => new PrereleaseIdentifier(i, allowLeadingZeros: false, nameof(prereleaseIdentifiers)))
+                          .ToReadOnlyList();
+        if (identifiers.Count == 0) return WithoutPrerelease();
+        return new SemVersion(Major, Minor, Patch,
+            string.Join(".", identifiers), identifiers, Metadata, MetadataIdentifiers);
+    }
+
+    /// <summary>
+    /// Creates a copy of the current instance with different prerelease identifiers.
+    /// </summary>
+    /// <param name="prereleaseIdentifier">The first identifier to replace the existing
+    /// prerelease identifiers.</param>
+    /// <param name="prereleaseIdentifiers">The rest of the identifiers to replace the
+    /// existing prerelease identifiers.</param>
+    /// <returns>The new version with the different prerelease identifiers.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="prereleaseIdentifiers"/> is
+    /// <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">A prerelease identifier has the default value.</exception>
+    public SemVersion WithPrerelease(
+                PrereleaseIdentifier prereleaseIdentifier,
+                params PrereleaseIdentifier[] prereleaseIdentifiers)
+    {
+        if (prereleaseIdentifiers is null) throw new ArgumentNullException(nameof(prereleaseIdentifiers));
+        var identifiers = prereleaseIdentifiers.Prepend(prereleaseIdentifier).ToReadOnlyList();
+        if (identifiers.Any(i => i == default)) throw new ArgumentException(PrereleaseIdentifierIsDefaultMessage, nameof(prereleaseIdentifiers));
+        return new SemVersion(Major, Minor, Patch,
+            string.Join(".", identifiers), identifiers, Metadata, MetadataIdentifiers);
+    }
+
+    /// <summary>
+    /// Creates a copy of the current instance with different prerelease identifiers.
+    /// </summary>
+    /// <param name="prereleaseIdentifiers">The identifiers to replace the prerelease identifiers.</param>
+    /// <returns>The new version with the different prerelease identifiers.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="prereleaseIdentifiers"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">A prerelease identifier has the default value.</exception>
+    public SemVersion WithPrerelease(IEnumerable<PrereleaseIdentifier> prereleaseIdentifiers)
+    {
+        if (prereleaseIdentifiers is null) throw new ArgumentNullException(nameof(prereleaseIdentifiers));
+        var identifiers = prereleaseIdentifiers.ToReadOnlyList();
+        if (identifiers.Count == 0) return WithoutPrerelease();
+        if (identifiers.Any(i => i == default)) throw new ArgumentException(PrereleaseIdentifierIsDefaultMessage, nameof(prereleaseIdentifiers));
+        return new SemVersion(Major, Minor, Patch,
+            string.Join(".", identifiers), identifiers, Metadata, MetadataIdentifiers);
+    }
+
+    /// <summary>
+    /// Creates a copy of the current instance without prerelease identifiers.
+    /// </summary>
+    /// <returns>The new version without prerelease identifiers.</returns>
+    public SemVersion WithoutPrerelease()
+    {
+        if (!IsPrerelease) return this;
+        return new SemVersion(Major, Minor, Patch,
+            "", ReadOnlyList<PrereleaseIdentifier>.Empty, Metadata, MetadataIdentifiers);
+    }
+
+    /// <summary>
+    /// Creates a copy of the current instance with different build metadata.
+    /// </summary>
+    /// <param name="metadata">The value to replace the build metadata.</param>
+    /// <returns>The new version with the different build metadata.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="metadata"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">A metadata identifier is empty or contains invalid
+    /// characters (i.e. characters that are not ASCII alphanumerics or hyphens).</exception>
+    public SemVersion WithMetadataParsedFrom(string metadata)
+    {
+        if (metadata is null) throw new ArgumentNullException(nameof(metadata));
+        if (metadata.Length == 0) return WithoutMetadata();
+        var identifiers = metadata.SplitAndMapToReadOnlyList('.',
+            i => new MetadataIdentifier(i, nameof(metadata)));
+        return new SemVersion(Major, Minor, Patch,
+            Prerelease, PrereleaseIdentifiers, metadata, identifiers);
+    }
+
+    /// <summary>
+    /// Creates a copy of the current instance with different build metadata identifiers.
+    /// </summary>
+    /// <param name="metadataIdentifier">The first identifier to replace the existing
+    /// build metadata identifiers.</param>
+    /// <param name="metadataIdentifiers">The rest of the build metadata identifiers to replace the
+    /// existing build metadata identifiers.</param>
+    /// <returns>The new version with the different build metadata identifiers.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="metadataIdentifier"/> or
+    /// <paramref name="metadataIdentifiers"/> is <see langword="null"/> or one of the metadata
+    /// identifiers is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">A metadata identifier is empty or contains invalid
+    /// characters (i.e. characters that are not ASCII alphanumerics or hyphens).</exception>
+    public SemVersion WithMetadata(string metadataIdentifier, params string[] metadataIdentifiers)
+    {
+        if (metadataIdentifier is null) throw new ArgumentNullException(nameof(metadataIdentifier));
+        if (metadataIdentifiers is null) throw new ArgumentNullException(nameof(metadataIdentifiers));
+        var identifiers = metadataIdentifiers
+                          .Prepend(metadataIdentifier)
+                          .Select(i => new MetadataIdentifier(i, nameof(metadataIdentifiers)))
+                          .ToReadOnlyList();
+        return new SemVersion(Major, Minor, Patch,
+            Prerelease, PrereleaseIdentifiers, string.Join(".", identifiers), identifiers);
+    }
+
+    /// <summary>
+    /// Creates a copy of the current instance with different build metadata identifiers.
+    /// </summary>
+    /// <param name="metadataIdentifiers">The identifiers to replace the build metadata identifiers.</param>
+    /// <returns>The new version with the different build metadata identifiers.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="metadataIdentifiers"/> is
+    /// <see langword="null"/> or one of the metadata identifiers is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">A metadata identifier is empty or contains invalid
+    /// characters (i.e. characters that are not ASCII alphanumerics or hyphens).</exception>
+    public SemVersion WithMetadata(IEnumerable<string> metadataIdentifiers)
+    {
+        if (metadataIdentifiers is null) throw new ArgumentNullException(nameof(metadataIdentifiers));
+        var identifiers = metadataIdentifiers
+                          .Select(i => new MetadataIdentifier(i, nameof(metadataIdentifiers)))
+                          .ToReadOnlyList();
+        if (identifiers.Count == 0) return WithoutMetadata();
+        return new SemVersion(Major, Minor, Patch,
+            Prerelease, PrereleaseIdentifiers, string.Join(".", identifiers), identifiers);
+    }
+
+    /// <summary>
+    /// Creates a copy of the current instance with different build metadata identifiers.
+    /// </summary>
+    /// <param name="metadataIdentifier">The first identifier to replace the existing
+    /// build metadata identifiers.</param>
+    /// <param name="metadataIdentifiers">The rest of the identifiers to replace the
+    /// existing build metadata identifiers.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="metadataIdentifiers"/> is
+    /// <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">A metadata identifier has the default value.</exception>
+    public SemVersion WithMetadata(
+        MetadataIdentifier metadataIdentifier,
+        params MetadataIdentifier[] metadataIdentifiers)
+    {
+        if (metadataIdentifiers is null) throw new ArgumentNullException(nameof(metadataIdentifiers));
+        var identifiers = metadataIdentifiers.Prepend(metadataIdentifier).ToReadOnlyList();
+        if (identifiers.Any(i => i == default))
+            throw new ArgumentException(MetadataIdentifierIsDefaultMessage, nameof(metadataIdentifiers));
+        return new SemVersion(Major, Minor, Patch,
+            Prerelease, PrereleaseIdentifiers, string.Join(".", identifiers), identifiers);
+    }
+
+    /// <summary>
+    /// Creates a copy of the current instance with different build metadata identifiers.
+    /// </summary>
+    /// <param name="metadataIdentifiers">The identifiers to replace the build metadata identifiers.</param>
+    /// <returns>The new version with the different build metadata identifiers.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="metadataIdentifiers"/> is
+    /// <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">A metadata identifier has the default value.</exception>
+    public SemVersion WithMetadata(IEnumerable<MetadataIdentifier> metadataIdentifiers)
+    {
+        if (metadataIdentifiers is null) throw new ArgumentNullException(nameof(metadataIdentifiers));
+        var identifiers = metadataIdentifiers.ToReadOnlyList();
+        if (identifiers.Count == 0) return WithoutMetadata();
+        if (identifiers.Any(i => i == default))
+            throw new ArgumentException(MetadataIdentifierIsDefaultMessage, nameof(metadataIdentifiers));
+        return new SemVersion(Major, Minor, Patch,
+            Prerelease, PrereleaseIdentifiers, string.Join(".", identifiers), identifiers);
+    }
+
+    /// <summary>
+    /// Creates a copy of the current instance without build metadata.
+    /// </summary>
+    /// <returns>The new version without build metadata.</returns>
+    public SemVersion WithoutMetadata()
+    {
+        if (MetadataIdentifiers.Count == 0) return this;
+        return new SemVersion(Major, Minor, Patch,
+            Prerelease, PrereleaseIdentifiers, "", ReadOnlyList<MetadataIdentifier>.Empty);
+    }
+
+    /// <summary>
+    /// Creates a copy of the current instance without prerelease identifiers or build metadata.
+    /// </summary>
+    /// <returns>The new version without prerelease identifiers or build metadata.</returns>
+    public SemVersion WithoutPrereleaseOrMetadata()
+    {
+        if (!IsPrerelease && MetadataIdentifiers.Count == 0) return this;
+        return new SemVersion(Major, Minor, Patch,
+            "", ReadOnlyList<PrereleaseIdentifier>.Empty, "", ReadOnlyList<MetadataIdentifier>.Empty);
+    }
+    #endregion
+
+    /// <summary>The major version number.</summary>
+    /// <value>The major version number.</value>
+    /// <remarks>An increase in the major version number indicates a backwards
+    /// incompatible change.</remarks>
+    public BigInteger Major { get; }
+
+    /// <summary>The minor version number.</summary>
+    /// <value>The minor version number.</value>
+    /// <remarks>An increase in the minor version number indicates backwards
+    /// compatible changes.</remarks>
+    public BigInteger Minor { get; }
+
+    /// <summary>The patch version number.</summary>
+    /// <value>The patch version number.</value>
+    /// <remarks>An increase in the patch version number indicates backwards
+    /// compatible bug fixes.</remarks>
+    public BigInteger Patch { get; }
+
+    /// <summary>
+    /// The prerelease identifiers for this version.
+    /// </summary>
+    /// <value>
+    /// The prerelease identifiers for this version or empty string if this is a release version.
+    /// </value>
+    /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="PrereleaseIdentifiers"]/*'/>
+    // Design Note: `null` is not used to represent a release version because it is not possible to
+    // express a non-empty string type, but it is possible to express a non-null string type.
+    public string Prerelease { get; }
+
+    /// <summary>
+    /// The prerelease identifiers for this version.
+    /// </summary>
+    /// <value>
+    /// The prerelease identifiers for this version or empty if this is a release version.
+    /// </value>
+    /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="PrereleaseIdentifiers"]/*'/>
+    public IReadOnlyList<PrereleaseIdentifier> PrereleaseIdentifiers { get; }
+
+    /// <summary>
+    /// Whether this is a prerelease version where the prerelease version is zero (i.e. "-0").
+    /// </summary>
+    internal bool PrereleaseIsZero
+        => PrereleaseIdentifiers.Count == 1
+           && PrereleaseIdentifiers[0] == PrereleaseIdentifier.Zero;
+
+    /// <summary>Whether this is a prerelease version.</summary>
+    /// <value>Whether this is a prerelease version. A semantic version with
+    /// prerelease identifiers is a prerelease version.</value>
+    /// <remarks>When this is <see langword="true"/>, the <see cref="Prerelease"/>
+    /// and <see cref="PrereleaseIdentifiers"/> properties are non-empty. When
+    /// this is <see langword="false"/>, the <see cref="Prerelease"/> property
+    /// will be an empty string and the <see cref="PrereleaseIdentifiers"/> will
+    /// be an empty collection.</remarks>
+    public bool IsPrerelease => Prerelease.Length != 0;
+
+    /// <summary>Whether this is a release version.</summary>
+    /// <value>Whether this is a release version. A semantic version without
+    /// prerelease identifiers is a release version.</value>
+    /// <remarks>When this is <see langword="true"/>, the <see cref="Prerelease"/>
+    /// property will be an empty string and the <see cref="PrereleaseIdentifiers"/>
+    /// will be an empty collection. When this is <see langword="false"/>,
+    /// the <see cref="Prerelease"/> and <see cref="PrereleaseIdentifiers"/>
+    /// properties are non-empty.</remarks>
+    public bool IsRelease => Prerelease.Length == 0;
+
+    /// <summary>The build metadata for this version.</summary>
+    /// <value>The build metadata for this version or empty string if there
+    /// is no metadata.</value>
+    /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="MetadataIdentifiers"]/*'/>
+    // Design Note: `null` is not used to represent a version without metadata because it is not
+    // possible to express a non-empty string type, but it is possible to express a non-null string
+    // type.
+    public string Metadata { get; }
+
+    /// <summary>The build metadata identifiers for this version.</summary>
+    /// <value>The build metadata identifiers for this version or empty if there
+    /// is no metadata.</value>
+    /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="MetadataIdentifiers"]/*'/>
+    public IReadOnlyList<MetadataIdentifier> MetadataIdentifiers { get; }
+
+    /// <summary>
+    /// Converts this version to an equivalent string value.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="string" /> equivalent of this version.
+    /// </returns>
+    public override string ToString()
+    {
+        var major = Major.ToString();
+        var minor = Minor.ToString();
+        var patch = Patch.ToString();
+        // Assume all separators ("..-+"), at most 4 extra chars
+        var estimatedLength = 4 + major.Length
+                                + minor.Length
+                                + patch.Length
+                                + Prerelease.Length + Metadata.Length;
+        var version = new StringBuilder(estimatedLength);
+        version.Append(major);
+        version.Append('.');
+        version.Append(minor);
+        version.Append('.');
+        version.Append(patch);
+        if (Prerelease.Length > 0)
+        {
+            version.Append('-');
+            version.Append(Prerelease);
+        }
+        if (Metadata.Length > 0)
+        {
+            version.Append('+');
+            version.Append(Metadata);
+        }
+        return version.ToString();
+    }
+
+    #region Equality
+    /// <summary>
+    /// Determines whether two semantic versions are equal.
+    /// </summary>
+    /// <returns><see langword="true"/> if the two versions are equal, otherwise <see langword="false"/>.</returns>
+    /// <remarks>Two versions are equal if every part of the version numbers are equal. Thus, two
+    /// versions with the same precedence may not be equal.</remarks>
+    public static bool Equals(SemVersion? left, SemVersion? right)
+    {
+        if (ReferenceEquals(left, right)) return true;
+        if (left is null || right is null) return false;
+        return left.Equals(right);
+    }
+
+    /// <summary>Determines whether the given object is equal to this version.</summary>
+    /// <returns><see langword="true"/> if <paramref name="obj"/> is equal to this version;
+    /// otherwise <see langword="false"/>.</returns>
+    /// <remarks>Two versions are equal if every part of the version numbers are equal. Thus, two
+    /// versions with the same precedence may not be equal.</remarks>
+    public override bool Equals(object? obj)
+        => obj is SemVersion version && Equals(version);
+
+    /// <summary>
+    /// Determines whether two semantic versions are equal.
+    /// </summary>
+    /// <returns><see langword="true"/> if <paramref name="other"/> is equal to this version;
+    /// otherwise <see langword="false"/>.</returns>
+    /// <remarks>Two versions are equal if every part of the version numbers are equal. Thus, two
+    /// versions with the same precedence may not be equal.</remarks>
+    public bool Equals(SemVersion? other)
+    {
+        if (other is null)
+            return false;
+
+        if (ReferenceEquals(this, other))
+            return true;
+
+        return Major == other.Major
+            && Minor == other.Minor
+            && Patch == other.Patch
+            && string.Equals(Prerelease, other.Prerelease, StringComparison.Ordinal)
+            && string.Equals(Metadata, other.Metadata, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Determines whether two semantic versions have the same precedence. Versions that differ
+    /// only by build metadata have the same precedence.
+    /// </summary>
+    /// <param name="other">The semantic version to compare to.</param>
+    /// <returns><see langword="true"/> if the version precedences are equal, otherwise
+    /// <see langword="false"/>.</returns>
+    public bool PrecedenceEquals(SemVersion? other)
+        => PrecedenceComparer.Compare(this, other!) == 0;
+
+    /// <summary>
+    /// Determines whether two semantic versions have the same precedence. Versions that differ
+    /// only by build metadata have the same precedence.
+    /// </summary>
+    /// <returns><see langword="true"/> if the version precedences are equal, otherwise
+    /// <see langword="false"/>.</returns>
+    public static bool PrecedenceEquals(SemVersion? left, SemVersion? right)
+        => PrecedenceComparer.Compare(left!, right!) == 0;
+
+    internal bool MajorMinorPatchEquals([NotNullWhen(true)] SemVersion? other)
+    {
+        if (other is null) return false;
+
+        if (ReferenceEquals(this, other)) return true;
+
+        return Major == other.Major
+               && Minor == other.Minor
+               && Patch == other.Patch;
+    }
+
+    /// <summary>
+    /// Gets a hash code for this instance.
+    /// </summary>
+    /// <returns>
+    /// A hash code for this instance, suitable for use in hashing algorithms
+    /// and data structures like a hash table.
+    /// </returns>
+    /// <remarks>Two versions are equal if every part of the version numbers are equal. Thus, two
+    /// versions with the same precedence may not have the same hash code.</remarks>
+    public override int GetHashCode()
+        => HashCode.Combine(Major, Minor, Patch, Prerelease, Metadata);
+
+    /// <summary>
+    /// Determines whether two semantic versions are equal.
+    /// </summary>
+    /// <returns><see langword="true"/> if the two versions are equal, otherwise <see langword="false"/>.</returns>
+    /// <remarks>Two versions are equal if every part of the version numbers are equal. Thus, two
+    /// versions with the same precedence may not be equal.</remarks>
+    public static bool operator ==(SemVersion? left, SemVersion? right) => Equals(left, right);
+
+    /// <summary>
+    /// Determines whether two semantic versions are <em>not</em> equal.
+    /// </summary>
+    /// <returns><see langword="true"/> if the two versions are <em>not</em> equal, otherwise <see langword="false"/>.</returns>
+    /// <remarks>Two versions are equal if every part of the version numbers are equal. Thus, two
+    /// versions with the same precedence may not be equal.</remarks>
+    public static bool operator !=(SemVersion? left, SemVersion? right) => !Equals(left, right);
+    #endregion
+
+    #region Comparison
+    /// <summary>
+    /// An <see cref="IEqualityComparer{T}"/> and <see cref="IComparer{T}"/>
+    /// that compares <see cref="SemVersion"/> by precedence. This can be used for sorting,
+    /// binary search, and using <see cref="SemVersion"/> as a dictionary key.
+    /// </summary>
+    /// <value>A precedence comparer that implements <see cref="IEqualityComparer{T}"/> and
+    /// <see cref="IComparer{T}"/> for <see cref="SemVersion"/>.</value>
+    /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="PrecedenceOrder"]/*'/>
+    public static ISemVersionComparer PrecedenceComparer { get; } = Comparers.PrecedenceComparer.Instance;
+
+    /// <summary>
+    /// An <see cref="IEqualityComparer{T}"/> and <see cref="IComparer{T}"/>
+    /// that compares <see cref="SemVersion"/> by sort order. This can be used for sorting,
+    /// binary search, and using <see cref="SemVersion"/> as a dictionary key.
+    /// </summary>
+    /// <value>A sort order comparer that implements <see cref="IEqualityComparer{T}"/> and
+    /// <see cref="IComparer{T}"/> for <see cref="SemVersion"/>.</value>
+    /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="SortOrder"]/*'/>
+    public static ISemVersionComparer SortOrderComparer { get; } = Comparers.SortOrderComparer.Instance;
+
+    /// <summary>
+    /// Compares two versions and indicates whether this instance precedes, follows, or is in the same
+    /// position as the other in the precedence order. Versions that differ only by build metadata
+    /// have the same precedence.
+    /// </summary>
+    /// <returns>
+    /// An integer that indicates whether this instance precedes, follows, or is in the same
+    /// position as <paramref name="other"/> in the precedence order.
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>Value</term>
+    ///         <description>Condition</description>
+    ///     </listheader>
+    ///     <item>
+    ///         <term>-1</term>
+    ///         <description>This instance precedes <paramref name="other"/> in the precedence order.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>0</term>
+    ///         <description>This instance has the same precedence as <paramref name="other"/>.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>1</term>
+    ///         <description>
+    ///             This instance follows <paramref name="other"/> in the precedence order
+    ///             or <paramref name="other"/> is <see langword="null" />.
+    ///         </description>
+    ///     </item>
+    /// </list>
+    /// </returns>
+    /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="PrecedenceOrder"]/*'/>
+    public int ComparePrecedenceTo(SemVersion? other) => PrecedenceComparer.Compare(this, other!);
+
+    /// <summary>
+    /// Compares two versions and indicates whether this instance precedes, follows, or is equal
+    /// to the other in the sort order. Note that sort order is more specific than precedence order.
+    /// </summary>
+    /// <returns>
+    /// An integer that indicates whether this instance precedes, follows, or is equal to the
+    /// other in the sort order.
+    /// <list type="table">
+    /// 	<listheader>
+    /// 		<term>Value</term>
+    /// 		<description>Condition</description>
+    /// 	</listheader>
+    /// 	<item>
+    /// 		<term>-1</term>
+    /// 		<description>This instance precedes the other in the sort order.</description>
+    /// 	</item>
+    /// 	<item>
+    /// 		<term>0</term>
+    /// 		<description>This instance is equal to the other.</description>
+    /// 	</item>
+    /// 	<item>
+    /// 		<term>1</term>
+    /// 		<description>
+    /// 			This instance follows the other in the sort order
+    /// 			or the other is <see langword="null" />.
+    /// 		</description>
+    /// 	</item>
+    /// </list>
+    /// </returns>
+    /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="SortOrder"]/*'/>
+    public int CompareSortOrderTo(SemVersion? other) => SortOrderComparer.Compare(this, other!);
+
+    /// <summary>
+    /// Compares two versions and indicates whether the first precedes, follows, or is in the same
+    /// position as the second in the precedence order. Versions that differ only by build metadata
+    /// have the same precedence.
+    /// </summary>
+    /// <returns>
+    /// An integer that indicates whether <paramref name="left"/> precedes, follows, or is in the same
+    /// position as <paramref name="right"/> in the precedence order.
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>Value</term>
+    ///         <description>Condition</description>
+    ///     </listheader>
+    ///     <item>
+    ///         <term>-1</term>
+    ///         <description>
+    ///             <paramref name="left"/> precedes <paramref name="right"/> in the precedence
+    ///             order or <paramref name="left"/> is <see langword="null" />.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>0</term>
+    ///         <description><paramref name="left"/> has the same precedence as <paramref name="right"/>.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>1</term>
+    ///         <description>
+    ///             <paramref name="left"/> follows <paramref name="right"/> in the precedence order
+    ///             or <paramref name="right"/> is <see langword="null" />.
+    ///         </description>
+    ///     </item>
+    /// </list>
+    /// </returns>
+    /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="PrecedenceOrder"]/*'/>
+    public static int ComparePrecedence(SemVersion? left, SemVersion? right)
+        => PrecedenceComparer.Compare(left!, right!);
+
+    /// <summary>
+    /// Compares two versions and indicates whether the first precedes, follows, or is equal to
+    /// the second in the sort order. Note that sort order is more specific than precedence order.
+    /// </summary>
+    /// <returns>
+    /// An integer that indicates whether <paramref name="left"/> precedes, follows, or is equal
+    /// to <paramref name="right"/> in the sort order.
+    /// <list type="table">
+    ///     <listheader>
+    ///         <term>Value</term>
+    ///         <description>Condition</description>
+    ///     </listheader>
+    ///     <item>
+    ///         <term>-1</term>
+    ///         <description>
+    ///             <paramref name="left"/> precedes <paramref name="right"/> in the sort
+    ///             order or <paramref name="left"/> is <see langword="null" />.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>0</term>
+    ///         <description><paramref name="left"/> is equal to <paramref name="right"/>.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>1</term>
+    ///         <description>
+    ///             <paramref name="left"/> follows <paramref name="right"/> in the sort order
+    ///             or <paramref name="right"/> is <see langword="null" />.
+    ///         </description>
+    ///     </item>
+    /// </list>
+    /// </returns>
+    /// <include file='SemVersionDocParts.xml' path='docParts/part[@id="SortOrder"]/*'/>
+    public static int CompareSortOrder(SemVersion? left, SemVersion? right)
+        => SortOrderComparer.Compare(left!, right!);
+    #endregion
+
+    #region Satisfies
+    /// <summary>
+    /// Checks if this version satisfies the given predicate.
+    /// </summary>
+    /// <param name="predicate">The predicate to evaluate on this version.</param>
+    /// <returns><see langword="true"/> if the version satisfies the predicate,
+    /// otherwise <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is
+    /// <see langword="null"/>.</exception>
+    public bool Satisfies(Predicate<SemVersion> predicate)
+    {
+        if (predicate is null) throw new ArgumentNullException(nameof(predicate));
+        return predicate(this);
+    }
+
+    /// <summary>
+    /// Checks if this version is contained in the given range.
+    /// </summary>
+    /// <param name="range">The range to evaluate.</param>
+    /// <returns><see langword="true"/> if the version is contained in the range,
+    /// otherwise <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="range"/> is
+    /// <see langword="null"/>.</exception>
+    public bool Satisfies(SemVersionRange range)
+    {
+        if (range is null) throw new ArgumentNullException(nameof(range));
+        return range.Contains(this);
+    }
+
+    /// <summary>
+    /// Checks if this version is contained in the given unbroken range.
+    /// </summary>
+    /// <param name="range">The unbroken range to evaluate.</param>
+    /// <returns><see langword="true"/> if the version is contained in the range,
+    /// otherwise <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="range"/> is
+    /// <see langword="null"/>.</exception>
+    public bool Satisfies(UnbrokenSemVersionRange range)
+    {
+        if (range is null) throw new ArgumentNullException(nameof(range));
+        return range.Contains(this);
+    }
+
+    /// <summary>
+    /// Checks if this version is contained in the given range.
+    /// </summary>
+    /// <param name="range">The range to parse and evaluate.</param>
+    /// <param name="options">A bitwise combination of enumeration values that indicates the style
+    /// elements that can be present in <paramref name="range"/>. The overload without this
+    /// parameter defaults to <see cref="SemVersionRangeOptions.Strict"/>.</param>
+    /// <param name="maxLength">The maximum length of <paramref name="range"/> that should be
+    /// parsed. This prevents attacks using very long range strings.</param>
+    /// <returns><see langword="true"/> if the version is contained in the range,
+    /// otherwise <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="range"/> is
+    /// <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="options"/> is not a valid
+    /// <see cref="SemVersionRangeOptions"/> value.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxLength"/> is less than
+    /// zero.</exception>
+    /// <exception cref="FormatException">The <paramref name="range"/> is invalid or not in a
+    /// format compliant with <paramref name="options"/>.</exception>
+    /// <remarks>If checks against a range will be performed repeatedly, it is much more
+    /// efficient to parse the range into a <see cref="SemVersionRange"/> once and use that
+    /// object to repeatedly check for containment.</remarks>
+    public bool Satisfies(
+        string range,
+        SemVersionRangeOptions options,
+        int maxLength = SemVersionRange.MaxRangeLength)
+    {
+        if (range == null) throw new ArgumentNullException(nameof(range));
+
+        var parsedRange = SemVersionRange.Parse(range, options, maxLength);
+        return parsedRange.Contains(this);
+    }
+
+    /// <summary>
+    /// Checks if this version is contained in the given range. The range is parsed using
+    /// <see cref="SemVersionRangeOptions.Strict"/>.
+    /// </summary>
+    /// <param name="range">The range to parse and evaluate.</param>
+    /// <param name="maxLength">The maximum length of <paramref name="range"/> that should be
+    /// parsed. This prevents attacks using very long range strings.</param>
+    /// <returns><see langword="true"/> if the version is contained in the range,
+    /// otherwise <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="range"/> is
+    /// <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxLength"/> is less than
+    /// zero.</exception>
+    /// <exception cref="FormatException">The <paramref name="range"/> is invalid or not in a
+    /// format compliant with <see cref="SemVersionRangeOptions.Strict"/>.</exception>
+    /// <remarks>If checks against a range will be performed repeatedly, it is much more
+    /// efficient to parse the range into a <see cref="SemVersionRange"/> once and use that
+    /// object to repeatedly check for containment.</remarks>
+    public bool Satisfies(string range, int maxLength = SemVersionRange.MaxRangeLength)
+        => Satisfies(range, SemVersionRangeOptions.Strict, maxLength);
+
+    /// <summary>
+    /// Checks if this version is contained in the given range in npm format.
+    /// </summary>
+    /// <param name="range">The npm format range to parse and evaluate.</param>
+    /// <param name="includeAllPrerelease">Whether to include all prerelease versions satisfying
+    /// the bounds in the range or to only include prerelease versions when it matches a bound
+    /// that explicitly includes prerelease versions.</param>
+    /// <param name="maxLength">The maximum length of <paramref name="range"/> that should be
+    /// parsed. This prevents attacks using very long range strings.</param>
+    /// <returns><see langword="true"/> if the version is contained in the range,
+    /// otherwise <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="range"/> is
+    /// <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxLength"/> is less than
+    /// zero.</exception>
+    /// <exception cref="FormatException">The <paramref name="range"/> is invalid.</exception>
+    /// <remarks>If checks against a range will be performed repeatedly, it is much more
+    /// efficient to parse the range into a <see cref="SemVersionRange"/> once using
+    /// <see cref="SemVersionRange.ParseNpm(string,bool,int)"/> and use that object to
+    /// repeatedly check for containment.</remarks>
+    public bool SatisfiesNpm(string range, bool includeAllPrerelease, int maxLength = SemVersionRange.MaxRangeLength)
+    {
+        if (range == null) throw new ArgumentNullException(nameof(range));
+
+        var parsedRange = SemVersionRange.ParseNpm(range, includeAllPrerelease, maxLength);
+        return parsedRange.Contains(this);
+    }
+
+    /// <summary>
+    /// Checks if this version is contained in the given range in npm format. Does not include
+    /// all prerelease when parsing the range.
+    /// </summary>
+    /// <param name="range">The npm format range to parse and evaluate.</param>
+    /// <param name="maxLength">The maximum length of <paramref name="range"/> that should be
+    /// parsed. This prevents attacks using very long range strings.</param>
+    /// <returns><see langword="true"/> if the version is contained in the range,
+    /// otherwise <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="range"/> is
+    /// <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxLength"/> is less than
+    /// zero.</exception>
+    /// <exception cref="FormatException">The <paramref name="range"/> is invalid.</exception>
+    /// <remarks>If checks against a range will be performed repeatedly, it is much more
+    /// efficient to parse the range into a <see cref="SemVersionRange"/> once using
+    /// <see cref="SemVersionRange.ParseNpm(string,int)"/> and use that object to
+    /// repeatedly check for containment.</remarks>
+    public bool SatisfiesNpm(string range, int maxLength = SemVersionRange.MaxRangeLength)
+        => SatisfiesNpm(range, false, maxLength);
+    #endregion
+}

--- a/src/Vendoring/SemVer/SemVersionDocParts.xml
+++ b/src/Vendoring/SemVer/SemVersionDocParts.xml
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<docParts>
+    <part id="CompareToReturns">
+        <returns>
+            An integer that indicates whether this instance precedes, follows, or is equal to
+            the other in the sort order.
+            <list type="table">
+                <listheader>
+                    <term>Value</term>
+                    <description>Condition</description>
+                </listheader>
+                <item>
+                    <term>Less than zero</term>
+                    <description>This instance precedes the other in the sort order.</description>
+                </item>
+                <item>
+                    <term>Zero</term>
+                    <description>This instance is equal to the other.</description>
+                </item>
+                <item>
+                    <term>Greater than zero</term>
+                    <description>
+                        This instance follows the other in the sort order
+                        or the other is <see langword="null" />.
+                    </description>
+                </item>
+            </list>
+        </returns>
+    </part>
+    <part id="MetadataIdentifiers">
+        <remarks>
+            <para>The build metadata is a series of dot separated identifiers separated from the
+            rest of the version number with a plus sign ('<c>+</c>'). Valid metadata identifiers are
+            non-empty and consist of ASCII alphanumeric characters and hyphens (<c>[0-9A-Za-z-]</c>).</para>
+
+            <para>The metadata does not affect precedence. Two version numbers differing only in
+            build metadata have the same precedence. However, metadata does affect sort order. An
+            otherwise identical version without metadata sorts before one that has metadata.</para>
+        </remarks>
+    </part>
+    <part id="PrereleaseIdentifiers">
+        <remarks>
+            <para>A prerelease version is denoted by appending a hyphen ('<c>-</c>') and a series
+            of dot separated identifiers immediately following the patch version number. Each
+            prerelease identifier may be numeric or alphanumeric. Valid numeric identifiers consist
+            of ASCII digits (<c>[0-9]</c>) without leading zeros. Valid alphanumeric identifiers are
+            non-empty strings of ASCII alphanumeric and hyphen characters (<c>[0-9A-Za-z-]</c>) with
+            at least one non-digit character.</para>
+
+            <para>Prerelease versions have lower precedence than release versions. Prerelease
+            version precedence is determined by comparing each prerelease identifier in order from
+            left to right. Numeric identifiers have lower precedence than alphanumeric identifiers.
+            Numeric identifiers are compared numerically. Alphanumeric identifiers are compared
+            lexically in ASCII sort order.</para>
+        </remarks>
+    </part>
+    <part id="PrecedenceOrder">
+        <remarks>
+            <para>Precedence order is determined by comparing the major, minor, patch, and prerelease
+            portion in order from left to right. Versions that differ only by build metadata have the
+            same precedence. The major, minor, and patch version numbers are compared numerically. A
+            prerelease version precedes a release version.</para>
+
+            <para>The prerelease portion is compared by comparing each prerelease identifier from
+            left to right. Numeric prerelease identifiers precede alphanumeric identifiers. Numeric
+            identifiers are compared numerically. Alphanumeric identifiers are compared lexically
+            in ASCII sort order. A longer series of prerelease identifiers follows a shorter series
+            if all the preceding identifiers are equal.</para>
+        </remarks>
+    </part>
+    <part id="SortOrder">
+        <remarks>
+            <para>Sort order is consistent with precedence order, but provides an order for versions
+            with the same precedence. Sort order is determined by comparing the major, minor,
+            patch, prerelease portion, and build metadata in order from left to right. The major,
+            minor, and patch version numbers are compared numerically. A prerelease version precedes
+            a release version.</para>
+            <para>The prerelease portion is compared by comparing each prerelease identifier from
+            left to right. Numeric prerelease identifiers precede alphanumeric identifiers. Numeric
+            identifiers are compared numerically. Alphanumeric identifiers are compared lexically
+            in ASCII sort order. A longer series of prerelease identifiers follows a shorter series
+            if all the preceding identifiers are equal.</para>
+            <para>Otherwise equal versions without build metadata precede those with metadata. The
+            build metadata is compared by comparing each metadata identifier. Identifiers are
+            compared lexically in ASCII sort order. A longer series of metadata identifiers follows
+            a shorter series if all the preceding identifiers are equal.</para>
+        </remarks>
+    </part>
+</docParts>

--- a/src/Vendoring/SemVer/SemVersionRange.cs
+++ b/src/Vendoring/SemVer/SemVersionRange.cs
@@ -1,0 +1,567 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Semver.Comparers;
+using Semver.Parsing;
+using Semver.Utility;
+
+namespace Semver;
+
+/// <summary>
+/// A range of <see cref="SemVersion"/> values. A range can have gaps in it and may include only
+/// some prerelease versions between included release versions. For a range that cannot have
+/// gaps see the <see cref="UnbrokenSemVersionRange"/> class.
+/// </summary>
+public sealed class SemVersionRange : IReadOnlyList<UnbrokenSemVersionRange>, IEquatable<SemVersionRange>
+{
+    internal const int MaxRangeLength = 2048;
+    internal const string InvalidOptionsMessage = "An invalid SemVersionRangeOptions value was used.";
+    internal const string InvalidMaxLengthMessage = "Must not be negative.";
+
+    /// <summary>
+    /// The empty range that contains no versions.
+    /// </summary>
+    /// <value>The empty range that contains no versions.</value>
+    public static SemVersionRange Empty { get; } = new SemVersionRange(ReadOnlyList<UnbrokenSemVersionRange>.Empty);
+
+    /// <summary>
+    /// The range that contains all release versions but no prerelease versions.
+    /// </summary>
+    /// <value>The range that contains all release versions but no prerelease versions.</value>
+    public static SemVersionRange AllRelease { get; } = new SemVersionRange(UnbrokenSemVersionRange.AllRelease);
+
+    /// <summary>
+    /// The range that contains both all release and prerelease versions.
+    /// </summary>
+    /// <value>The range that contains both all release and prerelease versions.</value>
+    public static SemVersionRange All { get; } = new SemVersionRange(UnbrokenSemVersionRange.All);
+
+    /// <summary>
+    /// Construct a range containing only a single version.
+    /// </summary>
+    /// <param name="version">The version the range should contain.</param>
+    /// <returns>A range containing only the given version.</returns>
+    public static SemVersionRange Equals(SemVersion version)
+        => Create(UnbrokenSemVersionRange.Equals(version));
+
+    /// <summary>
+    /// Construct a range containing versions greater than the given version.
+    /// </summary>
+    /// <param name="version">The range will contain all versions greater than this.</param>
+    /// <param name="includeAllPrerelease">Include all prerelease versions in the range rather
+    /// than just those matching the given version if it is prerelease.</param>
+    /// <returns>A range containing versions greater than the given version.</returns>
+    public static SemVersionRange GreaterThan(SemVersion version, bool includeAllPrerelease = false)
+        => Create(UnbrokenSemVersionRange.GreaterThan(version, includeAllPrerelease));
+
+    /// <summary>
+    /// Construct a range containing versions equal to or greater than the given version.
+    /// </summary>
+    /// <param name="version">The range will contain all versions greater than or equal to this.</param>
+    /// <param name="includeAllPrerelease">Include all prerelease versions in the range rather
+    /// than just those matching the given version if it is prerelease.</param>
+    /// <returns>A range containing versions greater than or equal to the given version.</returns>
+    public static SemVersionRange AtLeast(SemVersion version, bool includeAllPrerelease = false)
+         => Create(UnbrokenSemVersionRange.AtLeast(version, includeAllPrerelease));
+
+    /// <summary>
+    /// Construct a range containing versions less than the given version.
+    /// </summary>
+    /// <param name="version">The range will contain all versions less than this.</param>
+    /// <param name="includeAllPrerelease">Include all prerelease versions in the range rather
+    /// than just those matching the given version if it is prerelease.</param>
+    /// <returns>A range containing versions less than the given version.</returns>
+    public static SemVersionRange LessThan(SemVersion version, bool includeAllPrerelease = false)
+         => Create(UnbrokenSemVersionRange.LessThan(version, includeAllPrerelease));
+
+    /// <summary>
+    /// Construct a range containing versions equal to or less than the given version.
+    /// </summary>
+    /// <param name="version">The range will contain all versions less than or equal to this.</param>
+    /// <param name="includeAllPrerelease">Include all prerelease versions in the range rather
+    /// than just those matching the given version if it is prerelease.</param>
+    /// <returns>A range containing versions less than or equal to the given version.</returns>
+    public static SemVersionRange AtMost(SemVersion version, bool includeAllPrerelease = false)
+        => Create(UnbrokenSemVersionRange.AtMost(version, includeAllPrerelease));
+
+    /// <summary>
+    /// Construct a range containing all versions between the given versions including those versions.
+    /// </summary>
+    /// <param name="start">The range will contain only versions greater than or equal to this.</param>
+    /// <param name="end">The range will contain only versions less than or equal to this.</param>
+    /// <param name="includeAllPrerelease">Include all prerelease versions in the range rather
+    /// than just those matching the given versions if they are prerelease.</param>
+    /// <returns>A range containing versions between the given versions including those versions.</returns>
+    public static SemVersionRange Inclusive(SemVersion start, SemVersion end, bool includeAllPrerelease = false)
+        => Create(UnbrokenSemVersionRange.Inclusive(start, end, includeAllPrerelease));
+
+    /// <summary>
+    /// Construct a range containing all versions between the given versions including the start
+    /// but not the end.
+    /// </summary>
+    /// <param name="start">The range will contain only versions greater than or equal to this.</param>
+    /// <param name="end">The range will contain only versions less than this.</param>
+    /// <param name="includeAllPrerelease">Include all prerelease versions in the range rather
+    /// than just those matching the given versions if they are prerelease.</param>
+    /// <returns>A range containing versions between the given versions including the start but
+    /// not the end.</returns>
+    public static SemVersionRange InclusiveOfStart(SemVersion start, SemVersion end, bool includeAllPrerelease = false)
+        => Create(UnbrokenSemVersionRange.InclusiveOfStart(start, end, includeAllPrerelease));
+
+    /// <summary>
+    /// Construct a range containing all versions between the given versions including the end but
+    /// not the start.
+    /// </summary>
+    /// <param name="start">The range will contain only versions greater than this.</param>
+    /// <param name="end">The range will contain only versions less than or equal to this.</param>
+    /// <param name="includeAllPrerelease">Include all prerelease versions in the range rather
+    /// than just those matching the given versions if they are prerelease.</param>
+    /// <returns>A range containing versions between the given versions including the end but
+    /// not the start.</returns>
+    public static SemVersionRange InclusiveOfEnd(SemVersion start, SemVersion end, bool includeAllPrerelease = false)
+        => Create(UnbrokenSemVersionRange.InclusiveOfEnd(start, end, includeAllPrerelease));
+
+    /// <summary>
+    /// Construct a range containing all versions between the given versions excluding those versions.
+    /// </summary>
+    /// <param name="start">The range will contain only versions greater than this.</param>
+    /// <param name="end">The range will contain only versions less than this.</param>
+    /// <param name="includeAllPrerelease">Include all prerelease versions in the range rather
+    /// than just those matching the given versions if they are prerelease.</param>
+    /// <returns>A range containing versions between the given versions including the end but
+    /// not the start.</returns>
+    public static SemVersionRange Exclusive(SemVersion start, SemVersion end, bool includeAllPrerelease = false)
+        => Create(UnbrokenSemVersionRange.Exclusive(start, end, includeAllPrerelease));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static SemVersionRange Create(UnbrokenSemVersionRange range)
+        => UnbrokenSemVersionRange.Empty.Equals(range) ? Empty : new SemVersionRange(range);
+
+    /// <remarks>Ownership of the <paramref name="ranges"/> list must be given to this method.
+    /// The list will be mutated and used as the basis of an immutable list. It must not still
+    /// be referenced by the caller.</remarks>
+    internal static SemVersionRange Create(List<UnbrokenSemVersionRange> ranges)
+    {
+        DebugChecks.IsNotNull(ranges, nameof(ranges));
+
+        // Remove empty ranges and see if the result is empty
+        ranges.RemoveAll(range => UnbrokenSemVersionRange.Empty.Equals(range));
+        if (ranges.Count == 0) return Empty;
+
+        // Sort and merge ranges
+        ranges.Sort(UnbrokenSemVersionRangeComparer.Instance);
+        for (var i = 0; i < ranges.Count - 1; i++)
+            for (var j = ranges.Count - 1; j > i; j--)
+                if (ranges[i].TryUnion(ranges[j], out var union))
+                {
+                    ranges.RemoveAt(j);
+                    ranges[i] = union;
+                }
+
+        return new SemVersionRange(ranges.AsReadOnly());
+    }
+
+    /// <summary>
+    /// Construct a range that joins the given <see cref="UnbrokenSemVersionRange"/>s. It will
+    /// contain all versions contained by any of the given unbroken ranges.
+    /// </summary>
+    /// <param name="ranges">The unbroken ranges to join into a single range.</param>
+    /// <returns>A range that joins the given <see cref="UnbrokenSemVersionRange"/>s. It will
+    /// contain all versions contained by any of the given unbroken ranges.</returns>
+    /// <remarks>The unbroken ranges are simplified and sorted. So, the resulting
+    /// <see cref="SemVersionRange"/> may not contain the same number of
+    /// <see cref="UnbrokenSemVersionRange"/>s in the same order as passed to this method.</remarks>
+    public static SemVersionRange Create(IEnumerable<UnbrokenSemVersionRange> ranges)
+        => Create((ranges ?? throw new ArgumentNullException(nameof(ranges))).ToList());
+
+    /// <summary>
+    /// Construct a range that joins the given <see cref="UnbrokenSemVersionRange"/>s. It will
+    /// contain all versions contained by any of the given unbroken ranges.
+    /// </summary>
+    /// <param name="ranges">The unbroken ranges to join into a single range.</param>
+    /// <returns>A range that joins the given <see cref="UnbrokenSemVersionRange"/>s. It will
+    /// contain all versions contained by any of the given unbroken ranges.</returns>
+    /// <remarks>The unbroken ranges are simplified and sorted. So, the resulting
+    /// <see cref="SemVersionRange"/> may not contain the same number of
+    /// <see cref="UnbrokenSemVersionRange"/>s in the same order as passed to this method.</remarks>
+    public static SemVersionRange Create(params UnbrokenSemVersionRange[] ranges)
+        => Create((ranges ?? throw new ArgumentNullException(nameof(ranges))).ToList());
+
+    private readonly IReadOnlyList<UnbrokenSemVersionRange> ranges;
+
+    /// <remarks>Parameter validation is not performed. The unbroken range must not be empty.</remarks>
+    private SemVersionRange(UnbrokenSemVersionRange range)
+        : this(new List<UnbrokenSemVersionRange>(1) { range }.AsReadOnly())
+    {
+    }
+
+    /// <remarks>Parameter validation is not performed. The <paramref name="ranges"/> must be
+    /// an immutable list of properly ordered and combined ranges.</remarks>
+    private SemVersionRange(IReadOnlyList<UnbrokenSemVersionRange> ranges)
+    {
+        this.ranges = ranges;
+    }
+
+    /// <summary>
+    /// Determine whether this range contains the given version.
+    /// </summary>
+    /// <param name="version">The version to test against the range.</param>
+    /// <returns><see langword="true"/> if the version is contained in the range,
+    /// otherwise <see langword="false"/>.</returns>
+    public bool Contains(SemVersion? version)
+    {
+        // Using `for` loop for better performance
+        for (var i = 0; i < ranges.Count; i++)
+            if (ranges[i].Contains(version))
+                return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Convert this range into a predicate function indicating whether a version is contained
+    /// in the range.
+    /// </summary>
+    /// <param name="range">The range to convert into a predicate function.</param>
+    /// <returns>A predicate that indicates whether a given version is contained in this range.</returns>
+    public static implicit operator Predicate<SemVersion>(SemVersionRange range)
+        => range.Contains;
+
+    #region Standard Parsing
+    /// <summary>
+    /// Convert a version range string in the <a href="https://semver-nuget.org/ranges/">standard
+    /// range syntax</a> into a <see cref="SemVersionRange"/> using the given options.
+    /// </summary>
+    /// <param name="range">The version range string to parse. Accepts the
+    /// <a href="https://semver-nuget.org/ranges/">standard range syntax</a>.</param>
+    /// <param name="options">A bitwise combination of enumeration values that indicates the style
+    /// elements that can be present in <paramref name="range"/> and the options to use when
+    /// constructing the range.</param>
+    /// <param name="maxLength">The maximum length of <paramref name="range"/> that should be
+    /// parsed. This prevents attacks using very long version range strings.</param>
+    /// <exception cref="ArgumentException"><paramref name="options"/> is not a valid
+    /// <see cref="SemVersionRangeOptions"/> value.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxLength"/> is less than zero.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="range"/> is <see langword="null"/>.</exception>
+    /// <exception cref="FormatException">The <paramref name="range"/> is invalid or not in a
+    /// format compliant with <paramref name="options"/>.</exception>
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+    public static SemVersionRange Parse(
+        string range,
+        SemVersionRangeOptions options,
+        int maxLength = MaxRangeLength)
+#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
+    {
+        if (!options.IsValid())
+            throw new ArgumentException(InvalidOptionsMessage, nameof(options));
+        if (maxLength < 0)
+            throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength, InvalidMaxLengthMessage);
+
+        var ex = StandardRangeParser.Parse(range, options, null, maxLength, out var semverRange);
+        if (ex != null) throw ex;
+        DebugChecks.IsNotNull(semverRange, nameof(semverRange));
+        return semverRange;
+    }
+
+    /// <summary>
+    /// Convert a version range string in the <a href="https://semver-nuget.org/ranges/">standard
+    /// range syntax</a> into a <see cref="SemVersionRange"/> using the
+    /// <see cref="SemVersionRangeOptions.Strict"/> option.
+    /// </summary>
+    /// <param name="range">The version range string to parse. Accepts the
+    /// <a href="https://semver-nuget.org/ranges/">standard range syntax</a>.</param>
+    /// <param name="maxLength">The maximum length of <paramref name="range"/> that should be
+    /// parsed. This prevents attacks using very long version range strings.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxLength"/> is less than zero.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="range"/> is <see langword="null"/>.</exception>
+    /// <exception cref="FormatException">The <paramref name="range"/> is invalid or not in a
+    /// format compliant with the <see cref="SemVersionRangeOptions.Strict"/> option.</exception>
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+    public static SemVersionRange Parse(
+        string range,
+        int maxLength = MaxRangeLength)
+#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
+        => Parse(range, SemVersionRangeOptions.Strict, maxLength);
+
+    /// <summary>
+    /// Convert a version range string in the <a href="https://semver-nuget.org/ranges/">standard
+    /// range syntax</a> into a <see cref="SemVersionRange"/> using the given options.
+    /// </summary>
+    /// <param name="range">The version range string to parse. Accepts the
+    /// <a href="https://semver-nuget.org/ranges/">standard range syntax</a>.</param>
+    /// <param name="options">A bitwise combination of enumeration values that indicates the style
+    /// elements that can be present in <paramref name="range"/> and the options to use when
+    /// constructing the range.</param>
+    /// <param name="semverRange">The converted <see cref="SemVersionRange"/>.</param>
+    /// <param name="maxLength">The maximum length of <paramref name="range"/> that should be
+    /// parsed. This prevents attacks using very long version range strings.</param>
+    /// <returns><see langword="false"/> when an invalid version range string is passed,
+    /// otherwise <see langword="true"/>.</returns>
+    /// <exception cref="ArgumentException"><paramref name="options"/> is not a valid
+    /// <see cref="SemVersionRangeOptions"/> value.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxLength"/> is less than zero.</exception>
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+    public static bool TryParse(
+        string? range,
+        SemVersionRangeOptions options,
+        [NotNullWhen(true)]
+        out SemVersionRange? semverRange,
+        int maxLength = MaxRangeLength)
+#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
+    {
+        if (!options.IsValid()) throw new ArgumentException(InvalidOptionsMessage, nameof(options));
+        if (maxLength < 0)
+            throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength, InvalidMaxLengthMessage);
+
+        var exception = StandardRangeParser.Parse(range, options, VersionParsing.FailedException, maxLength, out semverRange);
+
+        DebugChecks.IsNotFailedException(exception, nameof(SemVersionParser), nameof(SemVersionParser.Parse));
+
+        return exception is null;
+    }
+
+    /// <summary>
+    /// Convert a version range string in the <a href="https://semver-nuget.org/ranges/">standard
+    /// range syntax</a> into a <see cref="SemVersionRange"/> using the
+    /// <see cref="SemVersionRangeOptions.Strict"/> option.
+    /// </summary>
+    /// <param name="range">The version range string to parse. Accepts the
+    /// <a href="https://semver-nuget.org/ranges/">standard range syntax</a>.</param>
+    /// <param name="semverRange">The converted <see cref="SemVersionRange"/>.</param>
+    /// <param name="maxLength">The maximum length of <paramref name="range"/> that should be
+    /// parsed. This prevents attacks using very long version range strings.</param>
+    /// <returns><see langword="false"/> when an invalid version range string is passed,
+    /// otherwise <see langword="true"/>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxLength"/> is less than zero.</exception>
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+    public static bool TryParse(
+        string? range,
+        [NotNullWhen(true)]
+        out SemVersionRange? semverRange,
+        int maxLength = MaxRangeLength)
+#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
+        => TryParse(range, SemVersionRangeOptions.Strict, out semverRange, maxLength);
+    #endregion
+
+    #region npm Parsing
+    /// <summary>
+    /// Convert a version range string in the <a href="https://github.com/npm/node-semver/#ranges">
+    /// npm syntax</a> into a <see cref="SemVersionRange"/>.
+    /// </summary>
+    /// <param name="range">The version range string to parse. Accepts the
+    /// <a href="https://github.com/npm/node-semver/#ranges">npm syntax</a>.</param>
+    /// <param name="includeAllPrerelease">Whether to include all prerelease versions in the
+    /// range rather than just prerelease versions matching a prerelease identifier in the range.</param>
+    /// <param name="maxLength">The maximum length of <paramref name="range"/> that should be
+    /// parsed. This prevents attacks using very long version range strings.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxLength"/> is less than zero.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="range"/> is <see langword="null"/>.</exception>
+    /// <exception cref="FormatException">The <paramref name="range"/> is invalid.</exception>
+    /// <remarks>The npm "loose" option is not supported. The
+    /// <see cref="Parse(string,SemVersionRangeOptions,int)"/> method provides more control over
+    /// parsing. However, it does not accept all the npm syntax.</remarks>
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+    public static SemVersionRange ParseNpm(
+#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
+        string range,
+        bool includeAllPrerelease,
+        int maxLength = MaxRangeLength)
+    {
+        if (maxLength < 0)
+            throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength, InvalidMaxLengthMessage);
+
+        var ex = NpmRangeParser.Parse(range, includeAllPrerelease, null, maxLength, out var semverRange);
+        if (ex != null) throw ex;
+        DebugChecks.IsNotNull(semverRange, nameof(semverRange));
+        return semverRange;
+    }
+
+    /// <summary>
+    /// Convert a version range string in the <a href="https://github.com/npm/node-semver/#ranges">
+    /// npm syntax</a> into a <see cref="SemVersionRange"/>.
+    /// </summary>
+    /// <param name="range">The version range string to parse. Accepts the
+    /// <a href="https://github.com/npm/node-semver/#ranges">npm syntax</a>.</param>
+    /// <param name="maxLength">The maximum length of <paramref name="range"/> that should be
+    /// parsed. This prevents attacks using very long version range strings.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxLength"/> is less than zero.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="range"/> is <see langword="null"/>.</exception>
+    /// <exception cref="FormatException">The <paramref name="range"/> is invalid.</exception>
+    /// <remarks>The npm "loose" option is not supported. The
+    /// <see cref="Parse(string,SemVersionRangeOptions,int)"/> method provides more control over
+    /// parsing. However, it does not accept all the npm syntax.</remarks>
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+    public static SemVersionRange ParseNpm(string range, int maxLength = MaxRangeLength)
+#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
+        => ParseNpm(range, false, maxLength);
+
+    /// <summary>
+    /// Convert a version range string in the <a href="https://github.com/npm/node-semver/#ranges">
+    /// npm syntax</a> into a <see cref="SemVersionRange"/>.
+    /// </summary>
+    /// <param name="range">The version range string to parse. Accepts the
+    /// <a href="https://github.com/npm/node-semver/#ranges">npm syntax</a>.</param>
+    /// <param name="includeAllPrerelease">Whether to include all prerelease versions in the
+    /// range rather than just prerelease versions matching a prerelease identifier in the range.</param>
+    /// <param name="semverRange">The converted <see cref="SemVersionRange"/>.</param>
+    /// <param name="maxLength">The maximum length of <paramref name="range"/> that should be
+    /// parsed. This prevents attacks using very long version range strings.</param>
+    /// <returns><see langword="false"/> when an invalid version range string is passed,
+    /// otherwise <see langword="true"/>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxLength"/> is less than zero.</exception>
+    /// <remarks>The npm "loose" option is not supported. The
+    /// <see cref="TryParse(string,SemVersionRangeOptions,out SemVersionRange,int)"/> method
+    /// provides more control over parsing. However, it does not accept all the npm syntax.</remarks>
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+    public static bool TryParseNpm(
+#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
+        string? range,
+        bool includeAllPrerelease,
+        [NotNullWhen(true)]
+        out SemVersionRange? semverRange,
+        int maxLength = MaxRangeLength)
+    {
+        if (maxLength < 0)
+            throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength, InvalidMaxLengthMessage);
+
+        var exception = NpmRangeParser.Parse(range, includeAllPrerelease, VersionParsing.FailedException, maxLength, out semverRange);
+
+        DebugChecks.IsNotFailedException(exception, nameof(NpmRangeParser), nameof(NpmRangeParser.Parse));
+
+        return exception is null;
+    }
+
+    /// <summary>
+    /// Convert a version range string in the <a href="https://github.com/npm/node-semver/#ranges">
+    /// npm syntax</a> into a <see cref="SemVersionRange"/>.
+    /// </summary>
+    /// <param name="range">The version range string to parse. Accepts the
+    /// <a href="https://github.com/npm/node-semver/#ranges">npm syntax</a>.</param>
+    /// <param name="semverRange">The converted <see cref="SemVersionRange"/>.</param>
+    /// <param name="maxLength">The maximum length of <paramref name="range"/> that should be
+    /// parsed. This prevents attacks using very long version range strings.</param>
+    /// <returns><see langword="false"/> when an invalid version range string is passed,
+    /// otherwise <see langword="true"/>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxLength"/> is less than zero.</exception>
+    /// <remarks>The npm "loose" option is not supported. The
+    /// <see cref="TryParse(string,SemVersionRangeOptions,out SemVersionRange,int)"/> method
+    /// provides more control over parsing. However, it does not accept all the npm syntax.</remarks>
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+    public static bool TryParseNpm(
+#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
+        string? range,
+        [NotNullWhen(true)]
+        out SemVersionRange? semverRange,
+        int maxLength = MaxRangeLength)
+        => TryParseNpm(range, false, out semverRange, maxLength);
+    #endregion
+
+    #region IReadOnlyList<UnbrokenSemVersionRange>
+    /// <summary>
+    /// The number of <see cref="UnbrokenSemVersionRange"/>s that make up this range.
+    /// </summary>
+    /// <value>The number of <see cref="UnbrokenSemVersionRange"/>s that make up this range.</value>
+    public int Count => ranges.Count;
+
+    /// <summary>
+    /// Get the <see cref="UnbrokenSemVersionRange"/> making up this range at the given index.
+    /// </summary>
+    /// <param name="index">The zero-based index of the <see cref="UnbrokenSemVersionRange"/> to
+    /// get.</param>
+    /// <returns>The <see cref="UnbrokenSemVersionRange"/> making up this range at the given
+    /// index.</returns>
+    public UnbrokenSemVersionRange this[int index] => ranges[index];
+
+    /// <summary>
+    /// Get an enumerator that iterates through the <see cref="UnbrokenSemVersionRange"/>s
+    /// making up this range.
+    /// </summary>
+    /// <returns>An enumerator that iterates through the <see cref="UnbrokenSemVersionRange"/>s
+    /// making up this range.</returns>
+    public IEnumerator<UnbrokenSemVersionRange> GetEnumerator() => ranges.GetEnumerator();
+
+    /// <summary>
+    /// Get an enumerator that iterates through the <see cref="UnbrokenSemVersionRange"/>s
+    /// making up this range.
+    /// </summary>
+    /// <returns>An enumerator that iterates through the <see cref="UnbrokenSemVersionRange"/>s
+    /// making up this range.</returns>
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    #endregion
+
+    #region Equality
+    /// <summary>
+    /// Determines whether two version ranges are equal. Due to the complexity of ranges, it may
+    /// be possible for two ranges to match the same set of versions but be expressed in
+    /// different ways and so not be equal.
+    /// </summary>
+    /// <returns><see langword="true"/> if <paramref name="other"/> is equal to this range;
+    /// otherwise <see langword="false"/>.</returns>
+    public bool Equals(SemVersionRange? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return ranges.SequenceEqual(other.ranges);
+    }
+
+    /// <summary>
+    /// Determines whether the given object is equal to this range. Due to the complexity of
+    /// ranges, it may be possible for two ranges to match the same set of versions but be
+    /// expressed in different ways and so not be equal.
+    /// </summary>
+    /// <returns><see langword="true"/> if <paramref name="obj"/> is equal to this range;
+    /// otherwise <see langword="false"/>.</returns>
+    public override bool Equals(object? obj)
+        => obj is SemVersionRange other && Equals(other);
+
+    /// <summary>
+    /// Gets a hash code for this instance.
+    /// </summary>
+    /// <returns>
+    /// A hash code for this instance, suitable for use in hashing algorithms
+    /// and data structures like a hash table.
+    /// </returns>
+    public override int GetHashCode()
+    {
+        var hashcode = new HashCode();
+        foreach (var range in ranges) hashcode.Add(range);
+        return hashcode.ToHashCode();
+    }
+
+    /// <summary>
+    /// Determines whether two version ranges are equal. Due to the complexity of ranges, it may
+    /// be possible for two ranges to match the same set of versions but be expressed in
+    /// different ways and so not be equal.
+    /// </summary>
+    /// <returns><see langword="true"/> if the two values are equal, otherwise <see langword="false"/>.</returns>
+    public static bool operator ==(SemVersionRange? left, SemVersionRange? right)
+        => Equals(left, right);
+
+    /// <summary>
+    /// Determines whether two version ranges are <em>not</em> equal. Due to the complexity of
+    /// ranges, it may be possible for two ranges to match the same set of versions but be
+    /// expressed in different ways and so not be equal.
+    /// </summary>
+    /// <returns><see langword="true"/> if the two ranges are <em>not</em> equal, otherwise <see langword="false"/>.</returns>
+    public static bool operator !=(SemVersionRange? left, SemVersionRange? right)
+        => !Equals(left, right);
+    #endregion
+
+    /// <summary>
+    /// Converts this version range to an equivalent string value in
+    /// <a href="https://semver-nuget.org/ranges/">standard range syntax</a>.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="string" /> equivalent of this version in
+    /// <a href="https://semver-nuget.org/ranges/">standard range syntax</a>.
+    /// </returns>
+    /// <remarks>Because version ranges are simplified and sorted, this method may return
+    /// a different, but equivalent, range string from the originally parsed one. Ranges
+    /// including all prerelease versions are indicated with the idiom of prefixing each
+    /// comparison group with "<c>*-*</c>". This includes all prerelease versions because it
+    /// matches all prerelease versions.</remarks>
+    public override string ToString() => string.Join(" || ", this);
+}

--- a/src/Vendoring/SemVer/SemVersionRangeOptions.cs
+++ b/src/Vendoring/SemVer/SemVersionRangeOptions.cs
@@ -1,0 +1,85 @@
+﻿using System;
+
+namespace Semver;
+
+/// <summary>
+/// <para>Determines the parsing options and allowed styles of range and version strings passed
+/// to the <see cref="SemVersionRange.Parse(string,SemVersionRangeOptions,int)"/> and
+/// <see cref="SemVersionRange.TryParse(string,SemVersionRangeOptions,out SemVersionRange,int)"/>
+/// methods. These styles only affect which strings are accepted when parsing. The
+/// constructed ranges and version numbers are valid semantic version ranges without any of the
+/// optional features in the original string.</para>
+///
+/// <para>Most options only allow additional version styles. However, the
+/// <see cref="IncludeAllPrerelease"/> option modifies how version ranges are interpreted. With
+/// this option, all prerelease versions within the range bounds will be considered to be in the
+/// range. Without this option, only prerelease versions where one comparison with the same
+/// major, minor, and patch versions is prerelease will satisfy the range. For more information,
+/// see the <a href="https://semver-nuget.org/ranges/">range expressions documentation</a>.</para>
+///
+/// <para>This enumeration supports a bitwise combination of its member values (e.g.
+/// <c>SemVersionRangeOptions.OptionalPatch | SemVersionRangeOptions.AllowV</c>).</para>
+/// </summary>
+[Flags]
+public enum SemVersionRangeOptions
+{
+    #region Matching SemVersionStyles
+    /// <summary>
+    /// Accept versions strictly conforming to the SemVer 2.0 spec without metadata.
+    /// </summary>
+    Strict = 0,
+
+    /// <summary>
+    /// <para>Allow leading zeros on major, minor, patch, and prerelease version numbers.</para>
+    ///
+    /// <para>Leading zeros will be removed from the constructed version number.</para>
+    /// </summary>
+    AllowLeadingZeros = 1,
+
+    /// <summary>
+    /// Allow a leading lowercase "v" on versions.
+    /// </summary>
+    AllowLowerV = 1 << 3,
+
+    /// <summary>
+    /// Allow a leading uppercase "V" on versions.
+    /// </summary>
+    AllowUpperV = 1 << 4,
+
+    /// <summary>
+    /// Allow a leading "v" or "V" on versions.
+    /// </summary>
+    AllowV = AllowLowerV | AllowUpperV,
+
+    /// <summary>
+    /// Patch version number is optional on versions.
+    /// </summary>
+    OptionalPatch = 1 << 5,
+
+    /// <summary>
+    /// Minor and patch version numbers are optional on versions.
+    /// </summary>
+    OptionalMinorPatch = 1 << 6 | OptionalPatch,
+    #endregion
+
+    #region Using values of SemVersionStyles that do not apply to ranges
+    /// <summary>
+    /// Include all prerelease versions in the range rather than just prerelease versions
+    /// matching a prerelease identifier in the range.
+    /// </summary>
+    IncludeAllPrerelease = 1 << 1,
+
+    /// <summary>
+    /// Allow version numbers with build metadata in version range expressions. The metadata
+    /// will be removed/ignored for the definition of the version range.
+    /// </summary>
+    AllowMetadata = 1 << 2,
+    #endregion
+
+    /// <summary>
+    /// <para>Accept any version string format supported.</para>
+    ///
+    /// <para>The formats accepted by this style will change if/when more formats are supported.</para>
+    /// </summary>
+    Loose = AllowLeadingZeros | AllowV | OptionalMinorPatch | AllowMetadata,
+}

--- a/src/Vendoring/SemVer/SemVersionRangeOptionsExtensions.cs
+++ b/src/Vendoring/SemVer/SemVersionRangeOptionsExtensions.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Runtime.CompilerServices;
+using static Semver.SemVersionRangeOptions;
+
+namespace Semver;
+
+internal static class SemVersionRangeOptionsExtensions
+{
+    private const SemVersionRangeOptions OptionsThatAreStyles
+        = AllowLeadingZeros | AllowV | OptionalMinorPatch;
+    private const SemVersionRangeOptions OptionalMinorWithoutPatch
+        = OptionalMinorPatch & ~OptionalPatch;
+
+    internal const SemVersionRangeOptions AllFlags
+        = AllowLeadingZeros | AllowV | OptionalMinorPatch | IncludeAllPrerelease | AllowMetadata;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsValid(this SemVersionRangeOptions options)
+        // It is some combination of the flags
+        => (options & AllFlags) == options
+           // Except for a flag for optional minor without optional patch
+           && (options & OptionalMinorPatch) != OptionalMinorWithoutPatch;
+
+    /// <summary>
+    /// The <see cref="Enum.HasFlag"/> method is surprisingly slow. This provides
+    /// a fast alternative for the <see cref="SemVersionRangeOptions"/> enum.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool HasOption(this SemVersionRangeOptions options, SemVersionRangeOptions flag)
+        => (options & flag) == flag;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static SemVersionStyles ToStyles(this SemVersionRangeOptions options)
+        => (SemVersionStyles)(options & OptionsThatAreStyles);
+}

--- a/src/Vendoring/SemVer/SemVersionStyles.cs
+++ b/src/Vendoring/SemVer/SemVersionStyles.cs
@@ -1,0 +1,79 @@
+﻿using System;
+
+namespace Semver;
+
+/// <summary>
+/// <para>Determines the styles that are allowed in version strings passed to the
+/// <see cref="SemVersion.Parse(string,SemVersionStyles,int)"/> and
+/// <see cref="SemVersion.TryParse(string,SemVersionStyles,out SemVersion,int)"/>
+/// methods. These styles only affect which strings are accepted when parsing. The
+/// constructed version numbers are valid semantic versions without any of the
+/// optional features in the original string.</para>
+///
+/// <para>This enumeration supports a bitwise combination of its member values (e.g.
+/// <c>SemVersionStyles.AllowWhitespace | SemVersionStyles.AllowV</c>).</para>
+/// </summary>
+[Flags]
+public enum SemVersionStyles
+{
+    /// <summary>
+    /// Accept version strings strictly conforming to the SemVer 2.0 spec.
+    /// </summary>
+    Strict = 0,
+
+    /// <summary>
+    /// <para>Allow leading zeros on major, minor, patch, and prerelease version numbers.</para>
+    ///
+    /// <para>Leading zeros will be removed from the constructed version number.</para>
+    /// </summary>
+    AllowLeadingZeros = 1,
+
+    /// <summary>
+    /// Allow leading whitespace. When combined with leading "v", the whitespace
+    /// must come before the "v".
+    /// </summary>
+    AllowLeadingWhitespace = 1 << 1,
+
+    /// <summary>
+    /// Allow trailing whitespace.
+    /// </summary>
+    AllowTrailingWhitespace = 1 << 2,
+
+    /// <summary>
+    /// Allow leading and/or trailing whitespace. When combined with leading "v",
+    /// the leading whitespace must come before the "v".
+    /// </summary>
+    AllowWhitespace = AllowLeadingWhitespace | AllowTrailingWhitespace,
+
+    /// <summary>
+    /// Allow a leading lowercase "v".
+    /// </summary>
+    AllowLowerV = 1 << 3,
+
+    /// <summary>
+    /// Allow a leading uppercase "V".
+    /// </summary>
+    AllowUpperV = 1 << 4,
+
+    /// <summary>
+    /// Allow a leading "v" or "V".
+    /// </summary>
+    AllowV = AllowLowerV | AllowUpperV,
+
+    /// <summary>
+    /// Patch version number is optional.
+    /// </summary>
+    OptionalPatch = 1 << 5,
+
+    /// <summary>
+    /// Minor and patch version numbers are optional.
+    /// </summary>
+    OptionalMinorPatch = 1 << 6 | OptionalPatch,
+
+    /// <summary>
+    /// <para>Accept any version string format supported.</para>
+    ///
+    /// <para>The formats accepted by this style will change if/when more formats are supported.</para>
+    /// </summary>
+    Any = unchecked((int)0xFFFF_FFFF),
+}

--- a/src/Vendoring/SemVer/SemVersionStylesExtensions.cs
+++ b/src/Vendoring/SemVer/SemVersionStylesExtensions.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using static Semver.SemVersionStyles;
+
+namespace Semver;
+
+internal static class SemVersionStylesExtensions
+{
+    internal const SemVersionStyles AllowAll = AllowLeadingZeros
+                                             | AllowLeadingWhitespace
+                                             | AllowTrailingWhitespace
+                                             | AllowWhitespace
+                                             | AllowLowerV
+                                             | AllowUpperV
+                                             | AllowV
+                                             | OptionalPatch
+                                             | OptionalMinorPatch;
+    private const SemVersionStyles OptionalMinorWithoutPatch = OptionalMinorPatch & ~OptionalPatch;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsValid(this SemVersionStyles styles)
+    {
+        // Either it is the Any style
+        if (styles == Any) return true;
+
+        // Or it is some combination of the flags
+        return (styles & AllowAll) == styles
+            // Except for a flag for optional minor without optional patch
+            && (styles & OptionalMinorPatch) != OptionalMinorWithoutPatch;
+    }
+
+    /// <summary>
+    /// The <see cref="Enum.HasFlag"/> method is surprisingly slow. This provides
+    /// a fast alternative for the <see cref="SemVersionStyles"/> enum.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool HasStyle(this SemVersionStyles styles, SemVersionStyles flag)
+        => (styles & flag) == flag;
+}

--- a/src/Vendoring/SemVer/UnbrokenSemVersionRange.cs
+++ b/src/Vendoring/SemVer/UnbrokenSemVersionRange.cs
@@ -1,0 +1,649 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using Semver.Comparers;
+using Semver.Ranges;
+
+namespace Semver;
+
+/// <summary>
+/// A range of <see cref="SemVersion"/> values with no gaps. The more general and flexible range
+/// class <see cref="SemVersionRange"/> is typically used instead. It combines multiple
+/// <see cref="UnbrokenSemVersionRange"/>s. <see cref="UnbrokenSemVersionRange"/> can be used
+/// directly if it is important to reflect that something must be a range with no gaps in it.
+/// </summary>
+/// <remarks>An <see cref="UnbrokenSemVersionRange"/> is represented as an interval between two
+/// versions, the <see cref="Start"/> and <see cref="End"/>. For each, that version may or may
+/// not be included.</remarks>
+public sealed class UnbrokenSemVersionRange : IEquatable<UnbrokenSemVersionRange>
+{
+    /// <summary>
+    /// A standard representation for the empty range that contains no versions.
+    /// </summary>
+    /// <value>A standard representation for the empty range that contains no versions.</value>
+    /// <remarks><para>There are an infinite number of ways to represent the empty range. Any range
+    /// where the start is greater than the end or where start equals end but one is not
+    /// inclusive would be empty.
+    /// See https://en.wikipedia.org/wiki/Interval_(mathematics)#Classification_of_intervals</para>
+    ///
+    /// <para>Since there is no maximum version the only unique empty range is <c>&lt;0.0.0-0</c>.</para>
+    /// </remarks>
+    public static UnbrokenSemVersionRange Empty { get; }
+        = new UnbrokenSemVersionRange(new LeftBoundedRange(null, false),
+            new RightBoundedRange(SemVersion.Min, false), false, false);
+
+    /// <summary>
+    /// The range that contains all release versions but no prerelease versions.
+    /// </summary>
+    /// <value>The range that contains all release versions but no prerelease versions.</value>
+    public static UnbrokenSemVersionRange AllRelease { get; } = Create(null, false, null, false, false);
+
+    /// <summary>
+    /// The range that contains both all release and prerelease versions.
+    /// </summary>
+    /// <value>The range that contains both all release and prerelease versions.</value>
+    public static UnbrokenSemVersionRange All { get; } = Create(null, false, null, false, true);
+
+    #region Static Factory Methods
+    /// <summary>
+    /// Construct a range containing only a single version.
+    /// </summary>
+    /// <param name="version">The version the range should contain.</param>
+    /// <returns>A range containing only the given version.</returns>
+    public static UnbrokenSemVersionRange Equals(SemVersion version)
+        => Create(Validate(version, nameof(version)), true, version, true, false);
+
+    /// <summary>
+    /// Construct a range containing versions greater than the given version.
+    /// </summary>
+    /// <param name="version">The range will contain all versions greater than this.</param>
+    /// <param name="includeAllPrerelease">Include all prerelease versions in the range rather
+    /// than just those matching the given version if it is prerelease.</param>
+    /// <returns>A range containing versions greater than the given version.</returns>
+    public static UnbrokenSemVersionRange GreaterThan(SemVersion version, bool includeAllPrerelease = false)
+        => Create(Validate(version, nameof(version)), false, null, false, includeAllPrerelease);
+
+    /// <summary>
+    /// Construct a range containing versions equal to or greater than the given version.
+    /// </summary>
+    /// <param name="version">The range will contain all versions greater than or equal to this.</param>
+    /// <param name="includeAllPrerelease">Include all prerelease versions in the range rather
+    /// than just those matching the given version if it is prerelease.</param>
+    /// <returns>A range containing versions greater than or equal to the given version.</returns>
+    public static UnbrokenSemVersionRange AtLeast(SemVersion version, bool includeAllPrerelease = false)
+        => Create(Validate(version, nameof(version)), true, null, false, includeAllPrerelease);
+
+    /// <summary>
+    /// Construct a range containing versions less than the given version.
+    /// </summary>
+    /// <param name="version">The range will contain all versions less than this.</param>
+    /// <param name="includeAllPrerelease">Include all prerelease versions in the range rather
+    /// than just those matching the given version if it is prerelease.</param>
+    /// <returns>A range containing versions less than the given version.</returns>
+    public static UnbrokenSemVersionRange LessThan(SemVersion version, bool includeAllPrerelease = false)
+        => Create(null, false, Validate(version, nameof(version)), false, includeAllPrerelease);
+
+    /// <summary>
+    /// Construct a range containing versions equal to or less than the given version.
+    /// </summary>
+    /// <param name="version">The range will contain all versions less than or equal to this.</param>
+    /// <param name="includeAllPrerelease">Include all prerelease versions in the range rather
+    /// than just those matching the given version if it is prerelease.</param>
+    /// <returns>A range containing versions less than or equal to the given version.</returns>
+    public static UnbrokenSemVersionRange AtMost(SemVersion version, bool includeAllPrerelease = false)
+        => Create(null, false, Validate(version, nameof(version)), true, includeAllPrerelease);
+
+    /// <summary>
+    /// Construct a range containing all versions between the given versions including those versions.
+    /// </summary>
+    /// <param name="start">The range will contain only versions greater than or equal to this.</param>
+    /// <param name="end">The range will contain only versions less than or equal to this.</param>
+    /// <param name="includeAllPrerelease">Include all prerelease versions in the range rather
+    /// than just those matching the given versions if they are prerelease.</param>
+    /// <returns>A range containing versions between the given versions including those versions.</returns>
+    public static UnbrokenSemVersionRange Inclusive(SemVersion start, SemVersion end, bool includeAllPrerelease = false)
+        => Create(Validate(start, nameof(start)), true,
+            Validate(end, nameof(end)), true, includeAllPrerelease);
+
+    /// <summary>
+    /// Construct a range containing all versions between the given versions including the start
+    /// but not the end.
+    /// </summary>
+    /// <param name="start">The range will contain only versions greater than or equal to this.</param>
+    /// <param name="end">The range will contain only versions less than this.</param>
+    /// <param name="includeAllPrerelease">Include all prerelease versions in the range rather
+    /// than just those matching the given versions if they are prerelease.</param>
+    /// <returns>A range containing versions between the given versions including the start but
+    /// not the end.</returns>
+    public static UnbrokenSemVersionRange InclusiveOfStart(SemVersion start, SemVersion end, bool includeAllPrerelease = false)
+        => Create(Validate(start, nameof(start)), true,
+            Validate(end, nameof(end)), false, includeAllPrerelease);
+
+    /// <summary>
+    /// Construct a range containing all versions between the given versions including the end but
+    /// not the start.
+    /// </summary>
+    /// <param name="start">The range will contain only versions greater than this.</param>
+    /// <param name="end">The range will contain only versions less than or equal to this.</param>
+    /// <param name="includeAllPrerelease">Include all prerelease versions in the range rather
+    /// than just those matching the given versions if they are prerelease.</param>
+    /// <returns>A range containing versions between the given versions including the end but
+    /// not the start.</returns>
+    public static UnbrokenSemVersionRange InclusiveOfEnd(SemVersion start, SemVersion end, bool includeAllPrerelease = false)
+        => Create(Validate(start, nameof(start)), false,
+            Validate(end, nameof(end)), true, includeAllPrerelease);
+
+    /// <summary>
+    /// Construct a range containing all versions between the given versions excluding those versions.
+    /// </summary>
+    /// <param name="start">The range will contain only versions greater than this.</param>
+    /// <param name="end">The range will contain only versions less than this.</param>
+    /// <param name="includeAllPrerelease">Include all prerelease versions in the range rather
+    /// than just those matching the given versions if they are prerelease.</param>
+    /// <returns>A range containing versions between the given versions including the end but
+    /// not the start.</returns>
+    public static UnbrokenSemVersionRange Exclusive(SemVersion start, SemVersion end, bool includeAllPrerelease = false)
+        => Create(Validate(start, nameof(start)), false,
+            Validate(end, nameof(end)), false, includeAllPrerelease);
+    #endregion
+
+    // TODO support parsing unbroken ranges?
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static UnbrokenSemVersionRange Create(
+        SemVersion? startVersion,
+        bool startInclusive,
+        SemVersion? endVersion,
+        bool endInclusive,
+        bool includeAllPrerelease)
+    {
+        var start = new LeftBoundedRange(startVersion, startInclusive);
+        var end = new RightBoundedRange(endVersion, endInclusive);
+        return Create(start, end, includeAllPrerelease);
+    }
+
+    internal static UnbrokenSemVersionRange Create(
+        LeftBoundedRange start,
+        RightBoundedRange end,
+        bool includeAllPrerelease)
+    {
+        // Always return the same empty range
+        if (IsEmpty(start, end, includeAllPrerelease)) return Empty;
+
+        var allPrereleaseCoveredByEnds = false;
+
+        if (start.Version is not null && end.Version is not null)
+        {
+            // Equals ranges include all prerelease if they are prerelease
+            if (start.Version == end.Version)
+                allPrereleaseCoveredByEnds = includeAllPrerelease = start.Version.IsPrerelease;
+            // Some ranges have all the prerelease versions in them covered by the bounds
+            else if (start.IncludesPrerelease || end.IncludesPrerelease)
+            {
+                if (start.Version.MajorMinorPatchEquals(end.Version))
+                    allPrereleaseCoveredByEnds = true;
+                else if ((end.IncludesPrerelease || end.Version.PrereleaseIsZero)
+                         && start.Version.Major == end.Version.Major && start.Version.Minor == end.Version.Minor
+                         && start.Version.Patch + BigInteger.One == end.Version.Patch)
+                    allPrereleaseCoveredByEnds = true;
+            }
+        }
+
+        return new UnbrokenSemVersionRange(start, end, includeAllPrerelease, allPrereleaseCoveredByEnds);
+    }
+
+    private UnbrokenSemVersionRange(
+        LeftBoundedRange leftBound,
+        RightBoundedRange rightBound,
+        bool includeAllPrerelease,
+        bool allPrereleaseCoveredByEnds)
+    {
+        LeftBound = leftBound;
+        RightBound = rightBound;
+        IncludeAllPrerelease = includeAllPrerelease | allPrereleaseCoveredByEnds;
+        this.allPrereleaseCoveredByEnds = allPrereleaseCoveredByEnds;
+    }
+
+    internal readonly LeftBoundedRange LeftBound;
+    internal readonly RightBoundedRange RightBound;
+    /// <summary>
+    /// If this <see cref="IncludeAllPrerelease"/> and those prerelease versions are entirely
+    /// covered by the left and right bounds so that effectively, it doesn't need to include all
+    /// prerelease.
+    /// </summary>
+    private readonly bool allPrereleaseCoveredByEnds;
+    private string? toStringCache;
+
+    /// <summary>
+    /// The start, left limit, or minimum of this range. Can be <see langword="null"/>.
+    /// </summary>
+    /// <value>The start or left end of this range. Can be <see langword="null"/>.</value>
+    /// <remarks>Ranges with no lower bound have a <see cref="Start"/> value
+    /// of <see langword="null"/>. This ensures that they do not unintentionally include any
+    /// prerelease versions.</remarks>
+    public SemVersion? Start => LeftBound.Version;
+
+    /// <summary>
+    /// Whether this range includes the <see cref="Start"/> value.
+    /// </summary>
+    /// <value>Whether this range includes the <see cref="Start"/> value.</value>
+    /// <remarks>When <see cref="Start"/> is <see langword="null"/>, <see cref="StartInclusive"/>
+    /// will always be <see langword="false"/>.</remarks>
+    [MemberNotNullWhen(true, "Start")]
+    public bool StartInclusive => LeftBound.Inclusive;
+
+    /// <summary>
+    /// The end, right limit, or maximum of this range. Can be <see langword="null"/>.
+    /// </summary>
+    /// <value>The end, right limit, or maximum of this range. Can be <see langword="null"/>.</value>
+    /// <remarks>Ranges with no upper bound have an <see cref="End"/> value
+    /// of <see langword="null"/>.</remarks>
+    public SemVersion? End => RightBound.Version;
+
+    /// <summary>
+    /// Whether this range includes the <see cref="End"/> value.
+    /// </summary>
+    /// <value>Whether this range includes the <see cref="End"/> value.</value>
+    public bool EndInclusive => RightBound.Inclusive;
+
+    /// <summary>
+    /// Whether this range includes all prerelease versions between <see cref="Start"/> and
+    /// <see cref="End"/>. If <see cref="IncludeAllPrerelease"/> is <see langword="false"/> then
+    /// prerelease versions matching the major, minor, and patch version of the <see cref="Start"/>
+    /// or <see cref="End"/> will be included only if that end is a prerelease version.
+    /// </summary>
+    public bool IncludeAllPrerelease { get; }
+
+    /// <summary>
+    /// Determine whether this range contains the given version.
+    /// </summary>
+    /// <param name="version">The version to test against the range.</param>
+    /// <returns><see langword="true"/> if the version is contained in the range,
+    /// otherwise <see langword="false"/>.</returns>
+    public bool Contains(SemVersion? version)
+    {
+        if (version is null) throw new ArgumentNullException(nameof(version));
+
+        if (!LeftBound.Contains(version) || !RightBound.Contains(version)) return false;
+
+        if (IncludeAllPrerelease || !version.IsPrerelease) return true;
+
+        // Prerelease versions must match either the start or end
+        return Start?.IsPrerelease == true && version.MajorMinorPatchEquals(Start)
+               || End?.IsPrerelease == true && version.MajorMinorPatchEquals(End);
+    }
+
+    /// <summary>
+    /// Convert this range into a predicate function indicating whether a version is contained
+    /// in the range.
+    /// </summary>
+    /// <param name="range">The range to convert into a predicate function.</param>
+    /// <returns>A predicate that indicates whether a given version is contained in this range.</returns>
+    public static implicit operator Predicate<SemVersion>(UnbrokenSemVersionRange range)
+        => range.Contains;
+
+    #region Equality
+    /// <summary>
+    /// Determines whether two version ranges are equal.
+    /// </summary>
+    /// <returns><see langword="true"/> if <paramref name="other"/> is equal to this range;
+    /// otherwise <see langword="false"/>.</returns>
+    public bool Equals(UnbrokenSemVersionRange? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return LeftBound.Equals(other.LeftBound)
+               && RightBound.Equals(other.RightBound)
+               && IncludeAllPrerelease == other.IncludeAllPrerelease;
+    }
+
+    /// <summary>
+    /// Determines whether the given object is equal to this range.
+    /// </summary>
+    /// <returns><see langword="true"/> if <paramref name="obj"/> is equal to this range;
+    /// otherwise <see langword="false"/>.</returns>
+    public override bool Equals(object? obj)
+        => obj is UnbrokenSemVersionRange other && Equals(other);
+
+    /// <summary>
+    /// Gets a hash code for this instance.
+    /// </summary>
+    /// <returns>
+    /// A hash code for this instance, suitable for use in hashing algorithms
+    /// and data structures like a hash table.
+    /// </returns>
+    public override int GetHashCode()
+        => HashCode.Combine(LeftBound, RightBound, IncludeAllPrerelease);
+
+    /// <summary>
+    /// Determines whether two version ranges are equal.
+    /// </summary>
+    /// <returns><see langword="true"/> if the two values are equal, otherwise <see langword="false"/>.</returns>
+    public static bool operator ==(UnbrokenSemVersionRange? left, UnbrokenSemVersionRange? right)
+        => Equals(left, right);
+
+    /// <summary>
+    /// Determines whether two version ranges are <em>not</em> equal. Due to the complexity of
+    /// ranges, it may be possible for two ranges to match the same set of versions but be
+    /// expressed in different ways and so not be equal.
+    /// </summary>
+    /// <returns><see langword="true"/> if the two ranges are <em>not</em> equal, otherwise <see langword="false"/>.</returns>
+    public static bool operator !=(UnbrokenSemVersionRange? left, UnbrokenSemVersionRange? right)
+        => !Equals(left, right);
+    #endregion
+
+    /// <summary>
+    /// Converts this version range to an equivalent string value in
+    /// <a href="https://semver-nuget.org/ranges/">standard range syntax</a>.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="string" /> equivalent of this version in
+    /// <a href="https://semver-nuget.org/ranges/">standard range syntax</a>.
+    /// </returns>
+    /// <remarks>Ranges including all prerelease versions are indicated with the idiom of prefixing
+    /// with "<c>*-*</c>". This includes all prerelease versions because it matches all prerelease
+    /// versions.</remarks>
+    public override string ToString()
+        => toStringCache ??= ToStringInternal();
+
+    private string ToStringInternal()
+    {
+        if (this == Empty)
+            // Must combine with including prerelease and still be empty
+            return "<0.0.0-0";
+
+        // Simple Equals ranges
+        if (StartInclusive && RightBound.Inclusive && SemVersion.Equals(Start, End))
+            return Start.ToString();
+
+        var includesPrereleaseNotCoveredByEnds = IncludeAllPrerelease && !allPrereleaseCoveredByEnds;
+
+        // All versions ranges
+        var leftUnbounded = LeftBound == LeftBoundedRange.Unbounded;
+        var rightUnbounded = RightBound == RightBoundedRange.Unbounded;
+        if (leftUnbounded && rightUnbounded)
+            return includesPrereleaseNotCoveredByEnds ? "*-*" : "*";
+
+        if (TryToSpecialString(includesPrereleaseNotCoveredByEnds, out var result))
+            return result;
+
+        string range;
+        if (leftUnbounded)
+            range = RightBound.ToString();
+        else if (rightUnbounded)
+            range = LeftBound.ToString();
+        else
+            range = $"{LeftBound} {RightBound}";
+
+        return includesPrereleaseNotCoveredByEnds ? "*-* " + range : range;
+    }
+
+    private bool TryToSpecialString(bool includesPrereleaseNotCoveredByEnds, [NotNullWhen(true)] out string? result)
+    {
+        // Most special ranges follow the pattern '>=X.Y.Z <P.Q.R-0'
+        if (StartInclusive && !RightBound.Inclusive && End?.PrereleaseIsZero == true)
+        {
+            // Wildcard Ranges like 2.*, 2.*-*, 2.3.*, and 2.3.*-*
+            if (Start.Patch == 0 && End.Patch == 0 && (!Start.IsPrerelease || Start.PrereleaseIsZero))
+            {
+                if (Start.Major == End.Major && Start.Minor + BigInteger.One == End.Minor)
+                    // Wildcard patch
+                    result = $"{Start.Major}.{Start.Minor}.*";
+                else if (Start.Major + BigInteger.One == End.Major && Start.Minor == 0 && End.Minor == 0)
+                    // Wildcard minor
+                    result = $"{Start.Major}.*";
+                else
+                    goto tilde;
+
+                if (!includesPrereleaseNotCoveredByEnds)
+                    return true;
+
+                result = Start.PrereleaseIsZero ? result + "-*" : "*-* " + result;
+                return true;
+            }
+
+            // Wildcard ranges like 2.1.4-* follow the pattern '>=X.Y.Z-0 <X.Y.(Z+1)-0'
+            if (Start.PrereleaseIsZero
+                && Start.Major == End.Major && Start.Minor == End.Minor
+                && Start.Patch + BigInteger.One == End.Patch)
+            {
+                result = $"{Start.Major}.{Start.Minor}.{Start.Patch}-*";
+                return true;
+            }
+
+        tilde:
+            // Tilde ranges like ~1.2.3, and ~1.2.3-rc
+            if (Start.Major == End.Major
+                && Start.Minor + BigInteger.One == End.Minor && End.Patch == 0)
+            {
+                result = (includesPrereleaseNotCoveredByEnds ? "*-* ~" : "~") + Start;
+                return true;
+            }
+
+            // Note: caret ranges like ^0.1.2 and ^0.2.3-rc are converted to tilde ranges
+
+            if (Start.Major != 0)
+            {
+                // Caret ranges like ^1.2.3 and ^1.2.3-rc
+                if (Start.Major + 1 == End.Major && End.Minor == 0 && End.Patch == 0)
+                {
+                    result = (includesPrereleaseNotCoveredByEnds ? "*-* ^" : "^") + Start;
+                    return true;
+                }
+            }
+            else if (End.Major == 0
+                     && Start.Minor == 0 && End.Minor == 0
+                     && Start.Patch + BigInteger.One == End.Patch)
+            {
+                // Caret ranges like ^0.0.2 and ^0.0.2-rc
+                result = (includesPrereleaseNotCoveredByEnds ? "*-* ^" : "^") + Start;
+                return true;
+            }
+        }
+
+        // Assign null once
+        result = null;
+
+        // Wildcards with prerelease follow the pattern >=X.Y.Z-φ.α.0 <X.Y.Z-φ.β
+        if (StartInclusive && !RightBound.Inclusive
+            && LeftBound.Version?.MajorMinorPatchEquals(RightBound.Version) == true
+            && LeftBound.Version.IsPrerelease && RightBound.Version.IsPrerelease)
+        {
+            var leftPrerelease = LeftBound.Version.PrereleaseIdentifiers;
+            var rightPrerelease = RightBound.Version.PrereleaseIdentifiers;
+            if (leftPrerelease.Count < 2
+                || leftPrerelease[^1] != PrereleaseIdentifier.Zero
+                || leftPrerelease.Count - 1 != rightPrerelease.Count)
+                return false;
+
+            // But they must be equal in prerelease up to the correct point
+            for (int i = 0; i < leftPrerelease.Count - 2; i++)
+                if (leftPrerelease[i] != rightPrerelease[i])
+                    return false;
+
+            // And the prerelease identifiers must have the correct relationship
+            if (leftPrerelease[^2].NextIdentifier()
+                != rightPrerelease[^1])
+                return false;
+
+            var originalPrerelease = string.Join(".", leftPrerelease.Take(leftPrerelease.Count - 1));
+            result = $"{Start.Major}.{Start.Minor}.{Start.Patch}-{originalPrerelease}.*";
+            return true;
+        }
+
+        return false;
+    }
+
+    internal bool Overlaps(UnbrokenSemVersionRange other)
+    {
+        // The empty range doesn't overlap anything, but passes the test below in some cases
+        if (Empty.Equals(this) || Empty.Equals(other)) return false;
+
+        // see https://stackoverflow.com/a/3269471/268898
+        return LeftBound.CompareTo(other.RightBound) <= 0
+               && other.LeftBound.CompareTo(RightBound) <= 0;
+    }
+
+    internal bool OverlapsOrAbuts(UnbrokenSemVersionRange other)
+    {
+        if (Overlaps(other)) return true;
+
+        // The empty range is never considered to abut anything even though its "ends" might
+        // actually abut things.
+        if (Empty.Equals(this) || Empty.Equals(other)) return false;
+
+        // To check abutting, we just need to put them in the right order and check the gap between them
+        var isLessThanOrEqual = UnbrokenSemVersionRangeComparer.Instance.Compare(this, other) <= 0;
+        var leftRangeEnd = (isLessThanOrEqual ? this : other).RightBound;
+        var rightRangeStart = (isLessThanOrEqual ? other : this).LeftBound;
+
+        // Note: the case where a major, minor, or patch version is at max value and so is just
+        // less than the next prerelease version is being ignored.
+
+        // If one of the ends is inclusive then it is sufficient for them to be the same version.
+        if ((leftRangeEnd.Inclusive || rightRangeStart.Inclusive)
+            && leftRangeEnd.Version?.Equals(rightRangeStart.Version) == true)
+            return true;
+
+        // But they could also abut if the prerelease versions between them are being excluded.
+        if (IncludeAllPrerelease || other.IncludeAllPrerelease
+            || leftRangeEnd.IncludesPrerelease || rightRangeStart.IncludesPrerelease)
+            return false;
+
+        return rightRangeStart.Inclusive
+               && leftRangeEnd.Version?.MajorMinorPatchEquals(rightRangeStart.Version) == true;
+    }
+
+    /// <summary>
+    /// Whether this range contains the other. For this to be the case, it must contain all the
+    /// versions accounting for which prerelease versions are in each range.
+    /// </summary>
+    internal bool Contains(UnbrokenSemVersionRange other)
+    {
+        // The empty set is a subset of every other set, even itself
+        if (other == Empty) return true;
+
+        // It contains prerelease we don't
+        if (other.IncludeAllPrerelease && !IncludeAllPrerelease) return false;
+
+        // If our bounds don't contain the other bounds, there is no containment
+        if (LeftBound.CompareTo(other.LeftBound) > 0
+            || other.RightBound.CompareTo(RightBound) > 0) return false;
+
+        // Our bounds contain the other bounds, but that doesn't mean it contains if there
+        // are prerelease versions that are being missed.
+
+        // If we contain all prerelease versions, it is safe
+        if (IncludeAllPrerelease) return true;
+
+        // Make sure we include prerelease at the start
+        if (other.LeftBound.IncludesPrerelease)
+        {
+            if (!(Start?.IsPrerelease ?? false)
+                || !Start.MajorMinorPatchEquals(other.Start)) return false;
+        }
+
+        // Make sure we include prerelease at the end
+        return !other.RightBound.IncludesPrerelease
+               || (End?.IsPrerelease == true && End.MajorMinorPatchEquals(other.End));
+    }
+
+    /// <summary>
+    /// Try to union this range with the other. This is a complex operation because it must
+    /// account for prerelease versions that may be accepted at the endpoints of the ranges.
+    /// </summary>
+    internal bool TryUnion(UnbrokenSemVersionRange other, [NotNullWhen(true)] out UnbrokenSemVersionRange? union)
+    {
+        // First deal with simple containment. This handles cases where the containing range
+        // includes all prerelease that aren't handled with the union below. It also handles
+        // containment of empty ranges.
+        if (Contains(other))
+        {
+            union = this;
+            return true;
+        }
+
+        if (other.Contains(this))
+        {
+            union = other;
+            return true;
+        }
+
+        // Assign null once, so it doesn't need to be assigned in every return case
+        union = null;
+
+        // Can't union ranges with different prerelease coverage
+        if (IncludeAllPrerelease != other.IncludeAllPrerelease) return false;
+
+        // No overlap means no union
+        if (!OverlapsOrAbuts(other)) return false;
+
+        var leftBound = LeftBound.Min(other.LeftBound);
+        var rightBound = RightBound.Max(other.RightBound);
+        var includeAllPrerelease = IncludeAllPrerelease; // note that other.IncludeAllPrerelease is equal
+
+        // Create the union early to use it for containment checks
+        var possibleUnion = Create(leftBound, rightBound, includeAllPrerelease);
+
+        // If all prerelease is included, then the prerelease versions from the dropped ends
+        // will be covered.
+        if (!includeAllPrerelease)
+        {
+            var otherLeftBound = LeftBound.Max(other.LeftBound);
+            if (otherLeftBound.IncludesPrerelease
+                && !possibleUnion.Contains(otherLeftBound.Version))
+                return false;
+
+            var otherRightBound = RightBound.Min(other.RightBound);
+            if (otherRightBound.IncludesPrerelease
+                && !possibleUnion.Contains(otherRightBound.Version))
+                return false;
+        }
+
+        union = possibleUnion;
+        return true;
+    }
+
+    private static bool IsEmpty(LeftBoundedRange start, RightBoundedRange end, bool includeAllPrerelease)
+    {
+        // Ranges with unbounded ends aren't empty
+        if (end.Version is null) return false;
+
+        var comparison = SemVersion.ComparePrecedence(start.Version, end.Version);
+        if (comparison > 0) return true;
+        if (comparison == 0) return !(start.Inclusive && end.Inclusive);
+
+        // else start < end
+
+        if (start.Version is null)
+        {
+            if (end.Inclusive) return false;
+            // A range like "<0.0.0" is empty if prerelease isn't allowed and
+            // "<0.0.0-0" is empty even it if isn't
+            return end.Version == SemVersion.Min
+                   || (!includeAllPrerelease && end.Version == SemVersion.MinRelease);
+        }
+
+        // A range like ">1.0.0 <1.0.1" is still empty if prerelease isn't allowed.
+        // If prerelease is allowed, there is always an infinite number of versions in the range
+        // (e.g. ">1.0.0-0 <1.0.1-0" contains "1.0.0-0.between").
+        if (start.Inclusive || end.Inclusive
+            || includeAllPrerelease || start.Version.IsPrerelease || end.Version.IsPrerelease)
+            return false;
+
+        return start.Version.Major == end.Version.Major
+               && start.Version.Minor == end.Version.Minor
+               && start.Version.Patch + BigInteger.One == end.Version.Patch;
+    }
+
+    private static SemVersion Validate(SemVersion version, string paramName)
+    {
+        if (version is null) throw new ArgumentNullException(paramName);
+        if (version.MetadataIdentifiers.Count > 0) throw new ArgumentException(InvalidMetadataMessage, paramName);
+        return version;
+    }
+
+    private const string InvalidMetadataMessage = "Cannot have metadata.";
+}

--- a/src/Vendoring/SemVer/Utility/CharExtensions.cs
+++ b/src/Vendoring/SemVer/Utility/CharExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Semver.Utility;
+
+internal static class CharExtensions
+{
+    /// <summary>
+    /// Is this character an ASCII digit '0' through '9'
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsDigit(this char c) => c is >= '0' and <= '9';
+
+    /// <summary>
+    /// Is this character and ASCII alphabetic character or hyphen [A-Za-z-]
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsAlphaOrHyphen(this char c)
+        => c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or '-';
+}

--- a/src/Vendoring/SemVer/Utility/DebugChecks.cs
+++ b/src/Vendoring/SemVer/Utility/DebugChecks.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Numerics;
+using Microsoft.Extensions.Primitives;
+using Semver.Parsing;
+
+namespace Semver.Utility;
+
+/// <summary>
+/// The <see cref="DebugChecks"/> class allows for the various conditional checks done only in
+/// debug builds to not count against the code coverage metrics.
+/// </summary>
+/// <remarks>When using a preprocessor conditional block, the contained lines are not covered by
+/// the unit tests (see example below). This is expected because the conditions should not be
+/// reachable. But it makes it difficult to evaluate at a glance whether full code coverage has
+/// been reached.
+/// <code>
+/// #if DEBUG
+///     if (condition) throw new Exception("...");
+/// #endif
+/// </code>
+/// </remarks>
+[ExcludeFromCodeCoverage]
+internal static class DebugChecks
+{
+    [Conditional("DEBUG")]
+    public static void IsValid(SemVersionStyles style, string paramName)
+    {
+        if (!style.IsValid())
+            throw new ArgumentException("DEBUG: " + SemVersion.InvalidSemVersionStylesMessage, paramName);
+    }
+
+    [Conditional("DEBUG")]
+    public static void IsValid(SemVersionRangeOptions rangeOptions, string paramName)
+    {
+        if (!rangeOptions.IsValid())
+            throw new ArgumentException("DEBUG: " + SemVersionRange.InvalidOptionsMessage, paramName);
+    }
+
+    [Conditional("DEBUG")]
+    public static void IsValidMaxLength(int maxLength, string paramName)
+    {
+        if (maxLength < 0)
+            throw new ArgumentOutOfRangeException(paramName, "DEBUG: " + SemVersionRange.InvalidMaxLengthMessage);
+    }
+
+    [Conditional("DEBUG")]
+    public static void IsNotWildcardVersionWithPrerelease(WildcardVersion wildcardVersion, SemVersion semver)
+    {
+        if (wildcardVersion != WildcardVersion.None && semver.IsPrerelease)
+            throw new InvalidOperationException("DEBUG: prerelease not allowed with wildcard");
+    }
+
+    [Conditional("DEBUG")]
+    public static void IsNotEmpty(StringSegment segment, string paramName)
+    {
+        if (segment.IsEmpty())
+            throw new ArgumentException("DEBUG: Cannot be empty", paramName);
+    }
+
+    [Conditional("DEBUG")]
+    public static void IsNotNull<T>([NotNull] T? value, string paramName)
+        where T : class
+    {
+        if (value == null)
+            throw new ArgumentNullException(paramName, "DEBUG: Value cannot be null.");
+    }
+
+    /// <summary>
+    /// This check ensures that an exception hasn't been constructed, but rather something always
+    /// returns <see cref="VersionParsing.FailedException"/>.
+    /// </summary>
+    [Conditional("DEBUG")]
+    public static void IsNotFailedException(Exception? exception, string className, string methodName)
+    {
+        if (exception != null && exception != VersionParsing.FailedException)
+            throw new InvalidOperationException($"DEBUG: {className}.{methodName} returned exception other than {nameof(VersionParsing.FailedException)}", exception);
+    }
+
+    [Conditional("DEBUG")]
+    public static void NoMetadata(SemVersion? version, string paramName)
+    {
+        if (version?.MetadataIdentifiers.Any() ?? false)
+            throw new ArgumentException("DEBUG: Cannot have metadata.", paramName);
+    }
+
+    [Conditional("DEBUG")]
+    public static void IsValidVersionNumber(BigInteger versionNumber, string kind, string paramName)
+    {
+        if (versionNumber < 0)
+            throw new ArgumentException($"DEBUG: {kind} version must be greater than or equal to zero.", paramName);
+    }
+
+    [Conditional("DEBUG")]
+    public static void ContainsNoDefaultValues<T>(IEnumerable<T> values, string kind, string paramName)
+        where T : struct
+    {
+        if (values.Any(i => EqualityComparer<T>.Default.Equals(i, default)))
+            throw new ArgumentException($"DEBUG: {kind} identifier cannot be default/null.", paramName);
+    }
+
+    [Conditional("DEBUG")]
+    public static void AreEqualWhenJoinedWithDots<T>(string value, string param1Name, IReadOnlyList<T> values, string param2Name)
+    {
+        if (value != string.Join(".", values))
+            throw new ArgumentException($"DEBUG: must be equal to {param2Name} when joined with dots.", param1Name);
+    }
+}

--- a/src/Vendoring/SemVer/Utility/Display.cs
+++ b/src/Vendoring/SemVer/Utility/Display.cs
@@ -1,0 +1,6 @@
+﻿namespace Semver.Utility;
+
+internal static class Display
+{
+    public const int Limit = 100;
+}

--- a/src/Vendoring/SemVer/Utility/EnumerableExtensions.cs
+++ b/src/Vendoring/SemVer/Utility/EnumerableExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace Semver.Utility;
+
+internal static class EnumerableExtensions
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static IReadOnlyList<T> ToReadOnlyList<T>(this IEnumerable<T> values)
+        => values.ToList().AsReadOnly();
+}

--- a/src/Vendoring/SemVer/Utility/IdentifierString.cs
+++ b/src/Vendoring/SemVer/Utility/IdentifierString.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Semver.Utility;
+
+/// <summary>
+/// Methods for working with the strings that make up identifiers
+/// </summary>
+internal static class IdentifierString
+{
+    /// <summary>
+    /// Compare two strings as they should be compared as identifiers.
+    /// </summary>
+    /// <remarks>This enforces ordinal comparison. It also fixes a technically
+    /// correct but odd thing where the comparison result can be a number
+    /// other than -1, 0, or 1.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int Compare(string left, string right)
+        => Math.Sign(string.CompareOrdinal(left, right));
+}

--- a/src/Vendoring/SemVer/Utility/ReadOnlyList.cs
+++ b/src/Vendoring/SemVer/Utility/ReadOnlyList.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace Semver.Utility;
+
+/// <summary>
+/// Internal helper for efficiently creating empty read only lists
+/// </summary>
+internal static class ReadOnlyList<T>
+{
+    public static readonly IReadOnlyList<T> Empty = new List<T>().AsReadOnly();
+}

--- a/src/Vendoring/SemVer/Utility/StringExtensions.cs
+++ b/src/Vendoring/SemVer/Utility/StringExtensions.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Primitives;
+
+namespace Semver.Utility;
+
+internal static class StringExtensions
+{
+    /// <summary>
+    /// Is this string composed entirely of ASCII digits '0' to '9'?
+    /// </summary>
+    public static bool IsDigits(this string value)
+    {
+        foreach (var c in value)
+            if (!c.IsDigit())
+                return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Is this string composed entirely of ASCII alphanumeric characters and hyphens?
+    /// </summary>
+    public static bool IsAlphanumericOrHyphens(this string value)
+    {
+        foreach (var c in value)
+            if (!c.IsAlphaOrHyphen() && !c.IsDigit())
+                return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Split a string, map the parts, and return a read only list of the values.
+    /// </summary>
+    /// <remarks>Splitting a string, mapping the result and storing into a <see cref="IReadOnlyList{T}"/>
+    /// is a common operation in this package. This method optimizes that. It avoids the
+    /// performance overhead of:
+    /// <list type="bullet">
+    ///   <item><description>Constructing the params array for <see cref="string.Split(char[])"/></description></item>
+    ///   <item><description>Constructing the intermediate <see cref="T:string[]"/> returned by <see cref="string.Split(char[])"/></description></item>
+    ///   <item><description><see cref="System.Linq.Enumerable.Select{TSource,TResult}(IEnumerable{TSource},Func{TSource,TResult})"/></description></item>
+    ///   <item><description>Not allocating list capacity based on the size</description></item>
+    /// </list>
+    /// Benchmarking shows this to be 30%+ faster and that may not reflect the whole benefit
+    /// since it doesn't fully account for reduced allocations.
+    /// </remarks>
+    public static IReadOnlyList<T> SplitAndMapToReadOnlyList<T>(
+        this string value,
+        char splitOn,
+        Func<string, T> func)
+    {
+        if (value.Length == 0) return ReadOnlyList<T>.Empty;
+
+        // Figure out how many items the resulting list will have
+        int count = 1; // Always one more item than there are separators
+        // Use `for` instead of `foreach` to ensure performance
+        for (int i = 0; i < value.Length; i++)
+            if (value[i] == splitOn)
+                count++;
+
+        // Allocate enough capacity for the items
+        var items = new List<T>(count);
+        int start = 0;
+        for (int i = 0; i < value.Length; i++)
+            if (value[i] == splitOn)
+            {
+                items.Add(func(value.Substring(start, i - start)));
+                start = i + 1;
+            }
+        // Add the final items from the last separator to the end of the string
+        items.Add(func(value.Substring(start, value.Length - start)));
+
+        return items.AsReadOnly();
+    }
+
+    /// <summary>
+    /// Trim leading zeros from a numeric string. If the string consists of all zeros, return
+    /// <c>"0"</c>.
+    /// </summary>
+    /// <remarks>The standard <see cref="string.TrimStart(char[])"/> method handles all zeros
+    /// by returning <c>""</c>. This efficiently handles the kind of trimming needed.</remarks>
+    public static string TrimLeadingZeros(this string value)
+    {
+        int start;
+        var searchUpTo = value.Length - 1;
+        for (start = 0; start < searchUpTo; start++)
+            if (value[start] != '0')
+                break;
+
+        return value[start..];
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static StringSegment Slice(this string value, int offset, int length)
+        => new(value, offset, length);
+
+    public static string LimitLength(this string value)
+    {
+        if (value.Length > Display.Limit)
+            return value[..(Display.Limit - 3)] + "...";
+
+        return value;
+    }
+}

--- a/src/Vendoring/SemVer/Utility/StringSegmentExtensions.cs
+++ b/src/Vendoring/SemVer/Utility/StringSegmentExtensions.cs
@@ -1,0 +1,81 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Primitives;
+
+namespace Semver.Utility;
+
+internal static class StringSegmentExtensions
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsEmpty(this StringSegment segment) => segment.Length == 0;
+
+    public static StringSegment TrimStartSpaces(this StringSegment segment)
+    {
+        var start = 0;
+        while (start < segment.Length && segment[start] == ' ') start++;
+        return segment.Subsegment(start);
+    }
+
+    /// <summary>
+    /// Trim leading zeros from a numeric string segment. If the segment consists of all zeros,
+    /// return <c>"0"</c>.
+    /// </summary>
+    /// <remarks>The standard <see cref="string.TrimStart(char[])"/> method handles all zeros
+    /// by returning <c>""</c>. This efficiently handles the kind of trimming needed.</remarks>
+    public static StringSegment TrimLeadingZeros(this StringSegment segment)
+    {
+        var start = 0;
+        while (start < segment.Length - 1 && segment[start] == '0') start++;
+        return segment.Subsegment(start);
+    }
+
+    public static string ToStringLimitLength(this StringSegment segment)
+    {
+        if (segment.Length > Display.Limit) return segment.Subsegment(0, Display.Limit - 3) + "...";
+
+        return segment.ToString();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void SplitBeforeFirst(this StringSegment segment, char c, out StringSegment left, out StringSegment right)
+    {
+        var index = segment.IndexOf(c);
+        if (index >= 0)
+        {
+            left = segment.Subsegment(0, index);
+            right = segment.Subsegment(index);
+        }
+        else
+        {
+            left = segment;
+            right = StringSegment.Empty;
+        }
+    }
+
+    public static int SplitCount(this StringSegment segment, char c)
+    {
+        int count = 1; // Always one more item than there are separators
+        // Use `for` instead of `foreach` to ensure performance
+        for (int i = 0; i < segment.Length; i++)
+            if (segment[i] == c)
+                count++;
+
+        return count;
+    }
+
+    /// <remarks>An optimized split for splitting on a single char.</remarks>
+    public static IEnumerable<StringSegment> Split(this StringSegment segment, char c)
+    {
+        var start = 0;
+        // Use `for` instead of `foreach` to ensure performance
+        for (int i = 0; i < segment.Length; i++)
+            if (segment[i] == c)
+            {
+                yield return segment.Subsegment(start, i - start);
+                start = i + 1;
+            }
+
+        // The final segment from the last separator to the end of the string
+        yield return segment.Subsegment(start);
+    }
+}

--- a/src/Vendoring/SemVer/Utility/Unreachable.cs
+++ b/src/Vendoring/SemVer/Utility/Unreachable.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using Semver.Parsing;
+
+namespace Semver.Utility;
+
+/// <summary>
+/// Used to clearly mark when a case should be unreachable and helps properly manage code coverage.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class Unreachable
+{
+    public static ArgumentException InvalidEnum(StandardOperator @operator)
+        => new ArgumentException($"DEBUG: Invalid {nameof(StandardOperator)} value {@operator}.");
+
+    public static ArgumentException InvalidEnum(WildcardVersion wildcardVersion)
+        => new ArgumentException($"DEBUG: Invalid {nameof(WildcardVersion)} value {wildcardVersion}.");
+}

--- a/src/Vendoring/SemVer/Utility/UnsafeOverload.cs
+++ b/src/Vendoring/SemVer/Utility/UnsafeOverload.cs
@@ -1,0 +1,10 @@
+﻿namespace Semver.Utility;
+
+/// <summary>
+/// Struct used as a marker to differentiate constructor overloads that would
+/// otherwise be the same as safe overloads.
+/// </summary>
+internal readonly struct UnsafeOverload
+{
+    public static readonly UnsafeOverload Marker = default;
+}

--- a/src/Vendoring/SemVer/Utility/VersionParsing.cs
+++ b/src/Vendoring/SemVer/Utility/VersionParsing.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Semver.Parsing;
+
+namespace Semver.Utility;
+
+internal static class VersionParsing
+{
+    /// <remarks>
+    /// This exception is used with the
+    /// <see cref="SemVersionParser.Parse(string,SemVersionStyles,Exception,int,out SemVersion)"/>
+    /// method to indicate parse failure without constructing a new exception.
+    /// This exception should never be thrown or exposed outside of this
+    /// package.
+    /// </remarks>
+    public static readonly Exception FailedException = new Exception("Parse Failed");
+}


### PR DESCRIPTION
SemVer is bringing in an old version of MS.Ext.Primitives that doesn't restore when NuGet signing validation is enabled on Linux.

Temporarily vendor SemVer code in this repo until an upstream fix can be made.

Fix #15222