### PR TITLE
Improve polyglot and resource-scoped error messages

### DIFF
--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
@@ -2026,10 +2026,18 @@ internal sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             process.on('uncaughtException', (error: Error) => {
                 if (error instanceof AppHostUsageError) {
                     console.error(`\n❌ AppHost Error: ${error.message}`);
+                } else if (error instanceof CapabilityError) {
+                    console.error(`\n❌ Capability Error: ${error.message}`);
+                    console.error(`   Code: ${error.code}`);
+                    if (error.capability) {
+                        console.error(`   Capability: ${error.capability}`);
+                    }
                 } else {
                     console.error(`\n❌ Uncaught Exception: ${error.message}`);
                 }
-                if (!(error instanceof AppHostUsageError) && error.stack) {
+                // Suppress stack traces for structured errors (AppHostUsageError, CapabilityError)
+                // to keep polyglot output clean. Use --verbose for full diagnostics.
+                if (!(error instanceof AppHostUsageError) && !(error instanceof CapabilityError) && error.stack) {
                     console.error(error.stack);
                 }
                 process.exit(1);

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/transport.ts
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/transport.ts
@@ -360,6 +360,7 @@ export class CapabilityError extends Error {
     ) {
         super(error.message);
         this.name = 'CapabilityError';
+        Object.setPrototypeOf(this, new.target.prototype);
     }
 
     /** Machine-readable error code */
@@ -380,6 +381,7 @@ export class AppHostUsageError extends Error {
     constructor(message: string) {
         super(message);
         this.name = 'AppHostUsageError';
+        Object.setPrototypeOf(this, new.target.prototype);
     }
 }
 

--- a/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
@@ -669,6 +669,18 @@ internal sealed class CapabilityDispatcher
     }
 
     /// <summary>
+    /// Checks if an exception indicates a type mismatch.
+    /// </summary>
+    private static bool IsTypeMismatchException(ArgumentException ex)
+    {
+        var message = ex.Message;
+        return message.Contains("cannot be converted") ||
+               message.Contains("could not be converted") ||
+               message.Contains("is not assignable") ||
+               message.Contains("type mismatch", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
     /// Finds the mismatched parameter by comparing actual argument types against expected parameter types.
     /// Falls back to parsing the exception message if no mismatch is found by inspection.
     /// </summary>

--- a/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
@@ -28,6 +28,7 @@ internal delegate Task<JsonNode?> CapabilityHandler(
 internal sealed class CapabilityDispatcher
 {
     private readonly ConcurrentDictionary<string, CapabilityRegistration> _capabilities = new();
+    private readonly Dictionary<string, HashSet<string>> _polyglotMethodNamesByClrName = new(StringComparer.Ordinal);
     private readonly HandleRegistry _handles;
     private readonly AtsMarshaller _marshaller;
     private readonly ILogger _logger;
@@ -41,6 +42,8 @@ internal sealed class CapabilityDispatcher
         public required string CapabilityId { get; init; }
         public required CapabilityHandler Handler { get; init; }
         public string? Description { get; init; }
+        public AtsCapabilityInfo? Capability { get; init; }
+        public string? ClrMemberName { get; init; }
     }
 
     /// <summary>
@@ -177,7 +180,13 @@ internal sealed class CapabilityDispatcher
                 // Bridge builder -> resource: if the handle contains an IResourceBuilder<T>
                 // but the property is declared on the resource type T, unwrap to the
                 // correct target object. See AtsCapabilityScanner.MapToAtsTypeId.
-                var target = ResolveContextTarget(contextObj!, prop.DeclaringType!);
+                var target = ResolveContextTarget(
+                    capability,
+                    capabilityId,
+                    args,
+                    handles,
+                    contextObj!,
+                    prop.DeclaringType!);
 
                 var value = prop.GetValue(target);
                 return Task.FromResult(_marshaller.MarshalToJson(value, capability.ReturnType));
@@ -187,8 +196,12 @@ internal sealed class CapabilityDispatcher
             {
                 CapabilityId = capabilityId,
                 Handler = getterHandler,
-                Description = capability.Description ?? $"Gets the {property.Name} property"
+                Description = capability.Description ?? $"Gets the {property.Name} property",
+                Capability = capability,
+                ClrMemberName = property.Name
             };
+
+            RegisterMethodAlias(property.Name, capability.MethodName);
         }
         else if (capability.CapabilityKind == AtsCapabilityKind.PropertySetter)
         {
@@ -221,10 +234,23 @@ internal sealed class CapabilityDispatcher
                     CapabilityId = capabilityId,
                     ParameterName = "value"
                 };
-                var value = _marshaller.UnmarshalFromJson(valueNode, prop.PropertyType, unmarshalContext);
+                var value = UnmarshalArgument(
+                    capability,
+                    prop.Name,
+                    prop.PropertyType,
+                    valueNode,
+                    unmarshalContext,
+                    handles,
+                    args);
 
                 // Bridge builder -> resource for setter as well.
-                var setTarget = ResolveContextTarget(contextObj!, prop.DeclaringType!);
+                var setTarget = ResolveContextTarget(
+                    capability,
+                    capabilityId,
+                    args,
+                    handles,
+                    contextObj!,
+                    prop.DeclaringType!);
                 prop.SetValue(setTarget, value);
 
                 // Return the context handle for fluent chaining
@@ -239,8 +265,12 @@ internal sealed class CapabilityDispatcher
             {
                 CapabilityId = capabilityId,
                 Handler = setterHandler,
-                Description = capability.Description ?? $"Sets the {property.Name} property"
+                Description = capability.Description ?? $"Sets the {property.Name} property",
+                Capability = capability,
+                ClrMemberName = property.Name
             };
+
+            RegisterMethodAlias(property.Name, capability.MethodName);
         }
     }
 
@@ -285,7 +315,14 @@ internal sealed class CapabilityDispatcher
                         CapabilityId = capabilityId,
                         ParameterName = paramName
                     };
-                    methodArgs[i] = _marshaller.UnmarshalFromJson(argNode, param.ParameterType, context);
+                    methodArgs[i] = UnmarshalArgument(
+                        capability,
+                        paramName,
+                        param.ParameterType,
+                        argNode,
+                        context,
+                        handles,
+                        args);
                 }
                 else if (param.HasDefaultValue)
                 {
@@ -308,7 +345,13 @@ internal sealed class CapabilityDispatcher
             // Bridge builder -> resource: if the handle contains an IResourceBuilder<T>
             // but the method is declared on the resource type T, unwrap to the
             // correct target object. See AtsCapabilityScanner.MapToAtsTypeId.
-            var invokeTarget = ResolveContextTarget(contextObj!, methodToInvoke.DeclaringType!);
+            var invokeTarget = ResolveContextTarget(
+                capability,
+                capabilityId,
+                args,
+                handles,
+                contextObj!,
+                methodToInvoke.DeclaringType!);
 
             object? result;
             try
@@ -334,8 +377,12 @@ internal sealed class CapabilityDispatcher
         {
             CapabilityId = capabilityId,
             Handler = handler,
-            Description = capability.Description ?? $"Invokes the {method.Name} method"
+            Description = capability.Description ?? $"Invokes the {method.Name} method",
+            Capability = capability,
+            ClrMemberName = method.Name
         };
+
+        RegisterMethodAlias(method.Name, capability.MethodName);
     }
 
     /// <summary>
@@ -364,7 +411,14 @@ internal sealed class CapabilityDispatcher
                         CapabilityId = capabilityId,
                         ParameterName = paramName
                     };
-                    methodArgs[i] = _marshaller.UnmarshalFromJson(argNode, param.ParameterType, context);
+                    methodArgs[i] = UnmarshalArgument(
+                        capability,
+                        paramName,
+                        param.ParameterType,
+                        argNode,
+                        context,
+                        handles,
+                        args);
                 }
                 else if (param.HasDefaultValue)
                 {
@@ -409,8 +463,28 @@ internal sealed class CapabilityDispatcher
         {
             CapabilityId = capabilityId,
             Handler = handler,
-            Description = capability.Description
+            Description = capability.Description,
+            Capability = capability,
+            ClrMemberName = method.Name
         };
+
+        RegisterMethodAlias(method.Name, capability.MethodName);
+    }
+
+    private void RegisterMethodAlias(string? clrMemberName, string? polyglotMethodName)
+    {
+        if (string.IsNullOrEmpty(clrMemberName) || string.IsNullOrEmpty(polyglotMethodName))
+        {
+            return;
+        }
+
+        if (!_polyglotMethodNamesByClrName.TryGetValue(clrMemberName, out var names))
+        {
+            names = new(StringComparer.Ordinal);
+            _polyglotMethodNamesByClrName[clrMemberName] = names;
+        }
+
+        names.Add(polyglotMethodName);
     }
 
     /// <summary>
@@ -453,19 +527,52 @@ internal sealed class CapabilityDispatcher
         {
             return await registration.Handler(args, _handles).ConfigureAwait(false);
         }
+        catch (PolyglotCapabilityInvocationException ex)
+        {
+            throw ex.ToCapabilityException();
+        }
         catch (CapabilityException)
         {
             throw;
         }
+        catch (ArgumentException ex) when (IsTypeMismatchException(ex))
+        {
+            throw PolyglotCapabilityErrorFormatter.CreateInternalError(
+                capabilityId,
+                registration.Capability?.MethodName,
+                registration.ClrMemberName,
+                args,
+                _handles,
+                ex,
+                _polyglotMethodNamesByClrName,
+                registration.Capability?.TargetParameterName,
+                errorCode: AtsErrorCodes.TypeMismatch).ToCapabilityException();
+        }
         catch (InvalidCastException ex)
         {
-            // Convert CLR cast failures to ATS error
-            throw CapabilityException.TypeMismatch(capabilityId, "unknown", "unknown", ex.Message);
+            throw PolyglotCapabilityErrorFormatter.CreateInternalError(
+                capabilityId,
+                registration.Capability?.MethodName,
+                registration.ClrMemberName,
+                args,
+                _handles,
+                ex,
+                _polyglotMethodNamesByClrName,
+                registration.Capability?.TargetParameterName,
+                errorCode: AtsErrorCodes.TypeMismatch).ToCapabilityException();
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Capability {CapabilityId} failed with {ExceptionType}: {Message}", capabilityId, ex.GetType().Name, ex.Message);
-            throw CapabilityException.InternalError(capabilityId, ex.Message, ex);
+            throw PolyglotCapabilityErrorFormatter.CreateInternalError(
+                capabilityId,
+                registration.Capability?.MethodName,
+                registration.ClrMemberName,
+                args,
+                _handles,
+                ex,
+                _polyglotMethodNamesByClrName,
+                registration.Capability?.TargetParameterName).ToCapabilityException();
         }
     }
 
@@ -605,9 +712,54 @@ internal sealed class CapabilityDispatcher
     /// member is declared on the resource type <c>T</c>, since
     /// <c>AtsCapabilityScanner.MapToAtsTypeId</c> maps both to the same type ID.
     /// </summary>
-    private static object ResolveContextTarget(object contextObj, Type declaringType)
+    private object? UnmarshalArgument(
+        AtsCapabilityInfo capability,
+        string parameterName,
+        Type parameterType,
+        JsonNode? argNode,
+        AtsMarshaller.UnmarshalContext context,
+        HandleRegistry handles,
+        JsonObject? args)
+    {
+        var handleRef = HandleRef.FromJsonNode(argNode);
+        if (handleRef is null)
+        {
+            return _marshaller.UnmarshalFromJson(argNode, parameterType, context);
+        }
+
+        if (!handles.TryGet(handleRef.HandleId, out var handleObject, out _))
+        {
+            throw CapabilityException.HandleNotFound(handleRef.HandleId, capability.CapabilityId);
+        }
+
+        return PolyglotCapabilityErrorFormatter.ResolveHandleArgument(
+            capability.CapabilityId,
+            capability.MethodName,
+            args,
+            handles,
+            parameterName,
+            parameterType,
+            handleObject!,
+            capability.TargetParameterName);
+    }
+
+    private static object ResolveContextTarget(
+        AtsCapabilityInfo capability,
+        string capabilityId,
+        JsonObject? args,
+        HandleRegistry handles,
+        object contextObj,
+        Type declaringType)
     {
         if (declaringType.IsInstanceOfType(contextObj))
+        {
+            return contextObj;
+        }
+
+        // Handle is an open-generic builder (e.g., IResourceBuilder<T>) and the context is also a builder
+        if (declaringType.ContainsGenericParameters &&
+            HostingTypeHelpers.IsResourceBuilderType(declaringType) &&
+            HostingTypeHelpers.IsResourceBuilderType(contextObj.GetType()))
         {
             return contextObj;
         }
@@ -625,9 +777,15 @@ internal sealed class CapabilityDispatcher
             }
         }
 
-        // No bridge matched — return as-is; the CLR will throw TargetException if the
-        // object truly doesn't match the declaring type.
-        return contextObj;
+        throw PolyglotCapabilityErrorFormatter.CreateTypeMismatch(
+            capabilityId,
+            capability.MethodName,
+            args,
+            handles,
+            capability.TargetParameterName ?? "context",
+            declaringType,
+            contextObj,
+            capability.TargetParameterName);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/CapabilityDispatcher.cs
@@ -236,7 +236,7 @@ internal sealed class CapabilityDispatcher
                 };
                 var value = UnmarshalArgument(
                     capability,
-                    prop.Name,
+                    "value",
                     prop.PropertyType,
                     valueNode,
                     unmarshalContext,
@@ -759,7 +759,7 @@ internal sealed class CapabilityDispatcher
         // Handle is an open-generic builder (e.g., IResourceBuilder<T>) and the context is also a builder
         if (declaringType.ContainsGenericParameters &&
             HostingTypeHelpers.IsResourceBuilderType(declaringType) &&
-            HostingTypeHelpers.IsResourceBuilderType(contextObj.GetType()))
+            PolyglotCapabilityErrorFormatter.CanUseOpenGenericResourceBuilder(declaringType, contextObj))
         {
             return contextObj;
         }

--- a/src/Aspire.Hosting.RemoteHost/Ats/PolyglotCapabilityInvocationException.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/PolyglotCapabilityInvocationException.cs
@@ -1,0 +1,478 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using Aspire.TypeSystem;
+
+namespace Aspire.Hosting.RemoteHost.Ats;
+
+/// <summary>
+/// Exception used to convert raw hosting failures into polyglot-friendly ATS errors.
+/// </summary>
+internal sealed class PolyglotCapabilityInvocationException : Exception
+{
+    private PolyglotCapabilityInvocationException(
+        string capabilityId,
+        string errorCode,
+        string message,
+        string? parameterName = null,
+        string? expected = null,
+        string? actual = null,
+        Exception? innerException = null)
+        : base(message, innerException)
+    {
+        CapabilityId = capabilityId;
+        ErrorCode = errorCode;
+        ParameterName = parameterName;
+        Expected = expected;
+        Actual = actual;
+    }
+
+    /// <summary>
+    /// Gets the capability ID that failed.
+    /// </summary>
+    public string CapabilityId { get; }
+
+    /// <summary>
+    /// Gets the ATS error code to return.
+    /// </summary>
+    public string ErrorCode { get; }
+
+    /// <summary>
+    /// Gets the parameter name when the failure is tied to one.
+    /// </summary>
+    public string? ParameterName { get; }
+
+    /// <summary>
+    /// Gets the expected type description for type mismatch failures.
+    /// </summary>
+    public string? Expected { get; }
+
+    /// <summary>
+    /// Gets the actual type description for type mismatch failures.
+    /// </summary>
+    public string? Actual { get; }
+
+    /// <summary>
+    /// Creates a type mismatch error.
+    /// </summary>
+    public static PolyglotCapabilityInvocationException TypeMismatch(
+        string capabilityId,
+        string parameterName,
+        string message,
+        string expected,
+        string actual,
+        Exception? innerException = null)
+    {
+        return new PolyglotCapabilityInvocationException(
+            capabilityId,
+            AtsErrorCodes.TypeMismatch,
+            message,
+            parameterName,
+            expected,
+            actual,
+            innerException);
+    }
+
+    /// <summary>
+    /// Creates an internal error with a user-facing message.
+    /// </summary>
+    public static PolyglotCapabilityInvocationException InternalError(
+        string capabilityId,
+        string message,
+        Exception? innerException = null,
+        string? errorCode = null)
+    {
+        return new PolyglotCapabilityInvocationException(
+            capabilityId,
+            errorCode ?? AtsErrorCodes.InternalError,
+            message,
+            innerException: innerException);
+    }
+
+    /// <summary>
+    /// Converts this exception to a structured ATS <see cref="CapabilityException"/>.
+    /// </summary>
+    public CapabilityException ToCapabilityException()
+    {
+        var error = new AtsError
+        {
+            Code = ErrorCode,
+            Message = Message,
+            Capability = CapabilityId,
+            Details = ParameterName is null && Expected is null && Actual is null
+                ? null
+                : new AtsErrorDetails
+                {
+                    Parameter = ParameterName,
+                    Expected = Expected,
+                    Actual = Actual
+                }
+        };
+
+        return InnerException is not null
+            ? new CapabilityException(error, InnerException)
+            : new CapabilityException(error);
+    }
+}
+
+/// <summary>
+/// Formats capability failures for polyglot callers.
+/// </summary>
+internal static partial class PolyglotCapabilityErrorFormatter
+{
+    public static PolyglotCapabilityInvocationException CreateInternalError(
+        string capabilityId,
+        string? polyglotMethodName,
+        string? clrMemberName,
+        JsonObject? args,
+        HandleRegistry handles,
+        Exception exception,
+        IReadOnlyDictionary<string, HashSet<string>>? polyglotMethodNamesByClrName = null,
+        string? targetParameterName = null,
+        string? errorCode = null)
+    {
+        var methodName = polyglotMethodName ?? AtsCapabilityScanner.DeriveMethodName(capabilityId);
+        var targetContext = TryGetTargetContext(args, handles, targetParameterName);
+        var scrubbedMessage = ScrubMessage(exception.Message, polyglotMethodName, clrMemberName, polyglotMethodNamesByClrName);
+        var message = exception.GetType().FullName == "Aspire.Hosting.DistributedApplicationException"
+            ? scrubbedMessage
+            : $"Could not invoke '{methodName}'{targetContext}: {scrubbedMessage}";
+
+        return PolyglotCapabilityInvocationException.InternalError(
+            capabilityId,
+            message,
+            exception,
+            errorCode);
+    }
+
+    public static PolyglotCapabilityInvocationException CreateTypeMismatch(
+        string capabilityId,
+        string? polyglotMethodName,
+        JsonObject? args,
+        HandleRegistry handles,
+        string parameterName,
+        Type expectedType,
+        object actualValue,
+        string? targetParameterName = null,
+        Exception? innerException = null)
+    {
+        var methodName = polyglotMethodName ?? AtsCapabilityScanner.DeriveMethodName(capabilityId);
+        var targetContext = TryGetTargetContext(args, handles, targetParameterName);
+        var expectedDescription = DescribeExpectedType(expectedType);
+        var actualDescription = DescribeActualValue(actualValue);
+        var message = $"Could not invoke '{methodName}'{targetContext} because parameter '{parameterName}' expects {expectedDescription}, but got {actualDescription}.";
+
+        return PolyglotCapabilityInvocationException.TypeMismatch(
+            capabilityId,
+            parameterName,
+            message,
+            expectedDescription,
+            actualDescription,
+            innerException);
+    }
+
+    public static object ResolveHandleArgument(
+        string capabilityId,
+        string? polyglotMethodName,
+        JsonObject? args,
+        HandleRegistry handles,
+        string parameterName,
+        Type expectedType,
+        object handleObject,
+        string? targetParameterName = null)
+    {
+        if (TryConvertHandle(handleObject, expectedType, out var converted))
+        {
+            return converted!;
+        }
+
+        throw CreateTypeMismatch(
+            capabilityId,
+            polyglotMethodName,
+            args,
+            handles,
+            parameterName,
+            expectedType,
+            handleObject,
+            targetParameterName);
+    }
+
+    private static bool TryConvertHandle(object handleObject, Type expectedType, out object? converted)
+    {
+        if (expectedType.IsInstanceOfType(handleObject))
+        {
+            converted = handleObject;
+            return true;
+        }
+
+        if (expectedType.ContainsGenericParameters &&
+            HostingTypeHelpers.IsResourceBuilderType(expectedType) &&
+            HostingTypeHelpers.IsResourceBuilderType(handleObject.GetType()))
+        {
+            converted = handleObject;
+            return true;
+        }
+
+        if (HostingTypeHelpers.IsResourceBuilderType(handleObject.GetType()) && HostingTypeHelpers.IsResourceType(expectedType))
+        {
+            var resource = handleObject.GetType()
+                .GetProperty("Resource")?
+                .GetValue(handleObject);
+
+            if (resource is not null && expectedType.IsInstanceOfType(resource))
+            {
+                converted = resource;
+                return true;
+            }
+        }
+
+        converted = null;
+        return false;
+    }
+
+    private static string TryGetTargetContext(JsonObject? args, HandleRegistry handles, string? targetParameterName)
+    {
+        if (args is null)
+        {
+            return string.Empty;
+        }
+
+        targetParameterName ??= "context";
+        if (!args.TryGetPropertyValue(targetParameterName, out var targetNode))
+        {
+            return string.Empty;
+        }
+
+        var resourceName = TryGetResourceName(targetNode, handles);
+        return resourceName is null ? string.Empty : $" on resource '{resourceName}'";
+    }
+
+    private static string? TryGetResourceName(JsonNode? node, HandleRegistry handles)
+    {
+        var handleRef = HandleRef.FromJsonNode(node);
+        if (handleRef is null || !handles.TryGet(handleRef.HandleId, out var handleObject, out _))
+        {
+            return null;
+        }
+
+        return TryGetResourceName(handleObject);
+    }
+
+    private static string? TryGetResourceName(object? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        if (HostingTypeHelpers.IsResourceType(value.GetType()))
+        {
+            return value.GetType().GetProperty("Name")?.GetValue(value)?.ToString();
+        }
+
+        if (HostingTypeHelpers.IsResourceBuilderType(value.GetType()))
+        {
+            var resource = value.GetType().GetProperty("Resource")?.GetValue(value);
+            return TryGetResourceName(resource);
+        }
+
+        return null;
+    }
+
+    private static string DescribeExpectedType(Type type)
+    {
+        if (type.IsGenericParameter)
+        {
+            return DescribeGenericParameter(type);
+        }
+
+        if (HostingTypeHelpers.IsResourceBuilderType(type) && type.IsGenericType)
+        {
+            return $"a resource builder for {DescribeResourceContract(type.GetGenericArguments()[0])}";
+        }
+
+        if (HostingTypeHelpers.IsResourceType(type))
+        {
+            return DescribeResourceContract(type);
+        }
+
+        return DescribeType(type, article: true);
+    }
+
+    private static string DescribeActualValue(object value)
+    {
+        if (HostingTypeHelpers.IsResourceBuilderType(value.GetType()))
+        {
+            return DescribeBuilderValue(value);
+        }
+
+        if (TryGetResourceName(value) is { } resourceName)
+        {
+            return $"resource '{resourceName}'";
+        }
+
+        return DescribeType(value.GetType(), article: true);
+    }
+
+    private static string DescribeBuilderValue(object value)
+    {
+        var resourceType = TryGetBuilderResourceType(value);
+        var resourceName = TryGetResourceName(value);
+
+        if (resourceType is not null)
+        {
+            var resourceDescription = DescribeResourceContract(resourceType);
+
+            return resourceName is not null
+                ? $"a resource builder for {resourceDescription} named '{resourceName}'"
+                : $"a resource builder for {resourceDescription}";
+        }
+
+        return resourceName is not null
+            ? $"a resource builder for resource '{resourceName}'"
+            : "a resource builder";
+    }
+
+    private static Type? TryGetBuilderResourceType(object value)
+    {
+        var valueType = value.GetType();
+        if (valueType.IsGenericType && HostingTypeHelpers.IsResourceBuilderType(valueType))
+        {
+            return valueType.GetGenericArguments()[0];
+        }
+
+        var resource = valueType.GetProperty("Resource")?.GetValue(value);
+        return resource?.GetType();
+    }
+
+    private static string DescribeResourceContract(Type type)
+    {
+        if (type.IsGenericParameter)
+        {
+            return DescribeGenericParameter(type);
+        }
+
+        var typeName = type.Name;
+
+        // String literals are used because this project does not reference Aspire.Hosting
+        // and therefore cannot use typeof() for these interfaces.
+        return type.FullName switch
+        {
+            "Aspire.Hosting.ApplicationModel.IResourceWithConnectionString" => "a resource with a connection string",
+            "Aspire.Hosting.ApplicationModel.IResourceWithServiceDiscovery" => "a resource with service discovery",
+            "Aspire.Hosting.ApplicationModel.IResourceWithEndpoints" => "a resource with endpoints",
+            "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment" => "a resource with environment variables",
+            _ when typeName == "ExternalServiceResource" => "an external service resource",
+            _ => DescribeType(type, article: true)
+        };
+    }
+
+    private static string DescribeGenericParameter(Type type)
+    {
+        var constraints = type.GetGenericParameterConstraints();
+
+        foreach (var constraint in constraints)
+        {
+            if (constraint.FullName == "Aspire.Hosting.ApplicationModel.IResource")
+            {
+                continue;
+            }
+
+            if (HostingTypeHelpers.IsResourceType(constraint))
+            {
+                return DescribeResourceContract(constraint);
+            }
+        }
+
+        return "a compatible value";
+    }
+
+    private static string DescribeType(Type type, bool article)
+    {
+        var name = type.IsGenericType
+            ? type.Name[..type.Name.IndexOf('`')]
+            : type.Name;
+
+        name = name switch
+        {
+            "String" => "string",
+            "Int32" => "integer",
+            "Boolean" => "boolean",
+            "Uri" => "URI",
+            _ => name.EndsWith("Resource", StringComparison.Ordinal) ? name[..^"Resource".Length] + " resource" : name
+        };
+
+        if (!article)
+        {
+            return name;
+        }
+
+        var articleValue = name.StartsWith("a ", StringComparison.OrdinalIgnoreCase)
+            || name.StartsWith("an ", StringComparison.OrdinalIgnoreCase)
+            ? string.Empty
+            : StartsWithVowelSound(name) ? "an " : "a ";
+
+        return articleValue + name;
+    }
+
+    private static bool StartsWithVowelSound(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return false;
+        }
+
+        // Words starting with vowel letters but consonant sounds (e.g., "URI" = "yoo-are-eye")
+        if (value.StartsWith("URI", StringComparison.Ordinal) ||
+            value.StartsWith("URL", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return "AEIOUaeiou".Contains(value[0]);
+    }
+
+    private static string ScrubMessage(string message, string? polyglotMethodName, string? clrMemberName, IReadOnlyDictionary<string, HashSet<string>>? polyglotMethodNamesByClrName)
+    {
+        if (string.IsNullOrEmpty(message))
+        {
+            return message;
+        }
+
+        if (!string.IsNullOrEmpty(polyglotMethodName) && !string.IsNullOrEmpty(clrMemberName))
+        {
+            message = Regex.Replace(
+                message,
+                $@"\b{Regex.Escape(clrMemberName)}\b",
+                polyglotMethodName);
+        }
+
+        if (polyglotMethodNamesByClrName is not null)
+        {
+            // Replace longest CLR names first to avoid partial matches.
+            foreach (var alias in polyglotMethodNamesByClrName.OrderByDescending(static pair => pair.Key.Length))
+            {
+                // Pick the first polyglot name from the set (typically there is only one).
+                var replacement = alias.Value.First();
+                message = Regex.Replace(
+                    message,
+                    $@"\b{Regex.Escape(alias.Key)}\b",
+                    replacement);
+            }
+        }
+
+        message = message.ReplaceLineEndings(" ");
+        message = DoubleWhitespaceRegex().Replace(message, " ");
+        message = ControlCharacterRegex().Replace(message, " ");
+
+        return message.Trim();
+    }
+
+    [GeneratedRegex(@"\s{2,}")]
+    private static partial Regex DoubleWhitespaceRegex();
+
+    [GeneratedRegex(@"\p{Cc}+")]
+    private static partial Regex ControlCharacterRegex();
+}

--- a/src/Aspire.Hosting.RemoteHost/Ats/PolyglotCapabilityInvocationException.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/PolyglotCapabilityInvocationException.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Reflection;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using Aspire.TypeSystem;
@@ -207,9 +208,7 @@ internal static partial class PolyglotCapabilityErrorFormatter
             return true;
         }
 
-        if (expectedType.ContainsGenericParameters &&
-            HostingTypeHelpers.IsResourceBuilderType(expectedType) &&
-            HostingTypeHelpers.IsResourceBuilderType(handleObject.GetType()))
+        if (CanUseOpenGenericResourceBuilder(expectedType, handleObject))
         {
             converted = handleObject;
             return true;
@@ -230,6 +229,23 @@ internal static partial class PolyglotCapabilityErrorFormatter
 
         converted = null;
         return false;
+    }
+
+    internal static bool CanUseOpenGenericResourceBuilder(Type expectedType, object handleObject)
+    {
+        if (!expectedType.ContainsGenericParameters ||
+            !HostingTypeHelpers.IsResourceBuilderType(expectedType) ||
+            !HostingTypeHelpers.IsResourceBuilderType(handleObject.GetType()))
+        {
+            return false;
+        }
+
+        var expectedResourceType = TryGetBuilderResourceType(expectedType);
+        var actualResourceType = TryGetBuilderResourceType(handleObject);
+
+        return expectedResourceType is not null &&
+            actualResourceType is not null &&
+            SatisfiesExpectedResourceType(actualResourceType, expectedResourceType);
     }
 
     private static string TryGetTargetContext(JsonObject? args, HandleRegistry handles, string? targetParameterName)
@@ -345,6 +361,63 @@ internal static partial class PolyglotCapabilityErrorFormatter
 
         var resource = valueType.GetProperty("Resource")?.GetValue(value);
         return resource?.GetType();
+    }
+
+    private static Type? TryGetBuilderResourceType(Type builderType)
+    {
+        if (builderType.IsGenericType && HostingTypeHelpers.IsResourceBuilderType(builderType))
+        {
+            return builderType.GetGenericArguments()[0];
+        }
+
+        var builderInterface = builderType.GetInterfaces().FirstOrDefault(static type =>
+            type.IsGenericType &&
+            string.Equals(type.GetGenericTypeDefinition().FullName, HostingTypeNames.ResourceBuilderInterface, StringComparison.Ordinal));
+
+        return builderInterface?.GetGenericArguments()[0];
+    }
+
+    private static bool SatisfiesExpectedResourceType(Type actualResourceType, Type expectedResourceType)
+    {
+        if (expectedResourceType.IsGenericParameter)
+        {
+            return SatisfiesGenericParameterConstraints(actualResourceType, expectedResourceType);
+        }
+
+        return !expectedResourceType.ContainsGenericParameters && expectedResourceType.IsAssignableFrom(actualResourceType);
+    }
+
+    private static bool SatisfiesGenericParameterConstraints(Type actualResourceType, Type genericParameter)
+    {
+        var specialConstraints = genericParameter.GenericParameterAttributes & GenericParameterAttributes.SpecialConstraintMask;
+
+        if (specialConstraints.HasFlag(GenericParameterAttributes.ReferenceTypeConstraint) && actualResourceType.IsValueType)
+        {
+            return false;
+        }
+
+        if (specialConstraints.HasFlag(GenericParameterAttributes.NotNullableValueTypeConstraint) &&
+            (!actualResourceType.IsValueType || Nullable.GetUnderlyingType(actualResourceType) is not null))
+        {
+            return false;
+        }
+
+        if (specialConstraints.HasFlag(GenericParameterAttributes.DefaultConstructorConstraint) &&
+            !actualResourceType.IsValueType &&
+            actualResourceType.GetConstructor(Type.EmptyTypes) is null)
+        {
+            return false;
+        }
+
+        foreach (var constraint in genericParameter.GetGenericParameterConstraints())
+        {
+            if (!constraint.IsAssignableFrom(actualResourceType))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static string DescribeResourceContract(Type type)

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -306,7 +306,7 @@ public class ResourceNotificationService : IDisposable
                     displayName
                     );
 
-                throw new DistributedApplicationException($"Dependency resource '{displayName}' failed to start.");
+                throw new DistributedApplicationException($"Resource '{resource.Name}' stopped waiting for dependency resource '{displayName}' because it failed to start.");
             }
             else if ((snapshot.State!.Text == KnownResourceStates.Finished || snapshot.State!.Text == KnownResourceStates.Exited) && snapshot.ExitCode is not null && snapshot.ExitCode != exitCode)
             {
@@ -319,7 +319,7 @@ public class ResourceNotificationService : IDisposable
                     );
 
                 throw new DistributedApplicationException(
-                    $"Resource '{displayName}' has entered the '{snapshot.State.Text}' state with exit code '{snapshot.ExitCode}', expected '{exitCode}'."
+                    $"Resource '{resource.Name}' stopped waiting for dependency resource '{displayName}' because it entered the '{snapshot.State.Text}' state with exit code '{snapshot.ExitCode}', expected '{exitCode}'."
                     );
             }
 
@@ -331,7 +331,7 @@ public class ResourceNotificationService : IDisposable
         }
     }
 
-    private async Task WaitUntilStateAsync(IResource resource, IResource dependency, WaitBehavior waitBehavior, 
+    private async Task WaitUntilStateAsync(IResource resource, IResource dependency, WaitBehavior waitBehavior,
         Func<ILogger, string, string, ResourceEvent, Task> postRunningAction, CancellationToken cancellationToken)
     {
         var resourceLogger = _resourceLoggerService.GetLogger(resource);
@@ -377,7 +377,7 @@ public class ResourceNotificationService : IDisposable
                         displayName
                         );
 
-                    throw new DistributedApplicationException($"Dependency resource '{displayName}' failed to start.");
+                    throw new DistributedApplicationException($"Resource '{resource.Name}' stopped waiting for dependency resource '{displayName}' because it failed to start.");
                 }
                 else if (snapshot.State!.Text == KnownResourceStates.Finished ||
                          snapshot.State.Text == KnownResourceStates.Exited ||
@@ -390,7 +390,7 @@ public class ResourceNotificationService : IDisposable
                         );
 
                     throw new DistributedApplicationException(
-                        $"Resource '{displayName}' has entered the '{snapshot.State.Text}' state prematurely."
+                        $"Resource '{resource.Name}' stopped waiting for dependency resource '{displayName}' because it entered the '{snapshot.State.Text}' state prematurely."
                         );
                 }
             }
@@ -557,7 +557,7 @@ public class ResourceNotificationService : IDisposable
                 break;
             }
         }
-        
+
         if (nameMatch is { } m && m.Value.LastSnapshot != null)
         {
             resourceEvent = new ResourceEvent(m.Value.Resource, m.Key, m.Value.LastSnapshot);
@@ -827,8 +827,8 @@ public class ResourceNotificationService : IDisposable
             return previousState;
         }
 
-        return previousState with 
-        { 
+        return previousState with
+        {
             IconName = newIconName,
             IconVariant = newIconVariant
         };

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -1050,7 +1050,7 @@ public static class ContainerResourceBuilderExtensions
 
         if (annotation is null)
         {
-            throw new InvalidOperationException("The resource does not have a Dockerfile build annotation. Call WithDockerfile before calling WithBuildArg.");
+            throw new InvalidOperationException($"The resource '{builder.Resource.Name}' does not have a Dockerfile build annotation. Call WithDockerfile before calling WithBuildArg.");
         }
 
         annotation.BuildArguments[name] = value;
@@ -1100,7 +1100,7 @@ public static class ContainerResourceBuilderExtensions
 
         if (value.Resource.Secret)
         {
-            throw new InvalidOperationException("Cannot add secret parameter as a build argument. Use WithBuildSecret instead.");
+            throw new InvalidOperationException($"Cannot add secret parameter '{value.Resource.Name}' as build argument '{name}' while configuring resource '{builder.Resource.Name}'. Use WithBuildSecret instead.");
         }
 
         return builder.WithBuildArg(name, value.Resource);
@@ -1150,7 +1150,7 @@ public static class ContainerResourceBuilderExtensions
 
         if (annotation is null)
         {
-            throw new InvalidOperationException("The resource does not have a Dockerfile build annotation. Call WithDockerfile before calling WithBuildSecret.");
+            throw new InvalidOperationException($"The resource '{builder.Resource.Name}' does not have a Dockerfile build annotation. Call WithDockerfile before calling WithBuildSecret.");
         }
 
         annotation.BuildSecrets[name] = value.Resource;

--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -143,7 +143,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         {
             if (!project.TryGetLastAnnotation<IProjectMetadata>(out var projectMetadata))
             {
-                throw new InvalidOperationException("A project resource is missing required metadata"); // Should never happen.
+                throw new InvalidOperationException($"Project resource '{project.Name}' is missing required metadata."); // Should never happen.
             }
 
             EnsureRequiredAnnotations(project);

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -177,7 +177,7 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
     {
         if (!project.TryGetLastAnnotation<IProjectMetadata>(out var metadata))
         {
-            throw new DistributedApplicationException("Project metadata not found.");
+            throw new DistributedApplicationException($"Project metadata was not found for resource '{project.Name}'.");
         }
 
         var relativePathToProjectFile = GetManifestRelativePath(metadata.ProjectPath);
@@ -327,7 +327,7 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
         {
             if (!container.TryGetContainerImageName(out var image))
             {
-                throw new DistributedApplicationException("Could not get container image name.");
+                throw new DistributedApplicationException($"Could not get the container image name for resource '{container.Name}'.");
             }
 
             if (deploymentTarget is not null)

--- a/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
+++ b/src/Aspire.Hosting/Publishing/ResourceContainerImageManager.cs
@@ -268,7 +268,7 @@ internal sealed class ResourceContainerImageManager(
         {
             if (!resource.TryGetContainerImageName(out var imageName))
             {
-                throw new InvalidOperationException("Resource image name could not be determined.");
+                throw new InvalidOperationException($"The container image name for resource '{resource.Name}' could not be determined.");
             }
 
             // This is a container resource so we'll use the container runtime to build the image
@@ -288,7 +288,7 @@ internal sealed class ResourceContainerImageManager(
         }
         else
         {
-            throw new NotSupportedException($"The resource type '{resource.GetType().Name}' is not supported.");
+            throw new NotSupportedException($"The resource '{resource.Name}' of type '{resource.GetType().Name}' is not supported.");
         }
     }
 
@@ -306,7 +306,7 @@ internal sealed class ResourceContainerImageManager(
             if (!success)
             {
                 logger.LogError("Building image for {ResourceName} failed", resource.Name);
-                throw new DistributedApplicationException($"Failed to build container image.");
+                throw new DistributedApplicationException($"Failed to build container image for resource '{resource.Name}'.");
             }
             else
             {
@@ -324,7 +324,7 @@ internal sealed class ResourceContainerImageManager(
         // This is a resource project so we'll use the .NET SDK to build the container image.
         if (!resource.TryGetLastAnnotation<IProjectMetadata>(out var projectMetadata))
         {
-            throw new DistributedApplicationException($"The resource '{projectMetadata}' does not have a project metadata annotation.");
+            throw new DistributedApplicationException($"The resource '{resource.Name}' does not have a project metadata annotation.");
         }
 
         var arguments = $"publish \"{projectMetadata.ProjectPath}\" --configuration Release /t:PublishContainer /p:ContainerRepository=\"{options.LocalImageName}\" /p:ContainerImageTag=\"{options.LocalImageTag}\"";

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -281,7 +281,7 @@ public static class ResourceBuilderExtensions
                     var url = await externalService.Resource.UrlParameter.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
                     if (!ExternalServiceResource.UrlIsValidForExternalService(url, out var _, out var message))
                     {
-                        throw new DistributedApplicationException($"The URL parameter '{externalService.Resource.UrlParameter.Name}' for the external service '{externalService.Resource.Name}' is invalid: {message}");
+                        throw new DistributedApplicationException($"The URL parameter '{externalService.Resource.UrlParameter.Name}' for source resource '{externalService.Resource.Name}' is invalid while configuring target resource '{builder.Resource.Name}': {message}");
                     }
                 }
 
@@ -1013,22 +1013,22 @@ public static class ResourceBuilderExtensions
 
         if (!uri.IsAbsoluteUri)
         {
-            throw new InvalidOperationException("The uri for service reference must be absolute.");
+            throw new InvalidOperationException($"The URI for service reference '{name}' is invalid while configuring target resource '{builder.Resource.Name}': it must be absolute.");
         }
 
-        if (!uri.AbsolutePath.EndsWith("/", StringComparison.Ordinal))
+        if (!uri.AbsolutePath.EndsWith('/'))
         {
-            throw new InvalidOperationException("The uri absolute path must end with '/'.");
+            throw new InvalidOperationException($"The URI for service reference '{name}' is invalid while configuring target resource '{builder.Resource.Name}': the absolute path must end with '/'.");
         }
 
         if (!string.IsNullOrEmpty(uri.Fragment))
         {
-            throw new InvalidOperationException("The URI cannot contain a fragment.");
+            throw new InvalidOperationException($"The URI for service reference '{name}' is invalid while configuring target resource '{builder.Resource.Name}': it cannot contain a fragment.");
         }
 
         if (!string.IsNullOrEmpty(uri.Query))
         {
-            throw new InvalidOperationException("The URI cannot contain a query string.");
+            throw new InvalidOperationException($"The URI for service reference '{name}' is invalid while configuring target resource '{builder.Resource.Name}': it cannot contain a query string.");
         }
 
         // Determine what to inject based on the annotation on the destination resource
@@ -1105,7 +1105,7 @@ public static class ResourceBuilderExtensions
                 }
                 else
                 {
-                    throw new DistributedApplicationException($"The URL parameter '{externalService.Resource.UrlParameter.Name}' for the external service '{externalService.Resource.Name}' is invalid: {message}");
+                    throw new DistributedApplicationException($"The URL parameter '{externalService.Resource.UrlParameter.Name}' for source resource '{externalService.Resource.Name}' is invalid while configuring target resource '{builder.Resource.Name}': {message}");
                 }
 
                 if (flags.HasFlag(ReferenceEnvironmentInjectionFlags.ServiceDiscovery))
@@ -1285,7 +1285,7 @@ public static class ResourceBuilderExtensions
 
         if (builder.Resource.Annotations.OfType<EndpointAnnotation>().Any(sb => string.Equals(sb.Name, annotation.Name, StringComparisons.EndpointAnnotationName)))
         {
-            throw new DistributedApplicationException($"Endpoint with name '{annotation.Name}' already exists. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp'). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in Aspire see: https://aka.ms/dotnet/aspire/networking");
+            throw new DistributedApplicationException($"Endpoint with name '{annotation.Name}' already exists on resource '{builder.Resource.Name}'. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp'). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in Aspire see: https://aka.ms/dotnet/aspire/networking");
         }
 
         // Set the environment variable on the resource
@@ -2292,7 +2292,7 @@ public static class ResourceBuilderExtensions
         {
             if (uri is null)
             {
-                throw new DistributedApplicationException($"The URI for the health check is not set. Ensure that the resource has been allocated before the health check is executed.");
+                throw new DistributedApplicationException($"The URI for the health check on resource '{builder.Resource.Name}' is not set. Ensure that the resource has been allocated before the health check is executed.");
             }
 
             options.AddUri(uri, setup => setup.ExpectHttpCode(statusCode ?? 200));

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/AtsGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/AtsGeneratedAspire.verified.ts
@@ -3525,10 +3525,18 @@ process.on('unhandledRejection', (reason: unknown) => {
 process.on('uncaughtException', (error: Error) => {
     if (error instanceof AppHostUsageError) {
         console.error(`\n❌ AppHost Error: ${error.message}`);
+    } else if (error instanceof CapabilityError) {
+        console.error(`\n❌ Capability Error: ${error.message}`);
+        console.error(`   Code: ${error.code}`);
+        if (error.capability) {
+            console.error(`   Capability: ${error.capability}`);
+        }
     } else {
         console.error(`\n❌ Uncaught Exception: ${error.message}`);
     }
-    if (!(error instanceof AppHostUsageError) && error.stack) {
+    // Suppress stack traces for structured errors (AppHostUsageError, CapabilityError)
+    // to keep polyglot output clean. Use --verbose for full diagnostics.
+    if (!(error instanceof AppHostUsageError) && !(error instanceof CapabilityError) && error.stack) {
         console.error(error.stack);
     }
     process.exit(1);

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -31750,10 +31750,18 @@ process.on('unhandledRejection', (reason: unknown) => {
 process.on('uncaughtException', (error: Error) => {
     if (error instanceof AppHostUsageError) {
         console.error(`\n❌ AppHost Error: ${error.message}`);
+    } else if (error instanceof CapabilityError) {
+        console.error(`\n❌ Capability Error: ${error.message}`);
+        console.error(`   Code: ${error.code}`);
+        if (error.capability) {
+            console.error(`   Capability: ${error.capability}`);
+        }
     } else {
         console.error(`\n❌ Uncaught Exception: ${error.message}`);
     }
-    if (!(error instanceof AppHostUsageError) && error.stack) {
+    // Suppress stack traces for structured errors (AppHostUsageError, CapabilityError)
+    // to keep polyglot output clean. Use --verbose for full diagnostics.
+    if (!(error instanceof AppHostUsageError) && !(error instanceof CapabilityError) && error.stack) {
         console.error(error.stack);
     }
     process.exit(1);

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/transport.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/transport.verified.ts
@@ -360,6 +360,7 @@ export class CapabilityError extends Error {
     ) {
         super(error.message);
         this.name = 'CapabilityError';
+        Object.setPrototypeOf(this, new.target.prototype);
     }
 
     /** Machine-readable error code */
@@ -380,6 +381,7 @@ export class AppHostUsageError extends Error {
     constructor(message: string) {
         super(message);
         this.name = 'AppHostUsageError';
+        Object.setPrototypeOf(this, new.target.prototype);
     }
 }
 

--- a/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
@@ -636,7 +636,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         });
 
         Assert.Equal(
-            "The resource does not have a Dockerfile build annotation. Call WithDockerfile before calling WithBuildArg.",
+            "The resource 'mycontainer' does not have a Dockerfile build annotation. Call WithDockerfile before calling WithBuildArg.",
             ex.Message
             );
     }

--- a/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
@@ -1513,6 +1513,30 @@ public class CapabilityDispatcherTests
     }
 
     [Fact]
+    public void Invoke_GenericBuilderCapability_WithIncompatibleBuilderHandle_UsesFriendlyTypeMismatch()
+    {
+        var handles = new HandleRegistry();
+        var dispatcher = new CapabilityDispatcher(handles, CreateTestMarshaller(handles), [typeof(TestGenericPolyglotErrorCapabilities).Assembly]);
+
+        var resource = new TestResourceWithProperties("backend");
+        var builderHandleId = handles.Register(new TestResourceBuilder<TestResourceWithProperties>(resource), "target-type");
+        var args = new JsonObject
+        {
+            ["builder"] = new JsonObject { ["$handle"] = builderHandleId }
+        };
+
+        var ex = Assert.Throws<CapabilityException>(() =>
+            dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/withHttpEndpoint", args));
+
+        Assert.Equal(AtsErrorCodes.TypeMismatch, ex.Error.Code);
+        Assert.Contains("expects a resource builder for a resource with endpoints", ex.Message);
+        Assert.Contains("got a resource builder for a TestResourceWithProperties named 'backend'", ex.Message);
+        Assert.Equal("builder", ex.Error.Details?.Parameter);
+        Assert.Equal("a resource builder for a resource with endpoints", ex.Error.Details?.Expected);
+        Assert.Equal("a resource builder for a TestResourceWithProperties named 'backend'", ex.Error.Details?.Actual);
+    }
+
+    [Fact]
     public void Invoke_PropertySetter_WithHandleValue_UsesTargetAndActualResourceNames()
     {
         var handles = new HandleRegistry();
@@ -1533,8 +1557,11 @@ public class CapabilityDispatcherTests
 
         Assert.Equal(AtsErrorCodes.TypeMismatch, ex.Error.Code);
         Assert.Contains("Could not invoke 'setColor' on resource 'frontend'", ex.Message);
-        Assert.Contains("parameter 'Color' expects a string", ex.Message);
+        Assert.Contains("parameter 'value' expects a string", ex.Message);
         Assert.Contains("named 'backend'", ex.Message);
+        Assert.Equal("value", ex.Error.Details?.Parameter);
+        Assert.Equal("a string", ex.Error.Details?.Expected);
+        Assert.Equal("a resource builder for a TestResourceWithProperties named 'backend'", ex.Error.Details?.Actual);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
@@ -1416,7 +1416,253 @@ public class CapabilityDispatcherTests
         var ex = Assert.Throws<CapabilityException>(() =>
             dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/TestResourceWithProperties.color", args));
 
+        Assert.Equal(AtsErrorCodes.TypeMismatch, ex.Error.Code);
+        Assert.Contains("parameter 'context'", ex.Message);
+        Assert.Contains("TestResourceWithProperties", ex.Message);
+    }
+
+    [Fact]
+    public void Invoke_TypeMismatch_UsesResourceNamesInsteadOfClrTypes()
+    {
+        var handles = new HandleRegistry();
+        var dispatcher = new CapabilityDispatcher(handles, CreateTestMarshaller(handles), [typeof(TestPolyglotErrorCapabilities).Assembly]);
+
+        var target = new TestResourceWithProperties("frontend");
+        var wrongSource = new TestResourceWithProperties("backend");
+        var targetHandleId = handles.Register(new TestResourceBuilder<TestResourceWithProperties>(target), "target-type");
+        var sourceHandleId = handles.Register(new TestResourceBuilder<TestResourceWithProperties>(wrongSource), "source-type");
+        var args = new JsonObject
+        {
+            ["builder"] = new JsonObject { ["$handle"] = targetHandleId },
+            ["source"] = new JsonObject { ["$handle"] = sourceHandleId }
+        };
+
+        var ex = Assert.Throws<CapabilityException>(() =>
+            dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/withReference", args));
+
+        Assert.Equal(AtsErrorCodes.TypeMismatch, ex.Error.Code);
+        Assert.Contains("Could not invoke 'withReference' on resource 'frontend'", ex.Message);
+        Assert.Contains("parameter 'source' expects a resource builder for a resource with a connection string", ex.Message);
+        Assert.Contains("a resource builder for a TestResourceWithProperties named 'backend'", ex.Message);
+        Assert.DoesNotContain("Aspire.Hosting.", ex.Message);
+    }
+
+    [Fact]
+    public void Invoke_InternalError_IsWrappedWithTargetResourceAndScrubbedMethodName()
+    {
+        var handles = new HandleRegistry();
+        var dispatcher = new CapabilityDispatcher(handles, CreateTestMarshaller(handles), [typeof(TestPolyglotErrorCapabilities).Assembly]);
+
+        var resource = new TestResourceWithProperties("api");
+        var builderHandleId = handles.Register(new TestResourceBuilder<TestResourceWithProperties>(resource), "target-type");
+        var args = new JsonObject
+        {
+            ["builder"] = new JsonObject { ["$handle"] = builderHandleId }
+        };
+
+        var ex = Assert.Throws<CapabilityException>(() =>
+            dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/withEndpoint", args));
+
         Assert.Equal(AtsErrorCodes.InternalError, ex.Error.Code);
+        Assert.Contains("Could not invoke 'withEndpoint' on resource 'api'", ex.Message);
+        Assert.Contains("Multiple calls to withEndpoint can conflict.", ex.Message);
+        Assert.DoesNotContain("WithEndpoint", ex.Message);
+    }
+
+    [Fact]
+    public void Invoke_GenericBuilderCapability_AllowsBuilderHandleAndPreservesUnderlyingMessage()
+    {
+        var handles = new HandleRegistry();
+        var dispatcher = new CapabilityDispatcher(handles, CreateTestMarshaller(handles), [typeof(TestGenericPolyglotErrorCapabilities).Assembly]);
+
+        var resource = new TestEndpointResource("officiator");
+        var builderHandleId = handles.Register(new TestResourceBuilder<TestEndpointResource>(resource), "target-type");
+        var args = new JsonObject
+        {
+            ["builder"] = new JsonObject { ["$handle"] = builderHandleId }
+        };
+
+        var ex = Assert.Throws<CapabilityException>(() =>
+            dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/withHttpEndpoint", args));
+
+        Assert.Equal(AtsErrorCodes.InternalError, ex.Error.Code);
+        Assert.Contains("Endpoint with name 'http' already exists on resource 'officiator'.", ex.Message);
+        Assert.Contains("Multiple calls to withEndpoint", ex.Message);
+        Assert.DoesNotContain("WithEndpoint", ex.Message);
+    }
+
+    [Fact]
+    public void Invoke_GenericBuilderCapability_TypeMismatchUsesConstraintDescription()
+    {
+        var handles = new HandleRegistry();
+        var dispatcher = new CapabilityDispatcher(handles, CreateTestMarshaller(handles), [typeof(TestGenericPolyglotErrorCapabilities).Assembly]);
+
+        var resource = new TestEndpointResource("officiator");
+        var resourceHandleId = handles.Register(resource, "target-type");
+        var args = new JsonObject
+        {
+            ["builder"] = new JsonObject { ["$handle"] = resourceHandleId }
+        };
+
+        var ex = Assert.Throws<CapabilityException>(() =>
+            dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/withHttpEndpoint", args));
+
+        Assert.Equal(AtsErrorCodes.TypeMismatch, ex.Error.Code);
+        Assert.Contains("expects a resource builder for a resource with endpoints", ex.Message);
+        Assert.Contains("got resource 'officiator'", ex.Message);
+    }
+
+    [Fact]
+    public void Invoke_PropertySetter_WithHandleValue_UsesTargetAndActualResourceNames()
+    {
+        var handles = new HandleRegistry();
+        var dispatcher = new CapabilityDispatcher(handles, CreateTestMarshaller(handles), [typeof(TestResourceWithProperties).Assembly]);
+
+        var target = new TestResourceWithProperties("frontend");
+        var wrongValue = new TestResourceWithProperties("backend");
+        var targetHandleId = handles.Register(new TestResourceBuilder<TestResourceWithProperties>(target), "target-type");
+        var valueHandleId = handles.Register(new TestResourceBuilder<TestResourceWithProperties>(wrongValue), "value-type");
+        var args = new JsonObject
+        {
+            ["context"] = new JsonObject { ["$handle"] = targetHandleId },
+            ["value"] = new JsonObject { ["$handle"] = valueHandleId }
+        };
+
+        var ex = Assert.Throws<CapabilityException>(() =>
+            dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/TestResourceWithProperties.setColor", args));
+
+        Assert.Equal(AtsErrorCodes.TypeMismatch, ex.Error.Code);
+        Assert.Contains("Could not invoke 'setColor' on resource 'frontend'", ex.Message);
+        Assert.Contains("parameter 'Color' expects a string", ex.Message);
+        Assert.Contains("named 'backend'", ex.Message);
+    }
+
+    [Fact]
+    public void Invoke_TypeMismatch_PopulatesFriendlyErrorDetails()
+    {
+        var handles = new HandleRegistry();
+        var dispatcher = new CapabilityDispatcher(handles, CreateTestMarshaller(handles), [typeof(TestPolyglotErrorCapabilities).Assembly]);
+
+        var target = new TestResourceWithProperties("frontend");
+        var wrongSource = new TestResourceWithProperties("backend");
+        var targetHandleId = handles.Register(new TestResourceBuilder<TestResourceWithProperties>(target), "target-type");
+        var sourceHandleId = handles.Register(new TestResourceBuilder<TestResourceWithProperties>(wrongSource), "source-type");
+        var args = new JsonObject
+        {
+            ["builder"] = new JsonObject { ["$handle"] = targetHandleId },
+            ["source"] = new JsonObject { ["$handle"] = sourceHandleId }
+        };
+
+        var ex = Assert.Throws<CapabilityException>(() =>
+            dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/withReference", args));
+
+        Assert.Equal("source", ex.Error.Details?.Parameter);
+        Assert.Equal("a resource builder for a resource with a connection string", ex.Error.Details?.Expected);
+        Assert.Equal("a resource builder for a TestResourceWithProperties named 'backend'", ex.Error.Details?.Actual);
+    }
+
+    [Fact]
+    public void PolyglotFormatter_CreateInternalError_UsesBuilderHandleResourceName()
+    {
+        var handles = new HandleRegistry();
+        var resource = new TestResourceWithProperties("orders");
+        var builderHandleId = handles.Register(new TestResourceBuilder<TestResourceWithProperties>(resource), "target-type");
+        var args = new JsonObject
+        {
+            ["builder"] = new JsonObject { ["$handle"] = builderHandleId }
+        };
+
+        var ex = PolyglotCapabilityErrorFormatter.CreateInternalError(
+            "Aspire.Hosting.RemoteHost.Tests/withEndpoint",
+            "withEndpoint",
+            "WithEndpoint",
+            args,
+            handles,
+            new InvalidOperationException("WithEndpoint failed.\r\nTry again."),
+            targetParameterName: "builder");
+
+        var capabilityException = ex.ToCapabilityException();
+
+        Assert.Equal(AtsErrorCodes.InternalError, capabilityException.Error.Code);
+        Assert.Equal("Could not invoke 'withEndpoint' on resource 'orders': withEndpoint failed. Try again.", capabilityException.Message);
+        Assert.DoesNotContain("WithEndpoint", capabilityException.Message);
+    }
+
+    [Fact]
+    public void PolyglotFormatter_CreateInternalError_StripsBareCarriageReturnArtifacts()
+    {
+        var handles = new HandleRegistry();
+        var resource = new TestResourceWithProperties("orders");
+        var builderHandleId = handles.Register(new TestResourceBuilder<TestResourceWithProperties>(resource), "target-type");
+        var args = new JsonObject
+        {
+            ["builder"] = new JsonObject { ["$handle"] = builderHandleId }
+        };
+
+        var ex = PolyglotCapabilityErrorFormatter.CreateInternalError(
+            "Aspire.Hosting.RemoteHost.Tests/withEndpoint",
+            "withEndpoint",
+            "WithEndpoint",
+            args,
+            handles,
+            new InvalidOperationException("The service collection cannot be modified because it is read-only.\r"),
+            targetParameterName: "builder");
+
+        var capabilityException = ex.ToCapabilityException();
+
+        Assert.Equal(
+            "Could not invoke 'withEndpoint' on resource 'orders': The service collection cannot be modified because it is read-only.",
+            capabilityException.Message);
+        Assert.DoesNotContain('\r', capabilityException.Message);
+    }
+
+    [Fact]
+    public void PolyglotFormatter_CreateTypeMismatch_UsesBuilderResourceNames()
+    {
+        var handles = new HandleRegistry();
+        var target = new TestResourceWithProperties("frontend");
+        var wrongSource = new TestResourceWithProperties("backend");
+        var args = new JsonObject
+        {
+            ["builder"] = new JsonObject { ["$handle"] = handles.Register(new TestResourceBuilder<TestResourceWithProperties>(target), "target-type") }
+        };
+
+        var ex = PolyglotCapabilityErrorFormatter.CreateTypeMismatch(
+            "Aspire.Hosting.RemoteHost.Tests/withReference",
+            "withReference",
+            args,
+            handles,
+            "source",
+            typeof(IResourceBuilder<IResourceWithConnectionString>),
+            new TestResourceBuilder<TestResourceWithProperties>(wrongSource),
+            "builder");
+
+        var capabilityException = ex.ToCapabilityException();
+
+        Assert.Equal(AtsErrorCodes.TypeMismatch, capabilityException.Error.Code);
+        Assert.Contains("Could not invoke 'withReference' on resource 'frontend'", capabilityException.Message);
+        Assert.Contains("resource builder for a TestResourceWithProperties named 'backend'", capabilityException.Message);
+        Assert.Equal("a resource builder for a resource with a connection string", capabilityException.Error.Details?.Expected);
+        Assert.Equal("a resource builder for a TestResourceWithProperties named 'backend'", capabilityException.Error.Details?.Actual);
+    }
+
+    [Fact]
+    public void PolyglotFormatter_CreateInternalError_WithoutTargetHandle_OmitsResourceContext()
+    {
+        var handles = new HandleRegistry();
+
+        var ex = PolyglotCapabilityErrorFormatter.CreateInternalError(
+            "Aspire.Hosting.RemoteHost.Tests/createGlobal",
+            "createGlobal",
+            "CreateGlobal",
+            args: null,
+            handles,
+            new InvalidOperationException("CreateGlobal failed."));
+
+        var capabilityException = ex.ToCapabilityException();
+
+        Assert.Equal("Could not invoke 'createGlobal': createGlobal failed.", capabilityException.Message);
+        Assert.DoesNotContain("on resource", capabilityException.Message);
     }
 
     private static CapabilityDispatcher CreateDispatcher(params System.Reflection.Assembly[] assemblies)
@@ -1496,6 +1742,36 @@ internal static class TestCapabilities
     public static bool CanObserveCancellation(CancellationToken cancellationToken)
     {
         return cancellationToken.IsCancellationRequested;
+    }
+}
+
+/// <summary>
+/// Test capabilities that exercise polyglot-specific error shaping.
+/// </summary>
+internal static class TestPolyglotErrorCapabilities
+{
+    [AspireExport("withReference", Description = "Adds a reference to another resource")]
+    public static void WithReference(IResourceBuilder<TestResourceWithProperties> builder, IResourceBuilder<IResourceWithConnectionString> source)
+    {
+        _ = builder;
+        _ = source;
+    }
+
+    [AspireExport("withEndpoint", Description = "Adds an endpoint")]
+    public static void WithEndpoint(IResourceBuilder<TestResourceWithProperties> builder)
+    {
+        _ = builder;
+        throw new InvalidOperationException("Multiple calls to WithEndpoint can conflict.");
+    }
+}
+
+internal static class TestGenericPolyglotErrorCapabilities
+{
+    [AspireExport("withHttpEndpoint", Description = "Adds an HTTP endpoint")]
+    public static void WithHttpEndpoint<T>(IResourceBuilder<T> builder) where T : IResourceWithEndpoints
+    {
+        throw new DistributedApplicationException(
+            $"Endpoint with name 'http' already exists on resource '{builder.Resource.Name}'. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp'). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in Aspire see: https://aka.ms/dotnet/aspire/networking");
     }
 }
 
@@ -1793,6 +2069,13 @@ internal sealed class TestResourceWithProperties : Resource
     public TestResourceWithProperties(string name) : base(name) { }
 
     public string Color { get; set; } = "default";
+}
+
+internal sealed class TestEndpointResource : Resource, IResourceWithEndpoints
+{
+    public TestEndpointResource(string name) : base(name)
+    {
+    }
 }
 
 /// <summary>

--- a/tests/Aspire.Hosting.Tests/ExternalServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExternalServiceTests.cs
@@ -191,10 +191,31 @@ public class ExternalServiceTests(ITestOutputHelper testOutputHelper)
                              .WithReference(externalService);
 
         // Should throw when trying to evaluate environment variables with invalid parameter value
-        await Assert.ThrowsAsync<DistributedApplicationException>(async () =>
+        var ex = await Assert.ThrowsAsync<DistributedApplicationException>(async () =>
         {
             await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(project.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
         });
+
+        Assert.Equal("The URL parameter 'nuget-url' for source resource 'nuget' is invalid while configuring target resource 'project': The URL for the external service must be an absolute URI.", ex.Message);
+    }
+
+    [Fact]
+    public async Task ExternalServiceEnvironmentWithInvalidParameterThrowsInRunMode()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        builder.Configuration["Parameters:nuget-url"] = "invalid-url";
+
+        var urlParam = builder.AddParameter("nuget-url");
+        var externalService = builder.AddExternalService("nuget", urlParam);
+        var project = builder.AddProject<TestProject>("project")
+                             .WithEnvironment("NUGET_URL", externalService);
+
+        var ex = await Assert.ThrowsAsync<DistributedApplicationException>(async () =>
+        {
+            await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(project.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
+        });
+
+        Assert.Equal("The URL parameter 'nuget-url' for source resource 'nuget' is invalid while configuring target resource 'project': The URL for the external service must be an absolute URI.", ex.Message);
     }
 
     [Fact]
@@ -552,7 +573,37 @@ public class ExternalServiceTests(ITestOutputHelper testOutputHelper)
 
         var uri = new Uri("https://api.example.com/service");
         var ex = Assert.Throws<InvalidOperationException>(() => project.WithReference("api", uri));
+        Assert.Contains("reference 'api'", ex.Message);
+        Assert.Contains("target resource 'project'", ex.Message);
         Assert.Contains("absolute path must end with '/'", ex.Message);
+    }
+
+    [Fact]
+    public void WithReferenceThrowsForUriWithFragment()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var project = builder.AddProject<TestProject>("project");
+
+        var uri = new Uri("https://api.example.com/service/#fragment");
+        var ex = Assert.Throws<InvalidOperationException>(() => project.WithReference("api", uri));
+        Assert.Contains("reference 'api'", ex.Message);
+        Assert.Contains("target resource 'project'", ex.Message);
+        Assert.Contains("fragment", ex.Message);
+    }
+
+    [Fact]
+    public void WithReferenceThrowsForUriWithQueryString()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var project = builder.AddProject<TestProject>("project");
+
+        var uri = new Uri("https://api.example.com/service/?query=1");
+        var ex = Assert.Throws<InvalidOperationException>(() => project.WithReference("api", uri));
+        Assert.Contains("reference 'api'", ex.Message);
+        Assert.Contains("target resource 'project'", ex.Message);
+        Assert.Contains("query string", ex.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/PublishAsDockerfileTests.cs
+++ b/tests/Aspire.Hosting.Tests/PublishAsDockerfileTests.cs
@@ -448,6 +448,67 @@ public class PublishAsDockerfileTests
         Assert.Equal(2, callbackCount);
     }
 
+    [Fact]
+    public void WithBuildArgWithoutDockerfileIncludesResourceName()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var container = builder.AddContainer("api", "api:latest");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => container.WithBuildArg("ARG1", "value1"));
+
+        Assert.Equal("The resource 'api' does not have a Dockerfile build annotation. Call WithDockerfile before calling WithBuildArg.", exception.Message);
+    }
+
+    [Fact]
+    public void WithBuildArgWithSecretParameterIncludesResourceName()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        using var tempDir = CreateDirectoryWithDockerFile();
+
+        var secret = builder.AddParameter("secret-param", secret: true);
+        var container = builder.AddContainer("api", "api:latest")
+            .WithDockerfile(tempDir.Path);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => container.WithBuildArg("ARG1", secret));
+
+        Assert.Equal("Cannot add secret parameter 'secret-param' as build argument 'ARG1' while configuring resource 'api'. Use WithBuildSecret instead.", exception.Message);
+    }
+
+    [Fact]
+    public void WithBuildSecretWithoutDockerfileIncludesResourceName()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var secret = builder.AddParameter("secret-param", secret: true);
+        var container = builder.AddContainer("api", "api:latest");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => container.WithBuildSecret("SECRET1", secret));
+
+        Assert.Equal("The resource 'api' does not have a Dockerfile build annotation. Call WithDockerfile before calling WithBuildSecret.", exception.Message);
+    }
+
+    [Fact]
+    public async Task ManifestPublishingProjectWithoutMetadataIncludesResourceName()
+    {
+        var project = new ProjectResource("project-without-metadata");
+
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() => ManifestUtils.GetManifest(project));
+
+        Assert.Equal("Project metadata was not found for resource 'project-without-metadata'.", exception.Message);
+    }
+
+    [Fact]
+    public async Task ManifestPublishingContainerWithoutImageNameIncludesResourceName()
+    {
+        var container = new ContainerResource("container-without-image");
+
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() => ManifestUtils.GetManifest(container));
+
+        Assert.Equal("Could not get the container image name for resource 'container-without-image'.", exception.Message);
+    }
+
     private static TestTempDirectory CreateDirectoryWithDockerFile()
     {
         var tempDir = new TestTempDirectory();

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
@@ -634,6 +634,39 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public async Task BuildImageAsync_ProjectBuildFailureIncludesResourceName()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(output);
+
+        builder.Services.AddLogging(logging =>
+        {
+            logging.AddFakeLogging();
+            logging.AddXunit(output);
+        });
+
+        using var tempDir = new TestTempDirectory();
+
+        var project = builder.AddResource(new ProjectResource("broken-project"))
+            .WithAnnotation(new TestProjectMetadata(Path.Combine(tempDir.Path, "missing.csproj")))
+            .WithContainerBuildOptions(ctx =>
+            {
+                ctx.Destination = ContainerImageDestination.Archive;
+                ctx.ImageFormat = ContainerImageFormat.Oci;
+                ctx.OutputPath = tempDir.Path;
+            });
+
+        using var app = builder.Build();
+
+        using var cts = new CancellationTokenSource(TestConstants.DefaultTimeoutTimeSpan);
+        var imageBuilder = app.Services.GetRequiredService<IResourceContainerImageManager>();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            imageBuilder.BuildImageAsync(project.Resource, cts.Token));
+
+        Assert.Contains("broken-project", exception.Message);
+    }
+
+    [Fact]
     [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
     public async Task CanBuildImageFromDockerfileWithBuildArgsSecretsAndStage()
     {
@@ -1403,4 +1436,11 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         // Verify CheckIfRunningAsync was called
         Assert.Equal(1, fakeContainerRuntime.CheckIfRunningCallCount);
     }
+}
+
+file sealed class TestProjectMetadata(string projectPath) : IProjectMetadata
+{
+    public string ProjectPath { get; } = projectPath;
+
+    public LaunchSettings LaunchSettings { get; } = new();
 }

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
@@ -660,7 +660,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         using var cts = new CancellationTokenSource(TestConstants.DefaultTimeoutTimeSpan);
         var imageBuilder = app.Services.GetRequiredService<IResourceContainerImageManager>();
 
-        var exception = await Assert.ThrowsAsync<Exception>(() =>
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
             imageBuilder.BuildImageAsync(project.Resource, cts.Token));
 
         Assert.Contains("broken-project", exception.Message);

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
@@ -660,7 +660,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         using var cts = new CancellationTokenSource(TestConstants.DefaultTimeoutTimeSpan);
         var imageBuilder = app.Services.GetRequiredService<IResourceContainerImageManager>();
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        var exception = await Assert.ThrowsAsync<Exception>(() =>
             imageBuilder.BuildImageAsync(project.Resource, cts.Token));
 
         Assert.Contains("broken-project", exception.Message);

--- a/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
@@ -165,7 +165,7 @@ public class WithEndpointTests
                     .WithHttpsEndpoint(3000, 2000, name: "mybinding");
         });
 
-        Assert.Equal("Endpoint with name 'mybinding' already exists. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp'). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in Aspire see: https://aka.ms/dotnet/aspire/networking", ex.Message);
+        Assert.Equal("Endpoint with name 'mybinding' already exists on resource 'projecta'. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp'). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in Aspire see: https://aka.ms/dotnet/aspire/networking", ex.Message);
     }
 
     [Fact]
@@ -180,7 +180,7 @@ public class WithEndpointTests
                     .WithHttpsEndpoint(3000, 2000);
         });
 
-        Assert.Equal("Endpoint with name 'https' already exists. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp'). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in Aspire see: https://aka.ms/dotnet/aspire/networking", ex.Message);
+        Assert.Equal("Endpoint with name 'https' already exists on resource 'projecta'. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp'). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in Aspire see: https://aka.ms/dotnet/aspire/networking", ex.Message);
     }
 
     [Fact]
@@ -194,7 +194,7 @@ public class WithEndpointTests
                    .WithHttpsEndpoint(2000, name: "mybinding");
         });
 
-        Assert.Equal("Endpoint with name 'mybinding' already exists. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp'). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in Aspire see: https://aka.ms/dotnet/aspire/networking", ex.Message);
+        Assert.Equal("Endpoint with name 'mybinding' already exists on resource 'projectb'. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp'). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in Aspire see: https://aka.ms/dotnet/aspire/networking", ex.Message);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Improve polyglot and resource-scoped error messages, this goes beyond just polyglot as it updates the exception messages themselves.

- Add PolyglotCapabilityInvocationException and PolyglotCapabilityErrorFormatter
  to convert raw hosting failures into polyglot-friendly ATS errors with
  resource names, method name scrubbing, and structured error details.
- Update CapabilityDispatcher to use the new formatter for type mismatches,
  internal errors, and handle argument resolution, including support for
  open-generic builder context targets.
- Use HashSet<string> for polyglot method name aliases to preserve all
  mappings when multiple capabilities share a CLR member name.
- Preserve TYPE_MISMATCH error code for ArgumentException and
  InvalidCastException via optional errorCode parameter.
- Enrich error messages across Aspire.Hosting (ResourceBuilderExtensions,
  ContainerResourceBuilderExtensions, ManifestPublishingContext, DcpExecutor,
  ResourceNotificationService, ResourceContainerImageManager) to include
  resource names for better diagnostics.
- Fix TypeScript Error subclass instanceof checks with Object.setPrototypeOf
  and add CapabilityError handling in the uncaught exception handler.
- Add comprehensive tests for polyglot error formatting, type mismatch
  descriptions, Dockerfile build arg/secret validation messages, and
  manifest publishing error messages.

Contributes to #15219

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No


### Examples

#### Before

```txt
❌ Capability Error: Endpoint with name 'http' already exists. Endpoint name may not have been explicitly specified
and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp'). Multiple calls to WithEndpoint
(and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique 
name. For more information on networking in Aspire see: https://aka.ms/dotnet/aspire/networking
   Code: INTERNAL_ERROR
   Capability: Aspire.Hosting/withHttpEndpoint
Waiting for the debugger to disconnect...
Waiting for the debugger to disconnect...
Waiting for the debugger to disconnect...
❌ An unexpected error occurred: The TypeScript (Node.js) apphost failed.
```

#### After

```txt
❌ Capability Error: endpoint with name 'http' already exists on resource 'officiator'. endpoint name may not have been explicitly specified and was 
derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp'). Multiple calls to withEndpoint (and related methods) may result in a 
conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in Aspire see:
https://aka.ms/dotnet/aspire/networking
   Code: INTERNAL_ERROR
   Capability: Aspire.Hosting/withHttpEndpoint
Waiting for the debugger to disconnect...
Waiting for the debugger to disconnect...
Waiting for the debugger to disconnect...
❌ An unexpected error occurred: The TypeScript (Node.js) apphost failed. 
```

#### Before

```txt
❌ Capability Error: The service collection cannot be modified because it is read-only.
   Code: INTERNAL_ERROR
   Capability: Aspire.Hosting/withHttpHealthCheck
Waiting for the debugger to disconnect...
Waiting for the debugger to disconnect...
Waiting for the debugger to disconnect...
❌ An unexpected error occurred: The JSON-RPC connection with the remote party was lost before the request could 
complete.
```

#### After

```txt
❌ Capability Error: Could not invoke 'withHttpHealthCheck' on resource 'python-player': The service collection cannot be modified because it is 
read-only.
   Code: INTERNAL_ERROR
   Capability: Aspire.Hosting/withHttpHealthCheck
Waiting for the debugger to disconnect...
Waiting for the debugger to disconnect...
Waiting for the debugger to disconnect...
❌ An unexpected error occurred: The TypeScript (Node.js) apphost failed. 
```

#### Before

```txt
❌ Capability Error: Capability 'Aspire.Hosting/withReference' requires handle of type 'expected type', got 'Object
of type 'Aspire.Hosting.DistributedApplicationResourceBuilder`1[[Aspire.Hosting.ApplicationModel.ProjectResource]]'
cannot be converted to type 'Aspire.Hosting.ApplicationModel.IResourceBuilder`1[[
Aspire.Hosting.ApplicationModel.IResourceWithConnectionString]]'.'
   Code: TYPE_MISMATCH
   Capability: Aspire.Hosting/withReference
Waiting for the debugger to disconnect...
Waiting for the debugger to disconnect...
Waiting for the debugger to disconnect...
❌ An unexpected error occurred: The TypeScript (Node.js) apphost failed. 
```

#### After

```txt
❌ Capability Error: Could not invoke 'withReference' on resource 'csharp-player' because parameter 'source' expects a resource builder for a resource with a connection string, but got a resource builder for a Project resource named 'officiator'.
   Code: TYPE_MISMATCH
   Capability: Aspire.Hosting/withReference
Waiting for the debugger to disconnect...
Waiting for the debugger to disconnect...
Waiting for the debugger to disconnect...
❌ An unexpected error occurred: The TypeScript (Node.js) apphost failed. 
```