### PR TITLE
Handle non-string user secrets in secret list

### DIFF
--- a/src/Shared/UserSecrets/SecretsStore.cs
+++ b/src/Shared/UserSecrets/SecretsStore.cs
@@ -144,7 +144,7 @@ internal sealed class SecretsStore
         var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var kvp in flat)
         {
-            var value = kvp.Value?.GetValue<string>();
+            var value = kvp.Value?.ToString();
             if (value is not null)
             {
                 result[kvp.Key] = value;

--- a/tests/Aspire.Cli.Tests/Secrets/SecretsStoreTests.cs
+++ b/tests/Aspire.Cli.Tests/Secrets/SecretsStoreTests.cs
@@ -160,6 +160,24 @@ public class SecretsStoreTests : IDisposable
     }
 
     [Fact]
+    public void Load_DecodesEncodedStringValues()
+    {
+        var path = GetSecretsPath();
+        var dir = Path.GetDirectoryName(path)!;
+        Directory.CreateDirectory(dir);
+
+        File.WriteAllText(path, """
+        {
+            "EncodedStringValue": "value with \"quotes\", \u0027apostrophes\u0027, and \u4F60\u597D"
+        }
+        """);
+
+        var store = new SecretsStore(path);
+
+        Assert.Equal("value with \"quotes\", 'apostrophes', and 你好", store.Get("EncodedStringValue"));
+    }
+
+    [Fact]
     public void Save_UsesRelaxedEscaping()
     {
         var path = GetSecretsPath();

--- a/tests/Aspire.Cli.Tests/Secrets/SecretsStoreTests.cs
+++ b/tests/Aspire.Cli.Tests/Secrets/SecretsStoreTests.cs
@@ -130,6 +130,36 @@ public class SecretsStoreTests : IDisposable
     }
 
     [Fact]
+    public void Load_ConvertsPrimitiveValuesToStrings()
+    {
+        var path = GetSecretsPath();
+        var dir = Path.GetDirectoryName(path)!;
+        Directory.CreateDirectory(dir);
+
+        File.WriteAllText(path, """
+        {
+            "StringValue": "text",
+            "NumberValue": 42,
+            "BoolValue": true,
+            "Nested": {
+                "InnerNumber": 3.14,
+                "InnerBool": false,
+                "InnerNull": null
+            }
+        }
+        """);
+
+        var store = new SecretsStore(path);
+
+        Assert.Equal("text", store.Get("StringValue"));
+        Assert.Equal("42", store.Get("NumberValue"));
+        Assert.Equal("true", store.Get("BoolValue"));
+        Assert.Equal("3.14", store.Get("Nested:InnerNumber"));
+        Assert.Equal("false", store.Get("Nested:InnerBool"));
+        Assert.Null(store.Get("Nested:InnerNull"));
+    }
+
+    [Fact]
     public void Save_UsesRelaxedEscaping()
     {
         var path = GetSecretsPath();


### PR DESCRIPTION
## Description

Fixes `aspire secret list` crashing when a user secrets entry is stored as a non-string JSON primitive.

This can happen through normal Aspire usage. The Azure provisioning flow persists deployment state into user secrets, including `Azure:AllowResourceGroupCreation`. That setting is written as a JSON boolean (`true`/`false`), not a JSON string. When `aspire secret list` loaded the secrets file, `SecretsStore.Load` flattened the JSON and then assumed every value could be read with `GetValue<string>()`. If the secrets file contained the persisted boolean, the command threw `InvalidOperationException` and failed before listing any secrets.

This change loads non-null flattened `JsonNode` values using their string representation instead, which preserves existing string behavior while allowing boolean and numeric entries to be listed safely. It also adds regression coverage for string, number, boolean, and null values.

Validation:
- `./dotnet.sh test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj -- --filter-class "*.SecretsStoreTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
