### PR TITLE
Refactor backmerge-release.yml to allow specifying source and target branches

### DIFF
--- a/.github/workflows/backmerge-release.yml
+++ b/.github/workflows/backmerge-release.yml
@@ -3,7 +3,18 @@ name: Backmerge Release to Main
 on:
   schedule:
     - cron: '0 0 * * *'  # Runs daily at 00:00 UTC (16:00 PST / 17:00 PDT)
-  workflow_dispatch:      # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      source:
+        description: 'Source branch to merge from'
+        required: true
+        default: 'release/13.2'
+        type: string
+      target:
+        description: 'Target branch to merge into'
+        required: true
+        default: 'main'
+        type: string
 
 permissions:
   contents: write
@@ -16,7 +27,21 @@ jobs:
     timeout-minutes: 15
     if: ${{ github.repository_owner == 'dotnet' }}
 
+    env:
+      SOURCE_BRANCH: ${{ inputs.source || 'release/13.2' }}
+      TARGET_BRANCH: ${{ inputs.target || 'main' }}
+
     steps:
+      - name: Compute merge branch name
+        id: vars
+        run: |
+          # Sanitize branch names for use in the merge branch (replace / with -)
+          SOURCE_SLUG=$(echo "$SOURCE_BRANCH" | sed 's/\//-/g')
+          TARGET_SLUG=$(echo "$TARGET_BRANCH" | sed 's/\//-/g')
+          MERGE_BRANCH="backmerge/${SOURCE_SLUG}-to-${TARGET_SLUG}"
+          echo "merge_branch=$MERGE_BRANCH" >> $GITHUB_OUTPUT
+          echo "Merge branch: $MERGE_BRANCH"
+
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
@@ -25,15 +50,15 @@ jobs:
       - name: Check for changes to backmerge
         id: check
         run: |
-          git fetch origin main release/13.2
-          BEHIND_COUNT=$(git rev-list --count origin/main..origin/release/13.2)
+          git fetch origin "$TARGET_BRANCH" "$SOURCE_BRANCH"
+          BEHIND_COUNT=$(git rev-list --count "origin/$TARGET_BRANCH".."origin/$SOURCE_BRANCH")
           echo "behind_count=$BEHIND_COUNT" >> $GITHUB_OUTPUT
           if [ "$BEHIND_COUNT" -gt 0 ]; then
             echo "changes=true" >> $GITHUB_OUTPUT
-            echo "Found $BEHIND_COUNT commits in release/13.2 not in main"
+            echo "Found $BEHIND_COUNT commits in $SOURCE_BRANCH not in $TARGET_BRANCH"
           else
             echo "changes=false" >> $GITHUB_OUTPUT
-            echo "No changes to backmerge - release/13.2 is up-to-date with main"
+            echo "No changes to backmerge - $SOURCE_BRANCH is up-to-date with $TARGET_BRANCH"
           fi
 
       - name: Attempt merge and create branch
@@ -43,13 +68,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git checkout origin/main
-          git checkout -b backmerge/release-13.2-to-main
+          MERGE_BRANCH="${{ steps.vars.outputs.merge_branch }}"
+          git checkout "origin/$TARGET_BRANCH"
+          git checkout -b "$MERGE_BRANCH"
 
           # Attempt the merge
-          if git merge origin/release/13.2 --no-edit; then
+          if git merge "origin/$SOURCE_BRANCH" --no-edit; then
             echo "merge_success=true" >> $GITHUB_OUTPUT
-            git push origin backmerge/release-13.2-to-main --force
+            git push origin "$MERGE_BRANCH" --force
             echo "Merge successful, branch pushed"
           else
             echo "merge_success=false" >> $GITHUB_OUTPUT
@@ -63,8 +89,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          MERGE_BRANCH="${{ steps.vars.outputs.merge_branch }}"
+
           # Check if a PR already exists for this branch
-          EXISTING_PR=$(gh pr list --head backmerge/release-13.2-to-main --base main --json number --jq '.[0].number // empty')
+          EXISTING_PR=$(gh pr list --head "$MERGE_BRANCH" --base "$TARGET_BRANCH" --json number --jq '.[0].number // empty')
 
           if [ -n "$EXISTING_PR" ]; then
             echo "PR #$EXISTING_PR already exists, updating it"
@@ -72,11 +100,11 @@ jobs:
           else
             PR_BODY="## Automated Backmerge
           
-          This PR merges changes from \`release/13.2\` back into \`main\`.
+          This PR merges changes from \`$SOURCE_BRANCH\` back into \`$TARGET_BRANCH\`.
           
           **Commits to merge:** ${{ steps.check.outputs.behind_count }}
           
-          This PR was created automatically to keep \`main\` up-to-date with release branch changes.
+          This PR was created automatically to keep \`$TARGET_BRANCH\` up-to-date with release branch changes.
           Once approved, please merge using a **merge commit** (not squash or rebase).
           
           ---
@@ -86,9 +114,9 @@ jobs:
             PR_BODY=$(echo "$PR_BODY" | sed 's/^          //')
 
             PR_URL=$(gh pr create \
-              --head backmerge/release-13.2-to-main \
-              --base main \
-              --title "[Automated] Backmerge release/13.2 to main" \
+              --head "$MERGE_BRANCH" \
+              --base "$TARGET_BRANCH" \
+              --title "[Automated] Backmerge $SOURCE_BRANCH to $TARGET_BRANCH" \
               --body "$PR_BODY" \
               --assignee joperezr,radical \
               --label area-engineering-systems)
@@ -105,8 +133,13 @@ jobs:
       - name: Create issue for merge conflicts
         if: steps.check.outputs.changes == 'true' && steps.merge.outputs.merge_success == 'false'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        env:
+          SOURCE_BRANCH: ${{ env.SOURCE_BRANCH }}
+          TARGET_BRANCH: ${{ env.TARGET_BRANCH }}
         with:
           script: |
+            const sourceBranch = process.env.SOURCE_BRANCH;
+            const targetBranch = process.env.TARGET_BRANCH;
             const workflowRunUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             // Check if there's already an open issue for this
@@ -125,7 +158,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: existingIssues.data[0].number,
-                body: `⚠️ Merge conflicts still exist.\n\n**Workflow run:** ${workflowRunUrl}\n\nPlease resolve the conflicts manually.`
+                body: `⚠️ Merge conflicts still exist between \`${sourceBranch}\` and \`${targetBranch}\`.\n\n**Workflow run:** ${workflowRunUrl}\n\nPlease resolve the conflicts manually.`
               });
               return;
             }
@@ -134,15 +167,15 @@ jobs:
             const issueBody = [
               '## Backmerge Conflict',
               '',
-              'The automated backmerge from `release/13.2` to `main` failed due to merge conflicts.',
+              `The automated backmerge from \`${sourceBranch}\` to \`${targetBranch}\` failed due to merge conflicts.`,
               '',
               '### What to do',
               '',
-              '1. Checkout main and attempt the merge locally:',
+              `1. Checkout ${targetBranch} and attempt the merge locally:`,
               '   ```bash',
-              '   git checkout main',
-              '   git pull origin main',
-              '   git merge origin/release/13.2',
+              `   git checkout ${targetBranch}`,
+              `   git pull origin ${targetBranch}`,
+              `   git merge origin/${sourceBranch}`,
               '   ```',
               '2. Resolve the conflicts',
               '3. Push the merge commit or create a PR manually',
@@ -159,7 +192,7 @@ jobs:
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: '[Backmerge] Merge conflicts between release/13.2 and main',
+              title: `[Backmerge] Merge conflicts between ${sourceBranch} and ${targetBranch}`,
               body: issueBody,
               assignees: ['joperezr', 'radical'],
               labels: ['area-engineering-systems', 'backmerge-conflict']


### PR DESCRIPTION
Useful for keeping feature branches up-to-date.

Now that the workflow is more general should we rename to something like `flow`?
