### PR TITLE
Fix polyglot cancellation token ergonomics

### DIFF
--- a/docs/specs/polyglot-apphost.md
+++ b/docs/specs/polyglot-apphost.md
@@ -563,6 +563,14 @@ Callbacks are passed as string IDs **when invoking a capability that accepts a d
 
 When the host later invokes that callback, arguments use **positional keys** (`p0`, `p1`, ...), not parameter names. See [invokeCallback](#invokecallback-host--guest) for the wire format.
 
+`CancellationToken` is special in generated TypeScript:
+
+- **User-authored inputs** accept `AbortSignal | CancellationToken`
+- **Host-provided values** are materialized as `CancellationToken`
+
+This keeps local TypeScript ergonomic while preserving remote token handles that
+need to round-trip back through the transport layer.
+
 #### Callback Handle Wrapping (TypeScript)
 
 When the host invokes a callback, handle parameters are automatically converted to typed wrapper classes:
@@ -755,9 +763,10 @@ Cancellation tokens enable cooperative cancellation of long-running callbacks.
 
 **Token flow:**
 1. Host creates token when invoking a callback that accepts `CancellationToken`
-2. Host passes token ID in callback args as `$cancellationToken`
-3. Guest can cancel by calling `cancelToken` RPC method
-4. Host disposes token when callback completes
+2. If `CancellationToken` is part of the callback signature, the host passes the token ID in the matching positional `pN` argument
+3. Host also includes the same token ID as `$cancellationToken` metadata for transport-level cancellation wiring
+4. Guest can cancel by calling `cancelToken` RPC method
+5. Host disposes token when callback completes
 
 ```json
 // Callback request with cancellation token
@@ -765,6 +774,7 @@ Cancellation tokens enable cooperative cancellation of long-running callbacks.
     "callback_1_1234567890",
     {
         "p0": {"$handle": "5", "$type": "Aspire.Hosting/Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext"},
+        "p1": "ct_a1b2c3d4-e5f6-7890-abcd-ef1234567890",
         "$cancellationToken": "ct_a1b2c3d4-e5f6-7890-abcd-ef1234567890"
     }
 ]}
@@ -971,6 +981,7 @@ Primitive type mapping:
 | `number` | `number` |
 | `boolean` | `boolean` |
 | `any` | `any` |
+| `CancellationToken` | `CancellationToken` for returned/host-provided values; `AbortSignal \| CancellationToken` for generated input parameters |
 | `{Assembly}/{Type}` | `Handle<'{Assembly}/{Type}'>` (typed handle alias) |
 
 ---
@@ -1013,6 +1024,32 @@ const api = await builder
 // Build and run
 await builder.build().run();
 ```
+
+### Cancellation Ergonomics
+
+Generated TypeScript APIs accept either `AbortSignal` or `CancellationToken`
+for user-supplied cancellation input.
+
+Use `AbortSignal` when you create cancellation in TypeScript:
+
+```typescript
+const controller = new AbortController();
+const connectionStringExpression = await db.uriExpression.get();
+const connectionString = await connectionStringExpression.getValue(controller.signal);
+```
+
+When the host gives you a token through callback context or another generated API,
+the generated SDK returns a `CancellationToken` so the remote handle can be passed
+through other generated calls without losing identity:
+
+```typescript
+const cancellationToken = await context.cancellationToken.get();
+const connectionStringExpression = await db.uriExpression.get();
+const connectionString = await connectionStringExpression.getValue(cancellationToken);
+```
+
+Both shapes are accepted by generated input parameters, so local and remote
+cancellation can be mixed naturally in the same AppHost.
 
 ### Fluent Async Chaining
 

--- a/playground/TypeScriptAppHost/.modules/aspire.ts
+++ b/playground/TypeScriptAppHost/.modules/aspire.ts
@@ -9,6 +9,7 @@ import {
     Handle,
     MarshalledHandle,
     AppHostUsageError,
+    CancellationToken,
     CapabilityError,
     registerCallback,
     wrapIfHandle,
@@ -206,6 +207,12 @@ type IResourceWithServiceDiscoveryHandle = Handle<'Aspire.Hosting/Aspire.Hosting
 
 /** Handle to IUserSecretsManager */
 type IUserSecretsManagerHandle = Handle<'Aspire.Hosting/Aspire.Hosting.IUserSecretsManager'>;
+
+/** Handle to IReportingStep */
+type IReportingStepHandle = Handle<'Aspire.Hosting/Aspire.Hosting.Pipelines.IReportingStep'>;
+
+/** Handle to IReportingTask */
+type IReportingTaskHandle = Handle<'Aspire.Hosting/Aspire.Hosting.Pipelines.IReportingTask'>;
 
 /** Handle to PipelineConfigurationContext */
 type PipelineConfigurationContextHandle = Handle<'Aspire.Hosting/Aspire.Hosting.Pipelines.PipelineConfigurationContext'>;
@@ -472,8 +479,37 @@ export interface AppendValueProviderOptions {
     format?: string;
 }
 
+export interface CompleteStepMarkdownOptions {
+    completionState?: string;
+    cancellationToken?: AbortSignal | CancellationToken;
+}
+
+export interface CompleteStepOptions {
+    completionState?: string;
+    cancellationToken?: AbortSignal | CancellationToken;
+}
+
+export interface CompleteTaskMarkdownOptions {
+    completionState?: string;
+    cancellationToken?: AbortSignal | CancellationToken;
+}
+
+export interface CompleteTaskOptions {
+    completionMessage?: string;
+    completionState?: string;
+    cancellationToken?: AbortSignal | CancellationToken;
+}
+
+export interface CreateMarkdownTaskOptions {
+    cancellationToken?: AbortSignal | CancellationToken;
+}
+
+export interface CreateTaskOptions {
+    cancellationToken?: AbortSignal | CancellationToken;
+}
+
 export interface GetValueAsyncOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface PublishAsDockerFileOptions {
@@ -486,11 +522,19 @@ export interface PublishResourceUpdateOptions {
 }
 
 export interface RunOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface SaveStateJsonOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
+}
+
+export interface UpdateTaskMarkdownOptions {
+    cancellationToken?: AbortSignal | CancellationToken;
+}
+
+export interface UpdateTaskOptions {
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface WaitForCompletionOptions {
@@ -841,11 +885,12 @@ export class CommandLineArgsCallbackContext {
 
     /** Gets the CancellationToken property */
     cancellationToken = {
-        get: async (): Promise<AbortSignal> => {
-            return await this._client.invokeCapability<AbortSignal>(
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.ApplicationModel/CommandLineArgsCallbackContext.cancellationToken',
                 { context: this._handle }
             );
+            return CancellationToken.fromValue(result);
         },
     };
 
@@ -936,9 +981,9 @@ export class DistributedApplication {
 
     /** Runs the distributed application */
     /** @internal */
-    async _runInternal(cancellationToken?: AbortSignal): Promise<DistributedApplication> {
+    async _runInternal(cancellationToken?: AbortSignal | CancellationToken): Promise<DistributedApplication> {
         const rpcArgs: Record<string, unknown> = { context: this._handle };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         await this._client.invokeCapability<void>(
             'Aspire.Hosting/run',
             rpcArgs
@@ -1263,7 +1308,7 @@ export class EndpointReference {
     async getValueAsync(options?: GetValueAsyncOptions): Promise<string> {
         const cancellationToken = options?.cancellationToken;
         const rpcArgs: Record<string, unknown> = { context: this._handle };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         return await this._client.invokeCapability<string>(
             'Aspire.Hosting.ApplicationModel/getValueAsync',
             rpcArgs
@@ -1381,11 +1426,12 @@ export class EnvironmentCallbackContext {
 
     /** Gets the CancellationToken property */
     cancellationToken = {
-        get: async (): Promise<AbortSignal> => {
-            return await this._client.invokeCapability<AbortSignal>(
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.ApplicationModel/EnvironmentCallbackContext.cancellationToken',
                 { context: this._handle }
             );
+            return CancellationToken.fromValue(result);
         },
     };
 
@@ -1466,16 +1512,17 @@ export class ExecuteCommandContext {
 
     /** Gets the CancellationToken property */
     cancellationToken = {
-        get: async (): Promise<AbortSignal> => {
-            return await this._client.invokeCapability<AbortSignal>(
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.ApplicationModel/ExecuteCommandContext.cancellationToken',
                 { context: this._handle }
             );
+            return CancellationToken.fromValue(result);
         },
-        set: async (value: AbortSignal): Promise<void> => {
+        set: async (value: AbortSignal | CancellationToken): Promise<void> => {
             await this._client.invokeCapability<void>(
                 'Aspire.Hosting.ApplicationModel/ExecuteCommandContext.setCancellationToken',
-                { context: this._handle, value }
+                { context: this._handle, value: CancellationToken.fromValue(value) }
             );
         }
     };
@@ -1693,16 +1740,17 @@ export class PipelineContext {
 
     /** Gets the CancellationToken property */
     cancellationToken = {
-        get: async (): Promise<AbortSignal> => {
-            return await this._client.invokeCapability<AbortSignal>(
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.Pipelines/PipelineContext.cancellationToken',
                 { context: this._handle }
             );
+            return CancellationToken.fromValue(result);
         },
-        set: async (value: AbortSignal): Promise<void> => {
+        set: async (value: AbortSignal | CancellationToken): Promise<void> => {
             await this._client.invokeCapability<void>(
                 'Aspire.Hosting.Pipelines/PipelineContext.setCancellationToken',
-                { context: this._handle, value }
+                { context: this._handle, value: CancellationToken.fromValue(value) }
             );
         }
     };
@@ -1899,6 +1947,17 @@ export class PipelineStepContext {
         },
     };
 
+    /** Gets the ReportingStep property */
+    reportingStep = {
+        get: async (): Promise<ReportingStep> => {
+            const handle = await this._client.invokeCapability<IReportingStepHandle>(
+                'Aspire.Hosting.Pipelines/PipelineStepContext.reportingStep',
+                { context: this._handle }
+            );
+            return new ReportingStep(handle, this._client);
+        },
+    };
+
     /** Gets the Model property */
     model = {
         get: async (): Promise<DistributedApplicationModel> => {
@@ -1945,11 +2004,12 @@ export class PipelineStepContext {
 
     /** Gets the CancellationToken property */
     cancellationToken = {
-        get: async (): Promise<AbortSignal> => {
-            return await this._client.invokeCapability<AbortSignal>(
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.Pipelines/PipelineStepContext.cancellationToken',
                 { context: this._handle }
             );
+            return CancellationToken.fromValue(result);
         },
     };
 
@@ -2031,6 +2091,21 @@ export class PipelineSummary {
         return new PipelineSummaryPromise(this._addInternal(key, value));
     }
 
+    /** Adds a Markdown-formatted value to the pipeline summary */
+    /** @internal */
+    async _addMarkdownInternal(key: string, markdownString: string): Promise<PipelineSummary> {
+        const rpcArgs: Record<string, unknown> = { summary: this._handle, key, markdownString };
+        await this._client.invokeCapability<void>(
+            'Aspire.Hosting/addMarkdown',
+            rpcArgs
+        );
+        return this;
+    }
+
+    addMarkdown(key: string, markdownString: string): PipelineSummaryPromise {
+        return new PipelineSummaryPromise(this._addMarkdownInternal(key, markdownString));
+    }
+
 }
 
 /**
@@ -2049,6 +2124,11 @@ export class PipelineSummaryPromise implements PromiseLike<PipelineSummary> {
     /** Invokes the Add method */
     add(key: string, value: string): PipelineSummaryPromise {
         return new PipelineSummaryPromise(this._promise.then(obj => obj.add(key, value)));
+    }
+
+    /** Adds a Markdown-formatted value to the pipeline summary */
+    addMarkdown(key: string, markdownString: string): PipelineSummaryPromise {
+        return new PipelineSummaryPromise(this._promise.then(obj => obj.addMarkdown(key, markdownString)));
     }
 
 }
@@ -2593,11 +2673,12 @@ export class ResourceUrlsCallbackContext {
 
     /** Gets the CancellationToken property */
     cancellationToken = {
-        get: async (): Promise<AbortSignal> => {
-            return await this._client.invokeCapability<AbortSignal>(
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.ApplicationModel/ResourceUrlsCallbackContext.cancellationToken',
                 { context: this._handle }
             );
+            return CancellationToken.fromValue(result);
         },
     };
 
@@ -4338,6 +4419,292 @@ export class LoggerFactoryPromise implements PromiseLike<LoggerFactory> {
 }
 
 // ============================================================================
+// ReportingStep
+// ============================================================================
+
+/**
+ * Type class for ReportingStep.
+ */
+export class ReportingStep {
+    constructor(private _handle: IReportingStepHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    /** Creates a reporting task with plain-text status text */
+    /** @internal */
+    async _createTaskInternal(statusText: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingTask> {
+        const rpcArgs: Record<string, unknown> = { reportingStep: this._handle, statusText };
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
+        const result = await this._client.invokeCapability<IReportingTaskHandle>(
+            'Aspire.Hosting/createTask',
+            rpcArgs
+        );
+        return new ReportingTask(result, this._client);
+    }
+
+    createTask(statusText: string, options?: CreateTaskOptions): ReportingTaskPromise {
+        const cancellationToken = options?.cancellationToken;
+        return new ReportingTaskPromise(this._createTaskInternal(statusText, cancellationToken));
+    }
+
+    /** Creates a reporting task with Markdown-formatted status text */
+    /** @internal */
+    async _createMarkdownTaskInternal(markdownString: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingTask> {
+        const rpcArgs: Record<string, unknown> = { reportingStep: this._handle, markdownString };
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
+        const result = await this._client.invokeCapability<IReportingTaskHandle>(
+            'Aspire.Hosting/createMarkdownTask',
+            rpcArgs
+        );
+        return new ReportingTask(result, this._client);
+    }
+
+    createMarkdownTask(markdownString: string, options?: CreateMarkdownTaskOptions): ReportingTaskPromise {
+        const cancellationToken = options?.cancellationToken;
+        return new ReportingTaskPromise(this._createMarkdownTaskInternal(markdownString, cancellationToken));
+    }
+
+    /** Logs a plain-text message for the reporting step */
+    /** @internal */
+    async _logStepInternal(level: string, message: string): Promise<ReportingStep> {
+        const rpcArgs: Record<string, unknown> = { reportingStep: this._handle, level, message };
+        await this._client.invokeCapability<void>(
+            'Aspire.Hosting/logStep',
+            rpcArgs
+        );
+        return this;
+    }
+
+    logStep(level: string, message: string): ReportingStepPromise {
+        return new ReportingStepPromise(this._logStepInternal(level, message));
+    }
+
+    /** Logs a Markdown-formatted message for the reporting step */
+    /** @internal */
+    async _logStepMarkdownInternal(level: string, markdownString: string): Promise<ReportingStep> {
+        const rpcArgs: Record<string, unknown> = { reportingStep: this._handle, level, markdownString };
+        await this._client.invokeCapability<void>(
+            'Aspire.Hosting/logStepMarkdown',
+            rpcArgs
+        );
+        return this;
+    }
+
+    logStepMarkdown(level: string, markdownString: string): ReportingStepPromise {
+        return new ReportingStepPromise(this._logStepMarkdownInternal(level, markdownString));
+    }
+
+    /** Completes the reporting step with plain-text completion text */
+    /** @internal */
+    async _completeStepInternal(completionText: string, completionState?: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingStep> {
+        const rpcArgs: Record<string, unknown> = { reportingStep: this._handle, completionText };
+        if (completionState !== undefined) rpcArgs.completionState = completionState;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
+        await this._client.invokeCapability<void>(
+            'Aspire.Hosting/completeStep',
+            rpcArgs
+        );
+        return this;
+    }
+
+    completeStep(completionText: string, options?: CompleteStepOptions): ReportingStepPromise {
+        const completionState = options?.completionState;
+        const cancellationToken = options?.cancellationToken;
+        return new ReportingStepPromise(this._completeStepInternal(completionText, completionState, cancellationToken));
+    }
+
+    /** Completes the reporting step with Markdown-formatted completion text */
+    /** @internal */
+    async _completeStepMarkdownInternal(markdownString: string, completionState?: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingStep> {
+        const rpcArgs: Record<string, unknown> = { reportingStep: this._handle, markdownString };
+        if (completionState !== undefined) rpcArgs.completionState = completionState;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
+        await this._client.invokeCapability<void>(
+            'Aspire.Hosting/completeStepMarkdown',
+            rpcArgs
+        );
+        return this;
+    }
+
+    completeStepMarkdown(markdownString: string, options?: CompleteStepMarkdownOptions): ReportingStepPromise {
+        const completionState = options?.completionState;
+        const cancellationToken = options?.cancellationToken;
+        return new ReportingStepPromise(this._completeStepMarkdownInternal(markdownString, completionState, cancellationToken));
+    }
+
+}
+
+/**
+ * Thenable wrapper for ReportingStep that enables fluent chaining.
+ */
+export class ReportingStepPromise implements PromiseLike<ReportingStep> {
+    constructor(private _promise: Promise<ReportingStep>) {}
+
+    then<TResult1 = ReportingStep, TResult2 = never>(
+        onfulfilled?: ((value: ReportingStep) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    /** Creates a reporting task with plain-text status text */
+    createTask(statusText: string, options?: CreateTaskOptions): ReportingTaskPromise {
+        return new ReportingTaskPromise(this._promise.then(obj => obj.createTask(statusText, options)));
+    }
+
+    /** Creates a reporting task with Markdown-formatted status text */
+    createMarkdownTask(markdownString: string, options?: CreateMarkdownTaskOptions): ReportingTaskPromise {
+        return new ReportingTaskPromise(this._promise.then(obj => obj.createMarkdownTask(markdownString, options)));
+    }
+
+    /** Logs a plain-text message for the reporting step */
+    logStep(level: string, message: string): ReportingStepPromise {
+        return new ReportingStepPromise(this._promise.then(obj => obj.logStep(level, message)));
+    }
+
+    /** Logs a Markdown-formatted message for the reporting step */
+    logStepMarkdown(level: string, markdownString: string): ReportingStepPromise {
+        return new ReportingStepPromise(this._promise.then(obj => obj.logStepMarkdown(level, markdownString)));
+    }
+
+    /** Completes the reporting step with plain-text completion text */
+    completeStep(completionText: string, options?: CompleteStepOptions): ReportingStepPromise {
+        return new ReportingStepPromise(this._promise.then(obj => obj.completeStep(completionText, options)));
+    }
+
+    /** Completes the reporting step with Markdown-formatted completion text */
+    completeStepMarkdown(markdownString: string, options?: CompleteStepMarkdownOptions): ReportingStepPromise {
+        return new ReportingStepPromise(this._promise.then(obj => obj.completeStepMarkdown(markdownString, options)));
+    }
+
+}
+
+// ============================================================================
+// ReportingTask
+// ============================================================================
+
+/**
+ * Type class for ReportingTask.
+ */
+export class ReportingTask {
+    constructor(private _handle: IReportingTaskHandle, private _client: AspireClientRpc) {}
+
+    /** Serialize for JSON-RPC transport */
+    toJSON(): MarshalledHandle { return this._handle.toJSON(); }
+
+    /** Updates the reporting task with plain-text status text */
+    /** @internal */
+    async _updateTaskInternal(statusText: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingTask> {
+        const rpcArgs: Record<string, unknown> = { reportingTask: this._handle, statusText };
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
+        await this._client.invokeCapability<void>(
+            'Aspire.Hosting/updateTask',
+            rpcArgs
+        );
+        return this;
+    }
+
+    updateTask(statusText: string, options?: UpdateTaskOptions): ReportingTaskPromise {
+        const cancellationToken = options?.cancellationToken;
+        return new ReportingTaskPromise(this._updateTaskInternal(statusText, cancellationToken));
+    }
+
+    /** Updates the reporting task with Markdown-formatted status text */
+    /** @internal */
+    async _updateTaskMarkdownInternal(markdownString: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingTask> {
+        const rpcArgs: Record<string, unknown> = { reportingTask: this._handle, markdownString };
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
+        await this._client.invokeCapability<void>(
+            'Aspire.Hosting/updateTaskMarkdown',
+            rpcArgs
+        );
+        return this;
+    }
+
+    updateTaskMarkdown(markdownString: string, options?: UpdateTaskMarkdownOptions): ReportingTaskPromise {
+        const cancellationToken = options?.cancellationToken;
+        return new ReportingTaskPromise(this._updateTaskMarkdownInternal(markdownString, cancellationToken));
+    }
+
+    /** Completes the reporting task with plain-text completion text */
+    /** @internal */
+    async _completeTaskInternal(completionMessage?: string, completionState?: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingTask> {
+        const rpcArgs: Record<string, unknown> = { reportingTask: this._handle };
+        if (completionMessage !== undefined) rpcArgs.completionMessage = completionMessage;
+        if (completionState !== undefined) rpcArgs.completionState = completionState;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
+        await this._client.invokeCapability<void>(
+            'Aspire.Hosting/completeTask',
+            rpcArgs
+        );
+        return this;
+    }
+
+    completeTask(options?: CompleteTaskOptions): ReportingTaskPromise {
+        const completionMessage = options?.completionMessage;
+        const completionState = options?.completionState;
+        const cancellationToken = options?.cancellationToken;
+        return new ReportingTaskPromise(this._completeTaskInternal(completionMessage, completionState, cancellationToken));
+    }
+
+    /** Completes the reporting task with Markdown-formatted completion text */
+    /** @internal */
+    async _completeTaskMarkdownInternal(markdownString: string, completionState?: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingTask> {
+        const rpcArgs: Record<string, unknown> = { reportingTask: this._handle, markdownString };
+        if (completionState !== undefined) rpcArgs.completionState = completionState;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
+        await this._client.invokeCapability<void>(
+            'Aspire.Hosting/completeTaskMarkdown',
+            rpcArgs
+        );
+        return this;
+    }
+
+    completeTaskMarkdown(markdownString: string, options?: CompleteTaskMarkdownOptions): ReportingTaskPromise {
+        const completionState = options?.completionState;
+        const cancellationToken = options?.cancellationToken;
+        return new ReportingTaskPromise(this._completeTaskMarkdownInternal(markdownString, completionState, cancellationToken));
+    }
+
+}
+
+/**
+ * Thenable wrapper for ReportingTask that enables fluent chaining.
+ */
+export class ReportingTaskPromise implements PromiseLike<ReportingTask> {
+    constructor(private _promise: Promise<ReportingTask>) {}
+
+    then<TResult1 = ReportingTask, TResult2 = never>(
+        onfulfilled?: ((value: ReportingTask) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ): PromiseLike<TResult1 | TResult2> {
+        return this._promise.then(onfulfilled, onrejected);
+    }
+
+    /** Updates the reporting task with plain-text status text */
+    updateTask(statusText: string, options?: UpdateTaskOptions): ReportingTaskPromise {
+        return new ReportingTaskPromise(this._promise.then(obj => obj.updateTask(statusText, options)));
+    }
+
+    /** Updates the reporting task with Markdown-formatted status text */
+    updateTaskMarkdown(markdownString: string, options?: UpdateTaskMarkdownOptions): ReportingTaskPromise {
+        return new ReportingTaskPromise(this._promise.then(obj => obj.updateTaskMarkdown(markdownString, options)));
+    }
+
+    /** Completes the reporting task with plain-text completion text */
+    completeTask(options?: CompleteTaskOptions): ReportingTaskPromise {
+        return new ReportingTaskPromise(this._promise.then(obj => obj.completeTask(options)));
+    }
+
+    /** Completes the reporting task with Markdown-formatted completion text */
+    completeTaskMarkdown(markdownString: string, options?: CompleteTaskMarkdownOptions): ReportingTaskPromise {
+        return new ReportingTaskPromise(this._promise.then(obj => obj.completeTaskMarkdown(markdownString, options)));
+    }
+
+}
+
+// ============================================================================
 // ServiceProvider
 // ============================================================================
 
@@ -4520,7 +4887,7 @@ export class UserSecretsManager {
         },
     };
 
-    /** Invokes the TrySetSecret method */
+    /** Attempts to set a user secret value */
     async trySetSecret(name: string, value: string): Promise<boolean> {
         const rpcArgs: Record<string, unknown> = { context: this._handle, name, value };
         return await this._client.invokeCapability<boolean>(
@@ -4531,9 +4898,9 @@ export class UserSecretsManager {
 
     /** Saves state to user secrets from a JSON string */
     /** @internal */
-    async _saveStateJsonInternal(json: string, cancellationToken?: AbortSignal): Promise<UserSecretsManager> {
+    async _saveStateJsonInternal(json: string, cancellationToken?: AbortSignal | CancellationToken): Promise<UserSecretsManager> {
         const rpcArgs: Record<string, unknown> = { userSecretsManager: this._handle, json };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         await this._client.invokeCapability<void>(
             'Aspire.Hosting/saveStateJson',
             rpcArgs
@@ -4544,6 +4911,21 @@ export class UserSecretsManager {
     saveStateJson(json: string, options?: SaveStateJsonOptions): UserSecretsManagerPromise {
         const cancellationToken = options?.cancellationToken;
         return new UserSecretsManagerPromise(this._saveStateJsonInternal(json, cancellationToken));
+    }
+
+    /** Gets a secret value if it exists, or sets it to the provided value if it does not */
+    /** @internal */
+    async _getOrSetSecretInternal(resourceBuilder: ResourceBuilderBase, name: string, value: string): Promise<UserSecretsManager> {
+        const rpcArgs: Record<string, unknown> = { userSecretsManager: this._handle, resourceBuilder, name, value };
+        await this._client.invokeCapability<void>(
+            'Aspire.Hosting/getOrSetSecret',
+            rpcArgs
+        );
+        return this;
+    }
+
+    getOrSetSecret(resourceBuilder: ResourceBuilderBase, name: string, value: string): UserSecretsManagerPromise {
+        return new UserSecretsManagerPromise(this._getOrSetSecretInternal(resourceBuilder, name, value));
     }
 
 }
@@ -4561,7 +4943,7 @@ export class UserSecretsManagerPromise implements PromiseLike<UserSecretsManager
         return this._promise.then(onfulfilled, onrejected);
     }
 
-    /** Invokes the TrySetSecret method */
+    /** Attempts to set a user secret value */
     trySetSecret(name: string, value: string): Promise<boolean> {
         return this._promise.then(obj => obj.trySetSecret(name, value));
     }
@@ -4569,6 +4951,11 @@ export class UserSecretsManagerPromise implements PromiseLike<UserSecretsManager
     /** Saves state to user secrets from a JSON string */
     saveStateJson(json: string, options?: SaveStateJsonOptions): UserSecretsManagerPromise {
         return new UserSecretsManagerPromise(this._promise.then(obj => obj.saveStateJson(json, options)));
+    }
+
+    /** Gets a secret value if it exists, or sets it to the provided value if it does not */
+    getOrSetSecret(resourceBuilder: ResourceBuilderBase, name: string, value: string): UserSecretsManagerPromise {
+        return new UserSecretsManagerPromise(this._promise.then(obj => obj.getOrSetSecret(resourceBuilder, name, value)));
     }
 
 }
@@ -5921,6 +6308,239 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
+    private async _withBindMountInternal(source: string, target: string, isReadOnly?: boolean): Promise<ContainerResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, source, target };
+        if (isReadOnly !== undefined) rpcArgs.isReadOnly = isReadOnly;
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withBindMount',
+            rpcArgs
+        );
+        return new ContainerResource(result, this._client);
+    }
+
+    /** Adds a bind mount */
+    withBindMount(source: string, target: string, options?: WithBindMountOptions): ContainerResourcePromise {
+        const isReadOnly = options?.isReadOnly;
+        return new ContainerResourcePromise(this._withBindMountInternal(source, target, isReadOnly));
+    }
+
+    /** @internal */
+    private async _withEntrypointInternal(entrypoint: string): Promise<ContainerResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, entrypoint };
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withEntrypoint',
+            rpcArgs
+        );
+        return new ContainerResource(result, this._client);
+    }
+
+    /** Sets the container entrypoint */
+    withEntrypoint(entrypoint: string): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._withEntrypointInternal(entrypoint));
+    }
+
+    /** @internal */
+    private async _withImageTagInternal(tag: string): Promise<ContainerResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, tag };
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withImageTag',
+            rpcArgs
+        );
+        return new ContainerResource(result, this._client);
+    }
+
+    /** Sets the container image tag */
+    withImageTag(tag: string): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._withImageTagInternal(tag));
+    }
+
+    /** @internal */
+    private async _withImageRegistryInternal(registry: string): Promise<ContainerResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, registry };
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withImageRegistry',
+            rpcArgs
+        );
+        return new ContainerResource(result, this._client);
+    }
+
+    /** Sets the container image registry */
+    withImageRegistry(registry: string): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._withImageRegistryInternal(registry));
+    }
+
+    /** @internal */
+    private async _withImageInternal(image: string, tag?: string): Promise<ContainerResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, image };
+        if (tag !== undefined) rpcArgs.tag = tag;
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withImage',
+            rpcArgs
+        );
+        return new ContainerResource(result, this._client);
+    }
+
+    /** Sets the container image */
+    withImage(image: string, options?: WithImageOptions): ContainerResourcePromise {
+        const tag = options?.tag;
+        return new ContainerResourcePromise(this._withImageInternal(image, tag));
+    }
+
+    /** @internal */
+    private async _withImageSHA256Internal(sha256: string): Promise<ContainerResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, sha256 };
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withImageSHA256',
+            rpcArgs
+        );
+        return new ContainerResource(result, this._client);
+    }
+
+    /** Sets the image SHA256 digest */
+    withImageSHA256(sha256: string): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._withImageSHA256Internal(sha256));
+    }
+
+    /** @internal */
+    private async _withContainerRuntimeArgsInternal(args: string[]): Promise<ContainerResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, args };
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withContainerRuntimeArgs',
+            rpcArgs
+        );
+        return new ContainerResource(result, this._client);
+    }
+
+    /** Adds runtime arguments for the container */
+    withContainerRuntimeArgs(args: string[]): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._withContainerRuntimeArgsInternal(args));
+    }
+
+    /** @internal */
+    private async _withLifetimeInternal(lifetime: ContainerLifetime): Promise<ContainerResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, lifetime };
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withLifetime',
+            rpcArgs
+        );
+        return new ContainerResource(result, this._client);
+    }
+
+    /** Sets the lifetime behavior of the container resource */
+    withLifetime(lifetime: ContainerLifetime): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._withLifetimeInternal(lifetime));
+    }
+
+    /** @internal */
+    private async _withImagePullPolicyInternal(pullPolicy: ImagePullPolicy): Promise<ContainerResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, pullPolicy };
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withImagePullPolicy',
+            rpcArgs
+        );
+        return new ContainerResource(result, this._client);
+    }
+
+    /** Sets the container image pull policy */
+    withImagePullPolicy(pullPolicy: ImagePullPolicy): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._withImagePullPolicyInternal(pullPolicy));
+    }
+
+    /** @internal */
+    private async _publishAsContainerInternal(): Promise<ContainerResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle };
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/publishAsContainer',
+            rpcArgs
+        );
+        return new ContainerResource(result, this._client);
+    }
+
+    /** Configures the resource to be published as a container */
+    publishAsContainer(): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._publishAsContainerInternal());
+    }
+
+    /** @internal */
+    private async _withDockerfileInternal(contextPath: string, dockerfilePath?: string, stage?: string): Promise<ContainerResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, contextPath };
+        if (dockerfilePath !== undefined) rpcArgs.dockerfilePath = dockerfilePath;
+        if (stage !== undefined) rpcArgs.stage = stage;
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withDockerfile',
+            rpcArgs
+        );
+        return new ContainerResource(result, this._client);
+    }
+
+    /** Configures the resource to use a Dockerfile */
+    withDockerfile(contextPath: string, options?: WithDockerfileOptions): ContainerResourcePromise {
+        const dockerfilePath = options?.dockerfilePath;
+        const stage = options?.stage;
+        return new ContainerResourcePromise(this._withDockerfileInternal(contextPath, dockerfilePath, stage));
+    }
+
+    /** @internal */
+    private async _withContainerNameInternal(name: string): Promise<ContainerResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, name };
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withContainerName',
+            rpcArgs
+        );
+        return new ContainerResource(result, this._client);
+    }
+
+    /** Sets the container name */
+    withContainerName(name: string): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._withContainerNameInternal(name));
+    }
+
+    /** @internal */
+    private async _withBuildArgInternal(name: string, value: ParameterResource): Promise<ContainerResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withBuildArg',
+            rpcArgs
+        );
+        return new ContainerResource(result, this._client);
+    }
+
+    /** Adds a build argument from a parameter resource */
+    withBuildArg(name: string, value: ParameterResource): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._withBuildArgInternal(name, value));
+    }
+
+    /** @internal */
+    private async _withBuildSecretInternal(name: string, value: ParameterResource): Promise<ContainerResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withBuildSecret',
+            rpcArgs
+        );
+        return new ContainerResource(result, this._client);
+    }
+
+    /** Adds a build secret from a parameter resource */
+    withBuildSecret(name: string, value: ParameterResource): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._withBuildSecretInternal(name, value));
+    }
+
+    /** @internal */
+    private async _withEndpointProxySupportInternal(proxyEnabled: boolean): Promise<ContainerResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, proxyEnabled };
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withEndpointProxySupport',
+            rpcArgs
+        );
+        return new ContainerResource(result, this._client);
+    }
+
+    /** Configures endpoint proxy support */
+    withEndpointProxySupport(proxyEnabled: boolean): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._withEndpointProxySupportInternal(proxyEnabled));
+    }
+
+    /** @internal */
     private async _withDockerfileBaseImageInternal(buildImage?: string, runtimeImage?: string): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (buildImage !== undefined) rpcArgs.buildImage = buildImage;
@@ -5937,6 +6557,21 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
         const buildImage = options?.buildImage;
         const runtimeImage = options?.runtimeImage;
         return new ContainerResourcePromise(this._withDockerfileBaseImageInternal(buildImage, runtimeImage));
+    }
+
+    /** @internal */
+    private async _withContainerNetworkAliasInternal(alias: string): Promise<ContainerResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, alias };
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withContainerNetworkAlias',
+            rpcArgs
+        );
+        return new ContainerResource(result, this._client);
+    }
+
+    /** Adds a network alias for the container */
+    withContainerNetworkAlias(alias: string): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._withContainerNetworkAliasInternal(alias));
     }
 
     /** @internal */
@@ -5986,6 +6621,21 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     /** Configures OTLP telemetry export with specific protocol */
     withOtlpExporterProtocol(protocol: OtlpProtocol): ContainerResourcePromise {
         return new ContainerResourcePromise(this._withOtlpExporterProtocolInternal(protocol));
+    }
+
+    /** @internal */
+    private async _publishAsConnectionStringInternal(): Promise<ContainerResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle };
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/publishAsConnectionString',
+            rpcArgs
+        );
+        return new ContainerResource(result, this._client);
+    }
+
+    /** Publishes the resource as a connection string */
+    publishAsConnectionString(): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._publishAsConnectionStringInternal());
     }
 
     /** @internal */
@@ -6918,6 +7568,25 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
         return new ContainerResourcePromise(this._withPipelineConfigurationInternal(callback));
     }
 
+    /** @internal */
+    private async _withVolumeInternal(target: string, name?: string, isReadOnly?: boolean): Promise<ContainerResource> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle, target };
+        if (name !== undefined) rpcArgs.name = name;
+        if (isReadOnly !== undefined) rpcArgs.isReadOnly = isReadOnly;
+        const result = await this._client.invokeCapability<ContainerResourceHandle>(
+            'Aspire.Hosting/withVolume',
+            rpcArgs
+        );
+        return new ContainerResource(result, this._client);
+    }
+
+    /** Adds a volume */
+    withVolume(target: string, options?: WithVolumeOptions): ContainerResourcePromise {
+        const name = options?.name;
+        const isReadOnly = options?.isReadOnly;
+        return new ContainerResourcePromise(this._withVolumeInternal(target, name, isReadOnly));
+    }
+
     /** Gets the resource name */
     async getResourceName(): Promise<string> {
         const rpcArgs: Record<string, unknown> = { resource: this._handle };
@@ -7072,9 +7741,89 @@ export class ContainerResourcePromise implements PromiseLike<ContainerResource> 
         return new ContainerResourcePromise(this._promise.then(obj => obj.withContainerRegistry(registry)));
     }
 
+    /** Adds a bind mount */
+    withBindMount(source: string, target: string, options?: WithBindMountOptions): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._promise.then(obj => obj.withBindMount(source, target, options)));
+    }
+
+    /** Sets the container entrypoint */
+    withEntrypoint(entrypoint: string): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._promise.then(obj => obj.withEntrypoint(entrypoint)));
+    }
+
+    /** Sets the container image tag */
+    withImageTag(tag: string): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._promise.then(obj => obj.withImageTag(tag)));
+    }
+
+    /** Sets the container image registry */
+    withImageRegistry(registry: string): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._promise.then(obj => obj.withImageRegistry(registry)));
+    }
+
+    /** Sets the container image */
+    withImage(image: string, options?: WithImageOptions): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._promise.then(obj => obj.withImage(image, options)));
+    }
+
+    /** Sets the image SHA256 digest */
+    withImageSHA256(sha256: string): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._promise.then(obj => obj.withImageSHA256(sha256)));
+    }
+
+    /** Adds runtime arguments for the container */
+    withContainerRuntimeArgs(args: string[]): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._promise.then(obj => obj.withContainerRuntimeArgs(args)));
+    }
+
+    /** Sets the lifetime behavior of the container resource */
+    withLifetime(lifetime: ContainerLifetime): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._promise.then(obj => obj.withLifetime(lifetime)));
+    }
+
+    /** Sets the container image pull policy */
+    withImagePullPolicy(pullPolicy: ImagePullPolicy): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._promise.then(obj => obj.withImagePullPolicy(pullPolicy)));
+    }
+
+    /** Configures the resource to be published as a container */
+    publishAsContainer(): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._promise.then(obj => obj.publishAsContainer()));
+    }
+
+    /** Configures the resource to use a Dockerfile */
+    withDockerfile(contextPath: string, options?: WithDockerfileOptions): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._promise.then(obj => obj.withDockerfile(contextPath, options)));
+    }
+
+    /** Sets the container name */
+    withContainerName(name: string): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._promise.then(obj => obj.withContainerName(name)));
+    }
+
+    /** Adds a build argument from a parameter resource */
+    withBuildArg(name: string, value: ParameterResource): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._promise.then(obj => obj.withBuildArg(name, value)));
+    }
+
+    /** Adds a build secret from a parameter resource */
+    withBuildSecret(name: string, value: ParameterResource): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._promise.then(obj => obj.withBuildSecret(name, value)));
+    }
+
+    /** Configures endpoint proxy support */
+    withEndpointProxySupport(proxyEnabled: boolean): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._promise.then(obj => obj.withEndpointProxySupport(proxyEnabled)));
+    }
+
     /** Sets the base image for a Dockerfile build */
     withDockerfileBaseImage(options?: WithDockerfileBaseImageOptions): ContainerResourcePromise {
         return new ContainerResourcePromise(this._promise.then(obj => obj.withDockerfileBaseImage(options)));
+    }
+
+    /** Adds a network alias for the container */
+    withContainerNetworkAlias(alias: string): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._promise.then(obj => obj.withContainerNetworkAlias(alias)));
     }
 
     /** Configures an MCP server endpoint on the resource */
@@ -7090,6 +7839,11 @@ export class ContainerResourcePromise implements PromiseLike<ContainerResource> 
     /** Configures OTLP telemetry export with specific protocol */
     withOtlpExporterProtocol(protocol: OtlpProtocol): ContainerResourcePromise {
         return new ContainerResourcePromise(this._promise.then(obj => obj.withOtlpExporterProtocol(protocol)));
+    }
+
+    /** Publishes the resource as a connection string */
+    publishAsConnectionString(): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._promise.then(obj => obj.publishAsConnectionString()));
     }
 
     /** Adds a required command dependency */
@@ -7355,6 +8109,11 @@ export class ContainerResourcePromise implements PromiseLike<ContainerResource> 
     /** Configures pipeline step dependencies via a callback */
     withPipelineConfiguration(callback: (obj: PipelineConfigurationContext) => Promise<void>): ContainerResourcePromise {
         return new ContainerResourcePromise(this._promise.then(obj => obj.withPipelineConfiguration(callback)));
+    }
+
+    /** Adds a volume */
+    withVolume(target: string, options?: WithVolumeOptions): ContainerResourcePromise {
+        return new ContainerResourcePromise(this._promise.then(obj => obj.withVolume(target, options)));
     }
 
     /** Gets the resource name */
@@ -13995,6 +14754,71 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
+    private async _publishAsDockerFileInternal(): Promise<ExecutableResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle };
+        const result = await this._client.invokeCapability<ExecutableResourceHandle>(
+            'Aspire.Hosting/publishAsDockerFile',
+            rpcArgs
+        );
+        return new ExecutableResource(result, this._client);
+    }
+
+    /** Publishes the executable as a Docker container */
+    publishAsDockerFile(): ExecutableResourcePromise {
+        return new ExecutableResourcePromise(this._publishAsDockerFileInternal());
+    }
+
+    /** @internal */
+    private async _publishAsDockerFileWithConfigureInternal(configure: (obj: ContainerResource) => Promise<void>): Promise<ExecutableResource> {
+        const configureId = registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as ContainerResourceHandle;
+            const obj = new ContainerResource(objHandle, this._client);
+            await configure(obj);
+        });
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, configure: configureId };
+        const result = await this._client.invokeCapability<ExecutableResourceHandle>(
+            'Aspire.Hosting/publishAsDockerFileWithConfigure',
+            rpcArgs
+        );
+        return new ExecutableResource(result, this._client);
+    }
+
+    /** Publishes an executable as a Docker file with optional container configuration */
+    publishAsDockerFileWithConfigure(configure: (obj: ContainerResource) => Promise<void>): ExecutableResourcePromise {
+        return new ExecutableResourcePromise(this._publishAsDockerFileWithConfigureInternal(configure));
+    }
+
+    /** @internal */
+    private async _withExecutableCommandInternal(command: string): Promise<ExecutableResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, command };
+        const result = await this._client.invokeCapability<ExecutableResourceHandle>(
+            'Aspire.Hosting/withExecutableCommand',
+            rpcArgs
+        );
+        return new ExecutableResource(result, this._client);
+    }
+
+    /** Sets the executable command */
+    withExecutableCommand(command: string): ExecutableResourcePromise {
+        return new ExecutableResourcePromise(this._withExecutableCommandInternal(command));
+    }
+
+    /** @internal */
+    private async _withWorkingDirectoryInternal(workingDirectory: string): Promise<ExecutableResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, workingDirectory };
+        const result = await this._client.invokeCapability<ExecutableResourceHandle>(
+            'Aspire.Hosting/withWorkingDirectory',
+            rpcArgs
+        );
+        return new ExecutableResource(result, this._client);
+    }
+
+    /** Sets the executable working directory */
+    withWorkingDirectory(workingDirectory: string): ExecutableResourcePromise {
+        return new ExecutableResourcePromise(this._withWorkingDirectoryInternal(workingDirectory));
+    }
+
+    /** @internal */
     private async _withMcpServerInternal(path?: string, endpointName?: string): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (path !== undefined) rpcArgs.path = path;
@@ -15132,6 +15956,26 @@ export class ExecutableResourcePromise implements PromiseLike<ExecutableResource
         return new ExecutableResourcePromise(this._promise.then(obj => obj.withDockerfileBaseImage(options)));
     }
 
+    /** Publishes the executable as a Docker container */
+    publishAsDockerFile(): ExecutableResourcePromise {
+        return new ExecutableResourcePromise(this._promise.then(obj => obj.publishAsDockerFile()));
+    }
+
+    /** Publishes an executable as a Docker file with optional container configuration */
+    publishAsDockerFileWithConfigure(configure: (obj: ContainerResource) => Promise<void>): ExecutableResourcePromise {
+        return new ExecutableResourcePromise(this._promise.then(obj => obj.publishAsDockerFileWithConfigure(configure)));
+    }
+
+    /** Sets the executable command */
+    withExecutableCommand(command: string): ExecutableResourcePromise {
+        return new ExecutableResourcePromise(this._promise.then(obj => obj.withExecutableCommand(command)));
+    }
+
+    /** Sets the executable working directory */
+    withWorkingDirectory(workingDirectory: string): ExecutableResourcePromise {
+        return new ExecutableResourcePromise(this._promise.then(obj => obj.withWorkingDirectory(workingDirectory)));
+    }
+
     /** Configures an MCP server endpoint on the resource */
     withMcpServer(options?: WithMcpServerOptions): ExecutableResourcePromise {
         return new ExecutableResourcePromise(this._promise.then(obj => obj.withMcpServer(options)));
@@ -16059,6 +16903,36 @@ export class JavaScriptAppResource extends ResourceBuilderBase<JavaScriptAppReso
     constructor(handle: JavaScriptAppResourceHandle, client: AspireClientRpc) {
         super(handle, client);
     }
+
+    /** Gets the Command property */
+    command = {
+        get: async (): Promise<string> => {
+            return await this._client.invokeCapability<string>(
+                'Aspire.Hosting.JavaScript/JavaScriptAppResource.command',
+                { context: this._handle }
+            );
+        },
+    };
+
+    /** Gets the WorkingDirectory property */
+    workingDirectory = {
+        get: async (): Promise<string> => {
+            return await this._client.invokeCapability<string>(
+                'Aspire.Hosting.JavaScript/JavaScriptAppResource.workingDirectory',
+                { context: this._handle }
+            );
+        },
+    };
+
+    /** Gets the Name property */
+    name = {
+        get: async (): Promise<string> => {
+            return await this._client.invokeCapability<string>(
+                'Aspire.Hosting.JavaScript/JavaScriptAppResource.name',
+                { context: this._handle }
+            );
+        },
+    };
 
     /** @internal */
     private async _withContainerRegistryInternal(registry: ResourceBuilderBase): Promise<JavaScriptAppResource> {
@@ -17278,6 +18152,135 @@ export class JavaScriptAppResource extends ResourceBuilderBase<JavaScriptAppReso
     }
 
     /** @internal */
+    private async _withNpmInternal(install?: boolean, installCommand?: string, installArgs?: string[]): Promise<JavaScriptAppResource> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle };
+        if (install !== undefined) rpcArgs.install = install;
+        if (installCommand !== undefined) rpcArgs.installCommand = installCommand;
+        if (installArgs !== undefined) rpcArgs.installArgs = installArgs;
+        const result = await this._client.invokeCapability<JavaScriptAppResourceHandle>(
+            'Aspire.Hosting.JavaScript/withNpm',
+            rpcArgs
+        );
+        return new JavaScriptAppResource(result, this._client);
+    }
+
+    /** Configures npm as the package manager */
+    withNpm(options?: WithNpmOptions): JavaScriptAppResourcePromise {
+        const install = options?.install;
+        const installCommand = options?.installCommand;
+        const installArgs = options?.installArgs;
+        return new JavaScriptAppResourcePromise(this._withNpmInternal(install, installCommand, installArgs));
+    }
+
+    /** @internal */
+    private async _withBunInternal(install?: boolean, installArgs?: string[]): Promise<JavaScriptAppResource> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle };
+        if (install !== undefined) rpcArgs.install = install;
+        if (installArgs !== undefined) rpcArgs.installArgs = installArgs;
+        const result = await this._client.invokeCapability<JavaScriptAppResourceHandle>(
+            'Aspire.Hosting.JavaScript/withBun',
+            rpcArgs
+        );
+        return new JavaScriptAppResource(result, this._client);
+    }
+
+    /** Configures Bun as the package manager */
+    withBun(options?: WithBunOptions): JavaScriptAppResourcePromise {
+        const install = options?.install;
+        const installArgs = options?.installArgs;
+        return new JavaScriptAppResourcePromise(this._withBunInternal(install, installArgs));
+    }
+
+    /** @internal */
+    private async _withYarnInternal(install?: boolean, installArgs?: string[]): Promise<JavaScriptAppResource> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle };
+        if (install !== undefined) rpcArgs.install = install;
+        if (installArgs !== undefined) rpcArgs.installArgs = installArgs;
+        const result = await this._client.invokeCapability<JavaScriptAppResourceHandle>(
+            'Aspire.Hosting.JavaScript/withYarn',
+            rpcArgs
+        );
+        return new JavaScriptAppResource(result, this._client);
+    }
+
+    /** Configures yarn as the package manager */
+    withYarn(options?: WithYarnOptions): JavaScriptAppResourcePromise {
+        const install = options?.install;
+        const installArgs = options?.installArgs;
+        return new JavaScriptAppResourcePromise(this._withYarnInternal(install, installArgs));
+    }
+
+    /** @internal */
+    private async _withPnpmInternal(install?: boolean, installArgs?: string[]): Promise<JavaScriptAppResource> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle };
+        if (install !== undefined) rpcArgs.install = install;
+        if (installArgs !== undefined) rpcArgs.installArgs = installArgs;
+        const result = await this._client.invokeCapability<JavaScriptAppResourceHandle>(
+            'Aspire.Hosting.JavaScript/withPnpm',
+            rpcArgs
+        );
+        return new JavaScriptAppResource(result, this._client);
+    }
+
+    /** Configures pnpm as the package manager */
+    withPnpm(options?: WithPnpmOptions): JavaScriptAppResourcePromise {
+        const install = options?.install;
+        const installArgs = options?.installArgs;
+        return new JavaScriptAppResourcePromise(this._withPnpmInternal(install, installArgs));
+    }
+
+    /** @internal */
+    private async _withBuildScriptInternal(scriptName: string, args?: string[]): Promise<JavaScriptAppResource> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle, scriptName };
+        if (args !== undefined) rpcArgs.args = args;
+        const result = await this._client.invokeCapability<JavaScriptAppResourceHandle>(
+            'Aspire.Hosting.JavaScript/withBuildScript',
+            rpcArgs
+        );
+        return new JavaScriptAppResource(result, this._client);
+    }
+
+    /** Specifies an npm script to run before starting the application */
+    withBuildScript(scriptName: string, options?: WithBuildScriptOptions): JavaScriptAppResourcePromise {
+        const args = options?.args;
+        return new JavaScriptAppResourcePromise(this._withBuildScriptInternal(scriptName, args));
+    }
+
+    /** @internal */
+    private async _withRunScriptInternal(scriptName: string, args?: string[]): Promise<JavaScriptAppResource> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle, scriptName };
+        if (args !== undefined) rpcArgs.args = args;
+        const result = await this._client.invokeCapability<JavaScriptAppResourceHandle>(
+            'Aspire.Hosting.JavaScript/withRunScript',
+            rpcArgs
+        );
+        return new JavaScriptAppResource(result, this._client);
+    }
+
+    /** Specifies an npm script to run during development */
+    withRunScript(scriptName: string, options?: WithRunScriptOptions): JavaScriptAppResourcePromise {
+        const args = options?.args;
+        return new JavaScriptAppResourcePromise(this._withRunScriptInternal(scriptName, args));
+    }
+
+    /** @internal */
+    private async _withBrowserDebuggerInternal(browser?: string): Promise<JavaScriptAppResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle };
+        if (browser !== undefined) rpcArgs.browser = browser;
+        const result = await this._client.invokeCapability<JavaScriptAppResourceHandle>(
+            'Aspire.Hosting.JavaScript/withBrowserDebugger',
+            rpcArgs
+        );
+        return new JavaScriptAppResource(result, this._client);
+    }
+
+    /** Configures a browser debugger for the JavaScript application */
+    withBrowserDebugger(options?: WithBrowserDebuggerOptions): JavaScriptAppResourcePromise {
+        const browser = options?.browser;
+        return new JavaScriptAppResourcePromise(this._withBrowserDebuggerInternal(browser));
+    }
+
+    /** @internal */
     private async _publishAsDockerComposeServiceInternal(configure: (arg1: DockerComposeServiceResource, arg2: Service) => Promise<void>): Promise<JavaScriptAppResource> {
         const configureId = registerCallback(async (argsData: unknown) => {
             const args = argsData as { p0: unknown, p1: unknown };
@@ -17665,6 +18668,41 @@ export class JavaScriptAppResourcePromise implements PromiseLike<JavaScriptAppRe
     /** Subscribes to the ResourceReady event */
     onResourceReady(callback: (arg: ResourceReadyEvent) => Promise<void>): JavaScriptAppResourcePromise {
         return new JavaScriptAppResourcePromise(this._promise.then(obj => obj.onResourceReady(callback)));
+    }
+
+    /** Configures npm as the package manager */
+    withNpm(options?: WithNpmOptions): JavaScriptAppResourcePromise {
+        return new JavaScriptAppResourcePromise(this._promise.then(obj => obj.withNpm(options)));
+    }
+
+    /** Configures Bun as the package manager */
+    withBun(options?: WithBunOptions): JavaScriptAppResourcePromise {
+        return new JavaScriptAppResourcePromise(this._promise.then(obj => obj.withBun(options)));
+    }
+
+    /** Configures yarn as the package manager */
+    withYarn(options?: WithYarnOptions): JavaScriptAppResourcePromise {
+        return new JavaScriptAppResourcePromise(this._promise.then(obj => obj.withYarn(options)));
+    }
+
+    /** Configures pnpm as the package manager */
+    withPnpm(options?: WithPnpmOptions): JavaScriptAppResourcePromise {
+        return new JavaScriptAppResourcePromise(this._promise.then(obj => obj.withPnpm(options)));
+    }
+
+    /** Specifies an npm script to run before starting the application */
+    withBuildScript(scriptName: string, options?: WithBuildScriptOptions): JavaScriptAppResourcePromise {
+        return new JavaScriptAppResourcePromise(this._promise.then(obj => obj.withBuildScript(scriptName, options)));
+    }
+
+    /** Specifies an npm script to run during development */
+    withRunScript(scriptName: string, options?: WithRunScriptOptions): JavaScriptAppResourcePromise {
+        return new JavaScriptAppResourcePromise(this._promise.then(obj => obj.withRunScript(scriptName, options)));
+    }
+
+    /** Configures a browser debugger for the JavaScript application */
+    withBrowserDebugger(options?: WithBrowserDebuggerOptions): JavaScriptAppResourcePromise {
+        return new JavaScriptAppResourcePromise(this._promise.then(obj => obj.withBrowserDebugger(options)));
     }
 
     /** Publishes the resource as a Docker Compose service with custom service configuration */
@@ -28905,6 +29943,58 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
+    private async _withReplicasInternal(replicas: number): Promise<ProjectResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, replicas };
+        const result = await this._client.invokeCapability<ProjectResourceHandle>(
+            'Aspire.Hosting/withReplicas',
+            rpcArgs
+        );
+        return new ProjectResource(result, this._client);
+    }
+
+    /** Sets the number of replicas */
+    withReplicas(replicas: number): ProjectResourcePromise {
+        return new ProjectResourcePromise(this._withReplicasInternal(replicas));
+    }
+
+    /** @internal */
+    private async _disableForwardedHeadersInternal(): Promise<ProjectResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle };
+        const result = await this._client.invokeCapability<ProjectResourceHandle>(
+            'Aspire.Hosting/disableForwardedHeaders',
+            rpcArgs
+        );
+        return new ProjectResource(result, this._client);
+    }
+
+    /** Disables forwarded headers for the project */
+    disableForwardedHeaders(): ProjectResourcePromise {
+        return new ProjectResourcePromise(this._disableForwardedHeadersInternal());
+    }
+
+    /** @internal */
+    private async _publishAsDockerFileInternal(configure?: (obj: ContainerResource) => Promise<void>): Promise<ProjectResource> {
+        const configureId = configure ? registerCallback(async (objData: unknown) => {
+            const objHandle = wrapIfHandle(objData) as ContainerResourceHandle;
+            const obj = new ContainerResource(objHandle, this._client);
+            await configure(obj);
+        }) : undefined;
+        const rpcArgs: Record<string, unknown> = { builder: this._handle };
+        if (configure !== undefined) rpcArgs.configure = configureId;
+        const result = await this._client.invokeCapability<ProjectResourceHandle>(
+            'Aspire.Hosting/publishProjectAsDockerFileWithConfigure',
+            rpcArgs
+        );
+        return new ProjectResource(result, this._client);
+    }
+
+    /** Publishes a project as a Docker file with optional container configuration */
+    publishAsDockerFile(options?: PublishAsDockerFileOptions): ProjectResourcePromise {
+        const configure = options?.configure;
+        return new ProjectResourcePromise(this._publishAsDockerFileInternal(configure));
+    }
+
+    /** @internal */
     private async _withRequiredCommandInternal(command: string, helpLink?: string): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, command };
         if (helpLink !== undefined) rpcArgs.helpLink = helpLink;
@@ -30021,6 +31111,21 @@ export class ProjectResourcePromise implements PromiseLike<ProjectResource> {
     /** Configures OTLP telemetry export with specific protocol */
     withOtlpExporterProtocol(protocol: OtlpProtocol): ProjectResourcePromise {
         return new ProjectResourcePromise(this._promise.then(obj => obj.withOtlpExporterProtocol(protocol)));
+    }
+
+    /** Sets the number of replicas */
+    withReplicas(replicas: number): ProjectResourcePromise {
+        return new ProjectResourcePromise(this._promise.then(obj => obj.withReplicas(replicas)));
+    }
+
+    /** Disables forwarded headers for the project */
+    disableForwardedHeaders(): ProjectResourcePromise {
+        return new ProjectResourcePromise(this._promise.then(obj => obj.disableForwardedHeaders()));
+    }
+
+    /** Publishes a project as a Docker file with optional container configuration */
+    publishAsDockerFile(options?: PublishAsDockerFileOptions): ProjectResourcePromise {
+        return new ProjectResourcePromise(this._promise.then(obj => obj.publishAsDockerFile(options)));
     }
 
     /** Adds a required command dependency */
@@ -40152,7 +41257,7 @@ export async function createBuilder(options?: CreateBuilderOptions): Promise<Dis
 }
 
 // Re-export commonly used types
-export { Handle, AppHostUsageError, CapabilityError, registerCallback } from './transport.js';
+export { Handle, AppHostUsageError, CancellationToken, CapabilityError, registerCallback } from './transport.js';
 export { refExpr, ReferenceExpression } from './base.js';
 
 // ============================================================================
@@ -40236,6 +41341,8 @@ registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Eventing.IDistributedApplic
 registerHandleWrapper('Microsoft.Extensions.Hosting.Abstractions/Microsoft.Extensions.Hosting.IHostEnvironment', (handle, client) => new HostEnvironment(handle as IHostEnvironmentHandle, client));
 registerHandleWrapper('Microsoft.Extensions.Logging.Abstractions/Microsoft.Extensions.Logging.ILogger', (handle, client) => new Logger(handle as ILoggerHandle, client));
 registerHandleWrapper('Microsoft.Extensions.Logging.Abstractions/Microsoft.Extensions.Logging.ILoggerFactory', (handle, client) => new LoggerFactory(handle as ILoggerFactoryHandle, client));
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Pipelines.IReportingStep', (handle, client) => new ReportingStep(handle as IReportingStepHandle, client));
+registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.Pipelines.IReportingTask', (handle, client) => new ReportingTask(handle as IReportingTaskHandle, client));
 registerHandleWrapper('System.ComponentModel/System.IServiceProvider', (handle, client) => new ServiceProvider(handle as IServiceProviderHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.IUserSecretsManager', (handle, client) => new UserSecretsManager(handle as IUserSecretsManagerHandle, client));
 registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ConnectionStringResource', (handle, client) => new ConnectionStringResource(handle as ConnectionStringResourceHandle, client));

--- a/playground/TypeScriptAppHost/.modules/base.ts
+++ b/playground/TypeScriptAppHost/.modules/base.ts
@@ -1,8 +1,8 @@
 // aspire.ts - Core Aspire types: base classes, ReferenceExpression
-import { Handle, AspireClient, MarshalledHandle, registerCancellation, registerHandleWrapper, unregisterCancellation } from './transport.js';
+import { Handle, AspireClient, MarshalledHandle, CancellationToken, registerCancellation, registerHandleWrapper, unregisterCancellation } from './transport.js';
 
 // Re-export transport types for convenience
-export { Handle, AspireClient, CapabilityError, registerCallback, unregisterCallback, registerCancellation, unregisterCancellation } from './transport.js';
+export { Handle, AspireClient, CapabilityError, CancellationToken, registerCallback, unregisterCallback, registerCancellation, unregisterCancellation } from './transport.js';
 export type { MarshalledHandle, AtsError, AtsErrorDetails, CallbackFunction } from './transport.js';
 export { AtsErrorCodes, isMarshalledHandle, isAtsError, wrapIfHandle } from './transport.js';
 
@@ -158,10 +158,10 @@ export class ReferenceExpression {
      * Resolves the expression to its string value on the server.
      * Only available on server-returned ReferenceExpression instances (handle mode).
      *
-     * @param cancellationToken - Optional AbortSignal for cancellation support
+     * @param cancellationToken - Optional AbortSignal or CancellationToken for cancellation support
      * @returns The resolved string value, or null if the expression resolves to null
      */
-    async getValue(cancellationToken?: AbortSignal): Promise<string | null> {
+    async getValue(cancellationToken?: AbortSignal | CancellationToken): Promise<string | null> {
         if (!this._handle || !this._client) {
             throw new Error('getValue is only available on server-returned ReferenceExpression instances');
         }

--- a/playground/TypeScriptAppHost/.modules/transport.ts
+++ b/playground/TypeScriptAppHost/.modules/transport.ts
@@ -93,6 +93,16 @@ export function isMarshalledHandle(value: unknown): value is MarshalledHandle {
     );
 }
 
+function isAbortSignal(value: unknown): value is AbortSignal {
+    return (
+        value !== null &&
+        typeof value === 'object' &&
+        'aborted' in value &&
+        'addEventListener' in value &&
+        'removeEventListener' in value
+    );
+}
+
 // ============================================================================
 // Handle
 // ============================================================================
@@ -133,6 +143,92 @@ export class Handle<T extends string = string> {
     /** String representation for debugging */
     toString(): string {
         return `Handle<${this._typeId}>(${this._handleId})`;
+    }
+}
+
+// ============================================================================
+// CancellationToken
+// ============================================================================
+
+/**
+ * Represents a transport-safe cancellation token value for the generated SDK.
+ *
+ * Use a plain {@link AbortSignal} when you create cancellation in user code.
+ * Generated APIs accept either an {@link AbortSignal} or a {@link CancellationToken}.
+ *
+ * Values returned from generated callbacks and context/property getters are
+ * {@link CancellationToken} instances because they may reference remote
+ * cancellation token handles received from the AppHost.
+ *
+ * @example
+ * ```typescript
+ * const controller = new AbortController();
+ * await connectionStringExpression.getValue(controller.signal);
+ * ```
+ *
+ * @example
+ * ```typescript
+ * const cancellationToken = await context.cancellationToken.get();
+ * const connectionStringExpression = await db.uriExpression.get();
+ * const connectionString = await connectionStringExpression.getValue(cancellationToken);
+ * ```
+ */
+export class CancellationToken {
+    private readonly _signal?: AbortSignal;
+    private readonly _remoteTokenId?: string;
+    private _registeredTokenId?: string;
+
+    constructor(signal?: AbortSignal);
+    constructor(tokenId?: string);
+    constructor(value?: AbortSignal | string | null) {
+        if (typeof value === 'string') {
+            this._remoteTokenId = value;
+        } else if (isAbortSignal(value)) {
+            this._signal = value;
+        }
+    }
+
+    /**
+     * Creates a cancellation token from a local {@link AbortSignal}.
+     */
+    static from(signal?: AbortSignal): CancellationToken {
+        return new CancellationToken(signal);
+    }
+
+    /**
+     * Creates a cancellation token from a transport value.
+     * Generated code uses this to materialize values that come from the AppHost.
+     */
+    static fromValue(value: unknown): CancellationToken {
+        if (value instanceof CancellationToken) {
+            return value;
+        }
+
+        if (typeof value === 'string') {
+            return new CancellationToken(value);
+        }
+
+        if (isAbortSignal(value)) {
+            return new CancellationToken(value);
+        }
+
+        return new CancellationToken();
+    }
+
+    /**
+     * Serializes the token for JSON-RPC transport.
+     */
+    toJSON(): string | undefined {
+        if (this._remoteTokenId) {
+            return this._remoteTokenId;
+        }
+
+        if (this._registeredTokenId !== undefined) {
+            return this._registeredTokenId;
+        }
+
+        this._registeredTokenId = registerCancellation(this._signal);
+        return this._registeredTokenId;
     }
 }
 
@@ -401,13 +497,17 @@ let cancellationIdCounter = 0;
 let currentClient: AspireClient | null = null;
 
 /**
- * Register an AbortSignal for cancellation support.
- * Returns a cancellation ID that should be passed to methods accepting CancellationToken.
+ * Registers cancellation support for a local signal or SDK cancellation token.
+ * Returns a cancellation ID that should be passed to methods accepting cancellation input.
  *
  * When the AbortSignal is aborted, sends a cancelToken request to the host.
  *
- * @param signal - The AbortSignal to register (optional)
- * @returns The cancellation ID, or undefined if no signal provided
+ * @param signalOrToken - The signal or token to register (optional)
+ * @returns The cancellation ID, or undefined if no value was provided or the token maps to CancellationToken.None
+ *
+ * @example
+ * const controller = new AbortController();
+ * await expression.getValue(controller.signal);
  *
  * @example
  * const controller = new AbortController();
@@ -415,10 +515,16 @@ let currentClient: AspireClient | null = null;
  * // Pass id to capability invocation
  * // Later: controller.abort() will cancel the operation
  */
-export function registerCancellation(signal?: AbortSignal): string | undefined {
-    if (!signal) {
+export function registerCancellation(signalOrToken?: AbortSignal | CancellationToken): string | undefined {
+    if (!signalOrToken) {
         return undefined;
     }
+
+    if (signalOrToken instanceof CancellationToken) {
+        return signalOrToken.toJSON();
+    }
+
+    const signal = signalOrToken;
 
     // Already aborted? Don't register
     if (signal.aborted) {

--- a/playground/TypeScriptAppHost/apphost.ts
+++ b/playground/TypeScriptAppHost/apphost.ts
@@ -25,6 +25,9 @@ console.log(`AppHost directory: ${dir}`);
 // Add PostgreSQL server and database
 const postgres = await builder.addPostgres("postgres");
 const db = await postgres.addDatabase("db");
+const localCancellation = new AbortController();
+const dbUriExpression = await db.uriExpression.get();
+const _dbUri = await dbUriExpression.getValue(localCancellation.signal);
 
 console.log("Added PostgreSQL server with database 'db'");
 

--- a/playground/polyglot/TypeScript/Aspire.Hosting/ValidationAppHost/.modules/aspire.ts
+++ b/playground/polyglot/TypeScript/Aspire.Hosting/ValidationAppHost/.modules/aspire.ts
@@ -9,6 +9,7 @@ import {
     Handle,
     MarshalledHandle,
     AppHostUsageError,
+    CancellationToken,
     CapabilityError,
     registerCallback,
     wrapIfHandle,
@@ -611,31 +612,31 @@ export interface AppendValueProviderOptions {
 
 export interface CompleteStepMarkdownOptions {
     completionState?: string;
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface CompleteStepOptions {
     completionState?: string;
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface CompleteTaskMarkdownOptions {
     completionState?: string;
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface CompleteTaskOptions {
     completionMessage?: string;
     completionState?: string;
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface CreateMarkdownTaskOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface CreateTaskOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface GetEndpointForNetworkOptions {
@@ -648,7 +649,7 @@ export interface GetEndpointOptions {
 }
 
 export interface GetValueAsyncOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface PublishAsDockerFileOptions {
@@ -661,19 +662,19 @@ export interface PublishResourceUpdateOptions {
 }
 
 export interface RunOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface SaveStateJsonOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface UpdateTaskMarkdownOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface UpdateTaskOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface WaitForCompletionOptions {
@@ -1043,11 +1044,12 @@ export class CommandLineArgsCallbackContext {
 
     /** Gets the CancellationToken property */
     cancellationToken = {
-        get: async (): Promise<AbortSignal> => {
-            return await this._client.invokeCapability<AbortSignal>(
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.ApplicationModel/CommandLineArgsCallbackContext.cancellationToken',
                 { context: this._handle }
             );
+            return CancellationToken.fromValue(result);
         },
     };
 
@@ -1138,9 +1140,9 @@ export class DistributedApplication {
 
     /** Runs the distributed application */
     /** @internal */
-    async _runInternal(cancellationToken?: AbortSignal): Promise<DistributedApplication> {
+    async _runInternal(cancellationToken?: AbortSignal | CancellationToken): Promise<DistributedApplication> {
         const rpcArgs: Record<string, unknown> = { context: this._handle };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         await this._client.invokeCapability<void>(
             'Aspire.Hosting/run',
             rpcArgs
@@ -1513,7 +1515,7 @@ export class EndpointReference {
     async getValueAsync(options?: GetValueAsyncOptions): Promise<string> {
         const cancellationToken = options?.cancellationToken;
         const rpcArgs: Record<string, unknown> = { context: this._handle };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         return await this._client.invokeCapability<string>(
             'Aspire.Hosting.ApplicationModel/getValueAsync',
             rpcArgs
@@ -1631,11 +1633,12 @@ export class EnvironmentCallbackContext {
 
     /** Gets the CancellationToken property */
     cancellationToken = {
-        get: async (): Promise<AbortSignal> => {
-            return await this._client.invokeCapability<AbortSignal>(
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.ApplicationModel/EnvironmentCallbackContext.cancellationToken',
                 { context: this._handle }
             );
+            return CancellationToken.fromValue(result);
         },
     };
 
@@ -1716,16 +1719,17 @@ export class ExecuteCommandContext {
 
     /** Gets the CancellationToken property */
     cancellationToken = {
-        get: async (): Promise<AbortSignal> => {
-            return await this._client.invokeCapability<AbortSignal>(
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.ApplicationModel/ExecuteCommandContext.cancellationToken',
                 { context: this._handle }
             );
+            return CancellationToken.fromValue(result);
         },
-        set: async (value: AbortSignal): Promise<void> => {
+        set: async (value: AbortSignal | CancellationToken): Promise<void> => {
             await this._client.invokeCapability<void>(
                 'Aspire.Hosting.ApplicationModel/ExecuteCommandContext.setCancellationToken',
-                { context: this._handle, value }
+                { context: this._handle, value: CancellationToken.fromValue(value) }
             );
         }
     };
@@ -1943,16 +1947,17 @@ export class PipelineContext {
 
     /** Gets the CancellationToken property */
     cancellationToken = {
-        get: async (): Promise<AbortSignal> => {
-            return await this._client.invokeCapability<AbortSignal>(
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.Pipelines/PipelineContext.cancellationToken',
                 { context: this._handle }
             );
+            return CancellationToken.fromValue(result);
         },
-        set: async (value: AbortSignal): Promise<void> => {
+        set: async (value: AbortSignal | CancellationToken): Promise<void> => {
             await this._client.invokeCapability<void>(
                 'Aspire.Hosting.Pipelines/PipelineContext.setCancellationToken',
-                { context: this._handle, value }
+                { context: this._handle, value: CancellationToken.fromValue(value) }
             );
         }
     };
@@ -2206,11 +2211,12 @@ export class PipelineStepContext {
 
     /** Gets the CancellationToken property */
     cancellationToken = {
-        get: async (): Promise<AbortSignal> => {
-            return await this._client.invokeCapability<AbortSignal>(
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.Pipelines/PipelineStepContext.cancellationToken',
                 { context: this._handle }
             );
+            return CancellationToken.fromValue(result);
         },
     };
 
@@ -2874,11 +2880,12 @@ export class ResourceUrlsCallbackContext {
 
     /** Gets the CancellationToken property */
     cancellationToken = {
-        get: async (): Promise<AbortSignal> => {
-            return await this._client.invokeCapability<AbortSignal>(
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.ApplicationModel/ResourceUrlsCallbackContext.cancellationToken',
                 { context: this._handle }
             );
+            return CancellationToken.fromValue(result);
         },
     };
 
@@ -4850,9 +4857,9 @@ export class ReportingStep {
 
     /** Creates a reporting task with plain-text status text */
     /** @internal */
-    async _createTaskInternal(statusText: string, cancellationToken?: AbortSignal): Promise<ReportingTask> {
+    async _createTaskInternal(statusText: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingTask> {
         const rpcArgs: Record<string, unknown> = { reportingStep: this._handle, statusText };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         const result = await this._client.invokeCapability<IReportingTaskHandle>(
             'Aspire.Hosting/createTask',
             rpcArgs
@@ -4867,9 +4874,9 @@ export class ReportingStep {
 
     /** Creates a reporting task with Markdown-formatted status text */
     /** @internal */
-    async _createMarkdownTaskInternal(markdownString: string, cancellationToken?: AbortSignal): Promise<ReportingTask> {
+    async _createMarkdownTaskInternal(markdownString: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingTask> {
         const rpcArgs: Record<string, unknown> = { reportingStep: this._handle, markdownString };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         const result = await this._client.invokeCapability<IReportingTaskHandle>(
             'Aspire.Hosting/createMarkdownTask',
             rpcArgs
@@ -4914,10 +4921,10 @@ export class ReportingStep {
 
     /** Completes the reporting step with plain-text completion text */
     /** @internal */
-    async _completeStepInternal(completionText: string, completionState?: string, cancellationToken?: AbortSignal): Promise<ReportingStep> {
+    async _completeStepInternal(completionText: string, completionState?: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingStep> {
         const rpcArgs: Record<string, unknown> = { reportingStep: this._handle, completionText };
         if (completionState !== undefined) rpcArgs.completionState = completionState;
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         await this._client.invokeCapability<void>(
             'Aspire.Hosting/completeStep',
             rpcArgs
@@ -4933,10 +4940,10 @@ export class ReportingStep {
 
     /** Completes the reporting step with Markdown-formatted completion text */
     /** @internal */
-    async _completeStepMarkdownInternal(markdownString: string, completionState?: string, cancellationToken?: AbortSignal): Promise<ReportingStep> {
+    async _completeStepMarkdownInternal(markdownString: string, completionState?: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingStep> {
         const rpcArgs: Record<string, unknown> = { reportingStep: this._handle, markdownString };
         if (completionState !== undefined) rpcArgs.completionState = completionState;
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         await this._client.invokeCapability<void>(
             'Aspire.Hosting/completeStepMarkdown',
             rpcArgs
@@ -5012,9 +5019,9 @@ export class ReportingTask {
 
     /** Updates the reporting task with plain-text status text */
     /** @internal */
-    async _updateTaskInternal(statusText: string, cancellationToken?: AbortSignal): Promise<ReportingTask> {
+    async _updateTaskInternal(statusText: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingTask> {
         const rpcArgs: Record<string, unknown> = { reportingTask: this._handle, statusText };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         await this._client.invokeCapability<void>(
             'Aspire.Hosting/updateTask',
             rpcArgs
@@ -5029,9 +5036,9 @@ export class ReportingTask {
 
     /** Updates the reporting task with Markdown-formatted status text */
     /** @internal */
-    async _updateTaskMarkdownInternal(markdownString: string, cancellationToken?: AbortSignal): Promise<ReportingTask> {
+    async _updateTaskMarkdownInternal(markdownString: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingTask> {
         const rpcArgs: Record<string, unknown> = { reportingTask: this._handle, markdownString };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         await this._client.invokeCapability<void>(
             'Aspire.Hosting/updateTaskMarkdown',
             rpcArgs
@@ -5046,11 +5053,11 @@ export class ReportingTask {
 
     /** Completes the reporting task with plain-text completion text */
     /** @internal */
-    async _completeTaskInternal(completionMessage?: string, completionState?: string, cancellationToken?: AbortSignal): Promise<ReportingTask> {
+    async _completeTaskInternal(completionMessage?: string, completionState?: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingTask> {
         const rpcArgs: Record<string, unknown> = { reportingTask: this._handle };
         if (completionMessage !== undefined) rpcArgs.completionMessage = completionMessage;
         if (completionState !== undefined) rpcArgs.completionState = completionState;
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         await this._client.invokeCapability<void>(
             'Aspire.Hosting/completeTask',
             rpcArgs
@@ -5067,10 +5074,10 @@ export class ReportingTask {
 
     /** Completes the reporting task with Markdown-formatted completion text */
     /** @internal */
-    async _completeTaskMarkdownInternal(markdownString: string, completionState?: string, cancellationToken?: AbortSignal): Promise<ReportingTask> {
+    async _completeTaskMarkdownInternal(markdownString: string, completionState?: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingTask> {
         const rpcArgs: Record<string, unknown> = { reportingTask: this._handle, markdownString };
         if (completionState !== undefined) rpcArgs.completionState = completionState;
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         await this._client.invokeCapability<void>(
             'Aspire.Hosting/completeTaskMarkdown',
             rpcArgs
@@ -5315,9 +5322,9 @@ export class UserSecretsManager {
 
     /** Saves state to user secrets from a JSON string */
     /** @internal */
-    async _saveStateJsonInternal(json: string, cancellationToken?: AbortSignal): Promise<UserSecretsManager> {
+    async _saveStateJsonInternal(json: string, cancellationToken?: AbortSignal | CancellationToken): Promise<UserSecretsManager> {
         const rpcArgs: Record<string, unknown> = { userSecretsManager: this._handle, json };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         await this._client.invokeCapability<void>(
             'Aspire.Hosting/saveStateJson',
             rpcArgs
@@ -26222,7 +26229,7 @@ export async function createBuilder(options?: CreateBuilderOptions): Promise<Dis
 }
 
 // Re-export commonly used types
-export { Handle, AppHostUsageError, CapabilityError, registerCallback } from './transport.js';
+export { Handle, AppHostUsageError, CancellationToken, CapabilityError, registerCallback } from './transport.js';
 export { refExpr, ReferenceExpression } from './base.js';
 
 // ============================================================================

--- a/playground/polyglot/TypeScript/Aspire.Hosting/ValidationAppHost/.modules/base.ts
+++ b/playground/polyglot/TypeScript/Aspire.Hosting/ValidationAppHost/.modules/base.ts
@@ -1,8 +1,8 @@
 // aspire.ts - Core Aspire types: base classes, ReferenceExpression
-import { Handle, AspireClient, MarshalledHandle, registerCancellation, registerHandleWrapper, unregisterCancellation } from './transport.js';
+import { Handle, AspireClient, MarshalledHandle, CancellationToken, registerCancellation, registerHandleWrapper, unregisterCancellation } from './transport.js';
 
 // Re-export transport types for convenience
-export { Handle, AspireClient, CapabilityError, registerCallback, unregisterCallback, registerCancellation, unregisterCancellation } from './transport.js';
+export { Handle, AspireClient, CapabilityError, CancellationToken, registerCallback, unregisterCallback, registerCancellation, unregisterCancellation } from './transport.js';
 export type { MarshalledHandle, AtsError, AtsErrorDetails, CallbackFunction } from './transport.js';
 export { AtsErrorCodes, isMarshalledHandle, isAtsError, wrapIfHandle } from './transport.js';
 
@@ -158,10 +158,10 @@ export class ReferenceExpression {
      * Resolves the expression to its string value on the server.
      * Only available on server-returned ReferenceExpression instances (handle mode).
      *
-     * @param cancellationToken - Optional AbortSignal for cancellation support
+     * @param cancellationToken - Optional AbortSignal or CancellationToken for cancellation support
      * @returns The resolved string value, or null if the expression resolves to null
      */
-    async getValue(cancellationToken?: AbortSignal): Promise<string | null> {
+    async getValue(cancellationToken?: AbortSignal | CancellationToken): Promise<string | null> {
         if (!this._handle || !this._client) {
             throw new Error('getValue is only available on server-returned ReferenceExpression instances');
         }

--- a/playground/polyglot/TypeScript/Aspire.Hosting/ValidationAppHost/.modules/transport.ts
+++ b/playground/polyglot/TypeScript/Aspire.Hosting/ValidationAppHost/.modules/transport.ts
@@ -93,6 +93,16 @@ export function isMarshalledHandle(value: unknown): value is MarshalledHandle {
     );
 }
 
+function isAbortSignal(value: unknown): value is AbortSignal {
+    return (
+        value !== null &&
+        typeof value === 'object' &&
+        'aborted' in value &&
+        'addEventListener' in value &&
+        'removeEventListener' in value
+    );
+}
+
 // ============================================================================
 // Handle
 // ============================================================================
@@ -133,6 +143,92 @@ export class Handle<T extends string = string> {
     /** String representation for debugging */
     toString(): string {
         return `Handle<${this._typeId}>(${this._handleId})`;
+    }
+}
+
+// ============================================================================
+// CancellationToken
+// ============================================================================
+
+/**
+ * Represents a transport-safe cancellation token value for the generated SDK.
+ *
+ * Use a plain {@link AbortSignal} when you create cancellation in user code.
+ * Generated APIs accept either an {@link AbortSignal} or a {@link CancellationToken}.
+ *
+ * Values returned from generated callbacks and context/property getters are
+ * {@link CancellationToken} instances because they may reference remote
+ * cancellation token handles received from the AppHost.
+ *
+ * @example
+ * ```typescript
+ * const controller = new AbortController();
+ * await connectionStringExpression.getValue(controller.signal);
+ * ```
+ *
+ * @example
+ * ```typescript
+ * const cancellationToken = await context.cancellationToken.get();
+ * const connectionStringExpression = await db.uriExpression.get();
+ * const connectionString = await connectionStringExpression.getValue(cancellationToken);
+ * ```
+ */
+export class CancellationToken {
+    private readonly _signal?: AbortSignal;
+    private readonly _remoteTokenId?: string;
+    private _registeredTokenId?: string;
+
+    constructor(signal?: AbortSignal);
+    constructor(tokenId?: string);
+    constructor(value?: AbortSignal | string | null) {
+        if (typeof value === 'string') {
+            this._remoteTokenId = value;
+        } else if (isAbortSignal(value)) {
+            this._signal = value;
+        }
+    }
+
+    /**
+     * Creates a cancellation token from a local {@link AbortSignal}.
+     */
+    static from(signal?: AbortSignal): CancellationToken {
+        return new CancellationToken(signal);
+    }
+
+    /**
+     * Creates a cancellation token from a transport value.
+     * Generated code uses this to materialize values that come from the AppHost.
+     */
+    static fromValue(value: unknown): CancellationToken {
+        if (value instanceof CancellationToken) {
+            return value;
+        }
+
+        if (typeof value === 'string') {
+            return new CancellationToken(value);
+        }
+
+        if (isAbortSignal(value)) {
+            return new CancellationToken(value);
+        }
+
+        return new CancellationToken();
+    }
+
+    /**
+     * Serializes the token for JSON-RPC transport.
+     */
+    toJSON(): string | undefined {
+        if (this._remoteTokenId) {
+            return this._remoteTokenId;
+        }
+
+        if (this._registeredTokenId !== undefined) {
+            return this._registeredTokenId;
+        }
+
+        this._registeredTokenId = registerCancellation(this._signal);
+        return this._registeredTokenId;
     }
 }
 
@@ -401,13 +497,17 @@ let cancellationIdCounter = 0;
 let currentClient: AspireClient | null = null;
 
 /**
- * Register an AbortSignal for cancellation support.
- * Returns a cancellation ID that should be passed to methods accepting CancellationToken.
+ * Registers cancellation support for a local signal or SDK cancellation token.
+ * Returns a cancellation ID that should be passed to methods accepting cancellation input.
  *
  * When the AbortSignal is aborted, sends a cancelToken request to the host.
  *
- * @param signal - The AbortSignal to register (optional)
- * @returns The cancellation ID, or undefined if no signal provided
+ * @param signalOrToken - The signal or token to register (optional)
+ * @returns The cancellation ID, or undefined if no value was provided or the token maps to CancellationToken.None
+ *
+ * @example
+ * const controller = new AbortController();
+ * await expression.getValue(controller.signal);
  *
  * @example
  * const controller = new AbortController();
@@ -415,10 +515,16 @@ let currentClient: AspireClient | null = null;
  * // Pass id to capability invocation
  * // Later: controller.abort() will cancel the operation
  */
-export function registerCancellation(signal?: AbortSignal): string | undefined {
-    if (!signal) {
+export function registerCancellation(signalOrToken?: AbortSignal | CancellationToken): string | undefined {
+    if (!signalOrToken) {
         return undefined;
     }
+
+    if (signalOrToken instanceof CancellationToken) {
+        return signalOrToken.toJSON();
+    }
+
+    const signal = signalOrToken;
 
     // Already aborted? Don't register
     if (signal.aborted) {

--- a/playground/polyglot/TypeScript/Aspire.Hosting/ValidationAppHost/apphost.ts
+++ b/playground/polyglot/TypeScript/Aspire.Hosting/ValidationAppHost/apphost.ts
@@ -27,6 +27,9 @@ const project = await builder.addProject("myproject", "./src/MyProject", "https"
 // addCSharpApp
 const csharpApp = await builder.addCSharpApp("csharpapp", "./src/CSharpApp");
 
+// addRedis
+const cache = await builder.addRedis("cache");
+
 // addDotnetTool
 const tool = await builder.addDotnetTool("mytool", "dotnet-ef");
 
@@ -194,7 +197,9 @@ await container.withPipelineStepFactory("custom-build-step", async (stepContext)
     const stepLoggerFactory = await stepServices.getLoggerFactory();
     const stepFactoryLogger = await stepLoggerFactory.createLogger("ValidationAppHost.PipelineStepContext");
     await stepFactoryLogger.logDebug("Pipeline step factory logger");
-    const _cancellationToken = await stepContext.cancellationToken.get();
+    const cancellationToken = await stepContext.cancellationToken.get();
+    const cacheUriExpression = await cache.uriExpression.get();
+    const _cacheUri = await cacheUriExpression.getValue(cancellationToken);
 }, {
     dependsOn: ["build"],
     requiredBy: ["deploy"],

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/AtsTypeScriptCodeGenerator.cs
@@ -183,7 +183,7 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         AtsConstants.DateOnly or AtsConstants.TimeOnly => "string",
         AtsConstants.TimeSpan => "number",
         AtsConstants.Guid or AtsConstants.Uri => "string",
-        AtsConstants.CancellationToken => "AbortSignal",
+        AtsConstants.CancellationToken => "CancellationToken",
         _ => typeId
     };
 
@@ -243,8 +243,27 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
     }
 
     /// <summary>
+    /// Maps a user-supplied input type to TypeScript.
+    /// For interface handle types, generated APIs accept wrapper instances.
+    /// For cancellation tokens, generated APIs accept either an AbortSignal or a transport-safe CancellationToken.
+    /// </summary>
+    private string MapInputTypeToTypeScript(AtsTypeRef? typeRef)
+    {
+        if (IsInterfaceHandleType(typeRef))
+        {
+            return "ResourceBuilderBase";
+        }
+
+        if (IsCancellationTokenType(typeRef))
+        {
+            return "AbortSignal | CancellationToken";
+        }
+
+        return MapTypeRefToTypeScript(typeRef);
+    }
+
+    /// <summary>
     /// Maps a parameter to its TypeScript type, handling callbacks specially.
-    /// For interface handle types, generates union types to accept both handles and wrapper classes.
     /// </summary>
     private string MapParameterToTypeScript(AtsParameterInfo param)
     {
@@ -253,16 +272,7 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             return GenerateCallbackTypeSignature(param.CallbackParameters, param.CallbackReturnType);
         }
 
-        var baseType = MapTypeRefToTypeScript(param.Type);
-
-        // For interface handle types, use ResourceBuilderBase as the parameter type
-        // All wrapper classes extend ResourceBuilderBase and have toJSON() for serialization
-        if (IsInterfaceHandleType(param.Type))
-        {
-            return "ResourceBuilderBase";
-        }
-
-        return baseType;
+        return MapInputTypeToTypeScript(param.Type);
     }
 
     /// <summary>
@@ -276,6 +286,41 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             return false;
         }
         return typeRef.Category == AtsTypeCategory.Handle && typeRef.IsInterface;
+    }
+
+    private static bool IsCancellationTokenType(AtsTypeRef? typeRef) => typeRef?.TypeId == AtsConstants.CancellationToken;
+
+    private static string GetRpcArgumentValueExpression(string parameterName, AtsTypeRef? typeRef)
+        => IsCancellationTokenType(typeRef)
+            ? $"CancellationToken.fromValue({parameterName})"
+            : parameterName;
+
+    private static string GetRpcArgumentEntry(string parameterName, AtsTypeRef? typeRef)
+    {
+        var valueExpression = GetRpcArgumentValueExpression(parameterName, typeRef);
+        return valueExpression == parameterName
+            ? parameterName
+            : $"{parameterName}: {valueExpression}";
+    }
+
+    private static string GetRpcArgumentEntry(AtsParameterInfo param, bool useRegisteredCallback = true)
+    {
+        if (useRegisteredCallback && param.IsCallback)
+        {
+            return $"{param.Name}: {param.Name}Id";
+        }
+
+        return GetRpcArgumentEntry(param.Name, param.Type);
+    }
+
+    private static string GetRpcArgumentExpression(AtsParameterInfo param, bool useRegisteredCallback = true)
+    {
+        if (useRegisteredCallback && param.IsCallback)
+        {
+            return $"{param.Name}Id";
+        }
+
+        return GetRpcArgumentValueExpression(param.Name, param.Type);
     }
 
     /// <summary>
@@ -343,6 +388,7 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
                 Handle,
                 MarshalledHandle,
                 AppHostUsageError,
+                CancellationToken,
                 CapabilityError,
                 registerCallback,
                 wrapIfHandle,
@@ -1005,20 +1051,24 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
                 GenerateCallbackRegistration(callbackParam);
             }
 
-            // Handle cancellation token registration if any
-            var cancellationParams2 = capability.Parameters.Where(IsCancellationToken).ToList();
-            foreach (var ctParam in cancellationParams2)
-            {
-                GenerateCancellationRegistration(ctParam);
-            }
-
             // Build args object with conditional inclusion
-            GenerateArgsObjectWithConditionals(targetParamName, requiredParams, optionalParams, cancellationParams2);
+            GenerateArgsObjectWithConditionals(targetParamName, requiredParams, optionalParams);
 
-            WriteLine($"        return await this._client.invokeCapability<{returnType}>(");
-            WriteLine($"            '{capability.CapabilityId}',");
-            WriteLine($"            rpcArgs");
-            WriteLine("        );");
+            if (capability.ReturnType?.TypeId == AtsConstants.CancellationToken)
+            {
+                WriteLine("        const result = await this._client.invokeCapability<string | null>(");
+                WriteLine($"            '{capability.CapabilityId}',");
+                WriteLine("            rpcArgs");
+                WriteLine("        );");
+                WriteLine("        return CancellationToken.fromValue(result);");
+            }
+            else
+            {
+                WriteLine($"        return await this._client.invokeCapability<{returnType}>(");
+                WriteLine($"            '{capability.CapabilityId}',");
+                WriteLine($"            rpcArgs");
+                WriteLine("        );");
+            }
             WriteLine("    }");
             WriteLine();
             return;
@@ -1038,15 +1088,8 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             GenerateCallbackRegistration(callbackParam);
         }
 
-        // Handle cancellation token registration if any
-        var cancellationParams = capability.Parameters.Where(IsCancellationToken).ToList();
-        foreach (var ctParam in cancellationParams)
-        {
-            GenerateCancellationRegistration(ctParam);
-        }
-
         // Build args object with conditional inclusion
-        GenerateArgsObjectWithConditionals(targetParamName, requiredParams, optionalParams, cancellationParams);
+        GenerateArgsObjectWithConditionals(targetParamName, requiredParams, optionalParams);
 
         if (returnsBuilder)
         {
@@ -1099,29 +1142,13 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
     private void GenerateArgsObjectWithConditionals(
         string targetParamName,
         List<AtsParameterInfo> requiredParams,
-        List<AtsParameterInfo> optionalParams,
-        List<AtsParameterInfo>? cancellationParams = null)
+        List<AtsParameterInfo> optionalParams)
     {
-        var cancellationParamNames = new HashSet<string>(cancellationParams?.Select(p => p.Name) ?? []);
-
         // Build the required args inline
         var requiredArgs = new List<string> { $"{targetParamName}: this._handle" };
         foreach (var param in requiredParams)
         {
-            if (param.IsCallback)
-            {
-                // Use the actual parameter name for the RPC call, not a hardcoded "callback"
-                requiredArgs.Add($"{param.Name}: {param.Name}Id");
-            }
-            else if (cancellationParamNames.Contains(param.Name))
-            {
-                // Use the registered cancellation ID
-                requiredArgs.Add($"{param.Name}: {param.Name}Id");
-            }
-            else
-            {
-                requiredArgs.Add(param.Name);
-            }
+            requiredArgs.Add(GetRpcArgumentEntry(param));
         }
 
         WriteLine($"        const rpcArgs: Record<string, unknown> = {{ {string.Join(", ", requiredArgs)} }};");
@@ -1129,11 +1156,8 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         // Conditionally add optional params
         foreach (var param in optionalParams)
         {
-            var isCancellation = cancellationParamNames.Contains(param.Name);
-            var argName = param.IsCallback || isCancellation ? $"{param.Name}Id" : param.Name;
-            var paramName = param.Name;
-            // Use the actual parameter name for the RPC call
-            WriteLine($"        if ({paramName} !== undefined) rpcArgs.{paramName} = {argName};");
+            var rpcExpression = GetRpcArgumentExpression(param);
+            WriteLine($"        if ({param.Name} !== undefined) rpcArgs.{param.Name} = {rpcExpression};");
         }
     }
 
@@ -1274,20 +1298,15 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
 
         // Build parameter list
         var paramDefs = new List<string> { "client: AspireClientRpc" };
-        var paramArgs = new List<string>();
-
         foreach (var param in capability.Parameters)
         {
             var tsType = MapParameterToTypeScript(param);
             var optional = param.IsOptional || param.IsNullable ? "?" : "";
             paramDefs.Add($"{param.Name}{optional}: {tsType}");
-            paramArgs.Add(param.Name);
         }
 
         var paramsString = string.Join(", ", paramDefs);
-        var argsObject = paramArgs.Count > 0
-            ? $"{{ {string.Join(", ", paramArgs)} }}"
-            : "{}";
+        var (requiredParams, optionalParams) = SeparateParameters(capability.Parameters);
 
         // Determine return type - check if return type has a Promise wrapper
         var capReturnTypeId = GetReturnTypeId(capability);
@@ -1312,9 +1331,17 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             Write($"export function {methodName}(");
             Write(paramsString);
             WriteLine($"): {returnPromiseWrapper} {{");
+            var requiredArgs = requiredParams
+                .Select(param => GetRpcArgumentEntry(param, useRegisteredCallback: false))
+                .ToList();
+            WriteLine($"    const rpcArgs: Record<string, unknown> = {{ {string.Join(", ", requiredArgs)} }};");
+            foreach (var param in optionalParams)
+            {
+                WriteLine($"    if ({param.Name} !== undefined) rpcArgs.{param.Name} = {GetRpcArgumentExpression(param, useRegisteredCallback: false)};");
+            }
             WriteLine($"    const promise = client.invokeCapability<{handleType}>(");
             WriteLine($"        '{capability.CapabilityId}',");
-            WriteLine($"        {argsObject}");
+            WriteLine("        rpcArgs");
             WriteLine($"    ).then(handle => new {returnWrapperClass}(handle, client));");
             WriteLine($"    return new {returnPromiseWrapper}(promise);");
             WriteLine("}");
@@ -1329,16 +1356,35 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             Write($"export async function {methodName}(");
             Write(paramsString);
             WriteLine($"): Promise<{returnType}> {{");
+            var requiredArgs = requiredParams
+                .Select(param => GetRpcArgumentEntry(param, useRegisteredCallback: false))
+                .ToList();
+            WriteLine($"    const rpcArgs: Record<string, unknown> = {{ {string.Join(", ", requiredArgs)} }};");
+            foreach (var param in optionalParams)
+            {
+                WriteLine($"    if ({param.Name} !== undefined) rpcArgs.{param.Name} = {GetRpcArgumentExpression(param, useRegisteredCallback: false)};");
+            }
             if (returnType == "void")
             {
                 WriteLine($"    await client.invokeCapability<void>(");
+            }
+            else if (capability.ReturnType?.TypeId == AtsConstants.CancellationToken)
+            {
+                WriteLine("    const result = await client.invokeCapability<string | null>(");
+                WriteLine($"        '{capability.CapabilityId}',");
+                WriteLine("        rpcArgs");
+                WriteLine("    );");
+                WriteLine("    return CancellationToken.fromValue(result);");
+                WriteLine("}");
+                WriteLine();
+                return;
             }
             else
             {
                 WriteLine($"    return await client.invokeCapability<{returnType}>(");
             }
             WriteLine($"        '{capability.CapabilityId}',");
-            WriteLine($"        {argsObject}");
+            WriteLine("        rpcArgs");
             WriteLine("    );");
             WriteLine("}");
         }
@@ -1415,33 +1461,6 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
     }
 
     /// <summary>
-    /// Checks if a parameter is a CancellationToken type.
-    /// </summary>
-    private static bool IsCancellationToken(AtsParameterInfo param)
-    {
-        return param.Type?.TypeId == AtsConstants.CancellationToken;
-    }
-
-    /// <summary>
-    /// Generates cancellation registration for a CancellationToken parameter.
-    /// </summary>
-    private void GenerateCancellationRegistration(AtsParameterInfo param)
-    {
-        var isOptional = param.IsOptional || param.IsNullable;
-        var paramName = param.Name;
-
-        // For optional cancellation tokens, wrap the registration in a conditional
-        if (isOptional)
-        {
-            WriteLine($"        const {paramName}Id = {paramName} ? registerCancellation({paramName}) : undefined;");
-        }
-        else
-        {
-            WriteLine($"        const {paramName}Id = registerCancellation({paramName});");
-        }
-    }
-
-    /// <summary>
     /// Generates the body of a callback function.
     /// </summary>
     private void GenerateCallbackBody(AtsParameterInfo callbackParam, IReadOnlyList<AtsCallbackParameterInfo>? callbackParameters)
@@ -1465,7 +1484,11 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             var tsType = MapTypeRefToTypeScript(cbParam.Type);
             var cbTypeId = cbParam.Type.TypeId;
 
-            if (_wrapperClassNames.TryGetValue(cbTypeId, out var wrapperClassName))
+            if (cbTypeId == AtsConstants.CancellationToken)
+            {
+                WriteLine($"            const {cbParam.Name} = CancellationToken.fromValue({cbParam.Name}Data);");
+            }
+            else if (_wrapperClassNames.TryGetValue(cbTypeId, out var wrapperClassName))
             {
                 // For types with wrapper classes, create an instance of the wrapper
                 var handleType = GetHandleTypeName(cbTypeId);
@@ -1495,7 +1518,11 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
                 var tsType = MapTypeRefToTypeScript(cbParam.Type);
                 var cbTypeId = cbParam.Type.TypeId;
 
-                if (_wrapperClassNames.TryGetValue(cbTypeId, out var wrapperClassName))
+                if (cbTypeId == AtsConstants.CancellationToken)
+                {
+                    WriteLine($"            const {cbParam.Name} = CancellationToken.fromValue(args.p{i});");
+                }
+                else if (_wrapperClassNames.TryGetValue(cbTypeId, out var wrapperClassName))
                 {
                     // For types with wrapper classes, create an instance of the wrapper
                     var handleType = GetHandleTypeName(cbTypeId);
@@ -1582,7 +1609,7 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             }
 
             // Re-export commonly used types
-            export { Handle, AppHostUsageError, CapabilityError, registerCallback } from './transport.js';
+            export { Handle, AppHostUsageError, CancellationToken, CapabilityError, registerCallback } from './transport.js';
             export { refExpr, ReferenceExpression } from './base.js';
             """);
         WriteLine();
@@ -1848,10 +1875,21 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         if (getter != null)
         {
             WriteLine($"        get: async (): Promise<{returnType}> => {{");
-            WriteLine($"            return await this._client.invokeCapability<{returnType}>(");
-            WriteLine($"                '{getter.CapabilityId}',");
-            WriteLine($"                {{ context: this._handle }}");
-            WriteLine("            );");
+            if (getter.ReturnType?.TypeId == AtsConstants.CancellationToken)
+            {
+                WriteLine("            const result = await this._client.invokeCapability<string | null>(");
+                WriteLine($"                '{getter.CapabilityId}',");
+                WriteLine("                { context: this._handle }");
+                WriteLine("            );");
+                WriteLine("            return CancellationToken.fromValue(result);");
+            }
+            else
+            {
+                WriteLine($"            return await this._client.invokeCapability<{returnType}>(");
+                WriteLine($"                '{getter.CapabilityId}',");
+                WriteLine($"                {{ context: this._handle }}");
+                WriteLine("            );");
+            }
             WriteLine("        },");
         }
 
@@ -1861,11 +1899,11 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             var valueParam = setter.Parameters.FirstOrDefault(p => p.Name == "value");
             if (valueParam != null)
             {
-                var valueType = MapTypeRefToTypeScript(valueParam.Type);
+                var valueType = MapInputTypeToTypeScript(valueParam.Type);
                 WriteLine($"        set: async (value: {valueType}): Promise<void> => {{");
                 WriteLine($"            await this._client.invokeCapability<void>(");
                 WriteLine($"                '{setter.CapabilityId}',");
-                WriteLine($"                {{ context: this._handle, value }}");
+                WriteLine($"                {{ context: this._handle, {GetRpcArgumentEntry("value", valueParam.Type)} }}");
                 WriteLine("            );");
                 WriteLine("        }");
             }
@@ -2056,17 +2094,28 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         var requiredArgs = new List<string> { $"{targetParamName}: this._handle" };
         foreach (var param in requiredParams)
         {
-            requiredArgs.Add(param.Name);
+            requiredArgs.Add(GetRpcArgumentEntry(param.Name, param.Type));
         }
         WriteLine($"        const rpcArgs: Record<string, unknown> = {{ {string.Join(", ", requiredArgs)} }};");
         foreach (var param in optionalParams)
         {
-            WriteLine($"        if ({param.Name} !== undefined) rpcArgs.{param.Name} = {param.Name};");
+            WriteLine($"        if ({param.Name} !== undefined) rpcArgs.{param.Name} = {GetRpcArgumentValueExpression(param.Name, param.Type)};");
         }
 
         if (returnType == "void")
         {
             WriteLine($"        await this._client.invokeCapability<void>(");
+        }
+        else if (method.ReturnType?.TypeId == AtsConstants.CancellationToken)
+        {
+            WriteLine("        const result = await this._client.invokeCapability<string | null>(");
+            WriteLine($"            '{method.CapabilityId}',");
+            WriteLine("            rpcArgs");
+            WriteLine("        );");
+            WriteLine("        return CancellationToken.fromValue(result);");
+            WriteLine("    }");
+            WriteLine();
+            return;
         }
         else
         {
@@ -2134,12 +2183,12 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
         var requiredArgs = new List<string> { $"{firstParamName}: this._handle" };
         foreach (var param in requiredParams)
         {
-            requiredArgs.Add(param.Name);
+            requiredArgs.Add(GetRpcArgumentEntry(param.Name, param.Type));
         }
         WriteLine($"        const rpcArgs: Record<string, unknown> = {{ {string.Join(", ", requiredArgs)} }};");
         foreach (var param in optionalParams)
         {
-            WriteLine($"        if ({param.Name} !== undefined) rpcArgs.{param.Name} = {param.Name};");
+            WriteLine($"        if ({param.Name} !== undefined) rpcArgs.{param.Name} = {GetRpcArgumentValueExpression(param.Name, param.Type)};");
         }
 
         if (returnType == "void")
@@ -2329,10 +2378,21 @@ public sealed class AtsTypeScriptCodeGenerator : ICodeGenerator
             // Build args with conditional inclusion
             GenerateArgsObjectWithConditionals(targetParamName, requiredParams, optionalParams);
 
-            WriteLine($"        return await this._client.invokeCapability<{returnType}>(");
-            WriteLine($"            '{capability.CapabilityId}',");
-            WriteLine($"            rpcArgs");
-            WriteLine("        );");
+            if (capability.ReturnType?.TypeId == AtsConstants.CancellationToken)
+            {
+                WriteLine("        const result = await this._client.invokeCapability<string | null>(");
+                WriteLine($"            '{capability.CapabilityId}',");
+                WriteLine("            rpcArgs");
+                WriteLine("        );");
+                WriteLine("        return CancellationToken.fromValue(result);");
+            }
+            else
+            {
+                WriteLine($"        return await this._client.invokeCapability<{returnType}>(");
+                WriteLine($"            '{capability.CapabilityId}',");
+                WriteLine($"            rpcArgs");
+                WriteLine("        );");
+            }
             WriteLine("    }");
         }
         WriteLine();

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/base.ts
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/base.ts
@@ -2,7 +2,7 @@
 import { Handle, AspireClient, MarshalledHandle, registerCancellation, registerHandleWrapper, unregisterCancellation } from './transport.js';
 
 // Re-export transport types for convenience
-export { Handle, AspireClient, CapabilityError, registerCallback, unregisterCallback, registerCancellation, unregisterCancellation } from './transport.js';
+export { Handle, AspireClient, CapabilityError, CancellationToken, registerCallback, unregisterCallback, registerCancellation, unregisterCancellation } from './transport.js';
 export type { MarshalledHandle, AtsError, AtsErrorDetails, CallbackFunction } from './transport.js';
 export { AtsErrorCodes, isMarshalledHandle, isAtsError, wrapIfHandle } from './transport.js';
 

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/base.ts
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/base.ts
@@ -1,5 +1,5 @@
 // aspire.ts - Core Aspire types: base classes, ReferenceExpression
-import { Handle, AspireClient, MarshalledHandle, registerCancellation, registerHandleWrapper, unregisterCancellation } from './transport.js';
+import { Handle, AspireClient, MarshalledHandle, CancellationToken, registerCancellation, registerHandleWrapper, unregisterCancellation } from './transport.js';
 
 // Re-export transport types for convenience
 export { Handle, AspireClient, CapabilityError, CancellationToken, registerCallback, unregisterCallback, registerCancellation, unregisterCancellation } from './transport.js';
@@ -158,10 +158,10 @@ export class ReferenceExpression {
      * Resolves the expression to its string value on the server.
      * Only available on server-returned ReferenceExpression instances (handle mode).
      *
-     * @param cancellationToken - Optional AbortSignal for cancellation support
+     * @param cancellationToken - Optional AbortSignal or CancellationToken for cancellation support
      * @returns The resolved string value, or null if the expression resolves to null
      */
-    async getValue(cancellationToken?: AbortSignal): Promise<string | null> {
+    async getValue(cancellationToken?: AbortSignal | CancellationToken): Promise<string | null> {
         if (!this._handle || !this._client) {
             throw new Error('getValue is only available on server-returned ReferenceExpression instances');
         }

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/transport.ts
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/transport.ts
@@ -93,6 +93,16 @@ export function isMarshalledHandle(value: unknown): value is MarshalledHandle {
     );
 }
 
+function isAbortSignal(value: unknown): value is AbortSignal {
+    return (
+        value !== null &&
+        typeof value === 'object' &&
+        'aborted' in value &&
+        'addEventListener' in value &&
+        'removeEventListener' in value
+    );
+}
+
 // ============================================================================
 // Handle
 // ============================================================================
@@ -133,6 +143,92 @@ export class Handle<T extends string = string> {
     /** String representation for debugging */
     toString(): string {
         return `Handle<${this._typeId}>(${this._handleId})`;
+    }
+}
+
+// ============================================================================
+// CancellationToken
+// ============================================================================
+
+/**
+ * Represents a transport-safe cancellation token value for the generated SDK.
+ *
+ * Use a plain {@link AbortSignal} when you create cancellation in user code.
+ * Generated APIs accept either an {@link AbortSignal} or a {@link CancellationToken}.
+ *
+ * Values returned from generated callbacks and context/property getters are
+ * {@link CancellationToken} instances because they may reference remote
+ * cancellation token handles received from the AppHost.
+ *
+ * @example
+ * ```typescript
+ * const controller = new AbortController();
+ * await connectionStringExpression.getValue(controller.signal);
+ * ```
+ *
+ * @example
+ * ```typescript
+ * const cancellationToken = await context.cancellationToken.get();
+ * const connectionStringExpression = await db.uriExpression.get();
+ * const connectionString = await connectionStringExpression.getValue(cancellationToken);
+ * ```
+ */
+export class CancellationToken {
+    private readonly _signal?: AbortSignal;
+    private readonly _remoteTokenId?: string;
+    private _registeredTokenId?: string | null;
+
+    constructor(signal?: AbortSignal);
+    constructor(tokenId?: string | null);
+    constructor(value?: AbortSignal | string | null) {
+        if (typeof value === 'string') {
+            this._remoteTokenId = value;
+        } else if (isAbortSignal(value)) {
+            this._signal = value;
+        }
+    }
+
+    /**
+     * Creates a cancellation token from a local {@link AbortSignal}.
+     */
+    static from(signal?: AbortSignal): CancellationToken {
+        return new CancellationToken(signal);
+    }
+
+    /**
+     * Creates a cancellation token from a transport value.
+     * Generated code uses this to materialize values that come from the AppHost.
+     */
+    static fromValue(value: unknown): CancellationToken {
+        if (value instanceof CancellationToken) {
+            return value;
+        }
+
+        if (typeof value === 'string') {
+            return new CancellationToken(value);
+        }
+
+        if (isAbortSignal(value)) {
+            return new CancellationToken(value);
+        }
+
+        return new CancellationToken();
+    }
+
+    /**
+     * Serializes the token for JSON-RPC transport.
+     */
+    toJSON(): string | null {
+        if (this._remoteTokenId) {
+            return this._remoteTokenId;
+        }
+
+        if (this._registeredTokenId !== undefined) {
+            return this._registeredTokenId;
+        }
+
+        this._registeredTokenId = registerCancellation(this._signal) ?? null;
+        return this._registeredTokenId;
     }
 }
 
@@ -401,13 +497,17 @@ let cancellationIdCounter = 0;
 let currentClient: AspireClient | null = null;
 
 /**
- * Register an AbortSignal for cancellation support.
- * Returns a cancellation ID that should be passed to methods accepting CancellationToken.
+ * Registers cancellation support for a local signal or SDK cancellation token.
+ * Returns a cancellation ID that should be passed to methods accepting cancellation input.
  *
  * When the AbortSignal is aborted, sends a cancelToken request to the host.
  *
- * @param signal - The AbortSignal to register (optional)
- * @returns The cancellation ID, or undefined if no signal provided
+ * @param signalOrToken - The signal or token to register (optional)
+ * @returns The cancellation ID, null for CancellationToken.None, or undefined if no value was provided
+ *
+ * @example
+ * const controller = new AbortController();
+ * await expression.getValue(controller.signal);
  *
  * @example
  * const controller = new AbortController();
@@ -415,10 +515,16 @@ let currentClient: AspireClient | null = null;
  * // Pass id to capability invocation
  * // Later: controller.abort() will cancel the operation
  */
-export function registerCancellation(signal?: AbortSignal): string | undefined {
-    if (!signal) {
+export function registerCancellation(signalOrToken?: AbortSignal | CancellationToken): string | null | undefined {
+    if (!signalOrToken) {
         return undefined;
     }
+
+    if (signalOrToken instanceof CancellationToken) {
+        return signalOrToken.toJSON();
+    }
+
+    const signal = signalOrToken;
 
     // Already aborted? Don't register
     if (signal.aborted) {

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/transport.ts
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/transport.ts
@@ -176,10 +176,10 @@ export class Handle<T extends string = string> {
 export class CancellationToken {
     private readonly _signal?: AbortSignal;
     private readonly _remoteTokenId?: string;
-    private _registeredTokenId?: string | null;
+    private _registeredTokenId?: string;
 
     constructor(signal?: AbortSignal);
-    constructor(tokenId?: string | null);
+    constructor(tokenId?: string);
     constructor(value?: AbortSignal | string | null) {
         if (typeof value === 'string') {
             this._remoteTokenId = value;
@@ -218,7 +218,7 @@ export class CancellationToken {
     /**
      * Serializes the token for JSON-RPC transport.
      */
-    toJSON(): string | null {
+    toJSON(): string | undefined {
         if (this._remoteTokenId) {
             return this._remoteTokenId;
         }
@@ -227,7 +227,7 @@ export class CancellationToken {
             return this._registeredTokenId;
         }
 
-        this._registeredTokenId = registerCancellation(this._signal) ?? null;
+        this._registeredTokenId = registerCancellation(this._signal);
         return this._registeredTokenId;
     }
 }
@@ -503,7 +503,7 @@ let currentClient: AspireClient | null = null;
  * When the AbortSignal is aborted, sends a cancelToken request to the host.
  *
  * @param signalOrToken - The signal or token to register (optional)
- * @returns The cancellation ID, null for CancellationToken.None, or undefined if no value was provided
+ * @returns The cancellation ID, or undefined if no value was provided or the token maps to CancellationToken.None
  *
  * @example
  * const controller = new AbortController();
@@ -515,7 +515,7 @@ let currentClient: AspireClient | null = null;
  * // Pass id to capability invocation
  * // Later: controller.abort() will cancel the operation
  */
-export function registerCancellation(signalOrToken?: AbortSignal | CancellationToken): string | null | undefined {
+export function registerCancellation(signalOrToken?: AbortSignal | CancellationToken): string | undefined {
     if (!signalOrToken) {
         return undefined;
     }

--- a/src/Aspire.Hosting.RemoteHost/Ats/AtsCallbackProxyFactory.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/AtsCallbackProxyFactory.cs
@@ -86,7 +86,7 @@ internal sealed class AtsCallbackProxyFactory : IDisposable
 
         // Build the body expression
         Expression body;
-        var argsExpr = parameters.Length == 0 || (parameters.Length == 1 && ctParamIndex == 0)
+        var argsExpr = parameters.Length == 0
             ? null
             : BuildMarshalArgs(paramExprs, parameters);
 
@@ -95,12 +95,12 @@ internal sealed class AtsCallbackProxyFactory : IDisposable
             if (!hasResult)
             {
                 body = HasDtoParameters(parameters)
-                    ? BuildAsyncVoidCallWithDtoWriteback(callbackId, argsExpr, ctExpr, paramExprs, parameters)
-                    : BuildAsyncVoidCall(callbackId, argsExpr, ctExpr);
+                    ? BuildAsyncVoidCallWithDtoWriteback(callbackId, argsExpr, ctExpr, ctParamIndex, paramExprs, parameters)
+                    : BuildAsyncVoidCall(callbackId, argsExpr, ctExpr, ctParamIndex);
             }
             else
             {
-                body = BuildAsyncResultCall(callbackId, resultType!, argsExpr, ctExpr);
+                body = BuildAsyncResultCall(callbackId, resultType!, argsExpr, ctExpr, ctParamIndex);
             }
         }
         else
@@ -108,12 +108,12 @@ internal sealed class AtsCallbackProxyFactory : IDisposable
             if (!hasResult)
             {
                 body = HasDtoParameters(parameters)
-                    ? BuildSyncVoidCallWithDtoWriteback(callbackId, argsExpr, ctExpr, paramExprs, parameters)
-                    : BuildSyncVoidCall(callbackId, argsExpr, ctExpr);
+                    ? BuildSyncVoidCallWithDtoWriteback(callbackId, argsExpr, ctExpr, ctParamIndex, paramExprs, parameters)
+                    : BuildSyncVoidCall(callbackId, argsExpr, ctExpr, ctParamIndex);
             }
             else
             {
-                body = BuildSyncResultCall(callbackId, resultType!, argsExpr, ctExpr);
+                body = BuildSyncResultCall(callbackId, resultType!, argsExpr, ctExpr, ctParamIndex);
             }
         }
 
@@ -143,6 +143,12 @@ internal sealed class AtsCallbackProxyFactory : IDisposable
             var param = parameters[i];
             var paramExpr = paramExprs[i];
 
+            if (param.ParameterType == typeof(CancellationToken))
+            {
+                paramIndex++;
+                continue;
+            }
+
             // Call MarshalArg to convert to JsonNode
             var marshalMethod = typeof(AtsCallbackProxyFactory).GetMethod(
                 nameof(MarshalArg),
@@ -168,7 +174,7 @@ internal sealed class AtsCallbackProxyFactory : IDisposable
         return _marshaller.MarshalToJson(value);
     }
 
-    private Expression BuildSyncVoidCall(string callbackId, Expression? argsExpr, Expression? ctExpr)
+    private Expression BuildSyncVoidCall(string callbackId, Expression? argsExpr, Expression? ctExpr, int ctParamIndex)
     {
         var invokeMethod = typeof(AtsCallbackProxyFactory).GetMethod(
             nameof(InvokeSyncVoid),
@@ -179,10 +185,11 @@ internal sealed class AtsCallbackProxyFactory : IDisposable
             invokeMethod,
             Expression.Constant(callbackId),
             argsExpr ?? Expression.Constant(null, typeof(JsonObject)),
-            ctExpr ?? Expression.Constant(CancellationToken.None, typeof(CancellationToken)));
+            ctExpr ?? Expression.Constant(CancellationToken.None, typeof(CancellationToken)),
+            Expression.Constant(ctParamIndex));
     }
 
-    private Expression BuildSyncResultCall(string callbackId, Type resultType, Expression? argsExpr, Expression? ctExpr)
+    private Expression BuildSyncResultCall(string callbackId, Type resultType, Expression? argsExpr, Expression? ctExpr, int ctParamIndex)
     {
         var invokeMethod = typeof(AtsCallbackProxyFactory).GetMethod(
             nameof(InvokeSyncResult),
@@ -193,10 +200,11 @@ internal sealed class AtsCallbackProxyFactory : IDisposable
             invokeMethod,
             Expression.Constant(callbackId),
             argsExpr ?? Expression.Constant(null, typeof(JsonObject)),
-            ctExpr ?? Expression.Constant(CancellationToken.None, typeof(CancellationToken)));
+            ctExpr ?? Expression.Constant(CancellationToken.None, typeof(CancellationToken)),
+            Expression.Constant(ctParamIndex));
     }
 
-    private Expression BuildAsyncVoidCall(string callbackId, Expression? argsExpr, Expression? ctExpr)
+    private Expression BuildAsyncVoidCall(string callbackId, Expression? argsExpr, Expression? ctExpr, int ctParamIndex)
     {
         var invokeMethod = typeof(AtsCallbackProxyFactory).GetMethod(
             nameof(InvokeAsyncVoid),
@@ -207,10 +215,11 @@ internal sealed class AtsCallbackProxyFactory : IDisposable
             invokeMethod,
             Expression.Constant(callbackId),
             argsExpr ?? Expression.Constant(null, typeof(JsonObject)),
-            ctExpr ?? Expression.Constant(CancellationToken.None, typeof(CancellationToken)));
+            ctExpr ?? Expression.Constant(CancellationToken.None, typeof(CancellationToken)),
+            Expression.Constant(ctParamIndex));
     }
 
-    private Expression BuildAsyncResultCall(string callbackId, Type resultType, Expression? argsExpr, Expression? ctExpr)
+    private Expression BuildAsyncResultCall(string callbackId, Type resultType, Expression? argsExpr, Expression? ctExpr, int ctParamIndex)
     {
         var invokeMethod = typeof(AtsCallbackProxyFactory).GetMethod(
             nameof(InvokeAsyncResult),
@@ -221,45 +230,46 @@ internal sealed class AtsCallbackProxyFactory : IDisposable
             invokeMethod,
             Expression.Constant(callbackId),
             argsExpr ?? Expression.Constant(null, typeof(JsonObject)),
-            ctExpr ?? Expression.Constant(CancellationToken.None, typeof(CancellationToken)));
+            ctExpr ?? Expression.Constant(CancellationToken.None, typeof(CancellationToken)),
+            Expression.Constant(ctParamIndex));
     }
 
-    private void InvokeSyncVoid(string callbackId, JsonObject? args, CancellationToken cancellationToken)
+    private void InvokeSyncVoid(string callbackId, JsonObject? args, CancellationToken cancellationToken, int ctParamIndex)
     {
-        AddCancellationTokenToArgs(ref args, cancellationToken);
+        AddCancellationTokenToArgs(ref args, cancellationToken, ctParamIndex);
         _invoker.InvokeAsync<JsonNode?>(callbackId, args, cancellationToken).GetAwaiter().GetResult();
     }
 
-    private void InvokeSyncVoidWithDtoWriteback(string callbackId, JsonObject? args, object?[] originalArgs, Type[] argTypes, CancellationToken cancellationToken)
+    private void InvokeSyncVoidWithDtoWriteback(string callbackId, JsonObject? args, object?[] originalArgs, Type[] argTypes, CancellationToken cancellationToken, int ctParamIndex)
     {
-        AddCancellationTokenToArgs(ref args, cancellationToken);
+        AddCancellationTokenToArgs(ref args, cancellationToken, ctParamIndex);
         var result = _invoker.InvokeAsync<JsonNode?>(callbackId, args, cancellationToken).GetAwaiter().GetResult();
         ApplyDtoWriteback(result, originalArgs, argTypes);
     }
 
-    private T? InvokeSyncResult<T>(string callbackId, JsonObject? args, CancellationToken cancellationToken)
+    private T? InvokeSyncResult<T>(string callbackId, JsonObject? args, CancellationToken cancellationToken, int ctParamIndex)
     {
-        AddCancellationTokenToArgs(ref args, cancellationToken);
+        AddCancellationTokenToArgs(ref args, cancellationToken, ctParamIndex);
         var result = _invoker.InvokeAsync<JsonNode?>(callbackId, args, cancellationToken).GetAwaiter().GetResult();
         return UnmarshalResult<T>(result, callbackId);
     }
 
-    private async Task InvokeAsyncVoid(string callbackId, JsonObject? args, CancellationToken cancellationToken)
+    private async Task InvokeAsyncVoid(string callbackId, JsonObject? args, CancellationToken cancellationToken, int ctParamIndex)
     {
-        AddCancellationTokenToArgs(ref args, cancellationToken);
+        AddCancellationTokenToArgs(ref args, cancellationToken, ctParamIndex);
         await _invoker.InvokeAsync<JsonNode?>(callbackId, args, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task InvokeAsyncVoidWithDtoWriteback(string callbackId, JsonObject? args, object?[] originalArgs, Type[] argTypes, CancellationToken cancellationToken)
+    private async Task InvokeAsyncVoidWithDtoWriteback(string callbackId, JsonObject? args, object?[] originalArgs, Type[] argTypes, CancellationToken cancellationToken, int ctParamIndex)
     {
-        AddCancellationTokenToArgs(ref args, cancellationToken);
+        AddCancellationTokenToArgs(ref args, cancellationToken, ctParamIndex);
         var result = await _invoker.InvokeAsync<JsonNode?>(callbackId, args, cancellationToken).ConfigureAwait(false);
         ApplyDtoWriteback(result, originalArgs, argTypes);
     }
 
-    private async Task<T?> InvokeAsyncResult<T>(string callbackId, JsonObject? args, CancellationToken cancellationToken)
+    private async Task<T?> InvokeAsyncResult<T>(string callbackId, JsonObject? args, CancellationToken cancellationToken, int ctParamIndex)
     {
-        AddCancellationTokenToArgs(ref args, cancellationToken);
+        AddCancellationTokenToArgs(ref args, cancellationToken, ctParamIndex);
         var result = await _invoker.InvokeAsync<JsonNode?>(callbackId, args, cancellationToken).ConfigureAwait(false);
         return UnmarshalResult<T>(result, callbackId);
     }
@@ -280,12 +290,16 @@ internal sealed class AtsCallbackProxyFactory : IDisposable
         return (T?)_marshaller.UnmarshalFromJson(result, typeof(T), context);
     }
 
-    private void AddCancellationTokenToArgs(ref JsonObject? args, CancellationToken cancellationToken)
+    private void AddCancellationTokenToArgs(ref JsonObject? args, CancellationToken cancellationToken, int ctParamIndex)
     {
         if (cancellationToken != CancellationToken.None)
         {
             var (tokenId, _) = _cancellationTokenRegistry.CreateLinked(cancellationToken);
             args ??= new JsonObject();
+            if (ctParamIndex >= 0)
+            {
+                args[$"p{ctParamIndex}"] = tokenId;
+            }
             args["$cancellationToken"] = tokenId;
         }
     }
@@ -297,7 +311,7 @@ internal sealed class AtsCallbackProxyFactory : IDisposable
             _marshaller.IsDtoType(p.ParameterType));
     }
 
-    private Expression BuildSyncVoidCallWithDtoWriteback(string callbackId, Expression? argsExpr, Expression? ctExpr, ParameterExpression[] paramExprs, ParameterInfo[] parameters)
+    private Expression BuildSyncVoidCallWithDtoWriteback(string callbackId, Expression? argsExpr, Expression? ctExpr, int ctParamIndex, ParameterExpression[] paramExprs, ParameterInfo[] parameters)
     {
         var (originalsExpr, typesExpr) = BuildOriginalArgsArrays(paramExprs, parameters);
 
@@ -312,10 +326,11 @@ internal sealed class AtsCallbackProxyFactory : IDisposable
             argsExpr ?? Expression.Constant(null, typeof(JsonObject)),
             originalsExpr,
             typesExpr,
-            ctExpr ?? Expression.Constant(CancellationToken.None, typeof(CancellationToken)));
+            ctExpr ?? Expression.Constant(CancellationToken.None, typeof(CancellationToken)),
+            Expression.Constant(ctParamIndex));
     }
 
-    private Expression BuildAsyncVoidCallWithDtoWriteback(string callbackId, Expression? argsExpr, Expression? ctExpr, ParameterExpression[] paramExprs, ParameterInfo[] parameters)
+    private Expression BuildAsyncVoidCallWithDtoWriteback(string callbackId, Expression? argsExpr, Expression? ctExpr, int ctParamIndex, ParameterExpression[] paramExprs, ParameterInfo[] parameters)
     {
         var (originalsExpr, typesExpr) = BuildOriginalArgsArrays(paramExprs, parameters);
 
@@ -330,7 +345,8 @@ internal sealed class AtsCallbackProxyFactory : IDisposable
             argsExpr ?? Expression.Constant(null, typeof(JsonObject)),
             originalsExpr,
             typesExpr,
-            ctExpr ?? Expression.Constant(CancellationToken.None, typeof(CancellationToken)));
+            ctExpr ?? Expression.Constant(CancellationToken.None, typeof(CancellationToken)),
+            Expression.Constant(ctParamIndex));
     }
 
     private static (Expression Originals, Expression Types) BuildOriginalArgsArrays(ParameterExpression[] paramExprs, ParameterInfo[] parameters)

--- a/src/Aspire.Hosting.RemoteHost/Ats/AtsCallbackProxyFactory.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/AtsCallbackProxyFactory.cs
@@ -137,17 +137,11 @@ internal sealed class AtsCallbackProxyFactory : IDisposable
         var jsonObjVar = Expression.Variable(jsonObjectType, "args");
         expressions.Add(Expression.Assign(jsonObjVar, newJsonObject));
 
-        var paramIndex = 0; // Track positional index (excludes CancellationToken)
+        var paramIndex = 0;
         for (int i = 0; i < parameters.Length; i++)
         {
             var param = parameters[i];
             var paramExpr = paramExprs[i];
-
-            // Skip CancellationToken for now (handled separately)
-            if (param.ParameterType == typeof(CancellationToken))
-            {
-                continue;
-            }
 
             // Call MarshalArg to convert to JsonNode
             var marshalMethod = typeof(AtsCallbackProxyFactory).GetMethod(

--- a/src/Aspire.Hosting.RemoteHost/Ats/AtsMarshaller.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/AtsMarshaller.cs
@@ -135,7 +135,7 @@ internal sealed class AtsMarshaller
             return null;
         }
 
-        if (typeRef.TypeId == Hosting.Ats.AtsConstants.CancellationToken && value is CancellationToken cancellationToken)
+        if (typeRef.TypeId == AtsConstants.CancellationToken && value is CancellationToken cancellationToken)
         {
             return SerializeCancellationToken(cancellationToken);
         }

--- a/src/Aspire.Hosting.RemoteHost/Ats/AtsMarshaller.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/AtsMarshaller.cs
@@ -135,6 +135,11 @@ internal sealed class AtsMarshaller
             return null;
         }
 
+        if (typeRef.TypeId == Hosting.Ats.AtsConstants.CancellationToken && value is CancellationToken cancellationToken)
+        {
+            return SerializeCancellationToken(cancellationToken);
+        }
+
         // Handle 'any' type - fall back to runtime type inspection
         if (typeRef.TypeId == TypeSystem.AtsConstants.Any)
         {
@@ -216,6 +221,11 @@ internal sealed class AtsMarshaller
         }
 
         var type = value.GetType();
+        if (type == typeof(CancellationToken))
+        {
+            return SerializeCancellationToken((CancellationToken)value);
+        }
+
         var category = _context.GetCategory(type);
 
         return category switch
@@ -239,6 +249,17 @@ internal sealed class AtsMarshaller
             jsonArray.Add(MarshalToJson(item));
         }
         return jsonArray;
+    }
+
+    private JsonNode? SerializeCancellationToken(CancellationToken cancellationToken)
+    {
+        if (cancellationToken == CancellationToken.None)
+        {
+            return null;
+        }
+
+        var (tokenId, _) = _cancellationTokenRegistry.CreateLinked(cancellationToken);
+        return JsonValue.Create(tokenId);
     }
 
     private JsonNode? MarshalListHandle(object value, Type type)

--- a/src/Aspire.Hosting.RemoteHost/Ats/AtsMarshaller.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/AtsMarshaller.cs
@@ -304,6 +304,11 @@ internal sealed class AtsMarshaller
     {
         if (node == null)
         {
+            if (targetType == typeof(CancellationToken))
+            {
+                return CancellationToken.None;
+            }
+
             return null;
         }
 

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
@@ -1110,13 +1110,15 @@ public class AtsTypeScriptCodeGeneratorTests
     }
 
     [Fact]
-    public void Generate_MethodWithCancellationToken_GeneratesAbortSignalParameter()
+    public void Generate_MethodWithCancellationToken_GeneratesCancellationTokenParameter()
     {
-        // Verify generated TypeScript has AbortSignal parameter
+        // Generated input parameters should accept AbortSignal for user-authored cancellation,
+        // while callbacks and returned values continue to use the SDK CancellationToken wrapper.
         var code = GenerateTwoPassCode();
 
-        // getStatusAsync should have an AbortSignal parameter in the generated code
-        Assert.Contains("AbortSignal", code);
+        Assert.Contains("cancellationToken?: AbortSignal | CancellationToken;", code);
+        Assert.Contains("set: async (value: AbortSignal | CancellationToken): Promise<void> => {", code);
+        Assert.Contains("withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>)", code);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/AtsGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/AtsGeneratedAspire.verified.ts
@@ -1,4 +1,4 @@
-﻿// aspire.ts - Capability-based Aspire SDK
+// aspire.ts - Capability-based Aspire SDK
 // This SDK uses the ATS (Aspire Type System) capability API.
 // Capabilities are endpoints like 'Aspire.Hosting/createBuilder'.
 //
@@ -9,6 +9,7 @@ import {
     Handle,
     MarshalledHandle,
     AppHostUsageError,
+    CancellationToken,
     CapabilityError,
     registerCallback,
     wrapIfHandle,
@@ -124,11 +125,11 @@ export interface AddTestRedisOptions {
 }
 
 export interface GetStatusAsyncOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface WaitForReadyAsyncOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface WithDataVolumeOptions {
@@ -196,16 +197,17 @@ export class TestCallbackContext {
 
     /** Gets the CancellationToken property */
     cancellationToken = {
-        get: async (): Promise<AbortSignal> => {
-            return await this._client.invokeCapability<AbortSignal>(
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestCallbackContext.cancellationToken',
                 { context: this._handle }
             );
+            return CancellationToken.fromValue(result);
         },
-        set: async (value: AbortSignal): Promise<void> => {
+        set: async (value: AbortSignal | CancellationToken): Promise<void> => {
             await this._client.invokeCapability<void>(
                 'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestCallbackContext.setCancellationToken',
-                { context: this._handle, value }
+                { context: this._handle, value: CancellationToken.fromValue(value) }
             );
         }
     };
@@ -741,9 +743,9 @@ export class TestDatabaseResource extends ResourceBuilderBase<TestDatabaseResour
     }
 
     /** @internal */
-    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<TestDatabaseResource> {
+    private async _withCancellableOperationInternal(operation: (arg: CancellationToken) => Promise<void>): Promise<TestDatabaseResource> {
         const operationId = registerCallback(async (argData: unknown) => {
-            const arg = wrapIfHandle(argData) as AbortSignal;
+            const arg = CancellationToken.fromValue(argData);
             await operation(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, operation: operationId };
@@ -755,7 +757,7 @@ export class TestDatabaseResource extends ResourceBuilderBase<TestDatabaseResour
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): TestDatabaseResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromise(this._withCancellableOperationInternal(operation));
     }
 
@@ -864,7 +866,7 @@ export class TestDatabaseResourcePromise implements PromiseLike<TestDatabaseReso
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): TestDatabaseResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromise(this._promise.then(obj => obj.withCancellableOperation(operation)));
     }
 
@@ -1224,9 +1226,8 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     /** Gets the status of the resource asynchronously */
     async getStatusAsync(options?: GetStatusAsyncOptions): Promise<string> {
         const cancellationToken = options?.cancellationToken;
-        const cancellationTokenId = cancellationToken ? registerCancellation(cancellationToken) : undefined;
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationTokenId;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         return await this._client.invokeCapability<string>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/getStatusAsync',
             rpcArgs
@@ -1234,9 +1235,9 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<TestRedisResource> {
+    private async _withCancellableOperationInternal(operation: (arg: CancellationToken) => Promise<void>): Promise<TestRedisResource> {
         const operationId = registerCallback(async (argData: unknown) => {
-            const arg = wrapIfHandle(argData) as AbortSignal;
+            const arg = CancellationToken.fromValue(argData);
             await operation(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, operation: operationId };
@@ -1248,16 +1249,15 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): TestRedisResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): TestRedisResourcePromise {
         return new TestRedisResourcePromise(this._withCancellableOperationInternal(operation));
     }
 
     /** Waits for the resource to be ready */
     async waitForReadyAsync(timeout: number, options?: WaitForReadyAsyncOptions): Promise<boolean> {
         const cancellationToken = options?.cancellationToken;
-        const cancellationTokenId = cancellationToken ? registerCancellation(cancellationToken) : undefined;
         const rpcArgs: Record<string, unknown> = { builder: this._handle, timeout };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationTokenId;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         return await this._client.invokeCapability<boolean>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/waitForReadyAsync',
             rpcArgs
@@ -1439,7 +1439,7 @@ export class TestRedisResourcePromise implements PromiseLike<TestRedisResource> 
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): TestRedisResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): TestRedisResourcePromise {
         return new TestRedisResourcePromise(this._promise.then(obj => obj.withCancellableOperation(operation)));
     }
 
@@ -1701,9 +1701,9 @@ export class TestVaultResource extends ResourceBuilderBase<TestVaultResourceHand
     }
 
     /** @internal */
-    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<TestVaultResource> {
+    private async _withCancellableOperationInternal(operation: (arg: CancellationToken) => Promise<void>): Promise<TestVaultResource> {
         const operationId = registerCallback(async (argData: unknown) => {
-            const arg = wrapIfHandle(argData) as AbortSignal;
+            const arg = CancellationToken.fromValue(argData);
             await operation(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, operation: operationId };
@@ -1715,7 +1715,7 @@ export class TestVaultResource extends ResourceBuilderBase<TestVaultResourceHand
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): TestVaultResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): TestVaultResourcePromise {
         return new TestVaultResourcePromise(this._withCancellableOperationInternal(operation));
     }
 
@@ -1822,7 +1822,7 @@ export class TestVaultResourcePromise implements PromiseLike<TestVaultResource> 
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): TestVaultResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): TestVaultResourcePromise {
         return new TestVaultResourcePromise(this._promise.then(obj => obj.withCancellableOperation(operation)));
     }
 
@@ -2039,9 +2039,9 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<Resource> {
+    private async _withCancellableOperationInternal(operation: (arg: CancellationToken) => Promise<void>): Promise<Resource> {
         const operationId = registerCallback(async (argData: unknown) => {
-            const arg = wrapIfHandle(argData) as AbortSignal;
+            const arg = CancellationToken.fromValue(argData);
             await operation(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, operation: operationId };
@@ -2053,7 +2053,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): ResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): ResourcePromise {
         return new ResourcePromise(this._withCancellableOperationInternal(operation));
     }
 
@@ -2135,7 +2135,7 @@ export class ResourcePromise implements PromiseLike<Resource> {
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): ResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): ResourcePromise {
         return new ResourcePromise(this._promise.then(obj => obj.withCancellableOperation(operation)));
     }
 
@@ -2345,7 +2345,7 @@ export async function createBuilder(options?: CreateBuilderOptions): Promise<Dis
 }
 
 // Re-export commonly used types
-export { Handle, AppHostUsageError, CapabilityError, registerCallback } from './transport.js';
+export { Handle, AppHostUsageError, CancellationToken, CapabilityError, registerCallback } from './transport.js';
 export { refExpr, ReferenceExpression } from './base.js';
 
 // ============================================================================

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -1,4 +1,4 @@
-// aspire.ts - Capability-based Aspire SDK
+﻿// aspire.ts - Capability-based Aspire SDK
 // This SDK uses the ATS (Aspire Type System) capability API.
 // Capabilities are endpoints like 'Aspire.Hosting/createBuilder'.
 //
@@ -478,31 +478,31 @@ export interface AppendValueProviderOptions {
 
 export interface CompleteStepMarkdownOptions {
     completionState?: string;
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface CompleteStepOptions {
     completionState?: string;
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface CompleteTaskMarkdownOptions {
     completionState?: string;
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface CompleteTaskOptions {
     completionMessage?: string;
     completionState?: string;
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface CreateMarkdownTaskOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface CreateTaskOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface GetStatusAsyncOptions {
@@ -527,15 +527,15 @@ export interface RunOptions {
 }
 
 export interface SaveStateJsonOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface UpdateTaskMarkdownOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface UpdateTaskOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface WaitForCompletionOptions {
@@ -1679,16 +1679,17 @@ export class PipelineContext {
 
     /** Gets the CancellationToken property */
     cancellationToken = {
-        get: async (): Promise<AbortSignal> => {
-            return await this._client.invokeCapability<AbortSignal>(
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.Pipelines/PipelineContext.cancellationToken',
                 { context: this._handle }
             );
+            return CancellationToken.fromValue(result);
         },
-        set: async (value: AbortSignal): Promise<void> => {
+        set: async (value: AbortSignal | CancellationToken): Promise<void> => {
             await this._client.invokeCapability<void>(
                 'Aspire.Hosting.Pipelines/PipelineContext.setCancellationToken',
-                { context: this._handle, value }
+                { context: this._handle, value: CancellationToken.fromValue(value) }
             );
         }
     };
@@ -3892,9 +3893,9 @@ export class ReportingStep {
 
     /** Creates a reporting task with plain-text status text */
     /** @internal */
-    async _createTaskInternal(statusText: string, cancellationToken?: AbortSignal): Promise<ReportingTask> {
+    async _createTaskInternal(statusText: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingTask> {
         const rpcArgs: Record<string, unknown> = { reportingStep: this._handle, statusText };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         const result = await this._client.invokeCapability<IReportingTaskHandle>(
             'Aspire.Hosting/createTask',
             rpcArgs
@@ -3909,9 +3910,9 @@ export class ReportingStep {
 
     /** Creates a reporting task with Markdown-formatted status text */
     /** @internal */
-    async _createMarkdownTaskInternal(markdownString: string, cancellationToken?: AbortSignal): Promise<ReportingTask> {
+    async _createMarkdownTaskInternal(markdownString: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingTask> {
         const rpcArgs: Record<string, unknown> = { reportingStep: this._handle, markdownString };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         const result = await this._client.invokeCapability<IReportingTaskHandle>(
             'Aspire.Hosting/createMarkdownTask',
             rpcArgs
@@ -3956,10 +3957,10 @@ export class ReportingStep {
 
     /** Completes the reporting step with plain-text completion text */
     /** @internal */
-    async _completeStepInternal(completionText: string, completionState?: string, cancellationToken?: AbortSignal): Promise<ReportingStep> {
+    async _completeStepInternal(completionText: string, completionState?: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingStep> {
         const rpcArgs: Record<string, unknown> = { reportingStep: this._handle, completionText };
         if (completionState !== undefined) rpcArgs.completionState = completionState;
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         await this._client.invokeCapability<void>(
             'Aspire.Hosting/completeStep',
             rpcArgs
@@ -3975,10 +3976,10 @@ export class ReportingStep {
 
     /** Completes the reporting step with Markdown-formatted completion text */
     /** @internal */
-    async _completeStepMarkdownInternal(markdownString: string, completionState?: string, cancellationToken?: AbortSignal): Promise<ReportingStep> {
+    async _completeStepMarkdownInternal(markdownString: string, completionState?: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingStep> {
         const rpcArgs: Record<string, unknown> = { reportingStep: this._handle, markdownString };
         if (completionState !== undefined) rpcArgs.completionState = completionState;
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         await this._client.invokeCapability<void>(
             'Aspire.Hosting/completeStepMarkdown',
             rpcArgs
@@ -4054,9 +4055,9 @@ export class ReportingTask {
 
     /** Updates the reporting task with plain-text status text */
     /** @internal */
-    async _updateTaskInternal(statusText: string, cancellationToken?: AbortSignal): Promise<ReportingTask> {
+    async _updateTaskInternal(statusText: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingTask> {
         const rpcArgs: Record<string, unknown> = { reportingTask: this._handle, statusText };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         await this._client.invokeCapability<void>(
             'Aspire.Hosting/updateTask',
             rpcArgs
@@ -4071,9 +4072,9 @@ export class ReportingTask {
 
     /** Updates the reporting task with Markdown-formatted status text */
     /** @internal */
-    async _updateTaskMarkdownInternal(markdownString: string, cancellationToken?: AbortSignal): Promise<ReportingTask> {
+    async _updateTaskMarkdownInternal(markdownString: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingTask> {
         const rpcArgs: Record<string, unknown> = { reportingTask: this._handle, markdownString };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         await this._client.invokeCapability<void>(
             'Aspire.Hosting/updateTaskMarkdown',
             rpcArgs
@@ -4088,11 +4089,11 @@ export class ReportingTask {
 
     /** Completes the reporting task with plain-text completion text */
     /** @internal */
-    async _completeTaskInternal(completionMessage?: string, completionState?: string, cancellationToken?: AbortSignal): Promise<ReportingTask> {
+    async _completeTaskInternal(completionMessage?: string, completionState?: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingTask> {
         const rpcArgs: Record<string, unknown> = { reportingTask: this._handle };
         if (completionMessage !== undefined) rpcArgs.completionMessage = completionMessage;
         if (completionState !== undefined) rpcArgs.completionState = completionState;
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         await this._client.invokeCapability<void>(
             'Aspire.Hosting/completeTask',
             rpcArgs
@@ -4109,10 +4110,10 @@ export class ReportingTask {
 
     /** Completes the reporting task with Markdown-formatted completion text */
     /** @internal */
-    async _completeTaskMarkdownInternal(markdownString: string, completionState?: string, cancellationToken?: AbortSignal): Promise<ReportingTask> {
+    async _completeTaskMarkdownInternal(markdownString: string, completionState?: string, cancellationToken?: AbortSignal | CancellationToken): Promise<ReportingTask> {
         const rpcArgs: Record<string, unknown> = { reportingTask: this._handle, markdownString };
         if (completionState !== undefined) rpcArgs.completionState = completionState;
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         await this._client.invokeCapability<void>(
             'Aspire.Hosting/completeTaskMarkdown',
             rpcArgs
@@ -4357,9 +4358,9 @@ export class UserSecretsManager {
 
     /** Saves state to user secrets from a JSON string */
     /** @internal */
-    async _saveStateJsonInternal(json: string, cancellationToken?: AbortSignal): Promise<UserSecretsManager> {
+    async _saveStateJsonInternal(json: string, cancellationToken?: AbortSignal | CancellationToken): Promise<UserSecretsManager> {
         const rpcArgs: Record<string, unknown> = { userSecretsManager: this._handle, json };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         await this._client.invokeCapability<void>(
             'Aspire.Hosting/saveStateJson',
             rpcArgs

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -1,4 +1,4 @@
-﻿// aspire.ts - Capability-based Aspire SDK
+// aspire.ts - Capability-based Aspire SDK
 // This SDK uses the ATS (Aspire Type System) capability API.
 // Capabilities are endpoints like 'Aspire.Hosting/createBuilder'.
 //
@@ -9,6 +9,7 @@ import {
     Handle,
     MarshalledHandle,
     AppHostUsageError,
+    CancellationToken,
     CapabilityError,
     registerCallback,
     wrapIfHandle,
@@ -505,11 +506,11 @@ export interface CreateTaskOptions {
 }
 
 export interface GetStatusAsyncOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface GetValueAsyncOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface PublishAsDockerFileOptions {
@@ -522,7 +523,7 @@ export interface PublishResourceUpdateOptions {
 }
 
 export interface RunOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface SaveStateJsonOptions {
@@ -542,7 +543,7 @@ export interface WaitForCompletionOptions {
 }
 
 export interface WaitForReadyAsyncOptions {
-    cancellationToken?: AbortSignal;
+    cancellationToken?: AbortSignal | CancellationToken;
 }
 
 export interface WaitForResourceStateOptions {
@@ -823,11 +824,12 @@ export class CommandLineArgsCallbackContext {
 
     /** Gets the CancellationToken property */
     cancellationToken = {
-        get: async (): Promise<AbortSignal> => {
-            return await this._client.invokeCapability<AbortSignal>(
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.ApplicationModel/CommandLineArgsCallbackContext.cancellationToken',
                 { context: this._handle }
             );
+            return CancellationToken.fromValue(result);
         },
     };
 
@@ -918,9 +920,9 @@ export class DistributedApplication {
 
     /** Runs the distributed application */
     /** @internal */
-    async _runInternal(cancellationToken?: AbortSignal): Promise<DistributedApplication> {
+    async _runInternal(cancellationToken?: AbortSignal | CancellationToken): Promise<DistributedApplication> {
         const rpcArgs: Record<string, unknown> = { context: this._handle };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         await this._client.invokeCapability<void>(
             'Aspire.Hosting/run',
             rpcArgs
@@ -1245,7 +1247,7 @@ export class EndpointReference {
     async getValueAsync(options?: GetValueAsyncOptions): Promise<string> {
         const cancellationToken = options?.cancellationToken;
         const rpcArgs: Record<string, unknown> = { context: this._handle };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationToken;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         return await this._client.invokeCapability<string>(
             'Aspire.Hosting.ApplicationModel/getValueAsync',
             rpcArgs
@@ -1363,11 +1365,12 @@ export class EnvironmentCallbackContext {
 
     /** Gets the CancellationToken property */
     cancellationToken = {
-        get: async (): Promise<AbortSignal> => {
-            return await this._client.invokeCapability<AbortSignal>(
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.ApplicationModel/EnvironmentCallbackContext.cancellationToken',
                 { context: this._handle }
             );
+            return CancellationToken.fromValue(result);
         },
     };
 
@@ -1448,16 +1451,17 @@ export class ExecuteCommandContext {
 
     /** Gets the CancellationToken property */
     cancellationToken = {
-        get: async (): Promise<AbortSignal> => {
-            return await this._client.invokeCapability<AbortSignal>(
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.ApplicationModel/ExecuteCommandContext.cancellationToken',
                 { context: this._handle }
             );
+            return CancellationToken.fromValue(result);
         },
-        set: async (value: AbortSignal): Promise<void> => {
+        set: async (value: AbortSignal | CancellationToken): Promise<void> => {
             await this._client.invokeCapability<void>(
                 'Aspire.Hosting.ApplicationModel/ExecuteCommandContext.setCancellationToken',
-                { context: this._handle, value }
+                { context: this._handle, value: CancellationToken.fromValue(value) }
             );
         }
     };
@@ -1938,11 +1942,12 @@ export class PipelineStepContext {
 
     /** Gets the CancellationToken property */
     cancellationToken = {
-        get: async (): Promise<AbortSignal> => {
-            return await this._client.invokeCapability<AbortSignal>(
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.Pipelines/PipelineStepContext.cancellationToken',
                 { context: this._handle }
             );
+            return CancellationToken.fromValue(result);
         },
     };
 
@@ -2606,11 +2611,12 @@ export class ResourceUrlsCallbackContext {
 
     /** Gets the CancellationToken property */
     cancellationToken = {
-        get: async (): Promise<AbortSignal> => {
-            return await this._client.invokeCapability<AbortSignal>(
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.ApplicationModel/ResourceUrlsCallbackContext.cancellationToken',
                 { context: this._handle }
             );
+            return CancellationToken.fromValue(result);
         },
     };
 
@@ -2685,16 +2691,17 @@ export class TestCallbackContext {
 
     /** Gets the CancellationToken property */
     cancellationToken = {
-        get: async (): Promise<AbortSignal> => {
-            return await this._client.invokeCapability<AbortSignal>(
+        get: async (): Promise<CancellationToken> => {
+            const result = await this._client.invokeCapability<string | null>(
                 'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestCallbackContext.cancellationToken',
                 { context: this._handle }
             );
+            return CancellationToken.fromValue(result);
         },
-        set: async (value: AbortSignal): Promise<void> => {
+        set: async (value: AbortSignal | CancellationToken): Promise<void> => {
             await this._client.invokeCapability<void>(
                 'Aspire.Hosting.CodeGeneration.TypeScript.Tests.TestTypes/TestCallbackContext.setCancellationToken',
-                { context: this._handle, value }
+                { context: this._handle, value: CancellationToken.fromValue(value) }
             );
         }
     };
@@ -5205,9 +5212,9 @@ export class ConnectionStringResource extends ResourceBuilderBase<ConnectionStri
     }
 
     /** @internal */
-    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<ConnectionStringResource> {
+    private async _withCancellableOperationInternal(operation: (arg: CancellationToken) => Promise<void>): Promise<ConnectionStringResource> {
         const operationId = registerCallback(async (argData: unknown) => {
-            const arg = wrapIfHandle(argData) as AbortSignal;
+            const arg = CancellationToken.fromValue(argData);
             await operation(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, operation: operationId };
@@ -5219,7 +5226,7 @@ export class ConnectionStringResource extends ResourceBuilderBase<ConnectionStri
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): ConnectionStringResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): ConnectionStringResourcePromise {
         return new ConnectionStringResourcePromise(this._withCancellableOperationInternal(operation));
     }
 
@@ -5471,7 +5478,7 @@ export class ConnectionStringResourcePromise implements PromiseLike<ConnectionSt
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): ConnectionStringResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): ConnectionStringResourcePromise {
         return new ConnectionStringResourcePromise(this._promise.then(obj => obj.withCancellableOperation(operation)));
     }
 
@@ -6113,9 +6120,9 @@ export class ContainerRegistryResource extends ResourceBuilderBase<ContainerRegi
     }
 
     /** @internal */
-    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<ContainerRegistryResource> {
+    private async _withCancellableOperationInternal(operation: (arg: CancellationToken) => Promise<void>): Promise<ContainerRegistryResource> {
         const operationId = registerCallback(async (argData: unknown) => {
-            const arg = wrapIfHandle(argData) as AbortSignal;
+            const arg = CancellationToken.fromValue(argData);
             await operation(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, operation: operationId };
@@ -6127,7 +6134,7 @@ export class ContainerRegistryResource extends ResourceBuilderBase<ContainerRegi
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): ContainerRegistryResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): ContainerRegistryResourcePromise {
         return new ContainerRegistryResourcePromise(this._withCancellableOperationInternal(operation));
     }
 
@@ -6329,7 +6336,7 @@ export class ContainerRegistryResourcePromise implements PromiseLike<ContainerRe
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): ContainerRegistryResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): ContainerRegistryResourcePromise {
         return new ContainerRegistryResourcePromise(this._promise.then(obj => obj.withCancellableOperation(operation)));
     }
 
@@ -7980,9 +7987,9 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** @internal */
-    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<ContainerResource> {
+    private async _withCancellableOperationInternal(operation: (arg: CancellationToken) => Promise<void>): Promise<ContainerResource> {
         const operationId = registerCallback(async (argData: unknown) => {
-            const arg = wrapIfHandle(argData) as AbortSignal;
+            const arg = CancellationToken.fromValue(argData);
             await operation(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, operation: operationId };
@@ -7994,7 +8001,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): ContainerResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): ContainerResourcePromise {
         return new ContainerResourcePromise(this._withCancellableOperationInternal(operation));
     }
 
@@ -8496,7 +8503,7 @@ export class ContainerResourcePromise implements PromiseLike<ContainerResource> 
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): ContainerResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): ContainerResourcePromise {
         return new ContainerResourcePromise(this._promise.then(obj => obj.withCancellableOperation(operation)));
     }
 
@@ -9932,9 +9939,9 @@ export class CSharpAppResource extends ResourceBuilderBase<CSharpAppResourceHand
     }
 
     /** @internal */
-    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<CSharpAppResource> {
+    private async _withCancellableOperationInternal(operation: (arg: CancellationToken) => Promise<void>): Promise<CSharpAppResource> {
         const operationId = registerCallback(async (argData: unknown) => {
-            const arg = wrapIfHandle(argData) as AbortSignal;
+            const arg = CancellationToken.fromValue(argData);
             await operation(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, operation: operationId };
@@ -9946,7 +9953,7 @@ export class CSharpAppResource extends ResourceBuilderBase<CSharpAppResourceHand
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): CSharpAppResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): CSharpAppResourcePromise {
         return new CSharpAppResourcePromise(this._withCancellableOperationInternal(operation));
     }
 
@@ -10378,7 +10385,7 @@ export class CSharpAppResourcePromise implements PromiseLike<CSharpAppResource> 
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): CSharpAppResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): CSharpAppResourcePromise {
         return new CSharpAppResourcePromise(this._promise.then(obj => obj.withCancellableOperation(operation)));
     }
 
@@ -11902,9 +11909,9 @@ export class DotnetToolResource extends ResourceBuilderBase<DotnetToolResourceHa
     }
 
     /** @internal */
-    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<DotnetToolResource> {
+    private async _withCancellableOperationInternal(operation: (arg: CancellationToken) => Promise<void>): Promise<DotnetToolResource> {
         const operationId = registerCallback(async (argData: unknown) => {
-            const arg = wrapIfHandle(argData) as AbortSignal;
+            const arg = CancellationToken.fromValue(argData);
             await operation(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, operation: operationId };
@@ -11916,7 +11923,7 @@ export class DotnetToolResource extends ResourceBuilderBase<DotnetToolResourceHa
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): DotnetToolResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): DotnetToolResourcePromise {
         return new DotnetToolResourcePromise(this._withCancellableOperationInternal(operation));
     }
 
@@ -12378,7 +12385,7 @@ export class DotnetToolResourcePromise implements PromiseLike<DotnetToolResource
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): DotnetToolResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): DotnetToolResourcePromise {
         return new DotnetToolResourcePromise(this._promise.then(obj => obj.withCancellableOperation(operation)));
     }
 
@@ -13812,9 +13819,9 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** @internal */
-    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<ExecutableResource> {
+    private async _withCancellableOperationInternal(operation: (arg: CancellationToken) => Promise<void>): Promise<ExecutableResource> {
         const operationId = registerCallback(async (argData: unknown) => {
-            const arg = wrapIfHandle(argData) as AbortSignal;
+            const arg = CancellationToken.fromValue(argData);
             await operation(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, operation: operationId };
@@ -13826,7 +13833,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): ExecutableResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): ExecutableResourcePromise {
         return new ExecutableResourcePromise(this._withCancellableOperationInternal(operation));
     }
 
@@ -14258,7 +14265,7 @@ export class ExecutableResourcePromise implements PromiseLike<ExecutableResource
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): ExecutableResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): ExecutableResourcePromise {
         return new ExecutableResourcePromise(this._promise.then(obj => obj.withCancellableOperation(operation)));
     }
 
@@ -14919,9 +14926,9 @@ export class ExternalServiceResource extends ResourceBuilderBase<ExternalService
     }
 
     /** @internal */
-    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<ExternalServiceResource> {
+    private async _withCancellableOperationInternal(operation: (arg: CancellationToken) => Promise<void>): Promise<ExternalServiceResource> {
         const operationId = registerCallback(async (argData: unknown) => {
-            const arg = wrapIfHandle(argData) as AbortSignal;
+            const arg = CancellationToken.fromValue(argData);
             await operation(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, operation: operationId };
@@ -14933,7 +14940,7 @@ export class ExternalServiceResource extends ResourceBuilderBase<ExternalService
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): ExternalServiceResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): ExternalServiceResourcePromise {
         return new ExternalServiceResourcePromise(this._withCancellableOperationInternal(operation));
     }
 
@@ -15140,7 +15147,7 @@ export class ExternalServiceResourcePromise implements PromiseLike<ExternalServi
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): ExternalServiceResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): ExternalServiceResourcePromise {
         return new ExternalServiceResourcePromise(this._promise.then(obj => obj.withCancellableOperation(operation)));
     }
 
@@ -15799,9 +15806,9 @@ export class ParameterResource extends ResourceBuilderBase<ParameterResourceHand
     }
 
     /** @internal */
-    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<ParameterResource> {
+    private async _withCancellableOperationInternal(operation: (arg: CancellationToken) => Promise<void>): Promise<ParameterResource> {
         const operationId = registerCallback(async (argData: unknown) => {
-            const arg = wrapIfHandle(argData) as AbortSignal;
+            const arg = CancellationToken.fromValue(argData);
             await operation(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, operation: operationId };
@@ -15813,7 +15820,7 @@ export class ParameterResource extends ResourceBuilderBase<ParameterResourceHand
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): ParameterResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): ParameterResourcePromise {
         return new ParameterResourcePromise(this._withCancellableOperationInternal(operation));
     }
 
@@ -16020,7 +16027,7 @@ export class ParameterResourcePromise implements PromiseLike<ParameterResource> 
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): ParameterResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): ParameterResourcePromise {
         return new ParameterResourcePromise(this._promise.then(obj => obj.withCancellableOperation(operation)));
     }
 
@@ -17456,9 +17463,9 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** @internal */
-    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<ProjectResource> {
+    private async _withCancellableOperationInternal(operation: (arg: CancellationToken) => Promise<void>): Promise<ProjectResource> {
         const operationId = registerCallback(async (argData: unknown) => {
-            const arg = wrapIfHandle(argData) as AbortSignal;
+            const arg = CancellationToken.fromValue(argData);
             await operation(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, operation: operationId };
@@ -17470,7 +17477,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): ProjectResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): ProjectResourcePromise {
         return new ProjectResourcePromise(this._withCancellableOperationInternal(operation));
     }
 
@@ -17902,7 +17909,7 @@ export class ProjectResourcePromise implements PromiseLike<ProjectResource> {
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): ProjectResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): ProjectResourcePromise {
         return new ProjectResourcePromise(this._promise.then(obj => obj.withCancellableOperation(operation)));
     }
 
@@ -19553,9 +19560,9 @@ export class TestDatabaseResource extends ResourceBuilderBase<TestDatabaseResour
     }
 
     /** @internal */
-    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<TestDatabaseResource> {
+    private async _withCancellableOperationInternal(operation: (arg: CancellationToken) => Promise<void>): Promise<TestDatabaseResource> {
         const operationId = registerCallback(async (argData: unknown) => {
-            const arg = wrapIfHandle(argData) as AbortSignal;
+            const arg = CancellationToken.fromValue(argData);
             await operation(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, operation: operationId };
@@ -19567,7 +19574,7 @@ export class TestDatabaseResource extends ResourceBuilderBase<TestDatabaseResour
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): TestDatabaseResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromise(this._withCancellableOperationInternal(operation));
     }
 
@@ -20069,7 +20076,7 @@ export class TestDatabaseResourcePromise implements PromiseLike<TestDatabaseReso
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): TestDatabaseResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): TestDatabaseResourcePromise {
         return new TestDatabaseResourcePromise(this._promise.then(obj => obj.withCancellableOperation(operation)));
     }
 
@@ -21878,9 +21885,8 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     /** Gets the status of the resource asynchronously */
     async getStatusAsync(options?: GetStatusAsyncOptions): Promise<string> {
         const cancellationToken = options?.cancellationToken;
-        const cancellationTokenId = cancellationToken ? registerCancellation(cancellationToken) : undefined;
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationTokenId;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         return await this._client.invokeCapability<string>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/getStatusAsync',
             rpcArgs
@@ -21888,9 +21894,9 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** @internal */
-    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<TestRedisResource> {
+    private async _withCancellableOperationInternal(operation: (arg: CancellationToken) => Promise<void>): Promise<TestRedisResource> {
         const operationId = registerCallback(async (argData: unknown) => {
-            const arg = wrapIfHandle(argData) as AbortSignal;
+            const arg = CancellationToken.fromValue(argData);
             await operation(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, operation: operationId };
@@ -21902,16 +21908,15 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): TestRedisResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): TestRedisResourcePromise {
         return new TestRedisResourcePromise(this._withCancellableOperationInternal(operation));
     }
 
     /** Waits for the resource to be ready */
     async waitForReadyAsync(timeout: number, options?: WaitForReadyAsyncOptions): Promise<boolean> {
         const cancellationToken = options?.cancellationToken;
-        const cancellationTokenId = cancellationToken ? registerCancellation(cancellationToken) : undefined;
         const rpcArgs: Record<string, unknown> = { builder: this._handle, timeout };
-        if (cancellationToken !== undefined) rpcArgs.cancellationToken = cancellationTokenId;
+        if (cancellationToken !== undefined) rpcArgs.cancellationToken = CancellationToken.fromValue(cancellationToken);
         return await this._client.invokeCapability<boolean>(
             'Aspire.Hosting.CodeGeneration.TypeScript.Tests/waitForReadyAsync',
             rpcArgs
@@ -22518,7 +22523,7 @@ export class TestRedisResourcePromise implements PromiseLike<TestRedisResource> 
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): TestRedisResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): TestRedisResourcePromise {
         return new TestRedisResourcePromise(this._promise.then(obj => obj.withCancellableOperation(operation)));
     }
 
@@ -24184,9 +24189,9 @@ export class TestVaultResource extends ResourceBuilderBase<TestVaultResourceHand
     }
 
     /** @internal */
-    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<TestVaultResource> {
+    private async _withCancellableOperationInternal(operation: (arg: CancellationToken) => Promise<void>): Promise<TestVaultResource> {
         const operationId = registerCallback(async (argData: unknown) => {
-            const arg = wrapIfHandle(argData) as AbortSignal;
+            const arg = CancellationToken.fromValue(argData);
             await operation(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, operation: operationId };
@@ -24198,7 +24203,7 @@ export class TestVaultResource extends ResourceBuilderBase<TestVaultResourceHand
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): TestVaultResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): TestVaultResourcePromise {
         return new TestVaultResourcePromise(this._withCancellableOperationInternal(operation));
     }
 
@@ -24715,7 +24720,7 @@ export class TestVaultResourcePromise implements PromiseLike<TestVaultResource> 
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): TestVaultResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): TestVaultResourcePromise {
         return new TestVaultResourcePromise(this._promise.then(obj => obj.withCancellableOperation(operation)));
     }
 
@@ -25478,9 +25483,9 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** @internal */
-    private async _withCancellableOperationInternal(operation: (arg: AbortSignal) => Promise<void>): Promise<Resource> {
+    private async _withCancellableOperationInternal(operation: (arg: CancellationToken) => Promise<void>): Promise<Resource> {
         const operationId = registerCallback(async (argData: unknown) => {
-            const arg = wrapIfHandle(argData) as AbortSignal;
+            const arg = CancellationToken.fromValue(argData);
             await operation(arg);
         });
         const rpcArgs: Record<string, unknown> = { builder: this._handle, operation: operationId };
@@ -25492,7 +25497,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): ResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): ResourcePromise {
         return new ResourcePromise(this._withCancellableOperationInternal(operation));
     }
 
@@ -25694,7 +25699,7 @@ export class ResourcePromise implements PromiseLike<Resource> {
     }
 
     /** Performs a cancellable operation */
-    withCancellableOperation(operation: (arg: AbortSignal) => Promise<void>): ResourcePromise {
+    withCancellableOperation(operation: (arg: CancellationToken) => Promise<void>): ResourcePromise {
         return new ResourcePromise(this._promise.then(obj => obj.withCancellableOperation(operation)));
     }
 
@@ -27001,7 +27006,7 @@ export async function createBuilder(options?: CreateBuilderOptions): Promise<Dis
 }
 
 // Re-export commonly used types
-export { Handle, AppHostUsageError, CapabilityError, registerCallback } from './transport.js';
+export { Handle, AppHostUsageError, CancellationToken, CapabilityError, registerCallback } from './transport.js';
 export { refExpr, ReferenceExpression } from './base.js';
 
 // ============================================================================

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/base.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/base.verified.ts
@@ -2,7 +2,7 @@
 import { Handle, AspireClient, MarshalledHandle, registerCancellation, registerHandleWrapper, unregisterCancellation } from './transport.js';
 
 // Re-export transport types for convenience
-export { Handle, AspireClient, CapabilityError, registerCallback, unregisterCallback, registerCancellation, unregisterCancellation } from './transport.js';
+export { Handle, AspireClient, CapabilityError, CancellationToken, registerCallback, unregisterCallback, registerCancellation, unregisterCancellation } from './transport.js';
 export type { MarshalledHandle, AtsError, AtsErrorDetails, CallbackFunction } from './transport.js';
 export { AtsErrorCodes, isMarshalledHandle, isAtsError, wrapIfHandle } from './transport.js';
 

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/base.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/base.verified.ts
@@ -1,5 +1,5 @@
 ﻿// aspire.ts - Core Aspire types: base classes, ReferenceExpression
-import { Handle, AspireClient, MarshalledHandle, registerCancellation, registerHandleWrapper, unregisterCancellation } from './transport.js';
+import { Handle, AspireClient, MarshalledHandle, CancellationToken, registerCancellation, registerHandleWrapper, unregisterCancellation } from './transport.js';
 
 // Re-export transport types for convenience
 export { Handle, AspireClient, CapabilityError, CancellationToken, registerCallback, unregisterCallback, registerCancellation, unregisterCancellation } from './transport.js';
@@ -158,10 +158,10 @@ export class ReferenceExpression {
      * Resolves the expression to its string value on the server.
      * Only available on server-returned ReferenceExpression instances (handle mode).
      *
-     * @param cancellationToken - Optional AbortSignal for cancellation support
+     * @param cancellationToken - Optional AbortSignal or CancellationToken for cancellation support
      * @returns The resolved string value, or null if the expression resolves to null
      */
-    async getValue(cancellationToken?: AbortSignal): Promise<string | null> {
+    async getValue(cancellationToken?: AbortSignal | CancellationToken): Promise<string | null> {
         if (!this._handle || !this._client) {
             throw new Error('getValue is only available on server-returned ReferenceExpression instances');
         }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TestTypes/TestExtensions.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/TestTypes/TestExtensions.cs
@@ -602,7 +602,7 @@ public static class TestExtensions
     // ===== CancellationToken Tests =====
 
     /// <summary>
-    /// Tests CancellationToken parameter - verifies mapping to AbortSignal in TypeScript.
+    /// Tests CancellationToken parameter - generated TypeScript should accept AbortSignal or CancellationToken for inputs.
     /// </summary>
     [AspireExport("getStatusAsync", Description = "Gets the status of the resource asynchronously")]
     public static Task<string> GetStatusAsync(
@@ -613,7 +613,7 @@ public static class TestExtensions
     }
 
     /// <summary>
-    /// Tests CancellationToken in callback parameter.
+    /// Tests CancellationToken in callback parameter - generated TypeScript should materialize host values as CancellationToken.
     /// </summary>
     [AspireExport("withCancellableOperation", Description = "Performs a cancellable operation")]
     public static IResourceBuilder<T> WithCancellableOperation<T>(

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsMarshallerTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsMarshallerTests.cs
@@ -166,6 +166,43 @@ public class AtsMarshallerTests
     }
 
     [Fact]
+    public void MarshalToJson_MarshalsCancellationTokenAsTokenId()
+    {
+        using var registry = new CancellationTokenRegistry();
+        var marshaller = CreateTestMarshaller(ctRegistry: registry);
+        using var cts = new CancellationTokenSource();
+
+        var result = marshaller.MarshalToJson(cts.Token);
+
+        var tokenValue = Assert.IsAssignableFrom<JsonValue>(result);
+        var tokenId = tokenValue.GetValue<string>();
+        Assert.StartsWith("ct_", tokenId);
+        Assert.True(registry.TryGetToken(tokenId, out var token));
+        Assert.True(token.CanBeCanceled);
+    }
+
+    [Fact]
+    public void MarshalToJson_WithCancellationTokenTypeRef_MarshalsAsTokenId()
+    {
+        using var registry = new CancellationTokenRegistry();
+        var marshaller = CreateTestMarshaller(ctRegistry: registry);
+        using var cts = new CancellationTokenSource();
+        var typeRef = new AtsTypeRef
+        {
+            TypeId = AtsConstants.CancellationToken,
+            Category = AtsTypeCategory.Primitive
+        };
+
+        var result = marshaller.MarshalToJson(cts.Token, typeRef);
+
+        var tokenValue = Assert.IsAssignableFrom<JsonValue>(result);
+        var tokenId = tokenValue.GetValue<string>();
+        Assert.StartsWith("ct_", tokenId);
+        Assert.True(registry.TryGetToken(tokenId, out var token));
+        Assert.True(token.CanBeCanceled);
+    }
+
+    [Fact]
     public void ConvertPrimitive_ConvertsStringCorrectly()
     {
         var value = JsonValue.Create("test");

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsMarshallerTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsMarshallerTests.cs
@@ -263,6 +263,17 @@ public class AtsMarshallerTests
     }
 
     [Fact]
+    public void UnmarshalFromJson_ReturnsCancellationTokenNoneForNullNode()
+    {
+        var (marshaller, context) = CreateMarshallerWithContext();
+
+        var result = marshaller.UnmarshalFromJson(null, typeof(CancellationToken), context);
+
+        var token = Assert.IsType<CancellationToken>(result);
+        Assert.Equal(CancellationToken.None, token);
+    }
+
+    [Fact]
     public void UnmarshalFromJson_UnmarshalsHandleReference()
     {
         var registry = new HandleRegistry();

--- a/tests/Aspire.Hosting.RemoteHost.Tests/CallbackProxyTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/CallbackProxyTests.cs
@@ -177,7 +177,26 @@ public class CallbackProxyTests
         var tokenId = args["p1"]?.GetValue<string>();
         Assert.NotNull(tokenId);
         Assert.StartsWith("ct_", tokenId);
-        Assert.StartsWith("ct_", args["$cancellationToken"]?.GetValue<string>());
+        Assert.Equal(tokenId, args["$cancellationToken"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task InvokedProxy_WithOnlyCancellationToken_UsesPositionalTokenId()
+    {
+        var invoker = new TestCallbackInvoker();
+        using var factory = CreateFactory(invoker);
+        using var cts = new CancellationTokenSource();
+
+        var proxy = (TestCallbackWithOnlyCancellation)factory.CreateProxy("test-callback", typeof(TestCallbackWithOnlyCancellation))!;
+
+        await proxy(cts.Token);
+
+        Assert.Single(invoker.Invocations);
+        var args = invoker.Invocations[0].Args as JsonObject;
+        Assert.NotNull(args);
+        var tokenId = args["p0"]?.GetValue<string>();
+        Assert.NotNull(tokenId);
+        Assert.Equal(tokenId, args["$cancellationToken"]?.GetValue<string>());
     }
 
     // Callback error handling tests
@@ -369,6 +388,8 @@ public class CallbackProxyTests
     public delegate Task<string> TestCallbackWithStringResult(string input);
 
     public delegate Task TestCallbackWithCancellation(string value, CancellationToken cancellationToken);
+
+    public delegate Task TestCallbackWithOnlyCancellation(CancellationToken cancellationToken);
 
     public delegate void TestSyncVoidCallbackWithDto(TestCallbackDto dto);
 

--- a/tests/Aspire.Hosting.RemoteHost.Tests/CallbackProxyTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/CallbackProxyTests.cs
@@ -173,9 +173,11 @@ public class CallbackProxyTests
         Assert.Single(invoker.Invocations);
         var args = invoker.Invocations[0].Args as JsonObject;
         Assert.NotNull(args);
-        // Arguments are passed with positional keys (p0, p1, p2, ...)
-        // CancellationToken is not included in positional args, but added as $cancellationToken if not None
         Assert.Equal("test", args["p0"]?.GetValue<string>());
+        var tokenId = args["p1"]?.GetValue<string>();
+        Assert.NotNull(tokenId);
+        Assert.StartsWith("ct_", tokenId);
+        Assert.StartsWith("ct_", args["$cancellationToken"]?.GetValue<string>());
     }
 
     // Callback error handling tests

--- a/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/CapabilityDispatcherTests.cs
@@ -278,6 +278,29 @@ public class CapabilityDispatcherTests
     }
 
     [Fact]
+    public void Invoke_CancellationTokenPropertyResultCanBePassedToCapability()
+    {
+        var handles = new HandleRegistry();
+        var dispatcher = new CapabilityDispatcher(handles, CreateTestMarshaller(handles), [typeof(TestCancellationTokenContext).Assembly]);
+        using var cts = new CancellationTokenSource();
+
+        var context = new TestCancellationTokenContext { CancellationToken = cts.Token };
+        var handleId = handles.Register(context, "Aspire.Hosting.RemoteHost.Tests/Aspire.Hosting.RemoteHost.Tests.TestCancellationTokenContext");
+        var getArgs = new JsonObject { ["context"] = new JsonObject { ["$handle"] = handleId } };
+
+        var tokenResult = dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/TestCancellationTokenContext.cancellationToken", getArgs);
+
+        Assert.NotNull(tokenResult);
+        cts.Cancel();
+
+        var invokeArgs = new JsonObject { ["cancellationToken"] = tokenResult };
+        var result = dispatcher.Invoke("Aspire.Hosting.RemoteHost.Tests/canObserveCancellation", invokeArgs);
+
+        Assert.NotNull(result);
+        Assert.True(result.GetValue<bool>());
+    }
+
+    [Fact]
     public void Constructor_RegistersVersionedContextTypeProperties()
     {
         var dispatcher = CreateDispatcher(typeof(VersionedContextType).Assembly);
@@ -1421,6 +1444,12 @@ internal static class TestCapabilities
         await Task.Delay(1);
         throw new InvalidOperationException("Async error: " + value);
     }
+
+    [AspireExport("canObserveCancellation", Description = "Tests cancellation token round-tripping")]
+    public static bool CanObserveCancellation(CancellationToken cancellationToken)
+    {
+        return cancellationToken.IsCancellationRequested;
+    }
 }
 
 /// <summary>
@@ -1435,6 +1464,12 @@ internal sealed class TestContextType
 
     // This property should be skipped - IDisposable is not ATS-compatible
     public IDisposable? NonAtsProperty { get; set; }
+}
+
+[AspireExport(ExposeProperties = true)]
+internal sealed class TestCancellationTokenContext
+{
+    public CancellationToken CancellationToken { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Description

Improve the generated TypeScript polyglot cancellation model so callers can use idiomatic `AbortSignal` inputs while still round-tripping host-provided cancellation token handles.

This updates the TypeScript generator and transport runtime so generated inputs accept `AbortSignal | CancellationToken`, host-originated values still materialize as `CancellationToken`, and remote-host marshalling preserves transport-safe token IDs instead of attempting to serialize raw .NET cancellation internals.

It also updates the polyglot spec/runtime docs with examples for both local `AbortSignal` usage and reusing `await context.cancellationToken.get()` in downstream calls.

Fixes #15139

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
