### PR TITLE
Add support for PackageExecutable resources

### DIFF
--- a/src/Aspire.Dashboard/Model/KnownPropertyLookup.cs
+++ b/src/Aspire.Dashboard/Model/KnownPropertyLookup.cs
@@ -71,6 +71,7 @@ public sealed class KnownPropertyLookup : IKnownPropertyLookup
         {
             KnownResourceTypes.Project => _projectProperties,
             KnownResourceTypes.Executable => _executableProperties,
+            KnownResourceTypes.PackageExecutable => _executableProperties,
             KnownResourceTypes.Container => _containerProperties,
             KnownResourceTypes.Parameter => _parameterProperties,
             _ => _resourceProperties

--- a/src/Aspire.Dashboard/Model/ResourceIconHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ResourceIconHelpers.cs
@@ -28,6 +28,7 @@ internal static class ResourceIconHelpers
         var icon = resource.ResourceType switch
         {
             KnownResourceTypes.Executable => iconResolver.ResolveIconName("Apps", desiredSize, desiredVariant),
+            KnownResourceTypes.PackageExecutable => iconResolver.ResolveIconName("Apps", desiredSize, desiredVariant),
             KnownResourceTypes.Project => ResolveProjectIcon(iconResolver, resource, desiredSize, desiredVariant),
             KnownResourceTypes.Container => iconResolver.ResolveIconName("Box", desiredSize, desiredVariant),
             KnownResourceTypes.Parameter => iconResolver.ResolveIconName("Key", desiredSize, desiredVariant),

--- a/src/Aspire.Dashboard/Model/ResourceViewModelExtensions.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModelExtensions.cs
@@ -44,6 +44,11 @@ internal static class ResourceViewModelExtensions
         return StringComparers.ResourceType.Equals(resource.ResourceType, KnownResourceTypes.Tool);
     }
 
+    public static bool IsPackageExecutable(this ResourceViewModel resource)
+    {
+        return StringComparers.ResourceType.Equals(resource.ResourceType, KnownResourceTypes.PackageExecutable);
+    }
+
     public static bool IsExecutable(this ResourceViewModel resource, bool allowSubtypes)
     {
         if (StringComparers.ResourceType.Equals(resource.ResourceType, KnownResourceTypes.Executable))
@@ -53,7 +58,8 @@ internal static class ResourceViewModelExtensions
 
         if (allowSubtypes)
         {
-            return StringComparers.ResourceType.Equals(resource.ResourceType, KnownResourceTypes.Project);
+            return StringComparers.ResourceType.Equals(resource.ResourceType, KnownResourceTypes.Project) ||
+                StringComparers.ResourceType.Equals(resource.ResourceType, KnownResourceTypes.PackageExecutable);
         }
 
         return false;

--- a/src/Aspire.Hosting/ApplicationModel/PackageExecutableAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/PackageExecutableAnnotation.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+internal sealed class PackageExecutableAnnotation : IResourceAnnotation
+{
+    public required string PackageId { get; set; }
+
+    public string? Version { get; set; }
+
+    public string? ExecutableName { get; set; }
+
+    public string? WorkingDirectory { get; set; }
+
+    public List<string> Sources { get; } = [];
+
+    public bool IgnoreExistingFeeds { get; set; }
+
+    public bool IgnoreFailedSources { get; set; }
+}

--- a/src/Aspire.Hosting/ApplicationModel/PackageExecutableResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/PackageExecutableResource.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// A resource that represents an executable restored from a NuGet package.
+/// </summary>
+/// <remarks>
+/// Package executable resources restore a specific package version at runtime and then execute a runnable asset from the
+/// restored package contents. Use <see cref="PackageExecutableResourceBuilderExtensions.WithPackageVersion{T}(IResourceBuilder{T}, string)"/>
+/// to pin the package version before the resource is started.
+/// </remarks>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Package = {PackageConfiguration?.PackageId}")]
+public class PackageExecutableResource : ExecutableResource
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PackageExecutableResource"/> class.
+    /// </summary>
+    /// <param name="name">The resource name.</param>
+    /// <param name="packageId">The package identifier that contains the executable.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="packageId"/> is null, empty, or whitespace.</exception>
+    public PackageExecutableResource(string name, string packageId)
+        : base(name, "dotnet", ".")
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId, nameof(packageId));
+
+        Annotations.Add(new PackageExecutableAnnotation
+        {
+            PackageId = packageId
+        });
+    }
+
+    internal PackageExecutableAnnotation? PackageConfiguration
+    {
+        get
+        {
+            this.TryGetLastAnnotation<PackageExecutableAnnotation>(out var configuration);
+            return configuration;
+        }
+    }
+
+    internal ResolvedPackageExecutableAnnotation? ResolvedExecutable
+    {
+        get
+        {
+            this.TryGetLastAnnotation<ResolvedPackageExecutableAnnotation>(out var resolvedExecutable);
+            return resolvedExecutable;
+        }
+    }
+}

--- a/src/Aspire.Hosting/ApplicationModel/ResolvedPackageExecutableAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResolvedPackageExecutableAnnotation.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+internal sealed class ResolvedPackageExecutableAnnotation : IResourceAnnotation
+{
+    public required string PackageId { get; set; }
+
+    public required string PackageVersion { get; set; }
+
+    public required string PackageDirectory { get; set; }
+
+    public required string ExecutablePath { get; set; }
+
+    public required string Command { get; set; }
+
+    public required string WorkingDirectory { get; set; }
+
+    public List<string> Arguments { get; } = [];
+}

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -1500,6 +1500,7 @@ public static class ResourceExtensions
         ContainerResource => KnownResourceTypes.Container,
         ContainerExecutableResource => KnownResourceTypes.ContainerExec,
         DotnetToolResource => KnownResourceTypes.Tool,
+        PackageExecutableResource => KnownResourceTypes.PackageExecutable,
         ExecutableResource => KnownResourceTypes.Executable,
         ParameterResource => KnownResourceTypes.Parameter,
         ConnectionStringResource => KnownResourceTypes.ConnectionString,

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -58,6 +58,7 @@
     <PackageReference Include="KubernetesClient" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="ModelContextProtocol" />
+    <PackageReference Include="NuGet.Commands" />
     <PackageReference Include="Polly.Core" />
     <PackageReference Include="JsonPatch.Net" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" />

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -610,7 +610,12 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         return resource switch
         {
             Container => KnownResourceTypes.Container,
-            Executable => appModelResource is ProjectResource ? KnownResourceTypes.Project : KnownResourceTypes.Executable,
+            Executable => appModelResource switch
+            {
+                ProjectResource => KnownResourceTypes.Project,
+                PackageExecutableResource => KnownResourceTypes.PackageExecutable,
+                _ => KnownResourceTypes.Executable
+            },
             ContainerExec => KnownResourceTypes.ContainerExec,
             _ => throw new InvalidOperationException($"Unknown resource type {resource.GetType().Name}")
         };
@@ -1594,7 +1599,12 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         CancellationToken cancellationToken)
     {
         var resourceLogger = _loggerService.GetLogger(resource);
-        var resourceType = resource is ProjectResource ? KnownResourceTypes.Project : KnownResourceTypes.Executable;
+        var resourceType = resource switch
+        {
+            ProjectResource => KnownResourceTypes.Project,
+            PackageExecutableResource => KnownResourceTypes.PackageExecutable,
+            _ => KnownResourceTypes.Executable
+        };
 
         try
         {

--- a/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
+++ b/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
@@ -108,7 +108,7 @@ internal class ResourceSnapshotBuilder
 
         return previous with
         {
-            ResourceType = previous.ResourceType ?? KnownResourceTypes.Executable,
+            ResourceType = previous.ResourceType ?? (appModelResource is PackageExecutableResource ? KnownResourceTypes.PackageExecutable : KnownResourceTypes.Executable),
             State = state,
             ExitCode = executable.Status?.ExitCode,
             Properties = previous.Properties.SetResourcePropertyRange([
@@ -183,7 +183,7 @@ internal class ResourceSnapshotBuilder
 
         return previous with
         {
-            ResourceType = previous.ResourceType ?? KnownResourceTypes.Executable,
+            ResourceType = previous.ResourceType ?? (appModelResource is PackageExecutableResource ? KnownResourceTypes.PackageExecutable : KnownResourceTypes.Executable),
             State = state,
             ExitCode = executable.Status?.ExitCode,
             Properties = previous.Properties.SetResourcePropertyRange([

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -168,6 +168,7 @@ internal sealed class ApplicationOrchestrator
         switch (context.ResourceType)
         {
             case KnownResourceTypes.Project:
+            case KnownResourceTypes.PackageExecutable:
             case KnownResourceTypes.Executable:
                 await PublishUpdateAsync(_notificationService, context.Resource, context.DcpResourceName, s => s with
                 {

--- a/src/Aspire.Hosting/PackageExecutableResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/PackageExecutableResourceBuilderExtensions.cs
@@ -3,10 +3,11 @@
 
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Packages;
+using Aspire.Hosting.PackageManagement;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using System.Text.Json;
 
 namespace Aspire.Hosting;
 
@@ -131,12 +132,7 @@ public static class PackageExecutableResourceBuilderExtensions
 
         builder.ApplicationBuilder.Resources.Remove(builder.Resource);
 
-        var publishContextPath = Path.Combine(
-            Path.GetTempPath(),
-            "aspire-package-executables",
-            "publish",
-            builder.Resource.Name,
-            Guid.NewGuid().ToString("n"));
+        var publishContextPath = GetPublishContextPath(builder.ApplicationBuilder.AppHostDirectory, builder.Resource.Name);
         Directory.CreateDirectory(publishContextPath);
         var container = new PackageExecutableContainerResource(builder.Resource, publishContextPath);
         var containerBuilder = builder.ApplicationBuilder.AddResource(container);
@@ -370,13 +366,117 @@ public static class PackageExecutableResourceBuilderExtensions
         var containerWorkingDirectory = string.Equals(workingDirectoryRelativePath, ".", StringComparison.Ordinal)
             ? "/app"
             : $"/app/{workingDirectoryRelativePath}";
+        var runtimeImage = GetRuntimeContainerImage(resolved.ExecutablePath);
 
         return string.Join("\n", [
-            "FROM mcr.microsoft.com/dotnet/runtime:10.0",
+            $"FROM {runtimeImage}",
             "WORKDIR /app",
             "COPY package/ /app/",
             $"WORKDIR {containerWorkingDirectory}"
         ]);
+    }
+
+    private static string GetPublishContextPath(string appHostDirectory, string resourceName)
+    {
+        return Path.Combine(appHostDirectory, "obj", "aspire-package-executables", "publish", resourceName);
+    }
+
+    private static string GetRuntimeContainerImage(string executablePath)
+    {
+        const string defaultImage = "mcr.microsoft.com/dotnet/runtime:10.0";
+
+        var runtimeConfigPath = Path.Combine(
+            Path.GetDirectoryName(executablePath)!,
+            $"{Path.GetFileNameWithoutExtension(executablePath)}.runtimeconfig.json");
+
+        if (!File.Exists(runtimeConfigPath))
+        {
+            return defaultImage;
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(runtimeConfigPath);
+            using var document = JsonDocument.Parse(stream);
+
+            if (!document.RootElement.TryGetProperty("runtimeOptions", out var runtimeOptions))
+            {
+                return defaultImage;
+            }
+
+            var frameworks = GetFrameworkReferences(runtimeOptions);
+            var selectedFramework = frameworks.FirstOrDefault(f => string.Equals(f.Name, "Microsoft.AspNetCore.App", StringComparison.Ordinal))
+                ?? frameworks.FirstOrDefault(f => string.Equals(f.Name, "Microsoft.NETCore.App", StringComparison.Ordinal));
+
+            if (selectedFramework is null || string.IsNullOrWhiteSpace(selectedFramework.Version))
+            {
+                return defaultImage;
+            }
+
+            var version = GetMajorMinorVersion(selectedFramework.Version);
+            if (version is null)
+            {
+                return defaultImage;
+            }
+
+            var imageFamily = string.Equals(selectedFramework.Name, "Microsoft.AspNetCore.App", StringComparison.Ordinal)
+                ? "aspnet"
+                : "runtime";
+
+            return $"mcr.microsoft.com/dotnet/{imageFamily}:{version}";
+        }
+        catch (IOException)
+        {
+            return defaultImage;
+        }
+        catch (JsonException)
+        {
+            return defaultImage;
+        }
+    }
+
+    private static List<FrameworkReference> GetFrameworkReferences(JsonElement runtimeOptions)
+    {
+        var frameworks = new List<FrameworkReference>();
+
+        if (runtimeOptions.TryGetProperty("framework", out var framework))
+        {
+            AddFrameworkReference(frameworks, framework);
+        }
+
+        if (runtimeOptions.TryGetProperty("frameworks", out var frameworkArray) && frameworkArray.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var frameworkElement in frameworkArray.EnumerateArray())
+            {
+                AddFrameworkReference(frameworks, frameworkElement);
+            }
+        }
+
+        return frameworks;
+    }
+
+    private static void AddFrameworkReference(List<FrameworkReference> frameworks, JsonElement framework)
+    {
+        if (!framework.TryGetProperty("name", out var nameProperty) || !framework.TryGetProperty("version", out var versionProperty))
+        {
+            return;
+        }
+
+        var name = nameProperty.GetString();
+        var version = versionProperty.GetString();
+
+        if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(version))
+        {
+            return;
+        }
+
+        frameworks.Add(new FrameworkReference(name, version));
+    }
+
+    private static string? GetMajorMinorVersion(string version)
+    {
+        var parts = version.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length >= 2 ? $"{parts[0]}.{parts[1]}" : null;
     }
 
     private static void ResetDirectory(string path)
@@ -412,4 +512,6 @@ public static class PackageExecutableResourceBuilderExtensions
 
         public override ResourceAnnotationCollection Annotations => packageResource.Annotations;
     }
+
+    private sealed record FrameworkReference(string Name, string Version);
 }

--- a/src/Aspire.Hosting/PackageExecutableResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/PackageExecutableResourceBuilderExtensions.cs
@@ -1,0 +1,415 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Packages;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Provides extension methods for adding package executable resources to the application model.
+/// </summary>
+/// <remarks>
+/// These helpers let an app host restore and execute a runnable NuGet package without requiring the package source code to
+/// be present in the solution. Package restore uses the app host directory as its configuration root so local NuGet.Config
+/// files and feed settings are applied consistently.
+/// </remarks>
+public static class PackageExecutableResourceBuilderExtensions
+{
+    /// <summary>
+    /// Adds a package-backed executable resource to the application model.
+    /// </summary>
+    /// <param name="builder">The distributed application builder.</param>
+    /// <param name="name">The resource name.</param>
+    /// <param name="packageId">The package identifier that contains the runnable executable.</param>
+    /// <returns>The resource builder.</returns>
+    /// <remarks>
+    /// Call <see cref="WithPackageVersion{T}(IResourceBuilder{T}, string)"/> to select the package version before running the
+    /// resource. The package is restored relative to <see cref="IDistributedApplicationBuilder.AppHostDirectory"/> so NuGet
+    /// configuration is resolved the same way as other app-host-relative resource inputs.
+    /// Runnable assets can be restored from either the package <c>lib</c> or <c>tools</c> layout.
+    /// Packages that place a framework-dependent entry point under <c>lib</c> should only rely on assemblies that are
+    /// already present in the target shared runtime, or otherwise included in the package.
+    /// If the application requires additional managed dependencies, package authors should include published output under
+    /// <c>tools/&lt;tfm&gt;/any</c> or another supported <c>tools</c> layout and select the entry point with
+    /// <see cref="WithPackageExecutable{T}(IResourceBuilder{T}, string)"/>.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var packageExecutable = builder.AddPackageExecutable("formatter", "Contoso.PackageExecutables.Formatter")
+    ///     .WithPackageVersion("1.2.3")
+    ///     .WithPackageExecutable("formatter.dll")
+    ///     .WithArgs("--watch");
+    /// </code>
+    /// </example>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> or <paramref name="packageId"/> is invalid.</exception>
+    [AspireExport("addPackageExecutable", Description = "Adds an executable resource backed by a NuGet package")]
+    public static IResourceBuilder<PackageExecutableResource> AddPackageExecutable(this IDistributedApplicationBuilder builder, [ResourceName] string name, string packageId)
+        => builder.AddPackageExecutable(new PackageExecutableResource(name, packageId));
+
+    /// <summary>
+    /// Adds a package-backed executable resource to the application model.
+    /// </summary>
+    /// <typeparam name="T">The package executable resource type.</typeparam>
+    /// <param name="builder">The distributed application builder.</param>
+    /// <param name="resource">The resource to add.</param>
+    /// <returns>The resource builder.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="resource"/> is null.</exception>
+    public static IResourceBuilder<T> AddPackageExecutable<T>(this IDistributedApplicationBuilder builder, T resource)
+        where T : PackageExecutableResource
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(resource);
+
+        AnchorWorkingDirectoryToAppHost(builder, resource);
+
+        builder.Services.TryAddSingleton<IPackageExecutableResolver, PackageExecutableResolver>();
+
+        var resourceBuilder = builder.AddResource(resource)
+            .WithCommand("dotnet")
+            .WithArgs(context =>
+            {
+                if (resource.ResolvedExecutable is { } resolved)
+                {
+                    context.Args.AddRange(GetResolvedArguments(resource, resolved, context.ExecutionContext?.IsPublishMode == true));
+                }
+            })
+            .OnBeforeResourceStarted(BeforeResourceStarted);
+
+        return resourceBuilder.PublishAsContainer();
+
+        static async Task BeforeResourceStarted(T resource, BeforeResourceStartedEvent @event, CancellationToken cancellationToken)
+        {
+            var resolver = @event.Services.GetRequiredService<IPackageExecutableResolver>();
+            var notifications = @event.Services.GetRequiredService<ResourceNotificationService>();
+            var resolved = await resolver.ResolveAsync(resource, cancellationToken).ConfigureAwait(false);
+
+            resource.WithResolvedExecutable(resolved);
+
+            await notifications.PublishUpdateAsync(resource, snapshot => snapshot with
+            {
+                Properties = snapshot.Properties.SetResourcePropertyRange([
+                    new(KnownProperties.Tool.Package, resolved.PackageId),
+                    new(KnownProperties.Tool.Version, resolved.PackageVersion),
+                    new(KnownProperties.Resource.Source, resolved.PackageId),
+                    new(KnownProperties.Resource.Type, KnownResourceTypes.PackageExecutable)
+                ])
+            }).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Converts a package executable resource to a container resource during publish.
+    /// </summary>
+    /// <typeparam name="T">The package executable resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="configure">Optional container configuration callback.</param>
+    /// <returns>The original resource builder.</returns>
+    /// <remarks>
+    /// Publishing package executable resources currently supports managed <c>.dll</c> entry points that run on the .NET
+    /// runtime image. Runtime execution does not require the .NET SDK once the app host has been built, but the target
+    /// environment must provide the appropriate .NET shared framework for both the app host and the packaged executable.
+    /// </remarks>
+    public static IResourceBuilder<T> PublishAsContainer<T>(this IResourceBuilder<T> builder, Action<IResourceBuilder<ContainerResource>>? configure = null)
+        where T : PackageExecutableResource
+    {
+        if (!builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
+        {
+            return builder;
+        }
+
+        if (builder.ApplicationBuilder.TryCreateResourceBuilder<PackageExecutableContainerResource>(builder.Resource.Name, out var existingBuilder))
+        {
+            configure?.Invoke(existingBuilder);
+            return builder;
+        }
+
+        builder.ApplicationBuilder.Resources.Remove(builder.Resource);
+
+        var publishContextPath = Path.Combine(
+            Path.GetTempPath(),
+            "aspire-package-executables",
+            "publish",
+            builder.Resource.Name,
+            Guid.NewGuid().ToString("n"));
+        Directory.CreateDirectory(publishContextPath);
+        var container = new PackageExecutableContainerResource(builder.Resource, publishContextPath);
+        var containerBuilder = builder.ApplicationBuilder.AddResource(container);
+
+        containerBuilder.WithImage(builder.Resource.Name)
+                        .WithEntrypoint("dotnet")
+                        .WithDockerfileFactory(publishContextPath, context => CreatePublishDockerfileAsync(builder.Resource, publishContextPath, context));
+
+        configure?.Invoke(containerBuilder);
+
+        return builder.WithManifestPublishingCallback(context => context.WriteContainerAsync(container));
+    }
+
+    /// <summary>
+    /// Sets the package version to restore.
+    /// </summary>
+    /// <typeparam name="T">The package executable resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="version">The package version.</param>
+    /// <returns>The resource builder.</returns>
+    /// <remarks>
+    /// Package executable resources require an explicit version so restore behavior remains deterministic.
+    /// </remarks>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="version"/> is null, empty, or whitespace.</exception>
+    [AspireExport("withPackageVersion", Description = "Sets the package version")]
+    public static IResourceBuilder<T> WithPackageVersion<T>(this IResourceBuilder<T> builder, string version)
+        where T : PackageExecutableResource
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+        builder.Resource.PackageConfiguration!.Version = version;
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a package source used during restore.
+    /// </summary>
+    /// <typeparam name="T">The package executable resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="source">The package source.</param>
+    /// <returns>The resource builder.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="source"/> is null, empty, or whitespace.</exception>
+    [AspireExport("withPackageSource", Description = "Adds a package source")]
+    public static IResourceBuilder<T> WithPackageSource<T>(this IResourceBuilder<T> builder, string source)
+        where T : PackageExecutableResource
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(source);
+        builder.Resource.PackageConfiguration!.Sources.Add(source);
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds multiple package sources used during restore.
+    /// </summary>
+    /// <typeparam name="T">The package executable resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="sources">The package sources.</param>
+    /// <returns>The resource builder.</returns>
+    public static IResourceBuilder<T> WithPackageSources<T>(this IResourceBuilder<T> builder, params string[] sources)
+        where T : PackageExecutableResource
+    {
+        ArgumentNullException.ThrowIfNull(sources);
+
+        foreach (var source in sources)
+        {
+            builder.WithPackageSource(source);
+        }
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Selects a specific executable file from the restored package contents.
+    /// </summary>
+    /// <typeparam name="T">The package executable resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="executableName">The executable file name or base name.</param>
+    /// <returns>The resource builder.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="executableName"/> is null, empty, or whitespace.</exception>
+    [AspireExport("withPackageExecutable", Description = "Selects the executable inside the package")]
+    public static IResourceBuilder<T> WithPackageExecutable<T>(this IResourceBuilder<T> builder, string executableName)
+        where T : PackageExecutableResource
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executableName);
+        builder.Resource.PackageConfiguration!.ExecutableName = executableName;
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the restore to ignore existing feeds declared in NuGet configuration.
+    /// </summary>
+    /// <typeparam name="T">The package executable resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <returns>The resource builder.</returns>
+    [AspireExport("withPackageIgnoreExistingFeeds", Description = "Ignores existing feeds during package restore")]
+    public static IResourceBuilder<T> WithPackageIgnoreExistingFeeds<T>(this IResourceBuilder<T> builder)
+        where T : PackageExecutableResource
+    {
+        builder.Resource.PackageConfiguration!.IgnoreExistingFeeds = true;
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the restore to continue when one package source fails but another source can satisfy the package.
+    /// </summary>
+    /// <typeparam name="T">The package executable resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <returns>The resource builder.</returns>
+    /// <remarks>
+    /// When enabled, Aspire first attempts restore with the full source set and then retries individual sources if the
+    /// combined restore fails. This keeps successful sources usable when one configured feed is unavailable.
+    /// </remarks>
+    [AspireExport("withPackageIgnoreFailedSources", Description = "Allows failed package sources during restore")]
+    public static IResourceBuilder<T> WithPackageIgnoreFailedSources<T>(this IResourceBuilder<T> builder)
+        where T : PackageExecutableResource
+    {
+        builder.Resource.PackageConfiguration!.IgnoreFailedSources = true;
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets the working directory for the executable relative to the restored package directory.
+    /// </summary>
+    /// <typeparam name="T">The package executable resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="workingDirectory">The working directory override.</param>
+    /// <returns>The resource builder.</returns>
+    /// <remarks>
+    /// The path must remain relative to the restored package contents. Rooted paths and directory traversal outside the
+    /// package are rejected when the package is resolved.
+    /// </remarks>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="workingDirectory"/> is null, empty, or whitespace.</exception>
+    [AspireExport("withPackageWorkingDirectory", Description = "Sets the package working directory")]
+    public static IResourceBuilder<T> WithPackageWorkingDirectory<T>(this IResourceBuilder<T> builder, string workingDirectory)
+        where T : PackageExecutableResource
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
+        builder.Resource.PackageConfiguration!.WorkingDirectory = workingDirectory;
+        return builder;
+    }
+
+    private static void AnchorWorkingDirectoryToAppHost<T>(IDistributedApplicationBuilder builder, T resource)
+        where T : PackageExecutableResource
+    {
+        if (resource.Annotations.OfType<ExecutableAnnotation>().LastOrDefault() is not { } executableAnnotation)
+        {
+            return;
+        }
+
+        if (Path.IsPathRooted(executableAnnotation.WorkingDirectory))
+        {
+            return;
+        }
+
+        executableAnnotation.WorkingDirectory = PathNormalizer.NormalizePathForCurrentPlatform(Path.Combine(builder.AppHostDirectory, executableAnnotation.WorkingDirectory));
+    }
+
+    private static void WithResolvedExecutable(this PackageExecutableResource resource, PackageExecutableResolutionResult resolved)
+    {
+        var existingAnnotations = resource.Annotations.OfType<ResolvedPackageExecutableAnnotation>().ToArray();
+        foreach (var existingAnnotation in existingAnnotations)
+        {
+            resource.Annotations.Remove(existingAnnotation);
+        }
+
+        var resolvedAnnotation = new ResolvedPackageExecutableAnnotation
+        {
+            PackageId = resolved.PackageId,
+            PackageVersion = resolved.PackageVersion,
+            PackageDirectory = resolved.PackageDirectory,
+            ExecutablePath = resolved.ExecutablePath,
+            Command = resolved.Command,
+            WorkingDirectory = resolved.WorkingDirectory,
+        };
+
+        resolvedAnnotation.Arguments.AddRange(resolved.Arguments);
+        resource.Annotations.Add(resolvedAnnotation);
+
+        if (resource.Annotations.OfType<ExecutableAnnotation>().LastOrDefault() is { } executableAnnotation)
+        {
+            executableAnnotation.Command = resolved.Command;
+            executableAnnotation.WorkingDirectory = resolved.WorkingDirectory;
+        }
+    }
+
+    private static IReadOnlyList<string> GetResolvedArguments(PackageExecutableResource resource, ResolvedPackageExecutableAnnotation resolved, bool isPublishMode)
+    {
+        if (!isPublishMode)
+        {
+            return resolved.Arguments;
+        }
+
+        if (!string.Equals(resolved.Command, "dotnet", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new DistributedApplicationException($"Publishing package executable resource '{resource.Name}' currently supports managed .dll executables only.");
+        }
+
+        var relativeExecutablePath = Path.GetRelativePath(resolved.WorkingDirectory, resolved.ExecutablePath)
+            .Replace('\\', '/');
+
+        var publishArguments = new List<string>
+        {
+            relativeExecutablePath
+        };
+
+        if (resolved.Arguments.Count > 1)
+        {
+            publishArguments.AddRange(resolved.Arguments.Skip(1));
+        }
+
+        return publishArguments;
+    }
+
+    private static async Task<string> CreatePublishDockerfileAsync(PackageExecutableResource resource, string publishContextPath, DockerfileFactoryContext context)
+    {
+        var resolver = context.Services.GetRequiredService<IPackageExecutableResolver>();
+        var resolved = await resolver.ResolveAsync(resource, context.CancellationToken).ConfigureAwait(false);
+
+        if (!string.Equals(resolved.Command, "dotnet", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new DistributedApplicationException($"Publishing package executable resource '{resource.Name}' currently supports managed .dll executables only.");
+        }
+
+        resource.WithResolvedExecutable(resolved);
+
+        var packageOutputPath = Path.Combine(publishContextPath, "package");
+        ResetDirectory(packageOutputPath);
+        CopyDirectory(resolved.PackageDirectory, packageOutputPath);
+
+        var workingDirectoryRelativePath = Path.GetRelativePath(resolved.PackageDirectory, resolved.WorkingDirectory)
+            .Replace('\\', '/');
+        var containerWorkingDirectory = string.Equals(workingDirectoryRelativePath, ".", StringComparison.Ordinal)
+            ? "/app"
+            : $"/app/{workingDirectoryRelativePath}";
+
+        return string.Join("\n", [
+            "FROM mcr.microsoft.com/dotnet/runtime:10.0",
+            "WORKDIR /app",
+            "COPY package/ /app/",
+            $"WORKDIR {containerWorkingDirectory}"
+        ]);
+    }
+
+    private static void ResetDirectory(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+
+        Directory.CreateDirectory(path);
+    }
+
+    private static void CopyDirectory(string sourcePath, string destinationPath)
+    {
+        foreach (var directory in Directory.EnumerateDirectories(sourcePath, "*", SearchOption.AllDirectories))
+        {
+            var relativePath = Path.GetRelativePath(sourcePath, directory);
+            Directory.CreateDirectory(Path.Combine(destinationPath, relativePath));
+        }
+
+        foreach (var file in Directory.EnumerateFiles(sourcePath, "*", SearchOption.AllDirectories))
+        {
+            var relativePath = Path.GetRelativePath(sourcePath, file);
+            var destinationFile = Path.Combine(destinationPath, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationFile)!);
+            File.Copy(file, destinationFile, overwrite: true);
+        }
+    }
+
+    private sealed class PackageExecutableContainerResource(PackageExecutableResource packageResource, string publishContextPath) : ContainerResource(packageResource.Name)
+    {
+        public string PublishContextPath { get; } = publishContextPath;
+
+        public override ResourceAnnotationCollection Annotations => packageResource.Annotations;
+    }
+}

--- a/src/Aspire.Hosting/PackageExecutableResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/PackageExecutableResourceBuilderExtensions.cs
@@ -5,6 +5,7 @@ using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.PackageManagement;
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using System.Text.Json;
@@ -21,6 +22,8 @@ namespace Aspire.Hosting;
 /// </remarks>
 public static class PackageExecutableResourceBuilderExtensions
 {
+    private const string BaseImageBuildArgumentName = "BASE_IMAGE";
+
     /// <summary>
     /// Adds a package-backed executable resource to the application model.
     /// </summary>
@@ -132,7 +135,7 @@ public static class PackageExecutableResourceBuilderExtensions
 
         builder.ApplicationBuilder.Resources.Remove(builder.Resource);
 
-        var publishContextPath = GetPublishContextPath(builder.ApplicationBuilder.AppHostDirectory, builder.Resource.Name);
+        var publishContextPath = GetPublishContextPath(builder.ApplicationBuilder.Configuration, builder.Resource.Name);
         Directory.CreateDirectory(publishContextPath);
         var container = new PackageExecutableContainerResource(builder.Resource, publishContextPath);
         var containerBuilder = builder.ApplicationBuilder.AddResource(container);
@@ -369,16 +372,24 @@ public static class PackageExecutableResourceBuilderExtensions
         var runtimeImage = GetRuntimeContainerImage(resolved.ExecutablePath);
 
         return string.Join("\n", [
-            $"FROM {runtimeImage}",
+            $"ARG {BaseImageBuildArgumentName}={runtimeImage}",
+            $"FROM ${{{BaseImageBuildArgumentName}}}",
             "WORKDIR /app",
             "COPY package/ /app/",
             $"WORKDIR {containerWorkingDirectory}"
         ]);
     }
 
-    private static string GetPublishContextPath(string appHostDirectory, string resourceName)
+    private static string GetPublishContextPath(IConfiguration configuration, string resourceName)
     {
-        return Path.Combine(appHostDirectory, "obj", "aspire-package-executables", "publish", resourceName);
+        var aspireStorePath = configuration[AspireStore.AspireStorePathKeyName];
+
+        if (string.IsNullOrWhiteSpace(aspireStorePath))
+        {
+            throw new InvalidOperationException($"Could not determine the Aspire store path. Set {AspireStore.AspireStorePathKeyName} before publishing package executable resources.");
+        }
+
+        return Path.Combine(aspireStorePath, ".aspire", "package-executables", "publish", resourceName);
     }
 
     private static string GetRuntimeContainerImage(string executablePath)

--- a/src/Aspire.Hosting/PackageManagement/IPackageExecutableResolver.cs
+++ b/src/Aspire.Hosting/PackageManagement/IPackageExecutableResolver.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.PackageManagement;
+
+internal interface IPackageExecutableResolver
+{
+    Task<PackageExecutableResolutionResult> ResolveAsync(PackageExecutableResource resource, CancellationToken cancellationToken);
+}

--- a/src/Aspire.Hosting/PackageManagement/PackageExecutableResolutionResult.cs
+++ b/src/Aspire.Hosting/PackageManagement/PackageExecutableResolutionResult.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.PackageManagement;
+
+internal sealed class PackageExecutableResolutionResult
+{
+    public required string PackageId { get; init; }
+
+    public required string PackageVersion { get; init; }
+
+    public required string PackageDirectory { get; init; }
+
+    public required string ExecutablePath { get; init; }
+
+    public required string Command { get; init; }
+
+    public required string WorkingDirectory { get; init; }
+
+    public IReadOnlyList<string> Arguments { get; init; } = [];
+}

--- a/src/Aspire.Hosting/PackageManagement/PackageExecutableResolver.cs
+++ b/src/Aspire.Hosting/PackageManagement/PackageExecutableResolver.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.Logging;
 using NuGet.Commands;
@@ -20,8 +22,8 @@ namespace Aspire.Hosting.PackageManagement;
 
 internal sealed class PackageExecutableResolver(ILogger<PackageExecutableResolver> logger) : IPackageExecutableResolver
 {
-    private const string DefaultTargetFramework = "net10.0";
-    private const string NuGetOrgUrl = "https://api.nuget.org/v3/index.json";
+    private static readonly NuGetFramework s_defaultTargetFramework = GetDefaultTargetFramework();
+    private static readonly string s_currentRuntimeIdentifier = GetCurrentRuntimeIdentifier();
 
     public async Task<PackageExecutableResolutionResult> ResolveAsync(PackageExecutableResource resource, CancellationToken cancellationToken)
     {
@@ -72,7 +74,12 @@ internal sealed class PackageExecutableResolver(ILogger<PackageExecutableResolve
     private async Task RestorePackageAsync(PackageExecutableAnnotation configuration, ISettings settings, string globalPackagesFolder, CancellationToken cancellationToken)
     {
         var packageSources = LoadPackageSources(configuration, settings);
-        var framework = NuGetFramework.Parse(DefaultTargetFramework);
+        if (packageSources.Count == 0)
+        {
+            throw new DistributedApplicationException($"Package executable resource '{configuration.PackageId}' could not determine any NuGet package sources. Configure a package source explicitly or provide one through NuGet.Config.");
+        }
+
+        var framework = s_defaultTargetFramework;
         var outputPath = Path.Combine(Path.GetTempPath(), "aspire-package-executables", Guid.NewGuid().ToString("n"));
         Directory.CreateDirectory(outputPath);
 
@@ -213,11 +220,6 @@ internal sealed class PackageExecutableResolver(ILogger<PackageExecutableResolve
             }
         }
 
-        if (!packageSources.Any(source => string.Equals(source.Source, NuGetOrgUrl, StringComparison.OrdinalIgnoreCase)))
-        {
-            packageSources.Add(new PackageSource(NuGetOrgUrl, "nuget.org"));
-        }
-
         return packageSources;
     }
 
@@ -252,20 +254,24 @@ internal sealed class PackageExecutableResolver(ILogger<PackageExecutableResolve
         }
 
         var candidates = candidateRoots
-            .SelectMany(root => Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
-            .Where(IsSupportedExecutableCandidate)
-            .Where(path => MatchesExecutableName(path, executableName))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .SelectMany(EnumerateExecutableCandidates)
+            .Where(candidate => MatchesExecutableName(candidate.Path, executableName))
             .ToArray();
 
         var searchLocations = string.Join("', '", candidateRoots);
 
-        return candidates.Length switch
+        if (candidates.Length == 0)
         {
-            0 => throw new DistributedApplicationException(executableName is null
+            throw new DistributedApplicationException(executableName is null
                 ? $"Unable to locate a runnable executable asset under '{searchLocations}' for package '{packageId}'. Use WithPackageExecutable(...) to select a specific executable file."
-                : $"Unable to locate an executable named '{executableName}' under '{searchLocations}' for package '{packageId}'."),
-            1 => candidates[0],
+                : $"Unable to locate an executable named '{executableName}' under '{searchLocations}' for package '{packageId}'.");
+        }
+
+        var selectedCandidates = SelectBestCandidates(candidates);
+
+        return selectedCandidates.Count switch
+        {
+            1 => selectedCandidates[0].Path,
             _ => throw new DistributedApplicationException(executableName is null
                 ? $"Multiple runnable executable assets were found under '{searchLocations}' for package '{packageId}'. Use WithPackageExecutable(...) to disambiguate."
                 : $"Multiple runnable executable assets matched '{executableName}' under '{searchLocations}' for package '{packageId}'.")
@@ -343,6 +349,170 @@ internal sealed class PackageExecutableResolver(ILogger<PackageExecutableResolve
         return string.Equals(fileName, executableName, StringComparison.OrdinalIgnoreCase)
             || string.Equals(fileNameWithoutExtension, executableName, StringComparison.OrdinalIgnoreCase);
     }
+
+    private static IReadOnlyList<ExecutableCandidate> SelectBestCandidates(IReadOnlyList<ExecutableCandidate> candidates)
+    {
+        var compatibleRidCandidates = candidates
+            .Where(IsCompatibleWithCurrentRuntime)
+            .ToArray();
+
+        var ridFilteredCandidates = compatibleRidCandidates.Length > 0 ? compatibleRidCandidates : candidates.ToArray();
+        var bestRidSpecificity = ridFilteredCandidates.Max(GetRuntimeIdentifierSpecificity);
+        ridFilteredCandidates = ridFilteredCandidates
+            .Where(candidate => GetRuntimeIdentifierSpecificity(candidate) == bestRidSpecificity)
+            .ToArray();
+
+        var frameworkCandidates = ridFilteredCandidates
+            .Where(candidate => candidate.Framework is not null)
+            .ToArray();
+
+        if (frameworkCandidates.Length == 0)
+        {
+            return ridFilteredCandidates;
+        }
+
+        var nearestFramework = new FrameworkReducer().GetNearest(s_defaultTargetFramework, frameworkCandidates.Select(candidate => candidate.Framework!));
+        if (nearestFramework is null)
+        {
+            return ridFilteredCandidates;
+        }
+
+        return frameworkCandidates
+            .Where(candidate => NuGetFramework.Comparer.Equals(candidate.Framework, nearestFramework))
+            .ToArray();
+    }
+
+    private static IEnumerable<ExecutableCandidate> EnumerateExecutableCandidates(string rootPath)
+    {
+        foreach (var path in Directory.EnumerateFiles(rootPath, "*", SearchOption.AllDirectories))
+        {
+            if (!IsSupportedExecutableCandidate(path))
+            {
+                continue;
+            }
+
+            yield return CreateExecutableCandidate(rootPath, path);
+        }
+    }
+
+    private static ExecutableCandidate CreateExecutableCandidate(string rootPath, string path)
+    {
+        var rootName = Path.GetFileName(rootPath);
+        var rootKind = string.Equals(rootName, "tools", StringComparison.OrdinalIgnoreCase)
+            ? CandidateRootKind.Tools
+            : CandidateRootKind.Lib;
+
+        var relativePath = Path.GetRelativePath(rootPath, path);
+        var segments = relativePath.Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries);
+
+        NuGetFramework? framework = null;
+        string? runtimeIdentifier = null;
+
+        if (rootKind == CandidateRootKind.Lib)
+        {
+            if (segments.Length > 1 && TryParseFramework(segments[0], out var parsedFramework))
+            {
+                framework = parsedFramework;
+            }
+        }
+        else
+        {
+            if (segments.Length > 2 && TryParseFramework(segments[0], out var parsedFramework))
+            {
+                framework = parsedFramework;
+                runtimeIdentifier = segments[1];
+            }
+            else if (segments.Length > 1)
+            {
+                runtimeIdentifier = segments[0];
+            }
+        }
+
+        return new ExecutableCandidate(path, framework, runtimeIdentifier, rootKind);
+    }
+
+    private static bool IsCompatibleWithCurrentRuntime(ExecutableCandidate candidate)
+    {
+        if (string.IsNullOrWhiteSpace(candidate.RuntimeIdentifier)
+            || string.Equals(candidate.RuntimeIdentifier, "any", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return string.Equals(candidate.RuntimeIdentifier, s_currentRuntimeIdentifier, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int GetRuntimeIdentifierSpecificity(ExecutableCandidate candidate)
+    {
+        if (string.Equals(candidate.RuntimeIdentifier, s_currentRuntimeIdentifier, StringComparison.OrdinalIgnoreCase))
+        {
+            return 2;
+        }
+
+        if (string.IsNullOrWhiteSpace(candidate.RuntimeIdentifier)
+            || string.Equals(candidate.RuntimeIdentifier, "any", StringComparison.OrdinalIgnoreCase))
+        {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private static bool TryParseFramework(string value, out NuGetFramework? framework)
+    {
+        framework = null;
+
+        try
+        {
+            var parsed = NuGetFramework.Parse(value);
+            if (parsed.IsUnsupported)
+            {
+                return false;
+            }
+
+            framework = parsed;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static NuGetFramework GetDefaultTargetFramework()
+    {
+        var targetFrameworkAttribute = typeof(PackageExecutableResolver).Assembly.GetCustomAttributes(typeof(TargetFrameworkAttribute), inherit: false)
+            .OfType<TargetFrameworkAttribute>()
+            .SingleOrDefault();
+
+        if (targetFrameworkAttribute is not null)
+        {
+            return NuGetFramework.ParseFrameworkName(targetFrameworkAttribute.FrameworkName, DefaultFrameworkNameProvider.Instance);
+        }
+
+        return NuGetFramework.Parse($"net{Environment.Version.Major}.0");
+    }
+
+    private static string GetCurrentRuntimeIdentifier()
+    {
+        var os = OperatingSystem.IsWindows() ? "win"
+            : OperatingSystem.IsLinux() ? "linux"
+            : OperatingSystem.IsMacOS() ? "osx"
+            : "any";
+
+        var architecture = RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.X64 => "x64",
+            Architecture.X86 => "x86",
+            Architecture.Arm64 => "arm64",
+            Architecture.Arm => "arm",
+            _ => "any"
+        };
+
+        return os == "any" || architecture == "any"
+            ? "any"
+            : $"{os}-{architecture}";
+    }
 }
 
 internal sealed class NuGetCommonLogger(MsalLogger logger) : NuGetLogger
@@ -396,3 +566,11 @@ internal sealed class NuGetCommonLogger(MsalLogger logger) : NuGetLogger
         _ => Microsoft.Extensions.Logging.LogLevel.Information
     };
 }
+
+internal enum CandidateRootKind
+{
+    Lib,
+    Tools
+}
+
+internal sealed record ExecutableCandidate(string Path, NuGetFramework? Framework, string? RuntimeIdentifier, CandidateRootKind RootKind);

--- a/src/Aspire.Hosting/PackageManagement/PackageExecutableResolver.cs
+++ b/src/Aspire.Hosting/PackageManagement/PackageExecutableResolver.cs
@@ -1,0 +1,398 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.Logging;
+using NuGet.Commands;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.ProjectModel;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using MsalLogger = Microsoft.Extensions.Logging.ILogger;
+using NuGetLogger = NuGet.Common.ILogger;
+using NuGetLogLevel = NuGet.Common.LogLevel;
+using NuGetLogMessage = NuGet.Common.ILogMessage;
+
+namespace Aspire.Hosting.PackageManagement;
+
+internal sealed class PackageExecutableResolver(ILogger<PackageExecutableResolver> logger) : IPackageExecutableResolver
+{
+    private const string DefaultTargetFramework = "net10.0";
+    private const string NuGetOrgUrl = "https://api.nuget.org/v3/index.json";
+
+    public async Task<PackageExecutableResolutionResult> ResolveAsync(PackageExecutableResource resource, CancellationToken cancellationToken)
+    {
+        var configuration = resource.PackageConfiguration ?? throw new DistributedApplicationException($"The package executable resource '{resource.Name}' is missing package configuration.");
+
+        var version = configuration.Version;
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            throw new DistributedApplicationException($"Package executable resource '{resource.Name}' requires an explicit package version. Call WithPackageVersion(...) before starting the resource.");
+        }
+
+        var appHostDirectory = resource.WorkingDirectory;
+        var settings = Settings.LoadDefaultSettings(appHostDirectory);
+        var globalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(settings);
+        var normalizedVersion = NuGetVersion.Parse(version).ToNormalizedString();
+        var packageDirectory = Path.Combine(globalPackagesFolder, configuration.PackageId.ToLowerInvariant(), normalizedVersion);
+
+        if (!Directory.Exists(packageDirectory))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await RestorePackageAsync(configuration, settings, globalPackagesFolder, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (!Directory.Exists(packageDirectory))
+        {
+            throw new DistributedApplicationException($"Unable to restore package '{configuration.PackageId}' version '{configuration.Version}' for resource '{resource.Name}'.");
+        }
+
+        var executablePath = ResolveExecutablePath(packageDirectory, configuration.ExecutableName, configuration.PackageId);
+        var workingDirectory = ResolveWorkingDirectory(packageDirectory, executablePath, configuration.WorkingDirectory, configuration.PackageId);
+        var command = executablePath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) ? "dotnet" : executablePath;
+        var arguments = executablePath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+            ? [executablePath]
+            : Array.Empty<string>();
+
+        return new PackageExecutableResolutionResult
+        {
+            PackageId = configuration.PackageId,
+            PackageVersion = normalizedVersion,
+            PackageDirectory = packageDirectory,
+            ExecutablePath = executablePath,
+            Command = command,
+            WorkingDirectory = workingDirectory,
+            Arguments = arguments
+        };
+    }
+
+    private async Task RestorePackageAsync(PackageExecutableAnnotation configuration, ISettings settings, string globalPackagesFolder, CancellationToken cancellationToken)
+    {
+        var packageSources = LoadPackageSources(configuration, settings);
+        var framework = NuGetFramework.Parse(DefaultTargetFramework);
+        var outputPath = Path.Combine(Path.GetTempPath(), "aspire-package-executables", Guid.NewGuid().ToString("n"));
+        Directory.CreateDirectory(outputPath);
+
+        try
+        {
+            var restoreAttempts = BuildRestoreAttempts(packageSources, configuration.IgnoreFailedSources);
+            List<string>? errors = null;
+
+            foreach (var sources in restoreAttempts)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var summary = await ExecuteRestoreAsync(configuration, framework, outputPath, globalPackagesFolder, sources).ConfigureAwait(false);
+                if (summary is { Success: true })
+                {
+                    return;
+                }
+
+                errors ??= [];
+                errors.AddRange(summary?.Errors?.Select(error => error.Message) ?? ["Unknown restore error"]);
+            }
+
+            throw new DistributedApplicationException($"Package restore failed for '{configuration.PackageId}' version '{configuration.Version}': {string.Join(Environment.NewLine, errors ?? ["Unknown restore error"])}");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(outputPath, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+
+    private async Task<RestoreSummary?> ExecuteRestoreAsync(PackageExecutableAnnotation configuration, NuGetFramework framework, string outputPath, string globalPackagesFolder, IReadOnlyList<PackageSource> packageSources)
+    {
+        var packageSpec = BuildPackageSpec(configuration, framework, outputPath, globalPackagesFolder, packageSources);
+        var dependencyGraphSpec = new DependencyGraphSpec();
+        dependencyGraphSpec.AddProject(packageSpec);
+        dependencyGraphSpec.AddRestore(packageSpec.RestoreMetadata.ProjectUniqueName);
+
+        var providerCache = new RestoreCommandProvidersCache();
+        var providers = new List<IPreLoadedRestoreRequestProvider>
+        {
+            new DependencyGraphSpecRequestProvider(providerCache, dependencyGraphSpec)
+        };
+
+        using var cacheContext = new SourceCacheContext();
+        var restoreContext = new RestoreArgs
+        {
+            CacheContext = cacheContext,
+            Log = new NuGetCommonLogger(logger),
+            PreLoadedRequestProviders = providers,
+            DisableParallel = Environment.ProcessorCount == 1,
+            AllowNoOp = false,
+            GlobalPackagesFolder = globalPackagesFolder,
+        };
+
+        var results = await RestoreRunner.RunAsync(restoreContext).ConfigureAwait(false);
+        return results.Count > 0 ? results[0] : null;
+    }
+
+    private static PackageSpec BuildPackageSpec(PackageExecutableAnnotation configuration, NuGetFramework framework, string outputPath, string packagesPath, IReadOnlyList<PackageSource> sources)
+    {
+        var version = configuration.Version!;
+        var projectName = "AspirePackageExecutableRestore";
+        var projectPath = Path.Combine(outputPath, "project.json");
+        var targetFrameworkName = framework.GetShortFolderName();
+
+        var dependency = new LibraryDependency
+        {
+            LibraryRange = new LibraryRange(
+                configuration.PackageId,
+                VersionRange.Parse(version),
+                LibraryDependencyTarget.Package)
+        };
+
+        var targetFramework = new TargetFrameworkInformation
+        {
+            FrameworkName = framework,
+            TargetAlias = targetFrameworkName,
+            Dependencies = ImmutableArray.Create(dependency)
+        };
+
+        var restoreMetadata = new ProjectRestoreMetadata
+        {
+            ProjectUniqueName = projectName,
+            ProjectName = projectName,
+            ProjectPath = projectPath,
+            ProjectStyle = ProjectStyle.PackageReference,
+            OutputPath = outputPath,
+            PackagesPath = packagesPath,
+            OriginalTargetFrameworks = [targetFrameworkName],
+        };
+
+        foreach (var source in sources)
+        {
+            restoreMetadata.Sources.Add(source);
+        }
+
+        restoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(framework)
+        {
+            TargetAlias = targetFrameworkName
+        });
+
+        return new PackageSpec([targetFramework])
+        {
+            Name = projectName,
+            FilePath = projectPath,
+            RestoreMetadata = restoreMetadata,
+        };
+    }
+
+    private static IReadOnlyList<PackageSource> LoadPackageSources(PackageExecutableAnnotation configuration, ISettings settings)
+    {
+        var packageSources = new List<PackageSource>();
+
+        foreach (var source in configuration.Sources)
+        {
+            packageSources.Add(new PackageSource(source));
+        }
+
+        if (!configuration.IgnoreExistingFeeds)
+        {
+            var provider = new PackageSourceProvider(settings);
+
+            foreach (var source in provider.LoadPackageSources())
+            {
+                if (source.IsEnabled && !packageSources.Any(existingSource => string.Equals(existingSource.Source, source.Source, StringComparison.OrdinalIgnoreCase)))
+                {
+                    packageSources.Add(source);
+                }
+            }
+        }
+
+        if (!packageSources.Any(source => string.Equals(source.Source, NuGetOrgUrl, StringComparison.OrdinalIgnoreCase)))
+        {
+            packageSources.Add(new PackageSource(NuGetOrgUrl, "nuget.org"));
+        }
+
+        return packageSources;
+    }
+
+    internal static IReadOnlyList<IReadOnlyList<PackageSource>> BuildRestoreAttempts(IReadOnlyList<PackageSource> packageSources, bool ignoreFailedSources)
+    {
+        ArgumentNullException.ThrowIfNull(packageSources);
+
+        if (!ignoreFailedSources || packageSources.Count <= 1)
+        {
+            return [packageSources];
+        }
+
+        var attempts = new List<IReadOnlyList<PackageSource>>(capacity: packageSources.Count + 1)
+        {
+            packageSources
+        };
+
+        foreach (var source in packageSources)
+        {
+            attempts.Add([source]);
+        }
+
+        return attempts;
+    }
+
+    private static string ResolveExecutablePath(string packageDirectory, string? executableName, string packageId)
+    {
+        var candidateRoots = GetCandidateRoots(packageDirectory);
+        if (candidateRoots.Count == 0)
+        {
+            throw new DistributedApplicationException($"Package '{packageId}' does not contain a supported executable layout. Package executable resources currently expect runnable assets under the package lib or tools folders.");
+        }
+
+        var candidates = candidateRoots
+            .SelectMany(root => Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+            .Where(IsSupportedExecutableCandidate)
+            .Where(path => MatchesExecutableName(path, executableName))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var searchLocations = string.Join("', '", candidateRoots);
+
+        return candidates.Length switch
+        {
+            0 => throw new DistributedApplicationException(executableName is null
+                ? $"Unable to locate a runnable executable asset under '{searchLocations}' for package '{packageId}'. Use WithPackageExecutable(...) to select a specific executable file."
+                : $"Unable to locate an executable named '{executableName}' under '{searchLocations}' for package '{packageId}'."),
+            1 => candidates[0],
+            _ => throw new DistributedApplicationException(executableName is null
+                ? $"Multiple runnable executable assets were found under '{searchLocations}' for package '{packageId}'. Use WithPackageExecutable(...) to disambiguate."
+                : $"Multiple runnable executable assets matched '{executableName}' under '{searchLocations}' for package '{packageId}'.")
+        };
+    }
+
+    private static IReadOnlyList<string> GetCandidateRoots(string packageDirectory)
+    {
+        var candidateRoots = new List<string>(capacity: 2);
+
+        var libDirectory = Path.Combine(packageDirectory, "lib");
+        if (Directory.Exists(libDirectory))
+        {
+            candidateRoots.Add(libDirectory);
+        }
+
+        var toolsDirectory = Path.Combine(packageDirectory, "tools");
+        if (Directory.Exists(toolsDirectory))
+        {
+            candidateRoots.Add(toolsDirectory);
+        }
+
+        return candidateRoots;
+    }
+
+    internal static string ResolveWorkingDirectory(string packageDirectory, string executablePath, string? workingDirectory, string packageId)
+    {
+        if (string.IsNullOrWhiteSpace(workingDirectory))
+        {
+            return Path.GetDirectoryName(executablePath) ?? packageDirectory;
+        }
+
+        if (Path.IsPathRooted(workingDirectory))
+        {
+            throw new DistributedApplicationException($"Package executable resource for package '{packageId}' requires a working directory relative to the restored package contents.");
+        }
+
+        var resolvedWorkingDirectory = Path.GetFullPath(Path.Combine(packageDirectory, workingDirectory));
+        var packageRoot = EnsureTrailingSeparator(Path.GetFullPath(packageDirectory));
+        var resolvedRoot = EnsureTrailingSeparator(resolvedWorkingDirectory);
+
+        if (!resolvedRoot.StartsWith(packageRoot, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new DistributedApplicationException($"Package executable resource for package '{packageId}' requires a working directory that stays within the restored package contents.");
+        }
+
+        return resolvedWorkingDirectory;
+    }
+
+    private static string EnsureTrailingSeparator(string path)
+    {
+        return path.EndsWith(Path.DirectorySeparatorChar) || path.EndsWith(Path.AltDirectorySeparatorChar)
+            ? path
+            : path + Path.DirectorySeparatorChar;
+    }
+
+    private static bool IsSupportedExecutableCandidate(string path)
+    {
+        var extension = Path.GetExtension(path);
+        return extension.Equals(".dll", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".exe", StringComparison.OrdinalIgnoreCase)
+            || string.IsNullOrEmpty(extension);
+    }
+
+    private static bool MatchesExecutableName(string path, string? executableName)
+    {
+        if (string.IsNullOrWhiteSpace(executableName))
+        {
+            return true;
+        }
+
+        var fileName = Path.GetFileName(path);
+        var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(path);
+
+        return string.Equals(fileName, executableName, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(fileNameWithoutExtension, executableName, StringComparison.OrdinalIgnoreCase);
+    }
+}
+
+internal sealed class NuGetCommonLogger(MsalLogger logger) : NuGetLogger
+{
+    public void Log(NuGetLogLevel level, string data)
+    {
+        if (!logger.IsEnabled(MapLevel(level)))
+        {
+            return;
+        }
+
+        logger.Log(MapLevel(level), "{Message}", data);
+    }
+
+    public void Log(NuGetLogMessage message) => Log(message.Level, message.Message);
+
+    public Task LogAsync(NuGetLogLevel level, string data)
+    {
+        Log(level, data);
+        return Task.CompletedTask;
+    }
+
+    public Task LogAsync(NuGetLogMessage message)
+    {
+        Log(message);
+        return Task.CompletedTask;
+    }
+
+    public void LogDebug(string data) => Log(NuGetLogLevel.Debug, data);
+
+    public void LogError(string data) => Log(NuGetLogLevel.Error, data);
+
+    public void LogInformation(string data) => Log(NuGetLogLevel.Information, data);
+
+    public void LogInformationSummary(string data) => Log(NuGetLogLevel.Information, data);
+
+    public void LogMinimal(string data) => Log(NuGetLogLevel.Minimal, data);
+
+    public void LogVerbose(string data) => Log(NuGetLogLevel.Verbose, data);
+
+    public void LogWarning(string data) => Log(NuGetLogLevel.Warning, data);
+
+    private static Microsoft.Extensions.Logging.LogLevel MapLevel(NuGetLogLevel level) => level switch
+    {
+        NuGetLogLevel.Debug => Microsoft.Extensions.Logging.LogLevel.Debug,
+        NuGetLogLevel.Verbose => Microsoft.Extensions.Logging.LogLevel.Trace,
+        NuGetLogLevel.Information => Microsoft.Extensions.Logging.LogLevel.Information,
+        NuGetLogLevel.Minimal => Microsoft.Extensions.Logging.LogLevel.Information,
+        NuGetLogLevel.Warning => Microsoft.Extensions.Logging.LogLevel.Warning,
+        NuGetLogLevel.Error => Microsoft.Extensions.Logging.LogLevel.Error,
+        _ => Microsoft.Extensions.Logging.LogLevel.Information
+    };
+}

--- a/src/Shared/Model/KnownResourceTypes.cs
+++ b/src/Shared/Model/KnownResourceTypes.cs
@@ -6,6 +6,7 @@ namespace Aspire.Dashboard.Model;
 internal static class KnownResourceTypes
 {
     public const string Executable = "Executable";
+    public const string PackageExecutable = "PackageExecutable";
     public const string ContainerExec = "ContainerExec";
     public const string Project = "Project";
     public const string Tool = "Tool";

--- a/src/Shared/Model/ResourceSourceViewModel.cs
+++ b/src/Shared/Model/ResourceSourceViewModel.cs
@@ -24,6 +24,13 @@ internal record ResourceSource(string Value, string OriginalValue)
             return new ResourceSource(toolPackage, toolPackage);
         }
 
+        if (StringComparers.ResourceType.Equals(resourceType, KnownResourceTypes.PackageExecutable) &&
+            properties.TryGetValue(KnownProperties.Resource.Source, out var packageSource) &&
+            !string.IsNullOrEmpty(packageSource))
+        {
+            return new ResourceSource(packageSource, packageSource);
+        }
+
         if (properties.TryGetValue(KnownProperties.Executable.Path, out var executablePath) &&
             !string.IsNullOrEmpty(executablePath))
         {

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
@@ -143,6 +143,22 @@ public sealed class ResourceSourceViewModelTests
                 ValueToVisualize: "path/to/executable arg1 arg2",
                 Tooltip: "path/to/executable arg1 arg2"));
 
+        // Package executable prefers the package source over the resolved path.
+        data.Add(new TestData(
+            ResourceType: "PackageExecutable",
+            ExecutablePath: "path/to/package/tools/net10.0/any/sample.dll",
+            ExecutableArguments: ["sample.dll", "--mode", "worker"],
+            AppArgs: null,
+            AppArgsSensitivity: null,
+            ProjectPath: null,
+            ContainerImage: null,
+            SourceProperty: "Contoso.PackageExecutables.SampleApp"),
+            new ExpectedData(
+            Value: "Contoso.PackageExecutables.SampleApp",
+            ContentAfterValue: [new ExpectedLaunchArgument("sample.dll", true), new ExpectedLaunchArgument("--mode", true), new ExpectedLaunchArgument("worker", true)],
+            ValueToVisualize: "Contoso.PackageExecutables.SampleApp sample.dll --mode worker",
+            Tooltip: "Contoso.PackageExecutables.SampleApp sample.dll --mode worker"));
+
         // Container image
         data.Add(new TestData(
                 ResourceType: "Container",

--- a/tests/Aspire.Hosting.Tests/Ats/AtsCapabilityScannerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Ats/AtsCapabilityScannerTests.cs
@@ -213,6 +213,20 @@ public class AtsCapabilityScannerTests
         Assert.NotNull(cancellationTokenType);
     }
 
+    [Fact]
+    public void ScanAssembly_PackageExecutableCapability_IsDiscovered()
+    {
+        var hostingAssembly = typeof(DistributedApplication).Assembly;
+        var result = AtsCapabilityScanner.ScanAssembly(hostingAssembly);
+
+        var capability = Assert.Single(result.Capabilities,
+            c => c.CapabilityId.EndsWith("/addPackageExecutable", StringComparison.Ordinal));
+
+        Assert.Equal("addPackageExecutable", capability.MethodName);
+        Assert.Equal("Aspire.Hosting", AtsCapabilityScanner.DerivePackage(capability.CapabilityId));
+        Assert.Equal(2, capability.Parameters.Count);
+    }
+
     #endregion
 
     #region Callback Parameter Type Resolution Tests

--- a/tests/Aspire.Hosting.Tests/PackageExecutableResourceBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/PackageExecutableResourceBuilderExtensionsTests.cs
@@ -1,0 +1,320 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.Hosting.Eventing;
+using Aspire.Hosting.Packages;
+using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Aspire.Hosting.Tests;
+
+[Trait("Partition", "2")]
+public class PackageExecutableResourceBuilderExtensionsTests
+{
+    [Fact]
+    public void AddPackageExecutableAddsResourceWithCorrectName()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var resource = builder.AddPackageExecutable("package-app", "Contoso.PackageExecutables.SampleApp");
+
+        Assert.Equal("package-app", resource.Resource.Name);
+        Assert.IsType<PackageExecutableResource>(resource.Resource);
+    }
+
+    [Fact]
+    public void AddPackageExecutableAddsPackageAnnotation()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var resource = builder.AddPackageExecutable("package-app", "Contoso.PackageExecutables.SampleApp");
+
+        var annotation = Assert.Single(resource.Resource.Annotations.OfType<PackageExecutableAnnotation>());
+        Assert.Equal("Contoso.PackageExecutables.SampleApp", annotation.PackageId);
+        Assert.Equal(KnownResourceTypes.PackageExecutable, resource.Resource.GetResourceType());
+        Assert.Equal(builder.AppHostDirectory, resource.Resource.WorkingDirectory);
+    }
+
+    [Fact]
+    public void AddPackageExecutableThrowsWhenPackageIdIsEmpty()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        Assert.Throws<ArgumentException>(() => builder.AddPackageExecutable("package-app", ""));
+    }
+
+    [Fact]
+    public void ConfigurationExtensionsMutatePackageAnnotation()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var resource = builder.AddPackageExecutable("package-app", "Contoso.PackageExecutables.SampleApp")
+            .WithPackageVersion("1.2.3")
+            .WithPackageSource("https://contoso.test/v3/index.json")
+            .WithPackageSources("https://packages1.test/v3/index.json", "https://packages2.test/v3/index.json")
+            .WithPackageExecutable("sample.dll")
+            .WithPackageIgnoreExistingFeeds()
+            .WithPackageIgnoreFailedSources()
+            .WithPackageWorkingDirectory("lib/net10.0");
+
+        var annotation = Assert.Single(resource.Resource.Annotations.OfType<PackageExecutableAnnotation>());
+        Assert.Equal("1.2.3", annotation.Version);
+        Assert.Equal("sample.dll", annotation.ExecutableName);
+        Assert.Equal("lib/net10.0", annotation.WorkingDirectory);
+        Assert.True(annotation.IgnoreExistingFeeds);
+        Assert.True(annotation.IgnoreFailedSources);
+        Assert.Equal(3, annotation.Sources.Count);
+    }
+
+    [Fact]
+    public async Task BeforeResourceStartedAppliesResolvedCommandAndArguments()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        builder.Services.AddSingleton<IPackageExecutableResolver>(new FakePackageExecutableResolver(new PackageExecutableResolutionResult
+        {
+            PackageId = "Contoso.PackageExecutables.SampleApp",
+            PackageVersion = "1.2.3",
+            PackageDirectory = Path.Combine(Path.GetTempPath(), "contoso-package"),
+            ExecutablePath = Path.Combine(Path.GetTempPath(), "contoso-package", "lib", "net10.0", "sample.dll"),
+            Command = "dotnet",
+            WorkingDirectory = Path.Combine(Path.GetTempPath(), "contoso-package", "lib", "net10.0"),
+            Arguments = ["sample.dll", "--mode", "worker"]
+        }));
+
+        var resource = builder.AddPackageExecutable("package-app", "Contoso.PackageExecutables.SampleApp")
+            .WithPackageVersion("1.2.3")
+            .WithArgs("--user-arg");
+
+        using var app = builder.Build();
+        var eventing = app.Services.GetRequiredService<IDistributedApplicationEventing>();
+
+        await eventing.PublishAsync(new BeforeResourceStartedEvent(resource.Resource, app.Services), CancellationToken.None);
+
+        var resolved = Assert.Single(resource.Resource.Annotations.OfType<ResolvedPackageExecutableAnnotation>());
+        Assert.Equal("1.2.3", resolved.PackageVersion);
+        Assert.Equal("dotnet", resource.Resource.Command);
+        Assert.Equal(resolved.WorkingDirectory, resource.Resource.WorkingDirectory);
+
+        var args = await ArgumentEvaluator.GetArgumentListAsync(resource.Resource);
+        Assert.Collection(args,
+            arg => Assert.Equal("sample.dll", arg),
+            arg => Assert.Equal("--mode", arg),
+            arg => Assert.Equal("worker", arg),
+            arg => Assert.Equal("--user-arg", arg));
+    }
+
+    [Fact]
+    public async Task AddPackageExecutableInPublishModeGeneratesContainerManifest()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        using var packageDirectory = new TempDirectory();
+
+        var libDirectory = Path.Combine(packageDirectory.Path, "lib", "net10.0");
+        Directory.CreateDirectory(libDirectory);
+        await File.WriteAllTextAsync(Path.Combine(libDirectory, "sample.dll"), string.Empty);
+        await File.WriteAllTextAsync(Path.Combine(libDirectory, "sample.runtimeconfig.json"), "{}");
+
+        builder.Services.AddSingleton<IPackageExecutableResolver>(new FakePackageExecutableResolver(new PackageExecutableResolutionResult
+        {
+            PackageId = "Contoso.PackageExecutables.SampleApp",
+            PackageVersion = "1.2.3",
+            PackageDirectory = packageDirectory.Path,
+            ExecutablePath = Path.Combine(libDirectory, "sample.dll"),
+            Command = "dotnet",
+            WorkingDirectory = libDirectory,
+            Arguments = [Path.Combine(libDirectory, "sample.dll")]
+        }));
+
+        var resource = builder.AddPackageExecutable("package-app", "Contoso.PackageExecutables.SampleApp")
+            .WithPackageVersion("1.2.3")
+            .WithArgs("--user-arg");
+
+        var container = Assert.Single(builder.Resources.OfType<ContainerResource>());
+        Assert.Equal("package-app", container.Name);
+
+        using var app = builder.Build();
+
+        var manifest = await GetManifestAsync(resource.Resource, app.Services, packageDirectory.Path);
+        Assert.Equal("container.v1", manifest["type"]?.GetValue<string>());
+        Assert.Equal("dotnet", manifest["entrypoint"]?.GetValue<string>());
+
+        var args = manifest["args"]?.AsArray();
+        Assert.NotNull(args);
+        Assert.Equal("sample.dll", args![0]!.GetValue<string>());
+        Assert.Equal("--user-arg", args[1]!.GetValue<string>());
+
+        var build = manifest["build"]?.AsObject();
+        Assert.NotNull(build);
+
+        var dockerfilePath = container.Annotations.OfType<DockerfileBuildAnnotation>().Single().DockerfilePath;
+        var dockerfile = await File.ReadAllTextAsync(dockerfilePath);
+        Assert.Contains("FROM mcr.microsoft.com/dotnet/runtime:10.0", dockerfile);
+        Assert.Contains("COPY package/ /app/", dockerfile);
+        Assert.Contains("WORKDIR /app/lib/net10.0", dockerfile);
+    }
+
+    [Fact]
+    public void ResolveWorkingDirectoryRejectsRootedPath()
+    {
+        var packageDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("n"));
+        var executablePath = Path.Combine(packageDirectory, "lib", "net10.0", "sample.dll");
+
+        var exception = Assert.Throws<DistributedApplicationException>(() =>
+            PackageExecutableResolver.ResolveWorkingDirectory(packageDirectory, executablePath, Path.GetPathRoot(packageDirectory)!, "Contoso.PackageExecutables.SampleApp"));
+
+        Assert.Contains("relative to the restored package contents", exception.Message);
+    }
+
+    [Fact]
+    public void ResolveWorkingDirectoryRejectsTraversalOutsidePackage()
+    {
+        var packageDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("n"));
+        var executablePath = Path.Combine(packageDirectory, "lib", "net10.0", "sample.dll");
+
+        var exception = Assert.Throws<DistributedApplicationException>(() =>
+            PackageExecutableResolver.ResolveWorkingDirectory(packageDirectory, executablePath, "../outside", "Contoso.PackageExecutables.SampleApp"));
+
+        Assert.Contains("stays within the restored package contents", exception.Message);
+    }
+
+    [Fact]
+    public void BuildRestoreAttemptsRetriesIndividualSourcesWhenIgnoreFailedSourcesIsEnabled()
+    {
+        var sources = new[]
+        {
+            new NuGet.Configuration.PackageSource("https://packages1.test/v3/index.json"),
+            new NuGet.Configuration.PackageSource("https://packages2.test/v3/index.json")
+        };
+
+        var attempts = PackageExecutableResolver.BuildRestoreAttempts(sources, ignoreFailedSources: true);
+
+        Assert.Equal(3, attempts.Count);
+        Assert.Equal(2, attempts[0].Count);
+        Assert.Single(attempts[1]);
+        Assert.Single(attempts[2]);
+        Assert.Equal("https://packages1.test/v3/index.json", attempts[1][0].Source);
+        Assert.Equal("https://packages2.test/v3/index.json", attempts[2][0].Source);
+    }
+
+    [Fact]
+    public async Task ResolverUsesAppHostWorkingDirectoryForNuGetSettings()
+    {
+        using var appHostDirectory = new TempDirectory();
+        using var packagesDirectory = new TempDirectory();
+
+        var packageDirectory = Path.Combine(packagesDirectory.Path, "contoso.packageexecutables.sampleapp", "1.2.3");
+        var libDirectory = Path.Combine(packageDirectory, "lib", "net10.0");
+        Directory.CreateDirectory(libDirectory);
+        await File.WriteAllTextAsync(Path.Combine(libDirectory, "sample.dll"), string.Empty);
+        await File.WriteAllTextAsync(Path.Combine(libDirectory, "sample.runtimeconfig.json"), "{}");
+
+        await File.WriteAllTextAsync(Path.Combine(appHostDirectory.Path, "NuGet.Config"), $$"""
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="globalPackagesFolder" value="{{packagesDirectory.Path}}" />
+  </config>
+</configuration>
+""");
+
+        using var builder = TestDistributedApplicationBuilder.Create(options =>
+        {
+            options.ProjectDirectory = appHostDirectory.Path;
+        });
+
+        var resource = builder.AddPackageExecutable("package-app", "Contoso.PackageExecutables.SampleApp")
+            .WithPackageVersion("1.2.3")
+            .WithPackageExecutable("sample.dll");
+
+        var resolver = new PackageExecutableResolver(NullLogger<PackageExecutableResolver>.Instance);
+        var result = await resolver.ResolveAsync(resource.Resource, CancellationToken.None);
+
+        Assert.Equal(appHostDirectory.Path, resource.Resource.WorkingDirectory);
+        Assert.Equal(packageDirectory, result.PackageDirectory);
+    }
+
+    [Fact]
+    public async Task ResolverSupportsPackagesThatShipRunnableAssetsUnderToolsLayout()
+    {
+        using var appHostDirectory = new TempDirectory();
+        using var packagesDirectory = new TempDirectory();
+
+        var packageDirectory = Path.Combine(packagesDirectory.Path, "contoso.packageexecutables.toollayout", "1.2.3");
+        var toolsDirectory = Path.Combine(packageDirectory, "tools", "net10.0", "any");
+        Directory.CreateDirectory(toolsDirectory);
+        await File.WriteAllTextAsync(Path.Combine(toolsDirectory, "sample.dll"), string.Empty);
+        await File.WriteAllTextAsync(Path.Combine(toolsDirectory, "sample.runtimeconfig.json"), "{}");
+        await File.WriteAllTextAsync(Path.Combine(appHostDirectory.Path, "NuGet.Config"), $$"""
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="globalPackagesFolder" value="{{packagesDirectory.Path}}" />
+  </config>
+</configuration>
+""");
+
+        using var builder = TestDistributedApplicationBuilder.Create(options =>
+        {
+            options.ProjectDirectory = appHostDirectory.Path;
+        });
+
+        var resource = builder.AddPackageExecutable("package-app", "Contoso.PackageExecutables.ToolLayout")
+            .WithPackageVersion("1.2.3")
+            .WithPackageExecutable("sample.dll");
+
+        var resolver = new PackageExecutableResolver(NullLogger<PackageExecutableResolver>.Instance);
+        var result = await resolver.ResolveAsync(resource.Resource, CancellationToken.None);
+
+        Assert.Equal(Path.Combine(toolsDirectory, "sample.dll"), result.ExecutablePath);
+        Assert.Equal(toolsDirectory, result.WorkingDirectory);
+    }
+
+    private sealed class FakePackageExecutableResolver(PackageExecutableResolutionResult result) : IPackageExecutableResolver
+    {
+        public Task<PackageExecutableResolutionResult> ResolveAsync(PackageExecutableResource resource, CancellationToken cancellationToken)
+            => Task.FromResult(result);
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "aspire-package-executable-tests", Guid.NewGuid().ToString("n"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+
+    private static async Task<JsonNode> GetManifestAsync(IResource resource, IServiceProvider services, string manifestDirectory)
+    {
+        using var memoryStream = new MemoryStream();
+        await using var writer = new Utf8JsonWriter(memoryStream);
+
+        var executionContext = services.GetRequiredService<DistributedApplicationExecutionContext>();
+        writer.WriteStartObject();
+        var context = new Aspire.Hosting.Publishing.ManifestPublishingContext(executionContext, Path.Combine(manifestDirectory, "manifest.json"), writer);
+        await context.WriteResourceAsync(resource);
+        writer.WriteEndObject();
+        await writer.FlushAsync();
+
+        memoryStream.Position = 0;
+        var document = JsonNode.Parse(memoryStream);
+        Assert.NotNull(document);
+
+        var manifest = document[resource.Name];
+        Assert.NotNull(manifest);
+        return manifest;
+    }
+}

--- a/tests/Aspire.Hosting.Tests/PackageExecutableResourceBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/PackageExecutableResourceBuilderExtensionsTests.cs
@@ -3,7 +3,7 @@
 
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.Eventing;
-using Aspire.Hosting.Packages;
+using Aspire.Hosting.PackageManagement;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -149,11 +149,66 @@ public class PackageExecutableResourceBuilderExtensionsTests
         var build = manifest["build"]?.AsObject();
         Assert.NotNull(build);
 
-        var dockerfilePath = container.Annotations.OfType<DockerfileBuildAnnotation>().Single().DockerfilePath;
+        var dockerfileAnnotation = container.Annotations.OfType<DockerfileBuildAnnotation>().Single();
+        Assert.StartsWith(Path.Combine(builder.AppHostDirectory, "obj", "aspire-package-executables", "publish", "package-app"), dockerfileAnnotation.ContextPath);
+
+        var dockerfilePath = dockerfileAnnotation.DockerfilePath;
         var dockerfile = await File.ReadAllTextAsync(dockerfilePath);
         Assert.Contains("FROM mcr.microsoft.com/dotnet/runtime:10.0", dockerfile);
         Assert.Contains("COPY package/ /app/", dockerfile);
         Assert.Contains("WORKDIR /app/lib/net10.0", dockerfile);
+    }
+
+    [Fact]
+    public async Task AddPackageExecutableInPublishModeUsesAspNetRuntimeImageWhenRuntimeConfigRequiresIt()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        using var packageDirectory = new TempDirectory();
+
+        var toolsDirectory = Path.Combine(packageDirectory.Path, "tools", "net8.0", "any");
+        Directory.CreateDirectory(toolsDirectory);
+        await File.WriteAllTextAsync(Path.Combine(toolsDirectory, "sample.dll"), string.Empty);
+        await File.WriteAllTextAsync(Path.Combine(toolsDirectory, "sample.runtimeconfig.json"), """
+{
+    "runtimeOptions": {
+        "tfm": "net8.0",
+        "frameworks": [
+            {
+                "name": "Microsoft.NETCore.App",
+                "version": "8.0.0"
+            },
+            {
+                "name": "Microsoft.AspNetCore.App",
+                "version": "8.0.0"
+            }
+        ]
+    }
+}
+""");
+
+        builder.Services.AddSingleton<IPackageExecutableResolver>(new FakePackageExecutableResolver(new PackageExecutableResolutionResult
+        {
+            PackageId = "Contoso.PackageExecutables.SampleApp",
+            PackageVersion = "1.2.3",
+            PackageDirectory = packageDirectory.Path,
+            ExecutablePath = Path.Combine(toolsDirectory, "sample.dll"),
+            Command = "dotnet",
+            WorkingDirectory = toolsDirectory,
+            Arguments = [Path.Combine(toolsDirectory, "sample.dll")]
+        }));
+
+        var resource = builder.AddPackageExecutable("package-app", "Contoso.PackageExecutables.SampleApp")
+                .WithPackageVersion("1.2.3");
+
+        using var app = builder.Build();
+
+        _ = await GetManifestAsync(resource.Resource, app.Services, packageDirectory.Path);
+
+        var container = Assert.Single(builder.Resources.OfType<ContainerResource>());
+        var dockerfilePath = container.Annotations.OfType<DockerfileBuildAnnotation>().Single().DockerfilePath;
+        var dockerfile = await File.ReadAllTextAsync(dockerfilePath);
+
+        Assert.Contains("FROM mcr.microsoft.com/dotnet/aspnet:8.0", dockerfile);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/PackageExecutableResourceBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/PackageExecutableResourceBuilderExtensionsTests.cs
@@ -8,6 +8,7 @@ using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -150,11 +151,12 @@ public class PackageExecutableResourceBuilderExtensionsTests
         Assert.NotNull(build);
 
         var dockerfileAnnotation = container.Annotations.OfType<DockerfileBuildAnnotation>().Single();
-        Assert.StartsWith(Path.Combine(builder.AppHostDirectory, "obj", "aspire-package-executables", "publish", "package-app"), dockerfileAnnotation.ContextPath);
+        Assert.StartsWith(Path.Combine(builder.Configuration["Aspire:Store:Path"]!, ".aspire", "package-executables", "publish", "package-app"), dockerfileAnnotation.ContextPath);
 
         var dockerfilePath = dockerfileAnnotation.DockerfilePath;
         var dockerfile = await File.ReadAllTextAsync(dockerfilePath);
-        Assert.Contains("FROM mcr.microsoft.com/dotnet/runtime:10.0", dockerfile);
+        Assert.Contains("ARG BASE_IMAGE=mcr.microsoft.com/dotnet/runtime:10.0", dockerfile);
+        Assert.Contains("FROM ${BASE_IMAGE}", dockerfile);
         Assert.Contains("COPY package/ /app/", dockerfile);
         Assert.Contains("WORKDIR /app/lib/net10.0", dockerfile);
     }
@@ -208,7 +210,8 @@ public class PackageExecutableResourceBuilderExtensionsTests
         var dockerfilePath = container.Annotations.OfType<DockerfileBuildAnnotation>().Single().DockerfilePath;
         var dockerfile = await File.ReadAllTextAsync(dockerfilePath);
 
-        Assert.Contains("FROM mcr.microsoft.com/dotnet/aspnet:8.0", dockerfile);
+        Assert.Contains("ARG BASE_IMAGE=mcr.microsoft.com/dotnet/aspnet:8.0", dockerfile);
+        Assert.Contains("FROM ${BASE_IMAGE}", dockerfile);
     }
 
     [Fact]
@@ -325,6 +328,75 @@ public class PackageExecutableResourceBuilderExtensionsTests
 
         Assert.Equal(Path.Combine(toolsDirectory, "sample.dll"), result.ExecutablePath);
         Assert.Equal(toolsDirectory, result.WorkingDirectory);
+    }
+
+    [Fact]
+    public async Task ResolverPrefersNearestFrameworkAndCurrentRidWhenMultipleCandidatesExist()
+    {
+        using var appHostDirectory = new TempDirectory();
+        using var packagesDirectory = new TempDirectory();
+
+        var packageDirectory = Path.Combine(packagesDirectory.Path, "contoso.packageexecutables.multitarget", "1.2.3");
+        var currentRid = GetCurrentRuntimeIdentifier();
+        var currentRidDirectory = Path.Combine(packageDirectory, "tools", "net10.0", currentRid);
+        var anyRidDirectory = Path.Combine(packageDirectory, "tools", "net10.0", "any");
+        var olderFrameworkDirectory = Path.Combine(packageDirectory, "tools", "net8.0", "any");
+
+        Directory.CreateDirectory(currentRidDirectory);
+        Directory.CreateDirectory(anyRidDirectory);
+        Directory.CreateDirectory(olderFrameworkDirectory);
+
+        await File.WriteAllTextAsync(Path.Combine(currentRidDirectory, "sample.dll"), string.Empty);
+        await File.WriteAllTextAsync(Path.Combine(currentRidDirectory, "sample.runtimeconfig.json"), "{}");
+        await File.WriteAllTextAsync(Path.Combine(anyRidDirectory, "sample.dll"), string.Empty);
+        await File.WriteAllTextAsync(Path.Combine(anyRidDirectory, "sample.runtimeconfig.json"), "{}");
+        await File.WriteAllTextAsync(Path.Combine(olderFrameworkDirectory, "sample.dll"), string.Empty);
+        await File.WriteAllTextAsync(Path.Combine(olderFrameworkDirectory, "sample.runtimeconfig.json"), "{}");
+
+        await File.WriteAllTextAsync(Path.Combine(appHostDirectory.Path, "NuGet.Config"), $$"""
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="globalPackagesFolder" value="{{packagesDirectory.Path}}" />
+  </config>
+</configuration>
+""");
+
+        using var builder = TestDistributedApplicationBuilder.Create(options =>
+        {
+            options.ProjectDirectory = appHostDirectory.Path;
+        });
+
+        var resource = builder.AddPackageExecutable("package-app", "Contoso.PackageExecutables.MultiTarget")
+            .WithPackageVersion("1.2.3")
+            .WithPackageExecutable("sample.dll");
+
+        var resolver = new PackageExecutableResolver(NullLogger<PackageExecutableResolver>.Instance);
+        var result = await resolver.ResolveAsync(resource.Resource, CancellationToken.None);
+
+        Assert.Equal(Path.Combine(currentRidDirectory, "sample.dll"), result.ExecutablePath);
+        Assert.Equal(currentRidDirectory, result.WorkingDirectory);
+    }
+
+    private static string GetCurrentRuntimeIdentifier()
+    {
+        var os = OperatingSystem.IsWindows() ? "win"
+            : OperatingSystem.IsLinux() ? "linux"
+            : OperatingSystem.IsMacOS() ? "osx"
+            : "any";
+
+        var architecture = RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.X64 => "x64",
+            Architecture.X86 => "x86",
+            Architecture.Arm64 => "arm64",
+            Architecture.Arm => "arm",
+            _ => "any"
+        };
+
+        return os == "any" || architecture == "any"
+            ? "any"
+            : $"{os}-{architecture}";
     }
 
     private sealed class FakePackageExecutableResolver(PackageExecutableResolutionResult result) : IPackageExecutableResolver


### PR DESCRIPTION
## Description

Adds first-class package-backed executable resources to `Aspire.Hosting`.

This PR introduces `AddPackageExecutable(...)` and related configuration APIs so an AppHost can restore a runnable NuGet package at startup and execute an entry point from the restored package contents.

Summary of the change:

- adds `PackageExecutableResource` and builder extensions for package-backed executables
- supports runnable assets restored from:
  - `lib/<tfm>`
  - `tools/<tfm>/any`
- allows explicit package configuration:
  - package version
  - package sources
  - ignore existing feeds
  - ignore failed sources
  - executable selection
  - working directory override
- resolves package executables before resource start and surfaces package metadata in the dashboard
- adds publish support by converting package executable resources to container resources for managed `.dll` entry points
- adds dashboard and snapshot updates so package executables appear as their own resource type
- adds unit tests for builder behavior, resolver behavior, ATS capability discovery, publish behavior, and dashboard source rendering

Motivation and context:

`Aspire.Hosting` already has `AddExecutable(...)`, but that assumes the executable already exists on disk. This change adds a model for executables whose runnable artifact comes from a NuGet package restored by the AppHost.

This is especially useful for scenarios where an integration needs to run packaged helper or provisioning logic without requiring the package source code to be present in the solution and without requiring the user to install a separate tool manually.

This proposal is also aligned with Aspire's polyglot direction because the new capability is exposed through ATS via `[AspireExport]`, which means guest-language apphosts can model the resource while the .NET backend continues to own NuGet restore and orchestration.

Dependencies / requirements:

- building or packing the AppHost still requires the .NET SDK
- running an already-built AppHost only requires the appropriate .NET runtime and shared frameworks for the AppHost and the packaged executable
- publish support currently targets managed `.dll` entry points running on the .NET runtime image
- `DotnetTool` packages are not the target of this feature; Aspire's existing `AddDotnetTool(...)` support remains a separate model

Fixes #15255

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to `aspire.dev` issue:
      - Pending feature approval
  - [ ] No
