### PR TITLE
Handle GenAI message part deserialization errors gracefully

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -98,7 +98,8 @@
                                     {
                                         <span class="error-message-text">@itemPart.ErrorMessage</span>
                                     }
-                                    else if (TryGetDataPart(itemPart, MimeTypeHelpers.SupportedImageTypes, out var imageData))
+
+                                    if (TryGetDataPart(itemPart, MimeTypeHelpers.SupportedImageTypes, out var imageData))
                                     {
                                         <img src="@imageData.Url" />
                                     }
@@ -140,6 +141,10 @@
                                                 </FluentAccordionItem>
                                             </FluentAccordion>
                                         </div>
+                                    }
+                                    else if (itemPart.ErrorMessage == itemPart.TextVisualizerViewModel.Text)
+                                    {
+                                        // Don't display text if it is the same as error message.
                                     }
                                     else
                                     {
@@ -498,7 +503,9 @@
                                 {
                                     <div class="error-message-text">@itemPart.ErrorMessage</div>
                                 }
-                                else
+
+                                // Don't display text if it is a copy of the error message
+                                if (itemPart.ErrorMessage != itemPart.TextVisualizerViewModel.Text)
                                 {
                                     <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" HideLineNumbers="true" Virtualize="false" />
                                 }

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIItemPartViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIItemPartViewModel.cs
@@ -55,6 +55,7 @@ public sealed class GenAIItemPartViewModel
         return new GenAIItemPartViewModel
         {
             MessagePart = part,
+            ErrorMessage = part is UnexpectedErrorPart errorPart ? errorPart.Error?.Message : null,
             TextVisualizerViewModel = CreateMessagePartVisualizer(part),
             AdditionalProperties = part is GenericPart genericPart
                 ? genericPart.AdditionalProperties?.Select(p => new GenAIPartPropertyViewModel { Name = p.Key, Value = p.Value.ToString() ?? string.Empty }).ToList()

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
@@ -168,6 +168,17 @@ public class GenericPart : MessagePart
 }
 
 /// <summary>
+/// Represents a message part that failed to deserialize as its expected type.
+/// This is not part of the GenAI standard. It exists to handle unexpected errors when reading JSON,
+/// allowing the remaining data to still be displayed.
+/// </summary>
+public class UnexpectedErrorPart : GenericPart
+{
+    [JsonIgnore]
+    public Exception? Error { get; set; }
+}
+
+/// <summary>
 /// A chat message containing a role and parts.
 /// </summary>
 public class ChatMessage
@@ -198,25 +209,52 @@ internal sealed class MessagePartConverter : JsonConverter<MessagePart>
     public override MessagePart? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         using var doc = JsonDocument.ParseValue(ref reader);
-        if (!doc.RootElement.TryGetProperty("type", out var typeProp))
+        string? type = null;
+        try
         {
-            throw new JsonException("Missing 'type' property.");
-        }
+            if (!doc.RootElement.TryGetProperty("type", out var typeProp))
+            {
+                throw new JsonException("Missing 'type' property.");
+            }
 
-        var type = typeProp.GetString();
-        return type switch
+            type = typeProp.GetString();
+
+            return type switch
+            {
+                MessagePart.TextType => doc.RootElement.Deserialize<TextPart>(options),
+                MessagePart.ToolCallType => TryParseStringArguments(doc.RootElement.Deserialize<ToolCallRequestPart>(options)),
+                MessagePart.ToolCallResponseType => doc.RootElement.Deserialize<ToolCallResponsePart>(options),
+                MessagePart.BlobType => doc.RootElement.Deserialize<BlobPart>(options),
+                MessagePart.FileType => doc.RootElement.Deserialize<FilePart>(options),
+                MessagePart.UriType => doc.RootElement.Deserialize<UriPart>(options),
+                MessagePart.ReasoningType => doc.RootElement.Deserialize<ReasoningPart>(options),
+                MessagePart.ServerToolCallType => TryParseServerToolCallArguments(doc.RootElement.Deserialize<ServerToolCallPart>(options)),
+                MessagePart.ServerToolCallResponseType => doc.RootElement.Deserialize<ServerToolCallResponsePart>(options),
+                _ => doc.RootElement.Deserialize<GenericPart>(options),
+            };
+        }
+        catch (JsonException ex)
         {
-            MessagePart.TextType => doc.RootElement.Deserialize<TextPart>(options),
-            MessagePart.ToolCallType => TryParseStringArguments(doc.RootElement.Deserialize<ToolCallRequestPart>(options)),
-            MessagePart.ToolCallResponseType => doc.RootElement.Deserialize<ToolCallResponsePart>(options),
-            MessagePart.BlobType => doc.RootElement.Deserialize<BlobPart>(options),
-            MessagePart.FileType => doc.RootElement.Deserialize<FilePart>(options),
-            MessagePart.UriType => doc.RootElement.Deserialize<UriPart>(options),
-            MessagePart.ReasoningType => doc.RootElement.Deserialize<ReasoningPart>(options),
-            MessagePart.ServerToolCallType => TryParseServerToolCallArguments(doc.RootElement.Deserialize<ServerToolCallPart>(options)),
-            MessagePart.ServerToolCallResponseType => doc.RootElement.Deserialize<ServerToolCallResponsePart>(options),
-            _ => doc.RootElement.Deserialize<GenericPart>(options),
-        };
+            var wrappedEx = new InvalidOperationException($"Error reading message part '{type ?? "(missing)"}': {ex.Message}", ex);
+
+            UnexpectedErrorPart? errorPart = null;
+            try
+            {
+                errorPart = doc.RootElement.Deserialize<UnexpectedErrorPart>(options);
+            }
+            catch
+            {
+                // Ignore. We rethrow the original exception.
+            }
+
+            if (errorPart is null)
+            {
+                throw wrappedEx;
+            }
+
+            errorPart.Error = wrappedEx;
+            return errorPart;
+        }
     }
 
     public override void Write(Utf8JsonWriter writer, MessagePart value, JsonSerializerOptions options)
@@ -264,6 +302,7 @@ internal sealed class MessagePartConverter : JsonConverter<MessagePart>
 [JsonSerializable(typeof(ServerToolCallPart))]
 [JsonSerializable(typeof(ServerToolCallResponsePart))]
 [JsonSerializable(typeof(GenericPart))]
+[JsonSerializable(typeof(UnexpectedErrorPart))]
 [JsonSerializable(typeof(ChatMessage))]
 [JsonSerializable(typeof(List<ChatMessage>))]
 public sealed partial class GenAIMessagesContext : JsonSerializerContext;

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIItemPartViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIItemPartViewModelTests.cs
@@ -167,4 +167,24 @@ public sealed class GenAIItemPartViewModelTests
         Assert.Contains("こんにちは", itemPart.TextVisualizerViewModel.Text);
         Assert.DoesNotContain("\\u", itemPart.TextVisualizerViewModel.Text);
     }
+
+    [Fact]
+    public void CreateMessagePart_UnexpectedErrorPart_SetsErrorMessage()
+    {
+        var errorPart = new UnexpectedErrorPart
+        {
+            Type = "text",
+            Error = new JsonException("Test deserialization error"),
+            AdditionalProperties = new Dictionary<string, JsonElement>
+            {
+                ["content"] = JsonDocument.Parse("""{"nested":"value"}""").RootElement
+            }
+        };
+
+        var itemPart = GenAIItemPartViewModel.CreateMessagePart(errorPart);
+
+        Assert.Equal("Test deserialization error", itemPart.ErrorMessage);
+        Assert.NotNull(itemPart.AdditionalProperties);
+        Assert.Single(itemPart.AdditionalProperties);
+    }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIMessageParsingHelperTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIMessageParsingHelperTests.cs
@@ -325,6 +325,7 @@ public sealed class GenAIMessageParsingHelperTests
             {
                 var errorPart = Assert.IsType<UnexpectedErrorPart>(part);
                 Assert.NotNull(errorPart.Error);
+                Assert.Contains("Missing 'type' property", errorPart.Error.Message);
                 Assert.NotNull(errorPart.AdditionalProperties);
                 Assert.True(errorPart.AdditionalProperties.ContainsKey("content"));
             });

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIMessageParsingHelperTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIMessageParsingHelperTests.cs
@@ -322,4 +322,34 @@ public sealed class GenAIMessageParsingHelperTests
         Assert.True(truncated);
         Assert.Empty(items);
     }
+
+    [Fact]
+    public void ReadMessagePart_KnownTypeDeserializationFails_MultipleParts_FallsBackToUnexpectedErrorPart()
+    {
+        // Mix of a valid text part and an invalid one that should fall back to UnexpectedErrorPart.
+        var json = """[{"type":"text","content":"hello"},{"type":"text","content":["array","of","values"]},{"type":"text","content":"hello"}]""";
+
+        var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessagePart);
+
+        Assert.False(truncated);
+        Assert.Collection(items,
+            part =>
+            {
+                var textPart = Assert.IsType<TextPart>(part);
+                Assert.Equal("hello", textPart.Content);
+            },
+            part =>
+            {
+                var errorPart = Assert.IsType<UnexpectedErrorPart>(part);
+                Assert.Equal("text", errorPart.Type);
+                Assert.NotNull(errorPart.Error);
+                Assert.NotNull(errorPart.AdditionalProperties);
+                Assert.Equal(JsonValueKind.Array, errorPart.AdditionalProperties["content"].ValueKind);
+            },
+            part =>
+            {
+                var textPart = Assert.IsType<TextPart>(part);
+                Assert.Equal("hello", textPart.Content);
+            });
+    }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIMessageParsingHelperTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIMessageParsingHelperTests.cs
@@ -313,14 +313,21 @@ public sealed class GenAIMessageParsingHelperTests
     }
 
     [Fact]
-    public void ReadMessagePart_MissingTypeProperty_ReturnsTruncated()
+    public void ReadMessagePart_MissingTypeProperty_FallsBackToUnexpectedErrorPart()
     {
         var json = """[{"content":"no type here"}]""";
 
         var (items, truncated) = GenAIMessageParsingHelper.DeserializeArrayIncrementally(json, GenAIMessageParsingHelper.ReadMessagePart);
 
-        Assert.True(truncated);
-        Assert.Empty(items);
+        Assert.False(truncated);
+        Assert.Collection(items,
+            part =>
+            {
+                var errorPart = Assert.IsType<UnexpectedErrorPart>(part);
+                Assert.NotNull(errorPart.Error);
+                Assert.NotNull(errorPart.AdditionalProperties);
+                Assert.True(errorPart.AdditionalProperties.ContainsKey("content"));
+            });
     }
 
     [Fact]


### PR DESCRIPTION
## Description

VS Code Copilot chat currently produces non-standard JSON. This PR improves handling invalid JSON. Instead of failing everything with an error, individual messages are still displayed, but with an error message:

<img width="1386" height="983" alt="image" src="https://github.com/user-attachments/assets/f0957bbc-1c8d-4d52-9065-f9a40e2f5eed" />

---

Add graceful error handling for GenAI message part deserialization failures in the dashboard.

When a message part has a known `type` (e.g. `text`) but its content doesn't match the expected schema, the JSON converter now falls back to an `UnexpectedErrorPart` instead of throwing and truncating all remaining parts. The error message is displayed in the UI alongside the raw properties, so users can still see all available data.

### Changes

- **`UnexpectedErrorPart`**: New type extending `GenericPart` that captures the deserialization `Exception`.
- **`MessagePartConverter.Read`**: Wraps typed deserialization in a try/catch for `JsonException`, falling back to `UnexpectedErrorPart` with the raw JSON properties preserved.
- **`GenAIItemPartViewModel.CreateMessagePart`**: Populates `ErrorMessage` from `UnexpectedErrorPart.Error`.
- **`GenAIVisualizerDialog.razor`**: Renders error message and property grid together for error parts. Avoids duplicating error text in the text visualizer.
- **Tests**: Added unit tests for `UnexpectedErrorPart` creation and converter fallback behavior with mixed valid/invalid parts.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
