### PR TITLE
Refactor CLI startup: extract logging, add StartupErrorWriter, consolidate JSON parse options

### DIFF
--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -3,7 +3,6 @@
 
 using System.CommandLine;
 using System.Globalization;
-using System.Text.Json;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
@@ -93,9 +92,9 @@ internal sealed class AddCommand : BaseCommand
 
             var source = parseResult.GetValue(s_sourceOption);
 
-            // For non-.NET projects, read the channel from the local Aspire configuration if available.
-            // Unlike .NET projects which have a nuget.config, polyglot apphosts persist the channel
-            // in aspire.config.json (or the legacy settings.json during migration).
+            // For non-.NET projects, read the channel from settings.json if available.
+            // Unlike .NET projects which have a nuget.config, polyglot apphosts store
+            // the channel in .aspire/settings.json during the build process.
             string? configuredChannel = null;
             if (project.LanguageId != KnownLanguageId.CSharp)
             {
@@ -103,18 +102,8 @@ internal sealed class AddCommand : BaseCommand
                 var isProjectReferenceMode = AspireRepositoryDetector.DetectRepositoryRoot(appHostDirectory) is not null;
                 if (!isProjectReferenceMode)
                 {
-                    // TODO: Remove legacy AspireJsonConfiguration fallback once confident most users
-                    // have migrated. Tracked by https://github.com/dotnet/aspire/issues/15239
-                    try
-                    {
-                        configuredChannel = AspireConfigFile.Load(appHostDirectory)?.Channel
-                            ?? AspireJsonConfiguration.Load(appHostDirectory)?.Channel;
-                    }
-                    catch (JsonException ex)
-                    {
-                        InteractionService.DisplayError(ex.Message);
-                        return ExitCodeConstants.FailedToLoadConfiguration;
-                    }
+                    var settings = AspireJsonConfiguration.Load(appHostDirectory);
+                    configuredChannel = settings?.Channel;
                 }
             }
 

--- a/src/Aspire.Cli/Commands/AddCommand.cs
+++ b/src/Aspire.Cli/Commands/AddCommand.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using System.Globalization;
+using System.Text.Json;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
@@ -92,9 +93,9 @@ internal sealed class AddCommand : BaseCommand
 
             var source = parseResult.GetValue(s_sourceOption);
 
-            // For non-.NET projects, read the channel from settings.json if available.
-            // Unlike .NET projects which have a nuget.config, polyglot apphosts store
-            // the channel in .aspire/settings.json during the build process.
+            // For non-.NET projects, read the channel from the local Aspire configuration if available.
+            // Unlike .NET projects which have a nuget.config, polyglot apphosts persist the channel
+            // in aspire.config.json (or the legacy settings.json during migration).
             string? configuredChannel = null;
             if (project.LanguageId != KnownLanguageId.CSharp)
             {
@@ -102,8 +103,18 @@ internal sealed class AddCommand : BaseCommand
                 var isProjectReferenceMode = AspireRepositoryDetector.DetectRepositoryRoot(appHostDirectory) is not null;
                 if (!isProjectReferenceMode)
                 {
-                    var settings = AspireJsonConfiguration.Load(appHostDirectory);
-                    configuredChannel = settings?.Channel;
+                    // TODO: Remove legacy AspireJsonConfiguration fallback once confident most users
+                    // have migrated. Tracked by https://github.com/dotnet/aspire/issues/15239
+                    try
+                    {
+                        configuredChannel = AspireConfigFile.Load(appHostDirectory)?.Channel
+                            ?? AspireJsonConfiguration.Load(appHostDirectory)?.Channel;
+                    }
+                    catch (JsonException ex)
+                    {
+                        InteractionService.DisplayError(ex.Message);
+                        return ExitCodeConstants.FailedToLoadConfiguration;
+                    }
                 }
             }
 

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -9,6 +9,7 @@ using System.Text.Json.Serialization;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Configuration;
+using Aspire.Cli.Diagnostics;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
@@ -65,7 +66,7 @@ internal sealed class RunCommand : BaseCommand
     private readonly ILogger<RunCommand> _logger;
     private readonly IAppHostProjectFactory _projectFactory;
     private readonly AppHostLauncher _appHostLauncher;
-    private readonly Diagnostics.FileLoggerProvider _fileLoggerProvider;
+    private readonly FileLoggerProvider _fileLoggerProvider;
     private bool _isDetachMode;
 
     protected override bool UpdateNotificationsEnabled => !_isDetachMode;
@@ -94,7 +95,7 @@ internal sealed class RunCommand : BaseCommand
         ILogger<RunCommand> logger,
         IAppHostProjectFactory projectFactory,
         AppHostLauncher appHostLauncher,
-        Diagnostics.FileLoggerProvider fileLoggerProvider)
+        FileLoggerProvider fileLoggerProvider)
         : base("run", RunCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _runner = runner;
@@ -522,7 +523,7 @@ internal sealed class RunCommand : BaseCommand
         return longestLabelLength;
     }
 
-    private static async Task CaptureAppHostLogsAsync(Diagnostics.FileLoggerProvider fileLoggerProvider, IAppHostCliBackchannel backchannel, IInteractionService interactionService, CancellationToken cancellationToken)
+    internal static async Task CaptureAppHostLogsAsync(FileLoggerProvider fileLoggerProvider, IAppHostCliBackchannel backchannel, IInteractionService interactionService, CancellationToken cancellationToken)
     {
         try
         {
@@ -542,7 +543,7 @@ internal sealed class RunCommand : BaseCommand
                 }
 
                 // Write to the unified log file via FileLoggerProvider
-                var shortCategory = Diagnostics.FileLoggerProvider.GetShortCategoryName(entry.CategoryName);
+                var shortCategory = FileLoggerProvider.GetShortCategoryName(entry.CategoryName);
                 fileLoggerProvider.WriteLog(entry.Timestamp, entry.LogLevel, $"AppHost/{shortCategory}", entry.Message);
             }
         }

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -542,7 +542,8 @@ internal sealed class RunCommand : BaseCommand
                 }
 
                 // Write to the unified log file via FileLoggerProvider
-                fileLoggerProvider.WriteLog(entry.Timestamp, entry.LogLevel, $"AppHost/{entry.CategoryName}", entry.Message);
+                var shortCategory = Diagnostics.FileLoggerProvider.GetShortCategoryName(entry.CategoryName);
+                fileLoggerProvider.WriteLog(entry.Timestamp, entry.LogLevel, $"AppHost/{shortCategory}", entry.Message);
             }
         }
         catch (OperationCanceledException)

--- a/src/Aspire.Cli/Commands/RunCommand.cs
+++ b/src/Aspire.Cli/Commands/RunCommand.cs
@@ -542,18 +542,7 @@ internal sealed class RunCommand : BaseCommand
                 }
 
                 // Write to the unified log file via FileLoggerProvider
-                var timestamp = entry.Timestamp.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture);
-                var level = entry.LogLevel switch
-                {
-                    LogLevel.Trace => "TRCE",
-                    LogLevel.Debug => "DBUG",
-                    LogLevel.Information => "INFO",
-                    LogLevel.Warning => "WARN",
-                    LogLevel.Error => "FAIL",
-                    LogLevel.Critical => "CRIT",
-                    _ => entry.LogLevel.ToString().ToUpperInvariant()
-                };
-                fileLoggerProvider.WriteLog($"[{timestamp}] [{level}] [AppHost/{entry.CategoryName}] {entry.Message}");
+                fileLoggerProvider.WriteLog(entry.Timestamp, entry.LogLevel, $"AppHost/{entry.CategoryName}", entry.Message);
             }
         }
         catch (OperationCanceledException)

--- a/src/Aspire.Cli/Configuration/AspireConfigFile.cs
+++ b/src/Aspire.Cli/Configuration/AspireConfigFile.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Aspire.Cli.Resources;
+using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Configuration;
@@ -121,7 +122,7 @@ internal sealed class AspireConfigFile
         catch (JsonException ex)
         {
             throw new JsonException(
-                string.Format(CultureInfo.CurrentCulture, ErrorStrings.InvalidJsonInConfigFile, filePath),
+                string.Format(CultureInfo.CurrentCulture, ErrorStrings.InvalidJsonInConfigFile, filePath, ex.Message),
                 ex.Path, ex.LineNumber, ex.BytePositionInLine, ex);
         }
     }
@@ -199,11 +200,7 @@ internal sealed class AspireConfigFile
             }
 
             var json = File.ReadAllText(apphostRunPath);
-            using var doc = JsonDocument.Parse(json, new JsonDocumentOptions
-            {
-                AllowTrailingCommas = true,
-                CommentHandling = JsonCommentHandling.Skip
-            });
+            using var doc = JsonDocument.Parse(json, ConfigurationHelper.ParseOptions);
 
             if (!doc.RootElement.TryGetProperty("profiles", out var profilesElement))
             {

--- a/src/Aspire.Cli/Configuration/ConfigurationService.cs
+++ b/src/Aspire.Cli/Configuration/ConfigurationService.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.Configuration;
@@ -11,11 +10,6 @@ namespace Aspire.Cli.Configuration;
 
 internal sealed class ConfigurationService(IConfiguration configuration, CliExecutionContext executionContext, FileInfo globalSettingsFile, ILogger<ConfigurationService> logger) : IConfigurationService
 {
-    private static readonly JsonDocumentOptions s_jsonDocumentOptions = new()
-    {
-        CommentHandling = JsonCommentHandling.Skip,
-        AllowTrailingCommas = true
-    };
     public async Task SetConfigurationAsync(string key, string value, bool isGlobal = false, CancellationToken cancellationToken = default)
     {
         var settingsFilePath = GetSettingsFilePath(isGlobal);
@@ -29,7 +23,7 @@ internal sealed class ConfigurationService(IConfiguration configuration, CliExec
             // Handle empty files or whitespace-only content
             settings = string.IsNullOrWhiteSpace(existingContent)
                 ? new JsonObject()
-                : JsonNode.Parse(existingContent, nodeOptions: null, s_jsonDocumentOptions)?.AsObject() ?? new JsonObject();
+                : JsonNode.Parse(existingContent, nodeOptions: null, ConfigurationHelper.ParseOptions)?.AsObject() ?? new JsonObject();
         }
         else
         {
@@ -61,7 +55,7 @@ internal sealed class ConfigurationService(IConfiguration configuration, CliExec
                 return false;
             }
 
-            var settings = JsonNode.Parse(existingContent, nodeOptions: null, s_jsonDocumentOptions)?.AsObject();
+            var settings = JsonNode.Parse(existingContent, nodeOptions: null, ConfigurationHelper.ParseOptions)?.AsObject();
 
             if (settings is null)
             {
@@ -168,7 +162,7 @@ internal sealed class ConfigurationService(IConfiguration configuration, CliExec
                 return;
             }
 
-            var settings = JsonNode.Parse(content, nodeOptions: null, s_jsonDocumentOptions)?.AsObject();
+            var settings = JsonNode.Parse(content, nodeOptions: null, ConfigurationHelper.ParseOptions)?.AsObject();
 
             if (settings is not null)
             {

--- a/src/Aspire.Cli/Diagnostics/FileLoggerProvider.cs
+++ b/src/Aspire.Cli/Diagnostics/FileLoggerProvider.cs
@@ -175,11 +175,10 @@ internal sealed class FileLoggerProvider : ILoggerProvider
     {
         var ts = timestamp.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture);
         var lvl = GetLogLevelString(level);
-        var shortCategory = GetShortCategoryName(category);
 
         var logMessage = exception is not null
-            ? $"[{ts}] [{lvl}] [{shortCategory}] {message}{Environment.NewLine}{exception}"
-            : $"[{ts}] [{lvl}] [{shortCategory}] {message}";
+            ? $"[{ts}] [{lvl}] [{category}] {message}{Environment.NewLine}{exception}"
+            : $"[{ts}] [{lvl}] [{category}] {message}";
 
         WriteLog(logMessage);
     }
@@ -247,6 +246,7 @@ internal sealed class FileLogger(FileLoggerProvider provider, string categoryNam
             return;
         }
 
-        provider.WriteLog(DateTimeOffset.UtcNow, logLevel, categoryName, message, exception);
+        var shortCategory = FileLoggerProvider.GetShortCategoryName(categoryName);
+        provider.WriteLog(DateTimeOffset.UtcNow, logLevel, shortCategory, message, exception);
     }
 }

--- a/src/Aspire.Cli/Diagnostics/FileLoggerProvider.cs
+++ b/src/Aspire.Cli/Diagnostics/FileLoggerProvider.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Text;
 using System.Threading.Channels;
+using Aspire.Cli.Interaction;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 
@@ -50,36 +51,18 @@ internal sealed class FileLoggerProvider : ILoggerProvider
     /// </summary>
     /// <param name="logsDirectory">The directory where log files will be written.</param>
     /// <param name="timeProvider">The time provider for timestamp generation.</param>
-    /// <param name="errorConsole">Optional console for error messages. Defaults to stderr.</param>
-    public FileLoggerProvider(string logsDirectory, TimeProvider timeProvider, IAnsiConsole? errorConsole = null)
+    /// <param name="errorWriter">Error writer for startup error messages.</param>
+    public FileLoggerProvider(string logsDirectory, TimeProvider timeProvider, IStartupErrorWriter errorWriter)
+        : this(GenerateLogFilePath(logsDirectory, timeProvider), errorWriter)
     {
-        _logFilePath = GenerateLogFilePath(logsDirectory, timeProvider);
-
-        try
-        {
-            Directory.CreateDirectory(logsDirectory);
-            _writer = new StreamWriter(_logFilePath, append: false, Encoding.UTF8)
-            {
-                AutoFlush = true
-            };
-
-            _channel = CreateChannel();
-            _writerTask = Task.Run(ProcessLogQueueAsync);
-        }
-        catch (IOException ex)
-        {
-            WriteWarning(errorConsole, _logFilePath, ex.Message);
-            _writer = null;
-            _channel = null;
-        }
     }
 
     /// <summary>
-    /// Creates a new FileLoggerProvider with a specific log file path (for testing).
+    /// Creates a new FileLoggerProvider with a specific log file path.
     /// </summary>
     /// <param name="logFilePath">The full path to the log file.</param>
-    /// <param name="errorConsole">Optional console for error messages. Defaults to stderr.</param>
-    internal FileLoggerProvider(string logFilePath, IAnsiConsole? errorConsole = null)
+    /// <param name="errorWriter">Error writer for startup error messages.</param>
+    internal FileLoggerProvider(string logFilePath, IStartupErrorWriter errorWriter)
     {
         _logFilePath = logFilePath;
 
@@ -101,7 +84,7 @@ internal sealed class FileLoggerProvider : ILoggerProvider
         }
         catch (IOException ex)
         {
-            WriteWarning(errorConsole, logFilePath, ex.Message);
+            WriteWarning(errorWriter, logFilePath, ex.Message);
             _writer = null;
             _channel = null;
         }
@@ -115,14 +98,9 @@ internal sealed class FileLoggerProvider : ILoggerProvider
             SingleWriter = false
         });
 
-    private static void WriteWarning(IAnsiConsole? console, string path, string message)
+    private static void WriteWarning(IStartupErrorWriter errorWriter, string path, string message)
     {
-        // Use provided console or create a minimal one for stderr
-        var errorConsole = console ?? AnsiConsole.Create(new AnsiConsoleSettings
-        {
-            Out = new AnsiConsoleOutput(Console.Error)
-        });
-        errorConsole.MarkupLine($"[yellow]⚠️ Warning:[/] Could not create log file at [blue]{path.EscapeMarkup()}[/]: {message.EscapeMarkup()}");
+        errorWriter.WriteMarkup($"Could not create log file at [blue]{path.EscapeMarkup()}[/]: {message.EscapeMarkup()}", KnownEmojis.Warning);
     }
 
     private async Task ProcessLogQueueAsync()
@@ -193,6 +171,36 @@ internal sealed class FileLoggerProvider : ILoggerProvider
         }
     }
 
+    internal void WriteLog(DateTimeOffset timestamp, LogLevel level, string category, string message, Exception? exception = null)
+    {
+        var ts = timestamp.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture);
+        var lvl = GetLogLevelString(level);
+        var shortCategory = GetShortCategoryName(category);
+
+        var logMessage = exception is not null
+            ? $"[{ts}] [{lvl}] [{shortCategory}] {message}{Environment.NewLine}{exception}"
+            : $"[{ts}] [{lvl}] [{shortCategory}] {message}";
+
+        WriteLog(logMessage);
+    }
+
+    internal static string GetLogLevelString(LogLevel logLevel) => logLevel switch
+    {
+        LogLevel.Trace => "TRCE",
+        LogLevel.Debug => "DBUG",
+        LogLevel.Information => "INFO",
+        LogLevel.Warning => "WARN",
+        LogLevel.Error => "FAIL",
+        LogLevel.Critical => "CRIT",
+        _ => logLevel.ToString().ToUpperInvariant()
+    };
+
+    internal static string GetShortCategoryName(string categoryName)
+    {
+        var lastDotIndex = categoryName.LastIndexOf('.');
+        return lastDotIndex >= 0 ? categoryName.Substring(lastDotIndex + 1) : categoryName;
+    }
+
     public void Dispose()
     {
         if (_disposed)
@@ -239,31 +247,6 @@ internal sealed class FileLogger(FileLoggerProvider provider, string categoryNam
             return;
         }
 
-        var timestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture);
-        var level = GetLogLevelString(logLevel);
-        var shortCategory = GetShortCategoryName(categoryName);
-
-        var logMessage = exception is not null
-            ? $"[{timestamp}] [{level}] [{shortCategory}] {message}{Environment.NewLine}{exception}"
-            : $"[{timestamp}] [{level}] [{shortCategory}] {message}";
-
-        provider.WriteLog(logMessage);
-    }
-
-    private static string GetLogLevelString(LogLevel logLevel) => logLevel switch
-    {
-        LogLevel.Trace => "TRCE",
-        LogLevel.Debug => "DBUG",
-        LogLevel.Information => "INFO",
-        LogLevel.Warning => "WARN",
-        LogLevel.Error => "FAIL",
-        LogLevel.Critical => "CRIT",
-        _ => logLevel.ToString().ToUpperInvariant()
-    };
-
-    private static string GetShortCategoryName(string categoryName)
-    {
-        var lastDotIndex = categoryName.LastIndexOf('.');
-        return lastDotIndex >= 0 ? categoryName.Substring(lastDotIndex + 1) : categoryName;
+        provider.WriteLog(DateTimeOffset.UtcNow, logLevel, categoryName, message, exception);
     }
 }

--- a/src/Aspire.Cli/Diagnostics/StartupErrorWriter.cs
+++ b/src/Aspire.Cli/Diagnostics/StartupErrorWriter.cs
@@ -58,7 +58,7 @@ internal sealed class StartupErrorWriter : IStartupErrorWriter
 
     public void Dispose()
     {
-        if (!_hasOutput)
+        if (!_hasOutput || !File.Exists(_logFilePath))
         {
             return;
         }

--- a/src/Aspire.Cli/Diagnostics/StartupErrorWriter.cs
+++ b/src/Aspire.Cli/Diagnostics/StartupErrorWriter.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Resources;
+using Aspire.Cli.Utils;
+using Spectre.Console;
+
+namespace Aspire.Cli.Diagnostics;
+
+/// <summary>
+/// Writes startup error messages to the console before DI services are available.
+/// On disposal, displays the log file path so the user can investigate.
+/// </summary>
+internal interface IStartupErrorWriter : IDisposable
+{
+    /// <summary>
+    /// Writes a plain text line to stderr, optionally prefixed with an emoji.
+    /// </summary>
+    void WriteLine(string message, KnownEmoji? emoji = null);
+
+    /// <summary>
+    /// Writes a Spectre Console markup string to stderr, optionally prefixed with an emoji.
+    /// </summary>
+    void WriteMarkup(string markup, KnownEmoji? emoji = null);
+}
+
+/// <summary>
+/// Default implementation that writes to an <see cref="IAnsiConsole"/> targeting stderr.
+/// </summary>
+internal sealed class StartupErrorWriter : IStartupErrorWriter
+{
+    private readonly IAnsiConsole _errorConsole;
+    private readonly string _logFilePath;
+    private bool _hasOutput;
+
+    public StartupErrorWriter(string logFilePath)
+    {
+        _logFilePath = logFilePath;
+        _errorConsole = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(Console.Error)
+        });
+    }
+
+    public void WriteLine(string message, KnownEmoji? emoji = null)
+    {
+        WriteMarkup($"[red bold]{message.EscapeMarkup()}[/]", emoji ?? KnownEmojis.CrossMark);
+    }
+
+    public void WriteMarkup(string markup, KnownEmoji? emoji = null)
+    {
+        _hasOutput = true;
+        var prefix = emoji is not null ? ConsoleHelpers.FormatEmojiPrefix(emoji.Value, _errorConsole) : string.Empty;
+        _errorConsole.MarkupLine(prefix + markup);
+    }
+
+    public void Dispose()
+    {
+        if (!_hasOutput)
+        {
+            return;
+        }
+
+        var prefix = ConsoleHelpers.FormatEmojiPrefix(KnownEmojis.PageFacingUp, _errorConsole);
+        _errorConsole.MarkupLine(prefix + string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.SeeLogsAt, _logFilePath.EscapeMarkup()));
+    }
+}

--- a/src/Aspire.Cli/ExitCodeConstants.cs
+++ b/src/Aspire.Cli/ExitCodeConstants.cs
@@ -24,5 +24,5 @@ internal static class ExitCodeConstants
     public const int FailedToExecuteResourceCommand = 16;
     public const int WaitTimeout = 17;
     public const int WaitResourceFailed = 18;
-    public const int FailedToLoadConfiguration = 19;
+    public const int FailedToStartCli = 19;
 }

--- a/src/Aspire.Cli/ExitCodeConstants.cs
+++ b/src/Aspire.Cli/ExitCodeConstants.cs
@@ -24,6 +24,6 @@ internal static class ExitCodeConstants
     public const int FailedToExecuteResourceCommand = 16;
     public const int WaitTimeout = 17;
     public const int WaitResourceFailed = 18;
-    public const int FailedToStartCli = 19;
-    public const int FailedToLoadConfiguration = 20;
+    public const int FailedToLoadConfiguration = 19;
+    public const int FailedToStartCli = 20;
 }

--- a/src/Aspire.Cli/ExitCodeConstants.cs
+++ b/src/Aspire.Cli/ExitCodeConstants.cs
@@ -25,4 +25,5 @@ internal static class ExitCodeConstants
     public const int WaitTimeout = 17;
     public const int WaitResourceFailed = 18;
     public const int FailedToStartCli = 19;
+    public const int FailedToLoadConfiguration = 20;
 }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -59,40 +59,62 @@ public class Program
     }
 
     /// <summary>
-    /// Parses logging options from command-line arguments.
-    /// Returns the console log level (if specified) and whether debug mode is enabled.
+    /// Contains all logging-related options parsed from command-line arguments.
     /// </summary>
-    private static (LogLevel? ConsoleLogLevel, bool DebugMode) ParseLoggingOptions(string[]? args)
+    /// <param name="ConsoleLogLevel">The console log level if specified via --log-level or --debug.</param>
+    /// <param name="DebugMode">Whether --debug or -d was specified.</param>
+    /// <param name="LogsDirectory">The directory where log files are stored.</param>
+    /// <param name="LogFilePath">The full path to the current session's log file.</param>
+    internal record CliLoggingOptions(LogLevel? ConsoleLogLevel, bool DebugMode, string LogsDirectory, string LogFilePath);
+
+    /// <summary>
+    /// Holds the objects created during early CLI startup, before DI is available.
+    /// </summary>
+    internal record CliStartupContext(
+        CliLoggingOptions LoggingOptions,
+        IStartupErrorWriter ErrorWriter,
+        ILoggerFactory LoggerFactory,
+        FileLoggerProvider FileLoggerProvider,
+        ILogger Logger);
+
+    /// <summary>
+    /// Parses logging options from command-line arguments.
+    /// Returns all logging configuration including log level, debug mode, and file paths.
+    /// </summary>
+    internal static CliLoggingOptions ParseLoggingOptions(string[]? args)
     {
-        if (args is null || args.Length == 0)
-        {
-            return (null, false);
-        }
-
-        // Check for --debug or -d (backward compatibility)
-        var debugMode = args.Any(a => a == "--debug" || a == "-d");
-
-        // Check for --log-level or -l
         LogLevel? logLevel = null;
-        for (var i = 0; i < args.Length; i++)
+        var debugMode = false;
+
+        if (args is not null && args.Length > 0)
         {
-            if ((args[i] == "--log-level" || args[i] == "-l") && i + 1 < args.Length)
+            // Check for --debug or -d (backward compatibility)
+            debugMode = args.Any(a => a == "--debug" || a == "-d");
+
+            // Check for --log-level or -l
+            for (var i = 0; i < args.Length; i++)
             {
-                if (Enum.TryParse<LogLevel>(args[i + 1], ignoreCase: true, out var parsedLevel))
+                if ((args[i] == "--log-level" || args[i] == "-l") && i + 1 < args.Length)
                 {
-                    logLevel = parsedLevel;
+                    if (Enum.TryParse<LogLevel>(args[i + 1], ignoreCase: true, out var parsedLevel))
+                    {
+                        logLevel = parsedLevel;
+                    }
+                    break;
                 }
-                break;
+            }
+
+            // --debug implies Debug log level if --log-level not specified
+            if (debugMode && logLevel is null)
+            {
+                logLevel = LogLevel.Debug;
             }
         }
 
-        // --debug implies Debug log level if --verbosity not specified
-        if (debugMode && logLevel is null)
-        {
-            logLevel = LogLevel.Debug;
-        }
+        var logsDirectory = Path.Combine(GetUsersAspirePath(), "logs");
+        var logFilePath = ParseLogFileOption(args) ?? FileLoggerProvider.GenerateLogFilePath(logsDirectory, TimeProvider.System);
 
-        return (logLevel, debugMode);
+        return new CliLoggingOptions(logLevel, debugMode, logsDirectory, logFilePath);
     }
 
     /// <summary>
@@ -122,7 +144,7 @@ public class Program
         return null;
     }
 
-    private static string GetGlobalSettingsPath()
+    private static string GetGlobalSettingsPath(ILogger logger)
     {
         var usersAspirePath = GetUsersAspirePath();
         var newPath = Path.Combine(usersAspirePath, Configuration.AspireConfigFile.FileName);
@@ -140,16 +162,76 @@ public class Program
                 var config = AspireConfigFile.FromLegacy(legacyConfig, profiles: null);
                 config.Save(usersAspirePath);
             }
-            catch
+            catch (Exception ex)
             {
                 // If migration fails, newPath will be created on first write.
+                logger.LogError(ex, "Failed to migrate legacy globalsettings.json to {NewPath}.", newPath);
             }
         }
 
         return newPath;
     }
 
-    internal static async Task<IHost> BuildApplicationAsync(string[] args, Dictionary<string, string?>? configurationValues = null)
+    /// <summary>
+    /// Creates and configures an <see cref="ILoggerFactory"/> for the CLI application.
+    /// Sets up OpenTelemetry logging, file logging, console logging, log-level filters,
+    /// and MCP console logging based on command-line arguments.
+    /// </summary>
+    /// <returns>A tuple containing the configured <see cref="ILoggerFactory"/> and the <see cref="FileLoggerProvider"/> used for file logging.</returns>
+    internal static (ILoggerFactory LoggerFactory, FileLoggerProvider FileLoggerProvider) CreateLoggerFactory(string[] args, CliLoggingOptions loggingOptions, IStartupErrorWriter errorWriter)
+    {
+        var consoleLogLevel = loggingOptions.ConsoleLogLevel;
+
+        var isMcpStartCommand = args?.Length >= 2 &&
+            ((args[0] == "mcp" && args[1] == "start") || (args[0] == "agent" && args[1] == "mcp"));
+
+        var extensionEndpoint = Environment.GetEnvironmentVariable(KnownConfigNames.ExtensionEndpoint);
+
+        // Create file logger provider from pre-computed path info
+        var fileLoggerProvider = new FileLoggerProvider(loggingOptions.LogFilePath, errorWriter);
+
+        var factory = LoggerFactory.Create(builder =>
+        {
+            // Always configure OpenTelemetry.
+            builder.AddOpenTelemetry(logging =>
+            {
+                logging.IncludeFormattedMessage = true;
+                logging.IncludeScopes = true;
+            });
+
+            // Always capture complete CLI session details to disk for diagnostics
+            builder.AddProvider(fileLoggerProvider);
+
+            // Configure log-level filters based on --log-level or --debug
+            if (consoleLogLevel is not null)
+            {
+                builder.AddFilter("Aspire.Cli", consoleLogLevel.Value);
+                builder.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.Warning);
+            }
+
+            // Configure console logging based on --verbosity or --debug
+            if (consoleLogLevel is not null && !isMcpStartCommand && extensionEndpoint is null)
+            {
+                // Use custom Spectre Console logger for clean debug output to stderr
+                builder.AddProvider(new SpectreConsoleLoggerProvider(Console.Error));
+            }
+
+            // For MCP start command, configure console logger to route all logs to stderr
+            // This keeps stdout clean for MCP protocol JSON-RPC messages
+            if (isMcpStartCommand)
+            {
+                builder.AddConsole(consoleLogOptions =>
+                {
+                    // Configure all logs to go to stderr
+                    consoleLogOptions.LogToStandardErrorThreshold = LogLevel.Trace;
+                });
+            }
+        });
+
+        return (factory, fileLoggerProvider);
+    }
+
+    internal static async Task<IHost> BuildApplicationAsync(string[] args, CliStartupContext startupContext, Dictionary<string, string?>? configurationValues = null)
     {
         // Check for --non-interactive flag early
         var nonInteractive = args?.Any(a => a == CommonOptionNames.NonInteractive) ?? false;
@@ -173,12 +255,12 @@ public class Program
         var builder = Host.CreateEmptyApplicationBuilder(settings);
 
         // Set up settings with appropriate paths.
-        var globalSettingsFilePath = GetGlobalSettingsPath();
+        var globalSettingsFilePath = GetGlobalSettingsPath(startupContext.Logger);
         var globalSettingsFile = new FileInfo(globalSettingsFilePath);
         var workingDirectory = new DirectoryInfo(Environment.CurrentDirectory);
         ConfigurationHelper.RegisterSettingsFiles(builder.Configuration, workingDirectory, globalSettingsFile);
 
-        await TrySetLocaleOverrideAsync(LocaleHelpers.GetLocaleOverride(builder.Configuration));
+        TrySetLocaleOverride(LocaleHelpers.GetLocaleOverride(builder.Configuration), startupContext.Logger, startupContext.ErrorWriter);
 
 #if !DEBUG
         // In release builds, limit shutdown wait time for telemetry flush to 200ms
@@ -189,12 +271,12 @@ public class Program
         });
 #endif
 
-        // Always configure OpenTelemetry.
-        builder.Logging.AddOpenTelemetry(logging =>
-        {
-            logging.IncludeFormattedMessage = true;
-            logging.IncludeScopes = true;
-        });
+        // Register the provided logger factory, replacing host defaults
+        builder.Services.AddSingleton<ILoggerFactory>(startupContext.LoggerFactory);
+        builder.Services.TryAddSingleton(typeof(ILogger<>), typeof(Logger<>));
+
+        // Register file logger provider for components that write directly to the log file
+        builder.Services.AddSingleton(startupContext.FileLoggerProvider);
 
         // Configure OpenTelemetry tracing. TelemetryManager reads configuration and creates
         // separate TracerProvider instances:
@@ -202,52 +284,10 @@ public class Program
         // - Diagnostic provider for OTLP/console exporters (exports all activities, DEBUG only)
         builder.Services.AddSingleton(new TelemetryManager(builder.Configuration, args));
 
-        // Parse logging options from args
-        var (consoleLogLevel, debugMode) = ParseLoggingOptions(args);
-        var extensionEndpoint = builder.Configuration[KnownConfigNames.ExtensionEndpoint];
-
-        // Always register FileLoggerProvider to capture logs to disk
-        // This captures complete CLI session details for diagnostics
-        var logsDirectory = Path.Combine(GetUsersAspirePath(), "logs");
-        var logFilePath = ParseLogFileOption(args);
-        var fileLoggerProvider = logFilePath is not null
-            ? new FileLoggerProvider(logFilePath)
-            : new FileLoggerProvider(logsDirectory, TimeProvider.System);
-        builder.Services.AddSingleton(fileLoggerProvider); // Register for direct access to LogFilePath
-        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider>(fileLoggerProvider));
-
-        // Configure console logging based on --verbosity or --debug
-        if (consoleLogLevel is not null && !isMcpStartCommand && extensionEndpoint is null)
-        {
-            builder.Logging.AddFilter("Aspire.Cli", consoleLogLevel.Value);
-            builder.Logging.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.Warning); // Reduce noise from hosting lifecycle
-            // Use custom Spectre Console logger for clean debug output to stderr
-            builder.Services.AddSingleton<ILoggerProvider>(sp =>
-                new SpectreConsoleLoggerProvider(sp.GetRequiredService<ConsoleEnvironment>().Error.Profile.Out.Writer));
-        }
-
-        // For MCP start command, configure console logger to route all logs to stderr
-        // This keeps stdout clean for MCP protocol JSON-RPC messages
-        if (isMcpStartCommand)
-        {
-            if (consoleLogLevel is not null)
-            {
-                builder.Logging.AddFilter("Aspire.Cli", consoleLogLevel.Value);
-                builder.Logging.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.Warning); // Reduce noise from hosting lifecycle
-            }
-
-            builder.Logging.AddConsole(consoleLogOptions =>
-            {
-                // Configure all logs to go to stderr
-                consoleLogOptions.LogToStandardErrorThreshold = LogLevel.Trace;
-            });
-        }
-
         // Shared services.
         builder.Services.AddSingleton(sp =>
         {
-            var logFilePath = sp.GetRequiredService<FileLoggerProvider>().LogFilePath;
-            return BuildCliExecutionContext(debugMode, logsDirectory, logFilePath);
+            return BuildCliExecutionContext(startupContext.LoggingOptions.DebugMode, startupContext.LoggingOptions.LogsDirectory, startupContext.LoggingOptions.LogFilePath);
         });
         builder.Services.AddSingleton(s => new ConsoleEnvironment(
             BuildAnsiConsole(s, Console.Out),
@@ -477,7 +517,7 @@ public class Program
         return new DirectoryInfo(cacheDirectoryPath);
     }
 
-    private static async Task TrySetLocaleOverrideAsync(string? localeOverride)
+    private static void TrySetLocaleOverride(string? localeOverride, ILogger logger, IStartupErrorWriter errorWriter)
     {
         if (localeOverride is not null)
         {
@@ -498,8 +538,8 @@ public class Program
                     throw new InvalidOperationException($"Unexpected result: {result}");
             }
 
-            // This writes directly to Console.Error because services aren't available yet.
-            await Console.Error.WriteLineAsync(errorMessage);
+            logger.LogError("Locale override failed: {ErrorMessage}", errorMessage);
+            errorWriter.WriteLine(errorMessage);
         }
     }
 
@@ -507,8 +547,8 @@ public class Program
     {
         var configuration = serviceProvider.GetRequiredService<IConfiguration>();
         var executionContext = serviceProvider.GetRequiredService<CliExecutionContext>();
-        var globalSettingsFile = new FileInfo(GetGlobalSettingsPath());
         var logger = serviceProvider.GetRequiredService<ILogger<ConfigurationService>>();
+        var globalSettingsFile = new FileInfo(GetGlobalSettingsPath(logger));
         return new ConfigurationService(configuration, executionContext, globalSettingsFile, logger);
     }
 
@@ -609,22 +649,30 @@ public class Program
 
         Console.OutputEncoding = Encoding.UTF8;
 
+        var loggingOptions = ParseLoggingOptions(args);
+        using var errorWriter = new StartupErrorWriter(loggingOptions.LogFilePath);
+        var (loggerFactory, fileLoggerProvider) = CreateLoggerFactory(args, loggingOptions, errorWriter);
+        var logger = loggerFactory.CreateLogger<Program>();
+        var startupContext = new CliStartupContext(loggingOptions, errorWriter, loggerFactory, fileLoggerProvider, logger);
+
+        logger.LogInformation("Version: {Version}", AspireCliTelemetry.GetCliVersion());
+        logger.LogInformation("Build ID: {BuildId}", AspireCliTelemetry.GetCliBuildId());
+        logger.LogInformation("Working directory: {WorkingDirectory}", Environment.CurrentDirectory);
+
         IHost app;
         try
         {
-            app = await BuildApplicationAsync(args);
+            app = await BuildApplicationAsync(args, startupContext);
+            await app.StartAsync().ConfigureAwait(false);
         }
-        catch (JsonException ex)
+        catch (Exception ex)
         {
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.Error.WriteLine(ex.Message);
-            Console.ResetColor();
-            return ExitCodeConstants.FailedToLoadConfiguration;
+            logger.LogError(ex, "Failed to load configuration or start CLI.");
+            errorWriter.WriteLine(ex.Message);
+            return ExitCodeConstants.FailedToStartCli;
         }
 
         using var _ = app;
-
-        await app.StartAsync().ConfigureAwait(false);
 
         // Display first run experience if this is the first time the CLI is run on this machine
         await DisplayFirstTimeUseNoticeIfNeededAsync(app.Services, args, cts.Token);
@@ -638,7 +686,6 @@ public class Program
 
         var telemetry = app.Services.GetRequiredService<AspireCliTelemetry>();
         var telemetryManager = app.Services.GetRequiredService<TelemetryManager>();
-        var logger = app.Services.GetRequiredService<ILogger<Program>>();
 
         using var mainActivity = telemetry.StartReportedActivity(name: TelemetryConstants.Activities.Main, kind: ActivityKind.Internal);
 
@@ -650,19 +697,11 @@ public class Program
             mainActivity.AddTag(TelemetryConstants.Tags.ProcessExecutableName, "aspire");
         }
 
-        // Create a dedicated logger for CLI session info
-        var cliLogger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger<Program>();
-
         try
         {
-            cliLogger.LogInformation("Version: {Version}", AspireCliTelemetry.GetCliVersion());
-            cliLogger.LogInformation("Build ID: {BuildId}", AspireCliTelemetry.GetCliBuildId());
-
             // Log command invocation details for debugging
             var commandLine = args.Length > 0 ? $"aspire {string.Join(" ", args)}" : "aspire";
-            var workingDir = Environment.CurrentDirectory;
-            cliLogger.LogInformation("Command: {CommandLine}", commandLine);
-            cliLogger.LogInformation("Working directory: {WorkingDirectory}", workingDir);
+            logger.LogInformation("Command: {CommandLine}", commandLine);
 
             logger.LogDebug("Parsing arguments: {Args}", string.Join(" ", args));
             var parseResult = rootCommand.Parse(args);
@@ -675,7 +714,7 @@ public class Program
             var exitCode = await parseResult.InvokeAsync(invokeConfig, cts.Token);
 
             // Log exit code for debugging
-            cliLogger.LogInformation("Exit code: {ExitCode}", exitCode);
+            logger.LogInformation("Exit code: {ExitCode}", exitCode);
 
             mainActivity?.SetTag(TelemetryConstants.Tags.ProcessExitCode, exitCode);
             mainActivity?.Stop();
@@ -697,12 +736,11 @@ public class Program
 
                 telemetry.RecordError("An unexpected error occurred.", ex);
 
-                var interactionService = app.Services.GetRequiredService<IInteractionService>();
-                interactionService.DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message));
+                errorWriter.WriteLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message));
             }
 
             // Log exit code for debugging
-            cliLogger.LogError("Exit code: {ExitCode} (exception)", unknownErrorExitCode);
+            logger.LogError("Exit code: {ExitCode} (exception)", unknownErrorExitCode);
 
             mainActivity?.SetTag(TelemetryConstants.Tags.ProcessExitCode, unknownErrorExitCode);
             mainActivity?.Stop();

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -69,13 +69,22 @@ public class Program
 
     /// <summary>
     /// Holds the objects created during early CLI startup, before DI is available.
+    /// Disposes the logger factory, file logger provider, and error writer.
     /// </summary>
-    internal record CliStartupContext(
+    internal sealed record CliStartupContext(
         CliLoggingOptions LoggingOptions,
         IStartupErrorWriter ErrorWriter,
         ILoggerFactory LoggerFactory,
         FileLoggerProvider FileLoggerProvider,
-        ILogger Logger);
+        ILogger Logger) : IDisposable
+    {
+        public void Dispose()
+        {
+            FileLoggerProvider.Dispose();
+            LoggerFactory.Dispose();
+            ErrorWriter.Dispose();
+        }
+    }
 
     /// <summary>
     /// Parses logging options from command-line arguments.
@@ -650,10 +659,10 @@ public class Program
         Console.OutputEncoding = Encoding.UTF8;
 
         var loggingOptions = ParseLoggingOptions(args);
-        using var errorWriter = new StartupErrorWriter(loggingOptions.LogFilePath);
+        var errorWriter = new StartupErrorWriter(loggingOptions.LogFilePath);
         var (loggerFactory, fileLoggerProvider) = CreateLoggerFactory(args, loggingOptions, errorWriter);
         var logger = loggerFactory.CreateLogger<Program>();
-        var startupContext = new CliStartupContext(loggingOptions, errorWriter, loggerFactory, fileLoggerProvider, logger);
+        using var startupContext = new CliStartupContext(loggingOptions, errorWriter, loggerFactory, fileLoggerProvider, logger);
 
         logger.LogInformation("Version: {Version}", AspireCliTelemetry.GetCliVersion());
         logger.LogInformation("Build ID: {BuildId}", AspireCliTelemetry.GetCliBuildId());

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -672,7 +672,6 @@ public class Program
         try
         {
             app = await BuildApplicationAsync(args, startupContext);
-            await app.StartAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -682,6 +681,8 @@ public class Program
         }
 
         using var _ = app;
+
+        await app.StartAsync().ConfigureAwait(false);
 
         // Display first run experience if this is the first time the CLI is run on this machine
         await DisplayFirstTimeUseNoticeIfNeededAsync(app.Services, args, cts.Token);

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -668,21 +668,23 @@ public class Program
         logger.LogInformation("Build ID: {BuildId}", AspireCliTelemetry.GetCliBuildId());
         logger.LogInformation("Working directory: {WorkingDirectory}", Environment.CurrentDirectory);
 
-        IHost app;
+        IHost? app = null;
         try
         {
             app = await BuildApplicationAsync(args, startupContext);
+            await app.StartAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {
+            app?.Dispose();
+
             logger.LogError(ex, "Failed to load configuration or start CLI.");
             errorWriter.WriteLine(ex.Message);
             return ExitCodeConstants.FailedToStartCli;
         }
 
+        // Ensure dispose of app when Main exits.
         using var _ = app;
-
-        await app.StartAsync().ConfigureAwait(false);
 
         // Display first run experience if this is the first time the CLI is run on this machine
         await DisplayFirstTimeUseNoticeIfNeededAsync(app.Services, args, cts.Token);

--- a/src/Aspire.Cli/Resources/ErrorStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/ErrorStrings.Designer.cs
@@ -338,7 +338,7 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again..
+        ///   Looks up a localized string similar to The configuration file '{0}' contains invalid JSON: {1}.
         /// </summary>
         public static string InvalidJsonInConfigFile {
             get {

--- a/src/Aspire.Cli/Resources/ErrorStrings.resx
+++ b/src/Aspire.Cli/Resources/ErrorStrings.resx
@@ -230,7 +230,7 @@
     <value>Project is not supported in the current environment: {0}</value>
   </data>
   <data name="InvalidJsonInConfigFile" xml:space="preserve">
-    <value>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</value>
-    <comment>{0} is the file path</comment>
+    <value>The configuration file '{0}' contains invalid JSON: {1}</value>
+    <comment>{0} is the file path, {1} is the exception message</comment>
   </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
@@ -108,9 +108,9 @@
         <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="InvalidJsonInConfigFile">
-        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
-        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
-        <note>{0} is the file path</note>
+        <source>The configuration file '{0}' contains invalid JSON: {1}</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON: {1}</target>
+        <note>{0} is the file path, {1} is the exception message</note>
       </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
@@ -108,9 +108,9 @@
         <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="InvalidJsonInConfigFile">
-        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
-        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
-        <note>{0} is the file path</note>
+        <source>The configuration file '{0}' contains invalid JSON: {1}</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON: {1}</target>
+        <note>{0} is the file path, {1} is the exception message</note>
       </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
@@ -108,9 +108,9 @@
         <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="InvalidJsonInConfigFile">
-        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
-        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
-        <note>{0} is the file path</note>
+        <source>The configuration file '{0}' contains invalid JSON: {1}</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON: {1}</target>
+        <note>{0} is the file path, {1} is the exception message</note>
       </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
@@ -108,9 +108,9 @@
         <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="InvalidJsonInConfigFile">
-        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
-        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
-        <note>{0} is the file path</note>
+        <source>The configuration file '{0}' contains invalid JSON: {1}</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON: {1}</target>
+        <note>{0} is the file path, {1} is the exception message</note>
       </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
@@ -108,9 +108,9 @@
         <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="InvalidJsonInConfigFile">
-        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
-        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
-        <note>{0} is the file path</note>
+        <source>The configuration file '{0}' contains invalid JSON: {1}</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON: {1}</target>
+        <note>{0} is the file path, {1} is the exception message</note>
       </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
@@ -108,9 +108,9 @@
         <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="InvalidJsonInConfigFile">
-        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
-        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
-        <note>{0} is the file path</note>
+        <source>The configuration file '{0}' contains invalid JSON: {1}</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON: {1}</target>
+        <note>{0} is the file path, {1} is the exception message</note>
       </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
@@ -108,9 +108,9 @@
         <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="InvalidJsonInConfigFile">
-        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
-        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
-        <note>{0} is the file path</note>
+        <source>The configuration file '{0}' contains invalid JSON: {1}</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON: {1}</target>
+        <note>{0} is the file path, {1} is the exception message</note>
       </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
@@ -108,9 +108,9 @@
         <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="InvalidJsonInConfigFile">
-        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
-        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
-        <note>{0} is the file path</note>
+        <source>The configuration file '{0}' contains invalid JSON: {1}</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON: {1}</target>
+        <note>{0} is the file path, {1} is the exception message</note>
       </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
@@ -108,9 +108,9 @@
         <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="InvalidJsonInConfigFile">
-        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
-        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
-        <note>{0} is the file path</note>
+        <source>The configuration file '{0}' contains invalid JSON: {1}</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON: {1}</target>
+        <note>{0} is the file path, {1} is the exception message</note>
       </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
@@ -108,9 +108,9 @@
         <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="InvalidJsonInConfigFile">
-        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
-        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
-        <note>{0} is the file path</note>
+        <source>The configuration file '{0}' contains invalid JSON: {1}</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON: {1}</target>
+        <note>{0} is the file path, {1} is the exception message</note>
       </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
@@ -108,9 +108,9 @@
         <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="InvalidJsonInConfigFile">
-        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
-        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
-        <note>{0} is the file path</note>
+        <source>The configuration file '{0}' contains invalid JSON: {1}</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON: {1}</target>
+        <note>{0} is the file path, {1} is the exception message</note>
       </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
@@ -108,9 +108,9 @@
         <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="InvalidJsonInConfigFile">
-        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
-        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
-        <note>{0} is the file path</note>
+        <source>The configuration file '{0}' contains invalid JSON: {1}</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON: {1}</target>
+        <note>{0} is the file path, {1} is the exception message</note>
       </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
@@ -108,9 +108,9 @@
         <note>{0} is a number</note>
       </trans-unit>
       <trans-unit id="InvalidJsonInConfigFile">
-        <source>The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</source>
-        <target state="new">The configuration file '{0}' contains invalid JSON. Please fix the syntax error and try again.</target>
-        <note>{0} is the file path</note>
+        <source>The configuration file '{0}' contains invalid JSON: {1}</source>
+        <target state="new">The configuration file '{0}' contains invalid JSON: {1}</target>
+        <note>{0} is the file path, {1} is the exception message</note>
       </trans-unit>
       <trans-unit id="InvalidLocaleProvided">
         <source>Invalid locale {0} provided will not be used.</source>

--- a/src/Aspire.Cli/Utils/ConfigurationHelper.cs
+++ b/src/Aspire.Cli/Utils/ConfigurationHelper.cs
@@ -12,6 +12,15 @@ namespace Aspire.Cli.Utils;
 
 internal static class ConfigurationHelper
 {
+    /// <summary>
+    /// Standard options for parsing JSON that may contain non-spec features like comments and trailing commas.
+    /// </summary>
+    public static readonly JsonDocumentOptions ParseOptions = new()
+    {
+        CommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true
+    };
+
     internal static void RegisterSettingsFiles(IConfigurationBuilder configuration, DirectoryInfo workingDirectory, FileInfo globalSettingsFile)
     {
         var currentDirectory = workingDirectory;
@@ -104,11 +113,7 @@ internal static class ConfigurationHelper
         try
         {
             var content = File.ReadAllText(filePath);
-            var node = JsonNode.Parse(content, documentOptions: new JsonDocumentOptions
-            {
-                CommentHandling = JsonCommentHandling.Skip,
-                AllowTrailingCommas = true
-            });
+            var node = JsonNode.Parse(content, documentOptions: ParseOptions);
             if (node is not null)
             {
                 var cleanJson = node.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
@@ -119,9 +124,9 @@ internal static class ConfigurationHelper
         }
         catch (JsonException ex)
         {
-            throw new JsonException(
-                string.Format(CultureInfo.CurrentCulture, ErrorStrings.InvalidJsonInConfigFile, filePath),
-                ex.Path, ex.LineNumber, ex.BytePositionInLine, ex);
+            throw new InvalidOperationException(
+                string.Format(CultureInfo.CurrentCulture, ErrorStrings.InvalidJsonInConfigFile, filePath, ex.Message),
+                ex);
         }
 
         configuration.AddJsonFile(filePath, optional: true);
@@ -141,11 +146,7 @@ internal static class ConfigurationHelper
                 return false;
             }
 
-            var settings = JsonNode.Parse(content, documentOptions: new JsonDocumentOptions
-            {
-                CommentHandling = JsonCommentHandling.Skip,
-                AllowTrailingCommas = true
-            })?.AsObject();
+            var settings = JsonNode.Parse(content, documentOptions: ParseOptions)?.AsObject();
 
             if (settings is null)
             {

--- a/src/Aspire.Cli/Utils/OutputCollector.cs
+++ b/src/Aspire.Cli/Utils/OutputCollector.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Diagnostics;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Utils;
 
@@ -35,7 +36,7 @@ internal sealed class OutputCollector
         lock (_lock)
         {
             _lines.Add(("stdout", line));
-            _fileLogger?.WriteLog(FormatLogLine("stdout", line));
+            _fileLogger?.WriteLog(DateTimeOffset.UtcNow, LogLevel.Information, _category, line);
         }
     }
 
@@ -44,7 +45,7 @@ internal sealed class OutputCollector
         lock (_lock)
         {
             _lines.Add(("stderr", line));
-            _fileLogger?.WriteLog(FormatLogLine("stderr", line));
+            _fileLogger?.WriteLog(DateTimeOffset.UtcNow, LogLevel.Error, _category, line);
         }
     }
 
@@ -54,12 +55,5 @@ internal sealed class OutputCollector
         {
             return _lines.ToArray();
         }
-    }
-
-    private string FormatLogLine(string stream, string line)
-    {
-        var timestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff", System.Globalization.CultureInfo.InvariantCulture);
-        var level = stream == "stderr" ? "FAIL" : "INFO";
-        return $"[{timestamp}] [{level}] [{_category}] {line}";
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Configuration;
+using Aspire.Cli.Diagnostics;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
@@ -1494,6 +1495,68 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
         public bool IsFeatureEnabled(string featureName, bool defaultValue = false)
         {
             return _features.TryGetValue(featureName, out var value) ? value : defaultValue;
+        }
+    }
+
+    [Fact]
+    public async Task CaptureAppHostLogsAsync_WritesCategoryWithAppHostPrefix()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var logFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "test.log");
+        var errorWriter = new TestStartupErrorWriter();
+        using var fileLoggerProvider = new FileLoggerProvider(logFilePath, errorWriter);
+
+        var entries = new BackchannelLogEntry[]
+        {
+            new()
+            {
+                Timestamp = new DateTimeOffset(2026, 3, 16, 12, 0, 0, TimeSpan.Zero),
+                LogLevel = LogLevel.Information,
+                Message = "Application started",
+                EventId = new EventId(),
+                CategoryName = "Microsoft.Hosting.Lifetime"
+            },
+            new()
+            {
+                Timestamp = new DateTimeOffset(2026, 3, 16, 12, 0, 1, TimeSpan.Zero),
+                LogLevel = LogLevel.Warning,
+                Message = "Slow response",
+                EventId = new EventId(),
+                CategoryName = "Microsoft.AspNetCore.Server.Kestrel"
+            },
+            new()
+            {
+                Timestamp = new DateTimeOffset(2026, 3, 16, 12, 0, 2, TimeSpan.Zero),
+                LogLevel = LogLevel.Error,
+                Message = "Connection refused",
+                EventId = new EventId(),
+                CategoryName = "SimpleCategory"
+            },
+        };
+
+        var backchannel = new TestAppHostBackchannel();
+        backchannel.GetAppHostLogEntriesAsyncCallback = YieldEntries;
+        var interactionService = new TestInteractionService();
+
+        await RunCommand.CaptureAppHostLogsAsync(fileLoggerProvider, backchannel, interactionService, CancellationToken.None);
+
+        fileLoggerProvider.Dispose();
+
+        var lines = await File.ReadAllLinesAsync(logFilePath);
+        var nonEmptyLines = lines.Where(l => !string.IsNullOrWhiteSpace(l)).ToArray();
+
+        Assert.Collection(nonEmptyLines,
+            line => Assert.Equal("[2026-03-16 12:00:00.000] [INFO] [AppHost/Lifetime] Application started", line),
+            line => Assert.Equal("[2026-03-16 12:00:01.000] [WARN] [AppHost/Kestrel] Slow response", line),
+            line => Assert.Equal("[2026-03-16 12:00:02.000] [FAIL] [AppHost/SimpleCategory] Connection refused", line));
+
+        async IAsyncEnumerable<BackchannelLogEntry> YieldEntries([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            foreach (var entry in entries)
+            {
+                yield return entry;
+            }
+            await Task.CompletedTask;
         }
     }
 

--- a/tests/Aspire.Cli.Tests/Configuration/ConfigurationHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Configuration/ConfigurationHelperTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Json;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
@@ -58,75 +57,6 @@ public class ConfigurationHelperTests(ITestOutputHelper outputHelper)
 
         Assert.Equal("MyApp.csproj", config["appHost:path"]);
         Assert.Equal("stable", config["channel"]);
-    }
-
-    [Fact]
-    public void RegisterSettingsFiles_HandlesTrailingCommas()
-    {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-
-        var config = BuildConfigurationFromSettingsFile(workspace, """
-            {
-              "appHost": { "path": "MyApp.csproj", },
-              "channel": "stable",
-            }
-            """);
-
-        Assert.Equal("MyApp.csproj", config["appHost:path"]);
-    }
-
-    [Fact]
-    public void RegisterSettingsFiles_HandlesBlockComments()
-    {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-
-        var config = BuildConfigurationFromSettingsFile(workspace, """
-            {
-              /* Block comment */
-              "channel": "daily"
-            }
-            """);
-
-        Assert.Equal("daily", config["channel"]);
-    }
-
-    [Fact]
-    public void RegisterSettingsFiles_ThrowsJsonException_ForInvalidJson()
-    {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-
-        var settingsPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
-        File.WriteAllText(settingsPath, "{ invalid json }");
-
-        var globalDir = workspace.CreateDirectory("global-aspire");
-        var globalSettingsFile = new FileInfo(Path.Combine(globalDir.FullName, AspireConfigFile.FileName));
-
-        var builder = new ConfigurationBuilder();
-
-        var ex = Assert.Throws<JsonException>(
-            () => ConfigurationHelper.RegisterSettingsFiles(builder, workspace.WorkspaceRoot, globalSettingsFile));
-
-        Assert.Contains(settingsPath, ex.Message);
-        Assert.Contains("invalid JSON", ex.Message);
-    }
-
-    [Fact]
-    public void RegisterSettingsFiles_ThrowsJsonException_ForTruncatedJson()
-    {
-        using var workspace = TemporaryWorkspace.Create(outputHelper);
-
-        var settingsPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
-        File.WriteAllText(settingsPath, """{ "appHost": { "path": """);
-
-        var globalDir = workspace.CreateDirectory("global-aspire");
-        var globalSettingsFile = new FileInfo(Path.Combine(globalDir.FullName, AspireConfigFile.FileName));
-
-        var builder = new ConfigurationBuilder();
-
-        var ex = Assert.Throws<JsonException>(
-            () => ConfigurationHelper.RegisterSettingsFiles(builder, workspace.WorkspaceRoot, globalSettingsFile));
-
-        Assert.Contains(settingsPath, ex.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Configuration/ConfigurationHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Configuration/ConfigurationHelperTests.cs
@@ -60,6 +60,36 @@ public class ConfigurationHelperTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void RegisterSettingsFiles_HandlesTrailingCommas()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var config = BuildConfigurationFromSettingsFile(workspace, """
+            {
+              "appHost": { "path": "MyApp.csproj", },
+              "channel": "stable",
+            }
+            """);
+
+        Assert.Equal("MyApp.csproj", config["appHost:path"]);
+    }
+
+    [Fact]
+    public void RegisterSettingsFiles_HandlesBlockComments()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var config = BuildConfigurationFromSettingsFile(workspace, """
+            {
+              /* Block comment */
+              "channel": "daily"
+            }
+            """);
+
+        Assert.Equal("daily", config["channel"]);
+    }
+
+    [Fact]
     public void RegisterSettingsFiles_HandlesCommentsAndTrailingCommas()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Cli.Tests/Telemetry/TelemetryConfigurationTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/TelemetryConfigurationTests.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Telemetry;
+using Aspire.Cli.Tests.TestServices;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 #if DEBUG
 using Microsoft.AspNetCore.InternalTesting;
 #endif
@@ -12,14 +15,21 @@ namespace Aspire.Cli.Tests.Telemetry;
 
 public class TelemetryConfigurationTests
 {
+    private static async Task<IHost> BuildHostAsync(Dictionary<string, string?>? config = null)
+    {
+        var loggingOptions = Program.ParseLoggingOptions([]);
+        var errorWriter = new TestStartupErrorWriter();
+        var (loggerFactory, fileLoggerProvider) = Program.CreateLoggerFactory([], loggingOptions, errorWriter);
+        var startupContext = new Program.CliStartupContext(loggingOptions, errorWriter, loggerFactory, fileLoggerProvider, loggerFactory.CreateLogger<Program>());
+        return await Program.BuildApplicationAsync([], startupContext, config);
+    }
+
     [Fact]
     public async Task AzureMonitor_Enabled_ByDefault()
     {
         // The Application Insights connection string is now hardcoded, so Azure Monitor
         // should be enabled by default when telemetry is not opted out
-        var config = new Dictionary<string, string?>();
-
-        using var host = await Program.BuildApplicationAsync([], config);
+        using var host = await BuildHostAsync();
 
         var telemetryManager = host.Services.GetService<TelemetryManager>();
         Assert.NotNull(telemetryManager);
@@ -36,7 +46,7 @@ public class TelemetryConfigurationTests
             [AspireCliTelemetry.TelemetryOptOutConfigKey] = optOutValue
         };
 
-        using var host = await Program.BuildApplicationAsync([], config);
+        using var host = await BuildHostAsync(config);
 
         var telemetryManager = host.Services.GetRequiredService<TelemetryManager>();
         // When telemetry is opted out, Azure Monitor should not be enabled
@@ -51,7 +61,7 @@ public class TelemetryConfigurationTests
             [AspireCliTelemetry.OtlpExporterEndpointConfigKey] = "http://localhost:4317"
         };
 
-        using var host = await Program.BuildApplicationAsync([], config);
+        using var host = await BuildHostAsync(config);
 
         var telemetryManager = host.Services.GetRequiredService<TelemetryManager>();
 
@@ -75,7 +85,7 @@ public class TelemetryConfigurationTests
             [AspireCliTelemetry.ConsoleExporterLevelConfigKey] = "Diagnostic"
         };
 
-        using var host = await Program.BuildApplicationAsync([], config);
+        using var host = await BuildHostAsync(config);
 
         var telemetryManager = host.Services.GetRequiredService<TelemetryManager>();
         Assert.True(telemetryManager.HasDiagnosticProvider);

--- a/tests/Aspire.Cli.Tests/TestServices/TestStartupErrorWriter.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestStartupErrorWriter.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Diagnostics;
+using Aspire.Cli.Interaction;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+internal sealed class TestStartupErrorWriter : IStartupErrorWriter
+{
+    public List<string> Lines { get; } = [];
+    public List<string> MarkupLines { get; } = [];
+
+    public void WriteLine(string message, KnownEmoji? emoji = null) => Lines.Add(message);
+
+    public void WriteMarkup(string markup, KnownEmoji? emoji = null) => MarkupLines.Add(markup);
+
+    public void Dispose()
+    {
+        // No-op in tests — don't write log file path to output
+    }
+}

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -78,10 +78,10 @@ internal static class CliTestHelper
 
         services.AddLogging(b => b.SetMinimumLevel(LogLevel.Trace)).AddXunitLogging(outputHelper);
 
-        // Register a FileLoggerProvider that writes to a test-specific temp directory
+        // Register logging options for test
         var testLogsDirectory = Path.Combine(options.WorkingDirectory.FullName, ".aspire", "logs");
-        var fileLoggerProvider = new FileLoggerProvider(testLogsDirectory, TimeProvider.System);
-        services.AddSingleton(fileLoggerProvider);
+        var testLogFilePath = FileLoggerProvider.GenerateLogFilePath(testLogsDirectory, TimeProvider.System);
+        services.AddSingleton(new FileLoggerProvider(testLogFilePath, new TestStartupErrorWriter()));
 
         services.AddMemoryCache();
 


### PR DESCRIPTION
## Description

The CLI runs logic during host startup:

- Setting culture
- Loading configuration
- Checking CLI log file is writable

This PR adds common pattern for logging and reporting startup errors. Error logs are written to disk during startup, errors are printed to console with cross and in red. The file log path is written to console.

Also, PR removed a bunch of duplication around FileLoggingProvider and general cleanup.

<img width="1420" height="376" alt="image" src="https://github.com/user-attachments/assets/80b5ec0d-d68c-4bc9-a940-7bc8a7e8074b" />

---

Refactor CLI startup infrastructure to improve error handling before DI is available, and consolidate common patterns.

### Changes

- **Extract `CreateLoggerFactory` helper**: Moved logging registration out of `BuildApplicationAsync` into a dedicated method that returns `(ILoggerFactory, FileLoggerProvider)`.
- **Add `CliStartupContext`**: New record that bundles all objects created during early startup (`LoggingOptions`, `ErrorWriter`, `LoggerFactory`, `FileLoggerProvider`, `Logger`). `BuildApplicationAsync` now takes this single context instead of many individual parameters.
- **Add `IStartupErrorWriter` / `StartupErrorWriter`**: Pre-DI error writer that writes formatted error messages to stderr via Spectre Console. On disposal, displays the log file path only if errors were written. Replaces scattered `Console.Error.WriteLine` / `Console.ForegroundColor` calls in `Main`.
- **`FileLoggerProvider` constructor chaining**: Directory-based constructor now delegates to the path-based constructor.
- **Consolidate `JsonDocumentOptions`**: Moved duplicate `JsonDocumentOptions` (with `AllowTrailingCommas` + `CommentHandling.Skip`) into `ConfigurationHelper.ParseOptions`. Reused across `ConfigurationHelper`, `ConfigurationService`, and `AspireConfigFile`.
- **`InvalidJsonInConfigFile` resource string**: Updated to include the exception message (`{1}`) for better diagnostics.
- **Pass `ILogger` into `BuildApplicationAsync`**: `GetGlobalSettingsPath` and `TrySetLocaleOverride` now log failures and write to the startup error writer.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
