### PR TITLE
Bump VS Code extension version to 1.0.5

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Aspire",
   "description": "%extension.description%",
   "publisher": "microsoft-aspire",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
   "icon": "dotnet-aspire-logo-128.png",
   "license": "SEE LICENSE IN LICENSE.TXT",


### PR DESCRIPTION
## Description

Bump the VS Code extension version from 1.0.4 to 1.0.5 in `extension/package.json`.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
