### PR TITLE
Fix playwright-cli install --skills using wrong working directory

### DIFF
--- a/src/Aspire.Cli/Agents/Playwright/IPlaywrightCliRunner.cs
+++ b/src/Aspire.Cli/Agents/Playwright/IPlaywrightCliRunner.cs
@@ -20,7 +20,8 @@ internal interface IPlaywrightCliRunner
     /// <summary>
     /// Installs Playwright CLI skill files into the workspace.
     /// </summary>
+    /// <param name="workingDirectory">The directory in which to run the skill installation command.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>True if skill installation succeeded, false otherwise.</returns>
-    Task<bool> InstallSkillsAsync(CancellationToken cancellationToken);
+    Task<bool> InstallSkillsAsync(string workingDirectory, CancellationToken cancellationToken);
 }

--- a/src/Aspire.Cli/Agents/Playwright/PlaywrightCliInstaller.cs
+++ b/src/Aspire.Cli/Agents/Playwright/PlaywrightCliInstaller.cs
@@ -117,7 +117,7 @@ internal sealed class PlaywrightCliInstaller(
                     packageInfo.Version);
 
                 // Still install skills in case they're missing.
-                var skillsInstalled = await playwrightCliRunner.InstallSkillsAsync(cancellationToken);
+                var skillsInstalled = await playwrightCliRunner.InstallSkillsAsync(context.RepositoryRoot.FullName, cancellationToken);
                 if (skillsInstalled)
                 {
                     MirrorSkillFiles(context);
@@ -219,7 +219,7 @@ internal sealed class PlaywrightCliInstaller(
 
             // Step 7: Generate skill files.
             logger.LogDebug("Generating Playwright CLI skill files");
-            var skillsResult = await playwrightCliRunner.InstallSkillsAsync(cancellationToken);
+            var skillsResult = await playwrightCliRunner.InstallSkillsAsync(context.RepositoryRoot.FullName, cancellationToken);
             if (skillsResult)
             {
                 MirrorSkillFiles(context);

--- a/src/Aspire.Cli/Agents/Playwright/PlaywrightCliRunner.cs
+++ b/src/Aspire.Cli/Agents/Playwright/PlaywrightCliRunner.cs
@@ -78,7 +78,7 @@ internal sealed class PlaywrightCliRunner(ILogger<PlaywrightCliRunner> logger) :
     }
 
     /// <inheritdoc />
-    public async Task<bool> InstallSkillsAsync(CancellationToken cancellationToken)
+    public async Task<bool> InstallSkillsAsync(string workingDirectory, CancellationToken cancellationToken)
     {
         var executablePath = PathLookupHelper.FindFullPathFromPath("playwright-cli");
         if (executablePath is null)
@@ -94,7 +94,8 @@ internal sealed class PlaywrightCliRunner(ILogger<PlaywrightCliRunner> logger) :
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
-                CreateNoWindow = true
+                CreateNoWindow = true,
+                WorkingDirectory = workingDirectory
             };
 
             startInfo.ArgumentList.Add("install");

--- a/tests/Aspire.Cli.EndToEnd.Tests/PlaywrightCliInstallTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PlaywrightCliInstallTests.cs
@@ -133,7 +133,7 @@ public sealed class PlaywrightCliInstallTests(ITestOutputHelper output)
         // Crucially, do NOT cd into the project — stay in the parent directory.
         await auto.TypeAsync("mkdir -p TestProject/.claude");
         await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
+        await auto.WaitForSuccessPromptFailFastAsync(counter);
 
         // Step 3: Run aspire agent init from the PARENT directory.
         // When prompted for workspace root, provide the project subdirectory.
@@ -162,19 +162,19 @@ public sealed class PlaywrightCliInstallTests(ITestOutputHelper output)
         await auto.EnterAsync();
 
         await auto.WaitUntilTextAsync("configuration complete", timeout: TimeSpan.FromMinutes(3));
-        await auto.WaitForSuccessPromptAsync(counter);
+        await auto.WaitForSuccessPromptFailFastAsync(counter);
 
         // Step 4: Verify skill file exists in the workspace root (project subdirectory).
         await auto.TypeAsync("ls TestProject/.claude/skills/playwright-cli/SKILL.md");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("SKILL.md", timeout: TimeSpan.FromSeconds(10));
-        await auto.WaitForSuccessPromptAsync(counter);
+        await auto.WaitForSuccessPromptFailFastAsync(counter);
 
         // Step 5: Verify no stray skill files were created in the CWD (parent directory).
         await auto.TypeAsync("test -d .claude/skills/playwright-cli && echo 'STRAY_FILES_FOUND' || echo 'NO_STRAY_FILES'");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("NO_STRAY_FILES", timeout: TimeSpan.FromSeconds(10));
-        await auto.WaitForSuccessPromptAsync(counter);
+        await auto.WaitForSuccessPromptFailFastAsync(counter);
 
         await auto.TypeAsync("exit");
         await auto.EnterAsync();

--- a/tests/Aspire.Cli.EndToEnd.Tests/PlaywrightCliInstallTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PlaywrightCliInstallTests.cs
@@ -4,6 +4,7 @@
 using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Tests.Utils;
 using Hex1b.Automation;
+using Hex1b.Input;
 using Aspire.TestUtilities;
 using Xunit;
 
@@ -90,6 +91,89 @@ public sealed class PlaywrightCliInstallTests(ITestOutputHelper output)
         await auto.TypeAsync("ls .claude/skills/playwright-cli/SKILL.md");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("SKILL.md", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+    }
+
+    /// <summary>
+    /// Verifies that when <c>aspire agent init</c> is run from a different directory than the
+    /// workspace root, <c>playwright-cli install --skills</c> generates skill files in the
+    /// workspace root, not the current working directory.
+    ///
+    /// This is a regression test for https://github.com/dotnet/aspire/issues/15140 where
+    /// the missing <c>WorkingDirectory</c> on <c>ProcessStartInfo</c> caused skill files
+    /// to be dropped in the CLI process's current working directory.
+    /// </summary>
+    [Fact]
+    public async Task AgentInit_WhenCwdDiffersFromWorkspaceRoot_PlacesSkillFilesInWorkspaceRoot()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, installMode, output, workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+
+        await auto.InstallAspireCliInDockerAsync(installMode, counter);
+
+        // Step 1: Create an Aspire project.
+        await auto.AspireNewAsync("TestProject", counter);
+
+        // Step 2: Create .claude folder inside the project to trigger Claude Code detection.
+        // Crucially, do NOT cd into the project — stay in the parent directory.
+        await auto.TypeAsync("mkdir -p TestProject/.claude");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Step 3: Run aspire agent init from the PARENT directory.
+        // When prompted for workspace root, provide the project subdirectory.
+        await auto.TypeAsync("aspire agent init");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("workspace:", timeout: TimeSpan.FromSeconds(30));
+        await auto.WaitAsync(500);
+
+        // Clear the default path and type the project subdirectory instead.
+        // The default will be the git root or CWD — we need to override it.
+        await auto.Ctrl().KeyAsync(Hex1bKey.U); // Clear the line
+        await auto.TypeAsync("TestProject");
+        await auto.EnterAsync();
+
+        // Select Claude Code environment.
+        await auto.WaitUntilTextAsync("agent environments", timeout: TimeSpan.FromSeconds(60));
+        await auto.TypeAsync(" ");
+        await auto.EnterAsync();
+
+        // Select Playwright CLI installation.
+        await auto.WaitUntilTextAsync("additional options", timeout: TimeSpan.FromSeconds(30));
+        await auto.WaitUntilTextAsync("Install Playwright CLI", timeout: TimeSpan.FromSeconds(10));
+        await auto.TypeAsync(" "); // Toggle first option (Aspire skill file)
+        await auto.DownAsync();
+        await auto.TypeAsync(" "); // Toggle Playwright CLI
+        await auto.EnterAsync();
+
+        await auto.WaitUntilTextAsync("configuration complete", timeout: TimeSpan.FromMinutes(3));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Step 4: Verify skill file exists in the workspace root (project subdirectory).
+        await auto.TypeAsync("ls TestProject/.claude/skills/playwright-cli/SKILL.md");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("SKILL.md", timeout: TimeSpan.FromSeconds(10));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Step 5: Verify no stray skill files were created in the CWD (parent directory).
+        await auto.TypeAsync("test -d .claude/skills/playwright-cli && echo 'STRAY_FILES_FOUND' || echo 'NO_STRAY_FILES'");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("NO_STRAY_FILES", timeout: TimeSpan.FromSeconds(10));
         await auto.WaitForSuccessPromptAsync(counter);
 
         await auto.TypeAsync("exit");

--- a/tests/Aspire.Cli.Tests/Agents/PlaywrightCliInstallerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/PlaywrightCliInstallerTests.cs
@@ -64,6 +64,46 @@ public class PlaywrightCliInstallerTests
     }
 
     [Fact]
+    public async Task InstallAsync_PassesRepositoryRootAsWorkingDirectory()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"aspire-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var version = SemVersion.Parse("0.1.1", SemVersionStyles.Strict);
+            var npmRunner = new TestNpmRunner
+            {
+                ResolveResult = new NpmPackageInfo { Version = version, Integrity = "sha512-abc123" }
+            };
+            var playwrightRunner = new TestPlaywrightCliRunner
+            {
+                InstalledVersion = version,
+                InstallSkillsResult = true
+            };
+            var installer = new PlaywrightCliInstaller(npmRunner, new TestNpmProvenanceChecker(), playwrightRunner, new TestInteractionService(), new ConfigurationBuilder().Build(), NullLogger<PlaywrightCliInstaller>.Instance);
+
+            var context = new AgentEnvironmentScanContext
+            {
+                WorkingDirectory = new DirectoryInfo(Path.GetTempPath()),
+                RepositoryRoot = new DirectoryInfo(tempDir)
+            };
+
+            await installer.InstallAsync(context, CancellationToken.None);
+
+            Assert.True(playwrightRunner.InstallSkillsCalled);
+            Assert.Equal(tempDir, playwrightRunner.InstallSkillsWorkingDirectory);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public async Task InstallAsync_WhenNewerVersionInstalled_SkipsInstallAndInstallsSkills()
     {
         var targetVersion = SemVersion.Parse("0.1.1", SemVersionStyles.Strict);
@@ -554,13 +594,15 @@ public class PlaywrightCliInstallerTests
         public SemVersion? InstalledVersion { get; set; }
         public bool InstallSkillsResult { get; set; }
         public bool InstallSkillsCalled { get; private set; }
+        public string? InstallSkillsWorkingDirectory { get; private set; }
 
         public Task<SemVersion?> GetVersionAsync(CancellationToken cancellationToken)
             => Task.FromResult(InstalledVersion);
 
-        public Task<bool> InstallSkillsAsync(CancellationToken cancellationToken)
+        public Task<bool> InstallSkillsAsync(string workingDirectory, CancellationToken cancellationToken)
         {
             InstallSkillsCalled = true;
+            InstallSkillsWorkingDirectory = workingDirectory;
             return Task.FromResult(InstallSkillsResult);
         }
     }

--- a/tests/Aspire.Cli.Tests/TestServices/FakePlaywrightServices.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/FakePlaywrightServices.cs
@@ -46,6 +46,6 @@ internal sealed class FakePlaywrightCliRunner : IPlaywrightCliRunner
     public Task<SemVersion?> GetVersionAsync(CancellationToken cancellationToken)
         => Task.FromResult<SemVersion?>(null);
 
-    public Task<bool> InstallSkillsAsync(CancellationToken cancellationToken)
+    public Task<bool> InstallSkillsAsync(string workingDirectory, CancellationToken cancellationToken)
         => Task.FromResult(true);
 }


### PR DESCRIPTION
## Summary

Set explicit `WorkingDirectory` on `ProcessStartInfo` when running `playwright-cli install --skills` so skill files are placed in the workspace root (`context.RepositoryRoot`) instead of inheriting the CLI process's current working directory.

## Problem

When running `aspire new` followed by agent init, `PlaywrightCliRunner.InstallSkillsAsync()` did not set `WorkingDirectory` on the `ProcessStartInfo`. This caused `playwright-cli install --skills` to generate skill files relative to the CLI process's CWD (where `aspire new` was invoked) rather than the project output folder.

## Changes

- **`IPlaywrightCliRunner.cs`** — Added `string workingDirectory` parameter to `InstallSkillsAsync`
- **`PlaywrightCliRunner.cs`** — Set `startInfo.WorkingDirectory = workingDirectory` when launching the process
- **`PlaywrightCliInstaller.cs`** — Pass `context.RepositoryRoot.FullName` at both `InstallSkillsAsync` call sites
- **Unit test** — Added `InstallAsync_PassesRepositoryRootAsWorkingDirectory` to verify the working directory is threaded correctly
- **E2E test** — Added `AgentInit_WhenCwdDiffersFromWorkspaceRoot_PlacesSkillFilesInWorkspaceRoot` regression test that verifies skill files are placed in the workspace root, not in the parent CWD

Fixes #15140