### PR TITLE
Fix polyglot TypeScript transport cleanup

### DIFF
--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/base.ts
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/base.ts
@@ -1,4 +1,4 @@
-// aspire.ts - Core Aspire types: base classes, ReferenceExpression
+﻿// base.ts - Core Aspire types: base classes, ReferenceExpression
 import { Handle, AspireClient, MarshalledHandle, CancellationToken, registerCancellation, registerHandleWrapper, unregisterCancellation } from './transport.js';
 
 // Re-export transport types for convenience
@@ -165,7 +165,7 @@ export class ReferenceExpression {
         if (!this._handle || !this._client) {
             throw new Error('getValue is only available on server-returned ReferenceExpression instances');
         }
-        const cancellationTokenId = registerCancellation(cancellationToken);
+        const cancellationTokenId = registerCancellation(this._client, cancellationToken);
         try {
             const rpcArgs: Record<string, unknown> = { context: this._handle };
             if (cancellationTokenId !== undefined) rpcArgs.cancellationToken = cancellationTokenId;
@@ -392,11 +392,20 @@ export class AspireList<T> {
         }) as T[];
     }
 
-    toJSON(): MarshalledHandle { 
-        if (this._resolvedHandle) {
-            return this._resolvedHandle.toJSON();
+    async toTransportValue(): Promise<MarshalledHandle> {
+        const handle = await this._ensureHandle();
+        return handle.toJSON();
+    }
+
+    toJSON(): MarshalledHandle {
+        if (!this._resolvedHandle) {
+            throw new Error(
+                'AspireList must be resolved before it can be serialized directly. ' +
+                'Pass it to generated SDK methods instead of calling JSON.stringify directly.'
+            );
         }
-        return this._handleOrContext.toJSON(); 
+
+        return this._resolvedHandle.toJSON();
     }
 }
 
@@ -551,8 +560,19 @@ export class AspireDict<K, V> {
         }) as Record<string, V>;
     }
 
-    async toJSON(): Promise<MarshalledHandle> {
+    async toTransportValue(): Promise<MarshalledHandle> {
         const handle = await this._ensureHandle();
         return handle.toJSON();
+    }
+
+    toJSON(): MarshalledHandle {
+        if (!this._resolvedHandle) {
+            throw new Error(
+                'AspireDict must be resolved before it can be serialized directly. ' +
+                'Pass it to generated SDK methods instead of calling JSON.stringify directly.'
+            );
+        }
+
+        return this._resolvedHandle.toJSON();
     }
 }

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/transport.ts
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/transport.ts
@@ -250,7 +250,9 @@ export class CancellationToken {
             return this._remoteTokenId;
         }
 
-        return registerCancellation(client, this._signal);
+        return client
+            ? registerCancellation(client, this._signal)
+            : registerCancellation(this._signal);
     }
 }
 

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
@@ -52,6 +52,9 @@ public class AtsTypeScriptCodeGeneratorTests
 
         await Verify(files["base.ts"], extension: "ts")
             .UseFileName("base");
+
+        await Verify(files["transport.ts"], extension: "ts")
+            .UseFileName("transport");
     }
 
     [Fact]
@@ -65,6 +68,7 @@ public class AtsTypeScriptCodeGeneratorTests
         Assert.Contains("registerHandleWrapper('Aspire.Hosting/Aspire.Hosting.ApplicationModel.ReferenceExpression'", files["base.ts"]);
         Assert.Contains("condition: extractHandleForExpr(this._condition),", files["base.ts"]);
         Assert.Contains("('$handle' in json || '$expr' in json)", files["base.ts"]);
+        Assert.Contains("registerCancellation(this._client, cancellationToken)", files["base.ts"]);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/base.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/base.verified.ts
@@ -1,4 +1,4 @@
-﻿// aspire.ts - Core Aspire types: base classes, ReferenceExpression
+// base.ts - Core Aspire types: base classes, ReferenceExpression
 import { Handle, AspireClient, MarshalledHandle, CancellationToken, registerCancellation, registerHandleWrapper, unregisterCancellation } from './transport.js';
 
 // Re-export transport types for convenience
@@ -165,7 +165,7 @@ export class ReferenceExpression {
         if (!this._handle || !this._client) {
             throw new Error('getValue is only available on server-returned ReferenceExpression instances');
         }
-        const cancellationTokenId = registerCancellation(cancellationToken);
+        const cancellationTokenId = registerCancellation(this._client, cancellationToken);
         try {
             const rpcArgs: Record<string, unknown> = { context: this._handle };
             if (cancellationTokenId !== undefined) rpcArgs.cancellationToken = cancellationTokenId;
@@ -392,11 +392,20 @@ export class AspireList<T> {
         }) as T[];
     }
 
-    toJSON(): MarshalledHandle { 
-        if (this._resolvedHandle) {
-            return this._resolvedHandle.toJSON();
+    async toTransportValue(): Promise<MarshalledHandle> {
+        const handle = await this._ensureHandle();
+        return handle.toJSON();
+    }
+
+    toJSON(): MarshalledHandle {
+        if (!this._resolvedHandle) {
+            throw new Error(
+                'AspireList must be resolved before it can be serialized directly. ' +
+                'Pass it to generated SDK methods instead of calling JSON.stringify directly.'
+            );
         }
-        return this._handleOrContext.toJSON(); 
+
+        return this._resolvedHandle.toJSON();
     }
 }
 
@@ -551,8 +560,19 @@ export class AspireDict<K, V> {
         }) as Record<string, V>;
     }
 
-    async toJSON(): Promise<MarshalledHandle> {
+    async toTransportValue(): Promise<MarshalledHandle> {
         const handle = await this._ensureHandle();
         return handle.toJSON();
+    }
+
+    toJSON(): MarshalledHandle {
+        if (!this._resolvedHandle) {
+            throw new Error(
+                'AspireDict must be resolved before it can be serialized directly. ' +
+                'Pass it to generated SDK methods instead of calling JSON.stringify directly.'
+            );
+        }
+
+        return this._resolvedHandle.toJSON();
     }
 }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/transport.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/transport.verified.ts
@@ -250,7 +250,9 @@ export class CancellationToken {
             return this._remoteTokenId;
         }
 
-        return registerCancellation(client, this._signal);
+        return client
+            ? registerCancellation(client, this._signal)
+            : registerCancellation(this._signal);
     }
 }
 

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/transport.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/transport.verified.ts
@@ -1,4 +1,4 @@
-// transport.ts - ATS transport layer: RPC, Handle, errors, callbacks
+﻿// transport.ts - ATS transport layer: RPC, Handle, errors, callbacks
 import * as net from 'net';
 import * as rpc from 'vscode-jsonrpc/node.js';
 


### PR DESCRIPTION
## Description

Tightens the generated polyglot TypeScript `transport.ts` and `base.ts` templates used by AppHost SDKs.

This fixes client-scoped cancellation routing and cleanup, hardens socket connect/disconnect lifecycle handling, makes nested handle wrapping recursive, and corrects lazy list/dictionary transport serialization. It also aligns the generated `base.ts` banner comment and adds/updates TypeScript codegen snapshots.

Fixes #14898

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
