### PR TITLE
Fix ATS dump CI warnings

### DIFF
--- a/.github/workflows/polyglot-validation/test-go.sh
+++ b/.github/workflows/polyglot-validation/test-go.sh
@@ -40,7 +40,7 @@ aspire add Aspire.Hosting.Redis --non-interactive -d 2>&1 || {
 # Insert Redis code into apphost.go
 echo "Configuring apphost.go with Redis..."
 if grep -q "builder.Build()" apphost.go; then
-    sed -i '/builder.Build()/i\// Add Redis cache resource\n\tredis, err := builder.AddRedis("cache", 0, nil)\n\tif err != nil {\n\t\tlog.Fatalf("Failed to add Redis: %v", err)\n\t}\n\t_, err = redis.WithImageRegistry("netaspireci.azurecr.io")\n\tif err != nil {\n\t\tlog.Fatalf("Failed to set image registry: %v", err)\n\t}' apphost.go
+    sed -i '/builder.Build()/i\// Add Redis cache resource\n\tredisPort := 0.0\n\tredis, err := builder.AddRedis("cache", \&redisPort, nil)\n\tif err != nil {\n\t\tlog.Fatalf("Failed to add Redis: %v", err)\n\t}\n\t_, err = redis.WithImageRegistry("netaspireci.azurecr.io")\n\tif err != nil {\n\t\tlog.Fatalf("Failed to set image registry: %v", err)\n\t}' apphost.go
     echo "✅ Redis configuration added to apphost.go"
 fi
 

--- a/src/Aspire.Hosting.CodeGeneration.Go/AtsGoCodeGenerator.cs
+++ b/src/Aspire.Hosting.CodeGeneration.Go/AtsGoCodeGenerator.cs
@@ -348,13 +348,10 @@ public sealed class AtsGoCodeGenerator : ICodeGenerator
                 continue;
             }
 
-            // Only use nil checks for pointer types (types starting with *)
             var paramTypeStr = MapTypeRefToGo(parameter.Type, parameter.IsOptional);
-            var isPointerType = paramTypeStr.StartsWith("*", StringComparison.Ordinal) ||
-                               paramTypeStr == "any" ||
-                               paramTypeStr.StartsWith("func(", StringComparison.Ordinal);
+            var isNilableType = IsNilableGoType(paramTypeStr);
 
-            if (parameter.IsOptional && isPointerType)
+            if (parameter.IsOptional && isNilableType)
             {
                 WriteLine($"\tif {paramName} != nil {{");
                 WriteLine($"\t\treqArgs[\"{parameter.Name}\"] = SerializeValue({paramName})");
@@ -680,9 +677,20 @@ public sealed class AtsGoCodeGenerator : ICodeGenerator
             _ => "any"
         };
 
-        // In Go, pointers are already optional (can be nil), so we don't need to wrap
+        if (isOptional && !IsNilableGoType(baseType))
+        {
+            return $"*{baseType}";
+        }
+
         return baseType;
     }
+
+    private static bool IsNilableGoType(string typeName) =>
+        typeName.StartsWith("*", StringComparison.Ordinal) ||
+        typeName.StartsWith("[]", StringComparison.Ordinal) ||
+        typeName.StartsWith("map[", StringComparison.Ordinal) ||
+        typeName == "any" ||
+        typeName.StartsWith("func(", StringComparison.Ordinal);
 
     private string MapHandleType(string typeId) =>
         _structNames.TryGetValue(typeId, out var name) ? name : "Handle";

--- a/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
@@ -37,7 +37,7 @@ public static class ConnectionStringBuilderExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    [AspireExport("addConnectionStringExpression", MethodName = "addConnectionString", Description = "Adds a connection string with a reference expression")]
+    [AspireExport("addConnectionStringExpression", Description = "Adds a connection string with a reference expression")]
     public static IResourceBuilder<ConnectionStringResource> AddConnectionString(this IDistributedApplicationBuilder builder, [ResourceName] string name, ReferenceExpression connectionStringExpression)
     {
         var cs = new ConnectionStringResource(name, connectionStringExpression);

--- a/src/Aspire.Hosting/ContainerRegistryResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerRegistryResourceBuilderExtensions.cs
@@ -88,7 +88,7 @@ public static class ContainerRegistryResourceBuilderExtensions
     /// </code>
     /// </example>
     [Experimental("ASPIRECOMPUTE003", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-    [AspireExport("addContainerRegistryFromString", MethodName = "addContainerRegistry", Description = "Adds a container registry with string endpoint")]
+    [AspireExport("addContainerRegistryFromString", Description = "Adds a container registry with string endpoint")]
     public static IResourceBuilder<ContainerRegistryResource> AddContainerRegistry(
         this IDistributedApplicationBuilder builder,
         [ResourceName] string name,

--- a/src/Aspire.Hosting/ExternalServiceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ExternalServiceBuilderExtensions.cs
@@ -46,7 +46,7 @@ public static class ExternalServiceBuilderExtensions
     /// <param name="name">The name of the resource.</param>
     /// <param name="uri">The URI of the external service.</param>
     /// <returns>An <see cref="IResourceBuilder{ExternalServiceResource}"/> instance.</returns>
-    [AspireExport("addExternalServiceUri", MethodName = "addExternalService", Description = "Adds an external service with a URI")]
+    [AspireExport("addExternalServiceUri", Description = "Adds an external service with a URI")]
     public static IResourceBuilder<ExternalServiceResource> AddExternalService(this IDistributedApplicationBuilder builder, [ResourceName] string name, Uri uri)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -63,7 +63,7 @@ public static class ExternalServiceBuilderExtensions
     /// <param name="name">The name of the resource.</param>
     /// <param name="urlParameter">The parameter containing the URL of the external service.</param>
     /// <returns>An <see cref="IResourceBuilder{ExternalServiceResource}"/> instance.</returns>
-    [AspireExport("addExternalServiceParameter", MethodName = "addExternalService", Description = "Adds an external service with a parameter URL")]
+    [AspireExport("addExternalServiceParameter", Description = "Adds an external service with a parameter URL")]
     public static IResourceBuilder<ExternalServiceResource> AddExternalService(this IDistributedApplicationBuilder builder, [ResourceName] string name, IResourceBuilder<ParameterResource> urlParameter)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
@@ -49,7 +49,7 @@ public static class ParameterResourceBuilderExtensions
     /// <remarks>publishValueAsDefault and secret are mutually exclusive.</remarks>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters",
                                                      Justification = "third parameters are mutually exclusive.")]
-    [AspireExport("addParameterWithValue", MethodName = "addParameter", Description = "Adds a parameter with a default value")]
+    [AspireExport("addParameterWithValue", Description = "Adds a parameter with a default value")]
     public static IResourceBuilder<ParameterResource> AddParameter(this IDistributedApplicationBuilder builder, [ResourceName] string name, string value, bool publishValueAsDefault = false, bool secret = false)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/tests/Aspire.Cli.Tests/Commands/SdkDumpCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SdkDumpCommandTests.cs
@@ -5,11 +5,17 @@ using Aspire.Cli.Commands;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.DotNet.RemoteExecutor;
 
 namespace Aspire.Cli.Tests.Commands;
 
 public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
 {
+    private static readonly RemoteInvokeOptions s_remoteInvokeOptions = new()
+    {
+        StartInfo = { RedirectStandardOutput = true }
+    };
+
     [Fact]
     public async Task SdkDumpWithHelpReturnsZero()
     {
@@ -175,5 +181,86 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
 
         // "Aspire.Hosting.Redis@" is not a valid semver, so it should fail version validation
         Assert.Equal(ExitCodeConstants.InvalidCommand, exitCode);
+    }
+
+    [Fact]
+    public void SdkDumpCi_ForHostingProject_DoesNotEmitWarnings()
+    {
+        using var result = RemoteExecutor.Invoke(async (baseDirectory) =>
+        {
+            var repoRoot = FindRepoRoot(baseDirectory);
+            var projectPath = Path.Combine(repoRoot, "src", "Aspire.Hosting", "Aspire.Hosting.csproj");
+            Assert.True(File.Exists(projectPath), $"Could not find Aspire.Hosting project at '{projectPath}'.");
+
+            var outputPath = Path.Combine(Path.GetTempPath(), "aspire-sdk-dump-tests", $"{Guid.NewGuid():N}.txt");
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+
+            var previousCurrentDirectory = Environment.CurrentDirectory;
+            var previousRepoRoot = Environment.GetEnvironmentVariable("ASPIRE_REPO_ROOT");
+            var previousNoLogo = Environment.GetEnvironmentVariable(CliConfigNames.NoLogo);
+            var previousDotNetTelemetry = Environment.GetEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT");
+            var previousDotNetFirstTime = Environment.GetEnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE");
+            var previousDotNetCertificate = Environment.GetEnvironmentVariable("DOTNET_GENERATE_ASPNET_CERTIFICATE");
+
+            try
+            {
+                Environment.CurrentDirectory = repoRoot;
+                Environment.SetEnvironmentVariable("ASPIRE_REPO_ROOT", repoRoot);
+                Environment.SetEnvironmentVariable(CliConfigNames.NoLogo, "true");
+                Environment.SetEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", "true");
+                Environment.SetEnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "true");
+                Environment.SetEnvironmentVariable("DOTNET_GENERATE_ASPNET_CERTIFICATE", "false");
+
+                var exitCode = await Program.Main(["sdk", "dump", "--format", "ci", "--output", outputPath, projectPath]);
+                Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+                var output = await File.ReadAllTextAsync(outputPath);
+                var warningLines = output
+                    .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+                    .Where(line => line.Contains("warning:", StringComparison.OrdinalIgnoreCase))
+                    .ToArray();
+
+                Console.WriteLine($"Warnings: {warningLines.Length}");
+                foreach (var warningLine in warningLines)
+                {
+                    Console.WriteLine(warningLine);
+                }
+
+                Assert.Empty(warningLines);
+            }
+            finally
+            {
+                Environment.CurrentDirectory = previousCurrentDirectory;
+                Environment.SetEnvironmentVariable("ASPIRE_REPO_ROOT", previousRepoRoot);
+                Environment.SetEnvironmentVariable(CliConfigNames.NoLogo, previousNoLogo);
+                Environment.SetEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", previousDotNetTelemetry);
+                Environment.SetEnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", previousDotNetFirstTime);
+                Environment.SetEnvironmentVariable("DOTNET_GENERATE_ASPNET_CERTIFICATE", previousDotNetCertificate);
+
+                if (File.Exists(outputPath))
+                {
+                    File.Delete(outputPath);
+                }
+            }
+        }, AppContext.BaseDirectory, options: s_remoteInvokeOptions);
+
+        outputHelper.WriteLine(result.Process.StandardOutput.ReadToEnd());
+    }
+
+    private static string FindRepoRoot(string startPath)
+    {
+        var currentDirectory = new DirectoryInfo(startPath);
+
+        while (currentDirectory is not null)
+        {
+            if (File.Exists(Path.Combine(currentDirectory.FullName, "Aspire.slnx")))
+            {
+                return currentDirectory.FullName;
+            }
+
+            currentDirectory = currentDirectory.Parent;
+        }
+
+        throw new InvalidOperationException($"Could not find Aspire.slnx starting from '{startPath}'.");
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/SdkDumpCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SdkDumpCommandTests.cs
@@ -216,6 +216,8 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
                 Assert.Equal(ExitCodeConstants.Success, exitCode);
 
                 var output = await File.ReadAllTextAsync(outputPath);
+                Assert.NotEmpty(output);
+
                 var warningLines = output
                     .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
                     .Where(line => line.Contains("warning:", StringComparison.OrdinalIgnoreCase))

--- a/tests/Aspire.Cli.Tests/Commands/SdkDumpCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/SdkDumpCommandTests.cs
@@ -186,21 +186,22 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
     [Fact]
     public void SdkDumpCi_ForHostingProject_DoesNotEmitWarnings()
     {
+        // Assertions and skips inside the callback are surfaced back to the parent test process.
         using var result = RemoteExecutor.Invoke(async (baseDirectory) =>
         {
-            var repoRoot = FindRepoRoot(baseDirectory);
+            var repoRoot = TryFindRepoRoot(baseDirectory);
+            if (repoRoot is null)
+            {
+                Assert.Skip($"Could not find Aspire.slnx starting from '{baseDirectory}'.");
+                return;
+            }
+
             var projectPath = Path.Combine(repoRoot, "src", "Aspire.Hosting", "Aspire.Hosting.csproj");
             Assert.True(File.Exists(projectPath), $"Could not find Aspire.Hosting project at '{projectPath}'.");
 
-            var outputPath = Path.Combine(Path.GetTempPath(), "aspire-sdk-dump-tests", $"{Guid.NewGuid():N}.txt");
-            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
-
-            var previousCurrentDirectory = Environment.CurrentDirectory;
-            var previousRepoRoot = Environment.GetEnvironmentVariable("ASPIRE_REPO_ROOT");
-            var previousNoLogo = Environment.GetEnvironmentVariable(CliConfigNames.NoLogo);
-            var previousDotNetTelemetry = Environment.GetEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT");
-            var previousDotNetFirstTime = Environment.GetEnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE");
-            var previousDotNetCertificate = Environment.GetEnvironmentVariable("DOTNET_GENERATE_ASPNET_CERTIFICATE");
+            var tempDirectory = Path.Combine(Path.GetTempPath(), "aspire-sdk-dump-tests", $"{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDirectory);
+            var outputPath = Path.Combine(tempDirectory, "capabilities.txt");
 
             try
             {
@@ -211,7 +212,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
                 Environment.SetEnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "true");
                 Environment.SetEnvironmentVariable("DOTNET_GENERATE_ASPNET_CERTIFICATE", "false");
 
-                var exitCode = await Program.Main(["sdk", "dump", "--format", "ci", "--output", outputPath, projectPath]);
+                var exitCode = await Program.Main(["sdk", "dump", "--format", "ci", "--output", outputPath, projectPath]).DefaultTimeout(TestConstants.LongTimeoutTimeSpan);
                 Assert.Equal(ExitCodeConstants.Success, exitCode);
 
                 var output = await File.ReadAllTextAsync(outputPath);
@@ -230,16 +231,9 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
             }
             finally
             {
-                Environment.CurrentDirectory = previousCurrentDirectory;
-                Environment.SetEnvironmentVariable("ASPIRE_REPO_ROOT", previousRepoRoot);
-                Environment.SetEnvironmentVariable(CliConfigNames.NoLogo, previousNoLogo);
-                Environment.SetEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", previousDotNetTelemetry);
-                Environment.SetEnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", previousDotNetFirstTime);
-                Environment.SetEnvironmentVariable("DOTNET_GENERATE_ASPNET_CERTIFICATE", previousDotNetCertificate);
-
-                if (File.Exists(outputPath))
+                if (Directory.Exists(tempDirectory))
                 {
-                    File.Delete(outputPath);
+                    Directory.Delete(tempDirectory, recursive: true);
                 }
             }
         }, AppContext.BaseDirectory, options: s_remoteInvokeOptions);
@@ -247,7 +241,7 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
         outputHelper.WriteLine(result.Process.StandardOutput.ReadToEnd());
     }
 
-    private static string FindRepoRoot(string startPath)
+    private static string? TryFindRepoRoot(string startPath)
     {
         var currentDirectory = new DirectoryInfo(startPath);
 
@@ -261,6 +255,6 @@ public class SdkDumpCommandTests(ITestOutputHelper outputHelper)
             currentDirectory = currentDirectory.Parent;
         }
 
-        throw new InvalidOperationException($"Could not find Aspire.slnx starting from '{startPath}'.");
+        return null;
     }
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/AtsGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/AtsGeneratedAspire.verified.go
@@ -102,12 +102,14 @@ func NewIDistributedApplicationBuilder(handle *Handle, client *AspireClient) *ID
 }
 
 // AddTestRedis adds a test Redis resource
-func (s *IDistributedApplicationBuilder) AddTestRedis(name string, port float64) (*TestRedisResource, error) {
+func (s *IDistributedApplicationBuilder) AddTestRedis(name string, port *float64) (*TestRedisResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["name"] = SerializeValue(name)
-	reqArgs["port"] = SerializeValue(port)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/addTestRedis", reqArgs)
 	if err != nil {
 		return nil, err
@@ -308,12 +310,16 @@ func NewTestDatabaseResource(handle *Handle, client *AspireClient) *TestDatabase
 }
 
 // WithOptionalString adds an optional string parameter
-func (s *TestDatabaseResource) WithOptionalString(value string, enabled bool) (*IResource, error) {
+func (s *TestDatabaseResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["value"] = SerializeValue(value)
-	reqArgs["enabled"] = SerializeValue(enabled)
+	if value != nil {
+		reqArgs["value"] = SerializeValue(value)
+	}
+	if enabled != nil {
+		reqArgs["enabled"] = SerializeValue(enabled)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/withOptionalString", reqArgs)
 	if err != nil {
 		return nil, err
@@ -512,11 +518,13 @@ func (s *TestDatabaseResource) WithCancellableOperation(operation func(...any) a
 }
 
 // WithDataVolume adds a data volume
-func (s *TestDatabaseResource) WithDataVolume(name string) (*TestDatabaseResource, error) {
+func (s *TestDatabaseResource) WithDataVolume(name *string) (*TestDatabaseResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["name"] = SerializeValue(name)
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/withDataVolume", reqArgs)
 	if err != nil {
 		return nil, err
@@ -626,12 +634,14 @@ func NewTestRedisResource(handle *Handle, client *AspireClient) *TestRedisResour
 }
 
 // AddTestChildDatabase adds a child database to a test Redis resource
-func (s *TestRedisResource) AddTestChildDatabase(name string, databaseName string) (*TestDatabaseResource, error) {
+func (s *TestRedisResource) AddTestChildDatabase(name string, databaseName *string) (*TestDatabaseResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["name"] = SerializeValue(name)
-	reqArgs["databaseName"] = SerializeValue(databaseName)
+	if databaseName != nil {
+		reqArgs["databaseName"] = SerializeValue(databaseName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/addTestChildDatabase", reqArgs)
 	if err != nil {
 		return nil, err
@@ -640,11 +650,13 @@ func (s *TestRedisResource) AddTestChildDatabase(name string, databaseName strin
 }
 
 // WithPersistence configures the Redis resource with persistence
-func (s *TestRedisResource) WithPersistence(mode TestPersistenceMode) (*TestRedisResource, error) {
+func (s *TestRedisResource) WithPersistence(mode *TestPersistenceMode) (*TestRedisResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["mode"] = SerializeValue(mode)
+	if mode != nil {
+		reqArgs["mode"] = SerializeValue(mode)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/withPersistence", reqArgs)
 	if err != nil {
 		return nil, err
@@ -653,12 +665,16 @@ func (s *TestRedisResource) WithPersistence(mode TestPersistenceMode) (*TestRedi
 }
 
 // WithOptionalString adds an optional string parameter
-func (s *TestRedisResource) WithOptionalString(value string, enabled bool) (*IResource, error) {
+func (s *TestRedisResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["value"] = SerializeValue(value)
-	reqArgs["enabled"] = SerializeValue(enabled)
+	if value != nil {
+		reqArgs["value"] = SerializeValue(value)
+	}
+	if enabled != nil {
+		reqArgs["enabled"] = SerializeValue(enabled)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/withOptionalString", reqArgs)
 	if err != nil {
 		return nil, err
@@ -970,12 +986,16 @@ func (s *TestRedisResource) WithMultiParamHandleCallback(callback func(...any) a
 }
 
 // WithDataVolume adds a data volume with persistence
-func (s *TestRedisResource) WithDataVolume(name string, isReadOnly bool) (*TestRedisResource, error) {
+func (s *TestRedisResource) WithDataVolume(name *string, isReadOnly *bool) (*TestRedisResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["isReadOnly"] = SerializeValue(isReadOnly)
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if isReadOnly != nil {
+		reqArgs["isReadOnly"] = SerializeValue(isReadOnly)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/withDataVolume", reqArgs)
 	if err != nil {
 		return nil, err
@@ -1092,12 +1112,16 @@ func NewTestVaultResource(handle *Handle, client *AspireClient) *TestVaultResour
 }
 
 // WithOptionalString adds an optional string parameter
-func (s *TestVaultResource) WithOptionalString(value string, enabled bool) (*IResource, error) {
+func (s *TestVaultResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["value"] = SerializeValue(value)
-	reqArgs["enabled"] = SerializeValue(enabled)
+	if value != nil {
+		reqArgs["value"] = SerializeValue(value)
+	}
+	if enabled != nil {
+		reqArgs["enabled"] = SerializeValue(enabled)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/withOptionalString", reqArgs)
 	if err != nil {
 		return nil, err

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -7937,6 +7937,20 @@ func NewIDistributedApplicationBuilder(handle *Handle, client *AspireClient) *ID
 	}
 }
 
+// AddConnectionStringExpression adds a connection string with a reference expression
+func (s *IDistributedApplicationBuilder) AddConnectionStringExpression(name string, connectionStringExpression *ReferenceExpression) (*ConnectionStringResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["name"] = SerializeValue(name)
+	reqArgs["connectionStringExpression"] = SerializeValue(connectionStringExpression)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/addConnectionStringExpression", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ConnectionStringResource), nil
+}
+
 // AddConnectionStringBuilder adds a connection string with a builder callback
 func (s *IDistributedApplicationBuilder) AddConnectionStringBuilder(name string, connectionStringBuilder func(...any) any) (*ConnectionStringResource, error) {
 	reqArgs := map[string]any{
@@ -7964,6 +7978,21 @@ func (s *IDistributedApplicationBuilder) AddContainerRegistry(name string, endpo
 		reqArgs["repository"] = SerializeValue(repository)
 	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/addContainerRegistry", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ContainerRegistryResource), nil
+}
+
+// AddContainerRegistryFromString adds a container registry with string endpoint
+func (s *IDistributedApplicationBuilder) AddContainerRegistryFromString(name string, endpoint string, repository string) (*ContainerRegistryResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["name"] = SerializeValue(name)
+	reqArgs["endpoint"] = SerializeValue(endpoint)
+	reqArgs["repository"] = SerializeValue(repository)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/addContainerRegistryFromString", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -8038,6 +8067,34 @@ func (s *IDistributedApplicationBuilder) AddExternalService(name string, url str
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["url"] = SerializeValue(url)
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/addExternalService", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ExternalServiceResource), nil
+}
+
+// AddExternalServiceUri adds an external service with a URI
+func (s *IDistributedApplicationBuilder) AddExternalServiceUri(name string, uri string) (*ExternalServiceResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["name"] = SerializeValue(name)
+	reqArgs["uri"] = SerializeValue(uri)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/addExternalServiceUri", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ExternalServiceResource), nil
+}
+
+// AddExternalServiceParameter adds an external service with a parameter URL
+func (s *IDistributedApplicationBuilder) AddExternalServiceParameter(name string, urlParameter *ParameterResource) (*ExternalServiceResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["name"] = SerializeValue(name)
+	reqArgs["urlParameter"] = SerializeValue(urlParameter)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/addExternalServiceParameter", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -8124,6 +8181,22 @@ func (s *IDistributedApplicationBuilder) AddParameter(name string, secret bool) 
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["secret"] = SerializeValue(secret)
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/addParameter", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ParameterResource), nil
+}
+
+// AddParameterWithValue adds a parameter with a default value
+func (s *IDistributedApplicationBuilder) AddParameterWithValue(name string, value string, publishValueAsDefault bool, secret bool) (*ParameterResource, error) {
+	reqArgs := map[string]any{
+		"builder": SerializeValue(s.Handle()),
+	}
+	reqArgs["name"] = SerializeValue(name)
+	reqArgs["value"] = SerializeValue(value)
+	reqArgs["publishValueAsDefault"] = SerializeValue(publishValueAsDefault)
+	reqArgs["secret"] = SerializeValue(secret)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/addParameterWithValue", reqArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -452,12 +452,16 @@ func (s *CSharpAppResource) WithContainerRegistry(registry *IResource) (*IResour
 }
 
 // WithDockerfileBaseImage sets the base image for a Dockerfile build
-func (s *CSharpAppResource) WithDockerfileBaseImage(buildImage string, runtimeImage string) (*IResource, error) {
+func (s *CSharpAppResource) WithDockerfileBaseImage(buildImage *string, runtimeImage *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["buildImage"] = SerializeValue(buildImage)
-	reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	if buildImage != nil {
+		reqArgs["buildImage"] = SerializeValue(buildImage)
+	}
+	if runtimeImage != nil {
+		reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withDockerfileBaseImage", reqArgs)
 	if err != nil {
 		return nil, err
@@ -466,12 +470,16 @@ func (s *CSharpAppResource) WithDockerfileBaseImage(buildImage string, runtimeIm
 }
 
 // WithMcpServer configures an MCP server endpoint on the resource
-func (s *CSharpAppResource) WithMcpServer(path string, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *CSharpAppResource) WithMcpServer(path *string, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withMcpServer", reqArgs)
 	if err != nil {
 		return nil, err
@@ -545,12 +553,14 @@ func (s *CSharpAppResource) PublishAsDockerFile(configure func(...any) any) (*Pr
 }
 
 // WithRequiredCommand adds a required command dependency
-func (s *CSharpAppResource) WithRequiredCommand(command string, helpLink string) (*IResource, error) {
+func (s *CSharpAppResource) WithRequiredCommand(command string, helpLink *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["command"] = SerializeValue(command)
-	reqArgs["helpLink"] = SerializeValue(helpLink)
+	if helpLink != nil {
+		reqArgs["helpLink"] = SerializeValue(helpLink)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withRequiredCommand", reqArgs)
 	if err != nil {
 		return nil, err
@@ -702,14 +712,20 @@ func (s *CSharpAppResource) WithArgsCallbackAsync(callback func(...any) any) (*I
 }
 
 // WithReference adds a reference to another resource
-func (s *CSharpAppResource) WithReference(source *IResource, connectionName string, optional bool, name string) (*IResourceWithEnvironment, error) {
+func (s *CSharpAppResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["source"] = SerializeValue(source)
-	reqArgs["connectionName"] = SerializeValue(connectionName)
-	reqArgs["optional"] = SerializeValue(optional)
-	reqArgs["name"] = SerializeValue(name)
+	if connectionName != nil {
+		reqArgs["connectionName"] = SerializeValue(connectionName)
+	}
+	if optional != nil {
+		reqArgs["optional"] = SerializeValue(optional)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
 	if err != nil {
 		return nil, err
@@ -758,18 +774,34 @@ func (s *CSharpAppResource) WithReferenceEndpoint(endpointReference *EndpointRef
 }
 
 // WithEndpoint adds a network endpoint
-func (s *CSharpAppResource) WithEndpoint(port float64, targetPort float64, scheme string, name string, env string, isProxied bool, isExternal bool, protocol ProtocolType) (*IResourceWithEndpoints, error) {
+func (s *CSharpAppResource) WithEndpoint(port *float64, targetPort *float64, scheme *string, name *string, env *string, isProxied *bool, isExternal *bool, protocol *ProtocolType) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["scheme"] = SerializeValue(scheme)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
-	reqArgs["isExternal"] = SerializeValue(isExternal)
-	reqArgs["protocol"] = SerializeValue(protocol)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if scheme != nil {
+		reqArgs["scheme"] = SerializeValue(scheme)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
+	if isExternal != nil {
+		reqArgs["isExternal"] = SerializeValue(isExternal)
+	}
+	if protocol != nil {
+		reqArgs["protocol"] = SerializeValue(protocol)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -778,15 +810,25 @@ func (s *CSharpAppResource) WithEndpoint(port float64, targetPort float64, schem
 }
 
 // WithHttpEndpoint adds an HTTP endpoint
-func (s *CSharpAppResource) WithHttpEndpoint(port float64, targetPort float64, name string, env string, isProxied bool) (*IResourceWithEndpoints, error) {
+func (s *CSharpAppResource) WithHttpEndpoint(port *float64, targetPort *float64, name *string, env *string, isProxied *bool) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -795,15 +837,25 @@ func (s *CSharpAppResource) WithHttpEndpoint(port float64, targetPort float64, n
 }
 
 // WithHttpsEndpoint adds an HTTPS endpoint
-func (s *CSharpAppResource) WithHttpsEndpoint(port float64, targetPort float64, name string, env string, isProxied bool) (*IResourceWithEndpoints, error) {
+func (s *CSharpAppResource) WithHttpsEndpoint(port *float64, targetPort *float64, name *string, env *string, isProxied *bool) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -879,12 +931,14 @@ func (s *CSharpAppResource) WithUrlsCallbackAsync(callback func(...any) any) (*I
 }
 
 // WithUrl adds or modifies displayed URLs
-func (s *CSharpAppResource) WithUrl(url string, displayText string) (*IResource, error) {
+func (s *CSharpAppResource) WithUrl(url string, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrl", reqArgs)
 	if err != nil {
 		return nil, err
@@ -893,12 +947,14 @@ func (s *CSharpAppResource) WithUrl(url string, displayText string) (*IResource,
 }
 
 // WithUrlExpression adds a URL using a reference expression
-func (s *CSharpAppResource) WithUrlExpression(url *ReferenceExpression, displayText string) (*IResource, error) {
+func (s *CSharpAppResource) WithUrlExpression(url *ReferenceExpression, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrlExpression", reqArgs)
 	if err != nil {
 		return nil, err
@@ -1031,12 +1087,14 @@ func (s *CSharpAppResource) WithExplicitStart() (*IResource, error) {
 }
 
 // WaitForCompletion waits for resource completion
-func (s *CSharpAppResource) WaitForCompletion(dependency *IResource, exitCode float64) (*IResourceWithWaitSupport, error) {
+func (s *CSharpAppResource) WaitForCompletion(dependency *IResource, exitCode *float64) (*IResourceWithWaitSupport, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	reqArgs["exitCode"] = SerializeValue(exitCode)
+	if exitCode != nil {
+		reqArgs["exitCode"] = SerializeValue(exitCode)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForCompletion", reqArgs)
 	if err != nil {
 		return nil, err
@@ -1058,13 +1116,19 @@ func (s *CSharpAppResource) WithHealthCheck(key string) (*IResource, error) {
 }
 
 // WithHttpHealthCheck adds an HTTP health check
-func (s *CSharpAppResource) WithHttpHealthCheck(path string, statusCode float64, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *CSharpAppResource) WithHttpHealthCheck(path *string, statusCode *float64, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["statusCode"] = SerializeValue(statusCode)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if statusCode != nil {
+		reqArgs["statusCode"] = SerializeValue(statusCode)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpHealthCheck", reqArgs)
 	if err != nil {
 		return nil, err
@@ -1172,12 +1236,14 @@ func (s *CSharpAppResource) WithChildRelationship(child *IResource) (*IResource,
 }
 
 // WithIconName sets the icon for the resource
-func (s *CSharpAppResource) WithIconName(iconName string, iconVariant IconVariant) (*IResource, error) {
+func (s *CSharpAppResource) WithIconName(iconName string, iconVariant *IconVariant) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["iconName"] = SerializeValue(iconName)
-	reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	if iconVariant != nil {
+		reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withIconName", reqArgs)
 	if err != nil {
 		return nil, err
@@ -1186,18 +1252,32 @@ func (s *CSharpAppResource) WithIconName(iconName string, iconVariant IconVarian
 }
 
 // WithHttpProbe adds an HTTP health probe to the resource
-func (s *CSharpAppResource) WithHttpProbe(probeType ProbeType, path string, initialDelaySeconds float64, periodSeconds float64, timeoutSeconds float64, failureThreshold float64, successThreshold float64, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *CSharpAppResource) WithHttpProbe(probeType ProbeType, path *string, initialDelaySeconds *float64, periodSeconds *float64, timeoutSeconds *float64, failureThreshold *float64, successThreshold *float64, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["probeType"] = SerializeValue(probeType)
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["initialDelaySeconds"] = SerializeValue(initialDelaySeconds)
-	reqArgs["periodSeconds"] = SerializeValue(periodSeconds)
-	reqArgs["timeoutSeconds"] = SerializeValue(timeoutSeconds)
-	reqArgs["failureThreshold"] = SerializeValue(failureThreshold)
-	reqArgs["successThreshold"] = SerializeValue(successThreshold)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if initialDelaySeconds != nil {
+		reqArgs["initialDelaySeconds"] = SerializeValue(initialDelaySeconds)
+	}
+	if periodSeconds != nil {
+		reqArgs["periodSeconds"] = SerializeValue(periodSeconds)
+	}
+	if timeoutSeconds != nil {
+		reqArgs["timeoutSeconds"] = SerializeValue(timeoutSeconds)
+	}
+	if failureThreshold != nil {
+		reqArgs["failureThreshold"] = SerializeValue(failureThreshold)
+	}
+	if successThreshold != nil {
+		reqArgs["successThreshold"] = SerializeValue(successThreshold)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpProbe", reqArgs)
 	if err != nil {
 		return nil, err
@@ -1244,7 +1324,7 @@ func (s *CSharpAppResource) WithRemoteImageTag(remoteImageTag string) (*ICompute
 }
 
 // WithPipelineStepFactory adds a pipeline step to the resource
-func (s *CSharpAppResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description string) (*IResource, error) {
+func (s *CSharpAppResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
@@ -1252,10 +1332,18 @@ func (s *CSharpAppResource) WithPipelineStepFactory(stepName string, callback fu
 	if callback != nil {
 		reqArgs["callback"] = RegisterCallback(callback)
 	}
-	reqArgs["dependsOn"] = SerializeValue(dependsOn)
-	reqArgs["requiredBy"] = SerializeValue(requiredBy)
-	reqArgs["tags"] = SerializeValue(tags)
-	reqArgs["description"] = SerializeValue(description)
+	if dependsOn != nil {
+		reqArgs["dependsOn"] = SerializeValue(dependsOn)
+	}
+	if requiredBy != nil {
+		reqArgs["requiredBy"] = SerializeValue(requiredBy)
+	}
+	if tags != nil {
+		reqArgs["tags"] = SerializeValue(tags)
+	}
+	if description != nil {
+		reqArgs["description"] = SerializeValue(description)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withPipelineStepFactory", reqArgs)
 	if err != nil {
 		return nil, err
@@ -1381,12 +1469,16 @@ func (s *CSharpAppResource) OnResourceReady(callback func(...any) any) (*IResour
 }
 
 // WithOptionalString adds an optional string parameter
-func (s *CSharpAppResource) WithOptionalString(value string, enabled bool) (*IResource, error) {
+func (s *CSharpAppResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["value"] = SerializeValue(value)
-	reqArgs["enabled"] = SerializeValue(enabled)
+	if value != nil {
+		reqArgs["value"] = SerializeValue(value)
+	}
+	if enabled != nil {
+		reqArgs["enabled"] = SerializeValue(enabled)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/withOptionalString", reqArgs)
 	if err != nil {
 		return nil, err
@@ -1741,12 +1833,16 @@ func (s *ConnectionStringResource) WithContainerRegistry(registry *IResource) (*
 }
 
 // WithDockerfileBaseImage sets the base image for a Dockerfile build
-func (s *ConnectionStringResource) WithDockerfileBaseImage(buildImage string, runtimeImage string) (*IResource, error) {
+func (s *ConnectionStringResource) WithDockerfileBaseImage(buildImage *string, runtimeImage *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["buildImage"] = SerializeValue(buildImage)
-	reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	if buildImage != nil {
+		reqArgs["buildImage"] = SerializeValue(buildImage)
+	}
+	if runtimeImage != nil {
+		reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withDockerfileBaseImage", reqArgs)
 	if err != nil {
 		return nil, err
@@ -1755,12 +1851,14 @@ func (s *ConnectionStringResource) WithDockerfileBaseImage(buildImage string, ru
 }
 
 // WithRequiredCommand adds a required command dependency
-func (s *ConnectionStringResource) WithRequiredCommand(command string, helpLink string) (*IResource, error) {
+func (s *ConnectionStringResource) WithRequiredCommand(command string, helpLink *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["command"] = SerializeValue(command)
-	reqArgs["helpLink"] = SerializeValue(helpLink)
+	if helpLink != nil {
+		reqArgs["helpLink"] = SerializeValue(helpLink)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withRequiredCommand", reqArgs)
 	if err != nil {
 		return nil, err
@@ -1827,12 +1925,14 @@ func (s *ConnectionStringResource) WithUrlsCallbackAsync(callback func(...any) a
 }
 
 // WithUrl adds or modifies displayed URLs
-func (s *ConnectionStringResource) WithUrl(url string, displayText string) (*IResource, error) {
+func (s *ConnectionStringResource) WithUrl(url string, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrl", reqArgs)
 	if err != nil {
 		return nil, err
@@ -1841,12 +1941,14 @@ func (s *ConnectionStringResource) WithUrl(url string, displayText string) (*IRe
 }
 
 // WithUrlExpression adds a URL using a reference expression
-func (s *ConnectionStringResource) WithUrlExpression(url *ReferenceExpression, displayText string) (*IResource, error) {
+func (s *ConnectionStringResource) WithUrlExpression(url *ReferenceExpression, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrlExpression", reqArgs)
 	if err != nil {
 		return nil, err
@@ -1949,12 +2051,14 @@ func (s *ConnectionStringResource) WithExplicitStart() (*IResource, error) {
 }
 
 // WaitForCompletion waits for resource completion
-func (s *ConnectionStringResource) WaitForCompletion(dependency *IResource, exitCode float64) (*IResourceWithWaitSupport, error) {
+func (s *ConnectionStringResource) WaitForCompletion(dependency *IResource, exitCode *float64) (*IResourceWithWaitSupport, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	reqArgs["exitCode"] = SerializeValue(exitCode)
+	if exitCode != nil {
+		reqArgs["exitCode"] = SerializeValue(exitCode)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForCompletion", reqArgs)
 	if err != nil {
 		return nil, err
@@ -2022,12 +2126,14 @@ func (s *ConnectionStringResource) WithChildRelationship(child *IResource) (*IRe
 }
 
 // WithIconName sets the icon for the resource
-func (s *ConnectionStringResource) WithIconName(iconName string, iconVariant IconVariant) (*IResource, error) {
+func (s *ConnectionStringResource) WithIconName(iconName string, iconVariant *IconVariant) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["iconName"] = SerializeValue(iconName)
-	reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	if iconVariant != nil {
+		reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withIconName", reqArgs)
 	if err != nil {
 		return nil, err
@@ -2048,7 +2154,7 @@ func (s *ConnectionStringResource) ExcludeFromMcp() (*IResource, error) {
 }
 
 // WithPipelineStepFactory adds a pipeline step to the resource
-func (s *ConnectionStringResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description string) (*IResource, error) {
+func (s *ConnectionStringResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
@@ -2056,10 +2162,18 @@ func (s *ConnectionStringResource) WithPipelineStepFactory(stepName string, call
 	if callback != nil {
 		reqArgs["callback"] = RegisterCallback(callback)
 	}
-	reqArgs["dependsOn"] = SerializeValue(dependsOn)
-	reqArgs["requiredBy"] = SerializeValue(requiredBy)
-	reqArgs["tags"] = SerializeValue(tags)
-	reqArgs["description"] = SerializeValue(description)
+	if dependsOn != nil {
+		reqArgs["dependsOn"] = SerializeValue(dependsOn)
+	}
+	if requiredBy != nil {
+		reqArgs["requiredBy"] = SerializeValue(requiredBy)
+	}
+	if tags != nil {
+		reqArgs["tags"] = SerializeValue(tags)
+	}
+	if description != nil {
+		reqArgs["description"] = SerializeValue(description)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withPipelineStepFactory", reqArgs)
 	if err != nil {
 		return nil, err
@@ -2185,12 +2299,16 @@ func (s *ConnectionStringResource) OnResourceReady(callback func(...any) any) (*
 }
 
 // WithOptionalString adds an optional string parameter
-func (s *ConnectionStringResource) WithOptionalString(value string, enabled bool) (*IResource, error) {
+func (s *ConnectionStringResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["value"] = SerializeValue(value)
-	reqArgs["enabled"] = SerializeValue(enabled)
+	if value != nil {
+		reqArgs["value"] = SerializeValue(value)
+	}
+	if enabled != nil {
+		reqArgs["enabled"] = SerializeValue(enabled)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/withOptionalString", reqArgs)
 	if err != nil {
 		return nil, err
@@ -2412,12 +2530,16 @@ func (s *ContainerRegistryResource) WithContainerRegistry(registry *IResource) (
 }
 
 // WithDockerfileBaseImage sets the base image for a Dockerfile build
-func (s *ContainerRegistryResource) WithDockerfileBaseImage(buildImage string, runtimeImage string) (*IResource, error) {
+func (s *ContainerRegistryResource) WithDockerfileBaseImage(buildImage *string, runtimeImage *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["buildImage"] = SerializeValue(buildImage)
-	reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	if buildImage != nil {
+		reqArgs["buildImage"] = SerializeValue(buildImage)
+	}
+	if runtimeImage != nil {
+		reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withDockerfileBaseImage", reqArgs)
 	if err != nil {
 		return nil, err
@@ -2426,12 +2548,14 @@ func (s *ContainerRegistryResource) WithDockerfileBaseImage(buildImage string, r
 }
 
 // WithRequiredCommand adds a required command dependency
-func (s *ContainerRegistryResource) WithRequiredCommand(command string, helpLink string) (*IResource, error) {
+func (s *ContainerRegistryResource) WithRequiredCommand(command string, helpLink *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["command"] = SerializeValue(command)
-	reqArgs["helpLink"] = SerializeValue(helpLink)
+	if helpLink != nil {
+		reqArgs["helpLink"] = SerializeValue(helpLink)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withRequiredCommand", reqArgs)
 	if err != nil {
 		return nil, err
@@ -2470,12 +2594,14 @@ func (s *ContainerRegistryResource) WithUrlsCallbackAsync(callback func(...any) 
 }
 
 // WithUrl adds or modifies displayed URLs
-func (s *ContainerRegistryResource) WithUrl(url string, displayText string) (*IResource, error) {
+func (s *ContainerRegistryResource) WithUrl(url string, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrl", reqArgs)
 	if err != nil {
 		return nil, err
@@ -2484,12 +2610,14 @@ func (s *ContainerRegistryResource) WithUrl(url string, displayText string) (*IR
 }
 
 // WithUrlExpression adds a URL using a reference expression
-func (s *ContainerRegistryResource) WithUrlExpression(url *ReferenceExpression, displayText string) (*IResource, error) {
+func (s *ContainerRegistryResource) WithUrlExpression(url *ReferenceExpression, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrlExpression", reqArgs)
 	if err != nil {
 		return nil, err
@@ -2597,12 +2725,14 @@ func (s *ContainerRegistryResource) WithChildRelationship(child *IResource) (*IR
 }
 
 // WithIconName sets the icon for the resource
-func (s *ContainerRegistryResource) WithIconName(iconName string, iconVariant IconVariant) (*IResource, error) {
+func (s *ContainerRegistryResource) WithIconName(iconName string, iconVariant *IconVariant) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["iconName"] = SerializeValue(iconName)
-	reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	if iconVariant != nil {
+		reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withIconName", reqArgs)
 	if err != nil {
 		return nil, err
@@ -2623,7 +2753,7 @@ func (s *ContainerRegistryResource) ExcludeFromMcp() (*IResource, error) {
 }
 
 // WithPipelineStepFactory adds a pipeline step to the resource
-func (s *ContainerRegistryResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description string) (*IResource, error) {
+func (s *ContainerRegistryResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
@@ -2631,10 +2761,18 @@ func (s *ContainerRegistryResource) WithPipelineStepFactory(stepName string, cal
 	if callback != nil {
 		reqArgs["callback"] = RegisterCallback(callback)
 	}
-	reqArgs["dependsOn"] = SerializeValue(dependsOn)
-	reqArgs["requiredBy"] = SerializeValue(requiredBy)
-	reqArgs["tags"] = SerializeValue(tags)
-	reqArgs["description"] = SerializeValue(description)
+	if dependsOn != nil {
+		reqArgs["dependsOn"] = SerializeValue(dependsOn)
+	}
+	if requiredBy != nil {
+		reqArgs["requiredBy"] = SerializeValue(requiredBy)
+	}
+	if tags != nil {
+		reqArgs["tags"] = SerializeValue(tags)
+	}
+	if description != nil {
+		reqArgs["description"] = SerializeValue(description)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withPipelineStepFactory", reqArgs)
 	if err != nil {
 		return nil, err
@@ -2745,12 +2883,16 @@ func (s *ContainerRegistryResource) OnResourceReady(callback func(...any) any) (
 }
 
 // WithOptionalString adds an optional string parameter
-func (s *ContainerRegistryResource) WithOptionalString(value string, enabled bool) (*IResource, error) {
+func (s *ContainerRegistryResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["value"] = SerializeValue(value)
-	reqArgs["enabled"] = SerializeValue(enabled)
+	if value != nil {
+		reqArgs["value"] = SerializeValue(value)
+	}
+	if enabled != nil {
+		reqArgs["enabled"] = SerializeValue(enabled)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/withOptionalString", reqArgs)
 	if err != nil {
 		return nil, err
@@ -2946,13 +3088,15 @@ func (s *ContainerResource) WithContainerRegistry(registry *IResource) (*IResour
 }
 
 // WithBindMount adds a bind mount
-func (s *ContainerResource) WithBindMount(source string, target string, isReadOnly bool) (*ContainerResource, error) {
+func (s *ContainerResource) WithBindMount(source string, target string, isReadOnly *bool) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["source"] = SerializeValue(source)
 	reqArgs["target"] = SerializeValue(target)
-	reqArgs["isReadOnly"] = SerializeValue(isReadOnly)
+	if isReadOnly != nil {
+		reqArgs["isReadOnly"] = SerializeValue(isReadOnly)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBindMount", reqArgs)
 	if err != nil {
 		return nil, err
@@ -3000,12 +3144,14 @@ func (s *ContainerResource) WithImageRegistry(registry string) (*ContainerResour
 }
 
 // WithImage sets the container image
-func (s *ContainerResource) WithImage(image string, tag string) (*ContainerResource, error) {
+func (s *ContainerResource) WithImage(image string, tag *string) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["image"] = SerializeValue(image)
-	reqArgs["tag"] = SerializeValue(tag)
+	if tag != nil {
+		reqArgs["tag"] = SerializeValue(tag)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withImage", reqArgs)
 	if err != nil {
 		return nil, err
@@ -3078,13 +3224,17 @@ func (s *ContainerResource) PublishAsContainer() (*ContainerResource, error) {
 }
 
 // WithDockerfile configures the resource to use a Dockerfile
-func (s *ContainerResource) WithDockerfile(contextPath string, dockerfilePath string, stage string) (*ContainerResource, error) {
+func (s *ContainerResource) WithDockerfile(contextPath string, dockerfilePath *string, stage *string) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["contextPath"] = SerializeValue(contextPath)
-	reqArgs["dockerfilePath"] = SerializeValue(dockerfilePath)
-	reqArgs["stage"] = SerializeValue(stage)
+	if dockerfilePath != nil {
+		reqArgs["dockerfilePath"] = SerializeValue(dockerfilePath)
+	}
+	if stage != nil {
+		reqArgs["stage"] = SerializeValue(stage)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withDockerfile", reqArgs)
 	if err != nil {
 		return nil, err
@@ -3147,12 +3297,16 @@ func (s *ContainerResource) WithEndpointProxySupport(proxyEnabled bool) (*Contai
 }
 
 // WithDockerfileBaseImage sets the base image for a Dockerfile build
-func (s *ContainerResource) WithDockerfileBaseImage(buildImage string, runtimeImage string) (*IResource, error) {
+func (s *ContainerResource) WithDockerfileBaseImage(buildImage *string, runtimeImage *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["buildImage"] = SerializeValue(buildImage)
-	reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	if buildImage != nil {
+		reqArgs["buildImage"] = SerializeValue(buildImage)
+	}
+	if runtimeImage != nil {
+		reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withDockerfileBaseImage", reqArgs)
 	if err != nil {
 		return nil, err
@@ -3174,12 +3328,16 @@ func (s *ContainerResource) WithContainerNetworkAlias(alias string) (*ContainerR
 }
 
 // WithMcpServer configures an MCP server endpoint on the resource
-func (s *ContainerResource) WithMcpServer(path string, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *ContainerResource) WithMcpServer(path *string, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withMcpServer", reqArgs)
 	if err != nil {
 		return nil, err
@@ -3225,12 +3383,14 @@ func (s *ContainerResource) PublishAsConnectionString() (*ContainerResource, err
 }
 
 // WithRequiredCommand adds a required command dependency
-func (s *ContainerResource) WithRequiredCommand(command string, helpLink string) (*IResource, error) {
+func (s *ContainerResource) WithRequiredCommand(command string, helpLink *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["command"] = SerializeValue(command)
-	reqArgs["helpLink"] = SerializeValue(helpLink)
+	if helpLink != nil {
+		reqArgs["helpLink"] = SerializeValue(helpLink)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withRequiredCommand", reqArgs)
 	if err != nil {
 		return nil, err
@@ -3382,14 +3542,20 @@ func (s *ContainerResource) WithArgsCallbackAsync(callback func(...any) any) (*I
 }
 
 // WithReference adds a reference to another resource
-func (s *ContainerResource) WithReference(source *IResource, connectionName string, optional bool, name string) (*IResourceWithEnvironment, error) {
+func (s *ContainerResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["source"] = SerializeValue(source)
-	reqArgs["connectionName"] = SerializeValue(connectionName)
-	reqArgs["optional"] = SerializeValue(optional)
-	reqArgs["name"] = SerializeValue(name)
+	if connectionName != nil {
+		reqArgs["connectionName"] = SerializeValue(connectionName)
+	}
+	if optional != nil {
+		reqArgs["optional"] = SerializeValue(optional)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
 	if err != nil {
 		return nil, err
@@ -3438,18 +3604,34 @@ func (s *ContainerResource) WithReferenceEndpoint(endpointReference *EndpointRef
 }
 
 // WithEndpoint adds a network endpoint
-func (s *ContainerResource) WithEndpoint(port float64, targetPort float64, scheme string, name string, env string, isProxied bool, isExternal bool, protocol ProtocolType) (*IResourceWithEndpoints, error) {
+func (s *ContainerResource) WithEndpoint(port *float64, targetPort *float64, scheme *string, name *string, env *string, isProxied *bool, isExternal *bool, protocol *ProtocolType) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["scheme"] = SerializeValue(scheme)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
-	reqArgs["isExternal"] = SerializeValue(isExternal)
-	reqArgs["protocol"] = SerializeValue(protocol)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if scheme != nil {
+		reqArgs["scheme"] = SerializeValue(scheme)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
+	if isExternal != nil {
+		reqArgs["isExternal"] = SerializeValue(isExternal)
+	}
+	if protocol != nil {
+		reqArgs["protocol"] = SerializeValue(protocol)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -3458,15 +3640,25 @@ func (s *ContainerResource) WithEndpoint(port float64, targetPort float64, schem
 }
 
 // WithHttpEndpoint adds an HTTP endpoint
-func (s *ContainerResource) WithHttpEndpoint(port float64, targetPort float64, name string, env string, isProxied bool) (*IResourceWithEndpoints, error) {
+func (s *ContainerResource) WithHttpEndpoint(port *float64, targetPort *float64, name *string, env *string, isProxied *bool) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -3475,15 +3667,25 @@ func (s *ContainerResource) WithHttpEndpoint(port float64, targetPort float64, n
 }
 
 // WithHttpsEndpoint adds an HTTPS endpoint
-func (s *ContainerResource) WithHttpsEndpoint(port float64, targetPort float64, name string, env string, isProxied bool) (*IResourceWithEndpoints, error) {
+func (s *ContainerResource) WithHttpsEndpoint(port *float64, targetPort *float64, name *string, env *string, isProxied *bool) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -3559,12 +3761,14 @@ func (s *ContainerResource) WithUrlsCallbackAsync(callback func(...any) any) (*I
 }
 
 // WithUrl adds or modifies displayed URLs
-func (s *ContainerResource) WithUrl(url string, displayText string) (*IResource, error) {
+func (s *ContainerResource) WithUrl(url string, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrl", reqArgs)
 	if err != nil {
 		return nil, err
@@ -3573,12 +3777,14 @@ func (s *ContainerResource) WithUrl(url string, displayText string) (*IResource,
 }
 
 // WithUrlExpression adds a URL using a reference expression
-func (s *ContainerResource) WithUrlExpression(url *ReferenceExpression, displayText string) (*IResource, error) {
+func (s *ContainerResource) WithUrlExpression(url *ReferenceExpression, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrlExpression", reqArgs)
 	if err != nil {
 		return nil, err
@@ -3697,12 +3903,14 @@ func (s *ContainerResource) WithExplicitStart() (*IResource, error) {
 }
 
 // WaitForCompletion waits for resource completion
-func (s *ContainerResource) WaitForCompletion(dependency *IResource, exitCode float64) (*IResourceWithWaitSupport, error) {
+func (s *ContainerResource) WaitForCompletion(dependency *IResource, exitCode *float64) (*IResourceWithWaitSupport, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	reqArgs["exitCode"] = SerializeValue(exitCode)
+	if exitCode != nil {
+		reqArgs["exitCode"] = SerializeValue(exitCode)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForCompletion", reqArgs)
 	if err != nil {
 		return nil, err
@@ -3724,13 +3932,19 @@ func (s *ContainerResource) WithHealthCheck(key string) (*IResource, error) {
 }
 
 // WithHttpHealthCheck adds an HTTP health check
-func (s *ContainerResource) WithHttpHealthCheck(path string, statusCode float64, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *ContainerResource) WithHttpHealthCheck(path *string, statusCode *float64, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["statusCode"] = SerializeValue(statusCode)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if statusCode != nil {
+		reqArgs["statusCode"] = SerializeValue(statusCode)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpHealthCheck", reqArgs)
 	if err != nil {
 		return nil, err
@@ -3838,12 +4052,14 @@ func (s *ContainerResource) WithChildRelationship(child *IResource) (*IResource,
 }
 
 // WithIconName sets the icon for the resource
-func (s *ContainerResource) WithIconName(iconName string, iconVariant IconVariant) (*IResource, error) {
+func (s *ContainerResource) WithIconName(iconName string, iconVariant *IconVariant) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["iconName"] = SerializeValue(iconName)
-	reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	if iconVariant != nil {
+		reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withIconName", reqArgs)
 	if err != nil {
 		return nil, err
@@ -3852,18 +4068,32 @@ func (s *ContainerResource) WithIconName(iconName string, iconVariant IconVarian
 }
 
 // WithHttpProbe adds an HTTP health probe to the resource
-func (s *ContainerResource) WithHttpProbe(probeType ProbeType, path string, initialDelaySeconds float64, periodSeconds float64, timeoutSeconds float64, failureThreshold float64, successThreshold float64, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *ContainerResource) WithHttpProbe(probeType ProbeType, path *string, initialDelaySeconds *float64, periodSeconds *float64, timeoutSeconds *float64, failureThreshold *float64, successThreshold *float64, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["probeType"] = SerializeValue(probeType)
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["initialDelaySeconds"] = SerializeValue(initialDelaySeconds)
-	reqArgs["periodSeconds"] = SerializeValue(periodSeconds)
-	reqArgs["timeoutSeconds"] = SerializeValue(timeoutSeconds)
-	reqArgs["failureThreshold"] = SerializeValue(failureThreshold)
-	reqArgs["successThreshold"] = SerializeValue(successThreshold)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if initialDelaySeconds != nil {
+		reqArgs["initialDelaySeconds"] = SerializeValue(initialDelaySeconds)
+	}
+	if periodSeconds != nil {
+		reqArgs["periodSeconds"] = SerializeValue(periodSeconds)
+	}
+	if timeoutSeconds != nil {
+		reqArgs["timeoutSeconds"] = SerializeValue(timeoutSeconds)
+	}
+	if failureThreshold != nil {
+		reqArgs["failureThreshold"] = SerializeValue(failureThreshold)
+	}
+	if successThreshold != nil {
+		reqArgs["successThreshold"] = SerializeValue(successThreshold)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpProbe", reqArgs)
 	if err != nil {
 		return nil, err
@@ -3910,7 +4140,7 @@ func (s *ContainerResource) WithRemoteImageTag(remoteImageTag string) (*ICompute
 }
 
 // WithPipelineStepFactory adds a pipeline step to the resource
-func (s *ContainerResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description string) (*IResource, error) {
+func (s *ContainerResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
@@ -3918,10 +4148,18 @@ func (s *ContainerResource) WithPipelineStepFactory(stepName string, callback fu
 	if callback != nil {
 		reqArgs["callback"] = RegisterCallback(callback)
 	}
-	reqArgs["dependsOn"] = SerializeValue(dependsOn)
-	reqArgs["requiredBy"] = SerializeValue(requiredBy)
-	reqArgs["tags"] = SerializeValue(tags)
-	reqArgs["description"] = SerializeValue(description)
+	if dependsOn != nil {
+		reqArgs["dependsOn"] = SerializeValue(dependsOn)
+	}
+	if requiredBy != nil {
+		reqArgs["requiredBy"] = SerializeValue(requiredBy)
+	}
+	if tags != nil {
+		reqArgs["tags"] = SerializeValue(tags)
+	}
+	if description != nil {
+		reqArgs["description"] = SerializeValue(description)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withPipelineStepFactory", reqArgs)
 	if err != nil {
 		return nil, err
@@ -3960,13 +4198,17 @@ func (s *ContainerResource) WithPipelineConfiguration(callback func(...any) any)
 }
 
 // WithVolume adds a volume
-func (s *ContainerResource) WithVolume(target string, name string, isReadOnly bool) (*ContainerResource, error) {
+func (s *ContainerResource) WithVolume(target string, name *string, isReadOnly *bool) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"resource": SerializeValue(s.Handle()),
 	}
 	reqArgs["target"] = SerializeValue(target)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["isReadOnly"] = SerializeValue(isReadOnly)
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if isReadOnly != nil {
+		reqArgs["isReadOnly"] = SerializeValue(isReadOnly)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withVolume", reqArgs)
 	if err != nil {
 		return nil, err
@@ -4062,12 +4304,16 @@ func (s *ContainerResource) OnResourceReady(callback func(...any) any) (*IResour
 }
 
 // WithOptionalString adds an optional string parameter
-func (s *ContainerResource) WithOptionalString(value string, enabled bool) (*IResource, error) {
+func (s *ContainerResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["value"] = SerializeValue(value)
-	reqArgs["enabled"] = SerializeValue(enabled)
+	if value != nil {
+		reqArgs["value"] = SerializeValue(value)
+	}
+	if enabled != nil {
+		reqArgs["enabled"] = SerializeValue(enabled)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/withOptionalString", reqArgs)
 	if err != nil {
 		return nil, err
@@ -4473,12 +4719,16 @@ func (s *DotnetToolResource) WithContainerRegistry(registry *IResource) (*IResou
 }
 
 // WithDockerfileBaseImage sets the base image for a Dockerfile build
-func (s *DotnetToolResource) WithDockerfileBaseImage(buildImage string, runtimeImage string) (*IResource, error) {
+func (s *DotnetToolResource) WithDockerfileBaseImage(buildImage *string, runtimeImage *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["buildImage"] = SerializeValue(buildImage)
-	reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	if buildImage != nil {
+		reqArgs["buildImage"] = SerializeValue(buildImage)
+	}
+	if runtimeImage != nil {
+		reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withDockerfileBaseImage", reqArgs)
 	if err != nil {
 		return nil, err
@@ -4615,12 +4865,16 @@ func (s *DotnetToolResource) WithWorkingDirectory(workingDirectory string) (*Exe
 }
 
 // WithMcpServer configures an MCP server endpoint on the resource
-func (s *DotnetToolResource) WithMcpServer(path string, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *DotnetToolResource) WithMcpServer(path *string, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withMcpServer", reqArgs)
 	if err != nil {
 		return nil, err
@@ -4654,12 +4908,14 @@ func (s *DotnetToolResource) WithOtlpExporterProtocol(protocol OtlpProtocol) (*I
 }
 
 // WithRequiredCommand adds a required command dependency
-func (s *DotnetToolResource) WithRequiredCommand(command string, helpLink string) (*IResource, error) {
+func (s *DotnetToolResource) WithRequiredCommand(command string, helpLink *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["command"] = SerializeValue(command)
-	reqArgs["helpLink"] = SerializeValue(helpLink)
+	if helpLink != nil {
+		reqArgs["helpLink"] = SerializeValue(helpLink)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withRequiredCommand", reqArgs)
 	if err != nil {
 		return nil, err
@@ -4811,14 +5067,20 @@ func (s *DotnetToolResource) WithArgsCallbackAsync(callback func(...any) any) (*
 }
 
 // WithReference adds a reference to another resource
-func (s *DotnetToolResource) WithReference(source *IResource, connectionName string, optional bool, name string) (*IResourceWithEnvironment, error) {
+func (s *DotnetToolResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["source"] = SerializeValue(source)
-	reqArgs["connectionName"] = SerializeValue(connectionName)
-	reqArgs["optional"] = SerializeValue(optional)
-	reqArgs["name"] = SerializeValue(name)
+	if connectionName != nil {
+		reqArgs["connectionName"] = SerializeValue(connectionName)
+	}
+	if optional != nil {
+		reqArgs["optional"] = SerializeValue(optional)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
 	if err != nil {
 		return nil, err
@@ -4867,18 +5129,34 @@ func (s *DotnetToolResource) WithReferenceEndpoint(endpointReference *EndpointRe
 }
 
 // WithEndpoint adds a network endpoint
-func (s *DotnetToolResource) WithEndpoint(port float64, targetPort float64, scheme string, name string, env string, isProxied bool, isExternal bool, protocol ProtocolType) (*IResourceWithEndpoints, error) {
+func (s *DotnetToolResource) WithEndpoint(port *float64, targetPort *float64, scheme *string, name *string, env *string, isProxied *bool, isExternal *bool, protocol *ProtocolType) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["scheme"] = SerializeValue(scheme)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
-	reqArgs["isExternal"] = SerializeValue(isExternal)
-	reqArgs["protocol"] = SerializeValue(protocol)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if scheme != nil {
+		reqArgs["scheme"] = SerializeValue(scheme)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
+	if isExternal != nil {
+		reqArgs["isExternal"] = SerializeValue(isExternal)
+	}
+	if protocol != nil {
+		reqArgs["protocol"] = SerializeValue(protocol)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -4887,15 +5165,25 @@ func (s *DotnetToolResource) WithEndpoint(port float64, targetPort float64, sche
 }
 
 // WithHttpEndpoint adds an HTTP endpoint
-func (s *DotnetToolResource) WithHttpEndpoint(port float64, targetPort float64, name string, env string, isProxied bool) (*IResourceWithEndpoints, error) {
+func (s *DotnetToolResource) WithHttpEndpoint(port *float64, targetPort *float64, name *string, env *string, isProxied *bool) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -4904,15 +5192,25 @@ func (s *DotnetToolResource) WithHttpEndpoint(port float64, targetPort float64, 
 }
 
 // WithHttpsEndpoint adds an HTTPS endpoint
-func (s *DotnetToolResource) WithHttpsEndpoint(port float64, targetPort float64, name string, env string, isProxied bool) (*IResourceWithEndpoints, error) {
+func (s *DotnetToolResource) WithHttpsEndpoint(port *float64, targetPort *float64, name *string, env *string, isProxied *bool) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -4988,12 +5286,14 @@ func (s *DotnetToolResource) WithUrlsCallbackAsync(callback func(...any) any) (*
 }
 
 // WithUrl adds or modifies displayed URLs
-func (s *DotnetToolResource) WithUrl(url string, displayText string) (*IResource, error) {
+func (s *DotnetToolResource) WithUrl(url string, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrl", reqArgs)
 	if err != nil {
 		return nil, err
@@ -5002,12 +5302,14 @@ func (s *DotnetToolResource) WithUrl(url string, displayText string) (*IResource
 }
 
 // WithUrlExpression adds a URL using a reference expression
-func (s *DotnetToolResource) WithUrlExpression(url *ReferenceExpression, displayText string) (*IResource, error) {
+func (s *DotnetToolResource) WithUrlExpression(url *ReferenceExpression, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrlExpression", reqArgs)
 	if err != nil {
 		return nil, err
@@ -5126,12 +5428,14 @@ func (s *DotnetToolResource) WithExplicitStart() (*IResource, error) {
 }
 
 // WaitForCompletion waits for resource completion
-func (s *DotnetToolResource) WaitForCompletion(dependency *IResource, exitCode float64) (*IResourceWithWaitSupport, error) {
+func (s *DotnetToolResource) WaitForCompletion(dependency *IResource, exitCode *float64) (*IResourceWithWaitSupport, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	reqArgs["exitCode"] = SerializeValue(exitCode)
+	if exitCode != nil {
+		reqArgs["exitCode"] = SerializeValue(exitCode)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForCompletion", reqArgs)
 	if err != nil {
 		return nil, err
@@ -5153,13 +5457,19 @@ func (s *DotnetToolResource) WithHealthCheck(key string) (*IResource, error) {
 }
 
 // WithHttpHealthCheck adds an HTTP health check
-func (s *DotnetToolResource) WithHttpHealthCheck(path string, statusCode float64, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *DotnetToolResource) WithHttpHealthCheck(path *string, statusCode *float64, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["statusCode"] = SerializeValue(statusCode)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if statusCode != nil {
+		reqArgs["statusCode"] = SerializeValue(statusCode)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpHealthCheck", reqArgs)
 	if err != nil {
 		return nil, err
@@ -5267,12 +5577,14 @@ func (s *DotnetToolResource) WithChildRelationship(child *IResource) (*IResource
 }
 
 // WithIconName sets the icon for the resource
-func (s *DotnetToolResource) WithIconName(iconName string, iconVariant IconVariant) (*IResource, error) {
+func (s *DotnetToolResource) WithIconName(iconName string, iconVariant *IconVariant) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["iconName"] = SerializeValue(iconName)
-	reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	if iconVariant != nil {
+		reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withIconName", reqArgs)
 	if err != nil {
 		return nil, err
@@ -5281,18 +5593,32 @@ func (s *DotnetToolResource) WithIconName(iconName string, iconVariant IconVaria
 }
 
 // WithHttpProbe adds an HTTP health probe to the resource
-func (s *DotnetToolResource) WithHttpProbe(probeType ProbeType, path string, initialDelaySeconds float64, periodSeconds float64, timeoutSeconds float64, failureThreshold float64, successThreshold float64, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *DotnetToolResource) WithHttpProbe(probeType ProbeType, path *string, initialDelaySeconds *float64, periodSeconds *float64, timeoutSeconds *float64, failureThreshold *float64, successThreshold *float64, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["probeType"] = SerializeValue(probeType)
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["initialDelaySeconds"] = SerializeValue(initialDelaySeconds)
-	reqArgs["periodSeconds"] = SerializeValue(periodSeconds)
-	reqArgs["timeoutSeconds"] = SerializeValue(timeoutSeconds)
-	reqArgs["failureThreshold"] = SerializeValue(failureThreshold)
-	reqArgs["successThreshold"] = SerializeValue(successThreshold)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if initialDelaySeconds != nil {
+		reqArgs["initialDelaySeconds"] = SerializeValue(initialDelaySeconds)
+	}
+	if periodSeconds != nil {
+		reqArgs["periodSeconds"] = SerializeValue(periodSeconds)
+	}
+	if timeoutSeconds != nil {
+		reqArgs["timeoutSeconds"] = SerializeValue(timeoutSeconds)
+	}
+	if failureThreshold != nil {
+		reqArgs["failureThreshold"] = SerializeValue(failureThreshold)
+	}
+	if successThreshold != nil {
+		reqArgs["successThreshold"] = SerializeValue(successThreshold)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpProbe", reqArgs)
 	if err != nil {
 		return nil, err
@@ -5339,7 +5665,7 @@ func (s *DotnetToolResource) WithRemoteImageTag(remoteImageTag string) (*IComput
 }
 
 // WithPipelineStepFactory adds a pipeline step to the resource
-func (s *DotnetToolResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description string) (*IResource, error) {
+func (s *DotnetToolResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
@@ -5347,10 +5673,18 @@ func (s *DotnetToolResource) WithPipelineStepFactory(stepName string, callback f
 	if callback != nil {
 		reqArgs["callback"] = RegisterCallback(callback)
 	}
-	reqArgs["dependsOn"] = SerializeValue(dependsOn)
-	reqArgs["requiredBy"] = SerializeValue(requiredBy)
-	reqArgs["tags"] = SerializeValue(tags)
-	reqArgs["description"] = SerializeValue(description)
+	if dependsOn != nil {
+		reqArgs["dependsOn"] = SerializeValue(dependsOn)
+	}
+	if requiredBy != nil {
+		reqArgs["requiredBy"] = SerializeValue(requiredBy)
+	}
+	if tags != nil {
+		reqArgs["tags"] = SerializeValue(tags)
+	}
+	if description != nil {
+		reqArgs["description"] = SerializeValue(description)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withPipelineStepFactory", reqArgs)
 	if err != nil {
 		return nil, err
@@ -5476,12 +5810,16 @@ func (s *DotnetToolResource) OnResourceReady(callback func(...any) any) (*IResou
 }
 
 // WithOptionalString adds an optional string parameter
-func (s *DotnetToolResource) WithOptionalString(value string, enabled bool) (*IResource, error) {
+func (s *DotnetToolResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["value"] = SerializeValue(value)
-	reqArgs["enabled"] = SerializeValue(enabled)
+	if value != nil {
+		reqArgs["value"] = SerializeValue(value)
+	}
+	if enabled != nil {
+		reqArgs["enabled"] = SerializeValue(enabled)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/withOptionalString", reqArgs)
 	if err != nil {
 		return nil, err
@@ -6045,12 +6383,16 @@ func (s *ExecutableResource) WithContainerRegistry(registry *IResource) (*IResou
 }
 
 // WithDockerfileBaseImage sets the base image for a Dockerfile build
-func (s *ExecutableResource) WithDockerfileBaseImage(buildImage string, runtimeImage string) (*IResource, error) {
+func (s *ExecutableResource) WithDockerfileBaseImage(buildImage *string, runtimeImage *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["buildImage"] = SerializeValue(buildImage)
-	reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	if buildImage != nil {
+		reqArgs["buildImage"] = SerializeValue(buildImage)
+	}
+	if runtimeImage != nil {
+		reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withDockerfileBaseImage", reqArgs)
 	if err != nil {
 		return nil, err
@@ -6112,12 +6454,16 @@ func (s *ExecutableResource) WithWorkingDirectory(workingDirectory string) (*Exe
 }
 
 // WithMcpServer configures an MCP server endpoint on the resource
-func (s *ExecutableResource) WithMcpServer(path string, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *ExecutableResource) WithMcpServer(path *string, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withMcpServer", reqArgs)
 	if err != nil {
 		return nil, err
@@ -6151,12 +6497,14 @@ func (s *ExecutableResource) WithOtlpExporterProtocol(protocol OtlpProtocol) (*I
 }
 
 // WithRequiredCommand adds a required command dependency
-func (s *ExecutableResource) WithRequiredCommand(command string, helpLink string) (*IResource, error) {
+func (s *ExecutableResource) WithRequiredCommand(command string, helpLink *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["command"] = SerializeValue(command)
-	reqArgs["helpLink"] = SerializeValue(helpLink)
+	if helpLink != nil {
+		reqArgs["helpLink"] = SerializeValue(helpLink)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withRequiredCommand", reqArgs)
 	if err != nil {
 		return nil, err
@@ -6308,14 +6656,20 @@ func (s *ExecutableResource) WithArgsCallbackAsync(callback func(...any) any) (*
 }
 
 // WithReference adds a reference to another resource
-func (s *ExecutableResource) WithReference(source *IResource, connectionName string, optional bool, name string) (*IResourceWithEnvironment, error) {
+func (s *ExecutableResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["source"] = SerializeValue(source)
-	reqArgs["connectionName"] = SerializeValue(connectionName)
-	reqArgs["optional"] = SerializeValue(optional)
-	reqArgs["name"] = SerializeValue(name)
+	if connectionName != nil {
+		reqArgs["connectionName"] = SerializeValue(connectionName)
+	}
+	if optional != nil {
+		reqArgs["optional"] = SerializeValue(optional)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
 	if err != nil {
 		return nil, err
@@ -6364,18 +6718,34 @@ func (s *ExecutableResource) WithReferenceEndpoint(endpointReference *EndpointRe
 }
 
 // WithEndpoint adds a network endpoint
-func (s *ExecutableResource) WithEndpoint(port float64, targetPort float64, scheme string, name string, env string, isProxied bool, isExternal bool, protocol ProtocolType) (*IResourceWithEndpoints, error) {
+func (s *ExecutableResource) WithEndpoint(port *float64, targetPort *float64, scheme *string, name *string, env *string, isProxied *bool, isExternal *bool, protocol *ProtocolType) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["scheme"] = SerializeValue(scheme)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
-	reqArgs["isExternal"] = SerializeValue(isExternal)
-	reqArgs["protocol"] = SerializeValue(protocol)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if scheme != nil {
+		reqArgs["scheme"] = SerializeValue(scheme)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
+	if isExternal != nil {
+		reqArgs["isExternal"] = SerializeValue(isExternal)
+	}
+	if protocol != nil {
+		reqArgs["protocol"] = SerializeValue(protocol)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -6384,15 +6754,25 @@ func (s *ExecutableResource) WithEndpoint(port float64, targetPort float64, sche
 }
 
 // WithHttpEndpoint adds an HTTP endpoint
-func (s *ExecutableResource) WithHttpEndpoint(port float64, targetPort float64, name string, env string, isProxied bool) (*IResourceWithEndpoints, error) {
+func (s *ExecutableResource) WithHttpEndpoint(port *float64, targetPort *float64, name *string, env *string, isProxied *bool) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -6401,15 +6781,25 @@ func (s *ExecutableResource) WithHttpEndpoint(port float64, targetPort float64, 
 }
 
 // WithHttpsEndpoint adds an HTTPS endpoint
-func (s *ExecutableResource) WithHttpsEndpoint(port float64, targetPort float64, name string, env string, isProxied bool) (*IResourceWithEndpoints, error) {
+func (s *ExecutableResource) WithHttpsEndpoint(port *float64, targetPort *float64, name *string, env *string, isProxied *bool) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -6485,12 +6875,14 @@ func (s *ExecutableResource) WithUrlsCallbackAsync(callback func(...any) any) (*
 }
 
 // WithUrl adds or modifies displayed URLs
-func (s *ExecutableResource) WithUrl(url string, displayText string) (*IResource, error) {
+func (s *ExecutableResource) WithUrl(url string, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrl", reqArgs)
 	if err != nil {
 		return nil, err
@@ -6499,12 +6891,14 @@ func (s *ExecutableResource) WithUrl(url string, displayText string) (*IResource
 }
 
 // WithUrlExpression adds a URL using a reference expression
-func (s *ExecutableResource) WithUrlExpression(url *ReferenceExpression, displayText string) (*IResource, error) {
+func (s *ExecutableResource) WithUrlExpression(url *ReferenceExpression, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrlExpression", reqArgs)
 	if err != nil {
 		return nil, err
@@ -6623,12 +7017,14 @@ func (s *ExecutableResource) WithExplicitStart() (*IResource, error) {
 }
 
 // WaitForCompletion waits for resource completion
-func (s *ExecutableResource) WaitForCompletion(dependency *IResource, exitCode float64) (*IResourceWithWaitSupport, error) {
+func (s *ExecutableResource) WaitForCompletion(dependency *IResource, exitCode *float64) (*IResourceWithWaitSupport, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	reqArgs["exitCode"] = SerializeValue(exitCode)
+	if exitCode != nil {
+		reqArgs["exitCode"] = SerializeValue(exitCode)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForCompletion", reqArgs)
 	if err != nil {
 		return nil, err
@@ -6650,13 +7046,19 @@ func (s *ExecutableResource) WithHealthCheck(key string) (*IResource, error) {
 }
 
 // WithHttpHealthCheck adds an HTTP health check
-func (s *ExecutableResource) WithHttpHealthCheck(path string, statusCode float64, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *ExecutableResource) WithHttpHealthCheck(path *string, statusCode *float64, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["statusCode"] = SerializeValue(statusCode)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if statusCode != nil {
+		reqArgs["statusCode"] = SerializeValue(statusCode)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpHealthCheck", reqArgs)
 	if err != nil {
 		return nil, err
@@ -6764,12 +7166,14 @@ func (s *ExecutableResource) WithChildRelationship(child *IResource) (*IResource
 }
 
 // WithIconName sets the icon for the resource
-func (s *ExecutableResource) WithIconName(iconName string, iconVariant IconVariant) (*IResource, error) {
+func (s *ExecutableResource) WithIconName(iconName string, iconVariant *IconVariant) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["iconName"] = SerializeValue(iconName)
-	reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	if iconVariant != nil {
+		reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withIconName", reqArgs)
 	if err != nil {
 		return nil, err
@@ -6778,18 +7182,32 @@ func (s *ExecutableResource) WithIconName(iconName string, iconVariant IconVaria
 }
 
 // WithHttpProbe adds an HTTP health probe to the resource
-func (s *ExecutableResource) WithHttpProbe(probeType ProbeType, path string, initialDelaySeconds float64, periodSeconds float64, timeoutSeconds float64, failureThreshold float64, successThreshold float64, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *ExecutableResource) WithHttpProbe(probeType ProbeType, path *string, initialDelaySeconds *float64, periodSeconds *float64, timeoutSeconds *float64, failureThreshold *float64, successThreshold *float64, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["probeType"] = SerializeValue(probeType)
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["initialDelaySeconds"] = SerializeValue(initialDelaySeconds)
-	reqArgs["periodSeconds"] = SerializeValue(periodSeconds)
-	reqArgs["timeoutSeconds"] = SerializeValue(timeoutSeconds)
-	reqArgs["failureThreshold"] = SerializeValue(failureThreshold)
-	reqArgs["successThreshold"] = SerializeValue(successThreshold)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if initialDelaySeconds != nil {
+		reqArgs["initialDelaySeconds"] = SerializeValue(initialDelaySeconds)
+	}
+	if periodSeconds != nil {
+		reqArgs["periodSeconds"] = SerializeValue(periodSeconds)
+	}
+	if timeoutSeconds != nil {
+		reqArgs["timeoutSeconds"] = SerializeValue(timeoutSeconds)
+	}
+	if failureThreshold != nil {
+		reqArgs["failureThreshold"] = SerializeValue(failureThreshold)
+	}
+	if successThreshold != nil {
+		reqArgs["successThreshold"] = SerializeValue(successThreshold)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpProbe", reqArgs)
 	if err != nil {
 		return nil, err
@@ -6836,7 +7254,7 @@ func (s *ExecutableResource) WithRemoteImageTag(remoteImageTag string) (*IComput
 }
 
 // WithPipelineStepFactory adds a pipeline step to the resource
-func (s *ExecutableResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description string) (*IResource, error) {
+func (s *ExecutableResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
@@ -6844,10 +7262,18 @@ func (s *ExecutableResource) WithPipelineStepFactory(stepName string, callback f
 	if callback != nil {
 		reqArgs["callback"] = RegisterCallback(callback)
 	}
-	reqArgs["dependsOn"] = SerializeValue(dependsOn)
-	reqArgs["requiredBy"] = SerializeValue(requiredBy)
-	reqArgs["tags"] = SerializeValue(tags)
-	reqArgs["description"] = SerializeValue(description)
+	if dependsOn != nil {
+		reqArgs["dependsOn"] = SerializeValue(dependsOn)
+	}
+	if requiredBy != nil {
+		reqArgs["requiredBy"] = SerializeValue(requiredBy)
+	}
+	if tags != nil {
+		reqArgs["tags"] = SerializeValue(tags)
+	}
+	if description != nil {
+		reqArgs["description"] = SerializeValue(description)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withPipelineStepFactory", reqArgs)
 	if err != nil {
 		return nil, err
@@ -6973,12 +7399,16 @@ func (s *ExecutableResource) OnResourceReady(callback func(...any) any) (*IResou
 }
 
 // WithOptionalString adds an optional string parameter
-func (s *ExecutableResource) WithOptionalString(value string, enabled bool) (*IResource, error) {
+func (s *ExecutableResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["value"] = SerializeValue(value)
-	reqArgs["enabled"] = SerializeValue(enabled)
+	if value != nil {
+		reqArgs["value"] = SerializeValue(value)
+	}
+	if enabled != nil {
+		reqArgs["enabled"] = SerializeValue(enabled)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/withOptionalString", reqArgs)
 	if err != nil {
 		return nil, err
@@ -7291,12 +7721,16 @@ func (s *ExternalServiceResource) WithContainerRegistry(registry *IResource) (*I
 }
 
 // WithDockerfileBaseImage sets the base image for a Dockerfile build
-func (s *ExternalServiceResource) WithDockerfileBaseImage(buildImage string, runtimeImage string) (*IResource, error) {
+func (s *ExternalServiceResource) WithDockerfileBaseImage(buildImage *string, runtimeImage *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["buildImage"] = SerializeValue(buildImage)
-	reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	if buildImage != nil {
+		reqArgs["buildImage"] = SerializeValue(buildImage)
+	}
+	if runtimeImage != nil {
+		reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withDockerfileBaseImage", reqArgs)
 	if err != nil {
 		return nil, err
@@ -7305,12 +7739,16 @@ func (s *ExternalServiceResource) WithDockerfileBaseImage(buildImage string, run
 }
 
 // WithExternalServiceHttpHealthCheck adds an HTTP health check to an external service
-func (s *ExternalServiceResource) WithExternalServiceHttpHealthCheck(path string, statusCode float64) (*ExternalServiceResource, error) {
+func (s *ExternalServiceResource) WithExternalServiceHttpHealthCheck(path *string, statusCode *float64) (*ExternalServiceResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["statusCode"] = SerializeValue(statusCode)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if statusCode != nil {
+		reqArgs["statusCode"] = SerializeValue(statusCode)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withExternalServiceHttpHealthCheck", reqArgs)
 	if err != nil {
 		return nil, err
@@ -7319,12 +7757,14 @@ func (s *ExternalServiceResource) WithExternalServiceHttpHealthCheck(path string
 }
 
 // WithRequiredCommand adds a required command dependency
-func (s *ExternalServiceResource) WithRequiredCommand(command string, helpLink string) (*IResource, error) {
+func (s *ExternalServiceResource) WithRequiredCommand(command string, helpLink *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["command"] = SerializeValue(command)
-	reqArgs["helpLink"] = SerializeValue(helpLink)
+	if helpLink != nil {
+		reqArgs["helpLink"] = SerializeValue(helpLink)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withRequiredCommand", reqArgs)
 	if err != nil {
 		return nil, err
@@ -7363,12 +7803,14 @@ func (s *ExternalServiceResource) WithUrlsCallbackAsync(callback func(...any) an
 }
 
 // WithUrl adds or modifies displayed URLs
-func (s *ExternalServiceResource) WithUrl(url string, displayText string) (*IResource, error) {
+func (s *ExternalServiceResource) WithUrl(url string, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrl", reqArgs)
 	if err != nil {
 		return nil, err
@@ -7377,12 +7819,14 @@ func (s *ExternalServiceResource) WithUrl(url string, displayText string) (*IRes
 }
 
 // WithUrlExpression adds a URL using a reference expression
-func (s *ExternalServiceResource) WithUrlExpression(url *ReferenceExpression, displayText string) (*IResource, error) {
+func (s *ExternalServiceResource) WithUrlExpression(url *ReferenceExpression, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrlExpression", reqArgs)
 	if err != nil {
 		return nil, err
@@ -7490,12 +7934,14 @@ func (s *ExternalServiceResource) WithChildRelationship(child *IResource) (*IRes
 }
 
 // WithIconName sets the icon for the resource
-func (s *ExternalServiceResource) WithIconName(iconName string, iconVariant IconVariant) (*IResource, error) {
+func (s *ExternalServiceResource) WithIconName(iconName string, iconVariant *IconVariant) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["iconName"] = SerializeValue(iconName)
-	reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	if iconVariant != nil {
+		reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withIconName", reqArgs)
 	if err != nil {
 		return nil, err
@@ -7516,7 +7962,7 @@ func (s *ExternalServiceResource) ExcludeFromMcp() (*IResource, error) {
 }
 
 // WithPipelineStepFactory adds a pipeline step to the resource
-func (s *ExternalServiceResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description string) (*IResource, error) {
+func (s *ExternalServiceResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
@@ -7524,10 +7970,18 @@ func (s *ExternalServiceResource) WithPipelineStepFactory(stepName string, callb
 	if callback != nil {
 		reqArgs["callback"] = RegisterCallback(callback)
 	}
-	reqArgs["dependsOn"] = SerializeValue(dependsOn)
-	reqArgs["requiredBy"] = SerializeValue(requiredBy)
-	reqArgs["tags"] = SerializeValue(tags)
-	reqArgs["description"] = SerializeValue(description)
+	if dependsOn != nil {
+		reqArgs["dependsOn"] = SerializeValue(dependsOn)
+	}
+	if requiredBy != nil {
+		reqArgs["requiredBy"] = SerializeValue(requiredBy)
+	}
+	if tags != nil {
+		reqArgs["tags"] = SerializeValue(tags)
+	}
+	if description != nil {
+		reqArgs["description"] = SerializeValue(description)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withPipelineStepFactory", reqArgs)
 	if err != nil {
 		return nil, err
@@ -7638,12 +8092,16 @@ func (s *ExternalServiceResource) OnResourceReady(callback func(...any) any) (*I
 }
 
 // WithOptionalString adds an optional string parameter
-func (s *ExternalServiceResource) WithOptionalString(value string, enabled bool) (*IResource, error) {
+func (s *ExternalServiceResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["value"] = SerializeValue(value)
-	reqArgs["enabled"] = SerializeValue(enabled)
+	if value != nil {
+		reqArgs["value"] = SerializeValue(value)
+	}
+	if enabled != nil {
+		reqArgs["enabled"] = SerializeValue(enabled)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/withOptionalString", reqArgs)
 	if err != nil {
 		return nil, err
@@ -7985,13 +8443,15 @@ func (s *IDistributedApplicationBuilder) AddContainerRegistry(name string, endpo
 }
 
 // AddContainerRegistryFromString adds a container registry with string endpoint
-func (s *IDistributedApplicationBuilder) AddContainerRegistryFromString(name string, endpoint string, repository string) (*ContainerRegistryResource, error) {
+func (s *IDistributedApplicationBuilder) AddContainerRegistryFromString(name string, endpoint string, repository *string) (*ContainerRegistryResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["endpoint"] = SerializeValue(endpoint)
-	reqArgs["repository"] = SerializeValue(repository)
+	if repository != nil {
+		reqArgs["repository"] = SerializeValue(repository)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/addContainerRegistryFromString", reqArgs)
 	if err != nil {
 		return nil, err
@@ -8014,14 +8474,18 @@ func (s *IDistributedApplicationBuilder) AddContainer(name string, image string)
 }
 
 // AddDockerfile adds a container resource built from a Dockerfile
-func (s *IDistributedApplicationBuilder) AddDockerfile(name string, contextPath string, dockerfilePath string, stage string) (*ContainerResource, error) {
+func (s *IDistributedApplicationBuilder) AddDockerfile(name string, contextPath string, dockerfilePath *string, stage *string) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["contextPath"] = SerializeValue(contextPath)
-	reqArgs["dockerfilePath"] = SerializeValue(dockerfilePath)
-	reqArgs["stage"] = SerializeValue(stage)
+	if dockerfilePath != nil {
+		reqArgs["dockerfilePath"] = SerializeValue(dockerfilePath)
+	}
+	if stage != nil {
+		reqArgs["stage"] = SerializeValue(stage)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/addDockerfile", reqArgs)
 	if err != nil {
 		return nil, err
@@ -8174,12 +8638,14 @@ func (s *IDistributedApplicationBuilder) Build() (*DistributedApplication, error
 }
 
 // AddParameter adds a parameter resource
-func (s *IDistributedApplicationBuilder) AddParameter(name string, secret bool) (*ParameterResource, error) {
+func (s *IDistributedApplicationBuilder) AddParameter(name string, secret *bool) (*ParameterResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["name"] = SerializeValue(name)
-	reqArgs["secret"] = SerializeValue(secret)
+	if secret != nil {
+		reqArgs["secret"] = SerializeValue(secret)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/addParameter", reqArgs)
 	if err != nil {
 		return nil, err
@@ -8188,14 +8654,18 @@ func (s *IDistributedApplicationBuilder) AddParameter(name string, secret bool) 
 }
 
 // AddParameterWithValue adds a parameter with a default value
-func (s *IDistributedApplicationBuilder) AddParameterWithValue(name string, value string, publishValueAsDefault bool, secret bool) (*ParameterResource, error) {
+func (s *IDistributedApplicationBuilder) AddParameterWithValue(name string, value string, publishValueAsDefault *bool, secret *bool) (*ParameterResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
-	reqArgs["publishValueAsDefault"] = SerializeValue(publishValueAsDefault)
-	reqArgs["secret"] = SerializeValue(secret)
+	if publishValueAsDefault != nil {
+		reqArgs["publishValueAsDefault"] = SerializeValue(publishValueAsDefault)
+	}
+	if secret != nil {
+		reqArgs["secret"] = SerializeValue(secret)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/addParameterWithValue", reqArgs)
 	if err != nil {
 		return nil, err
@@ -8204,13 +8674,15 @@ func (s *IDistributedApplicationBuilder) AddParameterWithValue(name string, valu
 }
 
 // AddParameterFromConfiguration adds a parameter sourced from configuration
-func (s *IDistributedApplicationBuilder) AddParameterFromConfiguration(name string, configurationKey string, secret bool) (*ParameterResource, error) {
+func (s *IDistributedApplicationBuilder) AddParameterFromConfiguration(name string, configurationKey string, secret *bool) (*ParameterResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["configurationKey"] = SerializeValue(configurationKey)
-	reqArgs["secret"] = SerializeValue(secret)
+	if secret != nil {
+		reqArgs["secret"] = SerializeValue(secret)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/addParameterFromConfiguration", reqArgs)
 	if err != nil {
 		return nil, err
@@ -8219,12 +8691,14 @@ func (s *IDistributedApplicationBuilder) AddParameterFromConfiguration(name stri
 }
 
 // AddConnectionString adds a connection string resource
-func (s *IDistributedApplicationBuilder) AddConnectionString(name string, environmentVariableName string) (*IResourceWithConnectionString, error) {
+func (s *IDistributedApplicationBuilder) AddConnectionString(name string, environmentVariableName *string) (*IResourceWithConnectionString, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["name"] = SerializeValue(name)
-	reqArgs["environmentVariableName"] = SerializeValue(environmentVariableName)
+	if environmentVariableName != nil {
+		reqArgs["environmentVariableName"] = SerializeValue(environmentVariableName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/addConnectionString", reqArgs)
 	if err != nil {
 		return nil, err
@@ -8338,12 +8812,14 @@ func (s *IDistributedApplicationBuilder) SubscribeAfterResourcesCreated(callback
 }
 
 // AddTestRedis adds a test Redis resource
-func (s *IDistributedApplicationBuilder) AddTestRedis(name string, port float64) (*TestRedisResource, error) {
+func (s *IDistributedApplicationBuilder) AddTestRedis(name string, port *float64) (*TestRedisResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["name"] = SerializeValue(name)
-	reqArgs["port"] = SerializeValue(port)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/addTestRedis", reqArgs)
 	if err != nil {
 		return nil, err
@@ -8626,12 +9102,14 @@ func (s *IReportingStep) LogStepMarkdown(level string, markdownString string) er
 }
 
 // CompleteStep completes the reporting step with plain-text completion text
-func (s *IReportingStep) CompleteStep(completionText string, completionState string, cancellationToken *CancellationToken) error {
+func (s *IReportingStep) CompleteStep(completionText string, completionState *string, cancellationToken *CancellationToken) error {
 	reqArgs := map[string]any{
 		"reportingStep": SerializeValue(s.Handle()),
 	}
 	reqArgs["completionText"] = SerializeValue(completionText)
-	reqArgs["completionState"] = SerializeValue(completionState)
+	if completionState != nil {
+		reqArgs["completionState"] = SerializeValue(completionState)
+	}
 	if cancellationToken != nil {
 		reqArgs["cancellationToken"] = RegisterCancellation(cancellationToken, s.Client())
 	}
@@ -8640,12 +9118,14 @@ func (s *IReportingStep) CompleteStep(completionText string, completionState str
 }
 
 // CompleteStepMarkdown completes the reporting step with Markdown-formatted completion text
-func (s *IReportingStep) CompleteStepMarkdown(markdownString string, completionState string, cancellationToken *CancellationToken) error {
+func (s *IReportingStep) CompleteStepMarkdown(markdownString string, completionState *string, cancellationToken *CancellationToken) error {
 	reqArgs := map[string]any{
 		"reportingStep": SerializeValue(s.Handle()),
 	}
 	reqArgs["markdownString"] = SerializeValue(markdownString)
-	reqArgs["completionState"] = SerializeValue(completionState)
+	if completionState != nil {
+		reqArgs["completionState"] = SerializeValue(completionState)
+	}
 	if cancellationToken != nil {
 		reqArgs["cancellationToken"] = RegisterCancellation(cancellationToken, s.Client())
 	}
@@ -8692,12 +9172,16 @@ func (s *IReportingTask) UpdateTaskMarkdown(markdownString string, cancellationT
 }
 
 // CompleteTask completes the reporting task with plain-text completion text
-func (s *IReportingTask) CompleteTask(completionMessage string, completionState string, cancellationToken *CancellationToken) error {
+func (s *IReportingTask) CompleteTask(completionMessage *string, completionState *string, cancellationToken *CancellationToken) error {
 	reqArgs := map[string]any{
 		"reportingTask": SerializeValue(s.Handle()),
 	}
-	reqArgs["completionMessage"] = SerializeValue(completionMessage)
-	reqArgs["completionState"] = SerializeValue(completionState)
+	if completionMessage != nil {
+		reqArgs["completionMessage"] = SerializeValue(completionMessage)
+	}
+	if completionState != nil {
+		reqArgs["completionState"] = SerializeValue(completionState)
+	}
 	if cancellationToken != nil {
 		reqArgs["cancellationToken"] = RegisterCancellation(cancellationToken, s.Client())
 	}
@@ -8706,12 +9190,14 @@ func (s *IReportingTask) CompleteTask(completionMessage string, completionState 
 }
 
 // CompleteTaskMarkdown completes the reporting task with Markdown-formatted completion text
-func (s *IReportingTask) CompleteTaskMarkdown(markdownString string, completionState string, cancellationToken *CancellationToken) error {
+func (s *IReportingTask) CompleteTaskMarkdown(markdownString string, completionState *string, cancellationToken *CancellationToken) error {
 	reqArgs := map[string]any{
 		"reportingTask": SerializeValue(s.Handle()),
 	}
 	reqArgs["markdownString"] = SerializeValue(markdownString)
-	reqArgs["completionState"] = SerializeValue(completionState)
+	if completionState != nil {
+		reqArgs["completionState"] = SerializeValue(completionState)
+	}
 	if cancellationToken != nil {
 		reqArgs["cancellationToken"] = RegisterCancellation(cancellationToken, s.Client())
 	}
@@ -9109,12 +9595,16 @@ func (s *ParameterResource) WithContainerRegistry(registry *IResource) (*IResour
 }
 
 // WithDockerfileBaseImage sets the base image for a Dockerfile build
-func (s *ParameterResource) WithDockerfileBaseImage(buildImage string, runtimeImage string) (*IResource, error) {
+func (s *ParameterResource) WithDockerfileBaseImage(buildImage *string, runtimeImage *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["buildImage"] = SerializeValue(buildImage)
-	reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	if buildImage != nil {
+		reqArgs["buildImage"] = SerializeValue(buildImage)
+	}
+	if runtimeImage != nil {
+		reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withDockerfileBaseImage", reqArgs)
 	if err != nil {
 		return nil, err
@@ -9123,12 +9613,14 @@ func (s *ParameterResource) WithDockerfileBaseImage(buildImage string, runtimeIm
 }
 
 // WithDescription sets a parameter description
-func (s *ParameterResource) WithDescription(description string, enableMarkdown bool) (*ParameterResource, error) {
+func (s *ParameterResource) WithDescription(description string, enableMarkdown *bool) (*ParameterResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["description"] = SerializeValue(description)
-	reqArgs["enableMarkdown"] = SerializeValue(enableMarkdown)
+	if enableMarkdown != nil {
+		reqArgs["enableMarkdown"] = SerializeValue(enableMarkdown)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withDescription", reqArgs)
 	if err != nil {
 		return nil, err
@@ -9137,12 +9629,14 @@ func (s *ParameterResource) WithDescription(description string, enableMarkdown b
 }
 
 // WithRequiredCommand adds a required command dependency
-func (s *ParameterResource) WithRequiredCommand(command string, helpLink string) (*IResource, error) {
+func (s *ParameterResource) WithRequiredCommand(command string, helpLink *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["command"] = SerializeValue(command)
-	reqArgs["helpLink"] = SerializeValue(helpLink)
+	if helpLink != nil {
+		reqArgs["helpLink"] = SerializeValue(helpLink)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withRequiredCommand", reqArgs)
 	if err != nil {
 		return nil, err
@@ -9181,12 +9675,14 @@ func (s *ParameterResource) WithUrlsCallbackAsync(callback func(...any) any) (*I
 }
 
 // WithUrl adds or modifies displayed URLs
-func (s *ParameterResource) WithUrl(url string, displayText string) (*IResource, error) {
+func (s *ParameterResource) WithUrl(url string, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrl", reqArgs)
 	if err != nil {
 		return nil, err
@@ -9195,12 +9691,14 @@ func (s *ParameterResource) WithUrl(url string, displayText string) (*IResource,
 }
 
 // WithUrlExpression adds a URL using a reference expression
-func (s *ParameterResource) WithUrlExpression(url *ReferenceExpression, displayText string) (*IResource, error) {
+func (s *ParameterResource) WithUrlExpression(url *ReferenceExpression, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrlExpression", reqArgs)
 	if err != nil {
 		return nil, err
@@ -9308,12 +9806,14 @@ func (s *ParameterResource) WithChildRelationship(child *IResource) (*IResource,
 }
 
 // WithIconName sets the icon for the resource
-func (s *ParameterResource) WithIconName(iconName string, iconVariant IconVariant) (*IResource, error) {
+func (s *ParameterResource) WithIconName(iconName string, iconVariant *IconVariant) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["iconName"] = SerializeValue(iconName)
-	reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	if iconVariant != nil {
+		reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withIconName", reqArgs)
 	if err != nil {
 		return nil, err
@@ -9334,7 +9834,7 @@ func (s *ParameterResource) ExcludeFromMcp() (*IResource, error) {
 }
 
 // WithPipelineStepFactory adds a pipeline step to the resource
-func (s *ParameterResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description string) (*IResource, error) {
+func (s *ParameterResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
@@ -9342,10 +9842,18 @@ func (s *ParameterResource) WithPipelineStepFactory(stepName string, callback fu
 	if callback != nil {
 		reqArgs["callback"] = RegisterCallback(callback)
 	}
-	reqArgs["dependsOn"] = SerializeValue(dependsOn)
-	reqArgs["requiredBy"] = SerializeValue(requiredBy)
-	reqArgs["tags"] = SerializeValue(tags)
-	reqArgs["description"] = SerializeValue(description)
+	if dependsOn != nil {
+		reqArgs["dependsOn"] = SerializeValue(dependsOn)
+	}
+	if requiredBy != nil {
+		reqArgs["requiredBy"] = SerializeValue(requiredBy)
+	}
+	if tags != nil {
+		reqArgs["tags"] = SerializeValue(tags)
+	}
+	if description != nil {
+		reqArgs["description"] = SerializeValue(description)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withPipelineStepFactory", reqArgs)
 	if err != nil {
 		return nil, err
@@ -9456,12 +9964,16 @@ func (s *ParameterResource) OnResourceReady(callback func(...any) any) (*IResour
 }
 
 // WithOptionalString adds an optional string parameter
-func (s *ParameterResource) WithOptionalString(value string, enabled bool) (*IResource, error) {
+func (s *ParameterResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["value"] = SerializeValue(value)
-	reqArgs["enabled"] = SerializeValue(enabled)
+	if value != nil {
+		reqArgs["value"] = SerializeValue(value)
+	}
+	if enabled != nil {
+		reqArgs["enabled"] = SerializeValue(enabled)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/withOptionalString", reqArgs)
 	if err != nil {
 		return nil, err
@@ -10259,12 +10771,16 @@ func (s *ProjectResource) WithContainerRegistry(registry *IResource) (*IResource
 }
 
 // WithDockerfileBaseImage sets the base image for a Dockerfile build
-func (s *ProjectResource) WithDockerfileBaseImage(buildImage string, runtimeImage string) (*IResource, error) {
+func (s *ProjectResource) WithDockerfileBaseImage(buildImage *string, runtimeImage *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["buildImage"] = SerializeValue(buildImage)
-	reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	if buildImage != nil {
+		reqArgs["buildImage"] = SerializeValue(buildImage)
+	}
+	if runtimeImage != nil {
+		reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withDockerfileBaseImage", reqArgs)
 	if err != nil {
 		return nil, err
@@ -10273,12 +10789,16 @@ func (s *ProjectResource) WithDockerfileBaseImage(buildImage string, runtimeImag
 }
 
 // WithMcpServer configures an MCP server endpoint on the resource
-func (s *ProjectResource) WithMcpServer(path string, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *ProjectResource) WithMcpServer(path *string, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withMcpServer", reqArgs)
 	if err != nil {
 		return nil, err
@@ -10352,12 +10872,14 @@ func (s *ProjectResource) PublishAsDockerFile(configure func(...any) any) (*Proj
 }
 
 // WithRequiredCommand adds a required command dependency
-func (s *ProjectResource) WithRequiredCommand(command string, helpLink string) (*IResource, error) {
+func (s *ProjectResource) WithRequiredCommand(command string, helpLink *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["command"] = SerializeValue(command)
-	reqArgs["helpLink"] = SerializeValue(helpLink)
+	if helpLink != nil {
+		reqArgs["helpLink"] = SerializeValue(helpLink)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withRequiredCommand", reqArgs)
 	if err != nil {
 		return nil, err
@@ -10509,14 +11031,20 @@ func (s *ProjectResource) WithArgsCallbackAsync(callback func(...any) any) (*IRe
 }
 
 // WithReference adds a reference to another resource
-func (s *ProjectResource) WithReference(source *IResource, connectionName string, optional bool, name string) (*IResourceWithEnvironment, error) {
+func (s *ProjectResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["source"] = SerializeValue(source)
-	reqArgs["connectionName"] = SerializeValue(connectionName)
-	reqArgs["optional"] = SerializeValue(optional)
-	reqArgs["name"] = SerializeValue(name)
+	if connectionName != nil {
+		reqArgs["connectionName"] = SerializeValue(connectionName)
+	}
+	if optional != nil {
+		reqArgs["optional"] = SerializeValue(optional)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
 	if err != nil {
 		return nil, err
@@ -10565,18 +11093,34 @@ func (s *ProjectResource) WithReferenceEndpoint(endpointReference *EndpointRefer
 }
 
 // WithEndpoint adds a network endpoint
-func (s *ProjectResource) WithEndpoint(port float64, targetPort float64, scheme string, name string, env string, isProxied bool, isExternal bool, protocol ProtocolType) (*IResourceWithEndpoints, error) {
+func (s *ProjectResource) WithEndpoint(port *float64, targetPort *float64, scheme *string, name *string, env *string, isProxied *bool, isExternal *bool, protocol *ProtocolType) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["scheme"] = SerializeValue(scheme)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
-	reqArgs["isExternal"] = SerializeValue(isExternal)
-	reqArgs["protocol"] = SerializeValue(protocol)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if scheme != nil {
+		reqArgs["scheme"] = SerializeValue(scheme)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
+	if isExternal != nil {
+		reqArgs["isExternal"] = SerializeValue(isExternal)
+	}
+	if protocol != nil {
+		reqArgs["protocol"] = SerializeValue(protocol)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -10585,15 +11129,25 @@ func (s *ProjectResource) WithEndpoint(port float64, targetPort float64, scheme 
 }
 
 // WithHttpEndpoint adds an HTTP endpoint
-func (s *ProjectResource) WithHttpEndpoint(port float64, targetPort float64, name string, env string, isProxied bool) (*IResourceWithEndpoints, error) {
+func (s *ProjectResource) WithHttpEndpoint(port *float64, targetPort *float64, name *string, env *string, isProxied *bool) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -10602,15 +11156,25 @@ func (s *ProjectResource) WithHttpEndpoint(port float64, targetPort float64, nam
 }
 
 // WithHttpsEndpoint adds an HTTPS endpoint
-func (s *ProjectResource) WithHttpsEndpoint(port float64, targetPort float64, name string, env string, isProxied bool) (*IResourceWithEndpoints, error) {
+func (s *ProjectResource) WithHttpsEndpoint(port *float64, targetPort *float64, name *string, env *string, isProxied *bool) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -10686,12 +11250,14 @@ func (s *ProjectResource) WithUrlsCallbackAsync(callback func(...any) any) (*IRe
 }
 
 // WithUrl adds or modifies displayed URLs
-func (s *ProjectResource) WithUrl(url string, displayText string) (*IResource, error) {
+func (s *ProjectResource) WithUrl(url string, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrl", reqArgs)
 	if err != nil {
 		return nil, err
@@ -10700,12 +11266,14 @@ func (s *ProjectResource) WithUrl(url string, displayText string) (*IResource, e
 }
 
 // WithUrlExpression adds a URL using a reference expression
-func (s *ProjectResource) WithUrlExpression(url *ReferenceExpression, displayText string) (*IResource, error) {
+func (s *ProjectResource) WithUrlExpression(url *ReferenceExpression, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrlExpression", reqArgs)
 	if err != nil {
 		return nil, err
@@ -10838,12 +11406,14 @@ func (s *ProjectResource) WithExplicitStart() (*IResource, error) {
 }
 
 // WaitForCompletion waits for resource completion
-func (s *ProjectResource) WaitForCompletion(dependency *IResource, exitCode float64) (*IResourceWithWaitSupport, error) {
+func (s *ProjectResource) WaitForCompletion(dependency *IResource, exitCode *float64) (*IResourceWithWaitSupport, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	reqArgs["exitCode"] = SerializeValue(exitCode)
+	if exitCode != nil {
+		reqArgs["exitCode"] = SerializeValue(exitCode)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForCompletion", reqArgs)
 	if err != nil {
 		return nil, err
@@ -10865,13 +11435,19 @@ func (s *ProjectResource) WithHealthCheck(key string) (*IResource, error) {
 }
 
 // WithHttpHealthCheck adds an HTTP health check
-func (s *ProjectResource) WithHttpHealthCheck(path string, statusCode float64, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *ProjectResource) WithHttpHealthCheck(path *string, statusCode *float64, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["statusCode"] = SerializeValue(statusCode)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if statusCode != nil {
+		reqArgs["statusCode"] = SerializeValue(statusCode)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpHealthCheck", reqArgs)
 	if err != nil {
 		return nil, err
@@ -10979,12 +11555,14 @@ func (s *ProjectResource) WithChildRelationship(child *IResource) (*IResource, e
 }
 
 // WithIconName sets the icon for the resource
-func (s *ProjectResource) WithIconName(iconName string, iconVariant IconVariant) (*IResource, error) {
+func (s *ProjectResource) WithIconName(iconName string, iconVariant *IconVariant) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["iconName"] = SerializeValue(iconName)
-	reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	if iconVariant != nil {
+		reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withIconName", reqArgs)
 	if err != nil {
 		return nil, err
@@ -10993,18 +11571,32 @@ func (s *ProjectResource) WithIconName(iconName string, iconVariant IconVariant)
 }
 
 // WithHttpProbe adds an HTTP health probe to the resource
-func (s *ProjectResource) WithHttpProbe(probeType ProbeType, path string, initialDelaySeconds float64, periodSeconds float64, timeoutSeconds float64, failureThreshold float64, successThreshold float64, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *ProjectResource) WithHttpProbe(probeType ProbeType, path *string, initialDelaySeconds *float64, periodSeconds *float64, timeoutSeconds *float64, failureThreshold *float64, successThreshold *float64, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["probeType"] = SerializeValue(probeType)
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["initialDelaySeconds"] = SerializeValue(initialDelaySeconds)
-	reqArgs["periodSeconds"] = SerializeValue(periodSeconds)
-	reqArgs["timeoutSeconds"] = SerializeValue(timeoutSeconds)
-	reqArgs["failureThreshold"] = SerializeValue(failureThreshold)
-	reqArgs["successThreshold"] = SerializeValue(successThreshold)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if initialDelaySeconds != nil {
+		reqArgs["initialDelaySeconds"] = SerializeValue(initialDelaySeconds)
+	}
+	if periodSeconds != nil {
+		reqArgs["periodSeconds"] = SerializeValue(periodSeconds)
+	}
+	if timeoutSeconds != nil {
+		reqArgs["timeoutSeconds"] = SerializeValue(timeoutSeconds)
+	}
+	if failureThreshold != nil {
+		reqArgs["failureThreshold"] = SerializeValue(failureThreshold)
+	}
+	if successThreshold != nil {
+		reqArgs["successThreshold"] = SerializeValue(successThreshold)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpProbe", reqArgs)
 	if err != nil {
 		return nil, err
@@ -11051,7 +11643,7 @@ func (s *ProjectResource) WithRemoteImageTag(remoteImageTag string) (*IComputeRe
 }
 
 // WithPipelineStepFactory adds a pipeline step to the resource
-func (s *ProjectResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description string) (*IResource, error) {
+func (s *ProjectResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
@@ -11059,10 +11651,18 @@ func (s *ProjectResource) WithPipelineStepFactory(stepName string, callback func
 	if callback != nil {
 		reqArgs["callback"] = RegisterCallback(callback)
 	}
-	reqArgs["dependsOn"] = SerializeValue(dependsOn)
-	reqArgs["requiredBy"] = SerializeValue(requiredBy)
-	reqArgs["tags"] = SerializeValue(tags)
-	reqArgs["description"] = SerializeValue(description)
+	if dependsOn != nil {
+		reqArgs["dependsOn"] = SerializeValue(dependsOn)
+	}
+	if requiredBy != nil {
+		reqArgs["requiredBy"] = SerializeValue(requiredBy)
+	}
+	if tags != nil {
+		reqArgs["tags"] = SerializeValue(tags)
+	}
+	if description != nil {
+		reqArgs["description"] = SerializeValue(description)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withPipelineStepFactory", reqArgs)
 	if err != nil {
 		return nil, err
@@ -11188,12 +11788,16 @@ func (s *ProjectResource) OnResourceReady(callback func(...any) any) (*IResource
 }
 
 // WithOptionalString adds an optional string parameter
-func (s *ProjectResource) WithOptionalString(value string, enabled bool) (*IResource, error) {
+func (s *ProjectResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["value"] = SerializeValue(value)
-	reqArgs["enabled"] = SerializeValue(enabled)
+	if value != nil {
+		reqArgs["value"] = SerializeValue(value)
+	}
+	if enabled != nil {
+		reqArgs["enabled"] = SerializeValue(enabled)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/withOptionalString", reqArgs)
 	if err != nil {
 		return nil, err
@@ -11513,23 +12117,27 @@ func (s *ReferenceExpressionBuilder) AppendLiteral(value string) error {
 }
 
 // AppendFormatted appends a formatted string value to the reference expression
-func (s *ReferenceExpressionBuilder) AppendFormatted(value string, format string) error {
+func (s *ReferenceExpressionBuilder) AppendFormatted(value string, format *string) error {
 	reqArgs := map[string]any{
 		"context": SerializeValue(s.Handle()),
 	}
 	reqArgs["value"] = SerializeValue(value)
-	reqArgs["format"] = SerializeValue(format)
+	if format != nil {
+		reqArgs["format"] = SerializeValue(format)
+	}
 	_, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/appendFormatted", reqArgs)
 	return err
 }
 
 // AppendValueProvider appends a value provider to the reference expression
-func (s *ReferenceExpressionBuilder) AppendValueProvider(valueProvider any, format string) error {
+func (s *ReferenceExpressionBuilder) AppendValueProvider(valueProvider any, format *string) error {
 	reqArgs := map[string]any{
 		"context": SerializeValue(s.Handle()),
 	}
 	reqArgs["valueProvider"] = SerializeValue(valueProvider)
-	reqArgs["format"] = SerializeValue(format)
+	if format != nil {
+		reqArgs["format"] = SerializeValue(format)
+	}
 	_, err := s.Client().InvokeCapability("Aspire.Hosting.ApplicationModel/appendValueProvider", reqArgs)
 	return err
 }
@@ -11627,12 +12235,14 @@ func NewResourceNotificationService(handle *Handle, client *AspireClient) *Resou
 }
 
 // WaitForResourceState waits for a resource to reach a specified state
-func (s *ResourceNotificationService) WaitForResourceState(resourceName string, targetState string) error {
+func (s *ResourceNotificationService) WaitForResourceState(resourceName string, targetState *string) error {
 	reqArgs := map[string]any{
 		"notificationService": SerializeValue(s.Handle()),
 	}
 	reqArgs["resourceName"] = SerializeValue(resourceName)
-	reqArgs["targetState"] = SerializeValue(targetState)
+	if targetState != nil {
+		reqArgs["targetState"] = SerializeValue(targetState)
+	}
 	_, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResourceState", reqArgs)
 	return err
 }
@@ -11688,13 +12298,17 @@ func (s *ResourceNotificationService) TryGetResourceState(resourceName string) (
 }
 
 // PublishResourceUpdate publishes an update for a resource's state
-func (s *ResourceNotificationService) PublishResourceUpdate(resource *IResource, state string, stateStyle string) error {
+func (s *ResourceNotificationService) PublishResourceUpdate(resource *IResource, state *string, stateStyle *string) error {
 	reqArgs := map[string]any{
 		"notificationService": SerializeValue(s.Handle()),
 	}
 	reqArgs["resource"] = SerializeValue(resource)
-	reqArgs["state"] = SerializeValue(state)
-	reqArgs["stateStyle"] = SerializeValue(stateStyle)
+	if state != nil {
+		reqArgs["state"] = SerializeValue(state)
+	}
+	if stateStyle != nil {
+		reqArgs["stateStyle"] = SerializeValue(stateStyle)
+	}
 	_, err := s.Client().InvokeCapability("Aspire.Hosting/publishResourceUpdate", reqArgs)
 	return err
 }
@@ -11998,13 +12612,15 @@ func (s *TestDatabaseResource) WithContainerRegistry(registry *IResource) (*IRes
 }
 
 // WithBindMount adds a bind mount
-func (s *TestDatabaseResource) WithBindMount(source string, target string, isReadOnly bool) (*ContainerResource, error) {
+func (s *TestDatabaseResource) WithBindMount(source string, target string, isReadOnly *bool) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["source"] = SerializeValue(source)
 	reqArgs["target"] = SerializeValue(target)
-	reqArgs["isReadOnly"] = SerializeValue(isReadOnly)
+	if isReadOnly != nil {
+		reqArgs["isReadOnly"] = SerializeValue(isReadOnly)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBindMount", reqArgs)
 	if err != nil {
 		return nil, err
@@ -12052,12 +12668,14 @@ func (s *TestDatabaseResource) WithImageRegistry(registry string) (*ContainerRes
 }
 
 // WithImage sets the container image
-func (s *TestDatabaseResource) WithImage(image string, tag string) (*ContainerResource, error) {
+func (s *TestDatabaseResource) WithImage(image string, tag *string) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["image"] = SerializeValue(image)
-	reqArgs["tag"] = SerializeValue(tag)
+	if tag != nil {
+		reqArgs["tag"] = SerializeValue(tag)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withImage", reqArgs)
 	if err != nil {
 		return nil, err
@@ -12130,13 +12748,17 @@ func (s *TestDatabaseResource) PublishAsContainer() (*ContainerResource, error) 
 }
 
 // WithDockerfile configures the resource to use a Dockerfile
-func (s *TestDatabaseResource) WithDockerfile(contextPath string, dockerfilePath string, stage string) (*ContainerResource, error) {
+func (s *TestDatabaseResource) WithDockerfile(contextPath string, dockerfilePath *string, stage *string) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["contextPath"] = SerializeValue(contextPath)
-	reqArgs["dockerfilePath"] = SerializeValue(dockerfilePath)
-	reqArgs["stage"] = SerializeValue(stage)
+	if dockerfilePath != nil {
+		reqArgs["dockerfilePath"] = SerializeValue(dockerfilePath)
+	}
+	if stage != nil {
+		reqArgs["stage"] = SerializeValue(stage)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withDockerfile", reqArgs)
 	if err != nil {
 		return nil, err
@@ -12199,12 +12821,16 @@ func (s *TestDatabaseResource) WithEndpointProxySupport(proxyEnabled bool) (*Con
 }
 
 // WithDockerfileBaseImage sets the base image for a Dockerfile build
-func (s *TestDatabaseResource) WithDockerfileBaseImage(buildImage string, runtimeImage string) (*IResource, error) {
+func (s *TestDatabaseResource) WithDockerfileBaseImage(buildImage *string, runtimeImage *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["buildImage"] = SerializeValue(buildImage)
-	reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	if buildImage != nil {
+		reqArgs["buildImage"] = SerializeValue(buildImage)
+	}
+	if runtimeImage != nil {
+		reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withDockerfileBaseImage", reqArgs)
 	if err != nil {
 		return nil, err
@@ -12226,12 +12852,16 @@ func (s *TestDatabaseResource) WithContainerNetworkAlias(alias string) (*Contain
 }
 
 // WithMcpServer configures an MCP server endpoint on the resource
-func (s *TestDatabaseResource) WithMcpServer(path string, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *TestDatabaseResource) WithMcpServer(path *string, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withMcpServer", reqArgs)
 	if err != nil {
 		return nil, err
@@ -12277,12 +12907,14 @@ func (s *TestDatabaseResource) PublishAsConnectionString() (*ContainerResource, 
 }
 
 // WithRequiredCommand adds a required command dependency
-func (s *TestDatabaseResource) WithRequiredCommand(command string, helpLink string) (*IResource, error) {
+func (s *TestDatabaseResource) WithRequiredCommand(command string, helpLink *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["command"] = SerializeValue(command)
-	reqArgs["helpLink"] = SerializeValue(helpLink)
+	if helpLink != nil {
+		reqArgs["helpLink"] = SerializeValue(helpLink)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withRequiredCommand", reqArgs)
 	if err != nil {
 		return nil, err
@@ -12434,14 +13066,20 @@ func (s *TestDatabaseResource) WithArgsCallbackAsync(callback func(...any) any) 
 }
 
 // WithReference adds a reference to another resource
-func (s *TestDatabaseResource) WithReference(source *IResource, connectionName string, optional bool, name string) (*IResourceWithEnvironment, error) {
+func (s *TestDatabaseResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["source"] = SerializeValue(source)
-	reqArgs["connectionName"] = SerializeValue(connectionName)
-	reqArgs["optional"] = SerializeValue(optional)
-	reqArgs["name"] = SerializeValue(name)
+	if connectionName != nil {
+		reqArgs["connectionName"] = SerializeValue(connectionName)
+	}
+	if optional != nil {
+		reqArgs["optional"] = SerializeValue(optional)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
 	if err != nil {
 		return nil, err
@@ -12490,18 +13128,34 @@ func (s *TestDatabaseResource) WithReferenceEndpoint(endpointReference *Endpoint
 }
 
 // WithEndpoint adds a network endpoint
-func (s *TestDatabaseResource) WithEndpoint(port float64, targetPort float64, scheme string, name string, env string, isProxied bool, isExternal bool, protocol ProtocolType) (*IResourceWithEndpoints, error) {
+func (s *TestDatabaseResource) WithEndpoint(port *float64, targetPort *float64, scheme *string, name *string, env *string, isProxied *bool, isExternal *bool, protocol *ProtocolType) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["scheme"] = SerializeValue(scheme)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
-	reqArgs["isExternal"] = SerializeValue(isExternal)
-	reqArgs["protocol"] = SerializeValue(protocol)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if scheme != nil {
+		reqArgs["scheme"] = SerializeValue(scheme)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
+	if isExternal != nil {
+		reqArgs["isExternal"] = SerializeValue(isExternal)
+	}
+	if protocol != nil {
+		reqArgs["protocol"] = SerializeValue(protocol)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -12510,15 +13164,25 @@ func (s *TestDatabaseResource) WithEndpoint(port float64, targetPort float64, sc
 }
 
 // WithHttpEndpoint adds an HTTP endpoint
-func (s *TestDatabaseResource) WithHttpEndpoint(port float64, targetPort float64, name string, env string, isProxied bool) (*IResourceWithEndpoints, error) {
+func (s *TestDatabaseResource) WithHttpEndpoint(port *float64, targetPort *float64, name *string, env *string, isProxied *bool) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -12527,15 +13191,25 @@ func (s *TestDatabaseResource) WithHttpEndpoint(port float64, targetPort float64
 }
 
 // WithHttpsEndpoint adds an HTTPS endpoint
-func (s *TestDatabaseResource) WithHttpsEndpoint(port float64, targetPort float64, name string, env string, isProxied bool) (*IResourceWithEndpoints, error) {
+func (s *TestDatabaseResource) WithHttpsEndpoint(port *float64, targetPort *float64, name *string, env *string, isProxied *bool) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -12611,12 +13285,14 @@ func (s *TestDatabaseResource) WithUrlsCallbackAsync(callback func(...any) any) 
 }
 
 // WithUrl adds or modifies displayed URLs
-func (s *TestDatabaseResource) WithUrl(url string, displayText string) (*IResource, error) {
+func (s *TestDatabaseResource) WithUrl(url string, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrl", reqArgs)
 	if err != nil {
 		return nil, err
@@ -12625,12 +13301,14 @@ func (s *TestDatabaseResource) WithUrl(url string, displayText string) (*IResour
 }
 
 // WithUrlExpression adds a URL using a reference expression
-func (s *TestDatabaseResource) WithUrlExpression(url *ReferenceExpression, displayText string) (*IResource, error) {
+func (s *TestDatabaseResource) WithUrlExpression(url *ReferenceExpression, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrlExpression", reqArgs)
 	if err != nil {
 		return nil, err
@@ -12749,12 +13427,14 @@ func (s *TestDatabaseResource) WithExplicitStart() (*IResource, error) {
 }
 
 // WaitForCompletion waits for resource completion
-func (s *TestDatabaseResource) WaitForCompletion(dependency *IResource, exitCode float64) (*IResourceWithWaitSupport, error) {
+func (s *TestDatabaseResource) WaitForCompletion(dependency *IResource, exitCode *float64) (*IResourceWithWaitSupport, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	reqArgs["exitCode"] = SerializeValue(exitCode)
+	if exitCode != nil {
+		reqArgs["exitCode"] = SerializeValue(exitCode)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForCompletion", reqArgs)
 	if err != nil {
 		return nil, err
@@ -12776,13 +13456,19 @@ func (s *TestDatabaseResource) WithHealthCheck(key string) (*IResource, error) {
 }
 
 // WithHttpHealthCheck adds an HTTP health check
-func (s *TestDatabaseResource) WithHttpHealthCheck(path string, statusCode float64, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *TestDatabaseResource) WithHttpHealthCheck(path *string, statusCode *float64, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["statusCode"] = SerializeValue(statusCode)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if statusCode != nil {
+		reqArgs["statusCode"] = SerializeValue(statusCode)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpHealthCheck", reqArgs)
 	if err != nil {
 		return nil, err
@@ -12890,12 +13576,14 @@ func (s *TestDatabaseResource) WithChildRelationship(child *IResource) (*IResour
 }
 
 // WithIconName sets the icon for the resource
-func (s *TestDatabaseResource) WithIconName(iconName string, iconVariant IconVariant) (*IResource, error) {
+func (s *TestDatabaseResource) WithIconName(iconName string, iconVariant *IconVariant) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["iconName"] = SerializeValue(iconName)
-	reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	if iconVariant != nil {
+		reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withIconName", reqArgs)
 	if err != nil {
 		return nil, err
@@ -12904,18 +13592,32 @@ func (s *TestDatabaseResource) WithIconName(iconName string, iconVariant IconVar
 }
 
 // WithHttpProbe adds an HTTP health probe to the resource
-func (s *TestDatabaseResource) WithHttpProbe(probeType ProbeType, path string, initialDelaySeconds float64, periodSeconds float64, timeoutSeconds float64, failureThreshold float64, successThreshold float64, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *TestDatabaseResource) WithHttpProbe(probeType ProbeType, path *string, initialDelaySeconds *float64, periodSeconds *float64, timeoutSeconds *float64, failureThreshold *float64, successThreshold *float64, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["probeType"] = SerializeValue(probeType)
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["initialDelaySeconds"] = SerializeValue(initialDelaySeconds)
-	reqArgs["periodSeconds"] = SerializeValue(periodSeconds)
-	reqArgs["timeoutSeconds"] = SerializeValue(timeoutSeconds)
-	reqArgs["failureThreshold"] = SerializeValue(failureThreshold)
-	reqArgs["successThreshold"] = SerializeValue(successThreshold)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if initialDelaySeconds != nil {
+		reqArgs["initialDelaySeconds"] = SerializeValue(initialDelaySeconds)
+	}
+	if periodSeconds != nil {
+		reqArgs["periodSeconds"] = SerializeValue(periodSeconds)
+	}
+	if timeoutSeconds != nil {
+		reqArgs["timeoutSeconds"] = SerializeValue(timeoutSeconds)
+	}
+	if failureThreshold != nil {
+		reqArgs["failureThreshold"] = SerializeValue(failureThreshold)
+	}
+	if successThreshold != nil {
+		reqArgs["successThreshold"] = SerializeValue(successThreshold)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpProbe", reqArgs)
 	if err != nil {
 		return nil, err
@@ -12962,7 +13664,7 @@ func (s *TestDatabaseResource) WithRemoteImageTag(remoteImageTag string) (*IComp
 }
 
 // WithPipelineStepFactory adds a pipeline step to the resource
-func (s *TestDatabaseResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description string) (*IResource, error) {
+func (s *TestDatabaseResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
@@ -12970,10 +13672,18 @@ func (s *TestDatabaseResource) WithPipelineStepFactory(stepName string, callback
 	if callback != nil {
 		reqArgs["callback"] = RegisterCallback(callback)
 	}
-	reqArgs["dependsOn"] = SerializeValue(dependsOn)
-	reqArgs["requiredBy"] = SerializeValue(requiredBy)
-	reqArgs["tags"] = SerializeValue(tags)
-	reqArgs["description"] = SerializeValue(description)
+	if dependsOn != nil {
+		reqArgs["dependsOn"] = SerializeValue(dependsOn)
+	}
+	if requiredBy != nil {
+		reqArgs["requiredBy"] = SerializeValue(requiredBy)
+	}
+	if tags != nil {
+		reqArgs["tags"] = SerializeValue(tags)
+	}
+	if description != nil {
+		reqArgs["description"] = SerializeValue(description)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withPipelineStepFactory", reqArgs)
 	if err != nil {
 		return nil, err
@@ -13012,13 +13722,17 @@ func (s *TestDatabaseResource) WithPipelineConfiguration(callback func(...any) a
 }
 
 // WithVolume adds a volume
-func (s *TestDatabaseResource) WithVolume(target string, name string, isReadOnly bool) (*ContainerResource, error) {
+func (s *TestDatabaseResource) WithVolume(target string, name *string, isReadOnly *bool) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"resource": SerializeValue(s.Handle()),
 	}
 	reqArgs["target"] = SerializeValue(target)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["isReadOnly"] = SerializeValue(isReadOnly)
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if isReadOnly != nil {
+		reqArgs["isReadOnly"] = SerializeValue(isReadOnly)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withVolume", reqArgs)
 	if err != nil {
 		return nil, err
@@ -13114,12 +13828,16 @@ func (s *TestDatabaseResource) OnResourceReady(callback func(...any) any) (*IRes
 }
 
 // WithOptionalString adds an optional string parameter
-func (s *TestDatabaseResource) WithOptionalString(value string, enabled bool) (*IResource, error) {
+func (s *TestDatabaseResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["value"] = SerializeValue(value)
-	reqArgs["enabled"] = SerializeValue(enabled)
+	if value != nil {
+		reqArgs["value"] = SerializeValue(value)
+	}
+	if enabled != nil {
+		reqArgs["enabled"] = SerializeValue(enabled)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/withOptionalString", reqArgs)
 	if err != nil {
 		return nil, err
@@ -13432,13 +14150,15 @@ func (s *TestRedisResource) WithContainerRegistry(registry *IResource) (*IResour
 }
 
 // WithBindMount adds a bind mount
-func (s *TestRedisResource) WithBindMount(source string, target string, isReadOnly bool) (*ContainerResource, error) {
+func (s *TestRedisResource) WithBindMount(source string, target string, isReadOnly *bool) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["source"] = SerializeValue(source)
 	reqArgs["target"] = SerializeValue(target)
-	reqArgs["isReadOnly"] = SerializeValue(isReadOnly)
+	if isReadOnly != nil {
+		reqArgs["isReadOnly"] = SerializeValue(isReadOnly)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBindMount", reqArgs)
 	if err != nil {
 		return nil, err
@@ -13486,12 +14206,14 @@ func (s *TestRedisResource) WithImageRegistry(registry string) (*ContainerResour
 }
 
 // WithImage sets the container image
-func (s *TestRedisResource) WithImage(image string, tag string) (*ContainerResource, error) {
+func (s *TestRedisResource) WithImage(image string, tag *string) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["image"] = SerializeValue(image)
-	reqArgs["tag"] = SerializeValue(tag)
+	if tag != nil {
+		reqArgs["tag"] = SerializeValue(tag)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withImage", reqArgs)
 	if err != nil {
 		return nil, err
@@ -13564,13 +14286,17 @@ func (s *TestRedisResource) PublishAsContainer() (*ContainerResource, error) {
 }
 
 // WithDockerfile configures the resource to use a Dockerfile
-func (s *TestRedisResource) WithDockerfile(contextPath string, dockerfilePath string, stage string) (*ContainerResource, error) {
+func (s *TestRedisResource) WithDockerfile(contextPath string, dockerfilePath *string, stage *string) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["contextPath"] = SerializeValue(contextPath)
-	reqArgs["dockerfilePath"] = SerializeValue(dockerfilePath)
-	reqArgs["stage"] = SerializeValue(stage)
+	if dockerfilePath != nil {
+		reqArgs["dockerfilePath"] = SerializeValue(dockerfilePath)
+	}
+	if stage != nil {
+		reqArgs["stage"] = SerializeValue(stage)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withDockerfile", reqArgs)
 	if err != nil {
 		return nil, err
@@ -13633,12 +14359,16 @@ func (s *TestRedisResource) WithEndpointProxySupport(proxyEnabled bool) (*Contai
 }
 
 // WithDockerfileBaseImage sets the base image for a Dockerfile build
-func (s *TestRedisResource) WithDockerfileBaseImage(buildImage string, runtimeImage string) (*IResource, error) {
+func (s *TestRedisResource) WithDockerfileBaseImage(buildImage *string, runtimeImage *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["buildImage"] = SerializeValue(buildImage)
-	reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	if buildImage != nil {
+		reqArgs["buildImage"] = SerializeValue(buildImage)
+	}
+	if runtimeImage != nil {
+		reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withDockerfileBaseImage", reqArgs)
 	if err != nil {
 		return nil, err
@@ -13660,12 +14390,16 @@ func (s *TestRedisResource) WithContainerNetworkAlias(alias string) (*ContainerR
 }
 
 // WithMcpServer configures an MCP server endpoint on the resource
-func (s *TestRedisResource) WithMcpServer(path string, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *TestRedisResource) WithMcpServer(path *string, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withMcpServer", reqArgs)
 	if err != nil {
 		return nil, err
@@ -13711,12 +14445,14 @@ func (s *TestRedisResource) PublishAsConnectionString() (*ContainerResource, err
 }
 
 // WithRequiredCommand adds a required command dependency
-func (s *TestRedisResource) WithRequiredCommand(command string, helpLink string) (*IResource, error) {
+func (s *TestRedisResource) WithRequiredCommand(command string, helpLink *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["command"] = SerializeValue(command)
-	reqArgs["helpLink"] = SerializeValue(helpLink)
+	if helpLink != nil {
+		reqArgs["helpLink"] = SerializeValue(helpLink)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withRequiredCommand", reqArgs)
 	if err != nil {
 		return nil, err
@@ -13896,14 +14632,20 @@ func (s *TestRedisResource) WithArgsCallbackAsync(callback func(...any) any) (*I
 }
 
 // WithReference adds a reference to another resource
-func (s *TestRedisResource) WithReference(source *IResource, connectionName string, optional bool, name string) (*IResourceWithEnvironment, error) {
+func (s *TestRedisResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["source"] = SerializeValue(source)
-	reqArgs["connectionName"] = SerializeValue(connectionName)
-	reqArgs["optional"] = SerializeValue(optional)
-	reqArgs["name"] = SerializeValue(name)
+	if connectionName != nil {
+		reqArgs["connectionName"] = SerializeValue(connectionName)
+	}
+	if optional != nil {
+		reqArgs["optional"] = SerializeValue(optional)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
 	if err != nil {
 		return nil, err
@@ -13952,18 +14694,34 @@ func (s *TestRedisResource) WithReferenceEndpoint(endpointReference *EndpointRef
 }
 
 // WithEndpoint adds a network endpoint
-func (s *TestRedisResource) WithEndpoint(port float64, targetPort float64, scheme string, name string, env string, isProxied bool, isExternal bool, protocol ProtocolType) (*IResourceWithEndpoints, error) {
+func (s *TestRedisResource) WithEndpoint(port *float64, targetPort *float64, scheme *string, name *string, env *string, isProxied *bool, isExternal *bool, protocol *ProtocolType) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["scheme"] = SerializeValue(scheme)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
-	reqArgs["isExternal"] = SerializeValue(isExternal)
-	reqArgs["protocol"] = SerializeValue(protocol)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if scheme != nil {
+		reqArgs["scheme"] = SerializeValue(scheme)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
+	if isExternal != nil {
+		reqArgs["isExternal"] = SerializeValue(isExternal)
+	}
+	if protocol != nil {
+		reqArgs["protocol"] = SerializeValue(protocol)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -13972,15 +14730,25 @@ func (s *TestRedisResource) WithEndpoint(port float64, targetPort float64, schem
 }
 
 // WithHttpEndpoint adds an HTTP endpoint
-func (s *TestRedisResource) WithHttpEndpoint(port float64, targetPort float64, name string, env string, isProxied bool) (*IResourceWithEndpoints, error) {
+func (s *TestRedisResource) WithHttpEndpoint(port *float64, targetPort *float64, name *string, env *string, isProxied *bool) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -13989,15 +14757,25 @@ func (s *TestRedisResource) WithHttpEndpoint(port float64, targetPort float64, n
 }
 
 // WithHttpsEndpoint adds an HTTPS endpoint
-func (s *TestRedisResource) WithHttpsEndpoint(port float64, targetPort float64, name string, env string, isProxied bool) (*IResourceWithEndpoints, error) {
+func (s *TestRedisResource) WithHttpsEndpoint(port *float64, targetPort *float64, name *string, env *string, isProxied *bool) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -14073,12 +14851,14 @@ func (s *TestRedisResource) WithUrlsCallbackAsync(callback func(...any) any) (*I
 }
 
 // WithUrl adds or modifies displayed URLs
-func (s *TestRedisResource) WithUrl(url string, displayText string) (*IResource, error) {
+func (s *TestRedisResource) WithUrl(url string, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrl", reqArgs)
 	if err != nil {
 		return nil, err
@@ -14087,12 +14867,14 @@ func (s *TestRedisResource) WithUrl(url string, displayText string) (*IResource,
 }
 
 // WithUrlExpression adds a URL using a reference expression
-func (s *TestRedisResource) WithUrlExpression(url *ReferenceExpression, displayText string) (*IResource, error) {
+func (s *TestRedisResource) WithUrlExpression(url *ReferenceExpression, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrlExpression", reqArgs)
 	if err != nil {
 		return nil, err
@@ -14211,12 +14993,14 @@ func (s *TestRedisResource) WithExplicitStart() (*IResource, error) {
 }
 
 // WaitForCompletion waits for resource completion
-func (s *TestRedisResource) WaitForCompletion(dependency *IResource, exitCode float64) (*IResourceWithWaitSupport, error) {
+func (s *TestRedisResource) WaitForCompletion(dependency *IResource, exitCode *float64) (*IResourceWithWaitSupport, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	reqArgs["exitCode"] = SerializeValue(exitCode)
+	if exitCode != nil {
+		reqArgs["exitCode"] = SerializeValue(exitCode)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForCompletion", reqArgs)
 	if err != nil {
 		return nil, err
@@ -14238,13 +15022,19 @@ func (s *TestRedisResource) WithHealthCheck(key string) (*IResource, error) {
 }
 
 // WithHttpHealthCheck adds an HTTP health check
-func (s *TestRedisResource) WithHttpHealthCheck(path string, statusCode float64, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *TestRedisResource) WithHttpHealthCheck(path *string, statusCode *float64, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["statusCode"] = SerializeValue(statusCode)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if statusCode != nil {
+		reqArgs["statusCode"] = SerializeValue(statusCode)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpHealthCheck", reqArgs)
 	if err != nil {
 		return nil, err
@@ -14352,12 +15142,14 @@ func (s *TestRedisResource) WithChildRelationship(child *IResource) (*IResource,
 }
 
 // WithIconName sets the icon for the resource
-func (s *TestRedisResource) WithIconName(iconName string, iconVariant IconVariant) (*IResource, error) {
+func (s *TestRedisResource) WithIconName(iconName string, iconVariant *IconVariant) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["iconName"] = SerializeValue(iconName)
-	reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	if iconVariant != nil {
+		reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withIconName", reqArgs)
 	if err != nil {
 		return nil, err
@@ -14366,18 +15158,32 @@ func (s *TestRedisResource) WithIconName(iconName string, iconVariant IconVarian
 }
 
 // WithHttpProbe adds an HTTP health probe to the resource
-func (s *TestRedisResource) WithHttpProbe(probeType ProbeType, path string, initialDelaySeconds float64, periodSeconds float64, timeoutSeconds float64, failureThreshold float64, successThreshold float64, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *TestRedisResource) WithHttpProbe(probeType ProbeType, path *string, initialDelaySeconds *float64, periodSeconds *float64, timeoutSeconds *float64, failureThreshold *float64, successThreshold *float64, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["probeType"] = SerializeValue(probeType)
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["initialDelaySeconds"] = SerializeValue(initialDelaySeconds)
-	reqArgs["periodSeconds"] = SerializeValue(periodSeconds)
-	reqArgs["timeoutSeconds"] = SerializeValue(timeoutSeconds)
-	reqArgs["failureThreshold"] = SerializeValue(failureThreshold)
-	reqArgs["successThreshold"] = SerializeValue(successThreshold)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if initialDelaySeconds != nil {
+		reqArgs["initialDelaySeconds"] = SerializeValue(initialDelaySeconds)
+	}
+	if periodSeconds != nil {
+		reqArgs["periodSeconds"] = SerializeValue(periodSeconds)
+	}
+	if timeoutSeconds != nil {
+		reqArgs["timeoutSeconds"] = SerializeValue(timeoutSeconds)
+	}
+	if failureThreshold != nil {
+		reqArgs["failureThreshold"] = SerializeValue(failureThreshold)
+	}
+	if successThreshold != nil {
+		reqArgs["successThreshold"] = SerializeValue(successThreshold)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpProbe", reqArgs)
 	if err != nil {
 		return nil, err
@@ -14424,7 +15230,7 @@ func (s *TestRedisResource) WithRemoteImageTag(remoteImageTag string) (*ICompute
 }
 
 // WithPipelineStepFactory adds a pipeline step to the resource
-func (s *TestRedisResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description string) (*IResource, error) {
+func (s *TestRedisResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
@@ -14432,10 +15238,18 @@ func (s *TestRedisResource) WithPipelineStepFactory(stepName string, callback fu
 	if callback != nil {
 		reqArgs["callback"] = RegisterCallback(callback)
 	}
-	reqArgs["dependsOn"] = SerializeValue(dependsOn)
-	reqArgs["requiredBy"] = SerializeValue(requiredBy)
-	reqArgs["tags"] = SerializeValue(tags)
-	reqArgs["description"] = SerializeValue(description)
+	if dependsOn != nil {
+		reqArgs["dependsOn"] = SerializeValue(dependsOn)
+	}
+	if requiredBy != nil {
+		reqArgs["requiredBy"] = SerializeValue(requiredBy)
+	}
+	if tags != nil {
+		reqArgs["tags"] = SerializeValue(tags)
+	}
+	if description != nil {
+		reqArgs["description"] = SerializeValue(description)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withPipelineStepFactory", reqArgs)
 	if err != nil {
 		return nil, err
@@ -14474,13 +15288,17 @@ func (s *TestRedisResource) WithPipelineConfiguration(callback func(...any) any)
 }
 
 // WithVolume adds a volume
-func (s *TestRedisResource) WithVolume(target string, name string, isReadOnly bool) (*ContainerResource, error) {
+func (s *TestRedisResource) WithVolume(target string, name *string, isReadOnly *bool) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"resource": SerializeValue(s.Handle()),
 	}
 	reqArgs["target"] = SerializeValue(target)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["isReadOnly"] = SerializeValue(isReadOnly)
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if isReadOnly != nil {
+		reqArgs["isReadOnly"] = SerializeValue(isReadOnly)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withVolume", reqArgs)
 	if err != nil {
 		return nil, err
@@ -14591,12 +15409,14 @@ func (s *TestRedisResource) OnResourceReady(callback func(...any) any) (*IResour
 }
 
 // AddTestChildDatabase adds a child database to a test Redis resource
-func (s *TestRedisResource) AddTestChildDatabase(name string, databaseName string) (*TestDatabaseResource, error) {
+func (s *TestRedisResource) AddTestChildDatabase(name string, databaseName *string) (*TestDatabaseResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["name"] = SerializeValue(name)
-	reqArgs["databaseName"] = SerializeValue(databaseName)
+	if databaseName != nil {
+		reqArgs["databaseName"] = SerializeValue(databaseName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/addTestChildDatabase", reqArgs)
 	if err != nil {
 		return nil, err
@@ -14605,11 +15425,13 @@ func (s *TestRedisResource) AddTestChildDatabase(name string, databaseName strin
 }
 
 // WithPersistence configures the Redis resource with persistence
-func (s *TestRedisResource) WithPersistence(mode TestPersistenceMode) (*TestRedisResource, error) {
+func (s *TestRedisResource) WithPersistence(mode *TestPersistenceMode) (*TestRedisResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["mode"] = SerializeValue(mode)
+	if mode != nil {
+		reqArgs["mode"] = SerializeValue(mode)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/withPersistence", reqArgs)
 	if err != nil {
 		return nil, err
@@ -14618,12 +15440,16 @@ func (s *TestRedisResource) WithPersistence(mode TestPersistenceMode) (*TestRedi
 }
 
 // WithOptionalString adds an optional string parameter
-func (s *TestRedisResource) WithOptionalString(value string, enabled bool) (*IResource, error) {
+func (s *TestRedisResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["value"] = SerializeValue(value)
-	reqArgs["enabled"] = SerializeValue(enabled)
+	if value != nil {
+		reqArgs["value"] = SerializeValue(value)
+	}
+	if enabled != nil {
+		reqArgs["enabled"] = SerializeValue(enabled)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/withOptionalString", reqArgs)
 	if err != nil {
 		return nil, err
@@ -14935,12 +15761,16 @@ func (s *TestRedisResource) WithMultiParamHandleCallback(callback func(...any) a
 }
 
 // WithDataVolume adds a data volume with persistence
-func (s *TestRedisResource) WithDataVolume(name string, isReadOnly bool) (*TestRedisResource, error) {
+func (s *TestRedisResource) WithDataVolume(name *string, isReadOnly *bool) (*TestRedisResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["isReadOnly"] = SerializeValue(isReadOnly)
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if isReadOnly != nil {
+		reqArgs["isReadOnly"] = SerializeValue(isReadOnly)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/withDataVolume", reqArgs)
 	if err != nil {
 		return nil, err
@@ -15070,13 +15900,15 @@ func (s *TestVaultResource) WithContainerRegistry(registry *IResource) (*IResour
 }
 
 // WithBindMount adds a bind mount
-func (s *TestVaultResource) WithBindMount(source string, target string, isReadOnly bool) (*ContainerResource, error) {
+func (s *TestVaultResource) WithBindMount(source string, target string, isReadOnly *bool) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["source"] = SerializeValue(source)
 	reqArgs["target"] = SerializeValue(target)
-	reqArgs["isReadOnly"] = SerializeValue(isReadOnly)
+	if isReadOnly != nil {
+		reqArgs["isReadOnly"] = SerializeValue(isReadOnly)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBindMount", reqArgs)
 	if err != nil {
 		return nil, err
@@ -15124,12 +15956,14 @@ func (s *TestVaultResource) WithImageRegistry(registry string) (*ContainerResour
 }
 
 // WithImage sets the container image
-func (s *TestVaultResource) WithImage(image string, tag string) (*ContainerResource, error) {
+func (s *TestVaultResource) WithImage(image string, tag *string) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["image"] = SerializeValue(image)
-	reqArgs["tag"] = SerializeValue(tag)
+	if tag != nil {
+		reqArgs["tag"] = SerializeValue(tag)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withImage", reqArgs)
 	if err != nil {
 		return nil, err
@@ -15202,13 +16036,17 @@ func (s *TestVaultResource) PublishAsContainer() (*ContainerResource, error) {
 }
 
 // WithDockerfile configures the resource to use a Dockerfile
-func (s *TestVaultResource) WithDockerfile(contextPath string, dockerfilePath string, stage string) (*ContainerResource, error) {
+func (s *TestVaultResource) WithDockerfile(contextPath string, dockerfilePath *string, stage *string) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["contextPath"] = SerializeValue(contextPath)
-	reqArgs["dockerfilePath"] = SerializeValue(dockerfilePath)
-	reqArgs["stage"] = SerializeValue(stage)
+	if dockerfilePath != nil {
+		reqArgs["dockerfilePath"] = SerializeValue(dockerfilePath)
+	}
+	if stage != nil {
+		reqArgs["stage"] = SerializeValue(stage)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withDockerfile", reqArgs)
 	if err != nil {
 		return nil, err
@@ -15271,12 +16109,16 @@ func (s *TestVaultResource) WithEndpointProxySupport(proxyEnabled bool) (*Contai
 }
 
 // WithDockerfileBaseImage sets the base image for a Dockerfile build
-func (s *TestVaultResource) WithDockerfileBaseImage(buildImage string, runtimeImage string) (*IResource, error) {
+func (s *TestVaultResource) WithDockerfileBaseImage(buildImage *string, runtimeImage *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["buildImage"] = SerializeValue(buildImage)
-	reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	if buildImage != nil {
+		reqArgs["buildImage"] = SerializeValue(buildImage)
+	}
+	if runtimeImage != nil {
+		reqArgs["runtimeImage"] = SerializeValue(runtimeImage)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withDockerfileBaseImage", reqArgs)
 	if err != nil {
 		return nil, err
@@ -15298,12 +16140,16 @@ func (s *TestVaultResource) WithContainerNetworkAlias(alias string) (*ContainerR
 }
 
 // WithMcpServer configures an MCP server endpoint on the resource
-func (s *TestVaultResource) WithMcpServer(path string, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *TestVaultResource) WithMcpServer(path *string, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withMcpServer", reqArgs)
 	if err != nil {
 		return nil, err
@@ -15349,12 +16195,14 @@ func (s *TestVaultResource) PublishAsConnectionString() (*ContainerResource, err
 }
 
 // WithRequiredCommand adds a required command dependency
-func (s *TestVaultResource) WithRequiredCommand(command string, helpLink string) (*IResource, error) {
+func (s *TestVaultResource) WithRequiredCommand(command string, helpLink *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["command"] = SerializeValue(command)
-	reqArgs["helpLink"] = SerializeValue(helpLink)
+	if helpLink != nil {
+		reqArgs["helpLink"] = SerializeValue(helpLink)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withRequiredCommand", reqArgs)
 	if err != nil {
 		return nil, err
@@ -15506,14 +16354,20 @@ func (s *TestVaultResource) WithArgsCallbackAsync(callback func(...any) any) (*I
 }
 
 // WithReference adds a reference to another resource
-func (s *TestVaultResource) WithReference(source *IResource, connectionName string, optional bool, name string) (*IResourceWithEnvironment, error) {
+func (s *TestVaultResource) WithReference(source *IResource, connectionName *string, optional *bool, name *string) (*IResourceWithEnvironment, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["source"] = SerializeValue(source)
-	reqArgs["connectionName"] = SerializeValue(connectionName)
-	reqArgs["optional"] = SerializeValue(optional)
-	reqArgs["name"] = SerializeValue(name)
+	if connectionName != nil {
+		reqArgs["connectionName"] = SerializeValue(connectionName)
+	}
+	if optional != nil {
+		reqArgs["optional"] = SerializeValue(optional)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
 	if err != nil {
 		return nil, err
@@ -15562,18 +16416,34 @@ func (s *TestVaultResource) WithReferenceEndpoint(endpointReference *EndpointRef
 }
 
 // WithEndpoint adds a network endpoint
-func (s *TestVaultResource) WithEndpoint(port float64, targetPort float64, scheme string, name string, env string, isProxied bool, isExternal bool, protocol ProtocolType) (*IResourceWithEndpoints, error) {
+func (s *TestVaultResource) WithEndpoint(port *float64, targetPort *float64, scheme *string, name *string, env *string, isProxied *bool, isExternal *bool, protocol *ProtocolType) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["scheme"] = SerializeValue(scheme)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
-	reqArgs["isExternal"] = SerializeValue(isExternal)
-	reqArgs["protocol"] = SerializeValue(protocol)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if scheme != nil {
+		reqArgs["scheme"] = SerializeValue(scheme)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
+	if isExternal != nil {
+		reqArgs["isExternal"] = SerializeValue(isExternal)
+	}
+	if protocol != nil {
+		reqArgs["protocol"] = SerializeValue(protocol)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -15582,15 +16452,25 @@ func (s *TestVaultResource) WithEndpoint(port float64, targetPort float64, schem
 }
 
 // WithHttpEndpoint adds an HTTP endpoint
-func (s *TestVaultResource) WithHttpEndpoint(port float64, targetPort float64, name string, env string, isProxied bool) (*IResourceWithEndpoints, error) {
+func (s *TestVaultResource) WithHttpEndpoint(port *float64, targetPort *float64, name *string, env *string, isProxied *bool) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -15599,15 +16479,25 @@ func (s *TestVaultResource) WithHttpEndpoint(port float64, targetPort float64, n
 }
 
 // WithHttpsEndpoint adds an HTTPS endpoint
-func (s *TestVaultResource) WithHttpsEndpoint(port float64, targetPort float64, name string, env string, isProxied bool) (*IResourceWithEndpoints, error) {
+func (s *TestVaultResource) WithHttpsEndpoint(port *float64, targetPort *float64, name *string, env *string, isProxied *bool) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["port"] = SerializeValue(port)
-	reqArgs["targetPort"] = SerializeValue(targetPort)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["env"] = SerializeValue(env)
-	reqArgs["isProxied"] = SerializeValue(isProxied)
+	if port != nil {
+		reqArgs["port"] = SerializeValue(port)
+	}
+	if targetPort != nil {
+		reqArgs["targetPort"] = SerializeValue(targetPort)
+	}
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if env != nil {
+		reqArgs["env"] = SerializeValue(env)
+	}
+	if isProxied != nil {
+		reqArgs["isProxied"] = SerializeValue(isProxied)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsEndpoint", reqArgs)
 	if err != nil {
 		return nil, err
@@ -15683,12 +16573,14 @@ func (s *TestVaultResource) WithUrlsCallbackAsync(callback func(...any) any) (*I
 }
 
 // WithUrl adds or modifies displayed URLs
-func (s *TestVaultResource) WithUrl(url string, displayText string) (*IResource, error) {
+func (s *TestVaultResource) WithUrl(url string, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrl", reqArgs)
 	if err != nil {
 		return nil, err
@@ -15697,12 +16589,14 @@ func (s *TestVaultResource) WithUrl(url string, displayText string) (*IResource,
 }
 
 // WithUrlExpression adds a URL using a reference expression
-func (s *TestVaultResource) WithUrlExpression(url *ReferenceExpression, displayText string) (*IResource, error) {
+func (s *TestVaultResource) WithUrlExpression(url *ReferenceExpression, displayText *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["url"] = SerializeValue(url)
-	reqArgs["displayText"] = SerializeValue(displayText)
+	if displayText != nil {
+		reqArgs["displayText"] = SerializeValue(displayText)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withUrlExpression", reqArgs)
 	if err != nil {
 		return nil, err
@@ -15821,12 +16715,14 @@ func (s *TestVaultResource) WithExplicitStart() (*IResource, error) {
 }
 
 // WaitForCompletion waits for resource completion
-func (s *TestVaultResource) WaitForCompletion(dependency *IResource, exitCode float64) (*IResourceWithWaitSupport, error) {
+func (s *TestVaultResource) WaitForCompletion(dependency *IResource, exitCode *float64) (*IResourceWithWaitSupport, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	reqArgs["exitCode"] = SerializeValue(exitCode)
+	if exitCode != nil {
+		reqArgs["exitCode"] = SerializeValue(exitCode)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForCompletion", reqArgs)
 	if err != nil {
 		return nil, err
@@ -15848,13 +16744,19 @@ func (s *TestVaultResource) WithHealthCheck(key string) (*IResource, error) {
 }
 
 // WithHttpHealthCheck adds an HTTP health check
-func (s *TestVaultResource) WithHttpHealthCheck(path string, statusCode float64, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *TestVaultResource) WithHttpHealthCheck(path *string, statusCode *float64, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["statusCode"] = SerializeValue(statusCode)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if statusCode != nil {
+		reqArgs["statusCode"] = SerializeValue(statusCode)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpHealthCheck", reqArgs)
 	if err != nil {
 		return nil, err
@@ -15962,12 +16864,14 @@ func (s *TestVaultResource) WithChildRelationship(child *IResource) (*IResource,
 }
 
 // WithIconName sets the icon for the resource
-func (s *TestVaultResource) WithIconName(iconName string, iconVariant IconVariant) (*IResource, error) {
+func (s *TestVaultResource) WithIconName(iconName string, iconVariant *IconVariant) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["iconName"] = SerializeValue(iconName)
-	reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	if iconVariant != nil {
+		reqArgs["iconVariant"] = SerializeValue(iconVariant)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withIconName", reqArgs)
 	if err != nil {
 		return nil, err
@@ -15976,18 +16880,32 @@ func (s *TestVaultResource) WithIconName(iconName string, iconVariant IconVarian
 }
 
 // WithHttpProbe adds an HTTP health probe to the resource
-func (s *TestVaultResource) WithHttpProbe(probeType ProbeType, path string, initialDelaySeconds float64, periodSeconds float64, timeoutSeconds float64, failureThreshold float64, successThreshold float64, endpointName string) (*IResourceWithEndpoints, error) {
+func (s *TestVaultResource) WithHttpProbe(probeType ProbeType, path *string, initialDelaySeconds *float64, periodSeconds *float64, timeoutSeconds *float64, failureThreshold *float64, successThreshold *float64, endpointName *string) (*IResourceWithEndpoints, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["probeType"] = SerializeValue(probeType)
-	reqArgs["path"] = SerializeValue(path)
-	reqArgs["initialDelaySeconds"] = SerializeValue(initialDelaySeconds)
-	reqArgs["periodSeconds"] = SerializeValue(periodSeconds)
-	reqArgs["timeoutSeconds"] = SerializeValue(timeoutSeconds)
-	reqArgs["failureThreshold"] = SerializeValue(failureThreshold)
-	reqArgs["successThreshold"] = SerializeValue(successThreshold)
-	reqArgs["endpointName"] = SerializeValue(endpointName)
+	if path != nil {
+		reqArgs["path"] = SerializeValue(path)
+	}
+	if initialDelaySeconds != nil {
+		reqArgs["initialDelaySeconds"] = SerializeValue(initialDelaySeconds)
+	}
+	if periodSeconds != nil {
+		reqArgs["periodSeconds"] = SerializeValue(periodSeconds)
+	}
+	if timeoutSeconds != nil {
+		reqArgs["timeoutSeconds"] = SerializeValue(timeoutSeconds)
+	}
+	if failureThreshold != nil {
+		reqArgs["failureThreshold"] = SerializeValue(failureThreshold)
+	}
+	if successThreshold != nil {
+		reqArgs["successThreshold"] = SerializeValue(successThreshold)
+	}
+	if endpointName != nil {
+		reqArgs["endpointName"] = SerializeValue(endpointName)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpProbe", reqArgs)
 	if err != nil {
 		return nil, err
@@ -16034,7 +16952,7 @@ func (s *TestVaultResource) WithRemoteImageTag(remoteImageTag string) (*ICompute
 }
 
 // WithPipelineStepFactory adds a pipeline step to the resource
-func (s *TestVaultResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description string) (*IResource, error) {
+func (s *TestVaultResource) WithPipelineStepFactory(stepName string, callback func(...any) any, dependsOn []string, requiredBy []string, tags []string, description *string) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
@@ -16042,10 +16960,18 @@ func (s *TestVaultResource) WithPipelineStepFactory(stepName string, callback fu
 	if callback != nil {
 		reqArgs["callback"] = RegisterCallback(callback)
 	}
-	reqArgs["dependsOn"] = SerializeValue(dependsOn)
-	reqArgs["requiredBy"] = SerializeValue(requiredBy)
-	reqArgs["tags"] = SerializeValue(tags)
-	reqArgs["description"] = SerializeValue(description)
+	if dependsOn != nil {
+		reqArgs["dependsOn"] = SerializeValue(dependsOn)
+	}
+	if requiredBy != nil {
+		reqArgs["requiredBy"] = SerializeValue(requiredBy)
+	}
+	if tags != nil {
+		reqArgs["tags"] = SerializeValue(tags)
+	}
+	if description != nil {
+		reqArgs["description"] = SerializeValue(description)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withPipelineStepFactory", reqArgs)
 	if err != nil {
 		return nil, err
@@ -16084,13 +17010,17 @@ func (s *TestVaultResource) WithPipelineConfiguration(callback func(...any) any)
 }
 
 // WithVolume adds a volume
-func (s *TestVaultResource) WithVolume(target string, name string, isReadOnly bool) (*ContainerResource, error) {
+func (s *TestVaultResource) WithVolume(target string, name *string, isReadOnly *bool) (*ContainerResource, error) {
 	reqArgs := map[string]any{
 		"resource": SerializeValue(s.Handle()),
 	}
 	reqArgs["target"] = SerializeValue(target)
-	reqArgs["name"] = SerializeValue(name)
-	reqArgs["isReadOnly"] = SerializeValue(isReadOnly)
+	if name != nil {
+		reqArgs["name"] = SerializeValue(name)
+	}
+	if isReadOnly != nil {
+		reqArgs["isReadOnly"] = SerializeValue(isReadOnly)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting/withVolume", reqArgs)
 	if err != nil {
 		return nil, err
@@ -16186,12 +17116,16 @@ func (s *TestVaultResource) OnResourceReady(callback func(...any) any) (*IResour
 }
 
 // WithOptionalString adds an optional string parameter
-func (s *TestVaultResource) WithOptionalString(value string, enabled bool) (*IResource, error) {
+func (s *TestVaultResource) WithOptionalString(value *string, enabled *bool) (*IResource, error) {
 	reqArgs := map[string]any{
 		"builder": SerializeValue(s.Handle()),
 	}
-	reqArgs["value"] = SerializeValue(value)
-	reqArgs["enabled"] = SerializeValue(enabled)
+	if value != nil {
+		reqArgs["value"] = SerializeValue(value)
+	}
+	if enabled != nil {
+		reqArgs["enabled"] = SerializeValue(enabled)
+	}
 	result, err := s.Client().InvokeCapability("Aspire.Hosting.CodeGeneration.Go.Tests/withOptionalString", reqArgs)
 	if err != nil {
 		return nil, err

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -5911,6 +5911,15 @@ class IDistributedApplicationBuilder extends HandleWrapperBase {
         super(handle, client);
     }
 
+    /** Adds a connection string with a reference expression */
+    public ConnectionStringResource addConnectionStringExpression(String name, ReferenceExpression connectionStringExpression) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("name", AspireClient.serializeValue(name));
+        reqArgs.put("connectionStringExpression", AspireClient.serializeValue(connectionStringExpression));
+        return (ConnectionStringResource) getClient().invokeCapability("Aspire.Hosting/addConnectionStringExpression", reqArgs);
+    }
+
     /** Adds a connection string with a builder callback */
     public ConnectionStringResource addConnectionStringBuilder(String name, Function<Object[], Object> connectionStringBuilder) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -5932,6 +5941,18 @@ class IDistributedApplicationBuilder extends HandleWrapperBase {
             reqArgs.put("repository", AspireClient.serializeValue(repository));
         }
         return (ContainerRegistryResource) getClient().invokeCapability("Aspire.Hosting/addContainerRegistry", reqArgs);
+    }
+
+    /** Adds a container registry with string endpoint */
+    public ContainerRegistryResource addContainerRegistryFromString(String name, String endpoint, String repository) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("name", AspireClient.serializeValue(name));
+        reqArgs.put("endpoint", AspireClient.serializeValue(endpoint));
+        if (repository != null) {
+            reqArgs.put("repository", AspireClient.serializeValue(repository));
+        }
+        return (ContainerRegistryResource) getClient().invokeCapability("Aspire.Hosting/addContainerRegistryFromString", reqArgs);
     }
 
     /** Adds a container resource */
@@ -5987,6 +6008,24 @@ class IDistributedApplicationBuilder extends HandleWrapperBase {
         return (ExternalServiceResource) getClient().invokeCapability("Aspire.Hosting/addExternalService", reqArgs);
     }
 
+    /** Adds an external service with a URI */
+    public ExternalServiceResource addExternalServiceUri(String name, String uri) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("name", AspireClient.serializeValue(name));
+        reqArgs.put("uri", AspireClient.serializeValue(uri));
+        return (ExternalServiceResource) getClient().invokeCapability("Aspire.Hosting/addExternalServiceUri", reqArgs);
+    }
+
+    /** Adds an external service with a parameter URL */
+    public ExternalServiceResource addExternalServiceParameter(String name, ParameterResource urlParameter) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("name", AspireClient.serializeValue(name));
+        reqArgs.put("urlParameter", AspireClient.serializeValue(urlParameter));
+        return (ExternalServiceResource) getClient().invokeCapability("Aspire.Hosting/addExternalServiceParameter", reqArgs);
+    }
+
     /** Gets the AppHostDirectory property */
     public String appHostDirectory() {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -6038,6 +6077,21 @@ class IDistributedApplicationBuilder extends HandleWrapperBase {
             reqArgs.put("secret", AspireClient.serializeValue(secret));
         }
         return (ParameterResource) getClient().invokeCapability("Aspire.Hosting/addParameter", reqArgs);
+    }
+
+    /** Adds a parameter with a default value */
+    public ParameterResource addParameterWithValue(String name, String value, Boolean publishValueAsDefault, Boolean secret) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("name", AspireClient.serializeValue(name));
+        reqArgs.put("value", AspireClient.serializeValue(value));
+        if (publishValueAsDefault != null) {
+            reqArgs.put("publishValueAsDefault", AspireClient.serializeValue(publishValueAsDefault));
+        }
+        if (secret != null) {
+            reqArgs.put("secret", AspireClient.serializeValue(secret));
+        }
+        return (ParameterResource) getClient().invokeCapability("Aspire.Hosting/addParameterWithValue", reqArgs);
     }
 
     /** Adds a parameter sourced from configuration */

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -4204,6 +4204,13 @@ class IDistributedApplicationBuilder(HandleWrapperBase):
     def __init__(self, handle: Handle, client: AspireClient):
         super().__init__(handle, client)
 
+    def add_connection_string_expression(self, name: str, connection_string_expression: ReferenceExpression) -> ConnectionStringResource:
+        """Adds a connection string with a reference expression"""
+        args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
+        args["name"] = serialize_value(name)
+        args["connectionStringExpression"] = serialize_value(connection_string_expression)
+        return self._client.invoke_capability("Aspire.Hosting/addConnectionStringExpression", args)
+
     def add_connection_string_builder(self, name: str, connection_string_builder: Callable[[ReferenceExpressionBuilder], None]) -> ConnectionStringResource:
         """Adds a connection string with a builder callback"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
@@ -4221,6 +4228,15 @@ class IDistributedApplicationBuilder(HandleWrapperBase):
         if repository is not None:
             args["repository"] = serialize_value(repository)
         return self._client.invoke_capability("Aspire.Hosting/addContainerRegistry", args)
+
+    def add_container_registry_from_string(self, name: str, endpoint: str, repository: str | None = None) -> ContainerRegistryResource:
+        """Adds a container registry with string endpoint"""
+        args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
+        args["name"] = serialize_value(name)
+        args["endpoint"] = serialize_value(endpoint)
+        if repository is not None:
+            args["repository"] = serialize_value(repository)
+        return self._client.invoke_capability("Aspire.Hosting/addContainerRegistryFromString", args)
 
     def add_container(self, name: str, image: str) -> ContainerResource:
         """Adds a container resource"""
@@ -4263,6 +4279,20 @@ class IDistributedApplicationBuilder(HandleWrapperBase):
         args["url"] = serialize_value(url)
         return self._client.invoke_capability("Aspire.Hosting/addExternalService", args)
 
+    def add_external_service_uri(self, name: str, uri: str) -> ExternalServiceResource:
+        """Adds an external service with a URI"""
+        args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
+        args["name"] = serialize_value(name)
+        args["uri"] = serialize_value(uri)
+        return self._client.invoke_capability("Aspire.Hosting/addExternalServiceUri", args)
+
+    def add_external_service_parameter(self, name: str, url_parameter: ParameterResource) -> ExternalServiceResource:
+        """Adds an external service with a parameter URL"""
+        args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
+        args["name"] = serialize_value(name)
+        args["urlParameter"] = serialize_value(url_parameter)
+        return self._client.invoke_capability("Aspire.Hosting/addExternalServiceParameter", args)
+
     def app_host_directory(self) -> str:
         """Gets the AppHostDirectory property"""
         args: Dict[str, Any] = { "context": serialize_value(self._handle) }
@@ -4299,6 +4329,15 @@ class IDistributedApplicationBuilder(HandleWrapperBase):
         args["name"] = serialize_value(name)
         args["secret"] = serialize_value(secret)
         return self._client.invoke_capability("Aspire.Hosting/addParameter", args)
+
+    def add_parameter_with_value(self, name: str, value: str, publish_value_as_default: bool = False, secret: bool = False) -> ParameterResource:
+        """Adds a parameter with a default value"""
+        args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
+        args["name"] = serialize_value(name)
+        args["value"] = serialize_value(value)
+        args["publishValueAsDefault"] = serialize_value(publish_value_as_default)
+        args["secret"] = serialize_value(secret)
+        return self._client.invoke_capability("Aspire.Hosting/addParameterWithValue", args)
 
     def add_parameter_from_configuration(self, name: str, configuration_key: str, secret: bool = False) -> ParameterResource:
         """Adds a parameter sourced from configuration"""

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -7317,6 +7317,17 @@ impl IDistributedApplicationBuilder {
         &self.client
     }
 
+    /// Adds a connection string with a reference expression
+    pub fn add_connection_string_expression(&self, name: &str, connection_string_expression: ReferenceExpression) -> Result<ConnectionStringResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
+        args.insert("connectionStringExpression".to_string(), serde_json::to_value(&connection_string_expression).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/addConnectionStringExpression", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ConnectionStringResource::new(handle, self.client.clone()))
+    }
+
     /// Adds a connection string with a builder callback
     pub fn add_connection_string_builder(&self, name: &str, connection_string_builder: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<ConnectionStringResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -7339,6 +7350,20 @@ impl IDistributedApplicationBuilder {
             args.insert("repository".to_string(), v.handle().to_json());
         }
         let result = self.client.invoke_capability("Aspire.Hosting/addContainerRegistry", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ContainerRegistryResource::new(handle, self.client.clone()))
+    }
+
+    /// Adds a container registry with string endpoint
+    pub fn add_container_registry_from_string(&self, name: &str, endpoint: &str, repository: Option<&str>) -> Result<ContainerRegistryResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
+        args.insert("endpoint".to_string(), serde_json::to_value(&endpoint).unwrap_or(Value::Null));
+        if let Some(ref v) = repository {
+            args.insert("repository".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/addContainerRegistryFromString", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerRegistryResource::new(handle, self.client.clone()))
     }
@@ -7406,6 +7431,28 @@ impl IDistributedApplicationBuilder {
         Ok(ExternalServiceResource::new(handle, self.client.clone()))
     }
 
+    /// Adds an external service with a URI
+    pub fn add_external_service_uri(&self, name: &str, uri: &str) -> Result<ExternalServiceResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
+        args.insert("uri".to_string(), serde_json::to_value(&uri).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/addExternalServiceUri", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ExternalServiceResource::new(handle, self.client.clone()))
+    }
+
+    /// Adds an external service with a parameter URL
+    pub fn add_external_service_parameter(&self, name: &str, url_parameter: &ParameterResource) -> Result<ExternalServiceResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
+        args.insert("urlParameter".to_string(), url_parameter.handle().to_json());
+        let result = self.client.invoke_capability("Aspire.Hosting/addExternalServiceParameter", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ExternalServiceResource::new(handle, self.client.clone()))
+    }
+
     /// Gets the AppHostDirectory property
     pub fn app_host_directory(&self) -> Result<String, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -7468,6 +7515,23 @@ impl IDistributedApplicationBuilder {
             args.insert("secret".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
         let result = self.client.invoke_capability("Aspire.Hosting/addParameter", args)?;
+        let handle: Handle = serde_json::from_value(result)?;
+        Ok(ParameterResource::new(handle, self.client.clone()))
+    }
+
+    /// Adds a parameter with a default value
+    pub fn add_parameter_with_value(&self, name: &str, value: &str, publish_value_as_default: Option<bool>, secret: Option<bool>) -> Result<ParameterResource, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("builder".to_string(), self.handle.to_json());
+        args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
+        args.insert("value".to_string(), serde_json::to_value(&value).unwrap_or(Value::Null));
+        if let Some(ref v) = publish_value_as_default {
+            args.insert("publishValueAsDefault".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        if let Some(ref v) = secret {
+            args.insert("secret".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
+        }
+        let result = self.client.invoke_capability("Aspire.Hosting/addParameterWithValue", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ParameterResource::new(handle, self.client.clone()))
     }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -440,6 +440,10 @@ export interface AddConnectionStringOptions {
     environmentVariableName?: string;
 }
 
+export interface AddContainerRegistryFromStringOptions {
+    repository?: string;
+}
+
 export interface AddContainerRegistryOptions {
     repository?: ParameterResource;
 }
@@ -454,6 +458,11 @@ export interface AddParameterFromConfigurationOptions {
 }
 
 export interface AddParameterOptions {
+    secret?: boolean;
+}
+
+export interface AddParameterWithValueOptions {
+    publishValueAsDefault?: boolean;
     secret?: boolean;
 }
 
@@ -3131,6 +3140,21 @@ export class DistributedApplicationBuilder {
         return new DistributedApplicationPromise(this._buildInternal());
     }
 
+    /** Adds a connection string with a reference expression */
+    /** @internal */
+    async _addConnectionStringExpressionInternal(name: string, connectionStringExpression: ReferenceExpression): Promise<ConnectionStringResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, connectionStringExpression };
+        const result = await this._client.invokeCapability<ConnectionStringResourceHandle>(
+            'Aspire.Hosting/addConnectionStringExpression',
+            rpcArgs
+        );
+        return new ConnectionStringResource(result, this._client);
+    }
+
+    addConnectionStringExpression(name: string, connectionStringExpression: ReferenceExpression): ConnectionStringResourcePromise {
+        return new ConnectionStringResourcePromise(this._addConnectionStringExpressionInternal(name, connectionStringExpression));
+    }
+
     /** Adds a connection string with a builder callback */
     /** @internal */
     async _addConnectionStringBuilderInternal(name: string, connectionStringBuilder: (obj: ReferenceExpressionBuilder) => Promise<void>): Promise<ConnectionStringResource> {
@@ -3166,6 +3190,23 @@ export class DistributedApplicationBuilder {
     addContainerRegistry(name: string, endpoint: ParameterResource, options?: AddContainerRegistryOptions): ContainerRegistryResourcePromise {
         const repository = options?.repository;
         return new ContainerRegistryResourcePromise(this._addContainerRegistryInternal(name, endpoint, repository));
+    }
+
+    /** Adds a container registry with string endpoint */
+    /** @internal */
+    async _addContainerRegistryFromStringInternal(name: string, endpoint: string, repository?: string): Promise<ContainerRegistryResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, endpoint };
+        if (repository !== undefined) rpcArgs.repository = repository;
+        const result = await this._client.invokeCapability<ContainerRegistryResourceHandle>(
+            'Aspire.Hosting/addContainerRegistryFromString',
+            rpcArgs
+        );
+        return new ContainerRegistryResource(result, this._client);
+    }
+
+    addContainerRegistryFromString(name: string, endpoint: string, options?: AddContainerRegistryFromStringOptions): ContainerRegistryResourcePromise {
+        const repository = options?.repository;
+        return new ContainerRegistryResourcePromise(this._addContainerRegistryFromStringInternal(name, endpoint, repository));
     }
 
     /** Adds a container resource */
@@ -3247,6 +3288,36 @@ export class DistributedApplicationBuilder {
         return new ExternalServiceResourcePromise(this._addExternalServiceInternal(name, url));
     }
 
+    /** Adds an external service with a URI */
+    /** @internal */
+    async _addExternalServiceUriInternal(name: string, uri: string): Promise<ExternalServiceResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, uri };
+        const result = await this._client.invokeCapability<ExternalServiceResourceHandle>(
+            'Aspire.Hosting/addExternalServiceUri',
+            rpcArgs
+        );
+        return new ExternalServiceResource(result, this._client);
+    }
+
+    addExternalServiceUri(name: string, uri: string): ExternalServiceResourcePromise {
+        return new ExternalServiceResourcePromise(this._addExternalServiceUriInternal(name, uri));
+    }
+
+    /** Adds an external service with a parameter URL */
+    /** @internal */
+    async _addExternalServiceParameterInternal(name: string, urlParameter: ParameterResource): Promise<ExternalServiceResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, urlParameter };
+        const result = await this._client.invokeCapability<ExternalServiceResourceHandle>(
+            'Aspire.Hosting/addExternalServiceParameter',
+            rpcArgs
+        );
+        return new ExternalServiceResource(result, this._client);
+    }
+
+    addExternalServiceParameter(name: string, urlParameter: ParameterResource): ExternalServiceResourcePromise {
+        return new ExternalServiceResourcePromise(this._addExternalServiceParameterInternal(name, urlParameter));
+    }
+
     /** Adds a parameter resource */
     /** @internal */
     async _addParameterInternal(name: string, secret?: boolean): Promise<ParameterResource> {
@@ -3262,6 +3333,25 @@ export class DistributedApplicationBuilder {
     addParameter(name: string, options?: AddParameterOptions): ParameterResourcePromise {
         const secret = options?.secret;
         return new ParameterResourcePromise(this._addParameterInternal(name, secret));
+    }
+
+    /** Adds a parameter with a default value */
+    /** @internal */
+    async _addParameterWithValueInternal(name: string, value: string, publishValueAsDefault?: boolean, secret?: boolean): Promise<ParameterResource> {
+        const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
+        if (publishValueAsDefault !== undefined) rpcArgs.publishValueAsDefault = publishValueAsDefault;
+        if (secret !== undefined) rpcArgs.secret = secret;
+        const result = await this._client.invokeCapability<ParameterResourceHandle>(
+            'Aspire.Hosting/addParameterWithValue',
+            rpcArgs
+        );
+        return new ParameterResource(result, this._client);
+    }
+
+    addParameterWithValue(name: string, value: string, options?: AddParameterWithValueOptions): ParameterResourcePromise {
+        const publishValueAsDefault = options?.publishValueAsDefault;
+        const secret = options?.secret;
+        return new ParameterResourcePromise(this._addParameterWithValueInternal(name, value, publishValueAsDefault, secret));
     }
 
     /** Adds a parameter sourced from configuration */
@@ -3463,6 +3553,11 @@ export class DistributedApplicationBuilderPromise implements PromiseLike<Distrib
         return new DistributedApplicationPromise(this._promise.then(obj => obj.build()));
     }
 
+    /** Adds a connection string with a reference expression */
+    addConnectionStringExpression(name: string, connectionStringExpression: ReferenceExpression): ConnectionStringResourcePromise {
+        return new ConnectionStringResourcePromise(this._promise.then(obj => obj.addConnectionStringExpression(name, connectionStringExpression)));
+    }
+
     /** Adds a connection string with a builder callback */
     addConnectionStringBuilder(name: string, connectionStringBuilder: (obj: ReferenceExpressionBuilder) => Promise<void>): ConnectionStringResourcePromise {
         return new ConnectionStringResourcePromise(this._promise.then(obj => obj.addConnectionStringBuilder(name, connectionStringBuilder)));
@@ -3471,6 +3566,11 @@ export class DistributedApplicationBuilderPromise implements PromiseLike<Distrib
     /** Adds a container registry resource */
     addContainerRegistry(name: string, endpoint: ParameterResource, options?: AddContainerRegistryOptions): ContainerRegistryResourcePromise {
         return new ContainerRegistryResourcePromise(this._promise.then(obj => obj.addContainerRegistry(name, endpoint, options)));
+    }
+
+    /** Adds a container registry with string endpoint */
+    addContainerRegistryFromString(name: string, endpoint: string, options?: AddContainerRegistryFromStringOptions): ContainerRegistryResourcePromise {
+        return new ContainerRegistryResourcePromise(this._promise.then(obj => obj.addContainerRegistryFromString(name, endpoint, options)));
     }
 
     /** Adds a container resource */
@@ -3498,9 +3598,24 @@ export class DistributedApplicationBuilderPromise implements PromiseLike<Distrib
         return new ExternalServiceResourcePromise(this._promise.then(obj => obj.addExternalService(name, url)));
     }
 
+    /** Adds an external service with a URI */
+    addExternalServiceUri(name: string, uri: string): ExternalServiceResourcePromise {
+        return new ExternalServiceResourcePromise(this._promise.then(obj => obj.addExternalServiceUri(name, uri)));
+    }
+
+    /** Adds an external service with a parameter URL */
+    addExternalServiceParameter(name: string, urlParameter: ParameterResource): ExternalServiceResourcePromise {
+        return new ExternalServiceResourcePromise(this._promise.then(obj => obj.addExternalServiceParameter(name, urlParameter)));
+    }
+
     /** Adds a parameter resource */
     addParameter(name: string, options?: AddParameterOptions): ParameterResourcePromise {
         return new ParameterResourcePromise(this._promise.then(obj => obj.addParameter(name, options)));
+    }
+
+    /** Adds a parameter with a default value */
+    addParameterWithValue(name: string, value: string, options?: AddParameterWithValueOptions): ParameterResourcePromise {
+        return new ParameterResourcePromise(this._promise.then(obj => obj.addParameterWithValue(name, value, options)));
     }
 
     /** Adds a parameter sourced from configuration */


### PR DESCRIPTION
## Description

This fixes the warnings emitted by `aspire sdk dump --format ci` when generating the ATS capability surface for `Aspire.Hosting`.

The root cause was overload-like ATS exports in `Aspire.Hosting` sharing generated method names, which caused the ATS scanner to report collisions during the CI dump. This change gives those exports distinct ATS ids, updates the generated polyglot snapshots, and replaces the scanner-only regression with a functional CLI test that verifies the CI dump does not emit warnings.

Validation:
- `./dotnet.sh test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj -- --filter-method "*.SdkDumpCi_ForHostingProject_DoesNotEmitWarnings" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `./dotnet.sh test tests/Aspire.Hosting.RemoteHost.Tests/Aspire.Hosting.RemoteHost.Tests.csproj -- --filter-method "*.ScanAssembly_HostingAssembly_CoreFrameworkAndLifecycleCapabilitiesAreRegistered" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
