### PR TITLE
Address apphost stdout review feedback

### DIFF
--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -286,10 +286,10 @@ internal class ConsoleInteractionService : IInteractionService
         var style = isErrorMessage ? s_errorMessageStyle
             : type switch
             {
-                "waiting" => s_waitingMessageStyle,
-                "running" => s_infoMessageStyle,
-                "exitCode" => s_exitCodeMessageStyle,
-                "failedToStart" => s_errorMessageStyle,
+                ConsoleLogTypes.Waiting => s_waitingMessageStyle,
+                ConsoleLogTypes.Running => s_infoMessageStyle,
+                ConsoleLogTypes.ExitCode => s_exitCodeMessageStyle,
+                ConsoleLogTypes.FailedToStart => s_errorMessageStyle,
                 _ => s_infoMessageStyle
             };
 
@@ -302,11 +302,11 @@ internal class ConsoleInteractionService : IInteractionService
         DisplayMessage(KnownEmojis.CheckMark, message, allowMarkup);
     }
 
-    public void DisplayLines(IEnumerable<(string Stream, string Line)> lines)
+    public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines)
     {
         foreach (var (stream, line) in lines)
         {
-            if (stream == "stdout")
+            if (stream == OutputLineStream.StdOut)
             {
                 MessageConsole.MarkupLineInterpolated($"{line.EscapeMarkup()}");
             }

--- a/src/Aspire.Cli/Interaction/ConsoleLogTypes.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleLogTypes.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Interaction;
+
+/// <summary>
+/// Known semantic types for console log messages emitted directly by the CLI.
+/// </summary>
+internal static class ConsoleLogTypes
+{
+    public const string Waiting = "waiting";
+    public const string Running = "running";
+    public const string ExitCode = "exitCode";
+    public const string FailedToStart = "failedToStart";
+}

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -342,9 +342,11 @@ internal class ExtensionInteractionService : IExtensionInteractionService
         Debug.Assert(result);
     }
 
-    public void DisplayLines(IEnumerable<(string Stream, string Line)> lines)
+    public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines)
     {
-        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayLinesAsync(lines.Select(line => new DisplayLineState(line.Stream.RemoveSpectreFormatting(), line.Line.RemoveSpectreFormatting())), _cancellationToken));
+        var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayLinesAsync(lines.Select(line => new DisplayLineState(
+            line.Stream == OutputLineStream.StdOut ? "stdout" : "stderr",
+            line.Line.RemoveSpectreFormatting())), _cancellationToken));
         Debug.Assert(result);
         _consoleInteractionService.DisplayLines(lines);
     }

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Backchannel;
+using Aspire.Cli.Utils;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 
@@ -25,7 +26,7 @@ internal interface IInteractionService
     void DisplayMarkupLine(string markup);
     void DisplaySuccess(string message, bool allowMarkup = false);
     void DisplaySubtleMessage(string message, bool allowMarkup = false);
-    void DisplayLines(IEnumerable<(string Stream, string Line)> lines);
+    void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines);
     void DisplayRenderable(IRenderable renderable);
     Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback);
     void DisplayCancellationMessage();
@@ -39,5 +40,7 @@ internal interface IInteractionService
     ConsoleOutput Console { get; set; }
 
     void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null);
+    // The semantic type is stringly-typed because some values originate from backchannel payloads.
+    // Use ConsoleLogTypes for CLI-defined values.
     void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false);
 }

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -308,8 +308,8 @@ internal sealed class DotNetAppHostProject : IAppHostProject
             "AppHost",
             (stream, line) => _interactionService.WriteConsoleLog(
                 line,
-                type: "running",
-                isErrorMessage: stream == "stderr"));
+                type: ConsoleLogTypes.Running,
+                isErrorMessage: stream == OutputLineStream.StdErr));
         context.OutputCollector = runOutputCollector;
 
         // Signal that build/preparation is complete

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -506,8 +506,8 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             {
                 launcher = _guestRuntime.CreateDefaultLauncher((stream, line) => _interactionService.WriteConsoleLog(
                     line,
-                    type: "running",
-                    isErrorMessage: stream == "stderr"));
+                    type: ConsoleLogTypes.Running,
+                    isErrorMessage: stream == OutputLineStream.StdErr));
             }
 
             // Start guest apphost - it will connect to AppHost server, define resources.
@@ -527,7 +527,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             {
                 _logger.LogError("{Language} apphost exited with code {ExitCode}", DisplayName, guestExitCode);
 
-                // Display the output (same pattern as DotNetCliRunner)
+                // Replay buffered output only when the process failed before live streaming began.
                 if (guestOutput is { HasLiveOutputCallback: false })
                 {
                     _interactionService.DisplayLines(guestOutput.GetLines());

--- a/src/Aspire.Cli/Projects/GuestRuntime.cs
+++ b/src/Aspire.Cli/Projects/GuestRuntime.cs
@@ -150,8 +150,10 @@ internal sealed class GuestRuntime
 
     /// <summary>
     /// Creates the default process-based launcher for this runtime.
+    /// Pass a callback only for interactive run flows that should stream output live.
+    /// Install and publish flows leave this <see langword="null"/> and replay buffered output later if needed.
     /// </summary>
-    public ProcessGuestLauncher CreateDefaultLauncher(Action<string, string>? liveOutputCallback = null) => new(_spec.Language, _logger, _commandResolver, liveOutputCallback);
+    public ProcessGuestLauncher CreateDefaultLauncher(Action<OutputLineStream, string>? liveOutputCallback = null) => new(_spec.Language, _logger, _commandResolver, liveOutputCallback);
 
     /// <summary>
     /// Replaces placeholders in command arguments with actual values.

--- a/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
+++ b/src/Aspire.Cli/Projects/ProcessGuestLauncher.cs
@@ -15,9 +15,9 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
     private readonly string _language;
     private readonly ILogger _logger;
     private readonly Func<string, string?> _commandResolver;
-    private readonly Action<string, string>? _liveOutputCallback;
+    private readonly Action<OutputLineStream, string>? _liveOutputCallback;
 
-    public ProcessGuestLauncher(string language, ILogger logger, Func<string, string?>? commandResolver = null, Action<string, string>? liveOutputCallback = null)
+    public ProcessGuestLauncher(string language, ILogger logger, Func<string, string?>? commandResolver = null, Action<OutputLineStream, string>? liveOutputCallback = null)
     {
         _language = language;
         _logger = logger;
@@ -72,6 +72,7 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
         {
             if (e.Data is null)
             {
+                // ProcessDataReceivedEventArgs.Data is null when the redirected stdout stream closes.
                 stdoutCompleted.TrySetResult();
             }
             else
@@ -85,6 +86,7 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
         {
             if (e.Data is null)
             {
+                // ProcessDataReceivedEventArgs.Data is null when the redirected stderr stream closes.
                 stderrCompleted.TrySetResult();
             }
             else
@@ -99,6 +101,7 @@ internal sealed class ProcessGuestLauncher : IGuestProcessLauncher
         process.BeginErrorReadLine();
 
         await process.WaitForExitAsync(cancellationToken);
+        // Wait for the redirected streams to finish draining so no trailing lines are lost.
         await Task.WhenAll(stdoutCompleted.Task, stderrCompleted.Task).WaitAsync(cancellationToken);
         return (process.ExitCode, outputCollector);
     }

--- a/src/Aspire.Cli/Utils/OutputCollector.cs
+++ b/src/Aspire.Cli/Utils/OutputCollector.cs
@@ -6,13 +6,19 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Utils;
 
+internal enum OutputLineStream
+{
+    StdOut,
+    StdErr
+}
+
 internal sealed class OutputCollector
 {
-    private readonly CircularBuffer<(string Stream, string Line)> _lines = new(10000); // 10k lines.
+    private readonly CircularBuffer<(OutputLineStream Stream, string Line)> _lines = new(10000); // 10k lines.
     private readonly object _lock = new object();
     private readonly FileLoggerProvider? _fileLogger;
     private readonly string _category;
-    private readonly Action<string, string>? _liveOutputCallback;
+    private readonly Action<OutputLineStream, string>? _liveOutputCallback;
 
     /// <summary>
     /// Creates an OutputCollector that only buffers output in memory.
@@ -26,8 +32,11 @@ internal sealed class OutputCollector
     /// </summary>
     /// <param name="fileLogger">Optional file logger for writing output to disk.</param>
     /// <param name="category">Category for log entries (e.g., "Build", "AppHost").</param>
-    /// <param name="liveOutputCallback">Optional callback invoked immediately when a line is appended.</param>
-    public OutputCollector(FileLoggerProvider? fileLogger, string category = "AppHost", Action<string, string>? liveOutputCallback = null)
+    /// <param name="liveOutputCallback">
+    /// Optional callback used by interactive run flows that need lines as they arrive.
+    /// Leave this <see langword="null"/> for buffer-only flows that replay output later on failure.
+    /// </param>
+    public OutputCollector(FileLoggerProvider? fileLogger, string category = "AppHost", Action<OutputLineStream, string>? liveOutputCallback = null)
     {
         _fileLogger = fileLogger;
         _category = category;
@@ -38,15 +47,15 @@ internal sealed class OutputCollector
 
     public void AppendOutput(string line)
     {
-        AppendLine("stdout", line);
+        AppendLine(OutputLineStream.StdOut, line);
     }
 
     public void AppendError(string line)
     {
-        AppendLine("stderr", line);
+        AppendLine(OutputLineStream.StdErr, line);
     }
 
-    public IEnumerable<(string Stream, string Line)> GetLines()
+    public IEnumerable<(OutputLineStream Stream, string Line)> GetLines()
     {
         lock (_lock)
         {
@@ -54,12 +63,12 @@ internal sealed class OutputCollector
         }
     }
 
-    private void AppendLine(string stream, string line)
+    private void AppendLine(OutputLineStream stream, string line)
     {
         lock (_lock)
         {
             _lines.Add((stream, line));
-            _fileLogger?.WriteLog(DateTimeOffset.UtcNow, stream == "stderr" ? LogLevel.Error : LogLevel.Information, _category, line);
+            _fileLogger?.WriteLog(DateTimeOffset.UtcNow, stream == OutputLineStream.StdErr ? LogLevel.Error : LogLevel.Information, _category, line);
         }
 
         _liveOutputCallback?.Invoke(stream, line);

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1574,7 +1574,7 @@ internal sealed class OrderTrackingInteractionService(List<string> operationOrde
     public void DisplayError(string errorMessage) { }
     public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) { }
     public void DisplaySuccess(string message, bool allowMarkup = false) { }
-    public void DisplayLines(IEnumerable<(string Stream, string Line)> lines) { }
+    public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines) { }
     public void DisplayCancellationMessage() { }
     public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default) => Task.FromResult(true);
     public Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default)

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -953,7 +953,7 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
     public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) { }
     public void DisplaySuccess(string message, bool allowMarkup = false) { }
     public void DisplaySubtleMessage(string message, bool allowMarkup = false) { }
-    public void DisplayLines(IEnumerable<(string Stream, string Line)> lines) { }
+    public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines) { }
     public void DisplayCancellationMessage() { }
     public void DisplayEmptyLine() { }
     public void DisplayPlainText(string text) { }

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -11,6 +11,7 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console;
 using Spectre.Console.Rendering;
@@ -1062,7 +1063,7 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
     public void DisplayMarkupLine(string markup) => _innerService.DisplayMarkupLine(markup);
     public void DisplaySuccess(string message, bool allowMarkup = false) => _innerService.DisplaySuccess(message, allowMarkup);
     public void DisplaySubtleMessage(string message, bool allowMarkup = false) => _innerService.DisplaySubtleMessage(message, allowMarkup);
-    public void DisplayLines(IEnumerable<(string Stream, string Line)> lines) => _innerService.DisplayLines(lines);
+    public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines) => _innerService.DisplayLines(lines);
     public void DisplayCancellationMessage() 
     {
         OnCancellationMessageDisplayed?.Invoke();

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -112,8 +112,8 @@ public class ConsoleInteractionServiceTests
         var interactionService = CreateInteractionService(console, executionContext);
         var lines = new[]
         {
-            ("stdout", "Command output with <angle> brackets"),
-            ("stderr", "Error output with [square] brackets")
+            (OutputLineStream.StdOut, "Command output with <angle> brackets"),
+            (OutputLineStream.StdErr, "Error output with [square] brackets")
         };
 
         // Act - this should not throw an exception due to markup parsing

--- a/tests/Aspire.Cli.Tests/Projects/ExtensionGuestLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ExtensionGuestLauncherTests.cs
@@ -4,6 +4,7 @@
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Projects;
+using Aspire.Cli.Utils;
 
 namespace Aspire.Cli.Tests.Projects;
 
@@ -165,7 +166,7 @@ public class ExtensionGuestLauncherTests
         public void DisplayError(string errorMessage) => throw new NotImplementedException();
         public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) => throw new NotImplementedException();
         public void DisplaySuccess(string message, bool allowMarkup = false) => throw new NotImplementedException();
-        public void DisplayLines(IEnumerable<(string Stream, string Line)> lines) => throw new NotImplementedException();
+        public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines) => throw new NotImplementedException();
         public void DisplayCancellationMessage() => throw new NotImplementedException();
         public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public void DisplaySubtleMessage(string message, bool allowMarkup = false) => throw new NotImplementedException();

--- a/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestRuntimeTests.cs
@@ -319,7 +319,7 @@ public class GuestRuntimeTests
             output.GetLines(),
             line =>
             {
-                Assert.Equal("stderr", line.Stream);
+                Assert.Equal(OutputLineStream.StdErr, line.Stream);
                 Assert.Equal("npm is not installed or not found in PATH. Please install Node.js and try again.", line.Line);
             });
     }
@@ -354,7 +354,7 @@ public class GuestRuntimeTests
             resolvedOutput.GetLines(),
             line =>
             {
-                Assert.Equal("stderr", line.Stream);
+                Assert.Equal(OutputLineStream.StdErr, line.Stream);
                 Assert.Equal("npx is not installed or not found in PATH. Please install Node.js and try again.", line.Line);
             });
     }

--- a/tests/Aspire.Cli.Tests/Projects/ProcessGuestLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProcessGuestLauncherTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Projects;
+using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Projects;
@@ -12,7 +13,7 @@ public class ProcessGuestLauncherTests
     public async Task LaunchAsync_ForwardsStdoutToLiveCallback()
     {
         // Arrange
-        var forwardedLines = new List<(string Stream, string Line)>();
+        var forwardedLines = new List<(OutputLineStream Stream, string Line)>();
         var launcher = new ProcessGuestLauncher(
             "typescript",
             NullLogger.Instance,
@@ -29,6 +30,6 @@ public class ProcessGuestLauncherTests
         // Assert
         Assert.Equal(0, exitCode);
         Assert.NotNull(output);
-        Assert.Contains(forwardedLines, line => line.Stream == "stdout" && !string.IsNullOrWhiteSpace(line.Line));
+        Assert.Contains(forwardedLines, line => line.Stream == OutputLineStream.StdOut && !string.IsNullOrWhiteSpace(line.Line));
     }
 }

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -481,7 +481,7 @@ public class DotNetTemplateFactoryTests
         public void DisplaySuccess(string message, bool allowMarkup = false) { }
         public void DisplayError(string message) { }
         public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false) { }
-        public void DisplayLines(IEnumerable<(string Stream, string Line)> lines) { }
+        public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines) { }
         public void DisplayCancellationMessage() { }
         public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;
         public void DisplayPlainText(string text) { }

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
@@ -112,7 +113,7 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
     {
     }
 
-    public void DisplayLines(IEnumerable<(string Stream, string Line)> lines)
+    public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines)
     {
     }
 

--- a/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.Utils;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 
@@ -153,7 +154,7 @@ internal sealed class TestInteractionService : IInteractionService
     {
     }
 
-    public void DisplayLines(IEnumerable<(string Stream, string Line)> lines)
+    public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines)
     {
     }
 

--- a/tests/Aspire.Cli.Tests/Utils/OutputCollectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/OutputCollectorTests.cs
@@ -44,8 +44,8 @@ public class OutputCollectorTests
         Assert.Equal(threadCount * linesPerThread, lines.Count);
 
         // Check that we have both stdout and stderr entries
-        var stdoutLines = lines.Where(l => l.Stream == "stdout").ToList();
-        var stderrLines = lines.Where(l => l.Stream == "stderr").ToList();
+        var stdoutLines = lines.Where(l => l.Stream == OutputLineStream.StdOut).ToList();
+        var stderrLines = lines.Where(l => l.Stream == OutputLineStream.StdErr).ToList();
 
         Assert.Equal(threadCount * linesPerThread / 2, stdoutLines.Count);
         Assert.Equal(threadCount * linesPerThread / 2, stderrLines.Count);
@@ -65,7 +65,7 @@ public class OutputCollectorTests
         // Assert - Snapshot should not be affected by subsequent additions
         Assert.Single(snapshot);
         Assert.Equal("initial line", snapshot[0].Line);
-        Assert.Equal("stdout", snapshot[0].Stream);
+        Assert.Equal(OutputLineStream.StdOut, snapshot[0].Stream);
 
         // New call should include the additional line
         var newSnapshot = collector.GetLines().ToList();
@@ -107,7 +107,7 @@ public class OutputCollectorTests
     public void OutputCollector_LiveCallback_ReceivesStdoutAndStderr()
     {
         // Arrange
-        var forwardedLines = new List<(string Stream, string Line)>();
+        var forwardedLines = new List<(OutputLineStream Stream, string Line)>();
         var collector = new OutputCollector(fileLogger: null, liveOutputCallback: (stream, line) => forwardedLines.Add((stream, line)));
 
         // Act
@@ -117,7 +117,7 @@ public class OutputCollectorTests
         // Assert
         Assert.True(collector.HasLiveOutputCallback);
         Assert.Equal(
-            [("stdout", "hello"), ("stderr", "oops")],
+            [(OutputLineStream.StdOut, "hello"), (OutputLineStream.StdErr, "oops")],
             forwardedLines);
     }
 }


### PR DESCRIPTION
## Description

Follow up on review feedback for the apphost stdout logging change.

This keeps the original behavior change intact while tightening the implementation details James called out during review:
- replace string-based stdout/stderr tracking with an internal `OutputLineStream` enum
- use shared `ConsoleLogTypes` constants for CLI-defined console log message types
- add clarifying comments around nullable live callbacks, buffered replay behavior, and `Process` stream completion semantics

This is a low-risk cleanup on top of the existing apphost stdout work for `aspire run` in non-detached runs. There are no additional dependencies.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
