### PR TITLE
Add TypeScript SDK refresh workflow

### DIFF
--- a/.github/workflows/refresh-typescript-sdks.yml
+++ b/.github/workflows/refresh-typescript-sdks.yml
@@ -1,0 +1,45 @@
+name: Refresh TypeScript Playground SDKs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 16 * * *' # 8am PST (16:00 UTC) - same schedule as manifest refresh
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  generate-and-pr:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'dotnet' }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Setup Node.js
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version: 20.x
+
+      - name: Run refreshTypeScriptSdks script
+        shell: pwsh
+        run: |
+          ./eng/refreshTypeScriptSdks.ps1
+
+      - name: Create or update pull request
+        uses: dotnet/actions-create-pull-request@e8d799aa1f8b17f324f9513832811b0a62f1e0b1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update-typescript-playground-sdks
+          base: main
+          commit-message: "[Automated] Update TypeScript Playground AppHost SDKs"
+          labels: |
+            area-app-model
+            area-engineering-systems
+          title: "[Automated] Update TypeScript Playground AppHost SDKs"
+          body: "Auto-generated update to refresh the TypeScript playground AppHost SDKs."

--- a/.github/workflows/refresh-typescript-sdks.yml
+++ b/.github/workflows/refresh-typescript-sdks.yml
@@ -3,7 +3,7 @@ name: Refresh TypeScript Playground SDKs
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 16 * * *' # 8am PST (16:00 UTC) - same schedule as manifest refresh
+    - cron: '0 16 * * *' # 8am PT / 16:00 UTC - same schedule as manifest refresh
 
 permissions:
   contents: write
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           global-json-file: global.json
 

--- a/eng/refreshTypeScriptSdks.ps1
+++ b/eng/refreshTypeScriptSdks.ps1
@@ -11,8 +11,8 @@ $PSNativeCommandUseErrorActionPreference = $true
 
 $scriptDir = $PSScriptRoot
 $repoRoot = Split-Path -Parent $scriptDir
-$playgroundRoot = Join-Path -Path $repoRoot -ChildPath 'playground' -AdditionalChildPath 'polyglot', 'TypeScript'
-$cliProject = Join-Path -Path $repoRoot -ChildPath 'src' -AdditionalChildPath 'Aspire.Cli', 'Aspire.Cli.csproj'
+$playgroundRoot = Join-Path -Path $repoRoot -ChildPath 'playground/polyglot/TypeScript'
+$cliProject = Join-Path -Path $repoRoot -ChildPath 'src/Aspire.Cli/Aspire.Cli.csproj'
 $requiredGeneratedFiles = @('aspire.ts', 'base.ts', 'transport.ts')
 
 function Invoke-RepoRestore {
@@ -49,12 +49,18 @@ function Get-ValidationAppHosts {
 }
 
 function Install-NodeDependencies([string]$appDir) {
-    $packageLockPath = Join-Path $appDir 'package-lock.json'
-    if (Test-Path $packageLockPath) {
-        & npm ci --ignore-scripts --no-audit --no-fund
+    Push-Location $appDir
+    try {
+        $packageLockPath = Join-Path $appDir 'package-lock.json'
+        if (Test-Path $packageLockPath) {
+            & npm ci --ignore-scripts --no-audit --no-fund
+        }
+        else {
+            & npm install --ignore-scripts --no-audit --no-fund
+        }
     }
-    else {
-        & npm install --ignore-scripts --no-audit --no-fund
+    finally {
+        Pop-Location
     }
 }
 
@@ -120,7 +126,7 @@ foreach ($appHost in $appHosts) {
     }
     catch {
         Write-Host "  ERROR failed to refresh $appName"
-        Write-Host $_.Exception.Message
+        Write-Host ($_ | Out-String)
         $failures.Add($appName)
     }
     finally {

--- a/eng/refreshTypeScriptSdks.ps1
+++ b/eng/refreshTypeScriptSdks.ps1
@@ -1,0 +1,146 @@
+#!/usr/bin/env pwsh
+
+[CmdletBinding()]
+param(
+    [string]$AppPattern = '*'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
+
+$scriptDir = $PSScriptRoot
+$repoRoot = Split-Path -Parent $scriptDir
+$playgroundRoot = Join-Path -Path $repoRoot -ChildPath 'playground' -AdditionalChildPath 'polyglot', 'TypeScript'
+$cliProject = Join-Path -Path $repoRoot -ChildPath 'src' -AdditionalChildPath 'Aspire.Cli', 'Aspire.Cli.csproj'
+$requiredGeneratedFiles = @('aspire.ts', 'base.ts', 'transport.ts')
+
+function Invoke-RepoRestore {
+    if ($IsWindows -or $env:OS -eq 'Windows_NT') {
+        & (Join-Path $repoRoot 'restore.cmd')
+    }
+    else {
+        & (Join-Path $repoRoot 'restore.sh')
+    }
+}
+
+function Get-ValidationAppHosts {
+    if (-not (Test-Path $playgroundRoot)) {
+        throw "TypeScript playground directory not found at '$playgroundRoot'."
+    }
+
+    $appHosts = foreach ($integrationDir in Get-ChildItem -Path $playgroundRoot -Directory | Sort-Object Name) {
+        if ($integrationDir.Name -notlike $AppPattern) {
+            continue
+        }
+
+        $appHostDir = Join-Path $integrationDir.FullName 'ValidationAppHost'
+        $appHostEntryPoint = Join-Path $appHostDir 'apphost.ts'
+        if (Test-Path $appHostEntryPoint) {
+            Get-Item $appHostDir
+        }
+    }
+
+    if (@($appHosts).Count -eq 0) {
+        throw "No TypeScript playground ValidationAppHost directories matched '$AppPattern'."
+    }
+
+    return @($appHosts)
+}
+
+function Install-NodeDependencies([string]$appDir) {
+    $packageLockPath = Join-Path $appDir 'package-lock.json'
+    if (Test-Path $packageLockPath) {
+        & npm ci --ignore-scripts --no-audit --no-fund
+    }
+    else {
+        & npm install --ignore-scripts --no-audit --no-fund
+    }
+}
+
+function Assert-GeneratedSdkFiles([string]$appDir) {
+    $generatedDir = Join-Path $appDir '.modules'
+    foreach ($file in $requiredGeneratedFiles) {
+        $path = Join-Path $generatedDir $file
+        if (-not (Test-Path $path)) {
+            throw "Expected generated SDK file '$path' was not created."
+        }
+    }
+}
+
+if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+    throw "The .NET SDK was not found in PATH."
+}
+
+if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+    throw "npm was not found in PATH."
+}
+
+Write-Host '=== Refreshing TypeScript playground SDKs ==='
+Write-Host "Playground root: $playgroundRoot"
+Write-Host "CLI project: $cliProject"
+
+Invoke-RepoRestore
+
+& dotnet build $cliProject /p:SkipNativeBuild=true
+
+$appHosts = Get-ValidationAppHosts
+Write-Host "Found $($appHosts.Count) TypeScript playground apps matching '$AppPattern'."
+
+$failures = [System.Collections.Generic.List[string]]::new()
+$updated = [System.Collections.Generic.List[string]]::new()
+
+foreach ($appHost in $appHosts) {
+    $appName = '{0}/{1}' -f (Split-Path -Path $appHost.FullName -Parent | Split-Path -Leaf), $appHost.Name
+
+    Write-Host ''
+    Write-Host '----------------------------------------'
+    Write-Host "Refreshing: $appName"
+    Write-Host '----------------------------------------'
+
+    Push-Location $appHost.FullName
+    try {
+        Write-Host '  -> Installing npm dependencies...'
+        Install-NodeDependencies -appDir $appHost.FullName
+
+        $generatedDir = Join-Path $appHost.FullName '.modules'
+        if (Test-Path $generatedDir) {
+            Write-Host '  -> Clearing existing generated SDK...'
+            Remove-Item -Path $generatedDir -Recurse -Force
+        }
+
+        Write-Host '  -> Running aspire restore...'
+        & dotnet run --no-build --project $cliProject -- restore
+
+        Write-Host '  -> Verifying generated SDK...'
+        Assert-GeneratedSdkFiles -appDir $appHost.FullName
+
+        Write-Host "  OK $appName refreshed"
+        $updated.Add($appName)
+    }
+    catch {
+        Write-Host "  ERROR failed to refresh $appName"
+        Write-Host $_.Exception.Message
+        $failures.Add($appName)
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+Write-Host ''
+Write-Host '----------------------------------------'
+Write-Host "Results: $($updated.Count) refreshed, $($failures.Count) failed out of $($appHosts.Count) apps"
+Write-Host '----------------------------------------'
+
+if ($failures.Count -gt 0) {
+    Write-Host ''
+    Write-Host 'Failed apps:'
+    foreach ($failure in $failures) {
+        Write-Host "  - $failure"
+    }
+
+    exit 1
+}
+
+Write-Host 'All TypeScript playground SDKs refreshed successfully.'


### PR DESCRIPTION
## Description

Adds scheduled automation to regenerate the checked-in TypeScript polyglot playground AppHost SDKs so they stay aligned with the current CLI/codegen output.

Summary of changes:
- adds `.github/workflows/refresh-typescript-sdks.yml` to run on a schedule or via manual dispatch
- adds `eng/refreshTypeScriptSdks.ps1` to discover `playground/polyglot/TypeScript/*/ValidationAppHost` apps, install npm dependencies, clear stale `.modules` output, run `aspire restore`, and verify the generated SDK files exist
- mirrors the existing manifest refresh pattern by having the workflow update a fixed automation branch and generated PR target `main`

Validation performed:
- validated the new workflow YAML parses successfully
- reviewed the PowerShell script statically
- did not run the PowerShell script end-to-end in this local environment because `pwsh` is not installed here; I plan to validate it on another machine

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
