### PR TITLE
Reject circular TypeScript transport arguments

### DIFF
--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/transport.ts
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/transport.ts
@@ -127,6 +127,13 @@ function createAbortError(message: string): Error {
     return error;
 }
 
+function createCircularReferenceError(capabilityId: string, path: string): AppHostUsageError {
+    return new AppHostUsageError(
+        `Argument '${path}' passed to capability '${capabilityId}' contains a circular reference. ` +
+        'Circular references are not supported by the AppHost transport.'
+    );
+}
+
 // ============================================================================
 // Handle
 // ============================================================================
@@ -373,9 +380,7 @@ function validateCapabilityArgs(
         return;
     }
 
-    const seen = new Set<object>();
-
-    const validateValue = (value: unknown, path: string): void => {
+    const validateValue = (value: unknown, path: string, ancestors: Set<object>): void => {
         if (value === null || value === undefined) {
             return;
         }
@@ -392,26 +397,27 @@ function validateCapabilityArgs(
             return;
         }
 
-        if (seen.has(value)) {
-            return;
+        if (ancestors.has(value)) {
+            throw createCircularReferenceError(capabilityId, path);
         }
 
-        seen.add(value);
+        const nextAncestors = new Set(ancestors);
+        nextAncestors.add(value);
 
         if (Array.isArray(value)) {
             for (let i = 0; i < value.length; i++) {
-                validateValue(value[i], `${path}[${i}]`);
+                validateValue(value[i], `${path}[${i}]`, nextAncestors);
             }
             return;
         }
 
         for (const [key, nestedValue] of Object.entries(value)) {
-            validateValue(nestedValue, `${path}.${key}`);
+            validateValue(nestedValue, `${path}.${key}`, nextAncestors);
         }
     };
 
     for (const [key, value] of Object.entries(args)) {
-        validateValue(value, key);
+        validateValue(value, key, new Set<object>());
     }
 }
 
@@ -630,7 +636,10 @@ export function registerCancellation(
 async function marshalTransportValue(
     value: unknown,
     client: AspireClient,
-    cancellationIds: string[]
+    cancellationIds: string[],
+    capabilityId: string,
+    path: string = 'args',
+    ancestors: Set<object> = new Set<object>()
 ): Promise<unknown> {
     if (value === null || value === undefined || typeof value !== 'object') {
         return value;
@@ -645,18 +654,27 @@ async function marshalTransportValue(
         return cancellationId;
     }
 
+    if (ancestors.has(value)) {
+        throw createCircularReferenceError(capabilityId, path);
+    }
+
+    const nextAncestors = new Set(ancestors);
+    nextAncestors.add(value);
+
     if (hasTransportValue(value)) {
-        return await marshalTransportValue(await value.toTransportValue(), client, cancellationIds);
+        return await marshalTransportValue(await value.toTransportValue(), client, cancellationIds, capabilityId, path, nextAncestors);
     }
 
     if (Array.isArray(value)) {
-        return await Promise.all(value.map(item => marshalTransportValue(item, client, cancellationIds)));
+        return await Promise.all(
+            value.map((item, index) => marshalTransportValue(item, client, cancellationIds, capabilityId, `${path}[${index}]`, nextAncestors))
+        );
     }
 
     if (isPlainObject(value)) {
         const entries = await Promise.all(
             Object.entries(value).map(async ([key, nestedValue]) =>
-                [key, await marshalTransportValue(nestedValue, client, cancellationIds)] as const)
+                [key, await marshalTransportValue(nestedValue, client, cancellationIds, capabilityId, `${path}.${key}`, nextAncestors)] as const)
         );
 
         return Object.fromEntries(entries);
@@ -909,7 +927,7 @@ export class AspireClient {
         const cancellationIds: string[] = [];
 
         try {
-            const rpcArgs = await marshalTransportValue(args ?? null, this, cancellationIds);
+            const rpcArgs = await marshalTransportValue(args ?? null, this, cancellationIds, capabilityId);
 
             // Ref counting: The vscode-jsonrpc socket keeps Node's event loop alive.
             // We ref() during RPC calls so the process doesn't exit mid-call, and

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/transport.ts
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/Resources/transport.ts
@@ -401,18 +401,20 @@ function validateCapabilityArgs(
             throw createCircularReferenceError(capabilityId, path);
         }
 
-        const nextAncestors = new Set(ancestors);
-        nextAncestors.add(value);
-
-        if (Array.isArray(value)) {
-            for (let i = 0; i < value.length; i++) {
-                validateValue(value[i], `${path}[${i}]`, nextAncestors);
+        ancestors.add(value);
+        try {
+            if (Array.isArray(value)) {
+                for (let i = 0; i < value.length; i++) {
+                    validateValue(value[i], `${path}[${i}]`, ancestors);
+                }
+                return;
             }
-            return;
-        }
 
-        for (const [key, nestedValue] of Object.entries(value)) {
-            validateValue(nestedValue, `${path}.${key}`, nextAncestors);
+            for (const [key, nestedValue] of Object.entries(value)) {
+                validateValue(nestedValue, `${path}.${key}`, ancestors);
+            }
+        } finally {
+            ancestors.delete(value);
         }
     };
 

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
@@ -72,21 +72,6 @@ public class AtsTypeScriptCodeGeneratorTests
     }
 
     [Fact]
-    public void GenerateDistributedApplication_WithTestTypes_TransportTsRejectsCircularReferences()
-    {
-        var atsContext = CreateContextFromTestAssembly();
-
-        var files = _generator.GenerateDistributedApplication(atsContext);
-        var transport = files["transport.ts"];
-
-        Assert.Contains("function createCircularReferenceError(capabilityId: string, path: string): AppHostUsageError", transport);
-        Assert.Contains("throw createCircularReferenceError(capabilityId, path);", transport);
-        Assert.Contains("ancestors.add(value);", transport);
-        Assert.Contains("ancestors.delete(value);", transport);
-        Assert.Contains("return await marshalTransportValue(await value.toTransportValue(), client, cancellationIds, capabilityId, path, nextAncestors);", transport);
-    }
-
-    [Fact]
     public void GenerateDistributedApplication_WithTestTypes_IncludesCapabilities()
     {
         // Arrange

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
@@ -72,6 +72,21 @@ public class AtsTypeScriptCodeGeneratorTests
     }
 
     [Fact]
+    public void GenerateDistributedApplication_WithTestTypes_TransportTsRejectsCircularReferences()
+    {
+        var atsContext = CreateContextFromTestAssembly();
+
+        var files = _generator.GenerateDistributedApplication(atsContext);
+        var transport = files["transport.ts"];
+
+        Assert.Contains("function createCircularReferenceError(capabilityId: string, path: string): AppHostUsageError", transport);
+        Assert.Contains("throw createCircularReferenceError(capabilityId, path);", transport);
+        Assert.Contains("ancestors.add(value);", transport);
+        Assert.Contains("ancestors.delete(value);", transport);
+        Assert.Contains("return await marshalTransportValue(await value.toTransportValue(), client, cancellationIds, capabilityId, path, nextAncestors);", transport);
+    }
+
+    [Fact]
     public void GenerateDistributedApplication_WithTestTypes_IncludesCapabilities()
     {
         // Arrange

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/transport.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/transport.verified.ts
@@ -127,6 +127,13 @@ function createAbortError(message: string): Error {
     return error;
 }
 
+function createCircularReferenceError(capabilityId: string, path: string): AppHostUsageError {
+    return new AppHostUsageError(
+        `Argument '${path}' passed to capability '${capabilityId}' contains a circular reference. ` +
+        'Circular references are not supported by the AppHost transport.'
+    );
+}
+
 // ============================================================================
 // Handle
 // ============================================================================
@@ -373,9 +380,7 @@ function validateCapabilityArgs(
         return;
     }
 
-    const seen = new Set<object>();
-
-    const validateValue = (value: unknown, path: string): void => {
+    const validateValue = (value: unknown, path: string, ancestors: Set<object>): void => {
         if (value === null || value === undefined) {
             return;
         }
@@ -392,26 +397,27 @@ function validateCapabilityArgs(
             return;
         }
 
-        if (seen.has(value)) {
-            return;
+        if (ancestors.has(value)) {
+            throw createCircularReferenceError(capabilityId, path);
         }
 
-        seen.add(value);
+        const nextAncestors = new Set(ancestors);
+        nextAncestors.add(value);
 
         if (Array.isArray(value)) {
             for (let i = 0; i < value.length; i++) {
-                validateValue(value[i], `${path}[${i}]`);
+                validateValue(value[i], `${path}[${i}]`, nextAncestors);
             }
             return;
         }
 
         for (const [key, nestedValue] of Object.entries(value)) {
-            validateValue(nestedValue, `${path}.${key}`);
+            validateValue(nestedValue, `${path}.${key}`, nextAncestors);
         }
     };
 
     for (const [key, value] of Object.entries(args)) {
-        validateValue(value, key);
+        validateValue(value, key, new Set<object>());
     }
 }
 
@@ -630,7 +636,10 @@ export function registerCancellation(
 async function marshalTransportValue(
     value: unknown,
     client: AspireClient,
-    cancellationIds: string[]
+    cancellationIds: string[],
+    capabilityId: string,
+    path: string = 'args',
+    ancestors: Set<object> = new Set<object>()
 ): Promise<unknown> {
     if (value === null || value === undefined || typeof value !== 'object') {
         return value;
@@ -645,18 +654,27 @@ async function marshalTransportValue(
         return cancellationId;
     }
 
+    if (ancestors.has(value)) {
+        throw createCircularReferenceError(capabilityId, path);
+    }
+
+    const nextAncestors = new Set(ancestors);
+    nextAncestors.add(value);
+
     if (hasTransportValue(value)) {
-        return await marshalTransportValue(await value.toTransportValue(), client, cancellationIds);
+        return await marshalTransportValue(await value.toTransportValue(), client, cancellationIds, capabilityId, path, nextAncestors);
     }
 
     if (Array.isArray(value)) {
-        return await Promise.all(value.map(item => marshalTransportValue(item, client, cancellationIds)));
+        return await Promise.all(
+            value.map((item, index) => marshalTransportValue(item, client, cancellationIds, capabilityId, `${path}[${index}]`, nextAncestors))
+        );
     }
 
     if (isPlainObject(value)) {
         const entries = await Promise.all(
             Object.entries(value).map(async ([key, nestedValue]) =>
-                [key, await marshalTransportValue(nestedValue, client, cancellationIds)] as const)
+                [key, await marshalTransportValue(nestedValue, client, cancellationIds, capabilityId, `${path}.${key}`, nextAncestors)] as const)
         );
 
         return Object.fromEntries(entries);
@@ -909,7 +927,7 @@ export class AspireClient {
         const cancellationIds: string[] = [];
 
         try {
-            const rpcArgs = await marshalTransportValue(args ?? null, this, cancellationIds);
+            const rpcArgs = await marshalTransportValue(args ?? null, this, cancellationIds, capabilityId);
 
             // Ref counting: The vscode-jsonrpc socket keeps Node's event loop alive.
             // We ref() during RPC calls so the process doesn't exit mid-call, and

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/transport.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/transport.verified.ts
@@ -401,18 +401,20 @@ function validateCapabilityArgs(
             throw createCircularReferenceError(capabilityId, path);
         }
 
-        const nextAncestors = new Set(ancestors);
-        nextAncestors.add(value);
-
-        if (Array.isArray(value)) {
-            for (let i = 0; i < value.length; i++) {
-                validateValue(value[i], `${path}[${i}]`, nextAncestors);
+        ancestors.add(value);
+        try {
+            if (Array.isArray(value)) {
+                for (let i = 0; i < value.length; i++) {
+                    validateValue(value[i], `${path}[${i}]`, ancestors);
+                }
+                return;
             }
-            return;
-        }
 
-        for (const [key, nestedValue] of Object.entries(value)) {
-            validateValue(nestedValue, `${path}.${key}`, nextAncestors);
+            for (const [key, nestedValue] of Object.entries(value)) {
+                validateValue(nestedValue, `${path}.${key}`, ancestors);
+            }
+        } finally {
+            ancestors.delete(value);
         }
     };
 


### PR DESCRIPTION
## Description

Adds a follow-up hardening fix for the generated polyglot TypeScript `transport.ts` template.

This change rejects circular capability argument graphs both during validation and during transport marshalling so recursive user-provided objects fail with a clear `AppHostUsageError` instead of recursing indefinitely. It also updates the generated `transport.ts` snapshot.

Fixes #14898

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
