### PR TITLE
Fix GuestAppHostProject launchSettings.json parsing with JSON comments

### DIFF
--- a/playground/TestShop/TestShop.AppHost/Properties/launchSettings.json
+++ b/playground/TestShop/TestShop.AppHost/Properties/launchSettings.json
@@ -10,7 +10,6 @@
         "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:17269",
         "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "https://localhost:18098",
-        //"ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "https://localhost:17269",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17269"
       }
     },
@@ -24,7 +23,6 @@
         "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:17270",
         "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "http://localhost:18099",
-        //"ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:17270",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17270",
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -690,12 +690,12 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 return null;
             }
 
-            _logger.LogDebug("Read {Count} environment variables from apphost.run.json", result.Count);
+            _logger.LogDebug("Read {Count} environment variables from {ConfigPath}", result.Count, configPath);
             return result;
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to read launchSettings.json");
+            _logger.LogWarning(ex, "Failed to read {ConfigPath}", configPath);
             return null;
         }
     }

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -588,7 +588,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         }
     }
 
-    private Dictionary<string, string> GetServerEnvironmentVariables(DirectoryInfo directory)
+    internal Dictionary<string, string> GetServerEnvironmentVariables(DirectoryInfo directory)
     {
         var envVars = ReadLaunchSettingsEnvironmentVariables(directory) ?? new Dictionary<string, string>();
 
@@ -634,8 +634,9 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
 
         try
         {
+            _logger.LogDebug("Reading launch settings from {ConfigPath}", configPath);
             var json = File.ReadAllText(configPath);
-            using var doc = JsonDocument.Parse(json);
+            using var doc = JsonDocument.Parse(json, ConfigurationHelper.ParseOptions);
 
             if (!doc.RootElement.TryGetProperty("profiles", out var profiles))
             {

--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
@@ -31,7 +31,7 @@ public class AppHostServerProjectTests(ITestOutputHelper outputHelper) : IDispos
         appPath ??= _workspace.WorkspaceRoot.FullName;
         var runner = new TestDotNetCliRunner();
         var packagingService = new MockPackagingService();
-        var configurationService = new TrackingConfigurationService();
+        var configurationService = new TestConfigurationService();
         var logger = NullLogger<DotNetBasedAppHostServerProject>.Instance;
 
         // Generate socket path same way as factory
@@ -237,7 +237,7 @@ public class AppHostServerProjectTests(ITestOutputHelper outputHelper) : IDispos
 
         // Configure global config to return "pr-old" (the WRONG channel)
         // This simulates a stale global config that hasn't been updated
-        var configurationService = new TrackingConfigurationService
+        var configurationService = new TestConfigurationService
         {
             OnGetConfiguration = key => key == "channel" ? "pr-old" : null
         };

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Configuration;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Projects;
 
@@ -292,5 +296,72 @@ public class GuestAppHostProjectTests(ITestOutputHelper outputHelper) : IDisposa
 
         await Verify(content, extension: "json")
             .UseFileName("AspireJsonConfiguration_SettingsJson");
+    }
+
+    [Fact]
+    public void GetServerEnvironmentVariables_ParsesLaunchSettingsWithComments()
+    {
+        var project = CreateGuestAppHostProject(_workspace.WorkspaceRoot);
+
+        var propertiesDir = _workspace.CreateDirectory("Properties");
+        var launchSettingsPath = Path.Combine(propertiesDir.FullName, "launchSettings.json");
+        File.WriteAllText(launchSettingsPath, """
+            {
+              "profiles": {
+                "https": {
+                  "commandName": "Project",
+                  "applicationUrl": "https://localhost:16319;http://localhost:16320",
+                  "environmentVariables": {
+                    "ASPNETCORE_ENVIRONMENT": "Development",
+                    "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:17269",
+                    // This is a commented-out environment variable
+                    //"ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "https://localhost:17269",
+                    "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17269"
+                  }
+                }
+              }
+            }
+            """);
+
+        var envVars = project.GetServerEnvironmentVariables(_workspace.WorkspaceRoot);
+
+        Assert.Equal("https://localhost:16319;http://localhost:16320", envVars["ASPNETCORE_URLS"]);
+        Assert.Equal("Development", envVars["ASPNETCORE_ENVIRONMENT"]);
+        Assert.Equal("https://localhost:17269", envVars["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]);
+        Assert.Equal("https://localhost:17269", envVars["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"]);
+        Assert.False(envVars.ContainsKey("ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL"));
+    }
+
+    private static GuestAppHostProject CreateGuestAppHostProject(DirectoryInfo workspaceRoot)
+    {
+        var language = new LanguageInfo(
+            LanguageId: "typescript/nodejs",
+            DisplayName: "TypeScript (Node.js)",
+            PackageName: "Aspire.Hosting.CodeGeneration.TypeScript",
+            DetectionPatterns: ["apphost.ts"],
+            CodeGenerator: "TypeScript");
+
+        // Point the config service at a non-existent file so GetConfigDirectory
+        // falls back to the directory we pass to GetServerEnvironmentVariables.
+        var configService = new TestConfigurationService
+        {
+            SettingsFilePath = Path.Combine(workspaceRoot.FullName, "nonexistent", "settings.json")
+        };
+
+        var configuration = new ConfigurationBuilder().Build();
+
+        return new GuestAppHostProject(
+            language: language,
+            interactionService: new TestInteractionService(),
+            backchannel: new TestAppHostBackchannel(),
+            appHostServerProjectFactory: new TestAppHostServerProjectFactory(),
+            certificateService: new TestCertificateService(),
+            runner: new TestDotNetCliRunner(),
+            packagingService: new TestPackagingService(),
+            configuration: configuration,
+            configurationService: configService,
+            features: new Features(configuration, NullLogger<Features>.Instance),
+            languageDiscovery: new TestLanguageDiscovery(),
+            logger: NullLogger<GuestAppHostProject>.Instance);
     }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostServerProjectFactory.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostServerProjectFactory.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Projects;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+internal sealed class TestAppHostServerProjectFactory : IAppHostServerProjectFactory
+{
+    public Task<IAppHostServerProject> CreateAsync(string appPath, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException("TestAppHostServerProjectFactory.CreateAsync is not implemented for this test.");
+    }
+}

--- a/tests/Aspire.Cli.Tests/TestServices/TestCertificateService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestCertificateService.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Certificates;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+internal sealed class TestCertificateService : ICertificateService
+{
+    public Task<EnsureCertificatesTrustedResult> EnsureCertificatesTrustedAsync(CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new EnsureCertificatesTrustedResult
+        {
+            EnvironmentVariables = new Dictionary<string, string>()
+        });
+    }
+}

--- a/tests/Aspire.Cli.Tests/TestServices/TestConfigurationService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestConfigurationService.cs
@@ -8,7 +8,7 @@ namespace Aspire.Cli.Tests.TestServices;
 /// <summary>
 /// Test implementation of IConfigurationService that tracks SetConfigurationAsync, DeleteConfigurationAsync, and GetConfigurationAsync calls.
 /// </summary>
-public sealed class TrackingConfigurationService : IConfigurationService
+public sealed class TestConfigurationService : IConfigurationService
 {
     public Action<string, string, bool>? OnSetConfiguration { get; set; }
     public Action<string, bool>? OnDeleteConfiguration { get; set; }
@@ -47,8 +47,10 @@ public sealed class TrackingConfigurationService : IConfigurationService
         return Task.FromResult(result);
     }
 
+    public string SettingsFilePath { get; set; } = string.Empty;
+
     public string GetSettingsFilePath(bool isGlobal)
     {
-        return string.Empty;
+        return SettingsFilePath;
     }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestPackagingService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestPackagingService.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Packaging;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+internal sealed class TestPackagingService : IPackagingService
+{
+    public Task<IEnumerable<PackageChannel>> GetChannelsAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Enumerable.Empty<PackageChannel>());
+    }
+}


### PR DESCRIPTION
## Description

Fix `GuestAppHostProject.ReadLaunchSettingsEnvironmentVariables` failing when `launchSettings.json` contains JSON comments (`//`).

The CLI's guest AppHost project handler was using `JsonDocument.Parse(json)` without comment-handling options, causing it to fail on `launchSettings.json` files containing `//` comments. This is the same format that Visual Studio and `dotnet run` support. The fix uses `ConfigurationHelper.ParseOptions` (which already exists in the codebase for this purpose) to skip comments and allow trailing commas.

Also removes the commented-out lines from the TestShop `launchSettings.json` that triggered the issue.

### Changes

- **`GuestAppHostProject.cs`**: Use `ConfigurationHelper.ParseOptions` when parsing `launchSettings.json`, add debug log for file being read, make `GetServerEnvironmentVariables` internal for testability
- **`launchSettings.json`** (TestShop): Remove invalid JSON comment lines
- **Test services**: Add `TestCertificateService`, `TestPackagingService`, `TestAppHostServerProjectFactory`, rename `TrackingConfigurationService` to `TestConfigurationService` with configurable `SettingsFilePath`
- **`GuestAppHostProjectTests.cs`**: Add test verifying launch settings with comments are parsed correctly

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
