### PR TITLE
Fix crash when Azure subscription names contain square brackets

### DIFF
--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -178,9 +178,16 @@ internal class ConsoleInteractionService : IInteractionService
             throw new EmptyChoicesException(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.NoItemsAvailableForSelection, promptText));
         }
 
+        // Wrap the caller's formatter to produce safe plain text for Spectre.Console.
+        // Spectre's SelectionPrompt treats converter output as markup and its search
+        // highlighting manipulates the markup string directly, which breaks escaped
+        // bracket sequences like [[Prod]]. Stripping markup after formatting ensures
+        // the text is safe for both rendering and search highlighting.
+        var safeFormatter = MakeSafeFormatter(choiceFormatter);
+
         var prompt = new SelectionPrompt<T>()
             .Title(promptText)
-            .UseConverter(choiceFormatter)
+            .UseConverter(safeFormatter)
             .AddChoices(choices)
             .PageSize(10)
             .EnableSearch();
@@ -210,9 +217,11 @@ internal class ConsoleInteractionService : IInteractionService
 
         var preSelectedSet = preSelected is not null ? new HashSet<T>(preSelected) : null;
 
+        var safeFormatter = MakeSafeFormatter(choiceFormatter);
+
         var prompt = new MultiSelectionPrompt<T>()
             .Title(promptText)
-            .UseConverter(choiceFormatter)
+            .UseConverter(safeFormatter)
             .PageSize(10);
 
         prompt.Required = !optional;
@@ -228,6 +237,28 @@ internal class ConsoleInteractionService : IInteractionService
 
         var result = await _outConsole.PromptAsync(prompt, cancellationToken);
         return result;
+    }
+
+    /// <summary>
+    /// Wraps a choice formatter to produce output that is safe for Spectre.Console's
+    /// SelectionPrompt and MultiSelectionPrompt with search enabled. Spectre's search
+    /// highlighting manipulates the markup string directly, which breaks escaped bracket
+    /// sequences like <c>[[Prod]]</c>. This method strips all markup from the formatted
+    /// text and then replaces square brackets with parentheses so that Spectre never
+    /// encounters bracket characters in the display text.
+    /// </summary>
+    internal static Func<T, string> MakeSafeFormatter<T>(Func<T, string> choiceFormatter)
+    {
+        return item =>
+        {
+            var formatted = choiceFormatter(item);
+            // Strip any Spectre markup to get the intended display text.
+            var plainText = Markup.Remove(formatted);
+            // Replace square brackets with parentheses. EscapeMarkup() alone is not
+            // sufficient because Spectre's search highlighting splits the escaped
+            // sequences [[...]] when inserting highlight tags, producing invalid markup.
+            return plainText.Replace('[', '(').Replace(']', ')');
+        };
     }
 
     public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion)

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -247,6 +247,11 @@ internal class ConsoleInteractionService : IInteractionService
     /// text and then replaces square brackets with parentheses so that Spectre never
     /// encounters bracket characters in the display text.
     /// </summary>
+    /// <remarks>
+    /// This is a workaround for https://github.com/spectreconsole/spectre.console/issues/2054.
+    /// Once the upstream fix is available, this method should be removed and callers should
+    /// use EscapeMarkup() directly. See https://github.com/dotnet/aspire/issues/15309.
+    /// </remarks>
     internal static Func<T, string> MakeSafeFormatter<T>(Func<T, string> choiceFormatter)
     {
         return item =>

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -252,8 +252,20 @@ internal class ConsoleInteractionService : IInteractionService
         return item =>
         {
             var formatted = choiceFormatter(item);
-            // Strip any Spectre markup to get the intended display text.
-            var plainText = Markup.Remove(formatted);
+
+            // Try to strip Spectre markup to get the intended display text.
+            // Markup.Remove() can throw if the formatted text contains unescaped
+            // brackets (e.g. raw "[Prod]"), so fall back to using the text as-is.
+            string plainText;
+            try
+            {
+                plainText = Markup.Remove(formatted);
+            }
+            catch (Exception)
+            {
+                plainText = formatted;
+            }
+
             // Replace square brackets with parentheses. EscapeMarkup() alone is not
             // sufficient because Spectre's search highlighting splits the escaped
             // sequences [[...]] when inserting highlight tags, producing invalid markup.

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -881,18 +881,14 @@ public class ConsoleInteractionServiceTests
 
         // Verify the bracket-containing subscriptions render with brackets replaced
         var prodOutput = safeFormatter(subscriptions[0]);
-        Assert.Contains("MSFT-Provisioning-01(Prod)", prodOutput);
-        Assert.Contains("0832b3b6", prodOutput);
-        // Must NOT contain raw square brackets
-        Assert.DoesNotContain("[", prodOutput);
-        Assert.DoesNotContain("]", prodOutput);
+        Assert.Equal("MSFT-Provisioning-01(Prod) (0832b3b6-22b3-4c47-8d8b-572054b97257)", prodOutput);
 
         var devOutput = safeFormatter(subscriptions[2]);
-        Assert.Contains("(Dev) Test Environment", devOutput);
+        Assert.Equal("(Dev) Test Environment (00000000-0000-0000-0000-000000000003)", devOutput);
 
         // Normal subscription without brackets should be unchanged
         var normalOutput = safeFormatter(subscriptions[1]);
-        Assert.Contains("Normal Subscription", normalOutput);
+        Assert.Equal("Normal Subscription (00000000-0000-0000-0000-000000000002)", normalOutput);
     }
 
     [Fact]
@@ -910,10 +906,7 @@ public class ConsoleInteractionServiceTests
         var result = safeFormatter("PostgreSQL");
 
         // Assert - the [bold] markup is stripped, brackets replaced with parens
-        Assert.Contains("PostgreSQL", result);
-        Assert.Contains("(description)", result);
-        Assert.DoesNotContain("[bold]", result);
-        Assert.DoesNotContain("[", result);
+        Assert.Equal("PostgreSQL (description)", result);
     }
 
     [Fact]
@@ -1006,10 +999,7 @@ public class ConsoleInteractionServiceTests
 
         // Assert - inner [[v2]] has double brackets which after EscapeMarkup become [[[[v2]]]]
         // Markup.Remove strips the escaping, then brackets are replaced
-        Assert.DoesNotContain("[", result);
-        Assert.DoesNotContain("]", result);
-        Assert.Contains("v2", result);
-        Assert.Contains("Beta", result);
+        Assert.Equal("Service ((v2)) (Beta)", result);
     }
 
     [Fact]
@@ -1022,14 +1012,13 @@ public class ConsoleInteractionServiceTests
 
         // Act & Assert - should not throw, brackets replaced via fallback
         var result1 = safeFormatter("[unclosed bracket");
-        Assert.DoesNotContain("[", result1);
+        Assert.Equal("(unclosed bracket", result1);
 
         var result2 = safeFormatter("extra closing]");
-        Assert.DoesNotContain("]", result2);
+        Assert.Equal("extra closing)", result2);
 
         var result3 = safeFormatter("][backwards][");
-        Assert.DoesNotContain("[", result3);
-        Assert.DoesNotContain("]", result3);
+        Assert.Equal(")(backwards)(", result3);
     }
 
     [Fact]
@@ -1046,9 +1035,6 @@ public class ConsoleInteractionServiceTests
         var result = safeFormatter("Service [Prod]");
 
         // Assert - markup is stripped, brackets in data are replaced
-        Assert.Contains("Service (Prod)", result);
-        Assert.DoesNotContain("[bold]", result);
-        Assert.DoesNotContain("[", result);
-        Assert.DoesNotContain("]", result);
+        Assert.Equal("Service (Prod)", result);
     }
 }

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -837,4 +837,97 @@ public class ConsoleInteractionServiceTests
         Assert.Contains("Azure Storage [Preview]", outputString);
         Assert.Contains("Aspire.Hosting.Azure.Storage", outputString);
     }
+
+    [Fact]
+    public void MakeSafeFormatter_WithBracketsInData_ProducesSafeOutput()
+    {
+        // Arrange - verifies that MakeSafeFormatter produces output that is safe
+        // for Spectre.Console's SelectionPrompt with EnableSearch(). The search
+        // highlighting feature in Spectre manipulates the markup string directly,
+        // which breaks escaped bracket sequences like [[Prod]]. MakeSafeFormatter
+        // strips markup and re-escapes to ensure the text is always safe.
+        // Regression test for https://github.com/dotnet/aspire/issues/13955
+        var output = new StringBuilder();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter(output))
+        });
+
+        // Simulate subscription names with brackets (from Azure API)
+        var subscriptions = new[]
+        {
+            KeyValuePair.Create("id1", "MSFT-Provisioning-01[Prod] (0832b3b6-22b3-4c47-8d8b-572054b97257)"),
+            KeyValuePair.Create("id2", "Normal Subscription (00000000-0000-0000-0000-000000000002)"),
+            KeyValuePair.Create("id3", "[Dev] Test Environment (00000000-0000-0000-0000-000000000003)"),
+        };
+
+        // The caller's formatter escapes markup (same as PipelineCommandBase.cs)
+        Func<KeyValuePair<string, string>, string> callerFormatter = choice => choice.Value.EscapeMarkup();
+
+        // MakeSafeFormatter wraps the caller's formatter
+        var safeFormatter = ConsoleInteractionService.MakeSafeFormatter(callerFormatter);
+
+        // Act & Assert - verify each subscription produces valid, safe output
+        foreach (var sub in subscriptions)
+        {
+            var safeOutput = safeFormatter(sub);
+
+            // The safe output should be renderable as Spectre markup without throwing
+            var exception = Record.Exception(() => console.MarkupLine(safeOutput));
+            Assert.Null(exception);
+        }
+
+        // Verify the bracket-containing subscriptions render with brackets replaced
+        var prodOutput = safeFormatter(subscriptions[0]);
+        Assert.Contains("MSFT-Provisioning-01(Prod)", prodOutput);
+        Assert.Contains("0832b3b6", prodOutput);
+        // Must NOT contain raw square brackets
+        Assert.DoesNotContain("[", prodOutput);
+        Assert.DoesNotContain("]", prodOutput);
+
+        var devOutput = safeFormatter(subscriptions[2]);
+        Assert.Contains("(Dev) Test Environment", devOutput);
+
+        // Normal subscription without brackets should be unchanged
+        var normalOutput = safeFormatter(subscriptions[1]);
+        Assert.Contains("Normal Subscription", normalOutput);
+    }
+
+    [Fact]
+    public void MakeSafeFormatter_WithIntentionalMarkup_StripsMarkupButPreservesText()
+    {
+        // Arrange - verifies that MakeSafeFormatter strips intentional markup tags
+        // (like [bold]) but preserves the underlying text content. This is the expected
+        // trade-off: selection prompts show plain text to avoid the Spectre search
+        // highlighting bug with escaped brackets.
+        Func<string, string> callerFormatter = item => $"[bold]{item}[/] (description)";
+
+        var safeFormatter = ConsoleInteractionService.MakeSafeFormatter(callerFormatter);
+
+        // Act
+        var result = safeFormatter("PostgreSQL");
+
+        // Assert - the [bold] markup is stripped, brackets replaced with parens
+        Assert.Contains("PostgreSQL", result);
+        Assert.Contains("(description)", result);
+        Assert.DoesNotContain("[bold]", result);
+        Assert.DoesNotContain("[", result);
+    }
+
+    [Fact]
+    public void MakeSafeFormatter_WithPlainText_ReturnsEscapedPlainText()
+    {
+        // Arrange
+        Func<string, string> callerFormatter = item => item;
+
+        var safeFormatter = ConsoleInteractionService.MakeSafeFormatter(callerFormatter);
+
+        // Act
+        var result = safeFormatter("Normal text without brackets");
+
+        // Assert
+        Assert.Equal("Normal text without brackets", result);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -917,7 +917,7 @@ public class ConsoleInteractionServiceTests
     }
 
     [Fact]
-    public void MakeSafeFormatter_WithPlainText_ReturnsEscapedPlainText()
+    public void MakeSafeFormatter_WithPlainText_ReturnsPlainText()
     {
         // Arrange
         Func<string, string> callerFormatter = item => item;
@@ -929,5 +929,126 @@ public class ConsoleInteractionServiceTests
 
         // Assert
         Assert.Equal("Normal text without brackets", result);
+    }
+
+    [Fact]
+    public void MakeSafeFormatter_WithUnescapedBrackets_DoesNotThrow()
+    {
+        // Arrange - the caller's formatter returns raw brackets without EscapeMarkup().
+        // Markup.Remove() may silently strip bracket content as if it were a tag, or
+        // may throw on malformed input. Either way, MakeSafeFormatter must not throw.
+        Func<string, string> callerFormatter = item => item;
+
+        var safeFormatter = ConsoleInteractionService.MakeSafeFormatter(callerFormatter);
+
+        // Act - should not throw regardless of how Markup.Remove handles the input
+        var exception = Record.Exception(() => safeFormatter("MSFT-Provisioning-01[Prod] (guid)"));
+
+        // Assert
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void MakeSafeFormatter_WithEmptyString_ReturnsEmptyString()
+    {
+        // Arrange
+        Func<string, string> callerFormatter = item => string.Empty;
+
+        var safeFormatter = ConsoleInteractionService.MakeSafeFormatter(callerFormatter);
+
+        // Act
+        var result = safeFormatter("anything");
+
+        // Assert
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void MakeSafeFormatter_WithMultipleBracketPairs_ReplacesAll()
+    {
+        // Arrange
+        Func<string, string> callerFormatter = item => item.EscapeMarkup();
+
+        var safeFormatter = ConsoleInteractionService.MakeSafeFormatter(callerFormatter);
+
+        // Act
+        var result = safeFormatter("[A] and [B] and [C]");
+
+        // Assert
+        Assert.Equal("(A) and (B) and (C)", result);
+    }
+
+    [Fact]
+    public void MakeSafeFormatter_WithBracketsAtBoundaries_ReplacesAll()
+    {
+        // Arrange
+        Func<string, string> callerFormatter = item => item.EscapeMarkup();
+
+        var safeFormatter = ConsoleInteractionService.MakeSafeFormatter(callerFormatter);
+
+        // Act
+        var result = safeFormatter("[start]middle[end]");
+
+        // Assert
+        Assert.Equal("(start)middle(end)", result);
+    }
+
+    [Fact]
+    public void MakeSafeFormatter_WithNestedBrackets_ReplacesAll()
+    {
+        // Arrange
+        Func<string, string> callerFormatter = item => item.EscapeMarkup();
+
+        var safeFormatter = ConsoleInteractionService.MakeSafeFormatter(callerFormatter);
+
+        // Act
+        var result = safeFormatter("Service [[v2]] [Beta]");
+
+        // Assert - inner [[v2]] has double brackets which after EscapeMarkup become [[[[v2]]]]
+        // Markup.Remove strips the escaping, then brackets are replaced
+        Assert.DoesNotContain("[", result);
+        Assert.DoesNotContain("]", result);
+        Assert.Contains("v2", result);
+        Assert.Contains("Beta", result);
+    }
+
+    [Fact]
+    public void MakeSafeFormatter_WithMismatchedBrackets_DoesNotThrow()
+    {
+        // Arrange - malformed bracket patterns that could confuse Markup.Remove()
+        Func<string, string> callerFormatter = item => item;
+
+        var safeFormatter = ConsoleInteractionService.MakeSafeFormatter(callerFormatter);
+
+        // Act & Assert - should not throw, brackets replaced via fallback
+        var result1 = safeFormatter("[unclosed bracket");
+        Assert.DoesNotContain("[", result1);
+
+        var result2 = safeFormatter("extra closing]");
+        Assert.DoesNotContain("]", result2);
+
+        var result3 = safeFormatter("][backwards][");
+        Assert.DoesNotContain("[", result3);
+        Assert.DoesNotContain("]", result3);
+    }
+
+    [Fact]
+    public void MakeSafeFormatter_WithEscapedMarkupAndBracketsInData_HandlesCorrectly()
+    {
+        // Arrange - formatter returns escaped markup that also contains bracket data.
+        // This simulates: the data has "[Prod]" and the formatter also adds markup styling.
+        Func<string, string> callerFormatter = item =>
+            $"[bold]{item.EscapeMarkup()}[/]";
+
+        var safeFormatter = ConsoleInteractionService.MakeSafeFormatter(callerFormatter);
+
+        // Act
+        var result = safeFormatter("Service [Prod]");
+
+        // Assert - markup is stripped, brackets in data are replaced
+        Assert.Contains("Service (Prod)", result);
+        Assert.DoesNotContain("[bold]", result);
+        Assert.DoesNotContain("[", result);
+        Assert.DoesNotContain("]", result);
     }
 }


### PR DESCRIPTION
## Summary

Spectre.Console's `SelectionPrompt` with `EnableSearch()` has a bug where search highlighting manipulates the markup string directly, breaking escaped bracket sequences like `[[Prod]]`. This causes `aspire deploy` to crash with `Could not find color or style 'Prod'` when subscription names like `MSFT-Provisioning-01[Prod]` are displayed in the selection prompt.

## Changes

- Added `MakeSafeFormatter<T>()` in `ConsoleInteractionService` that wraps the caller's choice formatter to strip Spectre markup and replace square brackets with parentheses, so Spectre's search highlighting never encounters bracket characters.
- Applied to both `PromptForSelectionAsync` and `PromptForSelectionsAsync`.
- Added unit tests for the new formatter.

## Root Cause

This is a bug in Spectre.Console — the search highlighting in `SelectionPrompt.Render()` computes character offsets from the rendered (markup-stripped) text but applies them to the raw markup string. Escaped brackets (`[[` / `]]`) are longer in markup than in rendered text, so the offsets are wrong and style tags get inserted mid-sequence, producing invalid markup.

Filed upstream: https://github.com/spectreconsole/spectre.console/issues/2054

Fixes #13955