### PR TITLE
Add support for Empty TypeScript AppHost template in automation tests

### DIFF
--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -12,6 +12,34 @@ namespace Aspire.Tests.Shared;
 internal static class Hex1bAutomatorTestHelpers
 {
     /// <summary>
+    /// Handles the optional language-selection prompt that may appear after choosing
+    /// certain templates (e.g., legacy "Empty AppHost" flows). If the prompt
+    /// "Which language would you like to use?" appears within a short timeout, this
+    /// method accepts the default selection by sending Enter. If no such prompt
+    /// appears, this method is a no-op.
+    /// </summary>
+    private static async Task HandleOptionalLanguagePromptAsync(Hex1bTerminalAutomator auto)
+    {
+        const string languagePromptText = "Which language would you like to use?";
+
+        try
+        {
+            await auto.WaitUntilAsync(
+                s => new CellPatternSearcher().Find(languagePromptText).Search(s).Count > 0,
+                timeout: TimeSpan.FromSeconds(2),
+                description: "optional language selection prompt");
+
+            // If we reach this point without a timeout, the prompt is present; accept
+            // the default language (e.g., C#) by pressing Enter.
+            await auto.EnterAsync();
+        }
+        catch (TimeoutException)
+        {
+            // No language prompt appeared within the timeout; proceed without action.
+        }
+    }
+
+    /// <summary>
     /// Waits for a shell success prompt matching the current sequence counter value,
     /// then increments the counter. Looks for the pattern: [N OK] $
     /// </summary>
@@ -244,10 +272,28 @@ internal static class Hex1bAutomatorTestHelpers
                 await auto.DownAsync();
                 await auto.DownAsync();
                 await auto.WaitUntilAsync(
-                    s => new CellPatternSearcher().Find("> Empty (C# AppHost)").Search(s).Count > 0,
+                    s =>
+                    {
+                        // Support both the new label and the legacy "Empty AppHost" label.
+                        var newLabelMatch = new CellPatternSearcher()
+                            .Find("> Empty (C# AppHost)")
+                            .Search(s).Count > 0;
+
+                        if (newLabelMatch)
+                        {
+                            return true;
+                        }
+
+                        var legacyLabelMatch = new CellPatternSearcher()
+                            .Find("> Empty AppHost")
+                            .Search(s).Count > 0;
+
+                        return legacyLabelMatch;
+                    },
                     timeout: TimeSpan.FromSeconds(5),
                     description: "Empty AppHost template selected");
                 await auto.EnterAsync();
+                await HandleOptionalLanguagePromptAsync(auto);
                 break;
 
             case AspireTemplate.EmptyTypeScriptAppHost:

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -249,6 +249,19 @@ internal static class Hex1bAutomatorTestHelpers
                     description: "Empty AppHost template selected");
                 await auto.EnterAsync();
                 break;
+
+            case AspireTemplate.EmptyTypeScriptAppHost:
+                await auto.DownAsync();
+                await auto.DownAsync();
+                await auto.DownAsync();
+                await auto.DownAsync();
+                await auto.DownAsync();
+                await auto.WaitUntilAsync(
+                    s => new CellPatternSearcher().Find("> Empty (TypeScript AppHost)").Search(s).Count > 0,
+                    timeout: TimeSpan.FromSeconds(5),
+                    description: "Empty TypeScript AppHost template selected");
+                await auto.EnterAsync();
+                break;
         }
 
         // Step 3: Enter project name

--- a/tests/Shared/Hex1bTestHelpers.cs
+++ b/tests/Shared/Hex1bTestHelpers.cs
@@ -53,9 +53,15 @@ internal enum AspireTemplate
 
     /// <summary>
     /// Empty (C# AppHost) — 5th option.
-    /// Prompts: template, project name, output path, URLs. No language, Redis, or test project prompt.
+    /// Prompts: template, project name, output path, URLs. No Redis or test project prompt.
     /// </summary>
     EmptyAppHost,
+
+    /// <summary>
+    /// Empty (TypeScript AppHost) — 6th option.
+    /// Prompts: template, project name, output path, URLs. No Redis or test project prompt.
+    /// </summary>
+    EmptyTypeScriptAppHost,
 }
 
 /// <summary>
@@ -451,6 +457,18 @@ internal static class Hex1bTestHelpers
                     .Key(Hex1bKey.DownArrow)
                     .Key(Hex1bKey.DownArrow)
                     .WaitUntil(s => emptyAppHostSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
+                    .Enter();
+                break;
+
+            case AspireTemplate.EmptyTypeScriptAppHost:
+                var emptyTsAppHostSelected = new CellPatternSearcher()
+                    .Find("> Empty (TypeScript AppHost)");
+                builder.Key(Hex1bKey.DownArrow)
+                    .Key(Hex1bKey.DownArrow)
+                    .Key(Hex1bKey.DownArrow)
+                    .Key(Hex1bKey.DownArrow)
+                    .Key(Hex1bKey.DownArrow)
+                    .WaitUntil(s => emptyTsAppHostSelected.Search(s).Count > 0, TimeSpan.FromSeconds(5))
                     .Enter();
                 break;
         }


### PR DESCRIPTION
## Description

Discovered is a failing CI job: https://github.com/dotnet/aspire/actions/runs/23166428585/job/67336239019?pr=15291#step:22:121

Likely missed, but assumed to be related to #15214