### PR TITLE
Fix TypeScript empty template SDK version mismatch and add E2E tests

### DIFF
--- a/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
@@ -33,26 +33,7 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
     /// <summary>
     /// Gets the default Aspire SDK version based on the CLI version.
     /// </summary>
-    public static string DefaultSdkVersion => GetEffectiveVersion();
-
-    private static string GetEffectiveVersion()
-    {
-        var version = VersionHelper.GetDefaultTemplateVersion();
-
-        // Strip the commit SHA suffix (e.g., "9.2.0+abc123" -> "9.2.0")
-        var plusIndex = version.IndexOf('+');
-        if (plusIndex > 0)
-        {
-            version = version[..plusIndex];
-        }
-
-        // Dev versions (e.g., "13.2.0-dev") don't exist on NuGet, fall back to latest stable
-        if (version.EndsWith("-dev", StringComparison.OrdinalIgnoreCase))
-        {
-            return "13.1.0";
-        }
-        return version;
-    }
+    public static string DefaultSdkVersion => VersionHelper.GetDefaultSdkVersion();
 
     private readonly string _projectModelPath;
     private readonly string _appPath;

--- a/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
+++ b/src/Aspire.Cli/Scaffolding/ScaffoldingService.cs
@@ -3,10 +3,9 @@
 
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
-using Aspire.Cli.Packaging;
 using Aspire.Cli.Projects;
+using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging;
-using Semver;
 
 namespace Aspire.Cli.Scaffolding;
 
@@ -19,23 +18,17 @@ internal sealed class ScaffoldingService : IScaffoldingService
     private readonly IAppHostServerProjectFactory _appHostServerProjectFactory;
     private readonly ILanguageDiscovery _languageDiscovery;
     private readonly IInteractionService _interactionService;
-    private readonly IPackagingService _packagingService;
-    private readonly IConfigurationService _configurationService;
     private readonly ILogger<ScaffoldingService> _logger;
 
     public ScaffoldingService(
         IAppHostServerProjectFactory appHostServerProjectFactory,
         ILanguageDiscovery languageDiscovery,
         IInteractionService interactionService,
-        IPackagingService packagingService,
-        IConfigurationService configurationService,
         ILogger<ScaffoldingService> logger)
     {
         _appHostServerProjectFactory = appHostServerProjectFactory;
         _languageDiscovery = languageDiscovery;
         _interactionService = interactionService;
-        _packagingService = packagingService;
-        _configurationService = configurationService;
         _logger = logger;
     }
 
@@ -56,7 +49,7 @@ internal sealed class ScaffoldingService : IScaffoldingService
         var language = context.Language;
 
         // Step 1: Resolve SDK and package strategy
-        var sdkVersion = await ResolveSdkVersionAsync(cancellationToken);
+        var sdkVersion = VersionHelper.GetDefaultSdkVersion();
         var config = AspireConfigFile.LoadOrCreate(directory.FullName, sdkVersion);
 
         // Include the code generation package for scaffolding and code gen
@@ -229,44 +222,5 @@ internal sealed class ScaffoldingService : IScaffoldingService
         }
 
         _logger.LogDebug("Generated {Count} code files in {Path}", generatedFiles.Count, outputPath);
-    }
-
-    /// <summary>
-    /// Resolves the SDK version to use for scaffolding.
-    /// If a channel is configured globally, queries that channel for available versions.
-    /// Otherwise, falls back to the default SDK version.
-    /// </summary>
-    private async Task<string> ResolveSdkVersionAsync(CancellationToken cancellationToken)
-    {
-        // Check for global channel setting
-        var channelName = await _configurationService.GetConfigurationAsync("channel", cancellationToken);
-        if (string.IsNullOrEmpty(channelName))
-        {
-            return DotNetBasedAppHostServerProject.DefaultSdkVersion;
-        }
-
-        // Find the matching channel
-        var allChannels = await _packagingService.GetChannelsAsync(cancellationToken);
-        var channel = allChannels.FirstOrDefault(c => string.Equals(c.Name, channelName, StringComparison.OrdinalIgnoreCase));
-        if (channel is null)
-        {
-            _logger.LogWarning("Configured channel '{Channel}' not found, using default SDK version", channelName);
-            return DotNetBasedAppHostServerProject.DefaultSdkVersion;
-        }
-
-        // Get template packages from the channel to determine SDK version
-        var templatePackages = await channel.GetTemplatePackagesAsync(new DirectoryInfo(Environment.CurrentDirectory), cancellationToken);
-        var latestPackage = templatePackages
-            .OrderByDescending(p => SemVersion.Parse(p.Version), SemVersion.PrecedenceComparer)
-            .FirstOrDefault();
-
-        if (latestPackage is null)
-        {
-            _logger.LogWarning("No packages found in channel '{Channel}', using default SDK version", channelName);
-            return DotNetBasedAppHostServerProject.DefaultSdkVersion;
-        }
-
-        _logger.LogDebug("Resolved SDK version {Version} from channel {Channel}", latestPackage.Version, channelName);
-        return latestPackage.Version;
     }
 }

--- a/src/Aspire.Cli/Utils/VersionHelper.cs
+++ b/src/Aspire.Cli/Utils/VersionHelper.cs
@@ -12,4 +12,22 @@ internal static class VersionHelper
     {
         return PackageUpdateHelpers.GetCurrentAssemblyVersion() ?? throw new InvalidOperationException(ErrorStrings.UnableToRetrieveAssemblyVersion);
     }
+
+    /// <summary>
+    /// Gets the default Aspire SDK version based on the CLI version.
+    /// The CLI version is the SDK version — the bundled server and packages must match.
+    /// </summary>
+    public static string GetDefaultSdkVersion()
+    {
+        var version = GetDefaultTemplateVersion();
+
+        // Strip the commit SHA suffix (e.g., "9.2.0+abc123" -> "9.2.0")
+        var plusIndex = version.IndexOf('+');
+        if (plusIndex > 0)
+        {
+            version = version[..plusIndex];
+        }
+
+        return version;
+    }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/EmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/EmptyAppHostTemplateTests.cs
@@ -15,13 +15,13 @@ namespace Aspire.Cli.EndToEnd.Tests;
 public sealed class EmptyAppHostTemplateTests(ITestOutputHelper output)
 {
     [Fact]
-    public async Task CreateEmptyAppHostProject()
+    public async Task CreateAndRunEmptyAppHostProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
         var workspace = TemporaryWorkspace.Create(output);
 
-        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, installMode, output, workspace: workspace);
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, installMode, output, mountDockerSocket: true, workspace: workspace);
 
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
@@ -33,7 +33,14 @@ public sealed class EmptyAppHostTemplateTests(ITestOutputHelper output)
 
         await auto.AspireNewAsync("AspireEmptyApp", counter, template: AspireTemplate.EmptyAppHost);
 
-        // Note: We don't run 'aspire run' for Empty AppHost since there's nothing to run
+        // Start the empty AppHost to verify the scaffolded project works
+        await auto.TypeAsync("cd AspireEmptyApp");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.AspireStartAsync(counter);
+        await auto.AspireStopAsync(counter);
+
         await auto.TypeAsync("exit");
         await auto.EnterAsync();
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -232,4 +232,87 @@ internal static class CliE2EAutomatorHelpers
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptFailFastAsync(counter, timeout: TimeSpan.FromSeconds(300));
     }
+
+    /// <summary>
+    /// Starts an Aspire AppHost with <c>aspire start --format json</c>, extracts the dashboard URL,
+    /// and verifies the dashboard is reachable. Caller is responsible for calling
+    /// <see cref="AspireStopAsync"/> when done.
+    /// On failure, dumps the latest CLI log file to the terminal output for debugging.
+    /// </summary>
+    internal static async Task AspireStartAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        TimeSpan? startTimeout = null)
+    {
+        var effectiveTimeout = startTimeout ?? TimeSpan.FromMinutes(3);
+        var jsonFile = "/tmp/aspire-start.json";
+        var expectedCounter = counter.Value;
+
+        // Start with JSON output
+        await auto.TypeAsync($"aspire start --format json | tee {jsonFile}");
+        await auto.EnterAsync();
+
+        // Wait for the command to finish — check for success or error exit
+        var succeeded = false;
+        await auto.WaitUntilAsync(snapshot =>
+        {
+            var successSearcher = new CellPatternSearcher()
+                .FindPattern(expectedCounter.ToString())
+                .RightText(" OK] $ ");
+            if (successSearcher.Search(snapshot).Count > 0)
+            {
+                succeeded = true;
+                return true;
+            }
+
+            var errorSearcher = new CellPatternSearcher()
+                .FindPattern(expectedCounter.ToString())
+                .RightText(" ERR:");
+            return errorSearcher.Search(snapshot).Count > 0;
+        }, timeout: effectiveTimeout, description: $"aspire start to complete [{expectedCounter} OK/ERR]");
+
+        counter.Increment();
+
+        if (!succeeded)
+        {
+            // Dump logs for debugging then fail
+            await auto.TypeAsync(
+                "LOG=$(ls -t ~/.aspire/logs/cli_*.log 2>/dev/null | head -1); " +
+                "echo '=== ASPIRE LOG ==='; " +
+                "[ -n \"$LOG\" ] && tail -100 \"$LOG\"; " +
+                "echo '=== END LOG ==='; " +
+                $"cat {jsonFile}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            throw new InvalidOperationException("aspire start failed. Check terminal output for CLI logs.");
+        }
+
+        // Extract dashboard URL and verify it's reachable
+        await auto.TypeAsync(
+            $"DASHBOARD_URL=$(sed -n " +
+            "'s/.*\"dashboardUrl\"[[:space:]]*:[[:space:]]*\"\\(https:\\/\\/localhost:[0-9]*\\).*/\\1/p' " +
+            $"{jsonFile} | head -1)");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync(
+            "curl -ksSL -o /dev/null -w 'dashboard-http-%{http_code}' \"$DASHBOARD_URL\" " +
+            "|| echo 'dashboard-http-failed'");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("dashboard-http-200", timeout: TimeSpan.FromSeconds(15));
+        await auto.WaitForSuccessPromptAsync(counter);
+    }
+
+    /// <summary>
+    /// Stops a running Aspire AppHost with <c>aspire stop</c>.
+    /// </summary>
+    internal static async Task AspireStopAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter)
+    {
+        await auto.TypeAsync("aspire stop");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+    }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptEmptyAppHostTemplateTests.cs
@@ -9,14 +9,14 @@ using Xunit;
 namespace Aspire.Cli.EndToEnd.Tests;
 
 /// <summary>
-/// End-to-end tests for the TypeScript Express/React starter template (aspire-ts-starter).
-/// Validates that aspire new creates a working Express API + React frontend project
-/// and that aspire run starts it successfully.
+/// End-to-end tests for the TypeScript Empty AppHost template (aspire-ts-empty).
+/// Validates that aspire new creates a working TypeScript AppHost project
+/// and that aspire start runs it successfully.
 /// </summary>
-public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
+public sealed class TypeScriptEmptyAppHostTemplateTests(ITestOutputHelper output)
 {
     [Fact]
-    public async Task CreateAndRunTypeScriptStarterProject()
+    public async Task CreateAndRunTypeScriptEmptyAppHostProject()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
@@ -32,26 +32,10 @@ public sealed class TypeScriptStarterTemplateTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliInDockerAsync(installMode, counter);
 
-        // Step 1: Create project using aspire new, selecting the Express/React template
-        await auto.AspireNewAsync("TsStarterApp", counter, template: AspireTemplate.ExpressReact);
+        await auto.AspireNewAsync("TsEmptyApp", counter, template: AspireTemplate.TypeScriptEmptyAppHost);
 
-        // Step 1.5: Verify starter creation also restored the generated TypeScript SDK.
-        var projectRoot = Path.Combine(workspace.WorkspaceRoot.FullName, "TsStarterApp");
-        var modulesDir = Path.Combine(projectRoot, ".modules");
-
-        if (!Directory.Exists(modulesDir))
-        {
-            throw new InvalidOperationException($".modules directory was not created at {modulesDir}");
-        }
-
-        var aspireModulePath = Path.Combine(modulesDir, "aspire.ts");
-        if (!File.Exists(aspireModulePath))
-        {
-            throw new InvalidOperationException($"Expected generated file not found: {aspireModulePath}");
-        }
-
-        // Step 2: Navigate into the project and start it
-        await auto.TypeAsync("cd TsStarterApp");
+        // Start the empty TypeScript AppHost to verify the scaffolded project works
+        await auto.TypeAsync("cd TsEmptyApp");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 

--- a/tests/Shared/Hex1bAutomatorTestHelpers.cs
+++ b/tests/Shared/Hex1bAutomatorTestHelpers.cs
@@ -226,9 +226,23 @@ internal static class Hex1bAutomatorTestHelpers
                     description: "Empty AppHost template selected");
                 await auto.EnterAsync();
                 break;
-        }
 
-        // Step 3: Enter project name
+            case AspireTemplate.TypeScriptEmptyAppHost:
+                await auto.DownAsync();
+                await auto.DownAsync();
+                await auto.DownAsync();
+                await auto.DownAsync();
+                await auto.DownAsync();
+                await auto.WaitUntilAsync(
+                    s => new CellPatternSearcher().Find("> Empty (TypeScript AppHost)").Search(s).Count > 0,
+                    timeout: TimeSpan.FromSeconds(5),
+                    description: "TypeScript Empty AppHost template selected");
+                await auto.EnterAsync();
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(template), template, $"Unsupported template: {template}");
+        }
         await auto.WaitUntilAsync(
             s => new CellPatternSearcher().Find("Enter the project name").Search(s).Count > 0,
             timeout: TimeSpan.FromSeconds(10),

--- a/tests/Shared/Hex1bTestHelpers.cs
+++ b/tests/Shared/Hex1bTestHelpers.cs
@@ -56,6 +56,12 @@ internal enum AspireTemplate
     /// Prompts: template, project name, output path, URLs. No language, Redis, or test project prompt.
     /// </summary>
     EmptyAppHost,
+
+    /// <summary>
+    /// Empty (TypeScript AppHost) — 6th option.
+    /// Prompts: template, project name, output path, URLs. No language, Redis, or test project prompt.
+    /// </summary>
+    TypeScriptEmptyAppHost,
 }
 
 /// <summary>


### PR DESCRIPTION
## Description

The `aspire new aspire-ts-empty` (Empty TypeScript AppHost) template fails with `No language support found for: typescript/nodejs` when the staging channel is configured.

### Root Cause

`ScaffoldingService.ResolveSdkVersionAsync()` queried the NuGet staging feed for `Aspire.ProjectTemplates` and picked the latest by semver. The staging feed contains stale `13.3.0-preview.1.*` packages from before the `Aspire.TypeSystem` extraction (#15028), which moved `ILanguageSupport` from `Aspire.Hosting.Ats` → `Aspire.TypeSystem`. Since `13.3.0 > 13.2.0` in semver, the resolution picked an older 13.3.0 build whose codegen DLL implements the **old** `Aspire.Hosting.Ats.ILanguageSupport` interface, while the bundled 13.2 server expects the **new** `Aspire.TypeSystem.ILanguageSupport`. The types are incompatible, so `LanguageSupportResolver` never discovers TypeScript support.

### Changes

- **Centralize SDK version** in `VersionHelper.GetDefaultSdkVersion()` — the CLI version **is** the SDK version, no need to query the NuGet feed. This matches the behavior of `GuestAppHostProject` (used by the Express/React starter) which already hardcodes the bundled version.
- **Remove feed query** from `ScaffoldingService` — eliminated `IPackagingService` and `IConfigurationService` dependencies that were only used for the now-removed feed query.
- **Add TypeScript Empty AppHost E2E test** — this template had zero E2E coverage, which is why the bug wasn't caught.
- **Add `aspire start` verification to both empty template E2E tests** — both C# and TS empty templates now verify the scaffolded project actually starts and the dashboard is reachable.
- **Extract `AspireStartAsync`/`AspireStopAsync` helpers** — reduces duplication across E2E tests and automatically dumps CLI logs on failure for debugging.

Fixes #15313

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
