### PR TITLE
Fix dashboard URL in aspire describe to use returnUrl instead of path concat

### DIFF
--- a/src/Aspire.Cli/Backchannel/ResourceSnapshotMapper.cs
+++ b/src/Aspire.Cli/Backchannel/ResourceSnapshotMapper.cs
@@ -116,12 +116,14 @@ internal static class ResourceSnapshotMapper
         // Get source information using the shared ResourceSourceViewModel
         var sourceViewModel = ResourceSource.GetSourceModel(snapshot.ResourceType, snapshot.Properties);
 
-        // Generate dashboard URL for this resource if a base URL is provided
+        // Generate dashboard URL for this resource if a base URL is provided.
+        // The dashboardBaseUrl is a login URL with a token (e.g., https://host/login?t=TOKEN).
+        // Add the resource path as a returnUrl so the user is redirected after login.
         string? dashboardUrl = null;
         if (!string.IsNullOrEmpty(dashboardBaseUrl))
         {
             var resourcePath = DashboardUrls.ResourcesUrl(snapshot.Name);
-            dashboardUrl = DashboardUrls.CombineUrl(dashboardBaseUrl, resourcePath);
+            dashboardUrl = DashboardUrls.AddReturnUrl(dashboardBaseUrl, resourcePath);
         }
 
         return new ResourceJson

--- a/src/Shared/DashboardUrls.cs
+++ b/src/Shared/DashboardUrls.cs
@@ -188,6 +188,19 @@ internal static class DashboardUrls
         return $"{trimmedBase}/{trimmedPath}";
     }
 
+    /// <summary>
+    /// Adds a path as a <c>returnUrl</c> query parameter to an existing URL.
+    /// Use this when the base URL already contains query parameters (e.g., a login URL with a token)
+    /// and the path should be visited after login.
+    /// </summary>
+    /// <param name="loginUrl">The login URL (e.g., "https://localhost:5000/login?t=TOKEN").</param>
+    /// <param name="returnPath">The path to redirect to after login (e.g., "/?resource=myapp").</param>
+    /// <returns>The URL with the returnUrl query parameter appended.</returns>
+    public static string AddReturnUrl(string loginUrl, string returnPath)
+    {
+        return AddQueryString(loginUrl, "returnUrl", returnPath);
+    }
+
     #region Telemetry API URLs
 
     private const string TelemetryApiBasePath = "api/telemetry";

--- a/tests/Aspire.Cli.Tests/Backchannel/ResourceSnapshotMapperTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/ResourceSnapshotMapperTests.cs
@@ -36,7 +36,7 @@ public class ResourceSnapshotMapperTests
         var allSnapshots = new List<ResourceSnapshot> { snapshot };
 
         // Act
-        var result = ResourceSnapshotMapper.MapToResourceJson(snapshot, allSnapshots, dashboardBaseUrl: "http://localhost:18080");
+        var result = ResourceSnapshotMapper.MapToResourceJson(snapshot, allSnapshots, dashboardBaseUrl: "http://localhost:18080/login?t=abc123");
 
         // Assert
         Assert.Equal("frontend", result.Name);
@@ -51,9 +51,11 @@ public class ResourceSnapshotMapperTests
         Assert.Single(result.Environment!);
         Assert.Equal("Development", result.Environment!["ASPNETCORE_ENVIRONMENT"]);
 
-        // Dashboard URL should be generated
+        // Dashboard URL should be the login URL with a returnUrl pointing to the resource
         Assert.NotNull(result.DashboardUrl);
         Assert.Contains("localhost:18080", result.DashboardUrl);
+        Assert.Contains("login?t=abc123", result.DashboardUrl);
+        Assert.Contains("returnUrl=", result.DashboardUrl);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Backchannel/ResourceSnapshotMapperTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/ResourceSnapshotMapperTests.cs
@@ -59,6 +59,45 @@ public class ResourceSnapshotMapperTests
     }
 
     [Fact]
+    public void MapToResourceJson_DashboardUrl_UsesReturnUrlNotPathConcat()
+    {
+        var snapshot = new ResourceSnapshot
+        {
+            Name = "my-resource",
+            DisplayName = "my-resource",
+            ResourceType = "Project",
+            State = "Running",
+        };
+
+        var result = ResourceSnapshotMapper.MapToResourceJson(
+            snapshot,
+            [snapshot],
+            dashboardBaseUrl: "https://host:16323/login?t=e3dad6d7140e583d");
+
+        // Must NOT produce the old malformed URL: .../login?t=TOKEN/?resource=name
+        Assert.DoesNotContain("?t=e3dad6d7140e583d/", result.DashboardUrl);
+
+        // Must use &returnUrl= with the resource path URL-encoded
+        Assert.StartsWith("https://host:16323/login?t=e3dad6d7140e583d&returnUrl=", result.DashboardUrl);
+    }
+
+    [Fact]
+    public void MapToResourceJson_NullDashboardBaseUrl_DashboardUrlIsNull()
+    {
+        var snapshot = new ResourceSnapshot
+        {
+            Name = "test",
+            DisplayName = "test",
+            ResourceType = "Project",
+            State = "Running",
+        };
+
+        var result = ResourceSnapshotMapper.MapToResourceJson(snapshot, [snapshot], dashboardBaseUrl: null);
+
+        Assert.Null(result.DashboardUrl);
+    }
+
+    [Fact]
     public void ResolveResources_ByExactName_ReturnsMatch()
     {
         var snapshots = new List<ResourceSnapshot>


### PR DESCRIPTION
## Description

Fix malformed dashboard URLs in `aspire describe` output.

The `dashboardBaseUrl` passed to `ResourceSnapshotMapper` is a login URL with a token (e.g., `https://host/login?t=TOKEN`). `CombineUrl` naively appended the resource path with `/`, producing malformed URLs:

```
https://host/login?t=TOKEN/?resource=name   ← broken
```

This PR uses `AddReturnUrl` instead, which properly appends a `returnUrl` query parameter so the dashboard redirects after login:

```
https://host/login?t=TOKEN&returnUrl=%2F%3Fresource%3Dname   ← correct
```

Re @JamesNK's [comment](https://github.com/dotnet/aspire/issues/15171#issuecomment-4052338183): agreed that not every URL needs to go through `/login`. However, `dashboardBaseUrl` in this code path is always the `BaseUrlWithLoginToken` from `DashboardUrlsHelper` — the base URL without the token isn't surfaced separately to the resource mapper. Since the `dashboardUrl` per resource is the only URL consumers get (e.g., from `aspire describe --format json`), we keep it as a full login URL with `returnUrl` so it works as a single click-through link. Consumers that want the plain dashboard base URL can strip the `/login?...` portion themselves.

Fixes #15171

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
