### PR TITLE
Fix Aspire.Hosting analyzer hookup

### DIFF
--- a/src/Aspire.Hosting.Analyzers/Infrastructure/WellKnownTypeData.cs
+++ b/src/Aspire.Hosting.Analyzers/Infrastructure/WellKnownTypeData.cs
@@ -19,6 +19,8 @@ internal static class WellKnownTypeData
         Aspire_Hosting_IDistributedApplicationBuilder,
         System_Threading_Tasks_Task,
         System_Threading_Tasks_Task_1,
+        System_Threading_Tasks_ValueTask,
+        System_Threading_Tasks_ValueTask_1,
 
         // Date/time and scalar types
         System_DateTimeOffset,
@@ -52,6 +54,8 @@ internal static class WellKnownTypeData
         "Aspire.Hosting.IDistributedApplicationBuilder",
         "System.Threading.Tasks.Task",
         "System.Threading.Tasks.Task`1",
+        "System.Threading.Tasks.ValueTask",
+        "System.Threading.Tasks.ValueTask`1",
 
         // Date/time and scalar types
         "System.DateTimeOffset",

--- a/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
+++ b/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
@@ -48,6 +48,8 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        var currentAssemblyExportedTypes = GetAssemblyExportedTypes(context.Compilation.Assembly, aspireExportAttribute);
+
         // Try to get AspireExportIgnoreAttribute for ASPIREEXPORT008
         INamedTypeSymbol? aspireExportIgnoreAttribute = null;
         try
@@ -75,7 +77,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         var exportsByKey = new ConcurrentDictionary<(string ExportId, string TargetType), ConcurrentBag<(IMethodSymbol Method, Location Location)>>();
 
         context.RegisterSymbolAction(
-            c => AnalyzeMethod(c, wellKnownTypes, aspireExportAttribute, aspireExportIgnoreAttribute, aspireUnionAttribute, exportsByKey),
+            c => AnalyzeMethod(c, wellKnownTypes, aspireExportAttribute, aspireExportIgnoreAttribute, aspireUnionAttribute, currentAssemblyExportedTypes, exportsByKey),
             SymbolKind.Method);
 
         // At the end of compilation, report duplicate export IDs
@@ -120,6 +122,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         INamedTypeSymbol aspireExportAttribute,
         INamedTypeSymbol? aspireExportIgnoreAttribute,
         INamedTypeSymbol? aspireUnionAttribute,
+        HashSet<ITypeSymbol> currentAssemblyExportedTypes,
         ConcurrentDictionary<(string ExportId, string TargetType), ConcurrentBag<(IMethodSymbol Method, Location Location)>> exportsByKey)
     {
         var method = (IMethodSymbol)context.Symbol;
@@ -148,7 +151,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         // ASPIREEXPORT008: Check for missing export attributes on builder extension methods
         if (exportAttribute is null && !hasExportIgnore && !isObsolete)
         {
-            AnalyzeMissingExportAttribute(context, method, wellKnownTypes, aspireExportAttribute);
+            AnalyzeMissingExportAttribute(context, method, wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes);
         }
 
         if (exportAttribute is null)
@@ -158,9 +161,10 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
 
         var attributeSyntax = exportAttribute.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken);
         var location = attributeSyntax?.GetLocation() ?? method.Locations.FirstOrDefault() ?? Location.None;
+        var containingTypeExportAttribute = GetContainingTypeAspireExportAttribute(method.ContainingType, aspireExportAttribute);
 
         // Rule 1: Method must be static
-        if (!method.IsStatic)
+        if (!method.IsStatic && containingTypeExportAttribute is null)
         {
             context.ReportDiagnostic(Diagnostic.Create(
                 Diagnostics.s_exportMethodMustBeStatic,
@@ -179,7 +183,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         }
 
         // Rule 3: Validate return type is ATS-compatible
-        if (!IsAtsCompatibleType(method.ReturnType, wellKnownTypes, aspireExportAttribute))
+        if (!IsAtsCompatibleType(method.ReturnType, wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes))
         {
             context.ReportDiagnostic(Diagnostic.Create(
                 Diagnostics.s_returnTypeMustBeAtsCompatible,
@@ -191,7 +195,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         // Rule 4: Validate parameter types are ATS-compatible
         foreach (var parameter in method.Parameters)
         {
-            if (!IsAtsCompatibleParameter(parameter, wellKnownTypes, aspireExportAttribute))
+            if (!IsAtsCompatibleParameter(parameter, wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes))
             {
                 context.ReportDiagnostic(Diagnostic.Create(
                     Diagnostics.s_parameterTypeMustBeAtsCompatible,
@@ -204,7 +208,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             // Rule 5 (ASPIREEXPORT005/006): Validate [AspireUnion] on parameters
             if (aspireUnionAttribute is not null)
             {
-                AnalyzeUnionAttribute(context, parameter.GetAttributes(), aspireUnionAttribute, wellKnownTypes, aspireExportAttribute);
+                AnalyzeUnionAttribute(context, parameter.GetAttributes(), aspireUnionAttribute, wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes);
             }
         }
 
@@ -229,7 +233,8 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         SymbolAnalysisContext context,
         IMethodSymbol method,
         WellKnownTypes wellKnownTypes,
-        INamedTypeSymbol aspireExportAttribute)
+        INamedTypeSymbol aspireExportAttribute,
+        HashSet<ITypeSymbol> currentAssemblyExportedTypes)
     {
         // Only check public static extension methods
         if (!method.IsStatic || !method.IsExtensionMethod || method.DeclaredAccessibility != Accessibility.Public)
@@ -244,13 +249,13 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
 
         // Only check methods extending exported handle types that participate in ATS.
         var firstParamType = method.Parameters[0].Type;
-        if (!RequiresExplicitExportCoverage(firstParamType, wellKnownTypes, aspireExportAttribute))
+        if (!RequiresExplicitExportCoverage(firstParamType, wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes))
         {
             return;
         }
 
         // Determine the incompatibility reason (if any) to include in the warning
-        var reason = GetIncompatibilityReason(method, wellKnownTypes, aspireExportAttribute);
+        var reason = GetIncompatibilityReason(method, wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes);
         var location = method.Locations.FirstOrDefault() ?? Location.None;
 
         context.ReportDiagnostic(Diagnostic.Create(
@@ -548,17 +553,19 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
     private static bool RequiresExplicitExportCoverage(
         ITypeSymbol type,
         WellKnownTypes wellKnownTypes,
-        INamedTypeSymbol aspireExportAttribute)
+        INamedTypeSymbol aspireExportAttribute,
+        HashSet<ITypeSymbol> currentAssemblyExportedTypes)
     {
         return IsBuilderType(type, wellKnownTypes) ||
                IsResourceType(type, wellKnownTypes) ||
-               HasAspireExportAttribute(type, aspireExportAttribute);
+               HasAspireExportAttribute(type, aspireExportAttribute, currentAssemblyExportedTypes);
     }
 
     private static string? GetIncompatibilityReason(
         IMethodSymbol method,
         WellKnownTypes wellKnownTypes,
-        INamedTypeSymbol aspireExportAttribute)
+        INamedTypeSymbol aspireExportAttribute,
+        HashSet<ITypeSymbol> currentAssemblyExportedTypes)
     {
         var reasons = new List<string>();
 
@@ -611,7 +618,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             // Check delegate types more carefully
             if (IsDelegateType(paramType))
             {
-                var reason = GetDelegateIncompatibilityReason(param, paramType, wellKnownTypes, aspireExportAttribute);
+                var reason = GetDelegateIncompatibilityReason(param, paramType, wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes);
                 if (reason is not null)
                 {
                     reasons.Add(reason);
@@ -619,14 +626,14 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            if (!IsAtsCompatibleValueType(paramType, wellKnownTypes, aspireExportAttribute))
+            if (!IsAtsCompatibleValueType(paramType, wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes))
             {
                 reasons.Add($"parameter '{param.Name}' of type '{paramType.ToDisplayString()}' is not ATS-compatible");
             }
         }
 
         // Check return type
-        if (!IsAtsCompatibleType(method.ReturnType, wellKnownTypes, aspireExportAttribute))
+        if (!IsAtsCompatibleType(method.ReturnType, wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes))
         {
             reasons.Add($"return type '{method.ReturnType.ToDisplayString()}' is not ATS-compatible");
         }
@@ -643,7 +650,8 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         IParameterSymbol param,
         ITypeSymbol delegateType,
         WellKnownTypes wellKnownTypes,
-        INamedTypeSymbol _)
+        INamedTypeSymbol aspireExportAttribute,
+        HashSet<ITypeSymbol> currentAssemblyExportedTypes)
     {
         if (delegateType is not INamedTypeSymbol namedDelegate)
         {
@@ -661,13 +669,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         foreach (var delegateParam in invokeMethod.Parameters)
         {
             var dpType = delegateParam.Type;
-            var dpTypeName = dpType.ToDisplayString();
-
-            // Check for known incompatible context types
-            if (dpTypeName is "System.IServiceProvider" or
-                "System.Text.Json.Utf8JsonWriter" or
-                "System.Threading.CancellationToken" or
-                "System.Net.Http.HttpRequestMessage")
+            if (!IsAtsCompatibleValueType(dpType, wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes))
             {
                 return $"parameter '{param.Name}' uses delegate with '{dpType.Name}' which is not ATS-compatible";
             }
@@ -700,7 +702,8 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         ImmutableArray<AttributeData> attributes,
         INamedTypeSymbol aspireUnionAttribute,
         WellKnownTypes wellKnownTypes,
-        INamedTypeSymbol aspireExportAttribute)
+        INamedTypeSymbol aspireExportAttribute,
+        HashSet<ITypeSymbol> currentAssemblyExportedTypes)
     {
         foreach (var attr in attributes)
         {
@@ -745,7 +748,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             {
                 if (typeConstant.Value is INamedTypeSymbol typeSymbol)
                 {
-                    if (!IsAtsCompatibleValueType(typeSymbol, wellKnownTypes, aspireExportAttribute))
+                    if (!IsAtsCompatibleValueType(typeSymbol, wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes))
                     {
                         context.ReportDiagnostic(Diagnostic.Create(
                             Diagnostics.s_unionTypeMustBeAtsCompatible,
@@ -853,7 +856,8 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
     private static bool IsAtsCompatibleType(
         ITypeSymbol type,
         WellKnownTypes wellKnownTypes,
-        INamedTypeSymbol aspireExportAttribute)
+        INamedTypeSymbol aspireExportAttribute,
+        HashSet<ITypeSymbol> currentAssemblyExportedTypes)
     {
         // void is allowed
         if (type.SpecialType == SpecialType.System_Void)
@@ -861,21 +865,22 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             return true;
         }
 
-        // Task and Task<T> are allowed (for async methods)
-        if (IsTaskType(type, wellKnownTypes, aspireExportAttribute))
+        // Task, Task<T>, ValueTask, and ValueTask<T> are allowed (for async methods)
+        if (IsAsyncResultType(type, wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes))
         {
             return true;
         }
 
-        return IsAtsCompatibleValueType(type, wellKnownTypes, aspireExportAttribute);
+        return IsAtsCompatibleValueType(type, wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes);
     }
 
-    private static bool IsTaskType(
+    private static bool IsAsyncResultType(
         ITypeSymbol type,
         WellKnownTypes wellKnownTypes,
-        INamedTypeSymbol aspireExportAttribute)
+        INamedTypeSymbol aspireExportAttribute,
+        HashSet<ITypeSymbol> currentAssemblyExportedTypes)
     {
-        // Check for Task
+        // Check for Task / ValueTask
         try
         {
             var taskType = wellKnownTypes.Get(WellKnownTypeData.WellKnownType.System_Threading_Tasks_Task);
@@ -889,7 +894,20 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             // Type not found
         }
 
-        // Check for Task<T>
+        try
+        {
+            var valueTaskType = wellKnownTypes.Get(WellKnownTypeData.WellKnownType.System_Threading_Tasks_ValueTask);
+            if (SymbolEqualityComparer.Default.Equals(type, valueTaskType))
+            {
+                return true;
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // Type not found
+        }
+
+        // Check for Task<T> / ValueTask<T>
         if (type is INamedTypeSymbol namedType && namedType.IsGenericType)
         {
             try
@@ -899,7 +917,21 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
                 {
                     // Validate the T in Task<T> is also ATS-compatible
                     return namedType.TypeArguments.Length == 1 &&
-                           IsAtsCompatibleValueType(namedType.TypeArguments[0], wellKnownTypes, aspireExportAttribute);
+                           IsAtsCompatibleValueType(namedType.TypeArguments[0], wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes);
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // Type not found
+            }
+
+            try
+            {
+                var valueTaskOfTType = wellKnownTypes.Get(WellKnownTypeData.WellKnownType.System_Threading_Tasks_ValueTask_1);
+                if (SymbolEqualityComparer.Default.Equals(namedType.OriginalDefinition, valueTaskOfTType))
+                {
+                    return namedType.TypeArguments.Length == 1 &&
+                           IsAtsCompatibleValueType(namedType.TypeArguments[0], wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes);
                 }
             }
             catch (InvalidOperationException)
@@ -914,7 +946,8 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
     private static bool IsAtsCompatibleValueType(
         ITypeSymbol type,
         WellKnownTypes wellKnownTypes,
-        INamedTypeSymbol? aspireExportAttribute = null)
+        INamedTypeSymbol? aspireExportAttribute = null,
+        HashSet<ITypeSymbol>? currentAssemblyExportedTypes = null)
     {
         // Handle nullable types
         if (type is INamedTypeSymbol namedType &&
@@ -939,11 +972,11 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         // Arrays of ATS-compatible types
         if (type is IArrayTypeSymbol arrayType)
         {
-            return IsAtsCompatibleValueType(arrayType.ElementType, wellKnownTypes, aspireExportAttribute);
+            return IsAtsCompatibleValueType(arrayType.ElementType, wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes);
         }
 
         // Collection types (Dictionary, List, IReadOnlyList, etc.)
-        if (IsAtsCompatibleCollectionType(type, wellKnownTypes, aspireExportAttribute))
+        if (IsAtsCompatibleCollectionType(type, wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes))
         {
             return true;
         }
@@ -961,7 +994,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         }
 
         // Types with [AspireExport] or [AspireDto] attribute
-        if (aspireExportAttribute != null && HasAspireExportAttribute(type, aspireExportAttribute))
+        if (aspireExportAttribute != null && HasAspireExportAttribute(type, aspireExportAttribute, currentAssemblyExportedTypes))
         {
             return true;
         }
@@ -1063,7 +1096,8 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
     private static bool IsAtsCompatibleCollectionType(
         ITypeSymbol type,
         WellKnownTypes wellKnownTypes,
-        INamedTypeSymbol? aspireExportAttribute)
+        INamedTypeSymbol? aspireExportAttribute,
+        HashSet<ITypeSymbol>? currentAssemblyExportedTypes)
     {
         if (type is not INamedTypeSymbol namedType || !namedType.IsGenericType)
         {
@@ -1076,8 +1110,8 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         {
             // Validate key and value types are ATS-compatible
             return namedType.TypeArguments.Length == 2 &&
-                   IsAtsCompatibleValueType(namedType.TypeArguments[0], wellKnownTypes, aspireExportAttribute) &&
-                   IsAtsCompatibleValueType(namedType.TypeArguments[1], wellKnownTypes, aspireExportAttribute);
+                   IsAtsCompatibleValueType(namedType.TypeArguments[0], wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes) &&
+                   IsAtsCompatibleValueType(namedType.TypeArguments[1], wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes);
         }
 
         // List<T> and IList<T>
@@ -1085,7 +1119,7 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             TryMatchGenericType(type, wellKnownTypes, WellKnownTypeData.WellKnownType.System_Collections_Generic_IList_1))
         {
             return namedType.TypeArguments.Length == 1 &&
-                   IsAtsCompatibleValueType(namedType.TypeArguments[0], wellKnownTypes, aspireExportAttribute);
+                   IsAtsCompatibleValueType(namedType.TypeArguments[0], wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes);
         }
 
         // IReadOnlyList<T> and IReadOnlyCollection<T>
@@ -1094,21 +1128,21 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             TryMatchGenericType(type, wellKnownTypes, WellKnownTypeData.WellKnownType.System_Collections_Generic_IEnumerable_1))
         {
             return namedType.TypeArguments.Length == 1 &&
-                   IsAtsCompatibleValueType(namedType.TypeArguments[0], wellKnownTypes, aspireExportAttribute);
+                   IsAtsCompatibleValueType(namedType.TypeArguments[0], wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes);
         }
 
         // IReadOnlyDictionary<K,V>
         if (TryMatchGenericType(type, wellKnownTypes, WellKnownTypeData.WellKnownType.System_Collections_Generic_IReadOnlyDictionary_2))
         {
             return namedType.TypeArguments.Length == 2 &&
-                   IsAtsCompatibleValueType(namedType.TypeArguments[0], wellKnownTypes, aspireExportAttribute) &&
-                   IsAtsCompatibleValueType(namedType.TypeArguments[1], wellKnownTypes, aspireExportAttribute);
+                   IsAtsCompatibleValueType(namedType.TypeArguments[0], wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes) &&
+                   IsAtsCompatibleValueType(namedType.TypeArguments[1], wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes);
         }
 
         return false;
     }
 
-    private static bool HasAspireExportAttribute(ITypeSymbol type, INamedTypeSymbol aspireExportAttribute)
+    private static bool HasAspireExportAttribute(ITypeSymbol type, INamedTypeSymbol aspireExportAttribute, HashSet<ITypeSymbol>? currentAssemblyExportedTypes)
     {
         // Check direct attributes on the type
         foreach (var attr in type.GetAttributes())
@@ -1117,6 +1151,11 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             {
                 return true;
             }
+        }
+
+        if (currentAssemblyExportedTypes?.Contains(type) == true)
+        {
+            return true;
         }
 
         var containingAssembly = type.ContainingAssembly;
@@ -1140,6 +1179,26 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    private static HashSet<ITypeSymbol> GetAssemblyExportedTypes(IAssemblySymbol assembly, INamedTypeSymbol aspireExportAttribute)
+    {
+        var exportedTypes = new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
+
+        foreach (var attr in assembly.GetAttributes())
+        {
+            if (!SymbolEqualityComparer.Default.Equals(attr.AttributeClass, aspireExportAttribute))
+            {
+                continue;
+            }
+
+            if (TryGetAssemblyExportedType(attr, out var exportedType) && exportedType is not null)
+            {
+                exportedTypes.Add(exportedType);
+            }
+        }
+
+        return exportedTypes;
     }
 
     private static bool TryGetAssemblyExportedType(AttributeData attribute, out ITypeSymbol? exportedType)
@@ -1234,7 +1293,8 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
     private static bool IsAtsCompatibleParameter(
         IParameterSymbol parameter,
         WellKnownTypes wellKnownTypes,
-        INamedTypeSymbol aspireExportAttribute)
+        INamedTypeSymbol aspireExportAttribute,
+        HashSet<ITypeSymbol> currentAssemblyExportedTypes)
     {
         var type = parameter.Type;
 
@@ -1247,10 +1307,10 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
         // params arrays are allowed if element type is compatible
         if (parameter.IsParams && type is IArrayTypeSymbol arrayType)
         {
-            return IsAtsCompatibleValueType(arrayType.ElementType, wellKnownTypes, aspireExportAttribute);
+            return IsAtsCompatibleValueType(arrayType.ElementType, wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes);
         }
 
-        return IsAtsCompatibleValueType(type, wellKnownTypes, aspireExportAttribute);
+        return IsAtsCompatibleValueType(type, wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes);
     }
 
     private static bool IsDelegateType(ITypeSymbol type)

--- a/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
+++ b/src/Aspire.Hosting.Integration.Analyzers/AspireExportAnalyzer.cs
@@ -148,8 +148,21 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
             }
         }
 
+        var containingTypeHasExportIgnore = false;
+        if (!hasExportIgnore && aspireExportIgnoreAttribute is not null)
+        {
+            foreach (var attr in method.ContainingType.GetAttributes())
+            {
+                if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, aspireExportIgnoreAttribute))
+                {
+                    containingTypeHasExportIgnore = true;
+                    break;
+                }
+            }
+        }
+
         // ASPIREEXPORT008: Check for missing export attributes on builder extension methods
-        if (exportAttribute is null && !hasExportIgnore && !isObsolete)
+        if (exportAttribute is null && !hasExportIgnore && !containingTypeHasExportIgnore && !isObsolete)
         {
             AnalyzeMissingExportAttribute(context, method, wellKnownTypes, aspireExportAttribute, currentAssemblyExportedTypes);
         }
@@ -510,8 +523,10 @@ public partial class AspireExportAnalyzer : DiagnosticAnalyzer
                 return null;
             }
 
-            // Check that the type argument is a concrete type, not a type parameter
-            if (namedType.TypeArguments.Length == 1 && namedType.TypeArguments[0] is not ITypeParameterSymbol)
+            // Check that the type argument is a concrete resource type, not a type parameter or interface.
+            if (namedType.TypeArguments.Length == 1 &&
+                namedType.TypeArguments[0] is not ITypeParameterSymbol &&
+                namedType.TypeArguments[0].TypeKind is not TypeKind.Interface)
             {
                 return namedType.TypeArguments[0].Name;
             }

--- a/src/Aspire.Hosting.RemoteHost/AtsCapabilityScanner.cs
+++ b/src/Aspire.Hosting.RemoteHost/AtsCapabilityScanner.cs
@@ -2538,7 +2538,8 @@ public static class AtsCapabilityScanner
     /// </summary>
     private static bool HasExportIgnoreAttribute(PropertyInfo property)
     {
-        return AttributeDataReader.HasAspireExportIgnoreData(property);
+        return AttributeDataReader.HasAspireExportIgnoreData(property) ||
+               (property.DeclaringType is not null && AttributeDataReader.HasAspireExportIgnoreData(property.DeclaringType));
     }
 
     /// <summary>
@@ -2546,7 +2547,8 @@ public static class AtsCapabilityScanner
     /// </summary>
     private static bool HasExportIgnoreAttribute(MethodInfo method)
     {
-        return AttributeDataReader.HasAspireExportIgnoreData(method);
+        return AttributeDataReader.HasAspireExportIgnoreData(method) ||
+               (method.DeclaringType is not null && AttributeDataReader.HasAspireExportIgnoreData(method.DeclaringType));
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/DistributedApplicationModelExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DistributedApplicationModelExtensions.cs
@@ -14,6 +14,7 @@ public static class DistributedApplicationModelExtensions
     /// </summary>
     /// <param name="model">The distributed application model to extract compute resources from.</param>
     /// <returns>An enumerable of compute <see cref="IResource"/> in the model.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Application model inspection helper — not part of the ATS surface.")]
     public static IEnumerable<IResource> GetComputeResources(this DistributedApplicationModel model)
     {
         foreach (var r in model.Resources)
@@ -43,6 +44,7 @@ public static class DistributedApplicationModelExtensions
     /// </summary>
     /// <param name="model">The distributed application model to extract build resources from.</param>
     /// <returns>An enumerable of build <see cref="IResource"/> in the model.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Application model inspection helper — not part of the ATS surface.")]
     public static IEnumerable<IResource> GetBuildResources(this DistributedApplicationModel model)
     {
         foreach (var r in model.Resources)
@@ -60,6 +62,7 @@ public static class DistributedApplicationModelExtensions
     /// </summary>
     /// <param name="model">The distributed application model to extract build and push resources from.</param>
     /// <returns>An enumerable of build and push <see cref="IResource"/> in the model.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Application model inspection helper — not part of the ATS surface.")]
     public static IEnumerable<IResource> GetBuildAndPushResources(this DistributedApplicationModel model)
     {
         foreach (var r in model.Resources)

--- a/src/Aspire.Hosting/ApplicationModel/DistributedApplicationModelExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DistributedApplicationModelExtensions.cs
@@ -14,7 +14,7 @@ public static class DistributedApplicationModelExtensions
     /// </summary>
     /// <param name="model">The distributed application model to extract compute resources from.</param>
     /// <returns>An enumerable of compute <see cref="IResource"/> in the model.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Application model inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Application model inspection helper — not part of the ATS surface.")]
     public static IEnumerable<IResource> GetComputeResources(this DistributedApplicationModel model)
     {
         foreach (var r in model.Resources)
@@ -44,7 +44,7 @@ public static class DistributedApplicationModelExtensions
     /// </summary>
     /// <param name="model">The distributed application model to extract build resources from.</param>
     /// <returns>An enumerable of build <see cref="IResource"/> in the model.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Application model inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Application model inspection helper — not part of the ATS surface.")]
     public static IEnumerable<IResource> GetBuildResources(this DistributedApplicationModel model)
     {
         foreach (var r in model.Resources)
@@ -62,7 +62,7 @@ public static class DistributedApplicationModelExtensions
     /// </summary>
     /// <param name="model">The distributed application model to extract build and push resources from.</param>
     /// <returns>An enumerable of build and push <see cref="IResource"/> in the model.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Application model inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Application model inspection helper — not part of the ATS surface.")]
     public static IEnumerable<IResource> GetBuildAndPushResources(this DistributedApplicationModel model)
     {
         foreach (var r in model.Resources)

--- a/src/Aspire.Hosting/ApplicationModel/ProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProjectResourceExtensions.cs
@@ -13,6 +13,7 @@ public static class ProjectResourceExtensions
     /// </summary>
     /// <param name="model">The distributed application model.</param>
     /// <returns>An enumerable collection of project resources.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Application model inspection helper — not part of the ATS surface.")]
     public static IEnumerable<ProjectResource> GetProjectResources(this DistributedApplicationModel model)
     {
         ArgumentNullException.ThrowIfNull(model);
@@ -26,6 +27,7 @@ public static class ProjectResourceExtensions
     /// <param name="projectResource">The project resource.</param>
     /// <returns>The project metadata.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the project resource doesn't have project metadata.</exception>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Project metadata is a .NET-specific contract and is not part of the ATS surface.")]
     public static IProjectMetadata GetProjectMetadata(this ProjectResource projectResource)
     {
         ArgumentNullException.ThrowIfNull(projectResource);

--- a/src/Aspire.Hosting/ApplicationModel/ProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProjectResourceExtensions.cs
@@ -13,7 +13,7 @@ public static class ProjectResourceExtensions
     /// </summary>
     /// <param name="model">The distributed application model.</param>
     /// <returns>An enumerable collection of project resources.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Application model inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Application model inspection helper — not part of the ATS surface.")]
     public static IEnumerable<ProjectResource> GetProjectResources(this DistributedApplicationModel model)
     {
         ArgumentNullException.ThrowIfNull(model);
@@ -27,7 +27,7 @@ public static class ProjectResourceExtensions
     /// <param name="projectResource">The project resource.</param>
     /// <returns>The project metadata.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the project resource doesn't have project metadata.</exception>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Project metadata is a .NET-specific contract and is not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Project metadata is a .NET-specific contract and is not part of the ATS surface.")]
     public static IProjectMetadata GetProjectMetadata(this ProjectResource projectResource)
     {
         ArgumentNullException.ThrowIfNull(projectResource);

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -24,6 +24,7 @@ public static class ResourceExtensions
     /// <param name="resource">The resource to get the annotation from.</param>
     /// <param name="annotation">When this method returns, contains the last annotation of the specified type from the resource, if found; otherwise, the default value for <typeparamref name="T"/>.</param>
     /// <returns><see langword="true"/> if the last annotation of the specified type was found in the resource; otherwise, <see langword="false"/>.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Generic annotation inspection helper — not part of the ATS surface.")]
     public static bool TryGetLastAnnotation<T>(this IResource resource, [NotNullWhen(true)] out T? annotation) where T : IResourceAnnotation
     {
         if (resource.Annotations.OfType<T>().LastOrDefault() is { } lastAnnotation)
@@ -45,6 +46,7 @@ public static class ResourceExtensions
     /// <param name="resource">The resource to retrieve annotations from.</param>
     /// <param name="result">When this method returns, contains the annotations of the specified type, if found; otherwise, <see langword="null"/>.</param>
     /// <returns><see langword="true"/> if annotations of the specified type were found; otherwise, <see langword="false"/>.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Generic annotation inspection helper — not part of the ATS surface.")]
     public static bool TryGetAnnotationsOfType<T>(this IResource resource, [NotNullWhen(true)] out IEnumerable<T>? result) where T : IResourceAnnotation
     {
         var matchingTypeAnnotations = resource.Annotations.OfType<T>();
@@ -67,6 +69,7 @@ public static class ResourceExtensions
     /// <typeparam name="T">The type of annotation to retrieve.</typeparam>
     /// <param name="resource">The resource to retrieve annotations from.</param>
     /// <returns><see langword="true"/> if an annotation of the specified type was found; otherwise, <see langword="false"/>.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Generic annotation inspection helper — not part of the ATS surface.")]
     public static bool HasAnnotationOfType<T>(this IResource resource) where T : IResourceAnnotation
     {
         return resource.Annotations.Any(a => a is T);
@@ -79,6 +82,7 @@ public static class ResourceExtensions
     /// <param name="resource">The resource to retrieve annotations from.</param>
     /// <param name="result">When this method returns, contains the annotations of the specified type, if found; otherwise, <see langword="null"/>.</param>
     /// <returns><see langword="true"/> if annotations of the specified type were found; otherwise, <see langword="false"/>.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Generic annotation inspection helper — not part of the ATS surface.")]
     public static bool TryGetAnnotationsIncludingAncestorsOfType<T>(this IResource resource, [NotNullWhen(true)] out IEnumerable<T>? result) where T : IResourceAnnotation
     {
         if (resource is IResourceWithParent)
@@ -116,6 +120,7 @@ public static class ResourceExtensions
     /// <typeparam name="T">The type of annotation to retrieve.</typeparam>
     /// <param name="resource">The resource to retrieve annotations from.</param>
     /// <returns><see langword="true"/> if an annotation of the specified type was found; otherwise, <see langword="false"/>.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Generic annotation inspection helper — not part of the ATS surface.")]
     public static bool HasAnnotationIncludingAncestorsOfType<T>(this IResource resource) where T : IResourceAnnotation
     {
         if (resource is IResourceWithParent)
@@ -149,6 +154,7 @@ public static class ResourceExtensions
     /// <param name="resource">The resource to get the environment variables from.</param>
     /// <param name="environmentVariables">The environment variables retrieved from the resource, if any.</param>
     /// <returns>True if the environment variables were successfully retrieved, false otherwise.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Environment callback inspection helper — not part of the ATS surface.")]
     public static bool TryGetEnvironmentVariables(this IResource resource, [NotNullWhen(true)] out IEnumerable<EnvironmentCallbackAnnotation>? environmentVariables)
     {
         return TryGetAnnotationsOfType(resource, out environmentVariables);
@@ -545,6 +551,7 @@ public static class ResourceExtensions
     /// Gets a value indicating whether the resource is excluded from being published.
     /// </summary>
     /// <param name="resource">The resource to determine if it should be excluded from being published.</param>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Manifest inspection helper — not part of the ATS surface.")]
     public static bool IsExcludedFromPublish(this IResource resource) =>
         resource.TryGetLastAnnotation<ManifestPublishingCallbackAnnotation>(out var lastAnnotation) && lastAnnotation == ManifestPublishingCallbackAnnotation.Ignore;
 
@@ -635,6 +642,7 @@ public static class ResourceExtensions
     /// <param name="resource">The resource to get the volume mounts for.</param>
     /// <param name="volumeMounts">When this method returns, contains the volume mounts for the specified resource, if found; otherwise, <c>null</c>.</param>
     /// <returns><c>true</c> if the volume mounts were successfully retrieved; otherwise, <c>false</c>.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Container mount inspection helper — not part of the ATS surface.")]
     public static bool TryGetContainerMounts(this IResource resource, [NotNullWhen(true)] out IEnumerable<ContainerMountAnnotation>? volumeMounts)
     {
         return TryGetAnnotationsOfType<ContainerMountAnnotation>(resource, out volumeMounts);
@@ -646,6 +654,7 @@ public static class ResourceExtensions
     /// <param name="resource">The resource to retrieve the endpoints for.</param>
     /// <param name="endpoints">The endpoints for the given resource, if found.</param>
     /// <returns>True if the endpoints were found, false otherwise.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Endpoint annotation inspection helper — not part of the ATS surface.")]
     public static bool TryGetEndpoints(this IResource resource, [NotNullWhen(true)] out IEnumerable<EndpointAnnotation>? endpoints)
     {
         return TryGetAnnotationsOfType(resource, out endpoints);
@@ -657,6 +666,7 @@ public static class ResourceExtensions
     /// <param name="resource">The resource to retrieve the URLs for.</param>
     /// <param name="urls">The URLs for the given resource, if found.</param>
     /// <returns>True if the URLs were found, false otherwise.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "URL annotation inspection helper — not part of the ATS surface.")]
     public static bool TryGetUrls(this IResource resource, [NotNullWhen(true)] out IEnumerable<ResourceUrlAnnotation>? urls)
     {
         return TryGetAnnotationsOfType(resource, out urls);
@@ -667,6 +677,7 @@ public static class ResourceExtensions
     /// </summary>
     /// <param name="resource">The <see cref="IResourceWithEndpoints"/> which contains <see cref="EndpointAnnotation"/> annotations.</param>
     /// <returns>An enumeration of <see cref="EndpointReference"/> based on the <see cref="EndpointAnnotation"/> annotations from the resources' <see cref="IResource.Annotations"/> collection.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Resource handle endpoint enumeration is not part of the ATS surface; use builder-based endpoint exports instead.")]
     public static IEnumerable<EndpointReference> GetEndpoints(this IResourceWithEndpoints resource)
     {
         if (TryGetAnnotationsOfType<EndpointAnnotation>(resource, out var endpoints))
@@ -683,6 +694,7 @@ public static class ResourceExtensions
     /// <param name="resource">The <see cref="IResourceWithEndpoints"/> which contains <see cref="EndpointAnnotation"/> annotations.</param>
     /// <param name="contextNetworkID">The ID of the network that serves as the context context for the endpoint references.</param>
     /// <returns>An enumeration of <see cref="EndpointReference"/> based on the <see cref="EndpointAnnotation"/> annotations from the resources' <see cref="IResource.Annotations"/> collection.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Network-specific endpoint enumeration is not part of the ATS surface.")]
     public static IEnumerable<EndpointReference> GetEndpoints(this IResourceWithEndpoints resource, NetworkIdentifier contextNetworkID)
     {
         if (TryGetAnnotationsOfType<EndpointAnnotation>(resource, out var endpoints))
@@ -699,6 +711,7 @@ public static class ResourceExtensions
     /// <param name="resource">The <see cref="IResourceWithEndpoints"/> which contains <see cref="EndpointAnnotation"/> annotations.</param>
     /// <param name="endpointName">The name of the endpoint.</param>
     /// <returns>An <see cref="EndpointReference"/>object providing resolvable reference for the specified endpoint.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Resource handle endpoint lookup is not part of the ATS surface; use builder-based endpoint exports instead.")]
     public static EndpointReference GetEndpoint(this IResourceWithEndpoints resource, string endpointName)
     {
         var endpoint = resource.TryGetEndpoints(out var endpoints) ?
@@ -721,6 +734,7 @@ public static class ResourceExtensions
     /// <param name="endpointName">The name of the endpoint.</param>
     /// <param name="contextNetworkID">The network ID of the network that provides the context for the returned <see cref="EndpointReference"/></param>
     /// <returns>An <see cref="EndpointReference"/>object providing resolvable reference for the specified endpoint.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Network-specific endpoint lookup is not part of the ATS surface.")]
     public static EndpointReference GetEndpoint(this IResourceWithEndpoints resource, string endpointName, NetworkIdentifier contextNetworkID)
     {
 
@@ -745,6 +759,7 @@ public static class ResourceExtensions
     /// <param name="resource">The resource containing endpoints to resolve.</param>
     /// <param name="portAllocator">Optional port allocator. If null, uses default allocation starting from port 8000.</param>
     /// <returns>A read-only list of resolved endpoints with computed port values.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Endpoint resolution exposes infrastructure-specific types that are not part of the ATS surface.")]
     public static IReadOnlyList<ResolvedEndpoint> ResolveEndpoints(this IResource resource, IPortAllocator? portAllocator = null)
     {
         if (!resource.TryGetEndpoints(out var endpoints))
@@ -828,6 +843,7 @@ public static class ResourceExtensions
     /// <param name="resource">The resource to get the container image name from.</param>
     /// <param name="imageName">The container image name if found, otherwise null.</param>
     /// <returns>True if the container image name was found, otherwise false.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Container image inspection helper — not part of the ATS surface.")]
     public static bool TryGetContainerImageName(this IResource resource, [NotNullWhen(true)] out string? imageName)
     {
         return TryGetContainerImageName(resource, useBuiltImage: true, out imageName);
@@ -840,6 +856,7 @@ public static class ResourceExtensions
     /// <param name="useBuiltImage">When true, uses the image name from DockerfileBuildAnnotation if present. When false, uses only ContainerImageAnnotation.</param>
     /// <param name="imageName">The container image name if found, otherwise null.</param>
     /// <returns>True if the container image name was found, otherwise false.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Container image inspection helper — not part of the ATS surface.")]
     public static bool TryGetContainerImageName(this IResource resource, bool useBuiltImage, [NotNullWhen(true)] out string? imageName)
     {
         // First check if there's a DockerfileBuildAnnotation with an image name/tag
@@ -881,6 +898,7 @@ public static class ResourceExtensions
     /// </summary>
     /// <param name="resource">The resource to get the replica count for.</param>
     /// <returns>The number of replicas for the specified resource.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Replica inspection helper — not part of the ATS surface.")]
     public static int GetReplicaCount(this IResource resource)
     {
         if (resource.TryGetLastAnnotation<ReplicaAnnotation>(out var replicaAnnotation))
@@ -902,6 +920,7 @@ public static class ResourceExtensions
     /// </remarks>
     /// <param name="resource">The resource to evaluate for image build requirements.</param>
     /// <returns>True if the resource requires image building; otherwise, false.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Publishing inspection helper — not part of the ATS surface.")]
     public static bool RequiresImageBuild(this IResource resource)
     {
         if (resource.IsExcludedFromPublish())
@@ -922,6 +941,7 @@ public static class ResourceExtensions
     /// </remarks>
     /// <param name="resource">The resource to evaluate for image push requirements.</param>
     /// <returns>True if the resource requires image building and pushing; otherwise, false.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Publishing inspection helper — not part of the ATS surface.")]
     public static bool RequiresImageBuildAndPush(this IResource resource)
     {
         return resource.RequiresImageBuild() && !resource.IsBuildOnlyContainer();
@@ -938,6 +958,7 @@ public static class ResourceExtensions
     /// </summary>
     /// <param name="resource">The resource to get the compute environment for.</param>
     /// <returns>The compute environment the resource is bound to, or <c>null</c> if the resource is not bound to any specific compute environment.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Compute-environment inspection helper — not part of the ATS surface.")]
     public static IComputeEnvironmentResource? GetComputeEnvironment(this IResource resource)
     {
         if (resource.TryGetLastAnnotation<ComputeEnvironmentAnnotation>(out var computeEnvironmentAnnotation))
@@ -951,6 +972,7 @@ public static class ResourceExtensions
     /// Gets the deployment target for the specified resource, if any. Throws an exception if
     /// there are multiple compute environments and a compute environment is not explicitly specified.
     /// </summary>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Deployment target inspection helper — not part of the ATS surface.")]
     public static DeploymentTargetAnnotation? GetDeploymentTargetAnnotation(this IResource resource, IComputeEnvironmentResource? targetComputeEnvironment = null)
     {
         IComputeEnvironmentResource? selectedComputeEnvironment = null;
@@ -1258,6 +1280,7 @@ public static class ResourceExtensions
     /// This method invokes environment variable and command-line argument callbacks to discover all references. The context resource (<paramref name="resource"/>) is not considered a dependency (even if it is transitively referenced).
     /// </para>
     /// </remarks>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Dependency discovery helper depends on execution context and is not part of the ATS surface.")]
     public static async Task<IReadOnlySet<IResource>> GetResourceDependenciesAsync(
         this IResource resource,
         DistributedApplicationExecutionContext executionContext,

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -24,7 +24,7 @@ public static class ResourceExtensions
     /// <param name="resource">The resource to get the annotation from.</param>
     /// <param name="annotation">When this method returns, contains the last annotation of the specified type from the resource, if found; otherwise, the default value for <typeparamref name="T"/>.</param>
     /// <returns><see langword="true"/> if the last annotation of the specified type was found in the resource; otherwise, <see langword="false"/>.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Generic annotation inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Generic annotation inspection helper — not part of the ATS surface.")]
     public static bool TryGetLastAnnotation<T>(this IResource resource, [NotNullWhen(true)] out T? annotation) where T : IResourceAnnotation
     {
         if (resource.Annotations.OfType<T>().LastOrDefault() is { } lastAnnotation)
@@ -46,7 +46,7 @@ public static class ResourceExtensions
     /// <param name="resource">The resource to retrieve annotations from.</param>
     /// <param name="result">When this method returns, contains the annotations of the specified type, if found; otherwise, <see langword="null"/>.</param>
     /// <returns><see langword="true"/> if annotations of the specified type were found; otherwise, <see langword="false"/>.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Generic annotation inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Generic annotation inspection helper — not part of the ATS surface.")]
     public static bool TryGetAnnotationsOfType<T>(this IResource resource, [NotNullWhen(true)] out IEnumerable<T>? result) where T : IResourceAnnotation
     {
         var matchingTypeAnnotations = resource.Annotations.OfType<T>();
@@ -69,7 +69,7 @@ public static class ResourceExtensions
     /// <typeparam name="T">The type of annotation to retrieve.</typeparam>
     /// <param name="resource">The resource to retrieve annotations from.</param>
     /// <returns><see langword="true"/> if an annotation of the specified type was found; otherwise, <see langword="false"/>.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Generic annotation inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Generic annotation inspection helper — not part of the ATS surface.")]
     public static bool HasAnnotationOfType<T>(this IResource resource) where T : IResourceAnnotation
     {
         return resource.Annotations.Any(a => a is T);
@@ -82,7 +82,7 @@ public static class ResourceExtensions
     /// <param name="resource">The resource to retrieve annotations from.</param>
     /// <param name="result">When this method returns, contains the annotations of the specified type, if found; otherwise, <see langword="null"/>.</param>
     /// <returns><see langword="true"/> if annotations of the specified type were found; otherwise, <see langword="false"/>.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Generic annotation inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Generic annotation inspection helper — not part of the ATS surface.")]
     public static bool TryGetAnnotationsIncludingAncestorsOfType<T>(this IResource resource, [NotNullWhen(true)] out IEnumerable<T>? result) where T : IResourceAnnotation
     {
         if (resource is IResourceWithParent)
@@ -120,7 +120,7 @@ public static class ResourceExtensions
     /// <typeparam name="T">The type of annotation to retrieve.</typeparam>
     /// <param name="resource">The resource to retrieve annotations from.</param>
     /// <returns><see langword="true"/> if an annotation of the specified type was found; otherwise, <see langword="false"/>.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Generic annotation inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Generic annotation inspection helper — not part of the ATS surface.")]
     public static bool HasAnnotationIncludingAncestorsOfType<T>(this IResource resource) where T : IResourceAnnotation
     {
         if (resource is IResourceWithParent)
@@ -154,7 +154,7 @@ public static class ResourceExtensions
     /// <param name="resource">The resource to get the environment variables from.</param>
     /// <param name="environmentVariables">The environment variables retrieved from the resource, if any.</param>
     /// <returns>True if the environment variables were successfully retrieved, false otherwise.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Environment callback inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Environment callback inspection helper — not part of the ATS surface.")]
     public static bool TryGetEnvironmentVariables(this IResource resource, [NotNullWhen(true)] out IEnumerable<EnvironmentCallbackAnnotation>? environmentVariables)
     {
         return TryGetAnnotationsOfType(resource, out environmentVariables);
@@ -551,7 +551,7 @@ public static class ResourceExtensions
     /// Gets a value indicating whether the resource is excluded from being published.
     /// </summary>
     /// <param name="resource">The resource to determine if it should be excluded from being published.</param>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Manifest inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Manifest inspection helper — not part of the ATS surface.")]
     public static bool IsExcludedFromPublish(this IResource resource) =>
         resource.TryGetLastAnnotation<ManifestPublishingCallbackAnnotation>(out var lastAnnotation) && lastAnnotation == ManifestPublishingCallbackAnnotation.Ignore;
 
@@ -642,7 +642,7 @@ public static class ResourceExtensions
     /// <param name="resource">The resource to get the volume mounts for.</param>
     /// <param name="volumeMounts">When this method returns, contains the volume mounts for the specified resource, if found; otherwise, <c>null</c>.</param>
     /// <returns><c>true</c> if the volume mounts were successfully retrieved; otherwise, <c>false</c>.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Container mount inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Container mount inspection helper — not part of the ATS surface.")]
     public static bool TryGetContainerMounts(this IResource resource, [NotNullWhen(true)] out IEnumerable<ContainerMountAnnotation>? volumeMounts)
     {
         return TryGetAnnotationsOfType<ContainerMountAnnotation>(resource, out volumeMounts);
@@ -654,7 +654,7 @@ public static class ResourceExtensions
     /// <param name="resource">The resource to retrieve the endpoints for.</param>
     /// <param name="endpoints">The endpoints for the given resource, if found.</param>
     /// <returns>True if the endpoints were found, false otherwise.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Endpoint annotation inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Endpoint annotation inspection helper — not part of the ATS surface.")]
     public static bool TryGetEndpoints(this IResource resource, [NotNullWhen(true)] out IEnumerable<EndpointAnnotation>? endpoints)
     {
         return TryGetAnnotationsOfType(resource, out endpoints);
@@ -666,7 +666,7 @@ public static class ResourceExtensions
     /// <param name="resource">The resource to retrieve the URLs for.</param>
     /// <param name="urls">The URLs for the given resource, if found.</param>
     /// <returns>True if the URLs were found, false otherwise.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "URL annotation inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "URL annotation inspection helper — not part of the ATS surface.")]
     public static bool TryGetUrls(this IResource resource, [NotNullWhen(true)] out IEnumerable<ResourceUrlAnnotation>? urls)
     {
         return TryGetAnnotationsOfType(resource, out urls);
@@ -677,7 +677,7 @@ public static class ResourceExtensions
     /// </summary>
     /// <param name="resource">The <see cref="IResourceWithEndpoints"/> which contains <see cref="EndpointAnnotation"/> annotations.</param>
     /// <returns>An enumeration of <see cref="EndpointReference"/> based on the <see cref="EndpointAnnotation"/> annotations from the resources' <see cref="IResource.Annotations"/> collection.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Resource handle endpoint enumeration is not part of the ATS surface; use builder-based endpoint exports instead.")]
+    [AspireExportIgnore(Reason = "Resource handle endpoint enumeration is not part of the ATS surface; use builder-based endpoint exports instead.")]
     public static IEnumerable<EndpointReference> GetEndpoints(this IResourceWithEndpoints resource)
     {
         if (TryGetAnnotationsOfType<EndpointAnnotation>(resource, out var endpoints))
@@ -694,7 +694,7 @@ public static class ResourceExtensions
     /// <param name="resource">The <see cref="IResourceWithEndpoints"/> which contains <see cref="EndpointAnnotation"/> annotations.</param>
     /// <param name="contextNetworkID">The ID of the network that serves as the context context for the endpoint references.</param>
     /// <returns>An enumeration of <see cref="EndpointReference"/> based on the <see cref="EndpointAnnotation"/> annotations from the resources' <see cref="IResource.Annotations"/> collection.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Network-specific endpoint enumeration is not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Network-specific endpoint enumeration is not part of the ATS surface.")]
     public static IEnumerable<EndpointReference> GetEndpoints(this IResourceWithEndpoints resource, NetworkIdentifier contextNetworkID)
     {
         if (TryGetAnnotationsOfType<EndpointAnnotation>(resource, out var endpoints))
@@ -711,7 +711,7 @@ public static class ResourceExtensions
     /// <param name="resource">The <see cref="IResourceWithEndpoints"/> which contains <see cref="EndpointAnnotation"/> annotations.</param>
     /// <param name="endpointName">The name of the endpoint.</param>
     /// <returns>An <see cref="EndpointReference"/>object providing resolvable reference for the specified endpoint.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Resource handle endpoint lookup is not part of the ATS surface; use builder-based endpoint exports instead.")]
+    [AspireExportIgnore(Reason = "Resource handle endpoint lookup is not part of the ATS surface; use builder-based endpoint exports instead.")]
     public static EndpointReference GetEndpoint(this IResourceWithEndpoints resource, string endpointName)
     {
         var endpoint = resource.TryGetEndpoints(out var endpoints) ?
@@ -734,7 +734,7 @@ public static class ResourceExtensions
     /// <param name="endpointName">The name of the endpoint.</param>
     /// <param name="contextNetworkID">The network ID of the network that provides the context for the returned <see cref="EndpointReference"/></param>
     /// <returns>An <see cref="EndpointReference"/>object providing resolvable reference for the specified endpoint.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Network-specific endpoint lookup is not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Network-specific endpoint lookup is not part of the ATS surface.")]
     public static EndpointReference GetEndpoint(this IResourceWithEndpoints resource, string endpointName, NetworkIdentifier contextNetworkID)
     {
 
@@ -759,7 +759,7 @@ public static class ResourceExtensions
     /// <param name="resource">The resource containing endpoints to resolve.</param>
     /// <param name="portAllocator">Optional port allocator. If null, uses default allocation starting from port 8000.</param>
     /// <returns>A read-only list of resolved endpoints with computed port values.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Endpoint resolution exposes infrastructure-specific types that are not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Endpoint resolution exposes infrastructure-specific types that are not part of the ATS surface.")]
     public static IReadOnlyList<ResolvedEndpoint> ResolveEndpoints(this IResource resource, IPortAllocator? portAllocator = null)
     {
         if (!resource.TryGetEndpoints(out var endpoints))
@@ -843,7 +843,7 @@ public static class ResourceExtensions
     /// <param name="resource">The resource to get the container image name from.</param>
     /// <param name="imageName">The container image name if found, otherwise null.</param>
     /// <returns>True if the container image name was found, otherwise false.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Container image inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Container image inspection helper — not part of the ATS surface.")]
     public static bool TryGetContainerImageName(this IResource resource, [NotNullWhen(true)] out string? imageName)
     {
         return TryGetContainerImageName(resource, useBuiltImage: true, out imageName);
@@ -856,7 +856,7 @@ public static class ResourceExtensions
     /// <param name="useBuiltImage">When true, uses the image name from DockerfileBuildAnnotation if present. When false, uses only ContainerImageAnnotation.</param>
     /// <param name="imageName">The container image name if found, otherwise null.</param>
     /// <returns>True if the container image name was found, otherwise false.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Container image inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Container image inspection helper — not part of the ATS surface.")]
     public static bool TryGetContainerImageName(this IResource resource, bool useBuiltImage, [NotNullWhen(true)] out string? imageName)
     {
         // First check if there's a DockerfileBuildAnnotation with an image name/tag
@@ -898,7 +898,7 @@ public static class ResourceExtensions
     /// </summary>
     /// <param name="resource">The resource to get the replica count for.</param>
     /// <returns>The number of replicas for the specified resource.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Replica inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Replica inspection helper — not part of the ATS surface.")]
     public static int GetReplicaCount(this IResource resource)
     {
         if (resource.TryGetLastAnnotation<ReplicaAnnotation>(out var replicaAnnotation))
@@ -920,7 +920,7 @@ public static class ResourceExtensions
     /// </remarks>
     /// <param name="resource">The resource to evaluate for image build requirements.</param>
     /// <returns>True if the resource requires image building; otherwise, false.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Publishing inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Publishing inspection helper — not part of the ATS surface.")]
     public static bool RequiresImageBuild(this IResource resource)
     {
         if (resource.IsExcludedFromPublish())
@@ -941,7 +941,7 @@ public static class ResourceExtensions
     /// </remarks>
     /// <param name="resource">The resource to evaluate for image push requirements.</param>
     /// <returns>True if the resource requires image building and pushing; otherwise, false.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Publishing inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Publishing inspection helper — not part of the ATS surface.")]
     public static bool RequiresImageBuildAndPush(this IResource resource)
     {
         return resource.RequiresImageBuild() && !resource.IsBuildOnlyContainer();
@@ -958,7 +958,7 @@ public static class ResourceExtensions
     /// </summary>
     /// <param name="resource">The resource to get the compute environment for.</param>
     /// <returns>The compute environment the resource is bound to, or <c>null</c> if the resource is not bound to any specific compute environment.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Compute-environment inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Compute-environment inspection helper — not part of the ATS surface.")]
     public static IComputeEnvironmentResource? GetComputeEnvironment(this IResource resource)
     {
         if (resource.TryGetLastAnnotation<ComputeEnvironmentAnnotation>(out var computeEnvironmentAnnotation))
@@ -972,7 +972,7 @@ public static class ResourceExtensions
     /// Gets the deployment target for the specified resource, if any. Throws an exception if
     /// there are multiple compute environments and a compute environment is not explicitly specified.
     /// </summary>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Deployment target inspection helper — not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Deployment target inspection helper — not part of the ATS surface.")]
     public static DeploymentTargetAnnotation? GetDeploymentTargetAnnotation(this IResource resource, IComputeEnvironmentResource? targetComputeEnvironment = null)
     {
         IComputeEnvironmentResource? selectedComputeEnvironment = null;
@@ -1280,7 +1280,7 @@ public static class ResourceExtensions
     /// This method invokes environment variable and command-line argument callbacks to discover all references. The context resource (<paramref name="resource"/>) is not considered a dependency (even if it is transitively referenced).
     /// </para>
     /// </remarks>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Dependency discovery helper depends on execution context and is not part of the ATS surface.")]
+    [AspireExportIgnore(Reason = "Dependency discovery helper depends on execution context and is not part of the ATS surface.")]
     public static async Task<IReadOnlySet<IResource>> GetResourceDependenciesAsync(
         this IResource resource,
         DistributedApplicationExecutionContext executionContext,

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -130,11 +130,6 @@
     <InternalsVisibleTo Include="Aspire.Hosting.RemoteHost.Tests" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- Reference the analyzer to ensure it's built but don't reference its output -->
-    <ProjectReference Include="..\Aspire.Hosting.Integration.Analyzers\Aspire.Hosting.Integration.Analyzers.csproj" ReferenceOutputAssembly="false" Private="true" />
-  </ItemGroup>
-
   <!-- Include the integration analyzer in the package -->
   <PropertyGroup>
     <BeforePack>$(BeforePack);IncludeIntegrationAnalyzerInPackage</BeforePack>

--- a/src/Aspire.Hosting/Ats/AspireExportIgnoreAttribute.cs
+++ b/src/Aspire.Hosting/Ats/AspireExportIgnoreAttribute.cs
@@ -6,7 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Aspire.Hosting;
 
 /// <summary>
-/// Excludes a property or method from ATS export when the containing type uses
+/// Excludes a property, method, or type from ATS export when the containing type uses
 /// <see cref="AspireExportAttribute.ExposeProperties"/> or <see cref="AspireExportAttribute.ExposeMethods"/>.
 /// </summary>
 /// <remarks>
@@ -17,6 +17,10 @@ namespace Aspire.Hosting;
 /// <para>
 /// This is useful when most members should be exposed but a few contain internal
 /// implementation details or types that shouldn't be part of the polyglot API.
+/// </para>
+/// <para>
+/// Apply this attribute to a type to suppress all automatic export coverage checks for the
+/// type's members when the type is intentionally not part of the ATS surface.
 /// </para>
 /// </remarks>
 /// <example>
@@ -33,7 +37,7 @@ namespace Aspire.Hosting;
 /// </code>
 /// </example>
 [AttributeUsage(
-    AttributeTargets.Property | AttributeTargets.Method,
+    AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Method,
     Inherited = false,
     AllowMultiple = false)]
 [Experimental("ASPIREATS001")]

--- a/src/Aspire.Hosting/ConnectionPropertiesExtensions.cs
+++ b/src/Aspire.Hosting/ConnectionPropertiesExtensions.cs
@@ -16,6 +16,7 @@ public static class ConnectionPropertiesExtensions
     /// <param name="source">The resource that exposes the base connection properties.</param>
     /// <param name="additional">The additional connection properties to merge into the values supplied by <paramref name="source"/>.</param>
     /// <returns>A sequence that contains the combined set of connection properties with duplicate keys resolved in favor of <paramref name="additional"/>.</returns>
+    [AspireExportIgnore(Reason = "Connection property merging is an internal helper and is not part of the ATS surface.")]
     public static IEnumerable<KeyValuePair<string, ReferenceExpression>> CombineProperties(this IResourceWithConnectionString source, IEnumerable<KeyValuePair<string, ReferenceExpression>> additional)
     {
         ArgumentNullException.ThrowIfNull(source);

--- a/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ConnectionStringBuilderExtensions.cs
@@ -142,7 +142,7 @@ public static class ConnectionStringBuilderExtensions
     /// builder.Build().Run();
     /// </code>
     /// </example>
-    [AspireExport("addConnectionStringBuilder", Description = "Adds a connection string with a builder callback")]
+    [AspireExport("addConnectionStringBuilder", Description = "Adds a connection string with a builder callback", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<ConnectionStringResource> AddConnectionString(this IDistributedApplicationBuilder builder, [ResourceName] string name, Action<ReferenceExpressionBuilder> connectionStringBuilder)
     {
         var rb = new ReferenceExpressionBuilder();

--- a/src/Aspire.Hosting/ContainerExecutableResourceExtensions.cs
+++ b/src/Aspire.Hosting/ContainerExecutableResourceExtensions.cs
@@ -15,6 +15,7 @@ internal static class ContainerExecutableResourceExtensions
     /// </summary>
     /// <param name="model">The distributed application model to retrieve executable resources from.</param>
     /// <returns>An enumerable collection of executable resources.</returns>
+    [AspireExportIgnore(Reason = "Application model inspection helper — not part of the ATS surface.")]
     public static IEnumerable<ContainerExecutableResource> GetContainerExecutableResources(this DistributedApplicationModel model)
     {
         ArgumentNullException.ThrowIfNull(model);

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -1091,7 +1091,7 @@ public static class ContainerResourceBuilderExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    [AspireExport("withBuildArg", Description = "Adds a build argument from a parameter resource")]
+    [AspireExport("withParameterBuildArg", MethodName = "withBuildArg", Description = "Adds a build argument from a parameter resource")]
     public static IResourceBuilder<T> WithBuildArg<T>(this IResourceBuilder<T> builder, string name, IResourceBuilder<ParameterResource> value) where T : ContainerResource
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -1139,7 +1139,7 @@ public static class ContainerResourceBuilderExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    [AspireExport("withBuildSecret", Description = "Adds a build secret from a parameter resource")]
+    [AspireExport("withParameterBuildSecret", MethodName = "withBuildSecret", Description = "Adds a build secret from a parameter resource")]
     public static IResourceBuilder<T> WithBuildSecret<T>(this IResourceBuilder<T> builder, string name, IResourceBuilder<ParameterResource> value) where T : ContainerResource
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting/ContainerResourceExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceExtensions.cs
@@ -15,6 +15,7 @@ public static class ContainerResourceExtensions
     /// </summary>
     /// <param name="model">The distributed application model to search for container resources.</param>
     /// <returns>A collection of container resources in the specified distributed application model.</returns>
+    [AspireExportIgnore(Reason = "Application model inspection helper — not part of the ATS surface.")]
     public static IEnumerable<IResource> GetContainerResources(this DistributedApplicationModel model)
     {
         ArgumentNullException.ThrowIfNull(model);
@@ -33,6 +34,7 @@ public static class ContainerResourceExtensions
     /// </summary>
     /// <param name="resource">The resource to check.</param>
     /// <returns>true if the specified resource is a container resource; otherwise, false.</returns>
+    [AspireExportIgnore(Reason = "Application model inspection helper — not part of the ATS surface.")]
     public static bool IsContainer(this IResource resource)
     {
         ArgumentNullException.ThrowIfNull(resource);

--- a/src/Aspire.Hosting/EmulatorResourceExtensions.cs
+++ b/src/Aspire.Hosting/EmulatorResourceExtensions.cs
@@ -15,6 +15,7 @@ public static class EmulatorResourceExtensions
     /// </summary>
     /// <param name="resource">The resource to check.</param>
     /// <returns>true if the specified resource is an emulator resource; otherwise, false.</returns>
+    [AspireExportIgnore(Reason = "Application model inspection helper — not part of the ATS surface.")]
     public static bool IsEmulator(this IResource resource)
     {
         ArgumentNullException.ThrowIfNull(resource);

--- a/src/Aspire.Hosting/ExecutableResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ExecutableResourceBuilderExtensions.cs
@@ -117,7 +117,7 @@ public static class ExecutableResourceBuilderExtensions
     /// <param name="builder">Resource builder</param>
     /// <param name="configure">Optional action to configure the container resource</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("publishAsDockerFileWithConfigure", Description = "Publishes an executable as a Docker file with optional container configuration")]
+    [AspireExport("publishAsDockerFileWithConfigure", Description = "Publishes an executable as a Docker file with optional container configuration", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<T> PublishAsDockerFile<T>(this IResourceBuilder<T> builder, Action<IResourceBuilder<ContainerResource>>? configure)
         where T : ExecutableResource
     {

--- a/src/Aspire.Hosting/ExecutableResourceExtensions.cs
+++ b/src/Aspire.Hosting/ExecutableResourceExtensions.cs
@@ -15,6 +15,7 @@ public static class ExecutableResourceExtensions
     /// </summary>
     /// <param name="model">The distributed application model to retrieve executable resources from.</param>
     /// <returns>An enumerable collection of executable resources.</returns>
+    [AspireExportIgnore(Reason = "Application model inspection helper — not part of the ATS surface.")]
     public static IEnumerable<ExecutableResource> GetExecutableResources(this DistributedApplicationModel model)
     {
         ArgumentNullException.ThrowIfNull(model);

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -282,7 +282,7 @@ public static class ProjectResourceBuilderExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    [AspireExport("addProjectWithOptions", Description = "Adds a project resource with configuration options")]
+    [AspireExport("addProjectWithOptions", Description = "Adds a project resource with configuration options", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<ProjectResource> AddProject(this IDistributedApplicationBuilder builder, [ResourceName] string name, string projectPath, Action<ProjectResourceOptions> configure)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -364,7 +364,7 @@ public static class ProjectResourceBuilderExtensions
     /// </example>
     /// </remarks>
     [Experimental("ASPIRECSHARPAPPS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-    [AspireExport("addCSharpAppWithOptions", Description = "Adds a C# application resource with configuration options")]
+    [AspireExport("addCSharpAppWithOptions", Description = "Adds a C# application resource with configuration options", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<CSharpAppResource> AddCSharpApp(this IDistributedApplicationBuilder builder, [ResourceName] string name, string path, Action<ProjectResourceOptions> configure)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -826,7 +826,7 @@ public static class ProjectResourceBuilderExtensions
     /// <param name="builder">Resource builder</param>
     /// <param name="configure">Optional action to configure the container resource</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [AspireExport("publishProjectAsDockerFileWithConfigure", MethodName = "publishAsDockerFile", Description = "Publishes a project as a Docker file with optional container configuration")]
+    [AspireExport("publishProjectAsDockerFileWithConfigure", MethodName = "publishAsDockerFile", Description = "Publishes a project as a Docker file with optional container configuration", RunSyncOnBackgroundThread = true)]
     public static IResourceBuilder<T> PublishAsDockerFile<T>(this IResourceBuilder<T> builder, Action<IResourceBuilder<ContainerResource>>? configure = null)
         where T : ProjectResource
     {

--- a/src/Aspire.Hosting/Publishing/PublishingExtensions.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingExtensions.cs
@@ -4,12 +4,14 @@
 #pragma warning disable ASPIREPIPELINES001
 
 using System.Diagnostics.CodeAnalysis;
+
 namespace Aspire.Hosting.Pipelines;
 
 /// <summary>
 /// Extension methods for <see cref="IReportingStep"/> and <see cref="IReportingTask"/> to provide direct operations.
 /// </summary>
 [Experimental("ASPIREPIPELINES001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+[AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
 public static class PublishingExtensions
 {
     /// <summary>
@@ -19,7 +21,6 @@ public static class PublishingExtensions
     /// <param name="message">Optional completion message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed step.</returns>
-    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingStep> SucceedAsync(
         this IReportingStep step,
         string? message = null,
@@ -37,7 +38,6 @@ public static class PublishingExtensions
     /// <param name="message">The Markdown-formatted completion message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed step.</returns>
-    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingStep> SucceedAsync(
         this IReportingStep step,
         MarkdownString message,
@@ -54,7 +54,6 @@ public static class PublishingExtensions
     /// <param name="message">Optional completion message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed step.</returns>
-    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingStep> WarnAsync(
         this IReportingStep step,
         string? message = null,
@@ -72,7 +71,6 @@ public static class PublishingExtensions
     /// <param name="message">The Markdown-formatted warning message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed step.</returns>
-    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingStep> WarnAsync(
         this IReportingStep step,
         MarkdownString message,
@@ -89,7 +87,6 @@ public static class PublishingExtensions
     /// <param name="errorMessage">Optional error message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed step.</returns>
-    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingStep> FailAsync(
         this IReportingStep step,
         string? errorMessage = null,
@@ -107,7 +104,6 @@ public static class PublishingExtensions
     /// <param name="errorMessage">The Markdown-formatted error message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed step.</returns>
-    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingStep> FailAsync(
         this IReportingStep step,
         MarkdownString errorMessage,
@@ -124,7 +120,6 @@ public static class PublishingExtensions
     /// <param name="statusText">The new status text.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The updated task.</returns>
-    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> UpdateStatusAsync(
         this IReportingTask task,
         string statusText,
@@ -141,7 +136,6 @@ public static class PublishingExtensions
     /// <param name="statusText">The new Markdown-formatted status text.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The updated task.</returns>
-    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> UpdateStatusAsync(
         this IReportingTask task,
         MarkdownString statusText,
@@ -158,7 +152,6 @@ public static class PublishingExtensions
     /// <param name="message">Optional completion message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed task.</returns>
-    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> SucceedAsync(
         this IReportingTask task,
         string? message = null,
@@ -175,7 +168,6 @@ public static class PublishingExtensions
     /// <param name="message">The Markdown-formatted completion message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed task.</returns>
-    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> SucceedAsync(
         this IReportingTask task,
         MarkdownString message,
@@ -192,7 +184,6 @@ public static class PublishingExtensions
     /// <param name="message">Optional completion message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed task.</returns>
-    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> WarnAsync(
         this IReportingTask task,
         string? message = null,
@@ -209,7 +200,6 @@ public static class PublishingExtensions
     /// <param name="message">The Markdown-formatted warning message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed task.</returns>
-    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> WarnAsync(
         this IReportingTask task,
         MarkdownString message,
@@ -226,7 +216,6 @@ public static class PublishingExtensions
     /// <param name="errorMessage">Optional error message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed task.</returns>
-    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> FailAsync(
         this IReportingTask task,
         string? errorMessage = null,
@@ -243,7 +232,6 @@ public static class PublishingExtensions
     /// <param name="errorMessage">The Markdown-formatted error message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed task.</returns>
-    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> FailAsync(
         this IReportingTask task,
         MarkdownString errorMessage,

--- a/src/Aspire.Hosting/Publishing/PublishingExtensions.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingExtensions.cs
@@ -4,7 +4,6 @@
 #pragma warning disable ASPIREPIPELINES001
 
 using System.Diagnostics.CodeAnalysis;
-
 namespace Aspire.Hosting.Pipelines;
 
 /// <summary>
@@ -20,6 +19,7 @@ public static class PublishingExtensions
     /// <param name="message">Optional completion message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed step.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingStep> SucceedAsync(
         this IReportingStep step,
         string? message = null,
@@ -37,6 +37,7 @@ public static class PublishingExtensions
     /// <param name="message">The Markdown-formatted completion message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed step.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingStep> SucceedAsync(
         this IReportingStep step,
         MarkdownString message,
@@ -53,6 +54,7 @@ public static class PublishingExtensions
     /// <param name="message">Optional completion message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed step.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingStep> WarnAsync(
         this IReportingStep step,
         string? message = null,
@@ -70,6 +72,7 @@ public static class PublishingExtensions
     /// <param name="message">The Markdown-formatted warning message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed step.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingStep> WarnAsync(
         this IReportingStep step,
         MarkdownString message,
@@ -86,6 +89,7 @@ public static class PublishingExtensions
     /// <param name="errorMessage">Optional error message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed step.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingStep> FailAsync(
         this IReportingStep step,
         string? errorMessage = null,
@@ -103,6 +107,7 @@ public static class PublishingExtensions
     /// <param name="errorMessage">The Markdown-formatted error message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed step.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingStep> FailAsync(
         this IReportingStep step,
         MarkdownString errorMessage,
@@ -119,6 +124,7 @@ public static class PublishingExtensions
     /// <param name="statusText">The new status text.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The updated task.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> UpdateStatusAsync(
         this IReportingTask task,
         string statusText,
@@ -135,6 +141,7 @@ public static class PublishingExtensions
     /// <param name="statusText">The new Markdown-formatted status text.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The updated task.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> UpdateStatusAsync(
         this IReportingTask task,
         MarkdownString statusText,
@@ -151,6 +158,7 @@ public static class PublishingExtensions
     /// <param name="message">Optional completion message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed task.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> SucceedAsync(
         this IReportingTask task,
         string? message = null,
@@ -167,6 +175,7 @@ public static class PublishingExtensions
     /// <param name="message">The Markdown-formatted completion message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed task.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> SucceedAsync(
         this IReportingTask task,
         MarkdownString message,
@@ -183,6 +192,7 @@ public static class PublishingExtensions
     /// <param name="message">Optional completion message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed task.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> WarnAsync(
         this IReportingTask task,
         string? message = null,
@@ -199,6 +209,7 @@ public static class PublishingExtensions
     /// <param name="message">The Markdown-formatted warning message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed task.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> WarnAsync(
         this IReportingTask task,
         MarkdownString message,
@@ -215,6 +226,7 @@ public static class PublishingExtensions
     /// <param name="errorMessage">Optional error message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed task.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> FailAsync(
         this IReportingTask task,
         string? errorMessage = null,
@@ -231,6 +243,7 @@ public static class PublishingExtensions
     /// <param name="errorMessage">The Markdown-formatted error message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed task.</returns>
+    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> FailAsync(
         this IReportingTask task,
         MarkdownString errorMessage,

--- a/src/Aspire.Hosting/Publishing/PublishingExtensions.cs
+++ b/src/Aspire.Hosting/Publishing/PublishingExtensions.cs
@@ -19,7 +19,7 @@ public static class PublishingExtensions
     /// <param name="message">Optional completion message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed step.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
+    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingStep> SucceedAsync(
         this IReportingStep step,
         string? message = null,
@@ -37,7 +37,7 @@ public static class PublishingExtensions
     /// <param name="message">The Markdown-formatted completion message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed step.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
+    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingStep> SucceedAsync(
         this IReportingStep step,
         MarkdownString message,
@@ -54,7 +54,7 @@ public static class PublishingExtensions
     /// <param name="message">Optional completion message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed step.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
+    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingStep> WarnAsync(
         this IReportingStep step,
         string? message = null,
@@ -72,7 +72,7 @@ public static class PublishingExtensions
     /// <param name="message">The Markdown-formatted warning message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed step.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
+    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingStep> WarnAsync(
         this IReportingStep step,
         MarkdownString message,
@@ -89,7 +89,7 @@ public static class PublishingExtensions
     /// <param name="errorMessage">Optional error message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed step.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
+    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingStep> FailAsync(
         this IReportingStep step,
         string? errorMessage = null,
@@ -107,7 +107,7 @@ public static class PublishingExtensions
     /// <param name="errorMessage">The Markdown-formatted error message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed step.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
+    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingStep> FailAsync(
         this IReportingStep step,
         MarkdownString errorMessage,
@@ -124,7 +124,7 @@ public static class PublishingExtensions
     /// <param name="statusText">The new status text.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The updated task.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
+    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> UpdateStatusAsync(
         this IReportingTask task,
         string statusText,
@@ -141,7 +141,7 @@ public static class PublishingExtensions
     /// <param name="statusText">The new Markdown-formatted status text.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The updated task.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
+    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> UpdateStatusAsync(
         this IReportingTask task,
         MarkdownString statusText,
@@ -158,7 +158,7 @@ public static class PublishingExtensions
     /// <param name="message">Optional completion message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed task.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
+    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> SucceedAsync(
         this IReportingTask task,
         string? message = null,
@@ -175,7 +175,7 @@ public static class PublishingExtensions
     /// <param name="message">The Markdown-formatted completion message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed task.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
+    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> SucceedAsync(
         this IReportingTask task,
         MarkdownString message,
@@ -192,7 +192,7 @@ public static class PublishingExtensions
     /// <param name="message">Optional completion message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed task.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
+    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> WarnAsync(
         this IReportingTask task,
         string? message = null,
@@ -209,7 +209,7 @@ public static class PublishingExtensions
     /// <param name="message">The Markdown-formatted warning message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed task.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
+    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> WarnAsync(
         this IReportingTask task,
         MarkdownString message,
@@ -226,7 +226,7 @@ public static class PublishingExtensions
     /// <param name="errorMessage">Optional error message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed task.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
+    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> FailAsync(
         this IReportingTask task,
         string? errorMessage = null,
@@ -243,7 +243,7 @@ public static class PublishingExtensions
     /// <param name="errorMessage">The Markdown-formatted error message.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The completed task.</returns>
-    [global::Aspire.Hosting.AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
+    [AspireExportIgnore(Reason = "Convenience wrapper over pipeline APIs — use the dedicated ATS pipeline exports instead.")]
     public static async Task<IReportingTask> FailAsync(
         this IReportingTask task,
         MarkdownString errorMessage,

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -761,6 +761,7 @@ public static class ResourceBuilderExtensions
     /// <param name="resource">The resource that provides the connection properties. Cannot be null.</param>
     /// <param name="key">The key of the connection property to retrieve. Cannot be null.</param>
     /// <returns>The value associated with the specified connection property key.</returns>
+    [AspireExport("getConnectionProperty", Description = "Gets a connection property by key")]
     public static ReferenceExpression GetConnectionProperty(this IResourceWithConnectionString resource, string key)
     {
         foreach (var connectionProperty in resource.GetConnectionProperties())
@@ -1569,7 +1570,7 @@ public static class ResourceBuilderExtensions
     /// <param name="builder">The resource builder to which container files will be copied to.</param>
     /// <param name="source">The resource which contains the container files to be copied.</param>
     /// <param name="destinationPath">The destination path within the resource's container where the files will be copied.</param>
-    [AspireExport("publishWithContainerFiles", Description = "Configures the resource to copy container files from the specified source during publishing")]
+    [AspireExport("publishWithContainerFilesFromResource", MethodName = "publishWithContainerFiles", Description = "Configures the resource to copy container files from the specified source during publishing")]
     public static IResourceBuilder<T> PublishWithContainerFiles<T>(
          this IResourceBuilder<T> builder,
          IResourceBuilder<IResourceWithContainerFiles> source,
@@ -1674,7 +1675,7 @@ public static class ResourceBuilderExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    [AspireExport("waitFor", Description = "Waits for another resource to be ready")]
+    [AspireExport("waitForResource", MethodName = "waitFor", Description = "Waits for another resource to be ready")]
     public static IResourceBuilder<T> WaitFor<T>(this IResourceBuilder<T> builder, IResourceBuilder<IResource> dependency) where T : IResourceWithWaitSupport
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -1782,7 +1783,7 @@ public static class ResourceBuilderExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    [AspireExport("waitForStart", Description = "Waits for another resource to start")]
+    [AspireExport("waitForResourceStart", MethodName = "waitForStart", Description = "Waits for another resource to start")]
     public static IResourceBuilder<T> WaitForStart<T>(this IResourceBuilder<T> builder, IResourceBuilder<IResource> dependency) where T : IResourceWithWaitSupport
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -1926,7 +1927,7 @@ public static class ResourceBuilderExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    [AspireExport("waitForCompletion", Description = "Waits for resource completion")]
+    [AspireExport("waitForResourceCompletion", MethodName = "waitForCompletion", Description = "Waits for resource completion")]
     public static IResourceBuilder<T> WaitForCompletion<T>(this IResourceBuilder<T> builder, IResourceBuilder<IResource> dependency, int exitCode = 0) where T : IResourceWithWaitSupport
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -2716,7 +2717,7 @@ public static class ResourceBuilderExtensions
     /// </example>
     /// </remarks>
     [Experimental("ASPIRECERTIFICATES001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-    [AspireExport("withHttpsDeveloperCertificate", Description = "Configures HTTPS with a developer certificate")]
+    [AspireExport("withParameterHttpsDeveloperCertificate", MethodName = "withHttpsDeveloperCertificate", Description = "Configures HTTPS with a developer certificate")]
     public static IResourceBuilder<TResource> WithHttpsDeveloperCertificate<TResource>(this IResourceBuilder<TResource> builder, IResourceBuilder<ParameterResource>? password = null)
         where TResource : IResourceWithEnvironment, IResourceWithArgs
     {
@@ -3116,7 +3117,7 @@ public static class ResourceBuilderExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    [AspireExport("withParentRelationship", Description = "Sets the parent relationship")]
+    [AspireExport("withBuilderParentRelationship", MethodName = "withParentRelationship", Description = "Sets the parent relationship")]
     public static IResourceBuilder<T> WithParentRelationship<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<IResource> parent) where T : IResource
@@ -3180,7 +3181,7 @@ public static class ResourceBuilderExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    [AspireExport("withChildRelationship", Description = "Sets a child relationship")]
+    [AspireExport("withBuilderChildRelationship", MethodName = "withChildRelationship", Description = "Sets a child relationship")]
     public static IResourceBuilder<T> WithChildRelationship<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<IResource> child) where T : IResource
@@ -3289,6 +3290,7 @@ public static class ResourceBuilderExtensions
     /// <param name="launchConfigurationType">The type of the resource.</param>
     /// <param name="argsCallback">Optional callback to add or modify command line arguments when running in an extension host. Useful if the entrypoint is usually provided as an argument to the resource executable.</param>
     [Experimental("ASPIREEXTENSION001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    [AspireExportIgnore(Reason = "Generic debug launch configuration support is not part of the ATS surface.")]
     public static IResourceBuilder<T> WithDebugSupport<T, TLaunchConfiguration>(this IResourceBuilder<T> builder, Func<string, TLaunchConfiguration> launchConfigurationProducer, string launchConfigurationType, Action<CommandLineArgsCallbackContext>? argsCallback = null)
         where T : IResource
     {
@@ -3348,6 +3350,7 @@ public static class ResourceBuilderExtensions
     /// <para>This method is not available in polyglot app hosts. The parameter name 'type' is a reserved keyword in Go and Rust.</para>
     /// </remarks>
     [Experimental("ASPIREPROBES001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    [AspireExportIgnore(Reason = "Use the ATS export stub with renamed probeType parameter instead.")]
     public static IResourceBuilder<T> WithHttpProbe<T>(this IResourceBuilder<T> builder, ProbeType type, string? path = null, int? initialDelaySeconds = null, int? periodSeconds = null, int? timeoutSeconds = null, int? failureThreshold = null, int? successThreshold = null, string? endpointName = null)
         where T : IResourceWithEndpoints, IResourceWithProbes
     {

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -549,7 +549,7 @@ public static class ResourceBuilderExtensions
         return builder.WithAnnotation(new ReferenceEnvironmentInjectionAnnotation(flags));
     }
 
-    [AspireExport("withReference", Description = "Adds a reference to another resource")]
+    [AspireExport("withGenericResourceReference", MethodName = "withReference", Description = "Adds a reference to another resource")]
     internal static IResourceBuilder<TDestination> WithReference<TDestination>(
         this IResourceBuilder<TDestination> builder,
         IResourceBuilder<IResource> source,

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -549,7 +549,7 @@ public static class ResourceBuilderExtensions
         return builder.WithAnnotation(new ReferenceEnvironmentInjectionAnnotation(flags));
     }
 
-    [AspireExport("withGenericResourceReference", MethodName = "withReference", Description = "Adds a reference to another resource")]
+    [AspireExport("withReference", Description = "Adds a reference to another resource")]
     internal static IResourceBuilder<TDestination> WithReference<TDestination>(
         this IResourceBuilder<TDestination> builder,
         IResourceBuilder<IResource> source,

--- a/src/Aspire.Hosting/Utils/ExtensionUtils.cs
+++ b/src/Aspire.Hosting/Utils/ExtensionUtils.cs
@@ -13,6 +13,7 @@ namespace Aspire.Hosting.Utils;
 #pragma warning disable ASPIREEXTENSION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 internal static class ExtensionUtils
 {
+    [AspireExportIgnore(Reason = "Debug support inspection is a local .NET helper and is not part of the ATS surface.")]
     public static bool SupportsDebugging(this IResource builder, IConfiguration configuration, [NotNullWhen(true)] out SupportsDebuggingAnnotation? supportsDebuggingAnnotation)
     {
         var supportedLaunchConfigurations = GetSupportedLaunchConfigurations(configuration);

--- a/src/Aspire.TypeSystem/AttributeDataReader.cs
+++ b/src/Aspire.TypeSystem/AttributeDataReader.cs
@@ -46,6 +46,12 @@ public static class AttributeDataReader
     // --- AspireExportIgnore lookup ---
 
     /// <summary>
+    /// Determines whether the specified <paramref name="type"/> has the AspireExportIgnore attribute.
+    /// </summary>
+    public static bool HasAspireExportIgnoreData(Type type)
+        => HasAttribute(type.GetCustomAttributesData(), AspireExportIgnoreAttributeFullName);
+
+    /// <summary>
     /// Determines whether the specified <paramref name="property"/> has the AspireExportIgnore attribute.
     /// </summary>
     public static bool HasAspireExportIgnoreData(PropertyInfo property)

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -19,11 +19,10 @@
   <ItemGroup Condition="$([System.String]::Copy('$(MSBuildProjectName)').StartsWith('Aspire.Hosting'))
                         and
                         '$(SkipAspireIntegrationAnalyzersReference)' != 'true'">
-    <ProjectReference Include="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', 'Aspire.Hosting.Integration.Analyzers', 'Aspire.Hosting.Integration.Analyzers.csproj'))"
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\Aspire.Hosting.Integration.Analyzers\Aspire.Hosting.Integration.Analyzers.csproj"
                     PrivateAssets="all"
                     ReferenceOutputAssembly="false"
-                    OutputItemType="Analyzer"
-                    SetTargetFramework="TargetFramework=netstandard2.0" />
+                    OutputItemType="Analyzer" />
   </ItemGroup>
 
   <!-- Used by Aspire.Workload.Testing.targets -->

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -16,13 +16,14 @@
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
 
-  <ItemGroup Condition="$([System.String]::Copy('$(MSBuildProjectName)').StartsWith('Aspire.Hosting.'))
+  <ItemGroup Condition="$([System.String]::Copy('$(MSBuildProjectName)').StartsWith('Aspire.Hosting'))
                         and
                         '$(SkipAspireIntegrationAnalyzersReference)' != 'true'">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\Aspire.Hosting.Integration.Analyzers\Aspire.Hosting.Integration.Analyzers.csproj"
+    <ProjectReference Include="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', 'Aspire.Hosting.Integration.Analyzers', 'Aspire.Hosting.Integration.Analyzers.csproj'))"
                     PrivateAssets="all"
                     ReferenceOutputAssembly="false"
-                    OutputItemType="Analyzer" />
+                    OutputItemType="Analyzer"
+                    SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
 
   <!-- Used by Aspire.Workload.Testing.targets -->

--- a/src/Shared/IConfigurationExtensions.cs
+++ b/src/Shared/IConfigurationExtensions.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
-using Aspire.Hosting;
 #if !CLI && !ASPIRE_DASHBOARD
-using Aspire.Hosting.Ats;
+using Aspire.Hosting;
 #endif
 using Microsoft.Extensions.Configuration;
 
@@ -18,10 +17,10 @@ internal sealed class AspireExportIgnoreAttribute : Attribute
 }
 #endif
 
+[AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
 internal static class IConfigurationExtensions
 {
 #if !CLI
-    [AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
     public static T GetValue<T>(this IConfiguration configuration, string primaryKey, string secondaryKey, T defaultValue)
     {
         var primaryValue = configuration.GetValue(typeof(T), primaryKey, null);
@@ -40,14 +39,12 @@ internal static class IConfigurationExtensions
     }
 #endif
 
-    [AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
     public static bool? GetBool(this IConfiguration configuration, string primaryKey, string secondaryKey)
     {
         var value = configuration.GetBool(primaryKey) ?? configuration.GetBool(secondaryKey);
         return value;
     }
 
-    [AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
     public static string? GetString(this IConfiguration configuration, string primaryKey, string secondaryKey, bool fallbackOnEmpty = false)
     {
         var primaryValue = configuration[primaryKey];
@@ -74,7 +71,6 @@ internal static class IConfigurationExtensions
     /// <param name="configuration">The <see cref="IConfiguration"/> this method extends.</param>
     /// <param name="key">The configuration key.</param>
     /// <returns>The parsed value, or <see langword="null"/> if no value exists or it couldn't be parsed.</returns>
-    [AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
     public static bool? GetBool(this IConfiguration configuration, string key)
     {
         var value = configuration[key];
@@ -105,7 +101,6 @@ internal static class IConfigurationExtensions
     /// <param name="key">The configuration key.</param>
     /// <param name="defaultValue">A default value, for when the configuration value is unspecified or white space.</param>
     /// <returns></returns>
-    [AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
     public static bool GetBool(this IConfiguration configuration, string key, bool defaultValue)
     {
         return configuration.GetBool(key) ?? defaultValue;
@@ -120,7 +115,6 @@ internal static class IConfigurationExtensions
     /// <returns>The parsed value, or the default value if specified and parsing failed. Returns <see langword="null"/> if <paramref name="defaultValue"/> is <see langword="null"/> and parsing failed.</returns>
     /// <exception cref="InvalidOperationException">The configuration value could not be accessed, or contained incorrectly formatted data.</exception>
     [return: NotNullIfNotNull(nameof(defaultValue))]
-    [AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
     public static Uri? GetUri(this IConfiguration configuration, string key, Uri? defaultValue = null)
     {
         try
@@ -151,7 +145,6 @@ internal static class IConfigurationExtensions
     /// <returns>The parsed values, or the default value if specified and parsing failed. Returns <see langword="null"/> if <paramref name="defaultValue"/> is <see langword="null"/> and parsing failed.</returns>
     /// <exception cref="InvalidOperationException">The configuration value could not be accessed, or contained incorrectly formatted data.</exception>
     [return: NotNullIfNotNull(nameof(defaultValue))]
-    [AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
     public static Uri[]? GetUris(this IConfiguration configuration, string key, Uri? defaultValue = null)
     {
         try
@@ -192,7 +185,6 @@ internal static class IConfigurationExtensions
     /// <exception cref="InvalidOperationException">The configuration value is not a valid member of the enum.</exception>
     /// <returns>The parsed enum member, or <paramref name="defaultValue"/> the configuration value was null or empty.</returns>
     [return: NotNullIfNotNull(nameof(defaultValue))]
-    [AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
     public static T? GetEnum<T>(this IConfiguration configuration, string key, T? defaultValue = default)
         where T : struct
     {
@@ -220,7 +212,6 @@ internal static class IConfigurationExtensions
     /// <param name="key">The configuration key.</param>
     /// <exception cref="InvalidOperationException">The configuration value is empty or not a valid member of the enum.</exception>
     /// <returns>The parsed enum member.</returns>
-    [AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
     public static T GetEnum<T>(this IConfiguration configuration, string key)
         where T : struct
     {
@@ -245,7 +236,6 @@ internal static class IConfigurationExtensions
     /// <param name="configuration">The <see cref="IConfiguration"/> this method extends.</param>
     /// <param name="configKey">The configuration key to look up.</param>
     /// <returns>The configuration value, or <see langword="null"/> if not found.</returns>
-    [AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
     public static string? GetValueWithNormalizedKey(this IConfiguration configuration, string configKey)
     {
         // First try to get the value with the exact configuration key

--- a/src/Shared/IConfigurationExtensions.cs
+++ b/src/Shared/IConfigurationExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using Aspire.Hosting;
 using Microsoft.Extensions.Configuration;
 
 namespace Aspire;
@@ -9,6 +10,7 @@ namespace Aspire;
 internal static class IConfigurationExtensions
 {
 #if !CLI
+    [AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
     public static T GetValue<T>(this IConfiguration configuration, string primaryKey, string secondaryKey, T defaultValue)
     {
         var primaryValue = configuration.GetValue(typeof(T), primaryKey, null);
@@ -27,12 +29,14 @@ internal static class IConfigurationExtensions
     }
 #endif
 
+    [AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
     public static bool? GetBool(this IConfiguration configuration, string primaryKey, string secondaryKey)
     {
         var value = configuration.GetBool(primaryKey) ?? configuration.GetBool(secondaryKey);
         return value;
     }
 
+    [AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
     public static string? GetString(this IConfiguration configuration, string primaryKey, string secondaryKey, bool fallbackOnEmpty = false)
     {
         var primaryValue = configuration[primaryKey];
@@ -59,6 +63,7 @@ internal static class IConfigurationExtensions
     /// <param name="configuration">The <see cref="IConfiguration"/> this method extends.</param>
     /// <param name="key">The configuration key.</param>
     /// <returns>The parsed value, or <see langword="null"/> if no value exists or it couldn't be parsed.</returns>
+    [AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
     public static bool? GetBool(this IConfiguration configuration, string key)
     {
         var value = configuration[key];
@@ -89,6 +94,7 @@ internal static class IConfigurationExtensions
     /// <param name="key">The configuration key.</param>
     /// <param name="defaultValue">A default value, for when the configuration value is unspecified or white space.</param>
     /// <returns></returns>
+    [AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
     public static bool GetBool(this IConfiguration configuration, string key, bool defaultValue)
     {
         return configuration.GetBool(key) ?? defaultValue;
@@ -103,6 +109,7 @@ internal static class IConfigurationExtensions
     /// <returns>The parsed value, or the default value if specified and parsing failed. Returns <see langword="null"/> if <paramref name="defaultValue"/> is <see langword="null"/> and parsing failed.</returns>
     /// <exception cref="InvalidOperationException">The configuration value could not be accessed, or contained incorrectly formatted data.</exception>
     [return: NotNullIfNotNull(nameof(defaultValue))]
+    [AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
     public static Uri? GetUri(this IConfiguration configuration, string key, Uri? defaultValue = null)
     {
         try
@@ -133,6 +140,7 @@ internal static class IConfigurationExtensions
     /// <returns>The parsed values, or the default value if specified and parsing failed. Returns <see langword="null"/> if <paramref name="defaultValue"/> is <see langword="null"/> and parsing failed.</returns>
     /// <exception cref="InvalidOperationException">The configuration value could not be accessed, or contained incorrectly formatted data.</exception>
     [return: NotNullIfNotNull(nameof(defaultValue))]
+    [AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
     public static Uri[]? GetUris(this IConfiguration configuration, string key, Uri? defaultValue = null)
     {
         try
@@ -173,6 +181,7 @@ internal static class IConfigurationExtensions
     /// <exception cref="InvalidOperationException">The configuration value is not a valid member of the enum.</exception>
     /// <returns>The parsed enum member, or <paramref name="defaultValue"/> the configuration value was null or empty.</returns>
     [return: NotNullIfNotNull(nameof(defaultValue))]
+    [AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
     public static T? GetEnum<T>(this IConfiguration configuration, string key, T? defaultValue = default)
         where T : struct
     {
@@ -200,6 +209,7 @@ internal static class IConfigurationExtensions
     /// <param name="key">The configuration key.</param>
     /// <exception cref="InvalidOperationException">The configuration value is empty or not a valid member of the enum.</exception>
     /// <returns>The parsed enum member.</returns>
+    [AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
     public static T GetEnum<T>(this IConfiguration configuration, string key)
         where T : struct
     {
@@ -224,6 +234,7 @@ internal static class IConfigurationExtensions
     /// <param name="configuration">The <see cref="IConfiguration"/> this method extends.</param>
     /// <param name="configKey">The configuration key to look up.</param>
     /// <returns>The configuration value, or <see langword="null"/> if not found.</returns>
+    [AspireExportIgnore(Reason = "Internal IConfiguration helper — use the dedicated ATS configuration exports instead.")]
     public static string? GetValueWithNormalizedKey(this IConfiguration configuration, string configKey)
     {
         // First try to get the value with the exact configuration key

--- a/src/Shared/IConfigurationExtensions.cs
+++ b/src/Shared/IConfigurationExtensions.cs
@@ -3,9 +3,20 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting;
+#if !CLI && !ASPIRE_DASHBOARD
+using Aspire.Hosting.Ats;
+#endif
 using Microsoft.Extensions.Configuration;
 
 namespace Aspire;
+
+#if CLI || ASPIRE_DASHBOARD
+[AttributeUsage(AttributeTargets.All)]
+internal sealed class AspireExportIgnoreAttribute : Attribute
+{
+    public string? Reason { get; set; }
+}
+#endif
 
 internal static class IConfigurationExtensions
 {

--- a/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
+++ b/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
@@ -1366,6 +1366,24 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
+    public async Task MissingExportAttribute_WithContainingTypeAspireExportIgnore_NoDiagnostics()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using Aspire.Hosting;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            [AspireExportIgnore(Reason = "Not part of the ATS surface.")]
+            public static class TestExtensions
+            {
+                public static void AddThing(this IDistributedApplicationBuilder builder, string name) { }
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
     public async Task MissingExportAttribute_ObsoleteMethod_NoDiagnostics()
     {
         var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
@@ -1633,6 +1651,29 @@ public class AspireExportAnalyzerTests
                     string name,
                     string value)
                     where T : IResource
+                    => builder;
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ExportNameMatchesMethodName_WithInterfaceTarget_NoDiagnostics()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using Aspire.Hosting;
+            using Aspire.Hosting.ApplicationModel;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public static class TestExports
+            {
+                [AspireExport("withReference")]
+                internal static IResourceBuilder<T> WithReference<T>(
+                    this IResourceBuilder<T> builder,
+                    IResourceBuilder<IResource> target)
+                    where T : IResourceWithEnvironment
                     => builder;
             }
             """, []);

--- a/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
+++ b/tests/Aspire.Hosting.Analyzers.Tests/AspireExportAnalyzerTests.cs
@@ -85,6 +85,25 @@ public class AspireExportAnalyzerTests
     }
 
     [Fact]
+    public async Task InstanceMethodOnExportedType_NoDiagnostics()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using Aspire.Hosting;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            [AspireExport]
+            public class TestExports
+            {
+                [AspireExport("instanceMethod")]
+                public string InstanceMethod() => "test";
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
     public async Task InvalidIdFormat_WithSlash_ReportsASPIREEXPORT002()
     {
         var diagnostic = AspireExportAnalyzer.Diagnostics.s_invalidExportIdFormat;
@@ -222,6 +241,28 @@ public class AspireExportAnalyzerTests
 
                 [AspireExport("asyncMethodWithResult")]
                 public static Task<string> AsyncMethodWithResult() => Task.FromResult("test");
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ValidValueTaskReturn_NoDiagnostics()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using Aspire.Hosting;
+            using System.Threading.Tasks;
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public static class TestExports
+            {
+                [AspireExport("asyncMethod")]
+                public static ValueTask AsyncMethod() => ValueTask.CompletedTask;
+
+                [AspireExport("asyncMethodWithResult")]
+                public static ValueTask<string> AsyncMethodWithResult() => ValueTask.FromResult("test");
             }
             """, []);
 
@@ -669,6 +710,48 @@ public class AspireExportAnalyzerTests
 
                 [AspireExport("returnsCustomType")]
                 public static MyCustomType ReturnsCustom() => new();
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task AssemblyExportedExternalType_NoDiagnostics()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using System;
+            using Aspire.Hosting;
+
+            [assembly: AspireExport(typeof(IServiceProvider))]
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public static class TestExports
+            {
+                [AspireExport("getProvider")]
+                public static IServiceProvider GetProvider(this IServiceProvider provider) => provider;
+            }
+            """, []);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ArrayOfAssemblyExportedExternalType_NoDiagnostics()
+    {
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using System;
+            using Aspire.Hosting;
+
+            [assembly: AspireExport(typeof(IServiceProvider))]
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public static class TestExports
+            {
+                [AspireExport("getChildren")]
+                public static IServiceProvider[] GetChildren(IServiceProvider[] providers) => providers;
             }
             """, []);
 
@@ -1382,6 +1465,29 @@ public class AspireExportAnalyzerTests
             }
             """,
             [new DiagnosticResult(diagnostic).WithLocation(13, 24).WithArguments("Configure", "Add [AspireExport] if ATS-compatible, or [AspireExportIgnore] with a reason.")]);
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task MissingExportAttribute_OnAssemblyExportedExternalTypeExtension_ReportsASPIREEXPORT008()
+    {
+        var diagnostic = AspireExportAnalyzer.Diagnostics.s_missingExportAttribute;
+
+        var test = AnalyzerTest.Create<AspireExportAnalyzer>("""
+            using System;
+            using Aspire.Hosting;
+
+            [assembly: AspireExport(typeof(IServiceProvider))]
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            public static class TestExports
+            {
+                public static void Configure(this IServiceProvider serviceProvider) { }
+            }
+            """,
+            [new DiagnosticResult(diagnostic).WithLocation(10, 24).WithArguments("Configure", "Add [AspireExport] if ATS-compatible, or [AspireExportIgnore] with a reason.")]);
 
         await test.RunAsync();
     }

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -726,7 +726,7 @@ func (s *CSharpAppResource) WithReference(source *IResource, connectionName *str
 	if name != nil {
 		reqArgs["name"] = SerializeValue(name)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -1001,7 +1001,7 @@ func (s *CSharpAppResource) PublishWithContainerFiles(source *IResourceWithConta
 	}
 	reqArgs["source"] = SerializeValue(source)
 	reqArgs["destinationPath"] = SerializeValue(destinationPath)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/publishWithContainerFiles", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/publishWithContainerFilesFromResource", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -1026,7 +1026,7 @@ func (s *CSharpAppResource) WaitFor(dependency *IResource) (*IResourceWithWaitSu
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitFor", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResource", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -1053,7 +1053,7 @@ func (s *CSharpAppResource) WaitForStart(dependency *IResource) (*IResourceWithW
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForStart", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResourceStart", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -1095,7 +1095,7 @@ func (s *CSharpAppResource) WaitForCompletion(dependency *IResource, exitCode *f
 	if exitCode != nil {
 		reqArgs["exitCode"] = SerializeValue(exitCode)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForCompletion", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResourceCompletion", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -1190,7 +1190,7 @@ func (s *CSharpAppResource) WithHttpsDeveloperCertificate(password *ParameterRes
 	if password != nil {
 		reqArgs["password"] = SerializeValue(password)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsDeveloperCertificate", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -1215,7 +1215,7 @@ func (s *CSharpAppResource) WithParentRelationship(parent *IResource) (*IResourc
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["parent"] = SerializeValue(parent)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParentRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -1228,7 +1228,7 @@ func (s *CSharpAppResource) WithChildRelationship(child *IResource) (*IResource,
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["child"] = SerializeValue(child)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withChildRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -1894,6 +1894,19 @@ func (s *ConnectionStringResource) WithConnectionPropertyValue(name string, valu
 	return result.(*IResourceWithConnectionString), nil
 }
 
+// GetConnectionProperty gets a connection property by key
+func (s *ConnectionStringResource) GetConnectionProperty(key string) (*ReferenceExpression, error) {
+	reqArgs := map[string]any{
+		"resource": SerializeValue(s.Handle()),
+	}
+	reqArgs["key"] = SerializeValue(key)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/getConnectionProperty", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ReferenceExpression), nil
+}
+
 // WithUrlsCallback customizes displayed URLs via callback
 func (s *ConnectionStringResource) WithUrlsCallback(callback func(...any) any) (*IResource, error) {
 	reqArgs := map[string]any{
@@ -1990,7 +2003,7 @@ func (s *ConnectionStringResource) WaitFor(dependency *IResource) (*IResourceWit
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitFor", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResource", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -2017,7 +2030,7 @@ func (s *ConnectionStringResource) WaitForStart(dependency *IResource) (*IResour
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForStart", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResourceStart", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -2059,7 +2072,7 @@ func (s *ConnectionStringResource) WaitForCompletion(dependency *IResource, exit
 	if exitCode != nil {
 		reqArgs["exitCode"] = SerializeValue(exitCode)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForCompletion", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResourceCompletion", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -2105,7 +2118,7 @@ func (s *ConnectionStringResource) WithParentRelationship(parent *IResource) (*I
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["parent"] = SerializeValue(parent)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParentRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -2118,7 +2131,7 @@ func (s *ConnectionStringResource) WithChildRelationship(child *IResource) (*IRe
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["child"] = SerializeValue(child)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withChildRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -2704,7 +2717,7 @@ func (s *ContainerRegistryResource) WithParentRelationship(parent *IResource) (*
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["parent"] = SerializeValue(parent)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParentRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -2717,7 +2730,7 @@ func (s *ContainerRegistryResource) WithChildRelationship(child *IResource) (*IR
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["child"] = SerializeValue(child)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withChildRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -3262,7 +3275,7 @@ func (s *ContainerResource) WithBuildArg(name string, value *ParameterResource) 
 	}
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuildArg", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildArg", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -3276,7 +3289,7 @@ func (s *ContainerResource) WithBuildSecret(name string, value *ParameterResourc
 	}
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuildSecret", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildSecret", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -3556,7 +3569,7 @@ func (s *ContainerResource) WithReference(source *IResource, connectionName *str
 	if name != nil {
 		reqArgs["name"] = SerializeValue(name)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -3842,7 +3855,7 @@ func (s *ContainerResource) WaitFor(dependency *IResource) (*IResourceWithWaitSu
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitFor", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResource", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -3869,7 +3882,7 @@ func (s *ContainerResource) WaitForStart(dependency *IResource) (*IResourceWithW
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForStart", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResourceStart", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -3911,7 +3924,7 @@ func (s *ContainerResource) WaitForCompletion(dependency *IResource, exitCode *f
 	if exitCode != nil {
 		reqArgs["exitCode"] = SerializeValue(exitCode)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForCompletion", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResourceCompletion", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -4006,7 +4019,7 @@ func (s *ContainerResource) WithHttpsDeveloperCertificate(password *ParameterRes
 	if password != nil {
 		reqArgs["password"] = SerializeValue(password)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsDeveloperCertificate", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -4031,7 +4044,7 @@ func (s *ContainerResource) WithParentRelationship(parent *IResource) (*IResourc
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["parent"] = SerializeValue(parent)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParentRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -4044,7 +4057,7 @@ func (s *ContainerResource) WithChildRelationship(child *IResource) (*IResource,
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["child"] = SerializeValue(child)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withChildRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -5081,7 +5094,7 @@ func (s *DotnetToolResource) WithReference(source *IResource, connectionName *st
 	if name != nil {
 		reqArgs["name"] = SerializeValue(name)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -5367,7 +5380,7 @@ func (s *DotnetToolResource) WaitFor(dependency *IResource) (*IResourceWithWaitS
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitFor", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResource", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -5394,7 +5407,7 @@ func (s *DotnetToolResource) WaitForStart(dependency *IResource) (*IResourceWith
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForStart", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResourceStart", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -5436,7 +5449,7 @@ func (s *DotnetToolResource) WaitForCompletion(dependency *IResource, exitCode *
 	if exitCode != nil {
 		reqArgs["exitCode"] = SerializeValue(exitCode)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForCompletion", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResourceCompletion", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -5531,7 +5544,7 @@ func (s *DotnetToolResource) WithHttpsDeveloperCertificate(password *ParameterRe
 	if password != nil {
 		reqArgs["password"] = SerializeValue(password)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsDeveloperCertificate", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -5556,7 +5569,7 @@ func (s *DotnetToolResource) WithParentRelationship(parent *IResource) (*IResour
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["parent"] = SerializeValue(parent)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParentRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -5569,7 +5582,7 @@ func (s *DotnetToolResource) WithChildRelationship(child *IResource) (*IResource
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["child"] = SerializeValue(child)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withChildRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -6670,7 +6683,7 @@ func (s *ExecutableResource) WithReference(source *IResource, connectionName *st
 	if name != nil {
 		reqArgs["name"] = SerializeValue(name)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -6956,7 +6969,7 @@ func (s *ExecutableResource) WaitFor(dependency *IResource) (*IResourceWithWaitS
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitFor", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResource", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -6983,7 +6996,7 @@ func (s *ExecutableResource) WaitForStart(dependency *IResource) (*IResourceWith
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForStart", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResourceStart", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -7025,7 +7038,7 @@ func (s *ExecutableResource) WaitForCompletion(dependency *IResource, exitCode *
 	if exitCode != nil {
 		reqArgs["exitCode"] = SerializeValue(exitCode)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForCompletion", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResourceCompletion", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -7120,7 +7133,7 @@ func (s *ExecutableResource) WithHttpsDeveloperCertificate(password *ParameterRe
 	if password != nil {
 		reqArgs["password"] = SerializeValue(password)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsDeveloperCertificate", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -7145,7 +7158,7 @@ func (s *ExecutableResource) WithParentRelationship(parent *IResource) (*IResour
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["parent"] = SerializeValue(parent)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParentRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -7158,7 +7171,7 @@ func (s *ExecutableResource) WithChildRelationship(child *IResource) (*IResource
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["child"] = SerializeValue(child)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withChildRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -7913,7 +7926,7 @@ func (s *ExternalServiceResource) WithParentRelationship(parent *IResource) (*IR
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["parent"] = SerializeValue(parent)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParentRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -7926,7 +7939,7 @@ func (s *ExternalServiceResource) WithChildRelationship(child *IResource) (*IRes
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["child"] = SerializeValue(child)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withChildRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -9785,7 +9798,7 @@ func (s *ParameterResource) WithParentRelationship(parent *IResource) (*IResourc
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["parent"] = SerializeValue(parent)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParentRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -9798,7 +9811,7 @@ func (s *ParameterResource) WithChildRelationship(child *IResource) (*IResource,
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["child"] = SerializeValue(child)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withChildRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -11045,7 +11058,7 @@ func (s *ProjectResource) WithReference(source *IResource, connectionName *strin
 	if name != nil {
 		reqArgs["name"] = SerializeValue(name)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -11320,7 +11333,7 @@ func (s *ProjectResource) PublishWithContainerFiles(source *IResourceWithContain
 	}
 	reqArgs["source"] = SerializeValue(source)
 	reqArgs["destinationPath"] = SerializeValue(destinationPath)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/publishWithContainerFiles", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/publishWithContainerFilesFromResource", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -11345,7 +11358,7 @@ func (s *ProjectResource) WaitFor(dependency *IResource) (*IResourceWithWaitSupp
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitFor", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResource", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -11372,7 +11385,7 @@ func (s *ProjectResource) WaitForStart(dependency *IResource) (*IResourceWithWai
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForStart", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResourceStart", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -11414,7 +11427,7 @@ func (s *ProjectResource) WaitForCompletion(dependency *IResource, exitCode *flo
 	if exitCode != nil {
 		reqArgs["exitCode"] = SerializeValue(exitCode)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForCompletion", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResourceCompletion", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -11509,7 +11522,7 @@ func (s *ProjectResource) WithHttpsDeveloperCertificate(password *ParameterResou
 	if password != nil {
 		reqArgs["password"] = SerializeValue(password)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsDeveloperCertificate", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -11534,7 +11547,7 @@ func (s *ProjectResource) WithParentRelationship(parent *IResource) (*IResource,
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["parent"] = SerializeValue(parent)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParentRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -11547,7 +11560,7 @@ func (s *ProjectResource) WithChildRelationship(child *IResource) (*IResource, e
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["child"] = SerializeValue(child)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withChildRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -12786,7 +12799,7 @@ func (s *TestDatabaseResource) WithBuildArg(name string, value *ParameterResourc
 	}
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuildArg", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildArg", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -12800,7 +12813,7 @@ func (s *TestDatabaseResource) WithBuildSecret(name string, value *ParameterReso
 	}
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuildSecret", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildSecret", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -13080,7 +13093,7 @@ func (s *TestDatabaseResource) WithReference(source *IResource, connectionName *
 	if name != nil {
 		reqArgs["name"] = SerializeValue(name)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -13366,7 +13379,7 @@ func (s *TestDatabaseResource) WaitFor(dependency *IResource) (*IResourceWithWai
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitFor", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResource", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -13393,7 +13406,7 @@ func (s *TestDatabaseResource) WaitForStart(dependency *IResource) (*IResourceWi
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForStart", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResourceStart", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -13435,7 +13448,7 @@ func (s *TestDatabaseResource) WaitForCompletion(dependency *IResource, exitCode
 	if exitCode != nil {
 		reqArgs["exitCode"] = SerializeValue(exitCode)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForCompletion", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResourceCompletion", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -13530,7 +13543,7 @@ func (s *TestDatabaseResource) WithHttpsDeveloperCertificate(password *Parameter
 	if password != nil {
 		reqArgs["password"] = SerializeValue(password)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsDeveloperCertificate", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -13555,7 +13568,7 @@ func (s *TestDatabaseResource) WithParentRelationship(parent *IResource) (*IReso
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["parent"] = SerializeValue(parent)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParentRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -13568,7 +13581,7 @@ func (s *TestDatabaseResource) WithChildRelationship(child *IResource) (*IResour
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["child"] = SerializeValue(child)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withChildRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -14324,7 +14337,7 @@ func (s *TestRedisResource) WithBuildArg(name string, value *ParameterResource) 
 	}
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuildArg", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildArg", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -14338,7 +14351,7 @@ func (s *TestRedisResource) WithBuildSecret(name string, value *ParameterResourc
 	}
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuildSecret", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildSecret", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -14646,11 +14659,24 @@ func (s *TestRedisResource) WithReference(source *IResource, connectionName *str
 	if name != nil {
 		reqArgs["name"] = SerializeValue(name)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs)
 	if err != nil {
 		return nil, err
 	}
 	return result.(*IResourceWithEnvironment), nil
+}
+
+// GetConnectionProperty gets a connection property by key
+func (s *TestRedisResource) GetConnectionProperty(key string) (*ReferenceExpression, error) {
+	reqArgs := map[string]any{
+		"resource": SerializeValue(s.Handle()),
+	}
+	reqArgs["key"] = SerializeValue(key)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/getConnectionProperty", reqArgs)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ReferenceExpression), nil
 }
 
 // WithReferenceUri adds a reference to a URI
@@ -14932,7 +14958,7 @@ func (s *TestRedisResource) WaitFor(dependency *IResource) (*IResourceWithWaitSu
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitFor", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResource", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -14959,7 +14985,7 @@ func (s *TestRedisResource) WaitForStart(dependency *IResource) (*IResourceWithW
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForStart", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResourceStart", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -15001,7 +15027,7 @@ func (s *TestRedisResource) WaitForCompletion(dependency *IResource, exitCode *f
 	if exitCode != nil {
 		reqArgs["exitCode"] = SerializeValue(exitCode)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForCompletion", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResourceCompletion", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -15096,7 +15122,7 @@ func (s *TestRedisResource) WithHttpsDeveloperCertificate(password *ParameterRes
 	if password != nil {
 		reqArgs["password"] = SerializeValue(password)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsDeveloperCertificate", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -15121,7 +15147,7 @@ func (s *TestRedisResource) WithParentRelationship(parent *IResource) (*IResourc
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["parent"] = SerializeValue(parent)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParentRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -15134,7 +15160,7 @@ func (s *TestRedisResource) WithChildRelationship(child *IResource) (*IResource,
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["child"] = SerializeValue(child)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withChildRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -16074,7 +16100,7 @@ func (s *TestVaultResource) WithBuildArg(name string, value *ParameterResource) 
 	}
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuildArg", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildArg", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -16088,7 +16114,7 @@ func (s *TestVaultResource) WithBuildSecret(name string, value *ParameterResourc
 	}
 	reqArgs["name"] = SerializeValue(name)
 	reqArgs["value"] = SerializeValue(value)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuildSecret", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterBuildSecret", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -16368,7 +16394,7 @@ func (s *TestVaultResource) WithReference(source *IResource, connectionName *str
 	if name != nil {
 		reqArgs["name"] = SerializeValue(name)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -16654,7 +16680,7 @@ func (s *TestVaultResource) WaitFor(dependency *IResource) (*IResourceWithWaitSu
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitFor", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResource", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -16681,7 +16707,7 @@ func (s *TestVaultResource) WaitForStart(dependency *IResource) (*IResourceWithW
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["dependency"] = SerializeValue(dependency)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForStart", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResourceStart", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -16723,7 +16749,7 @@ func (s *TestVaultResource) WaitForCompletion(dependency *IResource, exitCode *f
 	if exitCode != nil {
 		reqArgs["exitCode"] = SerializeValue(exitCode)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForCompletion", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/waitForResourceCompletion", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -16818,7 +16844,7 @@ func (s *TestVaultResource) WithHttpsDeveloperCertificate(password *ParameterRes
 	if password != nil {
 		reqArgs["password"] = SerializeValue(password)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withHttpsDeveloperCertificate", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -16843,7 +16869,7 @@ func (s *TestVaultResource) WithParentRelationship(parent *IResource) (*IResourc
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["parent"] = SerializeValue(parent)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withParentRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -16856,7 +16882,7 @@ func (s *TestVaultResource) WithChildRelationship(child *IResource) (*IResource,
 		"builder": SerializeValue(s.Handle()),
 	}
 	reqArgs["child"] = SerializeValue(child)
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withChildRelationship", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -726,7 +726,7 @@ func (s *CSharpAppResource) WithReference(source *IResource, connectionName *str
 	if name != nil {
 		reqArgs["name"] = SerializeValue(name)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -3569,7 +3569,7 @@ func (s *ContainerResource) WithReference(source *IResource, connectionName *str
 	if name != nil {
 		reqArgs["name"] = SerializeValue(name)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -5094,7 +5094,7 @@ func (s *DotnetToolResource) WithReference(source *IResource, connectionName *st
 	if name != nil {
 		reqArgs["name"] = SerializeValue(name)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -6683,7 +6683,7 @@ func (s *ExecutableResource) WithReference(source *IResource, connectionName *st
 	if name != nil {
 		reqArgs["name"] = SerializeValue(name)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -11058,7 +11058,7 @@ func (s *ProjectResource) WithReference(source *IResource, connectionName *strin
 	if name != nil {
 		reqArgs["name"] = SerializeValue(name)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -13093,7 +13093,7 @@ func (s *TestDatabaseResource) WithReference(source *IResource, connectionName *
 	if name != nil {
 		reqArgs["name"] = SerializeValue(name)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -14659,7 +14659,7 @@ func (s *TestRedisResource) WithReference(source *IResource, connectionName *str
 	if name != nil {
 		reqArgs["name"] = SerializeValue(name)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -16394,7 +16394,7 @@ func (s *TestVaultResource) WithReference(source *IResource, connectionName *str
 	if name != nil {
 		reqArgs["name"] = SerializeValue(name)
 	}
-	result, err := s.Client().InvokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs)
+	result, err := s.Client().InvokeCapability("Aspire.Hosting/withReference", reqArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -825,7 +825,7 @@ class CSharpAppResource extends ResourceBuilderBase {
         if (name != null) {
             reqArgs.put("name", AspireClient.serializeValue(name));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withReference", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs);
     }
 
     /** Adds a reference to a URI */
@@ -1020,7 +1020,7 @@ class CSharpAppResource extends ResourceBuilderBase {
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("source", AspireClient.serializeValue(source));
         reqArgs.put("destinationPath", AspireClient.serializeValue(destinationPath));
-        return (IContainerFilesDestinationResource) getClient().invokeCapability("Aspire.Hosting/publishWithContainerFiles", reqArgs);
+        return (IContainerFilesDestinationResource) getClient().invokeCapability("Aspire.Hosting/publishWithContainerFilesFromResource", reqArgs);
     }
 
     /** Excludes the resource from the deployment manifest */
@@ -1035,7 +1035,7 @@ class CSharpAppResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("dependency", AspireClient.serializeValue(dependency));
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitFor", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResource", reqArgs);
     }
 
     /** Waits for another resource with specific behavior */
@@ -1052,7 +1052,7 @@ class CSharpAppResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("dependency", AspireClient.serializeValue(dependency));
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForStart", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResourceStart", reqArgs);
     }
 
     /** Waits for another resource to start with specific behavior */
@@ -1079,7 +1079,7 @@ class CSharpAppResource extends ResourceBuilderBase {
         if (exitCode != null) {
             reqArgs.put("exitCode", AspireClient.serializeValue(exitCode));
         }
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForCompletion", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResourceCompletion", reqArgs);
     }
 
     /** Adds a health check by key */
@@ -1144,7 +1144,7 @@ class CSharpAppResource extends ResourceBuilderBase {
         if (password != null) {
             reqArgs.put("password", AspireClient.serializeValue(password));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withHttpsDeveloperCertificate", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", reqArgs);
     }
 
     /** Removes HTTPS certificate configuration */
@@ -1159,7 +1159,7 @@ class CSharpAppResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("parent", AspireClient.serializeValue(parent));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withParentRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs);
     }
 
     /** Sets a child relationship */
@@ -1167,7 +1167,7 @@ class CSharpAppResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("child", AspireClient.serializeValue(child));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withChildRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs);
     }
 
     /** Sets the icon for the resource */
@@ -1607,6 +1607,14 @@ class ConnectionStringResource extends ResourceBuilderBase {
         return (IResourceWithConnectionString) getClient().invokeCapability("Aspire.Hosting/withConnectionPropertyValue", reqArgs);
     }
 
+    /** Gets a connection property by key */
+    public ReferenceExpression getConnectionProperty(String key) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("key", AspireClient.serializeValue(key));
+        return (ReferenceExpression) getClient().invokeCapability("Aspire.Hosting/getConnectionProperty", reqArgs);
+    }
+
     /** Customizes displayed URLs via callback */
     public IResource withUrlsCallback(Function<Object[], Object> callback) {
         Map<String, Object> reqArgs = new HashMap<>();
@@ -1672,7 +1680,7 @@ class ConnectionStringResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("dependency", AspireClient.serializeValue(dependency));
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitFor", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResource", reqArgs);
     }
 
     /** Waits for another resource with specific behavior */
@@ -1689,7 +1697,7 @@ class ConnectionStringResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("dependency", AspireClient.serializeValue(dependency));
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForStart", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResourceStart", reqArgs);
     }
 
     /** Waits for another resource to start with specific behavior */
@@ -1716,7 +1724,7 @@ class ConnectionStringResource extends ResourceBuilderBase {
         if (exitCode != null) {
             reqArgs.put("exitCode", AspireClient.serializeValue(exitCode));
         }
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForCompletion", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResourceCompletion", reqArgs);
     }
 
     /** Adds a health check by key */
@@ -1747,7 +1755,7 @@ class ConnectionStringResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("parent", AspireClient.serializeValue(parent));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withParentRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs);
     }
 
     /** Sets a child relationship */
@@ -1755,7 +1763,7 @@ class ConnectionStringResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("child", AspireClient.serializeValue(child));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withChildRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs);
     }
 
     /** Sets the icon for the resource */
@@ -2142,7 +2150,7 @@ class ContainerRegistryResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("parent", AspireClient.serializeValue(parent));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withParentRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs);
     }
 
     /** Sets a child relationship */
@@ -2150,7 +2158,7 @@ class ContainerRegistryResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("child", AspireClient.serializeValue(child));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withChildRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs);
     }
 
     /** Sets the icon for the resource */
@@ -2506,7 +2514,7 @@ class ContainerResource extends ResourceBuilderBase {
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("name", AspireClient.serializeValue(name));
         reqArgs.put("value", AspireClient.serializeValue(value));
-        return (ContainerResource) getClient().invokeCapability("Aspire.Hosting/withBuildArg", reqArgs);
+        return (ContainerResource) getClient().invokeCapability("Aspire.Hosting/withParameterBuildArg", reqArgs);
     }
 
     /** Adds a build secret from a parameter resource */
@@ -2515,7 +2523,7 @@ class ContainerResource extends ResourceBuilderBase {
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("name", AspireClient.serializeValue(name));
         reqArgs.put("value", AspireClient.serializeValue(value));
-        return (ContainerResource) getClient().invokeCapability("Aspire.Hosting/withBuildSecret", reqArgs);
+        return (ContainerResource) getClient().invokeCapability("Aspire.Hosting/withParameterBuildSecret", reqArgs);
     }
 
     /** Configures endpoint proxy support */
@@ -2700,7 +2708,7 @@ class ContainerResource extends ResourceBuilderBase {
         if (name != null) {
             reqArgs.put("name", AspireClient.serializeValue(name));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withReference", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs);
     }
 
     /** Adds a reference to a URI */
@@ -2901,7 +2909,7 @@ class ContainerResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("dependency", AspireClient.serializeValue(dependency));
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitFor", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResource", reqArgs);
     }
 
     /** Waits for another resource with specific behavior */
@@ -2918,7 +2926,7 @@ class ContainerResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("dependency", AspireClient.serializeValue(dependency));
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForStart", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResourceStart", reqArgs);
     }
 
     /** Waits for another resource to start with specific behavior */
@@ -2945,7 +2953,7 @@ class ContainerResource extends ResourceBuilderBase {
         if (exitCode != null) {
             reqArgs.put("exitCode", AspireClient.serializeValue(exitCode));
         }
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForCompletion", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResourceCompletion", reqArgs);
     }
 
     /** Adds a health check by key */
@@ -3010,7 +3018,7 @@ class ContainerResource extends ResourceBuilderBase {
         if (password != null) {
             reqArgs.put("password", AspireClient.serializeValue(password));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withHttpsDeveloperCertificate", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", reqArgs);
     }
 
     /** Removes HTTPS certificate configuration */
@@ -3025,7 +3033,7 @@ class ContainerResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("parent", AspireClient.serializeValue(parent));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withParentRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs);
     }
 
     /** Sets a child relationship */
@@ -3033,7 +3041,7 @@ class ContainerResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("child", AspireClient.serializeValue(child));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withChildRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs);
     }
 
     /** Sets the icon for the resource */
@@ -3715,7 +3723,7 @@ class DotnetToolResource extends ResourceBuilderBase {
         if (name != null) {
             reqArgs.put("name", AspireClient.serializeValue(name));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withReference", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs);
     }
 
     /** Adds a reference to a URI */
@@ -3916,7 +3924,7 @@ class DotnetToolResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("dependency", AspireClient.serializeValue(dependency));
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitFor", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResource", reqArgs);
     }
 
     /** Waits for another resource with specific behavior */
@@ -3933,7 +3941,7 @@ class DotnetToolResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("dependency", AspireClient.serializeValue(dependency));
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForStart", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResourceStart", reqArgs);
     }
 
     /** Waits for another resource to start with specific behavior */
@@ -3960,7 +3968,7 @@ class DotnetToolResource extends ResourceBuilderBase {
         if (exitCode != null) {
             reqArgs.put("exitCode", AspireClient.serializeValue(exitCode));
         }
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForCompletion", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResourceCompletion", reqArgs);
     }
 
     /** Adds a health check by key */
@@ -4025,7 +4033,7 @@ class DotnetToolResource extends ResourceBuilderBase {
         if (password != null) {
             reqArgs.put("password", AspireClient.serializeValue(password));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withHttpsDeveloperCertificate", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", reqArgs);
     }
 
     /** Removes HTTPS certificate configuration */
@@ -4040,7 +4048,7 @@ class DotnetToolResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("parent", AspireClient.serializeValue(parent));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withParentRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs);
     }
 
     /** Sets a child relationship */
@@ -4048,7 +4056,7 @@ class DotnetToolResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("child", AspireClient.serializeValue(child));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withChildRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs);
     }
 
     /** Sets the icon for the resource */
@@ -4763,7 +4771,7 @@ class ExecutableResource extends ResourceBuilderBase {
         if (name != null) {
             reqArgs.put("name", AspireClient.serializeValue(name));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withReference", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs);
     }
 
     /** Adds a reference to a URI */
@@ -4964,7 +4972,7 @@ class ExecutableResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("dependency", AspireClient.serializeValue(dependency));
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitFor", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResource", reqArgs);
     }
 
     /** Waits for another resource with specific behavior */
@@ -4981,7 +4989,7 @@ class ExecutableResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("dependency", AspireClient.serializeValue(dependency));
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForStart", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResourceStart", reqArgs);
     }
 
     /** Waits for another resource to start with specific behavior */
@@ -5008,7 +5016,7 @@ class ExecutableResource extends ResourceBuilderBase {
         if (exitCode != null) {
             reqArgs.put("exitCode", AspireClient.serializeValue(exitCode));
         }
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForCompletion", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResourceCompletion", reqArgs);
     }
 
     /** Adds a health check by key */
@@ -5073,7 +5081,7 @@ class ExecutableResource extends ResourceBuilderBase {
         if (password != null) {
             reqArgs.put("password", AspireClient.serializeValue(password));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withHttpsDeveloperCertificate", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", reqArgs);
     }
 
     /** Removes HTTPS certificate configuration */
@@ -5088,7 +5096,7 @@ class ExecutableResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("parent", AspireClient.serializeValue(parent));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withParentRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs);
     }
 
     /** Sets a child relationship */
@@ -5096,7 +5104,7 @@ class ExecutableResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("child", AspireClient.serializeValue(child));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withChildRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs);
     }
 
     /** Sets the icon for the resource */
@@ -5598,7 +5606,7 @@ class ExternalServiceResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("parent", AspireClient.serializeValue(parent));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withParentRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs);
     }
 
     /** Sets a child relationship */
@@ -5606,7 +5614,7 @@ class ExternalServiceResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("child", AspireClient.serializeValue(child));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withChildRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs);
     }
 
     /** Sets the icon for the resource */
@@ -6854,7 +6862,7 @@ class ParameterResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("parent", AspireClient.serializeValue(parent));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withParentRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs);
     }
 
     /** Sets a child relationship */
@@ -6862,7 +6870,7 @@ class ParameterResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("child", AspireClient.serializeValue(child));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withChildRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs);
     }
 
     /** Sets the icon for the resource */
@@ -7673,7 +7681,7 @@ class ProjectResource extends ResourceBuilderBase {
         if (name != null) {
             reqArgs.put("name", AspireClient.serializeValue(name));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withReference", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs);
     }
 
     /** Adds a reference to a URI */
@@ -7868,7 +7876,7 @@ class ProjectResource extends ResourceBuilderBase {
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("source", AspireClient.serializeValue(source));
         reqArgs.put("destinationPath", AspireClient.serializeValue(destinationPath));
-        return (IContainerFilesDestinationResource) getClient().invokeCapability("Aspire.Hosting/publishWithContainerFiles", reqArgs);
+        return (IContainerFilesDestinationResource) getClient().invokeCapability("Aspire.Hosting/publishWithContainerFilesFromResource", reqArgs);
     }
 
     /** Excludes the resource from the deployment manifest */
@@ -7883,7 +7891,7 @@ class ProjectResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("dependency", AspireClient.serializeValue(dependency));
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitFor", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResource", reqArgs);
     }
 
     /** Waits for another resource with specific behavior */
@@ -7900,7 +7908,7 @@ class ProjectResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("dependency", AspireClient.serializeValue(dependency));
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForStart", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResourceStart", reqArgs);
     }
 
     /** Waits for another resource to start with specific behavior */
@@ -7927,7 +7935,7 @@ class ProjectResource extends ResourceBuilderBase {
         if (exitCode != null) {
             reqArgs.put("exitCode", AspireClient.serializeValue(exitCode));
         }
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForCompletion", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResourceCompletion", reqArgs);
     }
 
     /** Adds a health check by key */
@@ -7992,7 +8000,7 @@ class ProjectResource extends ResourceBuilderBase {
         if (password != null) {
             reqArgs.put("password", AspireClient.serializeValue(password));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withHttpsDeveloperCertificate", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", reqArgs);
     }
 
     /** Removes HTTPS certificate configuration */
@@ -8007,7 +8015,7 @@ class ProjectResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("parent", AspireClient.serializeValue(parent));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withParentRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs);
     }
 
     /** Sets a child relationship */
@@ -8015,7 +8023,7 @@ class ProjectResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("child", AspireClient.serializeValue(child));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withChildRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs);
     }
 
     /** Sets the icon for the resource */
@@ -8839,7 +8847,7 @@ class TestDatabaseResource extends ResourceBuilderBase {
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("name", AspireClient.serializeValue(name));
         reqArgs.put("value", AspireClient.serializeValue(value));
-        return (ContainerResource) getClient().invokeCapability("Aspire.Hosting/withBuildArg", reqArgs);
+        return (ContainerResource) getClient().invokeCapability("Aspire.Hosting/withParameterBuildArg", reqArgs);
     }
 
     /** Adds a build secret from a parameter resource */
@@ -8848,7 +8856,7 @@ class TestDatabaseResource extends ResourceBuilderBase {
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("name", AspireClient.serializeValue(name));
         reqArgs.put("value", AspireClient.serializeValue(value));
-        return (ContainerResource) getClient().invokeCapability("Aspire.Hosting/withBuildSecret", reqArgs);
+        return (ContainerResource) getClient().invokeCapability("Aspire.Hosting/withParameterBuildSecret", reqArgs);
     }
 
     /** Configures endpoint proxy support */
@@ -9033,7 +9041,7 @@ class TestDatabaseResource extends ResourceBuilderBase {
         if (name != null) {
             reqArgs.put("name", AspireClient.serializeValue(name));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withReference", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs);
     }
 
     /** Adds a reference to a URI */
@@ -9234,7 +9242,7 @@ class TestDatabaseResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("dependency", AspireClient.serializeValue(dependency));
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitFor", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResource", reqArgs);
     }
 
     /** Waits for another resource with specific behavior */
@@ -9251,7 +9259,7 @@ class TestDatabaseResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("dependency", AspireClient.serializeValue(dependency));
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForStart", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResourceStart", reqArgs);
     }
 
     /** Waits for another resource to start with specific behavior */
@@ -9278,7 +9286,7 @@ class TestDatabaseResource extends ResourceBuilderBase {
         if (exitCode != null) {
             reqArgs.put("exitCode", AspireClient.serializeValue(exitCode));
         }
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForCompletion", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResourceCompletion", reqArgs);
     }
 
     /** Adds a health check by key */
@@ -9343,7 +9351,7 @@ class TestDatabaseResource extends ResourceBuilderBase {
         if (password != null) {
             reqArgs.put("password", AspireClient.serializeValue(password));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withHttpsDeveloperCertificate", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", reqArgs);
     }
 
     /** Removes HTTPS certificate configuration */
@@ -9358,7 +9366,7 @@ class TestDatabaseResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("parent", AspireClient.serializeValue(parent));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withParentRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs);
     }
 
     /** Sets a child relationship */
@@ -9366,7 +9374,7 @@ class TestDatabaseResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("child", AspireClient.serializeValue(child));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withChildRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs);
     }
 
     /** Sets the icon for the resource */
@@ -9862,7 +9870,7 @@ class TestRedisResource extends ResourceBuilderBase {
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("name", AspireClient.serializeValue(name));
         reqArgs.put("value", AspireClient.serializeValue(value));
-        return (ContainerResource) getClient().invokeCapability("Aspire.Hosting/withBuildArg", reqArgs);
+        return (ContainerResource) getClient().invokeCapability("Aspire.Hosting/withParameterBuildArg", reqArgs);
     }
 
     /** Adds a build secret from a parameter resource */
@@ -9871,7 +9879,7 @@ class TestRedisResource extends ResourceBuilderBase {
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("name", AspireClient.serializeValue(name));
         reqArgs.put("value", AspireClient.serializeValue(value));
-        return (ContainerResource) getClient().invokeCapability("Aspire.Hosting/withBuildSecret", reqArgs);
+        return (ContainerResource) getClient().invokeCapability("Aspire.Hosting/withParameterBuildSecret", reqArgs);
     }
 
     /** Configures endpoint proxy support */
@@ -10074,7 +10082,15 @@ class TestRedisResource extends ResourceBuilderBase {
         if (name != null) {
             reqArgs.put("name", AspireClient.serializeValue(name));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withReference", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs);
+    }
+
+    /** Gets a connection property by key */
+    public ReferenceExpression getConnectionProperty(String key) {
+        Map<String, Object> reqArgs = new HashMap<>();
+        reqArgs.put("resource", AspireClient.serializeValue(getHandle()));
+        reqArgs.put("key", AspireClient.serializeValue(key));
+        return (ReferenceExpression) getClient().invokeCapability("Aspire.Hosting/getConnectionProperty", reqArgs);
     }
 
     /** Adds a reference to a URI */
@@ -10275,7 +10291,7 @@ class TestRedisResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("dependency", AspireClient.serializeValue(dependency));
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitFor", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResource", reqArgs);
     }
 
     /** Waits for another resource with specific behavior */
@@ -10292,7 +10308,7 @@ class TestRedisResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("dependency", AspireClient.serializeValue(dependency));
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForStart", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResourceStart", reqArgs);
     }
 
     /** Waits for another resource to start with specific behavior */
@@ -10319,7 +10335,7 @@ class TestRedisResource extends ResourceBuilderBase {
         if (exitCode != null) {
             reqArgs.put("exitCode", AspireClient.serializeValue(exitCode));
         }
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForCompletion", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResourceCompletion", reqArgs);
     }
 
     /** Adds a health check by key */
@@ -10384,7 +10400,7 @@ class TestRedisResource extends ResourceBuilderBase {
         if (password != null) {
             reqArgs.put("password", AspireClient.serializeValue(password));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withHttpsDeveloperCertificate", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", reqArgs);
     }
 
     /** Removes HTTPS certificate configuration */
@@ -10399,7 +10415,7 @@ class TestRedisResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("parent", AspireClient.serializeValue(parent));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withParentRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs);
     }
 
     /** Sets a child relationship */
@@ -10407,7 +10423,7 @@ class TestRedisResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("child", AspireClient.serializeValue(child));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withChildRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs);
     }
 
     /** Sets the icon for the resource */
@@ -11034,7 +11050,7 @@ class TestVaultResource extends ResourceBuilderBase {
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("name", AspireClient.serializeValue(name));
         reqArgs.put("value", AspireClient.serializeValue(value));
-        return (ContainerResource) getClient().invokeCapability("Aspire.Hosting/withBuildArg", reqArgs);
+        return (ContainerResource) getClient().invokeCapability("Aspire.Hosting/withParameterBuildArg", reqArgs);
     }
 
     /** Adds a build secret from a parameter resource */
@@ -11043,7 +11059,7 @@ class TestVaultResource extends ResourceBuilderBase {
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("name", AspireClient.serializeValue(name));
         reqArgs.put("value", AspireClient.serializeValue(value));
-        return (ContainerResource) getClient().invokeCapability("Aspire.Hosting/withBuildSecret", reqArgs);
+        return (ContainerResource) getClient().invokeCapability("Aspire.Hosting/withParameterBuildSecret", reqArgs);
     }
 
     /** Configures endpoint proxy support */
@@ -11228,7 +11244,7 @@ class TestVaultResource extends ResourceBuilderBase {
         if (name != null) {
             reqArgs.put("name", AspireClient.serializeValue(name));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withReference", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs);
     }
 
     /** Adds a reference to a URI */
@@ -11429,7 +11445,7 @@ class TestVaultResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("dependency", AspireClient.serializeValue(dependency));
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitFor", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResource", reqArgs);
     }
 
     /** Waits for another resource with specific behavior */
@@ -11446,7 +11462,7 @@ class TestVaultResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("dependency", AspireClient.serializeValue(dependency));
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForStart", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResourceStart", reqArgs);
     }
 
     /** Waits for another resource to start with specific behavior */
@@ -11473,7 +11489,7 @@ class TestVaultResource extends ResourceBuilderBase {
         if (exitCode != null) {
             reqArgs.put("exitCode", AspireClient.serializeValue(exitCode));
         }
-        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForCompletion", reqArgs);
+        return (IResourceWithWaitSupport) getClient().invokeCapability("Aspire.Hosting/waitForResourceCompletion", reqArgs);
     }
 
     /** Adds a health check by key */
@@ -11538,7 +11554,7 @@ class TestVaultResource extends ResourceBuilderBase {
         if (password != null) {
             reqArgs.put("password", AspireClient.serializeValue(password));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withHttpsDeveloperCertificate", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", reqArgs);
     }
 
     /** Removes HTTPS certificate configuration */
@@ -11553,7 +11569,7 @@ class TestVaultResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("parent", AspireClient.serializeValue(parent));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withParentRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderParentRelationship", reqArgs);
     }
 
     /** Sets a child relationship */
@@ -11561,7 +11577,7 @@ class TestVaultResource extends ResourceBuilderBase {
         Map<String, Object> reqArgs = new HashMap<>();
         reqArgs.put("builder", AspireClient.serializeValue(getHandle()));
         reqArgs.put("child", AspireClient.serializeValue(child));
-        return (IResource) getClient().invokeCapability("Aspire.Hosting/withChildRelationship", reqArgs);
+        return (IResource) getClient().invokeCapability("Aspire.Hosting/withBuilderChildRelationship", reqArgs);
     }
 
     /** Sets the icon for the resource */

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -825,7 +825,7 @@ class CSharpAppResource extends ResourceBuilderBase {
         if (name != null) {
             reqArgs.put("name", AspireClient.serializeValue(name));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withReference", reqArgs);
     }
 
     /** Adds a reference to a URI */
@@ -2708,7 +2708,7 @@ class ContainerResource extends ResourceBuilderBase {
         if (name != null) {
             reqArgs.put("name", AspireClient.serializeValue(name));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withReference", reqArgs);
     }
 
     /** Adds a reference to a URI */
@@ -3723,7 +3723,7 @@ class DotnetToolResource extends ResourceBuilderBase {
         if (name != null) {
             reqArgs.put("name", AspireClient.serializeValue(name));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withReference", reqArgs);
     }
 
     /** Adds a reference to a URI */
@@ -4771,7 +4771,7 @@ class ExecutableResource extends ResourceBuilderBase {
         if (name != null) {
             reqArgs.put("name", AspireClient.serializeValue(name));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withReference", reqArgs);
     }
 
     /** Adds a reference to a URI */
@@ -7681,7 +7681,7 @@ class ProjectResource extends ResourceBuilderBase {
         if (name != null) {
             reqArgs.put("name", AspireClient.serializeValue(name));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withReference", reqArgs);
     }
 
     /** Adds a reference to a URI */
@@ -9041,7 +9041,7 @@ class TestDatabaseResource extends ResourceBuilderBase {
         if (name != null) {
             reqArgs.put("name", AspireClient.serializeValue(name));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withReference", reqArgs);
     }
 
     /** Adds a reference to a URI */
@@ -10082,7 +10082,7 @@ class TestRedisResource extends ResourceBuilderBase {
         if (name != null) {
             reqArgs.put("name", AspireClient.serializeValue(name));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withReference", reqArgs);
     }
 
     /** Gets a connection property by key */
@@ -11244,7 +11244,7 @@ class TestVaultResource extends ResourceBuilderBase {
         if (name != null) {
             reqArgs.put("name", AspireClient.serializeValue(name));
         }
-        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withGenericResourceReference", reqArgs);
+        return (IResourceWithEnvironment) getClient().invokeCapability("Aspire.Hosting/withReference", reqArgs);
     }
 
     /** Adds a reference to a URI */

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -438,7 +438,7 @@ class CSharpAppResource(ResourceBuilderBase):
         args["optional"] = serialize_value(optional)
         if name is not None:
             args["name"] = serialize_value(name)
-        return self._client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)
+        return self._client.invoke_capability("Aspire.Hosting/withReference", args)
 
     def with_reference_uri(self, name: str, uri: str) -> IResourceWithEnvironment:
         """Adds a reference to a URI"""
@@ -1845,7 +1845,7 @@ class ContainerResource(ResourceBuilderBase):
         args["optional"] = serialize_value(optional)
         if name is not None:
             args["name"] = serialize_value(name)
-        return self._client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)
+        return self._client.invoke_capability("Aspire.Hosting/withReference", args)
 
     def with_reference_uri(self, name: str, uri: str) -> IResourceWithEnvironment:
         """Adds a reference to a URI"""
@@ -2590,7 +2590,7 @@ class DotnetToolResource(ResourceBuilderBase):
         args["optional"] = serialize_value(optional)
         if name is not None:
             args["name"] = serialize_value(name)
-        return self._client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)
+        return self._client.invoke_capability("Aspire.Hosting/withReference", args)
 
     def with_reference_uri(self, name: str, uri: str) -> IResourceWithEnvironment:
         """Adds a reference to a URI"""
@@ -3362,7 +3362,7 @@ class ExecutableResource(ResourceBuilderBase):
         args["optional"] = serialize_value(optional)
         if name is not None:
             args["name"] = serialize_value(name)
-        return self._client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)
+        return self._client.invoke_capability("Aspire.Hosting/withReference", args)
 
     def with_reference_uri(self, name: str, uri: str) -> IResourceWithEnvironment:
         """Adds a reference to a URI"""
@@ -5539,7 +5539,7 @@ class ProjectResource(ResourceBuilderBase):
         args["optional"] = serialize_value(optional)
         if name is not None:
             args["name"] = serialize_value(name)
-        return self._client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)
+        return self._client.invoke_capability("Aspire.Hosting/withReference", args)
 
     def with_reference_uri(self, name: str, uri: str) -> IResourceWithEnvironment:
         """Adds a reference to a URI"""
@@ -6565,7 +6565,7 @@ class TestDatabaseResource(ResourceBuilderBase):
         args["optional"] = serialize_value(optional)
         if name is not None:
             args["name"] = serialize_value(name)
-        return self._client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)
+        return self._client.invoke_capability("Aspire.Hosting/withReference", args)
 
     def with_reference_uri(self, name: str, uri: str) -> IResourceWithEnvironment:
         """Adds a reference to a URI"""
@@ -7330,7 +7330,7 @@ class TestRedisResource(ResourceBuilderBase):
         args["optional"] = serialize_value(optional)
         if name is not None:
             args["name"] = serialize_value(name)
-        return self._client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)
+        return self._client.invoke_capability("Aspire.Hosting/withReference", args)
 
     def get_connection_property(self, key: str) -> ReferenceExpression:
         """Gets a connection property by key"""
@@ -8193,7 +8193,7 @@ class TestVaultResource(ResourceBuilderBase):
         args["optional"] = serialize_value(optional)
         if name is not None:
             args["name"] = serialize_value(name)
-        return self._client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)
+        return self._client.invoke_capability("Aspire.Hosting/withReference", args)
 
     def with_reference_uri(self, name: str, uri: str) -> IResourceWithEnvironment:
         """Adds a reference to a URI"""

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -438,7 +438,7 @@ class CSharpAppResource(ResourceBuilderBase):
         args["optional"] = serialize_value(optional)
         if name is not None:
             args["name"] = serialize_value(name)
-        return self._client.invoke_capability("Aspire.Hosting/withReference", args)
+        return self._client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)
 
     def with_reference_uri(self, name: str, uri: str) -> IResourceWithEnvironment:
         """Adds a reference to a URI"""
@@ -578,7 +578,7 @@ class CSharpAppResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["source"] = serialize_value(source)
         args["destinationPath"] = serialize_value(destination_path)
-        return self._client.invoke_capability("Aspire.Hosting/publishWithContainerFiles", args)
+        return self._client.invoke_capability("Aspire.Hosting/publishWithContainerFilesFromResource", args)
 
     def exclude_from_manifest(self) -> IResource:
         """Excludes the resource from the deployment manifest"""
@@ -589,7 +589,7 @@ class CSharpAppResource(ResourceBuilderBase):
         """Waits for another resource to be ready"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
-        return self._client.invoke_capability("Aspire.Hosting/waitFor", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResource", args)
 
     def wait_for_with_behavior(self, dependency: IResource, wait_behavior: WaitBehavior) -> IResourceWithWaitSupport:
         """Waits for another resource with specific behavior"""
@@ -602,7 +602,7 @@ class CSharpAppResource(ResourceBuilderBase):
         """Waits for another resource to start"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
-        return self._client.invoke_capability("Aspire.Hosting/waitForStart", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResourceStart", args)
 
     def wait_for_start_with_behavior(self, dependency: IResource, wait_behavior: WaitBehavior) -> IResourceWithWaitSupport:
         """Waits for another resource to start with specific behavior"""
@@ -621,7 +621,7 @@ class CSharpAppResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
         args["exitCode"] = serialize_value(exit_code)
-        return self._client.invoke_capability("Aspire.Hosting/waitForCompletion", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResourceCompletion", args)
 
     def with_health_check(self, key: str) -> IResource:
         """Adds a health check by key"""
@@ -669,7 +669,7 @@ class CSharpAppResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         if password is not None:
             args["password"] = serialize_value(password)
-        return self._client.invoke_capability("Aspire.Hosting/withHttpsDeveloperCertificate", args)
+        return self._client.invoke_capability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", args)
 
     def without_https_certificate(self) -> IResourceWithEnvironment:
         """Removes HTTPS certificate configuration"""
@@ -680,13 +680,13 @@ class CSharpAppResource(ResourceBuilderBase):
         """Sets the parent relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["parent"] = serialize_value(parent)
-        return self._client.invoke_capability("Aspire.Hosting/withParentRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)
 
     def with_child_relationship(self, child: IResource) -> IResource:
         """Sets a child relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["child"] = serialize_value(child)
-        return self._client.invoke_capability("Aspire.Hosting/withChildRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)
 
     def with_icon_name(self, icon_name: str, icon_variant: IconVariant = None) -> IResource:
         """Sets the icon for the resource"""
@@ -1021,6 +1021,12 @@ class ConnectionStringResource(ResourceBuilderBase):
         args["value"] = serialize_value(value)
         return self._client.invoke_capability("Aspire.Hosting/withConnectionPropertyValue", args)
 
+    def get_connection_property(self, key: str) -> ReferenceExpression:
+        """Gets a connection property by key"""
+        args: Dict[str, Any] = { "resource": serialize_value(self._handle) }
+        args["key"] = serialize_value(key)
+        return self._client.invoke_capability("Aspire.Hosting/getConnectionProperty", args)
+
     def with_urls_callback(self, callback: Callable[[ResourceUrlsCallbackContext], None]) -> IResource:
         """Customizes displayed URLs via callback"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
@@ -1071,7 +1077,7 @@ class ConnectionStringResource(ResourceBuilderBase):
         """Waits for another resource to be ready"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
-        return self._client.invoke_capability("Aspire.Hosting/waitFor", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResource", args)
 
     def wait_for_with_behavior(self, dependency: IResource, wait_behavior: WaitBehavior) -> IResourceWithWaitSupport:
         """Waits for another resource with specific behavior"""
@@ -1084,7 +1090,7 @@ class ConnectionStringResource(ResourceBuilderBase):
         """Waits for another resource to start"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
-        return self._client.invoke_capability("Aspire.Hosting/waitForStart", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResourceStart", args)
 
     def wait_for_start_with_behavior(self, dependency: IResource, wait_behavior: WaitBehavior) -> IResourceWithWaitSupport:
         """Waits for another resource to start with specific behavior"""
@@ -1103,7 +1109,7 @@ class ConnectionStringResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
         args["exitCode"] = serialize_value(exit_code)
-        return self._client.invoke_capability("Aspire.Hosting/waitForCompletion", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResourceCompletion", args)
 
     def with_health_check(self, key: str) -> IResource:
         """Adds a health check by key"""
@@ -1127,13 +1133,13 @@ class ConnectionStringResource(ResourceBuilderBase):
         """Sets the parent relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["parent"] = serialize_value(parent)
-        return self._client.invoke_capability("Aspire.Hosting/withParentRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)
 
     def with_child_relationship(self, child: IResource) -> IResource:
         """Sets a child relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["child"] = serialize_value(child)
-        return self._client.invoke_capability("Aspire.Hosting/withChildRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)
 
     def with_icon_name(self, icon_name: str, icon_variant: IconVariant = None) -> IResource:
         """Sets the icon for the resource"""
@@ -1424,13 +1430,13 @@ class ContainerRegistryResource(ResourceBuilderBase):
         """Sets the parent relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["parent"] = serialize_value(parent)
-        return self._client.invoke_capability("Aspire.Hosting/withParentRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)
 
     def with_child_relationship(self, child: IResource) -> IResource:
         """Sets a child relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["child"] = serialize_value(child)
-        return self._client.invoke_capability("Aspire.Hosting/withChildRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)
 
     def with_icon_name(self, icon_name: str, icon_variant: IconVariant = None) -> IResource:
         """Sets the icon for the resource"""
@@ -1695,14 +1701,14 @@ class ContainerResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["name"] = serialize_value(name)
         args["value"] = serialize_value(value)
-        return self._client.invoke_capability("Aspire.Hosting/withBuildArg", args)
+        return self._client.invoke_capability("Aspire.Hosting/withParameterBuildArg", args)
 
     def with_build_secret(self, name: str, value: ParameterResource) -> ContainerResource:
         """Adds a build secret from a parameter resource"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["name"] = serialize_value(name)
         args["value"] = serialize_value(value)
-        return self._client.invoke_capability("Aspire.Hosting/withBuildSecret", args)
+        return self._client.invoke_capability("Aspire.Hosting/withParameterBuildSecret", args)
 
     def with_endpoint_proxy_support(self, proxy_enabled: bool) -> ContainerResource:
         """Configures endpoint proxy support"""
@@ -1839,7 +1845,7 @@ class ContainerResource(ResourceBuilderBase):
         args["optional"] = serialize_value(optional)
         if name is not None:
             args["name"] = serialize_value(name)
-        return self._client.invoke_capability("Aspire.Hosting/withReference", args)
+        return self._client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)
 
     def with_reference_uri(self, name: str, uri: str) -> IResourceWithEnvironment:
         """Adds a reference to a URI"""
@@ -1983,7 +1989,7 @@ class ContainerResource(ResourceBuilderBase):
         """Waits for another resource to be ready"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
-        return self._client.invoke_capability("Aspire.Hosting/waitFor", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResource", args)
 
     def wait_for_with_behavior(self, dependency: IResource, wait_behavior: WaitBehavior) -> IResourceWithWaitSupport:
         """Waits for another resource with specific behavior"""
@@ -1996,7 +2002,7 @@ class ContainerResource(ResourceBuilderBase):
         """Waits for another resource to start"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
-        return self._client.invoke_capability("Aspire.Hosting/waitForStart", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResourceStart", args)
 
     def wait_for_start_with_behavior(self, dependency: IResource, wait_behavior: WaitBehavior) -> IResourceWithWaitSupport:
         """Waits for another resource to start with specific behavior"""
@@ -2015,7 +2021,7 @@ class ContainerResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
         args["exitCode"] = serialize_value(exit_code)
-        return self._client.invoke_capability("Aspire.Hosting/waitForCompletion", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResourceCompletion", args)
 
     def with_health_check(self, key: str) -> IResource:
         """Adds a health check by key"""
@@ -2063,7 +2069,7 @@ class ContainerResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         if password is not None:
             args["password"] = serialize_value(password)
-        return self._client.invoke_capability("Aspire.Hosting/withHttpsDeveloperCertificate", args)
+        return self._client.invoke_capability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", args)
 
     def without_https_certificate(self) -> IResourceWithEnvironment:
         """Removes HTTPS certificate configuration"""
@@ -2074,13 +2080,13 @@ class ContainerResource(ResourceBuilderBase):
         """Sets the parent relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["parent"] = serialize_value(parent)
-        return self._client.invoke_capability("Aspire.Hosting/withParentRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)
 
     def with_child_relationship(self, child: IResource) -> IResource:
         """Sets a child relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["child"] = serialize_value(child)
-        return self._client.invoke_capability("Aspire.Hosting/withChildRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)
 
     def with_icon_name(self, icon_name: str, icon_variant: IconVariant = None) -> IResource:
         """Sets the icon for the resource"""
@@ -2584,7 +2590,7 @@ class DotnetToolResource(ResourceBuilderBase):
         args["optional"] = serialize_value(optional)
         if name is not None:
             args["name"] = serialize_value(name)
-        return self._client.invoke_capability("Aspire.Hosting/withReference", args)
+        return self._client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)
 
     def with_reference_uri(self, name: str, uri: str) -> IResourceWithEnvironment:
         """Adds a reference to a URI"""
@@ -2728,7 +2734,7 @@ class DotnetToolResource(ResourceBuilderBase):
         """Waits for another resource to be ready"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
-        return self._client.invoke_capability("Aspire.Hosting/waitFor", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResource", args)
 
     def wait_for_with_behavior(self, dependency: IResource, wait_behavior: WaitBehavior) -> IResourceWithWaitSupport:
         """Waits for another resource with specific behavior"""
@@ -2741,7 +2747,7 @@ class DotnetToolResource(ResourceBuilderBase):
         """Waits for another resource to start"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
-        return self._client.invoke_capability("Aspire.Hosting/waitForStart", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResourceStart", args)
 
     def wait_for_start_with_behavior(self, dependency: IResource, wait_behavior: WaitBehavior) -> IResourceWithWaitSupport:
         """Waits for another resource to start with specific behavior"""
@@ -2760,7 +2766,7 @@ class DotnetToolResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
         args["exitCode"] = serialize_value(exit_code)
-        return self._client.invoke_capability("Aspire.Hosting/waitForCompletion", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResourceCompletion", args)
 
     def with_health_check(self, key: str) -> IResource:
         """Adds a health check by key"""
@@ -2808,7 +2814,7 @@ class DotnetToolResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         if password is not None:
             args["password"] = serialize_value(password)
-        return self._client.invoke_capability("Aspire.Hosting/withHttpsDeveloperCertificate", args)
+        return self._client.invoke_capability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", args)
 
     def without_https_certificate(self) -> IResourceWithEnvironment:
         """Removes HTTPS certificate configuration"""
@@ -2819,13 +2825,13 @@ class DotnetToolResource(ResourceBuilderBase):
         """Sets the parent relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["parent"] = serialize_value(parent)
-        return self._client.invoke_capability("Aspire.Hosting/withParentRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)
 
     def with_child_relationship(self, child: IResource) -> IResource:
         """Sets a child relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["child"] = serialize_value(child)
-        return self._client.invoke_capability("Aspire.Hosting/withChildRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)
 
     def with_icon_name(self, icon_name: str, icon_variant: IconVariant = None) -> IResource:
         """Sets the icon for the resource"""
@@ -3356,7 +3362,7 @@ class ExecutableResource(ResourceBuilderBase):
         args["optional"] = serialize_value(optional)
         if name is not None:
             args["name"] = serialize_value(name)
-        return self._client.invoke_capability("Aspire.Hosting/withReference", args)
+        return self._client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)
 
     def with_reference_uri(self, name: str, uri: str) -> IResourceWithEnvironment:
         """Adds a reference to a URI"""
@@ -3500,7 +3506,7 @@ class ExecutableResource(ResourceBuilderBase):
         """Waits for another resource to be ready"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
-        return self._client.invoke_capability("Aspire.Hosting/waitFor", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResource", args)
 
     def wait_for_with_behavior(self, dependency: IResource, wait_behavior: WaitBehavior) -> IResourceWithWaitSupport:
         """Waits for another resource with specific behavior"""
@@ -3513,7 +3519,7 @@ class ExecutableResource(ResourceBuilderBase):
         """Waits for another resource to start"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
-        return self._client.invoke_capability("Aspire.Hosting/waitForStart", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResourceStart", args)
 
     def wait_for_start_with_behavior(self, dependency: IResource, wait_behavior: WaitBehavior) -> IResourceWithWaitSupport:
         """Waits for another resource to start with specific behavior"""
@@ -3532,7 +3538,7 @@ class ExecutableResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
         args["exitCode"] = serialize_value(exit_code)
-        return self._client.invoke_capability("Aspire.Hosting/waitForCompletion", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResourceCompletion", args)
 
     def with_health_check(self, key: str) -> IResource:
         """Adds a health check by key"""
@@ -3580,7 +3586,7 @@ class ExecutableResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         if password is not None:
             args["password"] = serialize_value(password)
-        return self._client.invoke_capability("Aspire.Hosting/withHttpsDeveloperCertificate", args)
+        return self._client.invoke_capability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", args)
 
     def without_https_certificate(self) -> IResourceWithEnvironment:
         """Removes HTTPS certificate configuration"""
@@ -3591,13 +3597,13 @@ class ExecutableResource(ResourceBuilderBase):
         """Sets the parent relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["parent"] = serialize_value(parent)
-        return self._client.invoke_capability("Aspire.Hosting/withParentRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)
 
     def with_child_relationship(self, child: IResource) -> IResource:
         """Sets a child relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["child"] = serialize_value(child)
-        return self._client.invoke_capability("Aspire.Hosting/withChildRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)
 
     def with_icon_name(self, icon_name: str, icon_variant: IconVariant = None) -> IResource:
         """Sets the icon for the resource"""
@@ -3971,13 +3977,13 @@ class ExternalServiceResource(ResourceBuilderBase):
         """Sets the parent relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["parent"] = serialize_value(parent)
-        return self._client.invoke_capability("Aspire.Hosting/withParentRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)
 
     def with_child_relationship(self, child: IResource) -> IResource:
         """Sets a child relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["child"] = serialize_value(child)
-        return self._client.invoke_capability("Aspire.Hosting/withChildRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)
 
     def with_icon_name(self, icon_name: str, icon_variant: IconVariant = None) -> IResource:
         """Sets the icon for the resource"""
@@ -4914,13 +4920,13 @@ class ParameterResource(ResourceBuilderBase):
         """Sets the parent relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["parent"] = serialize_value(parent)
-        return self._client.invoke_capability("Aspire.Hosting/withParentRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)
 
     def with_child_relationship(self, child: IResource) -> IResource:
         """Sets a child relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["child"] = serialize_value(child)
-        return self._client.invoke_capability("Aspire.Hosting/withChildRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)
 
     def with_icon_name(self, icon_name: str, icon_variant: IconVariant = None) -> IResource:
         """Sets the icon for the resource"""
@@ -5533,7 +5539,7 @@ class ProjectResource(ResourceBuilderBase):
         args["optional"] = serialize_value(optional)
         if name is not None:
             args["name"] = serialize_value(name)
-        return self._client.invoke_capability("Aspire.Hosting/withReference", args)
+        return self._client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)
 
     def with_reference_uri(self, name: str, uri: str) -> IResourceWithEnvironment:
         """Adds a reference to a URI"""
@@ -5673,7 +5679,7 @@ class ProjectResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["source"] = serialize_value(source)
         args["destinationPath"] = serialize_value(destination_path)
-        return self._client.invoke_capability("Aspire.Hosting/publishWithContainerFiles", args)
+        return self._client.invoke_capability("Aspire.Hosting/publishWithContainerFilesFromResource", args)
 
     def exclude_from_manifest(self) -> IResource:
         """Excludes the resource from the deployment manifest"""
@@ -5684,7 +5690,7 @@ class ProjectResource(ResourceBuilderBase):
         """Waits for another resource to be ready"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
-        return self._client.invoke_capability("Aspire.Hosting/waitFor", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResource", args)
 
     def wait_for_with_behavior(self, dependency: IResource, wait_behavior: WaitBehavior) -> IResourceWithWaitSupport:
         """Waits for another resource with specific behavior"""
@@ -5697,7 +5703,7 @@ class ProjectResource(ResourceBuilderBase):
         """Waits for another resource to start"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
-        return self._client.invoke_capability("Aspire.Hosting/waitForStart", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResourceStart", args)
 
     def wait_for_start_with_behavior(self, dependency: IResource, wait_behavior: WaitBehavior) -> IResourceWithWaitSupport:
         """Waits for another resource to start with specific behavior"""
@@ -5716,7 +5722,7 @@ class ProjectResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
         args["exitCode"] = serialize_value(exit_code)
-        return self._client.invoke_capability("Aspire.Hosting/waitForCompletion", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResourceCompletion", args)
 
     def with_health_check(self, key: str) -> IResource:
         """Adds a health check by key"""
@@ -5764,7 +5770,7 @@ class ProjectResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         if password is not None:
             args["password"] = serialize_value(password)
-        return self._client.invoke_capability("Aspire.Hosting/withHttpsDeveloperCertificate", args)
+        return self._client.invoke_capability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", args)
 
     def without_https_certificate(self) -> IResourceWithEnvironment:
         """Removes HTTPS certificate configuration"""
@@ -5775,13 +5781,13 @@ class ProjectResource(ResourceBuilderBase):
         """Sets the parent relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["parent"] = serialize_value(parent)
-        return self._client.invoke_capability("Aspire.Hosting/withParentRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)
 
     def with_child_relationship(self, child: IResource) -> IResource:
         """Sets a child relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["child"] = serialize_value(child)
-        return self._client.invoke_capability("Aspire.Hosting/withChildRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)
 
     def with_icon_name(self, icon_name: str, icon_variant: IconVariant = None) -> IResource:
         """Sets the icon for the resource"""
@@ -6415,14 +6421,14 @@ class TestDatabaseResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["name"] = serialize_value(name)
         args["value"] = serialize_value(value)
-        return self._client.invoke_capability("Aspire.Hosting/withBuildArg", args)
+        return self._client.invoke_capability("Aspire.Hosting/withParameterBuildArg", args)
 
     def with_build_secret(self, name: str, value: ParameterResource) -> ContainerResource:
         """Adds a build secret from a parameter resource"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["name"] = serialize_value(name)
         args["value"] = serialize_value(value)
-        return self._client.invoke_capability("Aspire.Hosting/withBuildSecret", args)
+        return self._client.invoke_capability("Aspire.Hosting/withParameterBuildSecret", args)
 
     def with_endpoint_proxy_support(self, proxy_enabled: bool) -> ContainerResource:
         """Configures endpoint proxy support"""
@@ -6559,7 +6565,7 @@ class TestDatabaseResource(ResourceBuilderBase):
         args["optional"] = serialize_value(optional)
         if name is not None:
             args["name"] = serialize_value(name)
-        return self._client.invoke_capability("Aspire.Hosting/withReference", args)
+        return self._client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)
 
     def with_reference_uri(self, name: str, uri: str) -> IResourceWithEnvironment:
         """Adds a reference to a URI"""
@@ -6703,7 +6709,7 @@ class TestDatabaseResource(ResourceBuilderBase):
         """Waits for another resource to be ready"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
-        return self._client.invoke_capability("Aspire.Hosting/waitFor", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResource", args)
 
     def wait_for_with_behavior(self, dependency: IResource, wait_behavior: WaitBehavior) -> IResourceWithWaitSupport:
         """Waits for another resource with specific behavior"""
@@ -6716,7 +6722,7 @@ class TestDatabaseResource(ResourceBuilderBase):
         """Waits for another resource to start"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
-        return self._client.invoke_capability("Aspire.Hosting/waitForStart", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResourceStart", args)
 
     def wait_for_start_with_behavior(self, dependency: IResource, wait_behavior: WaitBehavior) -> IResourceWithWaitSupport:
         """Waits for another resource to start with specific behavior"""
@@ -6735,7 +6741,7 @@ class TestDatabaseResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
         args["exitCode"] = serialize_value(exit_code)
-        return self._client.invoke_capability("Aspire.Hosting/waitForCompletion", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResourceCompletion", args)
 
     def with_health_check(self, key: str) -> IResource:
         """Adds a health check by key"""
@@ -6783,7 +6789,7 @@ class TestDatabaseResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         if password is not None:
             args["password"] = serialize_value(password)
-        return self._client.invoke_capability("Aspire.Hosting/withHttpsDeveloperCertificate", args)
+        return self._client.invoke_capability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", args)
 
     def without_https_certificate(self) -> IResourceWithEnvironment:
         """Removes HTTPS certificate configuration"""
@@ -6794,13 +6800,13 @@ class TestDatabaseResource(ResourceBuilderBase):
         """Sets the parent relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["parent"] = serialize_value(parent)
-        return self._client.invoke_capability("Aspire.Hosting/withParentRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)
 
     def with_child_relationship(self, child: IResource) -> IResource:
         """Sets a child relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["child"] = serialize_value(child)
-        return self._client.invoke_capability("Aspire.Hosting/withChildRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)
 
     def with_icon_name(self, icon_name: str, icon_variant: IconVariant = None) -> IResource:
         """Sets the icon for the resource"""
@@ -7166,14 +7172,14 @@ class TestRedisResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["name"] = serialize_value(name)
         args["value"] = serialize_value(value)
-        return self._client.invoke_capability("Aspire.Hosting/withBuildArg", args)
+        return self._client.invoke_capability("Aspire.Hosting/withParameterBuildArg", args)
 
     def with_build_secret(self, name: str, value: ParameterResource) -> ContainerResource:
         """Adds a build secret from a parameter resource"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["name"] = serialize_value(name)
         args["value"] = serialize_value(value)
-        return self._client.invoke_capability("Aspire.Hosting/withBuildSecret", args)
+        return self._client.invoke_capability("Aspire.Hosting/withParameterBuildSecret", args)
 
     def with_endpoint_proxy_support(self, proxy_enabled: bool) -> ContainerResource:
         """Configures endpoint proxy support"""
@@ -7324,7 +7330,13 @@ class TestRedisResource(ResourceBuilderBase):
         args["optional"] = serialize_value(optional)
         if name is not None:
             args["name"] = serialize_value(name)
-        return self._client.invoke_capability("Aspire.Hosting/withReference", args)
+        return self._client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)
+
+    def get_connection_property(self, key: str) -> ReferenceExpression:
+        """Gets a connection property by key"""
+        args: Dict[str, Any] = { "resource": serialize_value(self._handle) }
+        args["key"] = serialize_value(key)
+        return self._client.invoke_capability("Aspire.Hosting/getConnectionProperty", args)
 
     def with_reference_uri(self, name: str, uri: str) -> IResourceWithEnvironment:
         """Adds a reference to a URI"""
@@ -7468,7 +7480,7 @@ class TestRedisResource(ResourceBuilderBase):
         """Waits for another resource to be ready"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
-        return self._client.invoke_capability("Aspire.Hosting/waitFor", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResource", args)
 
     def wait_for_with_behavior(self, dependency: IResource, wait_behavior: WaitBehavior) -> IResourceWithWaitSupport:
         """Waits for another resource with specific behavior"""
@@ -7481,7 +7493,7 @@ class TestRedisResource(ResourceBuilderBase):
         """Waits for another resource to start"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
-        return self._client.invoke_capability("Aspire.Hosting/waitForStart", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResourceStart", args)
 
     def wait_for_start_with_behavior(self, dependency: IResource, wait_behavior: WaitBehavior) -> IResourceWithWaitSupport:
         """Waits for another resource to start with specific behavior"""
@@ -7500,7 +7512,7 @@ class TestRedisResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
         args["exitCode"] = serialize_value(exit_code)
-        return self._client.invoke_capability("Aspire.Hosting/waitForCompletion", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResourceCompletion", args)
 
     def with_health_check(self, key: str) -> IResource:
         """Adds a health check by key"""
@@ -7548,7 +7560,7 @@ class TestRedisResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         if password is not None:
             args["password"] = serialize_value(password)
-        return self._client.invoke_capability("Aspire.Hosting/withHttpsDeveloperCertificate", args)
+        return self._client.invoke_capability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", args)
 
     def without_https_certificate(self) -> IResourceWithEnvironment:
         """Removes HTTPS certificate configuration"""
@@ -7559,13 +7571,13 @@ class TestRedisResource(ResourceBuilderBase):
         """Sets the parent relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["parent"] = serialize_value(parent)
-        return self._client.invoke_capability("Aspire.Hosting/withParentRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)
 
     def with_child_relationship(self, child: IResource) -> IResource:
         """Sets a child relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["child"] = serialize_value(child)
-        return self._client.invoke_capability("Aspire.Hosting/withChildRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)
 
     def with_icon_name(self, icon_name: str, icon_variant: IconVariant = None) -> IResource:
         """Sets the icon for the resource"""
@@ -8037,14 +8049,14 @@ class TestVaultResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["name"] = serialize_value(name)
         args["value"] = serialize_value(value)
-        return self._client.invoke_capability("Aspire.Hosting/withBuildArg", args)
+        return self._client.invoke_capability("Aspire.Hosting/withParameterBuildArg", args)
 
     def with_build_secret(self, name: str, value: ParameterResource) -> ContainerResource:
         """Adds a build secret from a parameter resource"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["name"] = serialize_value(name)
         args["value"] = serialize_value(value)
-        return self._client.invoke_capability("Aspire.Hosting/withBuildSecret", args)
+        return self._client.invoke_capability("Aspire.Hosting/withParameterBuildSecret", args)
 
     def with_endpoint_proxy_support(self, proxy_enabled: bool) -> ContainerResource:
         """Configures endpoint proxy support"""
@@ -8181,7 +8193,7 @@ class TestVaultResource(ResourceBuilderBase):
         args["optional"] = serialize_value(optional)
         if name is not None:
             args["name"] = serialize_value(name)
-        return self._client.invoke_capability("Aspire.Hosting/withReference", args)
+        return self._client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)
 
     def with_reference_uri(self, name: str, uri: str) -> IResourceWithEnvironment:
         """Adds a reference to a URI"""
@@ -8325,7 +8337,7 @@ class TestVaultResource(ResourceBuilderBase):
         """Waits for another resource to be ready"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
-        return self._client.invoke_capability("Aspire.Hosting/waitFor", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResource", args)
 
     def wait_for_with_behavior(self, dependency: IResource, wait_behavior: WaitBehavior) -> IResourceWithWaitSupport:
         """Waits for another resource with specific behavior"""
@@ -8338,7 +8350,7 @@ class TestVaultResource(ResourceBuilderBase):
         """Waits for another resource to start"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
-        return self._client.invoke_capability("Aspire.Hosting/waitForStart", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResourceStart", args)
 
     def wait_for_start_with_behavior(self, dependency: IResource, wait_behavior: WaitBehavior) -> IResourceWithWaitSupport:
         """Waits for another resource to start with specific behavior"""
@@ -8357,7 +8369,7 @@ class TestVaultResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["dependency"] = serialize_value(dependency)
         args["exitCode"] = serialize_value(exit_code)
-        return self._client.invoke_capability("Aspire.Hosting/waitForCompletion", args)
+        return self._client.invoke_capability("Aspire.Hosting/waitForResourceCompletion", args)
 
     def with_health_check(self, key: str) -> IResource:
         """Adds a health check by key"""
@@ -8405,7 +8417,7 @@ class TestVaultResource(ResourceBuilderBase):
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         if password is not None:
             args["password"] = serialize_value(password)
-        return self._client.invoke_capability("Aspire.Hosting/withHttpsDeveloperCertificate", args)
+        return self._client.invoke_capability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", args)
 
     def without_https_certificate(self) -> IResourceWithEnvironment:
         """Removes HTTPS certificate configuration"""
@@ -8416,13 +8428,13 @@ class TestVaultResource(ResourceBuilderBase):
         """Sets the parent relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["parent"] = serialize_value(parent)
-        return self._client.invoke_capability("Aspire.Hosting/withParentRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)
 
     def with_child_relationship(self, child: IResource) -> IResource:
         """Sets a child relationship"""
         args: Dict[str, Any] = { "builder": serialize_value(self._handle) }
         args["child"] = serialize_value(child)
-        return self._client.invoke_capability("Aspire.Hosting/withChildRelationship", args)
+        return self._client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)
 
     def with_icon_name(self, icon_name: str, icon_variant: IconVariant = None) -> IResource:
         """Sets the icon for the resource"""

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -981,7 +981,7 @@ impl CSharpAppResource {
         if let Some(ref v) = name {
             args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withReference", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -1204,7 +1204,7 @@ impl CSharpAppResource {
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("source".to_string(), source.handle().to_json());
         args.insert("destinationPath".to_string(), serde_json::to_value(&destination_path).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/publishWithContainerFiles", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/publishWithContainerFilesFromResource", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IContainerFilesDestinationResource::new(handle, self.client.clone()))
     }
@@ -1223,7 +1223,7 @@ impl CSharpAppResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("dependency".to_string(), dependency.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/waitFor", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResource", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -1244,7 +1244,7 @@ impl CSharpAppResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("dependency".to_string(), dependency.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/waitForStart", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResourceStart", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -1277,7 +1277,7 @@ impl CSharpAppResource {
         if let Some(ref v) = exit_code {
             args.insert("exitCode".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/waitForCompletion", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResourceCompletion", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -1353,7 +1353,7 @@ impl CSharpAppResource {
         if let Some(ref v) = password {
             args.insert("password".to_string(), v.handle().to_json());
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsDeveloperCertificate", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -1372,7 +1372,7 @@ impl CSharpAppResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("parent".to_string(), parent.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withParentRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -1382,7 +1382,7 @@ impl CSharpAppResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("child".to_string(), child.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withChildRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -1945,6 +1945,15 @@ impl ConnectionStringResource {
         Ok(IResourceWithConnectionString::new(handle, self.client.clone()))
     }
 
+    /// Gets a connection property by key
+    pub fn get_connection_property(&self, key: &str) -> Result<ReferenceExpression, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("resource".to_string(), self.handle.to_json());
+        args.insert("key".to_string(), serde_json::to_value(&key).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/getConnectionProperty", args)?;
+        Ok(serde_json::from_value(result)?)
+    }
+
     /// Customizes displayed URLs via callback
     pub fn with_urls_callback(&self, callback: impl Fn(Vec<Value>) -> Value + Send + Sync + 'static) -> Result<IResource, Box<dyn std::error::Error>> {
         let mut args: HashMap<String, Value> = HashMap::new();
@@ -2019,7 +2028,7 @@ impl ConnectionStringResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("dependency".to_string(), dependency.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/waitFor", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResource", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -2040,7 +2049,7 @@ impl ConnectionStringResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("dependency".to_string(), dependency.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/waitForStart", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResourceStart", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -2073,7 +2082,7 @@ impl ConnectionStringResource {
         if let Some(ref v) = exit_code {
             args.insert("exitCode".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/waitForCompletion", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResourceCompletion", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -2109,7 +2118,7 @@ impl ConnectionStringResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("parent".to_string(), parent.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withParentRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -2119,7 +2128,7 @@ impl ConnectionStringResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("child".to_string(), child.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withChildRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -2586,7 +2595,7 @@ impl ContainerRegistryResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("parent".to_string(), parent.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withParentRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -2596,7 +2605,7 @@ impl ContainerRegistryResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("child".to_string(), child.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withChildRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -3033,7 +3042,7 @@ impl ContainerResource {
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
         args.insert("value".to_string(), value.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuildArg", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildArg", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -3044,7 +3053,7 @@ impl ContainerResource {
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
         args.insert("value".to_string(), value.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuildSecret", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildSecret", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -3263,7 +3272,7 @@ impl ContainerResource {
         if let Some(ref v) = name {
             args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withReference", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -3494,7 +3503,7 @@ impl ContainerResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("dependency".to_string(), dependency.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/waitFor", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResource", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -3515,7 +3524,7 @@ impl ContainerResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("dependency".to_string(), dependency.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/waitForStart", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResourceStart", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -3548,7 +3557,7 @@ impl ContainerResource {
         if let Some(ref v) = exit_code {
             args.insert("exitCode".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/waitForCompletion", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResourceCompletion", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -3624,7 +3633,7 @@ impl ContainerResource {
         if let Some(ref v) = password {
             args.insert("password".to_string(), v.handle().to_json());
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsDeveloperCertificate", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -3643,7 +3652,7 @@ impl ContainerResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("parent".to_string(), parent.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withParentRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -3653,7 +3662,7 @@ impl ContainerResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("child".to_string(), child.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withChildRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -4571,7 +4580,7 @@ impl DotnetToolResource {
         if let Some(ref v) = name {
             args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withReference", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -4802,7 +4811,7 @@ impl DotnetToolResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("dependency".to_string(), dependency.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/waitFor", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResource", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -4823,7 +4832,7 @@ impl DotnetToolResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("dependency".to_string(), dependency.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/waitForStart", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResourceStart", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -4856,7 +4865,7 @@ impl DotnetToolResource {
         if let Some(ref v) = exit_code {
             args.insert("exitCode".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/waitForCompletion", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResourceCompletion", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -4932,7 +4941,7 @@ impl DotnetToolResource {
         if let Some(ref v) = password {
             args.insert("password".to_string(), v.handle().to_json());
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsDeveloperCertificate", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -4951,7 +4960,7 @@ impl DotnetToolResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("parent".to_string(), parent.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withParentRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -4961,7 +4970,7 @@ impl DotnetToolResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("child".to_string(), child.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withChildRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -5859,7 +5868,7 @@ impl ExecutableResource {
         if let Some(ref v) = name {
             args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withReference", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -6090,7 +6099,7 @@ impl ExecutableResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("dependency".to_string(), dependency.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/waitFor", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResource", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -6111,7 +6120,7 @@ impl ExecutableResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("dependency".to_string(), dependency.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/waitForStart", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResourceStart", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -6144,7 +6153,7 @@ impl ExecutableResource {
         if let Some(ref v) = exit_code {
             args.insert("exitCode".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/waitForCompletion", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResourceCompletion", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -6220,7 +6229,7 @@ impl ExecutableResource {
         if let Some(ref v) = password {
             args.insert("password".to_string(), v.handle().to_json());
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsDeveloperCertificate", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -6239,7 +6248,7 @@ impl ExecutableResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("parent".to_string(), parent.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withParentRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -6249,7 +6258,7 @@ impl ExecutableResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("child".to_string(), child.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withChildRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -6868,7 +6877,7 @@ impl ExternalServiceResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("parent".to_string(), parent.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withParentRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -6878,7 +6887,7 @@ impl ExternalServiceResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("child".to_string(), child.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withChildRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -8778,7 +8787,7 @@ impl ParameterResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("parent".to_string(), parent.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withParentRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -8788,7 +8797,7 @@ impl ParameterResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("child".to_string(), child.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withChildRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -9861,7 +9870,7 @@ impl ProjectResource {
         if let Some(ref v) = name {
             args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withReference", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -10084,7 +10093,7 @@ impl ProjectResource {
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("source".to_string(), source.handle().to_json());
         args.insert("destinationPath".to_string(), serde_json::to_value(&destination_path).unwrap_or(Value::Null));
-        let result = self.client.invoke_capability("Aspire.Hosting/publishWithContainerFiles", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/publishWithContainerFilesFromResource", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IContainerFilesDestinationResource::new(handle, self.client.clone()))
     }
@@ -10103,7 +10112,7 @@ impl ProjectResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("dependency".to_string(), dependency.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/waitFor", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResource", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -10124,7 +10133,7 @@ impl ProjectResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("dependency".to_string(), dependency.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/waitForStart", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResourceStart", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -10157,7 +10166,7 @@ impl ProjectResource {
         if let Some(ref v) = exit_code {
             args.insert("exitCode".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/waitForCompletion", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResourceCompletion", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -10233,7 +10242,7 @@ impl ProjectResource {
         if let Some(ref v) = password {
             args.insert("password".to_string(), v.handle().to_json());
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsDeveloperCertificate", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -10252,7 +10261,7 @@ impl ProjectResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("parent".to_string(), parent.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withParentRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -10262,7 +10271,7 @@ impl ProjectResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("child".to_string(), child.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withChildRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -11400,7 +11409,7 @@ impl TestDatabaseResource {
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
         args.insert("value".to_string(), value.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuildArg", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildArg", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -11411,7 +11420,7 @@ impl TestDatabaseResource {
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
         args.insert("value".to_string(), value.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuildSecret", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildSecret", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -11630,7 +11639,7 @@ impl TestDatabaseResource {
         if let Some(ref v) = name {
             args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withReference", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -11861,7 +11870,7 @@ impl TestDatabaseResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("dependency".to_string(), dependency.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/waitFor", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResource", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -11882,7 +11891,7 @@ impl TestDatabaseResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("dependency".to_string(), dependency.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/waitForStart", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResourceStart", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -11915,7 +11924,7 @@ impl TestDatabaseResource {
         if let Some(ref v) = exit_code {
             args.insert("exitCode".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/waitForCompletion", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResourceCompletion", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -11991,7 +12000,7 @@ impl TestDatabaseResource {
         if let Some(ref v) = password {
             args.insert("password".to_string(), v.handle().to_json());
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsDeveloperCertificate", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -12010,7 +12019,7 @@ impl TestDatabaseResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("parent".to_string(), parent.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withParentRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -12020,7 +12029,7 @@ impl TestDatabaseResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("child".to_string(), child.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withChildRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -12636,7 +12645,7 @@ impl TestRedisResource {
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
         args.insert("value".to_string(), value.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuildArg", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildArg", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -12647,7 +12656,7 @@ impl TestRedisResource {
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
         args.insert("value".to_string(), value.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuildSecret", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildSecret", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -12888,9 +12897,18 @@ impl TestRedisResource {
         if let Some(ref v) = name {
             args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withReference", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
+    }
+
+    /// Gets a connection property by key
+    pub fn get_connection_property(&self, key: &str) -> Result<ReferenceExpression, Box<dyn std::error::Error>> {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        args.insert("resource".to_string(), self.handle.to_json());
+        args.insert("key".to_string(), serde_json::to_value(&key).unwrap_or(Value::Null));
+        let result = self.client.invoke_capability("Aspire.Hosting/getConnectionProperty", args)?;
+        Ok(serde_json::from_value(result)?)
     }
 
     /// Adds a reference to a URI
@@ -13119,7 +13137,7 @@ impl TestRedisResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("dependency".to_string(), dependency.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/waitFor", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResource", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -13140,7 +13158,7 @@ impl TestRedisResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("dependency".to_string(), dependency.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/waitForStart", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResourceStart", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -13173,7 +13191,7 @@ impl TestRedisResource {
         if let Some(ref v) = exit_code {
             args.insert("exitCode".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/waitForCompletion", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResourceCompletion", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -13249,7 +13267,7 @@ impl TestRedisResource {
         if let Some(ref v) = password {
             args.insert("password".to_string(), v.handle().to_json());
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsDeveloperCertificate", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -13268,7 +13286,7 @@ impl TestRedisResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("parent".to_string(), parent.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withParentRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -13278,7 +13296,7 @@ impl TestRedisResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("child".to_string(), child.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withChildRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -14036,7 +14054,7 @@ impl TestVaultResource {
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
         args.insert("value".to_string(), value.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuildArg", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildArg", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -14047,7 +14065,7 @@ impl TestVaultResource {
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("name".to_string(), serde_json::to_value(&name).unwrap_or(Value::Null));
         args.insert("value".to_string(), value.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withBuildSecret", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withParameterBuildSecret", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(ContainerResource::new(handle, self.client.clone()))
     }
@@ -14266,7 +14284,7 @@ impl TestVaultResource {
         if let Some(ref v) = name {
             args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withReference", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -14497,7 +14515,7 @@ impl TestVaultResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("dependency".to_string(), dependency.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/waitFor", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResource", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -14518,7 +14536,7 @@ impl TestVaultResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("dependency".to_string(), dependency.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/waitForStart", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResourceStart", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -14551,7 +14569,7 @@ impl TestVaultResource {
         if let Some(ref v) = exit_code {
             args.insert("exitCode".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/waitForCompletion", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/waitForResourceCompletion", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithWaitSupport::new(handle, self.client.clone()))
     }
@@ -14627,7 +14645,7 @@ impl TestVaultResource {
         if let Some(ref v) = password {
             args.insert("password".to_string(), v.handle().to_json());
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withHttpsDeveloperCertificate", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withParameterHttpsDeveloperCertificate", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -14646,7 +14664,7 @@ impl TestVaultResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("parent".to_string(), parent.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withParentRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderParentRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }
@@ -14656,7 +14674,7 @@ impl TestVaultResource {
         let mut args: HashMap<String, Value> = HashMap::new();
         args.insert("builder".to_string(), self.handle.to_json());
         args.insert("child".to_string(), child.handle().to_json());
-        let result = self.client.invoke_capability("Aspire.Hosting/withChildRelationship", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withBuilderChildRelationship", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResource::new(handle, self.client.clone()))
     }

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -981,7 +981,7 @@ impl CSharpAppResource {
         if let Some(ref v) = name {
             args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withReference", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -3272,7 +3272,7 @@ impl ContainerResource {
         if let Some(ref v) = name {
             args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withReference", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -4580,7 +4580,7 @@ impl DotnetToolResource {
         if let Some(ref v) = name {
             args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withReference", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -5868,7 +5868,7 @@ impl ExecutableResource {
         if let Some(ref v) = name {
             args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withReference", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -9870,7 +9870,7 @@ impl ProjectResource {
         if let Some(ref v) = name {
             args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withReference", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -11639,7 +11639,7 @@ impl TestDatabaseResource {
         if let Some(ref v) = name {
             args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withReference", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -12897,7 +12897,7 @@ impl TestRedisResource {
         if let Some(ref v) = name {
             args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withReference", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }
@@ -14284,7 +14284,7 @@ impl TestVaultResource {
         if let Some(ref v) = name {
             args.insert("name".to_string(), serde_json::to_value(v).unwrap_or(Value::Null));
         }
-        let result = self.client.invoke_capability("Aspire.Hosting/withGenericResourceReference", args)?;
+        let result = self.client.invoke_capability("Aspire.Hosting/withReference", args)?;
         let handle: Handle = serde_json::from_value(result)?;
         Ok(IResourceWithEnvironment::new(handle, self.client.clone()))
     }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
@@ -695,10 +695,10 @@ public class AtsTypeScriptCodeGeneratorTests
         // so the code generator uses the correct parameter name when invoking capabilities.
         var capabilities = ScanCapabilitiesFromHostingAssembly();
 
-        // Find withReference - now on the original ResourceBuilderExtensions.WithReference
-        // which uses "builder" as the first parameter name
+        // Find the public withReference capability by its generated method name.
+        // The underlying capability ID is intentionally distinct to avoid export collisions.
         var withReference = capabilities
-            .FirstOrDefault(c => c.CapabilityId == "Aspire.Hosting/withReference");
+            .FirstOrDefault(c => c.MethodName == "withReference");
 
         Assert.NotNull(withReference);
         Assert.Equal("builder", withReference.TargetParameterName);
@@ -721,7 +721,7 @@ public class AtsTypeScriptCodeGeneratorTests
     {
         var capabilities = ScanCapabilitiesFromHostingAssembly();
 
-        var withReference = Assert.Single(capabilities, c => c.CapabilityId == "Aspire.Hosting/withReference");
+        var withReference = Assert.Single(capabilities, c => c.MethodName == "withReference");
         Assert.Contains(withReference.Parameters, p => p.Name == "name" && p.IsOptional);
 
         Assert.DoesNotContain(capabilities, c => c.CapabilityId == "Aspire.Hosting/withServiceReference");

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/AtsTypeScriptCodeGeneratorTests.cs
@@ -695,10 +695,10 @@ public class AtsTypeScriptCodeGeneratorTests
         // so the code generator uses the correct parameter name when invoking capabilities.
         var capabilities = ScanCapabilitiesFromHostingAssembly();
 
-        // Find the public withReference capability by its generated method name.
-        // The underlying capability ID is intentionally distinct to avoid export collisions.
+        // Find withReference - now on the original ResourceBuilderExtensions.WithReference
+        // which uses "builder" as the first parameter name
         var withReference = capabilities
-            .FirstOrDefault(c => c.MethodName == "withReference");
+            .FirstOrDefault(c => c.CapabilityId == "Aspire.Hosting/withReference");
 
         Assert.NotNull(withReference);
         Assert.Equal("builder", withReference.TargetParameterName);
@@ -721,7 +721,7 @@ public class AtsTypeScriptCodeGeneratorTests
     {
         var capabilities = ScanCapabilitiesFromHostingAssembly();
 
-        var withReference = Assert.Single(capabilities, c => c.MethodName == "withReference");
+        var withReference = Assert.Single(capabilities, c => c.CapabilityId == "Aspire.Hosting/withReference");
         Assert.Contains(withReference.Parameters, p => p.Name == "name" && p.IsOptional);
 
         Assert.DoesNotContain(capabilities, c => c.CapabilityId == "Aspire.Hosting/withServiceReference");

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/HostingContainerResourceCapabilities.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/HostingContainerResourceCapabilities.verified.txt
@@ -168,7 +168,7 @@
     ]
   },
   {
-    CapabilityId: Aspire.Hosting/waitFor,
+    CapabilityId: Aspire.Hosting/waitForResource,
     MethodName: waitFor,
     TargetType: {
       TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport,
@@ -182,7 +182,7 @@
     ]
   },
   {
-    CapabilityId: Aspire.Hosting/waitForCompletion,
+    CapabilityId: Aspire.Hosting/waitForResourceCompletion,
     MethodName: waitForCompletion,
     TargetType: {
       TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport,
@@ -196,7 +196,7 @@
     ]
   },
   {
-    CapabilityId: Aspire.Hosting/waitForStart,
+    CapabilityId: Aspire.Hosting/waitForResourceStart,
     MethodName: waitForStart,
     TargetType: {
       TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport,
@@ -294,11 +294,11 @@
     ]
   },
   {
-    CapabilityId: Aspire.Hosting/withBuildArg,
-    MethodName: withBuildArg,
+    CapabilityId: Aspire.Hosting/withBuilderChildRelationship,
+    MethodName: withChildRelationship,
     TargetType: {
-      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource,
-      IsInterface: false
+      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResource,
+      IsInterface: true
     },
     ExpandedTargetTypes: [
       {
@@ -308,11 +308,11 @@
     ]
   },
   {
-    CapabilityId: Aspire.Hosting/withBuildSecret,
-    MethodName: withBuildSecret,
+    CapabilityId: Aspire.Hosting/withBuilderParentRelationship,
+    MethodName: withParentRelationship,
     TargetType: {
-      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource,
-      IsInterface: false
+      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResource,
+      IsInterface: true
     },
     ExpandedTargetTypes: [
       {
@@ -326,20 +326,6 @@
     MethodName: withCertificateTrustScope,
     TargetType: {
       TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment,
-      IsInterface: true
-    },
-    ExpandedTargetTypes: [
-      {
-        TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource,
-        IsInterface: false
-      }
-    ]
-  },
-  {
-    CapabilityId: Aspire.Hosting/withChildRelationship,
-    MethodName: withChildRelationship,
-    TargetType: {
-      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResource,
       IsInterface: true
     },
     ExpandedTargetTypes: [
@@ -630,6 +616,20 @@
     ]
   },
   {
+    CapabilityId: Aspire.Hosting/withGenericResourceReference,
+    MethodName: withReference,
+    TargetType: {
+      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment,
+      IsInterface: true
+    },
+    ExpandedTargetTypes: [
+      {
+        TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource,
+        IsInterface: false
+      }
+    ]
+  },
+  {
     CapabilityId: Aspire.Hosting/withHealthCheck,
     MethodName: withHealthCheck,
     TargetType: {
@@ -676,20 +676,6 @@
     MethodName: withHttpProbe,
     TargetType: {
       TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEndpoints,
-      IsInterface: true
-    },
-    ExpandedTargetTypes: [
-      {
-        TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource,
-        IsInterface: false
-      }
-    ]
-  },
-  {
-    CapabilityId: Aspire.Hosting/withHttpsDeveloperCertificate,
-    MethodName: withHttpsDeveloperCertificate,
-    TargetType: {
-      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment,
       IsInterface: true
     },
     ExpandedTargetTypes: [
@@ -868,10 +854,38 @@
     ]
   },
   {
-    CapabilityId: Aspire.Hosting/withParentRelationship,
-    MethodName: withParentRelationship,
+    CapabilityId: Aspire.Hosting/withParameterBuildArg,
+    MethodName: withBuildArg,
     TargetType: {
-      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResource,
+      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource,
+      IsInterface: false
+    },
+    ExpandedTargetTypes: [
+      {
+        TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource,
+        IsInterface: false
+      }
+    ]
+  },
+  {
+    CapabilityId: Aspire.Hosting/withParameterBuildSecret,
+    MethodName: withBuildSecret,
+    TargetType: {
+      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource,
+      IsInterface: false
+    },
+    ExpandedTargetTypes: [
+      {
+        TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource,
+        IsInterface: false
+      }
+    ]
+  },
+  {
+    CapabilityId: Aspire.Hosting/withParameterHttpsDeveloperCertificate,
+    MethodName: withHttpsDeveloperCertificate,
+    TargetType: {
+      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment,
       IsInterface: true
     },
     ExpandedTargetTypes: [
@@ -914,20 +928,6 @@
     MethodName: withPipelineStepFactory,
     TargetType: {
       TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResource,
-      IsInterface: true
-    },
-    ExpandedTargetTypes: [
-      {
-        TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource,
-        IsInterface: false
-      }
-    ]
-  },
-  {
-    CapabilityId: Aspire.Hosting/withReference,
-    MethodName: withReference,
-    TargetType: {
-      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment,
       IsInterface: true
     },
     ExpandedTargetTypes: [

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/HostingContainerResourceCapabilities.verified.txt
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/HostingContainerResourceCapabilities.verified.txt
@@ -616,20 +616,6 @@
     ]
   },
   {
-    CapabilityId: Aspire.Hosting/withGenericResourceReference,
-    MethodName: withReference,
-    TargetType: {
-      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment,
-      IsInterface: true
-    },
-    ExpandedTargetTypes: [
-      {
-        TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource,
-        IsInterface: false
-      }
-    ]
-  },
-  {
     CapabilityId: Aspire.Hosting/withHealthCheck,
     MethodName: withHealthCheck,
     TargetType: {
@@ -928,6 +914,20 @@
     MethodName: withPipelineStepFactory,
     TargetType: {
       TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResource,
+      IsInterface: true
+    },
+    ExpandedTargetTypes: [
+      {
+        TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.ContainerResource,
+        IsInterface: false
+      }
+    ]
+  },
+  {
+    CapabilityId: Aspire.Hosting/withReference,
+    MethodName: withReference,
+    TargetType: {
+      TypeId: Aspire.Hosting/Aspire.Hosting.ApplicationModel.IResourceWithEnvironment,
       IsInterface: true
     },
     ExpandedTargetTypes: [

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -4623,6 +4623,15 @@ export class ConnectionStringResource extends ResourceBuilderBase<ConnectionStri
         return new ConnectionStringResourcePromise(this._withConnectionPropertyValueInternal(name, value));
     }
 
+    /** Gets a connection property by key */
+    async getConnectionProperty(key: string): Promise<ReferenceExpression> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle, key };
+        return await this._client.invokeCapability<ReferenceExpression>(
+            'Aspire.Hosting/getConnectionProperty',
+            rpcArgs
+        );
+    }
+
     /** @internal */
     private async _withUrlsCallbackInternal(callback: (obj: ResourceUrlsCallbackContext) => Promise<void>): Promise<ConnectionStringResource> {
         const callbackId = registerCallback(async (objData: unknown) => {
@@ -4735,7 +4744,7 @@ export class ConnectionStringResource extends ResourceBuilderBase<ConnectionStri
     private async _waitForInternal(dependency: ResourceBuilderBase): Promise<ConnectionStringResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<ConnectionStringResourceHandle>(
-            'Aspire.Hosting/waitFor',
+            'Aspire.Hosting/waitForResource',
             rpcArgs
         );
         return new ConnectionStringResource(result, this._client);
@@ -4765,7 +4774,7 @@ export class ConnectionStringResource extends ResourceBuilderBase<ConnectionStri
     private async _waitForStartInternal(dependency: ResourceBuilderBase): Promise<ConnectionStringResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<ConnectionStringResourceHandle>(
-            'Aspire.Hosting/waitForStart',
+            'Aspire.Hosting/waitForResourceStart',
             rpcArgs
         );
         return new ConnectionStringResource(result, this._client);
@@ -4811,7 +4820,7 @@ export class ConnectionStringResource extends ResourceBuilderBase<ConnectionStri
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         if (exitCode !== undefined) rpcArgs.exitCode = exitCode;
         const result = await this._client.invokeCapability<ConnectionStringResourceHandle>(
-            'Aspire.Hosting/waitForCompletion',
+            'Aspire.Hosting/waitForResourceCompletion',
             rpcArgs
         );
         return new ConnectionStringResource(result, this._client);
@@ -4864,7 +4873,7 @@ export class ConnectionStringResource extends ResourceBuilderBase<ConnectionStri
     private async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<ConnectionStringResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, parent };
         const result = await this._client.invokeCapability<ConnectionStringResourceHandle>(
-            'Aspire.Hosting/withParentRelationship',
+            'Aspire.Hosting/withBuilderParentRelationship',
             rpcArgs
         );
         return new ConnectionStringResource(result, this._client);
@@ -4879,7 +4888,7 @@ export class ConnectionStringResource extends ResourceBuilderBase<ConnectionStri
     private async _withChildRelationshipInternal(child: ResourceBuilderBase): Promise<ConnectionStringResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, child };
         const result = await this._client.invokeCapability<ConnectionStringResourceHandle>(
-            'Aspire.Hosting/withChildRelationship',
+            'Aspire.Hosting/withBuilderChildRelationship',
             rpcArgs
         );
         return new ConnectionStringResource(result, this._client);
@@ -5386,6 +5395,11 @@ export class ConnectionStringResourcePromise implements PromiseLike<ConnectionSt
         return new ConnectionStringResourcePromise(this._promise.then(obj => obj.withConnectionPropertyValue(name, value)));
     }
 
+    /** Gets a connection property by key */
+    getConnectionProperty(key: string): Promise<ReferenceExpression> {
+        return this._promise.then(obj => obj.getConnectionProperty(key));
+    }
+
     /** Customizes displayed URLs via callback */
     withUrlsCallback(callback: (obj: ResourceUrlsCallbackContext) => Promise<void>): ConnectionStringResourcePromise {
         return new ConnectionStringResourcePromise(this._promise.then(obj => obj.withUrlsCallback(callback)));
@@ -5822,7 +5836,7 @@ export class ContainerRegistryResource extends ResourceBuilderBase<ContainerRegi
     private async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<ContainerRegistryResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, parent };
         const result = await this._client.invokeCapability<ContainerRegistryResourceHandle>(
-            'Aspire.Hosting/withParentRelationship',
+            'Aspire.Hosting/withBuilderParentRelationship',
             rpcArgs
         );
         return new ContainerRegistryResource(result, this._client);
@@ -5837,7 +5851,7 @@ export class ContainerRegistryResource extends ResourceBuilderBase<ContainerRegi
     private async _withChildRelationshipInternal(child: ResourceBuilderBase): Promise<ContainerRegistryResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, child };
         const result = await this._client.invokeCapability<ContainerRegistryResourceHandle>(
-            'Aspire.Hosting/withChildRelationship',
+            'Aspire.Hosting/withBuilderChildRelationship',
             rpcArgs
         );
         return new ContainerRegistryResource(result, this._client);
@@ -6672,7 +6686,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     private async _withBuildArgInternal(name: string, value: ParameterResource): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
-            'Aspire.Hosting/withBuildArg',
+            'Aspire.Hosting/withParameterBuildArg',
             rpcArgs
         );
         return new ContainerResource(result, this._client);
@@ -6687,7 +6701,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     private async _withBuildSecretInternal(name: string, value: ParameterResource): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
-            'Aspire.Hosting/withBuildSecret',
+            'Aspire.Hosting/withParameterBuildSecret',
             rpcArgs
         );
         return new ContainerResource(result, this._client);
@@ -7005,7 +7019,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
         if (optional !== undefined) rpcArgs.optional = optional;
         if (name !== undefined) rpcArgs.name = name;
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
-            'Aspire.Hosting/withReference',
+            'Aspire.Hosting/withGenericResourceReference',
             rpcArgs
         );
         return new ContainerResource(result, this._client);
@@ -7316,7 +7330,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     private async _waitForInternal(dependency: ResourceBuilderBase): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
-            'Aspire.Hosting/waitFor',
+            'Aspire.Hosting/waitForResource',
             rpcArgs
         );
         return new ContainerResource(result, this._client);
@@ -7346,7 +7360,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     private async _waitForStartInternal(dependency: ResourceBuilderBase): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
-            'Aspire.Hosting/waitForStart',
+            'Aspire.Hosting/waitForResourceStart',
             rpcArgs
         );
         return new ContainerResource(result, this._client);
@@ -7392,7 +7406,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         if (exitCode !== undefined) rpcArgs.exitCode = exitCode;
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
-            'Aspire.Hosting/waitForCompletion',
+            'Aspire.Hosting/waitForResourceCompletion',
             rpcArgs
         );
         return new ContainerResource(result, this._client);
@@ -7497,7 +7511,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (password !== undefined) rpcArgs.password = password;
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
-            'Aspire.Hosting/withHttpsDeveloperCertificate',
+            'Aspire.Hosting/withParameterHttpsDeveloperCertificate',
             rpcArgs
         );
         return new ContainerResource(result, this._client);
@@ -7528,7 +7542,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     private async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, parent };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
-            'Aspire.Hosting/withParentRelationship',
+            'Aspire.Hosting/withBuilderParentRelationship',
             rpcArgs
         );
         return new ContainerResource(result, this._client);
@@ -7543,7 +7557,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
     private async _withChildRelationshipInternal(child: ResourceBuilderBase): Promise<ContainerResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, child };
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
-            'Aspire.Hosting/withChildRelationship',
+            'Aspire.Hosting/withBuilderChildRelationship',
             rpcArgs
         );
         return new ContainerResource(result, this._client);
@@ -8923,7 +8937,7 @@ export class CSharpAppResource extends ResourceBuilderBase<CSharpAppResourceHand
         if (optional !== undefined) rpcArgs.optional = optional;
         if (name !== undefined) rpcArgs.name = name;
         const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
-            'Aspire.Hosting/withReference',
+            'Aspire.Hosting/withGenericResourceReference',
             rpcArgs
         );
         return new CSharpAppResource(result, this._client);
@@ -9219,7 +9233,7 @@ export class CSharpAppResource extends ResourceBuilderBase<CSharpAppResourceHand
     private async _publishWithContainerFilesInternal(source: ResourceBuilderBase, destinationPath: string): Promise<CSharpAppResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, source, destinationPath };
         const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
-            'Aspire.Hosting/publishWithContainerFiles',
+            'Aspire.Hosting/publishWithContainerFilesFromResource',
             rpcArgs
         );
         return new CSharpAppResource(result, this._client);
@@ -9249,7 +9263,7 @@ export class CSharpAppResource extends ResourceBuilderBase<CSharpAppResourceHand
     private async _waitForInternal(dependency: ResourceBuilderBase): Promise<CSharpAppResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
-            'Aspire.Hosting/waitFor',
+            'Aspire.Hosting/waitForResource',
             rpcArgs
         );
         return new CSharpAppResource(result, this._client);
@@ -9279,7 +9293,7 @@ export class CSharpAppResource extends ResourceBuilderBase<CSharpAppResourceHand
     private async _waitForStartInternal(dependency: ResourceBuilderBase): Promise<CSharpAppResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
-            'Aspire.Hosting/waitForStart',
+            'Aspire.Hosting/waitForResourceStart',
             rpcArgs
         );
         return new CSharpAppResource(result, this._client);
@@ -9325,7 +9339,7 @@ export class CSharpAppResource extends ResourceBuilderBase<CSharpAppResourceHand
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         if (exitCode !== undefined) rpcArgs.exitCode = exitCode;
         const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
-            'Aspire.Hosting/waitForCompletion',
+            'Aspire.Hosting/waitForResourceCompletion',
             rpcArgs
         );
         return new CSharpAppResource(result, this._client);
@@ -9430,7 +9444,7 @@ export class CSharpAppResource extends ResourceBuilderBase<CSharpAppResourceHand
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (password !== undefined) rpcArgs.password = password;
         const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
-            'Aspire.Hosting/withHttpsDeveloperCertificate',
+            'Aspire.Hosting/withParameterHttpsDeveloperCertificate',
             rpcArgs
         );
         return new CSharpAppResource(result, this._client);
@@ -9461,7 +9475,7 @@ export class CSharpAppResource extends ResourceBuilderBase<CSharpAppResourceHand
     private async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<CSharpAppResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, parent };
         const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
-            'Aspire.Hosting/withParentRelationship',
+            'Aspire.Hosting/withBuilderParentRelationship',
             rpcArgs
         );
         return new CSharpAppResource(result, this._client);
@@ -9476,7 +9490,7 @@ export class CSharpAppResource extends ResourceBuilderBase<CSharpAppResourceHand
     private async _withChildRelationshipInternal(child: ResourceBuilderBase): Promise<CSharpAppResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, child };
         const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
-            'Aspire.Hosting/withChildRelationship',
+            'Aspire.Hosting/withBuilderChildRelationship',
             rpcArgs
         );
         return new CSharpAppResource(result, this._client);
@@ -10870,7 +10884,7 @@ export class DotnetToolResource extends ResourceBuilderBase<DotnetToolResourceHa
         if (optional !== undefined) rpcArgs.optional = optional;
         if (name !== undefined) rpcArgs.name = name;
         const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
-            'Aspire.Hosting/withReference',
+            'Aspire.Hosting/withGenericResourceReference',
             rpcArgs
         );
         return new DotnetToolResource(result, this._client);
@@ -11181,7 +11195,7 @@ export class DotnetToolResource extends ResourceBuilderBase<DotnetToolResourceHa
     private async _waitForInternal(dependency: ResourceBuilderBase): Promise<DotnetToolResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
-            'Aspire.Hosting/waitFor',
+            'Aspire.Hosting/waitForResource',
             rpcArgs
         );
         return new DotnetToolResource(result, this._client);
@@ -11211,7 +11225,7 @@ export class DotnetToolResource extends ResourceBuilderBase<DotnetToolResourceHa
     private async _waitForStartInternal(dependency: ResourceBuilderBase): Promise<DotnetToolResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
-            'Aspire.Hosting/waitForStart',
+            'Aspire.Hosting/waitForResourceStart',
             rpcArgs
         );
         return new DotnetToolResource(result, this._client);
@@ -11257,7 +11271,7 @@ export class DotnetToolResource extends ResourceBuilderBase<DotnetToolResourceHa
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         if (exitCode !== undefined) rpcArgs.exitCode = exitCode;
         const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
-            'Aspire.Hosting/waitForCompletion',
+            'Aspire.Hosting/waitForResourceCompletion',
             rpcArgs
         );
         return new DotnetToolResource(result, this._client);
@@ -11362,7 +11376,7 @@ export class DotnetToolResource extends ResourceBuilderBase<DotnetToolResourceHa
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (password !== undefined) rpcArgs.password = password;
         const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
-            'Aspire.Hosting/withHttpsDeveloperCertificate',
+            'Aspire.Hosting/withParameterHttpsDeveloperCertificate',
             rpcArgs
         );
         return new DotnetToolResource(result, this._client);
@@ -11393,7 +11407,7 @@ export class DotnetToolResource extends ResourceBuilderBase<DotnetToolResourceHa
     private async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<DotnetToolResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, parent };
         const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
-            'Aspire.Hosting/withParentRelationship',
+            'Aspire.Hosting/withBuilderParentRelationship',
             rpcArgs
         );
         return new DotnetToolResource(result, this._client);
@@ -11408,7 +11422,7 @@ export class DotnetToolResource extends ResourceBuilderBase<DotnetToolResourceHa
     private async _withChildRelationshipInternal(child: ResourceBuilderBase): Promise<DotnetToolResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, child };
         const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
-            'Aspire.Hosting/withChildRelationship',
+            'Aspire.Hosting/withBuilderChildRelationship',
             rpcArgs
         );
         return new DotnetToolResource(result, this._client);
@@ -12742,7 +12756,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
         if (optional !== undefined) rpcArgs.optional = optional;
         if (name !== undefined) rpcArgs.name = name;
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
-            'Aspire.Hosting/withReference',
+            'Aspire.Hosting/withGenericResourceReference',
             rpcArgs
         );
         return new ExecutableResource(result, this._client);
@@ -13053,7 +13067,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     private async _waitForInternal(dependency: ResourceBuilderBase): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
-            'Aspire.Hosting/waitFor',
+            'Aspire.Hosting/waitForResource',
             rpcArgs
         );
         return new ExecutableResource(result, this._client);
@@ -13083,7 +13097,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     private async _waitForStartInternal(dependency: ResourceBuilderBase): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
-            'Aspire.Hosting/waitForStart',
+            'Aspire.Hosting/waitForResourceStart',
             rpcArgs
         );
         return new ExecutableResource(result, this._client);
@@ -13129,7 +13143,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         if (exitCode !== undefined) rpcArgs.exitCode = exitCode;
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
-            'Aspire.Hosting/waitForCompletion',
+            'Aspire.Hosting/waitForResourceCompletion',
             rpcArgs
         );
         return new ExecutableResource(result, this._client);
@@ -13234,7 +13248,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (password !== undefined) rpcArgs.password = password;
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
-            'Aspire.Hosting/withHttpsDeveloperCertificate',
+            'Aspire.Hosting/withParameterHttpsDeveloperCertificate',
             rpcArgs
         );
         return new ExecutableResource(result, this._client);
@@ -13265,7 +13279,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     private async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, parent };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
-            'Aspire.Hosting/withParentRelationship',
+            'Aspire.Hosting/withBuilderParentRelationship',
             rpcArgs
         );
         return new ExecutableResource(result, this._client);
@@ -13280,7 +13294,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
     private async _withChildRelationshipInternal(child: ResourceBuilderBase): Promise<ExecutableResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, child };
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
-            'Aspire.Hosting/withChildRelationship',
+            'Aspire.Hosting/withBuilderChildRelationship',
             rpcArgs
         );
         return new ExecutableResource(result, this._client);
@@ -14476,7 +14490,7 @@ export class ExternalServiceResource extends ResourceBuilderBase<ExternalService
     private async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<ExternalServiceResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, parent };
         const result = await this._client.invokeCapability<ExternalServiceResourceHandle>(
-            'Aspire.Hosting/withParentRelationship',
+            'Aspire.Hosting/withBuilderParentRelationship',
             rpcArgs
         );
         return new ExternalServiceResource(result, this._client);
@@ -14491,7 +14505,7 @@ export class ExternalServiceResource extends ResourceBuilderBase<ExternalService
     private async _withChildRelationshipInternal(child: ResourceBuilderBase): Promise<ExternalServiceResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, child };
         const result = await this._client.invokeCapability<ExternalServiceResourceHandle>(
-            'Aspire.Hosting/withChildRelationship',
+            'Aspire.Hosting/withBuilderChildRelationship',
             rpcArgs
         );
         return new ExternalServiceResource(result, this._client);
@@ -15356,7 +15370,7 @@ export class ParameterResource extends ResourceBuilderBase<ParameterResourceHand
     private async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<ParameterResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, parent };
         const result = await this._client.invokeCapability<ParameterResourceHandle>(
-            'Aspire.Hosting/withParentRelationship',
+            'Aspire.Hosting/withBuilderParentRelationship',
             rpcArgs
         );
         return new ParameterResource(result, this._client);
@@ -15371,7 +15385,7 @@ export class ParameterResource extends ResourceBuilderBase<ParameterResourceHand
     private async _withChildRelationshipInternal(child: ResourceBuilderBase): Promise<ParameterResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, child };
         const result = await this._client.invokeCapability<ParameterResourceHandle>(
-            'Aspire.Hosting/withChildRelationship',
+            'Aspire.Hosting/withBuilderChildRelationship',
             rpcArgs
         );
         return new ParameterResource(result, this._client);
@@ -16333,7 +16347,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
         if (optional !== undefined) rpcArgs.optional = optional;
         if (name !== undefined) rpcArgs.name = name;
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
-            'Aspire.Hosting/withReference',
+            'Aspire.Hosting/withGenericResourceReference',
             rpcArgs
         );
         return new ProjectResource(result, this._client);
@@ -16629,7 +16643,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     private async _publishWithContainerFilesInternal(source: ResourceBuilderBase, destinationPath: string): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, source, destinationPath };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
-            'Aspire.Hosting/publishWithContainerFiles',
+            'Aspire.Hosting/publishWithContainerFilesFromResource',
             rpcArgs
         );
         return new ProjectResource(result, this._client);
@@ -16659,7 +16673,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     private async _waitForInternal(dependency: ResourceBuilderBase): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
-            'Aspire.Hosting/waitFor',
+            'Aspire.Hosting/waitForResource',
             rpcArgs
         );
         return new ProjectResource(result, this._client);
@@ -16689,7 +16703,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     private async _waitForStartInternal(dependency: ResourceBuilderBase): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
-            'Aspire.Hosting/waitForStart',
+            'Aspire.Hosting/waitForResourceStart',
             rpcArgs
         );
         return new ProjectResource(result, this._client);
@@ -16735,7 +16749,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         if (exitCode !== undefined) rpcArgs.exitCode = exitCode;
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
-            'Aspire.Hosting/waitForCompletion',
+            'Aspire.Hosting/waitForResourceCompletion',
             rpcArgs
         );
         return new ProjectResource(result, this._client);
@@ -16840,7 +16854,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (password !== undefined) rpcArgs.password = password;
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
-            'Aspire.Hosting/withHttpsDeveloperCertificate',
+            'Aspire.Hosting/withParameterHttpsDeveloperCertificate',
             rpcArgs
         );
         return new ProjectResource(result, this._client);
@@ -16871,7 +16885,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     private async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, parent };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
-            'Aspire.Hosting/withParentRelationship',
+            'Aspire.Hosting/withBuilderParentRelationship',
             rpcArgs
         );
         return new ProjectResource(result, this._client);
@@ -16886,7 +16900,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
     private async _withChildRelationshipInternal(child: ResourceBuilderBase): Promise<ProjectResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, child };
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
-            'Aspire.Hosting/withChildRelationship',
+            'Aspire.Hosting/withBuilderChildRelationship',
             rpcArgs
         );
         return new ProjectResource(result, this._client);
@@ -18055,7 +18069,7 @@ export class TestDatabaseResource extends ResourceBuilderBase<TestDatabaseResour
     private async _withBuildArgInternal(name: string, value: ParameterResource): Promise<TestDatabaseResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
         const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
-            'Aspire.Hosting/withBuildArg',
+            'Aspire.Hosting/withParameterBuildArg',
             rpcArgs
         );
         return new TestDatabaseResource(result, this._client);
@@ -18070,7 +18084,7 @@ export class TestDatabaseResource extends ResourceBuilderBase<TestDatabaseResour
     private async _withBuildSecretInternal(name: string, value: ParameterResource): Promise<TestDatabaseResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
         const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
-            'Aspire.Hosting/withBuildSecret',
+            'Aspire.Hosting/withParameterBuildSecret',
             rpcArgs
         );
         return new TestDatabaseResource(result, this._client);
@@ -18388,7 +18402,7 @@ export class TestDatabaseResource extends ResourceBuilderBase<TestDatabaseResour
         if (optional !== undefined) rpcArgs.optional = optional;
         if (name !== undefined) rpcArgs.name = name;
         const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
-            'Aspire.Hosting/withReference',
+            'Aspire.Hosting/withGenericResourceReference',
             rpcArgs
         );
         return new TestDatabaseResource(result, this._client);
@@ -18699,7 +18713,7 @@ export class TestDatabaseResource extends ResourceBuilderBase<TestDatabaseResour
     private async _waitForInternal(dependency: ResourceBuilderBase): Promise<TestDatabaseResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
-            'Aspire.Hosting/waitFor',
+            'Aspire.Hosting/waitForResource',
             rpcArgs
         );
         return new TestDatabaseResource(result, this._client);
@@ -18729,7 +18743,7 @@ export class TestDatabaseResource extends ResourceBuilderBase<TestDatabaseResour
     private async _waitForStartInternal(dependency: ResourceBuilderBase): Promise<TestDatabaseResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
-            'Aspire.Hosting/waitForStart',
+            'Aspire.Hosting/waitForResourceStart',
             rpcArgs
         );
         return new TestDatabaseResource(result, this._client);
@@ -18775,7 +18789,7 @@ export class TestDatabaseResource extends ResourceBuilderBase<TestDatabaseResour
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         if (exitCode !== undefined) rpcArgs.exitCode = exitCode;
         const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
-            'Aspire.Hosting/waitForCompletion',
+            'Aspire.Hosting/waitForResourceCompletion',
             rpcArgs
         );
         return new TestDatabaseResource(result, this._client);
@@ -18880,7 +18894,7 @@ export class TestDatabaseResource extends ResourceBuilderBase<TestDatabaseResour
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (password !== undefined) rpcArgs.password = password;
         const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
-            'Aspire.Hosting/withHttpsDeveloperCertificate',
+            'Aspire.Hosting/withParameterHttpsDeveloperCertificate',
             rpcArgs
         );
         return new TestDatabaseResource(result, this._client);
@@ -18911,7 +18925,7 @@ export class TestDatabaseResource extends ResourceBuilderBase<TestDatabaseResour
     private async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<TestDatabaseResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, parent };
         const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
-            'Aspire.Hosting/withParentRelationship',
+            'Aspire.Hosting/withBuilderParentRelationship',
             rpcArgs
         );
         return new TestDatabaseResource(result, this._client);
@@ -18926,7 +18940,7 @@ export class TestDatabaseResource extends ResourceBuilderBase<TestDatabaseResour
     private async _withChildRelationshipInternal(child: ResourceBuilderBase): Promise<TestDatabaseResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, child };
         const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
-            'Aspire.Hosting/withChildRelationship',
+            'Aspire.Hosting/withBuilderChildRelationship',
             rpcArgs
         );
         return new TestDatabaseResource(result, this._client);
@@ -20184,7 +20198,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     private async _withBuildArgInternal(name: string, value: ParameterResource): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
-            'Aspire.Hosting/withBuildArg',
+            'Aspire.Hosting/withParameterBuildArg',
             rpcArgs
         );
         return new TestRedisResource(result, this._client);
@@ -20199,7 +20213,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     private async _withBuildSecretInternal(name: string, value: ParameterResource): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
-            'Aspire.Hosting/withBuildSecret',
+            'Aspire.Hosting/withParameterBuildSecret',
             rpcArgs
         );
         return new TestRedisResource(result, this._client);
@@ -20547,7 +20561,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
         if (optional !== undefined) rpcArgs.optional = optional;
         if (name !== undefined) rpcArgs.name = name;
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
-            'Aspire.Hosting/withReference',
+            'Aspire.Hosting/withGenericResourceReference',
             rpcArgs
         );
         return new TestRedisResource(result, this._client);
@@ -20559,6 +20573,15 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
         const optional = options?.optional;
         const name = options?.name;
         return new TestRedisResourcePromise(this._withReferenceInternal(source, connectionName, optional, name));
+    }
+
+    /** Gets a connection property by key */
+    async getConnectionProperty(key: string): Promise<ReferenceExpression> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle, key };
+        return await this._client.invokeCapability<ReferenceExpression>(
+            'Aspire.Hosting/getConnectionProperty',
+            rpcArgs
+        );
     }
 
     /** @internal */
@@ -20858,7 +20881,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     private async _waitForInternal(dependency: ResourceBuilderBase): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
-            'Aspire.Hosting/waitFor',
+            'Aspire.Hosting/waitForResource',
             rpcArgs
         );
         return new TestRedisResource(result, this._client);
@@ -20888,7 +20911,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     private async _waitForStartInternal(dependency: ResourceBuilderBase): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
-            'Aspire.Hosting/waitForStart',
+            'Aspire.Hosting/waitForResourceStart',
             rpcArgs
         );
         return new TestRedisResource(result, this._client);
@@ -20934,7 +20957,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         if (exitCode !== undefined) rpcArgs.exitCode = exitCode;
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
-            'Aspire.Hosting/waitForCompletion',
+            'Aspire.Hosting/waitForResourceCompletion',
             rpcArgs
         );
         return new TestRedisResource(result, this._client);
@@ -21039,7 +21062,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (password !== undefined) rpcArgs.password = password;
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
-            'Aspire.Hosting/withHttpsDeveloperCertificate',
+            'Aspire.Hosting/withParameterHttpsDeveloperCertificate',
             rpcArgs
         );
         return new TestRedisResource(result, this._client);
@@ -21070,7 +21093,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     private async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, parent };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
-            'Aspire.Hosting/withParentRelationship',
+            'Aspire.Hosting/withBuilderParentRelationship',
             rpcArgs
         );
         return new TestRedisResource(result, this._client);
@@ -21085,7 +21108,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
     private async _withChildRelationshipInternal(child: ResourceBuilderBase): Promise<TestRedisResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, child };
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
-            'Aspire.Hosting/withChildRelationship',
+            'Aspire.Hosting/withBuilderChildRelationship',
             rpcArgs
         );
         return new TestRedisResource(result, this._client);
@@ -22019,6 +22042,11 @@ export class TestRedisResourcePromise implements PromiseLike<TestRedisResource> 
         return new TestRedisResourcePromise(this._promise.then(obj => obj.withReference(source, options)));
     }
 
+    /** Gets a connection property by key */
+    getConnectionProperty(key: string): Promise<ReferenceExpression> {
+        return this._promise.then(obj => obj.getConnectionProperty(key));
+    }
+
     /** Adds a reference to a URI */
     withReferenceUri(name: string, uri: string): TestRedisResourcePromise {
         return new TestRedisResourcePromise(this._promise.then(obj => obj.withReferenceUri(name, uri)));
@@ -22607,7 +22635,7 @@ export class TestVaultResource extends ResourceBuilderBase<TestVaultResourceHand
     private async _withBuildArgInternal(name: string, value: ParameterResource): Promise<TestVaultResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
         const result = await this._client.invokeCapability<TestVaultResourceHandle>(
-            'Aspire.Hosting/withBuildArg',
+            'Aspire.Hosting/withParameterBuildArg',
             rpcArgs
         );
         return new TestVaultResource(result, this._client);
@@ -22622,7 +22650,7 @@ export class TestVaultResource extends ResourceBuilderBase<TestVaultResourceHand
     private async _withBuildSecretInternal(name: string, value: ParameterResource): Promise<TestVaultResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, name, value };
         const result = await this._client.invokeCapability<TestVaultResourceHandle>(
-            'Aspire.Hosting/withBuildSecret',
+            'Aspire.Hosting/withParameterBuildSecret',
             rpcArgs
         );
         return new TestVaultResource(result, this._client);
@@ -22940,7 +22968,7 @@ export class TestVaultResource extends ResourceBuilderBase<TestVaultResourceHand
         if (optional !== undefined) rpcArgs.optional = optional;
         if (name !== undefined) rpcArgs.name = name;
         const result = await this._client.invokeCapability<TestVaultResourceHandle>(
-            'Aspire.Hosting/withReference',
+            'Aspire.Hosting/withGenericResourceReference',
             rpcArgs
         );
         return new TestVaultResource(result, this._client);
@@ -23251,7 +23279,7 @@ export class TestVaultResource extends ResourceBuilderBase<TestVaultResourceHand
     private async _waitForInternal(dependency: ResourceBuilderBase): Promise<TestVaultResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<TestVaultResourceHandle>(
-            'Aspire.Hosting/waitFor',
+            'Aspire.Hosting/waitForResource',
             rpcArgs
         );
         return new TestVaultResource(result, this._client);
@@ -23281,7 +23309,7 @@ export class TestVaultResource extends ResourceBuilderBase<TestVaultResourceHand
     private async _waitForStartInternal(dependency: ResourceBuilderBase): Promise<TestVaultResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<TestVaultResourceHandle>(
-            'Aspire.Hosting/waitForStart',
+            'Aspire.Hosting/waitForResourceStart',
             rpcArgs
         );
         return new TestVaultResource(result, this._client);
@@ -23327,7 +23355,7 @@ export class TestVaultResource extends ResourceBuilderBase<TestVaultResourceHand
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         if (exitCode !== undefined) rpcArgs.exitCode = exitCode;
         const result = await this._client.invokeCapability<TestVaultResourceHandle>(
-            'Aspire.Hosting/waitForCompletion',
+            'Aspire.Hosting/waitForResourceCompletion',
             rpcArgs
         );
         return new TestVaultResource(result, this._client);
@@ -23432,7 +23460,7 @@ export class TestVaultResource extends ResourceBuilderBase<TestVaultResourceHand
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (password !== undefined) rpcArgs.password = password;
         const result = await this._client.invokeCapability<TestVaultResourceHandle>(
-            'Aspire.Hosting/withHttpsDeveloperCertificate',
+            'Aspire.Hosting/withParameterHttpsDeveloperCertificate',
             rpcArgs
         );
         return new TestVaultResource(result, this._client);
@@ -23463,7 +23491,7 @@ export class TestVaultResource extends ResourceBuilderBase<TestVaultResourceHand
     private async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<TestVaultResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, parent };
         const result = await this._client.invokeCapability<TestVaultResourceHandle>(
-            'Aspire.Hosting/withParentRelationship',
+            'Aspire.Hosting/withBuilderParentRelationship',
             rpcArgs
         );
         return new TestVaultResource(result, this._client);
@@ -23478,7 +23506,7 @@ export class TestVaultResource extends ResourceBuilderBase<TestVaultResourceHand
     private async _withChildRelationshipInternal(child: ResourceBuilderBase): Promise<TestVaultResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, child };
         const result = await this._client.invokeCapability<TestVaultResourceHandle>(
-            'Aspire.Hosting/withChildRelationship',
+            'Aspire.Hosting/withBuilderChildRelationship',
             rpcArgs
         );
         return new TestVaultResource(result, this._client);
@@ -24621,7 +24649,7 @@ export class ContainerFilesDestinationResource extends ResourceBuilderBase<ICont
     private async _publishWithContainerFilesInternal(source: ResourceBuilderBase, destinationPath: string): Promise<ContainerFilesDestinationResource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, source, destinationPath };
         const result = await this._client.invokeCapability<IContainerFilesDestinationResourceHandle>(
-            'Aspire.Hosting/publishWithContainerFiles',
+            'Aspire.Hosting/publishWithContainerFilesFromResource',
             rpcArgs
         );
         return new ContainerFilesDestinationResource(result, this._client);
@@ -24880,7 +24908,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     private async _withParentRelationshipInternal(parent: ResourceBuilderBase): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, parent };
         const result = await this._client.invokeCapability<IResourceHandle>(
-            'Aspire.Hosting/withParentRelationship',
+            'Aspire.Hosting/withBuilderParentRelationship',
             rpcArgs
         );
         return new Resource(result, this._client);
@@ -24895,7 +24923,7 @@ export class Resource extends ResourceBuilderBase<IResourceHandle> {
     private async _withChildRelationshipInternal(child: ResourceBuilderBase): Promise<Resource> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, child };
         const result = await this._client.invokeCapability<IResourceHandle>(
-            'Aspire.Hosting/withChildRelationship',
+            'Aspire.Hosting/withBuilderChildRelationship',
             rpcArgs
         );
         return new Resource(result, this._client);
@@ -25651,6 +25679,15 @@ export class ResourceWithConnectionString extends ResourceBuilderBase<IResourceW
         return new ResourceWithConnectionStringPromise(this._withConnectionPropertyValueInternal(name, value));
     }
 
+    /** Gets a connection property by key */
+    async getConnectionProperty(key: string): Promise<ReferenceExpression> {
+        const rpcArgs: Record<string, unknown> = { resource: this._handle, key };
+        return await this._client.invokeCapability<ReferenceExpression>(
+            'Aspire.Hosting/getConnectionProperty',
+            rpcArgs
+        );
+    }
+
     /** @internal */
     private async _onConnectionStringAvailableInternal(callback: (arg: ConnectionStringAvailableEvent) => Promise<void>): Promise<ResourceWithConnectionString> {
         const callbackId = registerCallback(async (argData: unknown) => {
@@ -25726,6 +25763,11 @@ export class ResourceWithConnectionStringPromise implements PromiseLike<Resource
     /** Adds a connection property with a string value */
     withConnectionPropertyValue(name: string, value: string): ResourceWithConnectionStringPromise {
         return new ResourceWithConnectionStringPromise(this._promise.then(obj => obj.withConnectionPropertyValue(name, value)));
+    }
+
+    /** Gets a connection property by key */
+    getConnectionProperty(key: string): Promise<ReferenceExpression> {
+        return this._promise.then(obj => obj.getConnectionProperty(key));
     }
 
     /** Subscribes to the ConnectionStringAvailable event */
@@ -26286,7 +26328,7 @@ export class ResourceWithEnvironment extends ResourceBuilderBase<IResourceWithEn
         if (optional !== undefined) rpcArgs.optional = optional;
         if (name !== undefined) rpcArgs.name = name;
         const result = await this._client.invokeCapability<IResourceWithEnvironmentHandle>(
-            'Aspire.Hosting/withReference',
+            'Aspire.Hosting/withGenericResourceReference',
             rpcArgs
         );
         return new ResourceWithEnvironment(result, this._client);
@@ -26380,7 +26422,7 @@ export class ResourceWithEnvironment extends ResourceBuilderBase<IResourceWithEn
         const rpcArgs: Record<string, unknown> = { builder: this._handle };
         if (password !== undefined) rpcArgs.password = password;
         const result = await this._client.invokeCapability<IResourceWithEnvironmentHandle>(
-            'Aspire.Hosting/withHttpsDeveloperCertificate',
+            'Aspire.Hosting/withParameterHttpsDeveloperCertificate',
             rpcArgs
         );
         return new ResourceWithEnvironment(result, this._client);
@@ -26569,7 +26611,7 @@ export class ResourceWithWaitSupport extends ResourceBuilderBase<IResourceWithWa
     private async _waitForInternal(dependency: ResourceBuilderBase): Promise<ResourceWithWaitSupport> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<IResourceWithWaitSupportHandle>(
-            'Aspire.Hosting/waitFor',
+            'Aspire.Hosting/waitForResource',
             rpcArgs
         );
         return new ResourceWithWaitSupport(result, this._client);
@@ -26599,7 +26641,7 @@ export class ResourceWithWaitSupport extends ResourceBuilderBase<IResourceWithWa
     private async _waitForStartInternal(dependency: ResourceBuilderBase): Promise<ResourceWithWaitSupport> {
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         const result = await this._client.invokeCapability<IResourceWithWaitSupportHandle>(
-            'Aspire.Hosting/waitForStart',
+            'Aspire.Hosting/waitForResourceStart',
             rpcArgs
         );
         return new ResourceWithWaitSupport(result, this._client);
@@ -26630,7 +26672,7 @@ export class ResourceWithWaitSupport extends ResourceBuilderBase<IResourceWithWa
         const rpcArgs: Record<string, unknown> = { builder: this._handle, dependency };
         if (exitCode !== undefined) rpcArgs.exitCode = exitCode;
         const result = await this._client.invokeCapability<IResourceWithWaitSupportHandle>(
-            'Aspire.Hosting/waitForCompletion',
+            'Aspire.Hosting/waitForResourceCompletion',
             rpcArgs
         );
         return new ResourceWithWaitSupport(result, this._client);

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -7019,7 +7019,7 @@ export class ContainerResource extends ResourceBuilderBase<ContainerResourceHand
         if (optional !== undefined) rpcArgs.optional = optional;
         if (name !== undefined) rpcArgs.name = name;
         const result = await this._client.invokeCapability<ContainerResourceHandle>(
-            'Aspire.Hosting/withGenericResourceReference',
+            'Aspire.Hosting/withReference',
             rpcArgs
         );
         return new ContainerResource(result, this._client);
@@ -8937,7 +8937,7 @@ export class CSharpAppResource extends ResourceBuilderBase<CSharpAppResourceHand
         if (optional !== undefined) rpcArgs.optional = optional;
         if (name !== undefined) rpcArgs.name = name;
         const result = await this._client.invokeCapability<CSharpAppResourceHandle>(
-            'Aspire.Hosting/withGenericResourceReference',
+            'Aspire.Hosting/withReference',
             rpcArgs
         );
         return new CSharpAppResource(result, this._client);
@@ -10884,7 +10884,7 @@ export class DotnetToolResource extends ResourceBuilderBase<DotnetToolResourceHa
         if (optional !== undefined) rpcArgs.optional = optional;
         if (name !== undefined) rpcArgs.name = name;
         const result = await this._client.invokeCapability<DotnetToolResourceHandle>(
-            'Aspire.Hosting/withGenericResourceReference',
+            'Aspire.Hosting/withReference',
             rpcArgs
         );
         return new DotnetToolResource(result, this._client);
@@ -12756,7 +12756,7 @@ export class ExecutableResource extends ResourceBuilderBase<ExecutableResourceHa
         if (optional !== undefined) rpcArgs.optional = optional;
         if (name !== undefined) rpcArgs.name = name;
         const result = await this._client.invokeCapability<ExecutableResourceHandle>(
-            'Aspire.Hosting/withGenericResourceReference',
+            'Aspire.Hosting/withReference',
             rpcArgs
         );
         return new ExecutableResource(result, this._client);
@@ -16347,7 +16347,7 @@ export class ProjectResource extends ResourceBuilderBase<ProjectResourceHandle> 
         if (optional !== undefined) rpcArgs.optional = optional;
         if (name !== undefined) rpcArgs.name = name;
         const result = await this._client.invokeCapability<ProjectResourceHandle>(
-            'Aspire.Hosting/withGenericResourceReference',
+            'Aspire.Hosting/withReference',
             rpcArgs
         );
         return new ProjectResource(result, this._client);
@@ -18402,7 +18402,7 @@ export class TestDatabaseResource extends ResourceBuilderBase<TestDatabaseResour
         if (optional !== undefined) rpcArgs.optional = optional;
         if (name !== undefined) rpcArgs.name = name;
         const result = await this._client.invokeCapability<TestDatabaseResourceHandle>(
-            'Aspire.Hosting/withGenericResourceReference',
+            'Aspire.Hosting/withReference',
             rpcArgs
         );
         return new TestDatabaseResource(result, this._client);
@@ -20561,7 +20561,7 @@ export class TestRedisResource extends ResourceBuilderBase<TestRedisResourceHand
         if (optional !== undefined) rpcArgs.optional = optional;
         if (name !== undefined) rpcArgs.name = name;
         const result = await this._client.invokeCapability<TestRedisResourceHandle>(
-            'Aspire.Hosting/withGenericResourceReference',
+            'Aspire.Hosting/withReference',
             rpcArgs
         );
         return new TestRedisResource(result, this._client);
@@ -22968,7 +22968,7 @@ export class TestVaultResource extends ResourceBuilderBase<TestVaultResourceHand
         if (optional !== undefined) rpcArgs.optional = optional;
         if (name !== undefined) rpcArgs.name = name;
         const result = await this._client.invokeCapability<TestVaultResourceHandle>(
-            'Aspire.Hosting/withGenericResourceReference',
+            'Aspire.Hosting/withReference',
             rpcArgs
         );
         return new TestVaultResource(result, this._client);
@@ -26328,7 +26328,7 @@ export class ResourceWithEnvironment extends ResourceBuilderBase<IResourceWithEn
         if (optional !== undefined) rpcArgs.optional = optional;
         if (name !== undefined) rpcArgs.name = name;
         const result = await this._client.invokeCapability<IResourceWithEnvironmentHandle>(
-            'Aspire.Hosting/withGenericResourceReference',
+            'Aspire.Hosting/withReference',
             rpcArgs
         );
         return new ResourceWithEnvironment(result, this._client);

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AttributeDataReaderTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AttributeDataReaderTests.cs
@@ -70,6 +70,14 @@ public class AttributeDataReaderTests
     }
 
     [Fact]
+    public void HasAspireExportIgnoreData_FindsOfficialAttribute_OnType()
+    {
+        var result = AttributeDataReader.HasAspireExportIgnoreData(typeof(OfficialIgnoredType));
+
+        Assert.True(result);
+    }
+
+    [Fact]
     public void HasAspireDtoData_FindsOfficialAttribute()
     {
         var result = AttributeDataReader.HasAspireDtoData(typeof(OfficialDtoType));
@@ -214,6 +222,11 @@ public class AttributeDataReaderTests
         public OfficialMethodsResource(string name) : base(name) { }
 
         public void DoSomething() { }
+    }
+
+    [AspireExportIgnore]
+    public class OfficialIgnoredType
+    {
     }
 
     [AspireDto]


### PR DESCRIPTION
## Description

- Fix the `Aspire.Hosting` analyzer hookup so the shared analyzer wiring validates both `Aspire.Hosting` and `Aspire.Hosting.*` projects.
- Align export validation with runtime and codegen behavior for assembly-exported external types, instance members on exported types, `ValueTask`/`ValueTask<T>`, arrays of assembly-exported external types, and type-level `[AspireExportIgnore]`.
- Apply the follow-up review fixes by simplifying `src/Directory.Build.targets`, restoring the `withReference` capability ID, consolidating ignore coverage onto types where appropriate, and refreshing the affected codegen snapshots and regression tests.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
