### PR TITLE
Fix Foundry run-mode project restart

### DIFF
--- a/src/Aspire.Hosting.Foundry/FoundryExtensions.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryExtensions.cs
@@ -23,6 +23,7 @@ namespace Aspire.Hosting;
 public static class FoundryExtensions
 {
     private const string DefaultCapabilityHostName = "foundry-caphost";
+    internal const string LocalProjectsNotSupportedMessage = "Microsoft Foundry projects are not supported when the parent Foundry resource is configured with RunAsFoundryLocal().";
 
     /// <summary>
     /// Adds a Microsoft Foundry resource to the application model.
@@ -140,6 +141,7 @@ public static class FoundryExtensions
         }
 
         var resource = builder.Resource;
+        ThrowIfProjectsConfiguredForLocal(builder, resource);
         resource.Annotations.Add(new EmulatorResourceAnnotation());
 
         builder.ApplicationBuilder.Services.AddSingleton<FoundryLocalManager>();
@@ -167,6 +169,16 @@ public static class FoundryExtensions
         builder.WithHealthCheck(healthCheckKey);
 
         return builder;
+    }
+
+    internal static void ThrowIfProjectsConfiguredForLocal(IResourceBuilder<FoundryResource> builder, FoundryResource resource)
+    {
+        if (builder.ApplicationBuilder.Resources
+            .OfType<AzureCognitiveServicesProjectResource>()
+            .Any(project => ReferenceEquals(project.Parent, resource)))
+        {
+            throw new InvalidOperationException(LocalProjectsNotSupportedMessage);
+        }
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Foundry/Project/ProjectBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/Project/ProjectBuilderExtension.cs
@@ -598,10 +598,7 @@ public static class AzureCognitiveServicesProjectExtensions
         }
 
         var resource = new AzureContainerRegistryResource(name, configureInfrastructure);
-        if (builder.ExecutionContext.IsPublishMode)
-        {
-            builder.AddResource(resource);
-        }
+        builder.AddResource(resource);
         return resource;
     }
 }

--- a/src/Aspire.Hosting.Foundry/Project/ProjectBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/Project/ProjectBuilderExtension.cs
@@ -41,6 +41,10 @@ public static class AzureCognitiveServicesProjectExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(name);
+        if (builder.Resource.IsEmulator)
+        {
+            throw new InvalidOperationException(FoundryExtensions.LocalProjectsNotSupportedMessage);
+        }
 
         builder.ApplicationBuilder.Services.Configure<AzureProvisioningOptions>(o => o.SupportsTargetedRoleAssignments = true);
 

--- a/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/FoundryExtensionsTests.cs
@@ -195,6 +195,20 @@ public class FoundryExtensionsTests
     }
 
     [Fact]
+    public void AddProject_AddsDefaultContainerRegistryInRunMode()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        var project = builder.AddFoundry("myAIFoundry")
+            .AddProject("my-project");
+
+        var registry = Assert.Single(builder.Resources.OfType<AzureContainerRegistryResource>());
+
+        Assert.Equal("my-project-acr", registry.Name);
+        Assert.Same(registry, project.Resource.ContainerRegistry);
+    }
+
+    [Fact]
     public async Task AddProject_WithPublishAsExistingFoundry_GeneratesBicepThatReferencesExistingParent()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);

--- a/tests/Aspire.Hosting.Foundry.Tests/AddProjectTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/AddProjectTests.cs
@@ -43,4 +43,30 @@ public class AddProjectTests
                 && value is "{test-project.outputs.endpoint}";
         });
     }
+
+    [Fact]
+    public void AddProject_AfterRunAsFoundryLocal_Throws()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        var foundry = builder.AddFoundry("account")
+            .RunAsFoundryLocal();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => foundry.AddProject("my-project"));
+
+        Assert.Equal(FoundryExtensions.LocalProjectsNotSupportedMessage, exception.Message);
+    }
+
+    [Fact]
+    public void RunAsFoundryLocal_AfterAddProject_Throws()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        var foundry = builder.AddFoundry("account");
+        foundry.AddProject("my-project");
+
+        var exception = Assert.Throws<InvalidOperationException>(foundry.RunAsFoundryLocal);
+
+        Assert.Equal(FoundryExtensions.LocalProjectsNotSupportedMessage, exception.Message);
+    }
 }

--- a/tests/Aspire.Hosting.Foundry.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/ProjectResourceTests.cs
@@ -42,7 +42,9 @@ public class ProjectResourceTests
         var project = builder.AddFoundry("account")
             .AddProject("my-project");
 
-        Assert.Empty(builder.Resources.OfType<AzureContainerRegistryResource>());
+        var registry = Assert.Single(builder.Resources.OfType<AzureContainerRegistryResource>());
+        Assert.Equal("my-project-acr", registry.Name);
+        Assert.Same(project.Resource.DefaultContainerRegistry, registry);
         Assert.Same(project.Resource.DefaultContainerRegistry, project.Resource.ContainerRegistry);
     }
 


### PR DESCRIPTION
## Description

Fixes a run-mode restart failure for Foundry projects.

When a Foundry project used its default container registry, the registry resource was only added to the app model in publish mode. In run mode, the project still referenced the registry outputs during provisioning and restart, which meant the registry state was never restored or persisted. That caused restart failures such as missing `proj-acr` outputs and prevented `Azure:Deployments:proj:*` state from being written.

This change always registers the default Foundry container registry resource and adds a regression test covering run-mode registration.

Validation:
- `./dotnet.sh test --tl:off tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj -- --filter-method "*.AddProject_AddsDefaultContainerRegistryInRunMode" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- Reproduced with `playground/FoundryAgentBasic/FoundryAgentBasic.AppHost` using `aspire start`/`stop`/`start`
- Confirmed `proj` reaches `Running` and user secrets now contain both `Azure:Deployments:proj-acr:*` and `Azure:Deployments:proj:*`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
