### PR TITLE
Improve CLI error messages for dependency and project creation failures

### DIFF
--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -147,6 +147,12 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
             InteractionService.DisplayMessage(KnownEmojis.Information, $"Creating {languageInfo.DisplayName} AppHost...");
             InteractionService.DisplayEmptyLine();
             var polyglotResult = await CreatePolyglotAppHostAsync(languageInfo, cancellationToken);
+            if (polyglotResult != 0)
+            {
+                InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ProjectCouldNotBeCreated, ExecutionContext.LogFilePath));
+                return polyglotResult;
+            }
+
             return await _agentInitCommand.PromptAndChainAsync(_hostEnvironment, InteractionService, polyglotResult, _executionContext.WorkingDirectory, cancellationToken);
         }
 
@@ -179,6 +185,12 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
             InteractionService.DisplayEmptyLine();
             initResult = await CreateEmptyAppHostAsync(parseResult, cancellationToken);
             workspaceRoot = _executionContext.WorkingDirectory;
+        }
+
+        if (initResult != 0)
+        {
+            InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ProjectCouldNotBeCreated, ExecutionContext.LogFilePath));
+            return initResult;
         }
 
         return await _agentInitCommand.PromptAndChainAsync(_hostEnvironment, InteractionService, initResult, workspaceRoot, cancellationToken);

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Interaction;
@@ -253,6 +254,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             if (!resolveResult.Success)
             {
                 InteractionService.DisplayError(resolveResult.ErrorMessage);
+                InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ProjectCouldNotBeCreated, ExecutionContext.LogFilePath));
                 return ExitCodeConstants.InvalidCommand;
             }
 
@@ -270,6 +272,12 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             Language = template.LanguageId
         };
         var templateResult = await template.ApplyTemplateAsync(inputs, parseResult, cancellationToken);
+        if (templateResult.ExitCode != 0)
+        {
+            InteractionService.DisplayError(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ProjectCouldNotBeCreated, ExecutionContext.LogFilePath));
+            return templateResult.ExitCode;
+        }
+
         if (templateResult.OutputPath is not null && ExtensionHelper.IsExtensionHost(InteractionService, out var extensionInteractionService, out _))
         {
             extensionInteractionService.OpenEditor(templateResult.OutputPath);

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -352,15 +352,24 @@ internal class ConsoleInteractionService : IInteractionService
 
     public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines)
     {
-        foreach (var (stream, line) in lines)
+        var linesArray = lines.ToArray();
+
+        // Special case one stderr line to include error icon.
+        if (linesArray.Length == 1 && linesArray[0].Stream == OutputLineStream.StdErr)
+        {
+            DisplayError(linesArray[0].Line);
+            return;
+        }
+
+        foreach (var (stream, line) in linesArray)
         {
             if (stream == OutputLineStream.StdOut)
             {
-                MessageConsole.MarkupLineInterpolated($"{line.EscapeMarkup()}");
+                MessageConsole.MarkupLine(line.EscapeMarkup());
             }
             else
             {
-                MessageConsole.MarkupLineInterpolated($"[red]{line.EscapeMarkup()}[/]");
+                MessageConsole.MarkupLine($"[red]{line.EscapeMarkup()}[/]");
             }
         }
     }

--- a/src/Aspire.Cli/Resources/ErrorStrings.resx
+++ b/src/Aspire.Cli/Resources/ErrorStrings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MinimumSdkVersionNotMet" xml:space="preserve">
-    <value>The Aspire CLI requires .NET SDK version {0} or later. Detected: {1}.</value>
+    <value>C# apphost requires .NET SDK version {0} or later. Detected: {1}.</value>
   </data>
   <data name="InvalidLocaleProvided" xml:space="preserve">
     <value>Invalid locale {0} provided will not be used.</value>

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
@@ -250,6 +250,15 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The app could not be created. See logs at {0}.
+        /// </summary>
+        public static string ProjectCouldNotBeCreated {
+            get {
+                return ResourceManager.GetString("ProjectCouldNotBeCreated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The --apphost option specified a project that does not exist..
         /// </summary>
         public static string ProjectOptionDoesntExist {

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
@@ -188,6 +188,9 @@
   <data name="ProjectCouldNotBeBuilt" xml:space="preserve">
     <value>The project could not be built. See logs at {0}</value>
   </data>
+  <data name="ProjectCouldNotBeCreated" xml:space="preserve">
+    <value>The app could not be created. See logs at {0}</value>
+  </data>
   <data name="OperationCancelled" xml:space="preserve">
     <value>The operation was canceled.</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.cs.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MinimumSdkVersionNotMet">
-        <source>The Aspire CLI requires .NET SDK version {0} or later. Detected: {1}.</source>
-        <target state="translated">Rozhraní příkazového řádku Aspire vyžaduje sadu .NET SDK verze {0} nebo novější. Zjištěno: {1}.</target>
+        <source>C# apphost requires .NET SDK version {0} or later. Detected: {1}.</source>
+        <target state="needs-review-translation">Rozhraní příkazového řádku Aspire vyžaduje sadu .NET SDK verze {0} nebo novější. Zjištěno: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleProjectFilesFound">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.de.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MinimumSdkVersionNotMet">
-        <source>The Aspire CLI requires .NET SDK version {0} or later. Detected: {1}.</source>
-        <target state="translated">Die Aspire-CLI erfordert .NET SDK-Version {0} oder höher. Erkannt: {1}.</target>
+        <source>C# apphost requires .NET SDK version {0} or later. Detected: {1}.</source>
+        <target state="needs-review-translation">Die Aspire-CLI erfordert .NET SDK-Version {0} oder höher. Erkannt: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleProjectFilesFound">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.es.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MinimumSdkVersionNotMet">
-        <source>The Aspire CLI requires .NET SDK version {0} or later. Detected: {1}.</source>
-        <target state="translated">La CLI de Aspire requiere la versión {0} del SDK de .NET o posterior. Detectado: {1}.</target>
+        <source>C# apphost requires .NET SDK version {0} or later. Detected: {1}.</source>
+        <target state="needs-review-translation">La CLI de Aspire requiere la versión {0} del SDK de .NET o posterior. Detectado: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleProjectFilesFound">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.fr.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MinimumSdkVersionNotMet">
-        <source>The Aspire CLI requires .NET SDK version {0} or later. Detected: {1}.</source>
-        <target state="translated">L’interface CLI Aspire nécessite le kit SDK .NET version {0} ou ultérieure. A détecté : {1}.</target>
+        <source>C# apphost requires .NET SDK version {0} or later. Detected: {1}.</source>
+        <target state="needs-review-translation">L’interface CLI Aspire nécessite le kit SDK .NET version {0} ou ultérieure. A détecté : {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleProjectFilesFound">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.it.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MinimumSdkVersionNotMet">
-        <source>The Aspire CLI requires .NET SDK version {0} or later. Detected: {1}.</source>
-        <target state="translated">L'interfaccia della riga di comando di Aspire richiede .NET SDK versione {0} o successiva. Rilevata: {1}.</target>
+        <source>C# apphost requires .NET SDK version {0} or later. Detected: {1}.</source>
+        <target state="needs-review-translation">L'interfaccia della riga di comando di Aspire richiede .NET SDK versione {0} o successiva. Rilevata: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleProjectFilesFound">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ja.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MinimumSdkVersionNotMet">
-        <source>The Aspire CLI requires .NET SDK version {0} or later. Detected: {1}.</source>
-        <target state="translated">Aspire CLI には .NET SDK バージョン {0} 以降が必要です。以下を検出しました: {1}。</target>
+        <source>C# apphost requires .NET SDK version {0} or later. Detected: {1}.</source>
+        <target state="needs-review-translation">Aspire CLI には .NET SDK バージョン {0} 以降が必要です。以下を検出しました: {1}。</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleProjectFilesFound">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ko.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MinimumSdkVersionNotMet">
-        <source>The Aspire CLI requires .NET SDK version {0} or later. Detected: {1}.</source>
-        <target state="translated">Aspire CLI를 사용하려면 .NET SDK 버전 {0} 이상이 필요합니다. 감지됨: {1}.</target>
+        <source>C# apphost requires .NET SDK version {0} or later. Detected: {1}.</source>
+        <target state="needs-review-translation">Aspire CLI를 사용하려면 .NET SDK 버전 {0} 이상이 필요합니다. 감지됨: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleProjectFilesFound">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pl.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MinimumSdkVersionNotMet">
-        <source>The Aspire CLI requires .NET SDK version {0} or later. Detected: {1}.</source>
-        <target state="translated">Interfejs wiersza polecenia platformy Aspire wymaga zestawu .NET SDK w wersji {0} lub nowszej. Wykryto {1}.</target>
+        <source>C# apphost requires .NET SDK version {0} or later. Detected: {1}.</source>
+        <target state="needs-review-translation">Interfejs wiersza polecenia platformy Aspire wymaga zestawu .NET SDK w wersji {0} lub nowszej. Wykryto {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleProjectFilesFound">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.pt-BR.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MinimumSdkVersionNotMet">
-        <source>The Aspire CLI requires .NET SDK version {0} or later. Detected: {1}.</source>
-        <target state="translated">A CLI do Aspire requer a versão do SDK do .NET {0} ou posterior. Detectado: {1}.</target>
+        <source>C# apphost requires .NET SDK version {0} or later. Detected: {1}.</source>
+        <target state="needs-review-translation">A CLI do Aspire requer a versão do SDK do .NET {0} ou posterior. Detectado: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleProjectFilesFound">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.ru.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MinimumSdkVersionNotMet">
-        <source>The Aspire CLI requires .NET SDK version {0} or later. Detected: {1}.</source>
-        <target state="translated">Для Aspire CLI требуется версия .NET SDK {0} или более поздняя. Обнаружено: {1}.</target>
+        <source>C# apphost requires .NET SDK version {0} or later. Detected: {1}.</source>
+        <target state="needs-review-translation">Для Aspire CLI требуется версия .NET SDK {0} или более поздняя. Обнаружено: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleProjectFilesFound">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.tr.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MinimumSdkVersionNotMet">
-        <source>The Aspire CLI requires .NET SDK version {0} or later. Detected: {1}.</source>
-        <target state="translated">Aspire CLI için .NET SDK sürümünün {0} veya daha yeni olması gerekiyor. Algılanan: {1}.</target>
+        <source>C# apphost requires .NET SDK version {0} or later. Detected: {1}.</source>
+        <target state="needs-review-translation">Aspire CLI için .NET SDK sürümünün {0} veya daha yeni olması gerekiyor. Algılanan: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleProjectFilesFound">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hans.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MinimumSdkVersionNotMet">
-        <source>The Aspire CLI requires .NET SDK version {0} or later. Detected: {1}.</source>
-        <target state="translated">Aspire CLI 需要 .NET SDK {0} 或更高版本。检测到: {1}。</target>
+        <source>C# apphost requires .NET SDK version {0} or later. Detected: {1}.</source>
+        <target state="needs-review-translation">Aspire CLI 需要 .NET SDK {0} 或更高版本。检测到: {1}。</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleProjectFilesFound">

--- a/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/ErrorStrings.zh-Hant.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MinimumSdkVersionNotMet">
-        <source>The Aspire CLI requires .NET SDK version {0} or later. Detected: {1}.</source>
-        <target state="translated">Aspire CLI 需要 .NET SDK 版本 {0} 或更新版本。已偵測到: {1}。</target>
+        <source>C# apphost requires .NET SDK version {0} or later. Detected: {1}.</source>
+        <target state="needs-review-translation">Aspire CLI 需要 .NET SDK 版本 {0} 或更新版本。已偵測到: {1}。</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleProjectFilesFound">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
@@ -102,6 +102,11 @@
         <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreated">
+        <source>The app could not be created. See logs at {0}</source>
+        <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
         <source>The --apphost option specified a project that does not exist.</source>
         <target state="translated">Parametr --apphost určil projekt, který neexistuje.</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
@@ -102,6 +102,11 @@
         <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreated">
+        <source>The app could not be created. See logs at {0}</source>
+        <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
         <source>The --apphost option specified a project that does not exist.</source>
         <target state="translated">Die Option „--apphost“ hat ein Projekt angegeben, das nicht vorhanden ist.</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
@@ -102,6 +102,11 @@
         <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreated">
+        <source>The app could not be created. See logs at {0}</source>
+        <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
         <source>The --apphost option specified a project that does not exist.</source>
         <target state="translated">La opción --apphost especificó un proyecto que no existe.</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
@@ -102,6 +102,11 @@
         <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreated">
+        <source>The app could not be created. See logs at {0}</source>
+        <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
         <source>The --apphost option specified a project that does not exist.</source>
         <target state="translated">L’option --apphost spécifiait un projet qui n’existe pas.</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
@@ -102,6 +102,11 @@
         <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreated">
+        <source>The app could not be created. See logs at {0}</source>
+        <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
         <source>The --apphost option specified a project that does not exist.</source>
         <target state="translated">L'opzione --apphost ha specificato un progetto che non esiste.</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
@@ -102,6 +102,11 @@
         <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreated">
+        <source>The app could not be created. See logs at {0}</source>
+        <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
         <source>The --apphost option specified a project that does not exist.</source>
         <target state="translated">--apphost オプションで、存在しないプロジェクトが指定されています。</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
@@ -102,6 +102,11 @@
         <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreated">
+        <source>The app could not be created. See logs at {0}</source>
+        <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
         <source>The --apphost option specified a project that does not exist.</source>
         <target state="translated">--apphost 옵션에서 존재하지 않는 프로젝트를 지정했습니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
@@ -102,6 +102,11 @@
         <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreated">
+        <source>The app could not be created. See logs at {0}</source>
+        <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
         <source>The --apphost option specified a project that does not exist.</source>
         <target state="translated">Opcja --apphost określiła projekt, który nie istnieje.</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
@@ -102,6 +102,11 @@
         <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreated">
+        <source>The app could not be created. See logs at {0}</source>
+        <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
         <source>The --apphost option specified a project that does not exist.</source>
         <target state="translated">A opção --apphost especificou um projeto que não existe.</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
@@ -102,6 +102,11 @@
         <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreated">
+        <source>The app could not be created. See logs at {0}</source>
+        <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
         <source>The --apphost option specified a project that does not exist.</source>
         <target state="translated">В параметре --apphost указан несуществующий проект.</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
@@ -102,6 +102,11 @@
         <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreated">
+        <source>The app could not be created. See logs at {0}</source>
+        <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
         <source>The --apphost option specified a project that does not exist.</source>
         <target state="translated">--apphost seçeneği var olmayan bir projeyi belirtti.</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
@@ -102,6 +102,11 @@
         <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreated">
+        <source>The app could not be created. See logs at {0}</source>
+        <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
         <source>The --apphost option specified a project that does not exist.</source>
         <target state="translated">--apphost 选项指定了不存在的项目。</target>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
@@ -102,6 +102,11 @@
         <target state="new">The project could not be built. See logs at {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectCouldNotBeCreated">
+        <source>The app could not be created. See logs at {0}</source>
+        <target state="new">The app could not be created. See logs at {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectOptionDoesntExist">
         <source>The --apphost option specified a project that does not exist.</source>
         <target state="translated">--apphost 選項指定的專案不存在。</target>

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -1,10 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.NuGet;
 using Aspire.Cli.Packaging;
+using Aspire.Cli.Projects;
+using Aspire.Cli.Resources;
+using Aspire.Cli.Scaffolding;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
@@ -541,6 +545,109 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         
         // Assert - should fail with non-zero exit code for invalid channel
         Assert.NotEqual(0, exitCode);
+    }
+
+    [Fact]
+    public async Task InitCommand_WhenCSharpInitializationFails_DisplaysCreationErrorMessage()
+    {
+        TestInteractionService? testInteractionService = null;
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Create a solution file only (no project files in the same directory)
+        var solutionFile = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "Test.sln"));
+        File.WriteAllText(solutionFile.FullName, "Fake solution file");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = (sp) =>
+            {
+                testInteractionService = new TestInteractionService();
+                return testInteractionService;
+            };
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.GetSolutionProjectsAsyncCallback = (_, _, _) =>
+                {
+                    return (0, Array.Empty<FileInfo>());
+                };
+                runner.NewProjectAsyncCallback = (templateName, projectName, outputPath, invocationOptions, ct) =>
+                {
+                    return 1; // Simulate failure for C# template
+                };
+                return runner;
+            };
+            options.PackagingServiceFactory = (sp) =>
+            {
+                return new TestPackagingService();
+            };
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        var executionContext = serviceProvider.GetRequiredService<CliExecutionContext>();
+        var expectedMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ProjectCouldNotBeCreated, executionContext.LogFilePath);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.NotNull(testInteractionService);
+        Assert.Contains(expectedMessage, testInteractionService.DisplayedErrors);
+    }
+
+    [Fact]
+    public async Task InitCommand_WhenTypeScriptInitializationFails_DisplaysCreationErrorMessage()
+    {
+        TestInteractionService? testInteractionService = null;
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = (sp) =>
+            {
+                testInteractionService = new TestInteractionService();
+                return testInteractionService;
+            };
+
+            options.LanguageServiceFactory = (sp) =>
+            {
+                var projectFactory = sp.GetRequiredService<IAppHostProjectFactory>();
+                var tsProject = projectFactory.GetProject(new LanguageInfo(
+                    LanguageId: new LanguageId(KnownLanguageId.TypeScript),
+                    DisplayName: "TypeScript (Node.js)",
+                    PackageName: "@aspire/app-host",
+                    DetectionPatterns: ["apphost.ts"],
+                    CodeGenerator: "typescript",
+                    AppHostFileName: "apphost.ts"));
+                return new TestLanguageService { DefaultProject = tsProject };
+            };
+        });
+
+        services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
+        {
+            ScaffoldAsyncCallback = (context, cancellationToken) =>
+            {
+                return Task.FromResult(false); // Simulate failure for TypeScript scaffolding
+            }
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var initCommand = serviceProvider.GetRequiredService<InitCommand>();
+
+        var parseResult = initCommand.Parse("init");
+        var exitCode = await parseResult.InvokeAsync().DefaultTimeout();
+
+        var executionContext = serviceProvider.GetRequiredService<CliExecutionContext>();
+        var expectedMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ProjectCouldNotBeCreated, executionContext.LogFilePath);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.NotNull(testInteractionService);
+        Assert.Contains(expectedMessage, testInteractionService.DisplayedErrors);
     }
 
     private sealed class TestPackagingServiceWithChannelTracking(Action<string> onChannelUsed) : IPackagingService

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using Aspire.Cli.Utils;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Commands;
@@ -1470,6 +1471,121 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         // the template to try to prompt for options.
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task NewCommand_WhenCSharpTemplateApplyFails_DisplaysCreationErrorMessage()
+    {
+        TestInteractionService? testInteractionService = null;
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = (sp) =>
+            {
+                testInteractionService = new TestInteractionService();
+                return testInteractionService;
+            };
+
+            options.NewCommandPrompterFactory = (sp) =>
+            {
+                var interactionService = sp.GetRequiredService<IInteractionService>();
+                return new TestNewCommandPrompter(interactionService);
+            };
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
+                {
+                    var package = new NuGetPackage()
+                    {
+                        Id = "Aspire.ProjectTemplates",
+                        Source = "nuget",
+                        Version = "9.2.0"
+                    };
+
+                    return (0, new NuGetPackage[] { package });
+                };
+
+                runner.NewProjectAsyncCallback = (templateName, projectName, outputPath, invocationOptions, ct) =>
+                {
+                    return 1; // Simulate failure
+                };
+
+                return runner;
+            };
+        });
+
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new aspire-starter --use-redis-cache --test-framework None");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        var executionContext = provider.GetRequiredService<CliExecutionContext>();
+        var expectedMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ProjectCouldNotBeCreated, executionContext.LogFilePath);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.NotNull(testInteractionService);
+        Assert.Contains(expectedMessage, testInteractionService.DisplayedErrors);
+    }
+
+    [Fact]
+    public async Task NewCommand_WhenTypeScriptTemplateApplyFails_DisplaysCreationErrorMessage()
+    {
+        TestInteractionService? testInteractionService = null;
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.InteractionServiceFactory = (sp) =>
+            {
+                testInteractionService = new TestInteractionService();
+                return testInteractionService;
+            };
+
+            options.DotNetCliRunnerFactory = (sp) =>
+            {
+                var runner = new TestDotNetCliRunner();
+                runner.SearchPackagesAsyncCallback = (dir, query, prerelease, take, skip, nugetSource, useCache, options, cancellationToken) =>
+                {
+                    var package = new NuGetPackage()
+                    {
+                        Id = "Aspire.ProjectTemplates",
+                        Source = "nuget",
+                        Version = "9.2.0"
+                    };
+
+                    return (0, new NuGetPackage[] { package });
+                };
+
+                return runner;
+            };
+        });
+
+        services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
+        {
+            ScaffoldAsyncCallback = (context, cancellationToken) =>
+            {
+                return Task.FromResult(false); // Simulate failure for TypeScript template
+            }
+        });
+
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new aspire-ts-empty --name TestApp --output .");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        var executionContext = provider.GetRequiredService<CliExecutionContext>();
+        var expectedMessage = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ProjectCouldNotBeCreated, executionContext.LogFilePath);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.NotNull(testInteractionService);
+        Assert.Contains(expectedMessage, testInteractionService.DisplayedErrors);
     }
 }
 

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1421,9 +1421,13 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
+        var executionContext = provider.GetRequiredService<CliExecutionContext>();
+        var expectedCreationError = string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.ProjectCouldNotBeCreated, executionContext.LogFilePath);
+
         Assert.Equal(ExitCodeConstants.FailedToBuildArtifacts, exitCode);
-        Assert.Single(interactionService.DisplayedErrors);
-        Assert.Equal("Automatic 'aspire restore' failed for the new TypeScript starter project. Run 'aspire restore' in the project directory for more details.", interactionService.DisplayedErrors[0]);
+        Assert.Collection(interactionService.DisplayedErrors,
+            error => Assert.Equal("Automatic 'aspire restore' failed for the new TypeScript starter project. Run 'aspire restore' in the project directory for more details.", error),
+            error => Assert.Equal(expectedCreationError, error));
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/DotNetSdkInstallerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNetSdkInstallerTests.cs
@@ -167,7 +167,7 @@ public class DotNetSdkInstallerTests
             "10.0.100",
             "(not found)");
 
-        Assert.Equal("The Aspire CLI requires .NET SDK version 10.0.100 or later. Detected: (not found).", message);
+        Assert.Equal("C# apphost requires .NET SDK version 10.0.100 or later. Detected: (not found).", message);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -123,8 +123,8 @@ public class ConsoleInteractionServiceTests
         Assert.Null(exception);
         var outputString = output.ToString();
         Assert.Contains("Command output with <angle> brackets", outputString);
-        // Square brackets get escaped to [[square]] when using EscapeMarkup()
-        Assert.Contains("Error output with [[square]] brackets", outputString);
+        // EscapeMarkup() escapes [ to [[ for Spectre's parser, but Spectre renders [[ back to literal [
+        Assert.Contains("Error output with [square] brackets", outputString);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Improve CLI error messages for dependency and project creation failures:

- Changed `MinimumSdkVersionNotMet` error string to be specific to C# apphost: "C# apphost requires .NET SDK version {0} or later. Detected: {1}."
- Added "The app could not be created. See logs at {0}" error display in `NewCommand` and `InitCommand` when project creation fails, for both C# and TypeScript/polyglot paths.

Fixes https://github.com/dotnet/aspire/issues/15314

## Checklist

Check off each item if the described requirement is met.

- [x] Is this feature complete?
- [x] Are there unit tests?
- [ ] Has the public API surface been reviewed? N/A - no public API changes
- [ ] Does the change fix a security vulnerability? N/A
- [ ] Does it require a docs update? No
