### PR TITLE
[release/13.2] Fix legacy settings migration path adjustment for appHostPath

### DIFF
--- a/src/Aspire.Cli/Configuration/AspireConfigFile.cs
+++ b/src/Aspire.Cli/Configuration/AspireConfigFile.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Configuration;
@@ -181,9 +182,9 @@ internal sealed class AspireConfigFile
             // to the OS separator for Path operations and back to '/' for storage.
             if (config.AppHost?.Path is { Length: > 0 } migratedPath && !Path.IsPathRooted(migratedPath))
             {
-                var normalized = migratedPath.Replace('\\', '/').Replace('/', Path.DirectorySeparatorChar);
                 var legacySettingsDir = Path.Combine(directory, AspireJsonConfiguration.SettingsFolder);
-                var absolutePath = Path.GetFullPath(Path.Combine(legacySettingsDir, normalized));
+                var absolutePath = PathNormalizer.NormalizePathForCurrentPlatform(
+                    Path.Combine(legacySettingsDir, migratedPath));
                 config.AppHost.Path = Path.GetRelativePath(directory, absolutePath)
                     .Replace('\\', '/');
             }

--- a/src/Aspire.Cli/Configuration/AspireConfigFile.cs
+++ b/src/Aspire.Cli/Configuration/AspireConfigFile.cs
@@ -177,12 +177,15 @@ internal sealed class AspireConfigFile
             // Legacy .aspire/settings.json stores appHostPath relative to the .aspire/ directory,
             // but aspire.config.json stores it relative to the config file's own directory (the parent
             // of .aspire/). Re-base the path so it resolves correctly from the new location.
-            if (config.AppHost?.Path is { } migratedPath && !Path.IsPathRooted(migratedPath))
+            // Paths are always stored with '/' separators regardless of platform, but we normalize
+            // to the OS separator for Path operations and back to '/' for storage.
+            if (config.AppHost?.Path is { Length: > 0 } migratedPath && !Path.IsPathRooted(migratedPath))
             {
+                var normalized = migratedPath.Replace('\\', '/').Replace('/', Path.DirectorySeparatorChar);
                 var legacySettingsDir = Path.Combine(directory, AspireJsonConfiguration.SettingsFolder);
-                var absolutePath = Path.GetFullPath(Path.Combine(legacySettingsDir, migratedPath));
+                var absolutePath = Path.GetFullPath(Path.Combine(legacySettingsDir, normalized));
                 config.AppHost.Path = Path.GetRelativePath(directory, absolutePath)
-                    .Replace(Path.DirectorySeparatorChar, '/');
+                    .Replace('\\', '/');
             }
 
             // Persist the migrated config (legacy files are kept for older CLI versions)

--- a/src/Aspire.Cli/Configuration/AspireConfigFile.cs
+++ b/src/Aspire.Cli/Configuration/AspireConfigFile.cs
@@ -174,6 +174,17 @@ internal sealed class AspireConfigFile
             var profiles = ReadApphostRunProfiles(Path.Combine(directory, "apphost.run.json"));
             config = FromLegacy(legacyConfig, profiles);
 
+            // Legacy .aspire/settings.json stores appHostPath relative to the .aspire/ directory,
+            // but aspire.config.json stores it relative to the config file's own directory (the parent
+            // of .aspire/). Re-base the path so it resolves correctly from the new location.
+            if (config.AppHost?.Path is { } migratedPath && !Path.IsPathRooted(migratedPath))
+            {
+                var legacySettingsDir = Path.Combine(directory, AspireJsonConfiguration.SettingsFolder);
+                var absolutePath = Path.GetFullPath(Path.Combine(legacySettingsDir, migratedPath));
+                config.AppHost.Path = Path.GetRelativePath(directory, absolutePath)
+                    .Replace(Path.DirectorySeparatorChar, '/');
+            }
+
             // Persist the migrated config (legacy files are kept for older CLI versions)
             config.Save(directory);
         }

--- a/src/Aspire.Cli/Configuration/AspireConfigFile.cs
+++ b/src/Aspire.Cli/Configuration/AspireConfigFile.cs
@@ -185,8 +185,8 @@ internal sealed class AspireConfigFile
                 var legacySettingsDir = Path.Combine(directory, AspireJsonConfiguration.SettingsFolder);
                 var absolutePath = PathNormalizer.NormalizePathForCurrentPlatform(
                     Path.Combine(legacySettingsDir, migratedPath));
-                config.AppHost.Path = Path.GetRelativePath(directory, absolutePath)
-                    .Replace('\\', '/');
+                config.AppHost.Path = PathNormalizer.NormalizePathForStorage(
+                    Path.GetRelativePath(directory, absolutePath));
             }
 
             // Persist the migrated config (legacy files are kept for older CLI versions)

--- a/src/Shared/PathNormalizer.cs
+++ b/src/Shared/PathNormalizer.cs
@@ -17,4 +17,13 @@ internal static class PathNormalizer
 
         return Path.GetFullPath(path);
     }
+
+    /// <summary>
+    /// Normalizes a path for storage in configuration files by replacing
+    /// backslash separators with forward slashes.
+    /// </summary>
+    public static string NormalizePathForStorage(string path)
+    {
+        return path.Replace('\\', '/');
+    }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/LocalConfigMigrationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/LocalConfigMigrationTests.cs
@@ -86,43 +86,27 @@ public sealed class LocalConfigMigrationTests(ITestOutputHelper output)
         await auto.TypeAsync("aspire run");
         await auto.EnterAsync();
 
-        // Wait for the apphost to start (Ctrl+C message) or an explicit failure message.
-        // Don't match generic "ERR:" which could match shell prompt patterns.
-        await auto.WaitUntilAsync(s =>
-            s.ContainsText("Press CTRL+C to stop the apphost and exit.") ||
-            s.ContainsText("Apphost failed"),
-            timeout: TimeSpan.FromMinutes(3),
-            description: "aspire run started or reported failure");
+        // The migration creates aspire.config.json during apphost discovery, before
+        // the actual run. Poll the host-side filesystem via the bind mount rather
+        // than parsing terminal output, which is fragile across different failure modes.
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json");
+        var deadline = DateTime.UtcNow.AddMinutes(3);
+        while (!File.Exists(configPath) && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
+        }
 
-        // Stop the apphost (Ctrl+C) and wait for the shell prompt
+        // Stop the apphost if it's still running (Ctrl+C is safe even if already exited)
         await auto.Ctrl().KeyAsync(Hex1bKey.C);
         await auto.WaitForAnyPromptAsync(counter, timeout: TimeSpan.FromSeconds(30));
 
         // Step 4: Verify aspire.config.json was created with the corrected path.
         // The path should be "apphost.ts" (relative to workspace root),
         // NOT "../apphost.ts" (the legacy .aspire/-relative path).
-        // The grep pattern '"path": "apphost.ts"' will NOT match '"path": "../apphost.ts"'
-        // because grep does substring matching on the full pattern string.
-        await auto.TypeAsync("grep '\"path\": \"apphost.ts\"' aspire.config.json");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
-
-        // Also verify on the host side via bind mount for a precise assertion
-        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json");
-        if (File.Exists(configPath))
-        {
-            var content = File.ReadAllText(configPath);
-            if (content.Contains("\"../apphost.ts\""))
-            {
-                throw new InvalidOperationException(
-                    $"Host-side aspire.config.json still contains uncorrected path '../apphost.ts'. Content:\n{content}");
-            }
-            if (!content.Contains("\"apphost.ts\""))
-            {
-                throw new InvalidOperationException(
-                    $"Host-side aspire.config.json does not contain expected path 'apphost.ts'. Content:\n{content}");
-            }
-        }
+        Assert.True(File.Exists(configPath), "aspire.config.json was not created by migration");
+        var content = File.ReadAllText(configPath);
+        Assert.DoesNotContain("\"../apphost.ts\"", content);
+        Assert.Contains("\"apphost.ts\"", content);
 
         await auto.TypeAsync("exit");
         await auto.EnterAsync();

--- a/tests/Aspire.Cli.EndToEnd.Tests/LocalConfigMigrationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/LocalConfigMigrationTests.cs
@@ -1,0 +1,162 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Hex1b.Input;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests verifying that legacy .aspire/settings.json files with relative paths
+/// are correctly migrated to aspire.config.json with adjusted paths.
+/// </summary>
+/// <remarks>
+/// When .aspire/settings.json stores appHostPath relative to the .aspire/ directory
+/// (e.g., "../src/apphost.ts"), the migration to aspire.config.json must re-base the path
+/// to be relative to the config file's own directory (e.g., "src/apphost.ts").
+/// </remarks>
+public sealed class LocalConfigMigrationTests(ITestOutputHelper output)
+{
+    /// <summary>
+    /// Verifies that migrating a legacy .aspire/settings.json with a "../src/apphost.ts" path
+    /// produces an aspire.config.json with the correct "src/apphost.ts" relative path.
+    /// </summary>
+    /// <remarks>
+    /// This scenario reproduces the bug where FromLegacy() copied appHostPath verbatim,
+    /// without adjusting from .aspire/-relative to project-root-relative.
+    /// </remarks>
+    [Fact]
+    public async Task LegacySettingsMigration_AdjustsRelativeAppHostPath()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(
+            repoRoot, installMode, output,
+            variant: CliE2ETestHelpers.DockerfileVariant.Polyglot,
+            mountDockerSocket: true,
+            workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliInDockerAsync(installMode, counter);
+
+        // Step 1: Create a valid TypeScript AppHost using aspire init.
+        // This produces apphost.ts plus .modules/, aspire.config.json, etc.
+        await auto.TypeAsync("aspire init");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("Which language would you like to use?", timeout: TimeSpan.FromSeconds(30));
+        await auto.DownAsync();
+        await auto.WaitUntilTextAsync("> TypeScript (Node.js)", timeout: TimeSpan.FromSeconds(5));
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("Created apphost.ts", timeout: TimeSpan.FromMinutes(2));
+        await auto.DeclineAgentInitPromptAsync(counter);
+
+        // Step 2: Rearrange files to simulate a legacy project where the apphost
+        // lives in a subdirectory (src/) with a .aspire/settings.json pointing to it.
+        // Move apphost.ts into src/
+        await auto.TypeAsync("mkdir -p src && mv apphost.ts src/apphost.ts");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Remove the aspire.config.json created by aspire init
+        await auto.TypeAsync("rm -f aspire.config.json");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Step 3: Write a legacy .aspire/settings.json with the path relative to .aspire/
+        // (i.e., "../src/apphost.ts" which is how the preview CLI stored it).
+        var legacySettingsJson = """{"appHostPath":"../src/apphost.ts","language":"typescript/nodejs","sdkVersion":"13.2.0","channel":"staging"}""";
+        await auto.TypeAsync($"mkdir -p .aspire && echo '{legacySettingsJson}' > .aspire/settings.json");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Verify settings.json was written correctly
+        await auto.TypeAsync("cat .aspire/settings.json");
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("../src/apphost.ts", timeout: TimeSpan.FromSeconds(5));
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Step 4: Run aspire run to trigger the migration from .aspire/settings.json
+        // to aspire.config.json. The migration happens in LoadConfiguration() which
+        // is called before the actual build/run step.
+        await auto.TypeAsync("aspire run");
+        await auto.EnterAsync();
+
+        // Wait for either the Ctrl+C message (success) or a reasonable timeout.
+        // The key thing is that the migration happens before the build step,
+        // so aspire.config.json will be created regardless of run outcome.
+        await auto.WaitUntilAsync(s =>
+        {
+            // Success: apphost started
+            if (s.ContainsText("Press CTRL+C to stop the apphost and exit."))
+            {
+                return true;
+            }
+            // The run proceeded far enough to create aspire.config.json
+            // (even if it fails during build, the migration already happened)
+            if (s.ContainsText("ERR:"))
+            {
+                return true;
+            }
+            return false;
+        }, timeout: TimeSpan.FromMinutes(3), description: "aspire run started or failed after migration");
+
+        // Stop the apphost if it's running (Ctrl+C), or just wait for the prompt
+        await auto.Ctrl().KeyAsync(Hex1bKey.C);
+        await auto.WaitForAnyPromptAsync(counter, timeout: TimeSpan.FromSeconds(30));
+
+        // Step 5: Verify aspire.config.json was created with the corrected path.
+        // The path should be "src/apphost.ts" (relative to repo root),
+        // NOT "../src/apphost.ts" (which was the legacy .aspire/-relative path).
+        await auto.TypeAsync("cat aspire.config.json");
+        await auto.EnterAsync();
+
+        // Verify the corrected path appears in the config
+        await auto.WaitUntilAsync(s =>
+        {
+            // The path should NOT contain "../src/apphost.ts"
+            if (s.ContainsText("../src/apphost.ts"))
+            {
+                throw new InvalidOperationException(
+                    "aspire.config.json contains the uncorrected legacy path '../src/apphost.ts'. " +
+                    "Migration should have adjusted it to 'src/apphost.ts'.");
+            }
+
+            // The path SHOULD contain "src/apphost.ts"
+            return s.ContainsText("src/apphost.ts");
+        }, timeout: TimeSpan.FromSeconds(10), description: "aspire.config.json with corrected path 'src/apphost.ts'");
+
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // Also verify on the host side via bind mount
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json");
+        if (File.Exists(configPath))
+        {
+            var content = File.ReadAllText(configPath);
+            if (content.Contains("\"../src/apphost.ts\""))
+            {
+                throw new InvalidOperationException(
+                    $"Host-side aspire.config.json still contains uncorrected path '../src/apphost.ts'. Content:\n{content}");
+            }
+            if (!content.Contains("\"src/apphost.ts\""))
+            {
+                throw new InvalidOperationException(
+                    $"Host-side aspire.config.json does not contain expected path 'src/apphost.ts'. Content:\n{content}");
+            }
+        }
+
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/LocalConfigMigrationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/LocalConfigMigrationTests.cs
@@ -79,12 +79,6 @@ public sealed class LocalConfigMigrationTests(ITestOutputHelper output)
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Verify settings.json was written correctly
-        await auto.TypeAsync("cat .aspire/settings.json");
-        await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("../src/apphost.ts", timeout: TimeSpan.FromSeconds(5));
-        await auto.WaitForSuccessPromptAsync(counter);
-
         // Step 4: Run aspire run to trigger the migration from .aspire/settings.json
         // to aspire.config.json. The migration happens in LoadConfiguration() which
         // is called before the actual build/run step.
@@ -117,24 +111,10 @@ public sealed class LocalConfigMigrationTests(ITestOutputHelper output)
         // Step 5: Verify aspire.config.json was created with the corrected path.
         // The path should be "src/apphost.ts" (relative to repo root),
         // NOT "../src/apphost.ts" (which was the legacy .aspire/-relative path).
-        await auto.TypeAsync("cat aspire.config.json");
+        // Use grep with the exact JSON key-value to avoid matching stale terminal
+        // output from the earlier echo of legacy settings.json content.
+        await auto.TypeAsync("grep '\"path\": \"src/apphost.ts\"' aspire.config.json");
         await auto.EnterAsync();
-
-        // Verify the corrected path appears in the config
-        await auto.WaitUntilAsync(s =>
-        {
-            // The path should NOT contain "../src/apphost.ts"
-            if (s.ContainsText("../src/apphost.ts"))
-            {
-                throw new InvalidOperationException(
-                    "aspire.config.json contains the uncorrected legacy path '../src/apphost.ts'. " +
-                    "Migration should have adjusted it to 'src/apphost.ts'.");
-            }
-
-            // The path SHOULD contain "src/apphost.ts"
-            return s.ContainsText("src/apphost.ts");
-        }, timeout: TimeSpan.FromSeconds(10), description: "aspire.config.json with corrected path 'src/apphost.ts'");
-
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Also verify on the host side via bind mount

--- a/tests/Aspire.Cli.EndToEnd.Tests/LocalConfigMigrationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/LocalConfigMigrationTests.cs
@@ -15,18 +15,25 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 /// <remarks>
 /// When .aspire/settings.json stores appHostPath relative to the .aspire/ directory
-/// (e.g., "../src/apphost.ts"), the migration to aspire.config.json must re-base the path
-/// to be relative to the config file's own directory (e.g., "src/apphost.ts").
+/// (e.g., "../apphost.ts"), the migration to aspire.config.json must re-base the path
+/// to be relative to the config file's own directory (e.g., "apphost.ts").
 /// </remarks>
 public sealed class LocalConfigMigrationTests(ITestOutputHelper output)
 {
     /// <summary>
-    /// Verifies that migrating a legacy .aspire/settings.json with a "../src/apphost.ts" path
-    /// produces an aspire.config.json with the correct "src/apphost.ts" relative path.
+    /// Verifies that migrating a legacy .aspire/settings.json with a "../apphost.ts" path
+    /// produces an aspire.config.json with the correct "apphost.ts" relative path.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// This scenario reproduces the bug where FromLegacy() copied appHostPath verbatim,
     /// without adjusting from .aspire/-relative to project-root-relative.
+    /// </para>
+    /// <para>
+    /// The test keeps the TS project intact (apphost.ts at root with .modules/) so that
+    /// aspire run can actually start successfully. The re-basing logic "../apphost.ts" →
+    /// "apphost.ts" exercises the same code path as "../src/apphost.ts" → "src/apphost.ts".
+    /// </para>
     /// </remarks>
     [Fact]
     public async Task LegacySettingsMigration_AdjustsRelativeAppHostPath()
@@ -50,7 +57,7 @@ public sealed class LocalConfigMigrationTests(ITestOutputHelper output)
         await auto.InstallAspireCliInDockerAsync(installMode, counter);
 
         // Step 1: Create a valid TypeScript AppHost using aspire init.
-        // This produces apphost.ts plus .modules/, aspire.config.json, etc.
+        // This produces apphost.ts, .modules/, aspire.config.json, etc.
         await auto.TypeAsync("aspire init");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("Which language would you like to use?", timeout: TimeSpan.FromSeconds(30));
@@ -60,77 +67,60 @@ public sealed class LocalConfigMigrationTests(ITestOutputHelper output)
         await auto.WaitUntilTextAsync("Created apphost.ts", timeout: TimeSpan.FromMinutes(2));
         await auto.DeclineAgentInitPromptAsync(counter);
 
-        // Step 2: Rearrange files to simulate a legacy project where the apphost
-        // lives in a subdirectory (src/) with a .aspire/settings.json pointing to it.
-        // Move apphost.ts into src/
-        await auto.TypeAsync("mkdir -p src && mv apphost.ts src/apphost.ts");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
-
-        // Remove the aspire.config.json created by aspire init
+        // Step 2: Replace aspire.config.json with a legacy .aspire/settings.json.
+        // The legacy format stores appHostPath relative to the .aspire/ directory,
+        // so "../apphost.ts" points up from .aspire/ to the workspace root where
+        // apphost.ts lives. The project files stay in place so aspire run can work.
         await auto.TypeAsync("rm -f aspire.config.json");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Step 3: Write a legacy .aspire/settings.json with the path relative to .aspire/
-        // (i.e., "../src/apphost.ts" which is how the preview CLI stored it).
-        var legacySettingsJson = """{"appHostPath":"../src/apphost.ts","language":"typescript/nodejs","sdkVersion":"13.2.0","channel":"staging"}""";
+        var legacySettingsJson = """{"appHostPath":"../apphost.ts","language":"typescript/nodejs","sdkVersion":"13.2.0","channel":"staging"}""";
         await auto.TypeAsync($"mkdir -p .aspire && echo '{legacySettingsJson}' > .aspire/settings.json");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Step 4: Run aspire run to trigger the migration from .aspire/settings.json
-        // to aspire.config.json. The migration happens in LoadConfiguration() which
-        // is called before the actual build/run step.
+        // Step 3: Run aspire run to trigger the migration from .aspire/settings.json
+        // to aspire.config.json. The migration happens during apphost discovery,
+        // before the actual build/run step.
         await auto.TypeAsync("aspire run");
         await auto.EnterAsync();
 
-        // Wait for either the Ctrl+C message (success) or a reasonable timeout.
-        // The key thing is that the migration happens before the build step,
-        // so aspire.config.json will be created regardless of run outcome.
+        // Wait for the apphost to start (Ctrl+C message) or an explicit failure message.
+        // Don't match generic "ERR:" which could match shell prompt patterns.
         await auto.WaitUntilAsync(s =>
-        {
-            // Success: apphost started
-            if (s.ContainsText("Press CTRL+C to stop the apphost and exit."))
-            {
-                return true;
-            }
-            // The run proceeded far enough to create aspire.config.json
-            // (even if it fails during build, the migration already happened)
-            if (s.ContainsText("ERR:"))
-            {
-                return true;
-            }
-            return false;
-        }, timeout: TimeSpan.FromMinutes(3), description: "aspire run started or failed after migration");
+            s.ContainsText("Press CTRL+C to stop the apphost and exit.") ||
+            s.ContainsText("Apphost failed"),
+            timeout: TimeSpan.FromMinutes(3),
+            description: "aspire run started or reported failure");
 
-        // Stop the apphost if it's running (Ctrl+C), or just wait for the prompt
+        // Stop the apphost (Ctrl+C) and wait for the shell prompt
         await auto.Ctrl().KeyAsync(Hex1bKey.C);
         await auto.WaitForAnyPromptAsync(counter, timeout: TimeSpan.FromSeconds(30));
 
-        // Step 5: Verify aspire.config.json was created with the corrected path.
-        // The path should be "src/apphost.ts" (relative to repo root),
-        // NOT "../src/apphost.ts" (which was the legacy .aspire/-relative path).
-        // Use grep with the exact JSON key-value to avoid matching stale terminal
-        // output from the earlier echo of legacy settings.json content.
-        await auto.TypeAsync("grep '\"path\": \"src/apphost.ts\"' aspire.config.json");
+        // Step 4: Verify aspire.config.json was created with the corrected path.
+        // The path should be "apphost.ts" (relative to workspace root),
+        // NOT "../apphost.ts" (the legacy .aspire/-relative path).
+        // The grep pattern '"path": "apphost.ts"' will NOT match '"path": "../apphost.ts"'
+        // because grep does substring matching on the full pattern string.
+        await auto.TypeAsync("grep '\"path\": \"apphost.ts\"' aspire.config.json");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Also verify on the host side via bind mount
+        // Also verify on the host side via bind mount for a precise assertion
         var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, "aspire.config.json");
         if (File.Exists(configPath))
         {
             var content = File.ReadAllText(configPath);
-            if (content.Contains("\"../src/apphost.ts\""))
+            if (content.Contains("\"../apphost.ts\""))
             {
                 throw new InvalidOperationException(
-                    $"Host-side aspire.config.json still contains uncorrected path '../src/apphost.ts'. Content:\n{content}");
+                    $"Host-side aspire.config.json still contains uncorrected path '../apphost.ts'. Content:\n{content}");
             }
-            if (!content.Contains("\"src/apphost.ts\""))
+            if (!content.Contains("\"apphost.ts\""))
             {
                 throw new InvalidOperationException(
-                    $"Host-side aspire.config.json does not contain expected path 'src/apphost.ts'. Content:\n{content}");
+                    $"Host-side aspire.config.json does not contain expected path 'apphost.ts'. Content:\n{content}");
             }
         }
 

--- a/tests/Aspire.Cli.Tests/Configuration/AspireConfigFileTests.cs
+++ b/tests/Aspire.Cli.Tests/Configuration/AspireConfigFileTests.cs
@@ -380,12 +380,13 @@ public class AspireConfigFileTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void LoadOrCreate_MigratesLegacy_PreservesAlreadyCorrectPath()
+    public void LoadOrCreate_MigratesLegacy_RebasesPathRelativeToAspireDir()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var root = workspace.WorkspaceRoot.FullName;
 
-        // A path that's already relative to root (e.g., if .aspire/apphost.ts existed)
+        // "apphost.ts" in legacy settings means .aspire/apphost.ts (relative to .aspire/ dir),
+        // which should become ".aspire/apphost.ts" relative to the repo root after migration.
         var settingsPath = Path.Combine(root, ".aspire", "settings.json");
         File.WriteAllText(settingsPath, """
             {
@@ -395,7 +396,6 @@ public class AspireConfigFileTests(ITestOutputHelper outputHelper)
 
         var config = AspireConfigFile.LoadOrCreate(root);
 
-        // Re-basing from .aspire/ to root: .aspire/apphost.ts relative to root = .aspire/apphost.ts
         Assert.Equal(".aspire/apphost.ts", config.AppHost?.Path);
     }
 
@@ -443,5 +443,86 @@ public class AspireConfigFileTests(ITestOutputHelper outputHelper)
 
         // Absolute paths should not be modified
         Assert.Equal(absolutePath, config.AppHost?.Path);
+    }
+
+    [Fact]
+    public void LoadOrCreate_MigratesLegacy_NormalizesBackslashSeparators()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        // Simulate a settings file created on Windows with backslash separators.
+        // Even though we always store '/', handle '\' gracefully in case of manual edits.
+        var settingsPath = Path.Combine(root, ".aspire", "settings.json");
+        File.WriteAllText(settingsPath, """
+            {
+                "appHostPath": "..\\src\\apphost.ts",
+                "language": "typescript/nodejs"
+            }
+            """);
+
+        var config = AspireConfigFile.LoadOrCreate(root);
+
+        // Should be re-based and normalized to forward slashes
+        Assert.Equal("src/apphost.ts", config.AppHost?.Path);
+    }
+
+    [Fact]
+    public void LoadOrCreate_MigratesLegacy_OutputAlwaysUsesForwardSlashes()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        var settingsPath = Path.Combine(root, ".aspire", "settings.json");
+        File.WriteAllText(settingsPath, """
+            {
+                "appHostPath": "../deeply/nested/path/apphost.ts"
+            }
+            """);
+
+        var config = AspireConfigFile.LoadOrCreate(root);
+
+        // Verify output uses forward slashes regardless of platform
+        Assert.Equal("deeply/nested/path/apphost.ts", config.AppHost?.Path);
+        Assert.DoesNotContain("\\", config.AppHost?.Path);
+    }
+
+    [Fact]
+    public void LoadOrCreate_MigratesLegacy_SkipsEmptyPath()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        var settingsPath = Path.Combine(root, ".aspire", "settings.json");
+        File.WriteAllText(settingsPath, """
+            {
+                "appHostPath": "",
+                "language": "typescript/nodejs"
+            }
+            """);
+
+        var config = AspireConfigFile.LoadOrCreate(root);
+
+        // Empty path should not be transformed to "."
+        Assert.Equal("", config.AppHost?.Path);
+    }
+
+    [Fact]
+    public void LoadOrCreate_MigratesLegacy_SkipsNullPath()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        var settingsPath = Path.Combine(root, ".aspire", "settings.json");
+        File.WriteAllText(settingsPath, """
+            {
+                "language": "typescript/nodejs"
+            }
+            """);
+
+        var config = AspireConfigFile.LoadOrCreate(root);
+
+        // No appHostPath means no migration needed; path stays null
+        Assert.Null(config.AppHost?.Path);
     }
 }

--- a/tests/Aspire.Cli.Tests/Configuration/AspireConfigFileTests.cs
+++ b/tests/Aspire.Cli.Tests/Configuration/AspireConfigFileTests.cs
@@ -534,17 +534,18 @@ public class AspireConfigFileTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var root = workspace.WorkspaceRoot.FullName;
 
-        // "./path/apphost.ts" is relative to .aspire/ dir, resolves to .aspire/path/apphost.ts
+        // "./MyApp.AppHost/apphost.ts" from .aspire/ dir resolves to .aspire/MyApp.AppHost/apphost.ts
+        // relative to root. While unusual, verifies dot-slash handling doesn't break.
         var settingsPath = Path.Combine(root, ".aspire", "settings.json");
         File.WriteAllText(settingsPath, """
             {
-                "appHostPath": "./path/apphost.ts"
+                "appHostPath": "./../MyApp.AppHost/apphost.ts"
             }
             """);
 
         var config = AspireConfigFile.LoadOrCreate(root);
 
-        Assert.Equal(".aspire/path/apphost.ts", config.AppHost?.Path);
+        Assert.Equal("MyApp.AppHost/apphost.ts", config.AppHost?.Path);
     }
 
     [Fact]
@@ -553,17 +554,18 @@ public class AspireConfigFileTests(ITestOutputHelper outputHelper)
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var root = workspace.WorkspaceRoot.FullName;
 
-        // "path/apphost.ts" without ../ is relative to .aspire/, resolves to .aspire/path/apphost.ts
+        // A bare relative path without ../ from .aspire/ stays under .aspire/ when resolved.
+        // In practice legacy paths always start with ../ but we verify the math is correct.
         var settingsPath = Path.Combine(root, ".aspire", "settings.json");
         File.WriteAllText(settingsPath, """
             {
-                "appHostPath": "path/apphost.ts"
+                "appHostPath": "../MyApp.AppHost/MyApp.AppHost.csproj"
             }
             """);
 
         var config = AspireConfigFile.LoadOrCreate(root);
 
-        Assert.Equal(".aspire/path/apphost.ts", config.AppHost?.Path);
+        Assert.Equal("MyApp.AppHost/MyApp.AppHost.csproj", config.AppHost?.Path);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Configuration/AspireConfigFileTests.cs
+++ b/tests/Aspire.Cli.Tests/Configuration/AspireConfigFileTests.cs
@@ -380,23 +380,25 @@ public class AspireConfigFileTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void LoadOrCreate_MigratesLegacy_RebasesPathRelativeToAspireDir()
+    public void LoadOrCreate_MigratesLegacy_RebasesSubdirectoryPath()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var root = workspace.WorkspaceRoot.FullName;
 
-        // "apphost.ts" in legacy settings means .aspire/apphost.ts (relative to .aspire/ dir),
-        // which should become ".aspire/apphost.ts" relative to the repo root after migration.
+        // Legacy .aspire/settings.json stores appHostPath relative to .aspire/ directory.
+        // A path like "../MyApp.AppHost/MyApp.AppHost.csproj" points from .aspire/ up to
+        // the repo root, then into a subdirectory. After migration it should become
+        // "MyApp.AppHost/MyApp.AppHost.csproj" (relative to the repo root).
         var settingsPath = Path.Combine(root, ".aspire", "settings.json");
         File.WriteAllText(settingsPath, """
             {
-                "appHostPath": "apphost.ts"
+                "appHostPath": "../MyApp.AppHost/MyApp.AppHost.csproj"
             }
             """);
 
         var config = AspireConfigFile.LoadOrCreate(root);
 
-        Assert.Equal(".aspire/apphost.ts", config.AppHost?.Path);
+        Assert.Equal("MyApp.AppHost/MyApp.AppHost.csproj", config.AppHost?.Path);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Configuration/AspireConfigFileTests.cs
+++ b/tests/Aspire.Cli.Tests/Configuration/AspireConfigFileTests.cs
@@ -336,4 +336,112 @@ public class AspireConfigFileTests(ITestOutputHelper outputHelper)
         Assert.True(loaded.Profiles.ContainsKey("default"));
         Assert.Equal("https://localhost:5001", loaded.Profiles["default"].ApplicationUrl);
     }
+
+    [Fact]
+    public void LoadOrCreate_MigratesLegacy_AdjustsRelativePathFromAspireDir()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        // Legacy .aspire/settings.json stores paths relative to the .aspire/ directory
+        var settingsPath = Path.Combine(root, ".aspire", "settings.json");
+        File.WriteAllText(settingsPath, """
+            {
+                "appHostPath": "../src/apphost.ts",
+                "language": "typescript/nodejs",
+                "sdkVersion": "13.2.0"
+            }
+            """);
+
+        var config = AspireConfigFile.LoadOrCreate(root);
+
+        // Path should be re-based from .aspire/-relative to root-relative
+        Assert.Equal("src/apphost.ts", config.AppHost?.Path);
+    }
+
+    [Fact]
+    public void LoadOrCreate_MigratesLegacy_AdjustsPathForApphostAtRoot()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        // Legacy path "../apphost.ts" means apphost is at the repo root
+        var settingsPath = Path.Combine(root, ".aspire", "settings.json");
+        File.WriteAllText(settingsPath, """
+            {
+                "appHostPath": "../apphost.ts",
+                "language": "typescript/nodejs"
+            }
+            """);
+
+        var config = AspireConfigFile.LoadOrCreate(root);
+
+        Assert.Equal("apphost.ts", config.AppHost?.Path);
+    }
+
+    [Fact]
+    public void LoadOrCreate_MigratesLegacy_PreservesAlreadyCorrectPath()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        // A path that's already relative to root (e.g., if .aspire/apphost.ts existed)
+        var settingsPath = Path.Combine(root, ".aspire", "settings.json");
+        File.WriteAllText(settingsPath, """
+            {
+                "appHostPath": "apphost.ts"
+            }
+            """);
+
+        var config = AspireConfigFile.LoadOrCreate(root);
+
+        // Re-basing from .aspire/ to root: .aspire/apphost.ts relative to root = .aspire/apphost.ts
+        Assert.Equal(".aspire/apphost.ts", config.AppHost?.Path);
+    }
+
+    [Fact]
+    public void LoadOrCreate_MigratesLegacy_SavesConfigFile()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        var settingsPath = Path.Combine(root, ".aspire", "settings.json");
+        File.WriteAllText(settingsPath, """
+            {
+                "appHostPath": "../src/apphost.ts",
+                "sdkVersion": "13.2.0"
+            }
+            """);
+
+        AspireConfigFile.LoadOrCreate(root);
+
+        // Verify aspire.config.json was created with correct content
+        var configPath = Path.Combine(root, AspireConfigFile.FileName);
+        Assert.True(File.Exists(configPath));
+
+        var saved = AspireConfigFile.Load(root);
+        Assert.NotNull(saved);
+        Assert.Equal("src/apphost.ts", saved.AppHost?.Path);
+        Assert.Equal("13.2.0", saved.SdkVersion);
+    }
+
+    [Fact]
+    public void LoadOrCreate_MigratesLegacy_LeavesAbsolutePathUnchanged()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        var absolutePath = Path.Combine(root, "src", "apphost.ts").Replace(Path.DirectorySeparatorChar, '/');
+        var settingsPath = Path.Combine(root, ".aspire", "settings.json");
+        File.WriteAllText(settingsPath, $$"""
+            {
+                "appHostPath": "{{absolutePath}}"
+            }
+            """);
+
+        var config = AspireConfigFile.LoadOrCreate(root);
+
+        // Absolute paths should not be modified
+        Assert.Equal(absolutePath, config.AppHost?.Path);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Configuration/AspireConfigFileTests.cs
+++ b/tests/Aspire.Cli.Tests/Configuration/AspireConfigFileTests.cs
@@ -527,4 +527,81 @@ public class AspireConfigFileTests(ITestOutputHelper outputHelper)
         // No appHostPath means no migration needed; path stays null
         Assert.Null(config.AppHost?.Path);
     }
+
+    [Fact]
+    public void LoadOrCreate_MigratesLegacy_DotSlashRelativePath()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        // "./path/apphost.ts" is relative to .aspire/ dir, resolves to .aspire/path/apphost.ts
+        var settingsPath = Path.Combine(root, ".aspire", "settings.json");
+        File.WriteAllText(settingsPath, """
+            {
+                "appHostPath": "./path/apphost.ts"
+            }
+            """);
+
+        var config = AspireConfigFile.LoadOrCreate(root);
+
+        Assert.Equal(".aspire/path/apphost.ts", config.AppHost?.Path);
+    }
+
+    [Fact]
+    public void LoadOrCreate_MigratesLegacy_BareRelativePath()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        // "path/apphost.ts" without ../ is relative to .aspire/, resolves to .aspire/path/apphost.ts
+        var settingsPath = Path.Combine(root, ".aspire", "settings.json");
+        File.WriteAllText(settingsPath, """
+            {
+                "appHostPath": "path/apphost.ts"
+            }
+            """);
+
+        var config = AspireConfigFile.LoadOrCreate(root);
+
+        Assert.Equal(".aspire/path/apphost.ts", config.AppHost?.Path);
+    }
+
+    [Fact]
+    public void LoadOrCreate_MigratesLegacy_LeavesUnixRootedPathUnchanged()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        var settingsPath = Path.Combine(root, ".aspire", "settings.json");
+        File.WriteAllText(settingsPath, """
+            {
+                "appHostPath": "/path/apphost.ts"
+            }
+            """);
+
+        var config = AspireConfigFile.LoadOrCreate(root);
+
+        Assert.Equal("/path/apphost.ts", config.AppHost?.Path);
+    }
+
+    [Fact]
+    public void LoadOrCreate_MigratesLegacy_LeavesWindowsRootedPathUnchanged()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "Windows-rooted paths are only recognized on Windows.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var root = workspace.WorkspaceRoot.FullName;
+
+        var settingsPath = Path.Combine(root, ".aspire", "settings.json");
+        File.WriteAllText(settingsPath, $$"""
+            {
+                "appHostPath": "c:\\path\\apphost.ts"
+            }
+            """);
+
+        var config = AspireConfigFile.LoadOrCreate(root);
+
+        // On Windows, c:\ is rooted and should be left unchanged
+        Assert.Equal("c:\\path\\apphost.ts", config.AppHost?.Path);
+    }
 }


### PR DESCRIPTION
## Description

Fix legacy `.aspire/settings.json` → `aspire.config.json` migration producing incorrect relative paths for the `appHostPath`.

**Problem:** When migrating from the legacy `.aspire/settings.json` format to the new `aspire.config.json`, the `appHostPath` was copied verbatim by `FromLegacy()`. However, the legacy format stores paths relative to the `.aspire/` directory (e.g., `../src/apphost.ts`), while the new format stores paths relative to the config file's own directory (the project root). This caused migrated paths to resolve incorrectly — for example, `../src/apphost.ts` (valid from `.aspire/`) becomes invalid from the project root because it resolves above the repo.

**Fix:** After `FromLegacy()` migration in `LoadOrCreate()`, the path is re-based: resolved against the legacy `.aspire/` directory, then made relative to the config directory. So `../src/apphost.ts` correctly becomes `src/apphost.ts`.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
