### PR TITLE
Update agent init E2E tests for selection flow

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/AgentCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/AgentCommandTests.cs
@@ -131,18 +131,14 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
         await auto.WaitAsync(500); // Small delay to ensure prompt is ready
         await auto.EnterAsync(); // Accept default workspace path
         await auto.WaitUntilAsync(
-            s => s.ContainsText("configure") || s.ContainsText("No agent environments") || s.ContainsText("omplete"),
-            timeout: TimeSpan.FromSeconds(60), description: "configure prompt, completion, or no environments message");
-
-        // If we got the configure prompt, just press Enter to accept defaults
-        // If we got complete/no-env, this Enter is harmless
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
-
-        // Debug: Show the scanner log file to diagnose what the scanner found
-        await auto.TypeAsync("cat /tmp/aspire-deprecated-scan.log 2>/dev/null || echo 'No debug log found'");
-        await auto.EnterAsync();
-        await auto.WaitUntilTextAsync("Scanning context", timeout: TimeSpan.FromSeconds(10));
+            s => s.ContainsText("skill files be installed"),
+            timeout: TimeSpan.FromSeconds(60), description: "skill location prompt");
+        await auto.EnterAsync(); // Accept default skill locations (Standard)
+        await auto.WaitUntilAsync(
+            s => s.ContainsText("skills should be installed"),
+            timeout: TimeSpan.FromSeconds(30), description: "skill selection prompt");
+        await auto.EnterAsync(); // Accept default skills
+        await auto.WaitUntilTextAsync("complete", timeout: TimeSpan.FromSeconds(30));
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Step 3: Verify config was updated to new format

--- a/tests/Aspire.Cli.EndToEnd.Tests/PlaywrightCliInstallTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/PlaywrightCliInstallTests.cs
@@ -64,18 +64,19 @@ public sealed class PlaywrightCliInstallTests(ITestOutputHelper output)
         await auto.WaitAsync(500);
         await auto.EnterAsync(); // Accept default workspace path
 
-        // Second prompt: agent environments (select Claude Code)
-        await auto.WaitUntilTextAsync("agent environments", timeout: TimeSpan.FromSeconds(60));
-        await auto.TypeAsync(" "); // Toggle first option (Claude Code)
+        // Second prompt: skill locations. Select Claude Code only.
+        await auto.WaitUntilAsync(
+            s => s.ContainsText("skill files be installed"),
+            timeout: TimeSpan.FromSeconds(60), description: "skill location prompt");
+        await auto.TypeAsync(" "); // Toggle off default Standard location
+        await auto.DownAsync();
+        await auto.TypeAsync(" "); // Toggle on Claude Code location
         await auto.EnterAsync();
 
-        // Third prompt: additional options (select Playwright CLI installation)
-        // Aspire skill file (priority 0) appears first, Playwright CLI (priority 1) second.
-        await auto.WaitUntilTextAsync("additional options", timeout: TimeSpan.FromSeconds(30));
-        await auto.WaitUntilTextAsync("Install Playwright CLI", timeout: TimeSpan.FromSeconds(10));
-        await auto.TypeAsync(" "); // Toggle first option (Aspire skill file)
-        await auto.DownAsync(); // Move to Playwright CLI option
-        await auto.TypeAsync(" "); // Toggle Playwright CLI option
+        // Third prompt: skills. Accept defaults (Aspire, Playwright CLI, dotnet-inspect).
+        await auto.WaitUntilAsync(
+            s => s.ContainsText("skills should be installed"),
+            timeout: TimeSpan.FromSeconds(30), description: "skill selection prompt");
         await auto.EnterAsync();
 
         // Wait for installation to complete (this downloads from npm, can take a while)
@@ -148,17 +149,19 @@ public sealed class PlaywrightCliInstallTests(ITestOutputHelper output)
         await auto.TypeAsync("TestProject");
         await auto.EnterAsync();
 
-        // Select Claude Code environment.
-        await auto.WaitUntilTextAsync("agent environments", timeout: TimeSpan.FromSeconds(60));
-        await auto.TypeAsync(" ");
+        // Select Claude Code as the only skill location.
+        await auto.WaitUntilAsync(
+            s => s.ContainsText("skill files be installed"),
+            timeout: TimeSpan.FromSeconds(60), description: "skill location prompt");
+        await auto.TypeAsync(" "); // Toggle off default Standard location
+        await auto.DownAsync();
+        await auto.TypeAsync(" "); // Toggle on Claude Code location
         await auto.EnterAsync();
 
-        // Select Playwright CLI installation.
-        await auto.WaitUntilTextAsync("additional options", timeout: TimeSpan.FromSeconds(30));
-        await auto.WaitUntilTextAsync("Install Playwright CLI", timeout: TimeSpan.FromSeconds(10));
-        await auto.TypeAsync(" "); // Toggle first option (Aspire skill file)
-        await auto.DownAsync();
-        await auto.TypeAsync(" "); // Toggle Playwright CLI
+        // Accept default skills, which include Playwright CLI.
+        await auto.WaitUntilAsync(
+            s => s.ContainsText("skills should be installed"),
+            timeout: TimeSpan.FromSeconds(30), description: "skill selection prompt");
         await auto.EnterAsync();
 
         await auto.WaitUntilTextAsync("configuration complete", timeout: TimeSpan.FromMinutes(3));


### PR DESCRIPTION
## Description

Updates the `aspire agent init` end-to-end tests to match the refactored selection flow.

- switches the agent-init E2E assertions from the old agent-environment prompts to the new skill-location and skill-selection prompts
- updates the Playwright CLI installer scenarios to explicitly select the Claude Code skill location under the new flow
- removes the stale deprecated-scan debug-log expectation from the migration test so it validates the actual config migration behavior

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
