### PR TITLE
[release/13.2] Stabilize Aspire.Hosting.Docker package

### DIFF
--- a/src/Aspire.Hosting.Docker/Aspire.Hosting.Docker.csproj
+++ b/src/Aspire.Hosting.Docker/Aspire.Hosting.Docker.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <PackageTags>aspire hosting docker docker-compose</PackageTags>
     <Description>Docker Compose publishing for Aspire.</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/tests/Shared/RepoTesting/Directory.Packages.Helix.props
+++ b/tests/Shared/RepoTesting/Directory.Packages.Helix.props
@@ -34,7 +34,7 @@
     <PackageVersion Include="Aspire.Hosting.Azure.Sql" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.2.0" />
     <PackageVersion Include="Aspire.Hosting.Azure.WebPubSub" Version="13.2.0" />
-    <PackageVersion Include="Aspire.Hosting.Docker" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.Hosting.Docker" Version="13.2.0" />
     <PackageVersion Include="Aspire.Hosting.Garnet" Version="13.2.0" />
     <PackageVersion Include="Aspire.Hosting.Kafka" Version="13.2.0" />
     <PackageVersion Include="Aspire.Hosting.Keycloak" Version="$(PackageVersion)" />


### PR DESCRIPTION
## Summary

Remove `SuppressFinalPackageVersion` from the `Aspire.Hosting.Docker` project so that it ships as a stable (non-prerelease) package.

## Changes

- Removed `<SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>` from the csproj
- Added `<DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>` since this is the first stable version and there is no prior baseline to validate against (same pattern used by other newly-stabilized packages like `Aspire.Hosting.Azure.Network`, `Aspire.Hosting.DevTunnels`, etc.)

## Notes

- The `[Experimental("ASPIRECOMPUTE002")]` attribute on `GetHostAddressExpression` is inherited from the `IComputeEnvironmentResource` interface in `Aspire.Hosting` and is not related to this package's prerelease status — it remains unchanged.
