### PR TITLE
Fix dashboard image in marketplace README and bump extension version to 1.0.6

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -135,7 +135,7 @@ Right-click a resource to start, stop, or restart it, view its logs, run resourc
 
 The dashboard gives you a live view of your running app — all your resources and their health, endpoint URLs, console logs from every service, structured logs (via OpenTelemetry), distributed traces across services, and metrics.
 
-![Aspire Dashboard showing running resources](resources/aspire-dashboard-dark.png)
+![Aspire Dashboard showing running resources](https://raw.githubusercontent.com/dotnet/aspire/main/extension/resources/aspire-dashboard-dark.png)
 
 It opens automatically when you start your app. You can pick which browser it uses with the `aspire.dashboardBrowser` setting — system default browser, or Chrome, Edge, or Firefox as a debug session. When using a debug browser, the `aspire.closeDashboardOnDebugEnd` setting controls whether it closes automatically when you stop debugging. Firefox also requires the [Firefox Debugger](https://marketplace.visualstudio.com/items?itemName=firefox-devtools.vscode-firefox-debug) extension.
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Aspire",
   "description": "%extension.description%",
   "publisher": "microsoft-aspire",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
   "icon": "dotnet-aspire-logo-128.png",
   "license": "SEE LICENSE IN LICENSE.TXT",


### PR DESCRIPTION
## Description

Fix the Aspire Dashboard image not displaying on the VS Code Marketplace page.

The README used a relative path (`resources/aspire-dashboard-dark.png`) for the dashboard screenshot, which doesn't resolve on the Marketplace since the extension lives in the `extension/` subdirectory of the repo. Changed to an absolute raw GitHub URL, matching the pattern used by other Microsoft extensions (e.g., ms-python.python).

Also bumps the extension version from 1.0.5 to 1.0.6.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
