### PR TITLE
[release/13.2] Fix dashboard GitHub Copilot integration

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -118,7 +118,7 @@
     <PackageVersion Include="NATS.Net" Version="2.7.2" />
     <PackageVersion Include="NCrontab.Signed" Version="3.4.0" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.1" />
-    <PackageVersion Include="OpenAI" Version="2.7.0" />
+    <PackageVersion Include="OpenAI" Version="2.8.0" />
     <PackageVersion Include="Oracle.ManagedDataAccess.OpenTelemetry" Version="23.26.100" />
     <PackageVersion Include="Polly.Core" Version="8.6.5" />
     <PackageVersion Include="Polly.Extensions" Version="8.6.5" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -41,7 +41,7 @@
     <MicrosoftDotNetBuildTasksArchivesVersion>11.0.0-beta.25610.3</MicrosoftDotNetBuildTasksArchivesVersion>
     <!-- dotnet/extensions -->
     <MicrosoftExtensionsAIVersion>10.2.0</MicrosoftExtensionsAIVersion>
-    <MicrosoftExtensionsAIOpenAIVersion>10.1.0-preview.1.25608.1</MicrosoftExtensionsAIOpenAIVersion>
+    <MicrosoftExtensionsAIOpenAIVersion>10.2.0-preview.1.26063.2</MicrosoftExtensionsAIOpenAIVersion>
     <MicrosoftExtensionsAIAzureAIInferenceVersion>10.0.0-preview.1.25559.3</MicrosoftExtensionsAIAzureAIInferenceVersion>
     <MicrosoftExtensionsHttpResilienceVersion>10.2.0</MicrosoftExtensionsHttpResilienceVersion>
     <MicrosoftExtensionsDependencyInjectionAutoActivationVersion>10.2.0</MicrosoftExtensionsDependencyInjectionAutoActivationVersion>

--- a/src/Aspire.Dashboard/Model/Assistant/AssistantChatDataContext.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/AssistantChatDataContext.cs
@@ -102,6 +102,7 @@ public sealed class AssistantChatDataContext
         return SharedAIHelpers.GetTraceJson(spans, r => OtlpHelpers.GetResourceName(r, resources), AIHelpers.GetDashboardUrl(_dashboardOptions.CurrentValue));
     }
 
+    // resourceName is provided as a non-nullable string to prevent it JSON schema from including an array. An array breaks VS integration.
     [Description("Get structured logs for resources.")]
     public async Task<string> GetStructuredLogsAsync(
         [Description("The resource name. This limits logs returned to the specified resource. If no resource name is specified then structured logs for all resources are returned.")]
@@ -147,6 +148,7 @@ public sealed class AssistantChatDataContext
         return response;
     }
 
+    // resourceName is provided as a non-nullable string to prevent it JSON schema from including an array. An array breaks VS integration.
     [Description("Get distributed traces for resources. A distributed trace is used to track operations. A distributed trace can span multiple resources across a distributed system. Includes a list of distributed traces with their IDs, resources in the trace, duration and whether an error occurred in the trace.")]
     public async Task<string> GetTracesAsync(
         [Description("The resource name. This limits traces returned to the specified resource. If no resource name is specified then distributed traces for all resources are returned.")]

--- a/src/Aspire.Dashboard/Model/Assistant/AssistantChatDataContext.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/AssistantChatDataContext.cs
@@ -105,7 +105,7 @@ public sealed class AssistantChatDataContext
     [Description("Get structured logs for resources.")]
     public async Task<string> GetStructuredLogsAsync(
         [Description("The resource name. This limits logs returned to the specified resource. If no resource name is specified then structured logs for all resources are returned.")]
-        string? resourceName = null,
+        string resourceName,
         CancellationToken cancellationToken = default)
     {
         // TODO: The resourceName might be a name that resolves to multiple replicas, e.g. catalogservice has two replicas.
@@ -150,7 +150,7 @@ public sealed class AssistantChatDataContext
     [Description("Get distributed traces for resources. A distributed trace is used to track operations. A distributed trace can span multiple resources across a distributed system. Includes a list of distributed traces with their IDs, resources in the trace, duration and whether an error occurred in the trace.")]
     public async Task<string> GetTracesAsync(
         [Description("The resource name. This limits traces returned to the specified resource. If no resource name is specified then distributed traces for all resources are returned.")]
-        string? resourceName = null,
+        string resourceName,
         CancellationToken cancellationToken = default)
     {
         // TODO: The resourceName might be a name that resolves to multiple replicas, e.g. catalogservice has two replicas.

--- a/src/Aspire.Dashboard/Model/Assistant/AssistantChatDataContext.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/AssistantChatDataContext.cs
@@ -102,7 +102,7 @@ public sealed class AssistantChatDataContext
         return SharedAIHelpers.GetTraceJson(spans, r => OtlpHelpers.GetResourceName(r, resources), AIHelpers.GetDashboardUrl(_dashboardOptions.CurrentValue));
     }
 
-    // resourceName is provided as a non-nullable string to prevent it JSON schema from including an array. An array breaks VS integration.
+    // resourceName is provided as a non-nullable string to prevent the JSON schema from including an array. An array breaks VS integration.
     [Description("Get structured logs for resources.")]
     public async Task<string> GetStructuredLogsAsync(
         [Description("The resource name. This limits logs returned to the specified resource. If no resource name is specified then structured logs for all resources are returned.")]
@@ -148,7 +148,7 @@ public sealed class AssistantChatDataContext
         return response;
     }
 
-    // resourceName is provided as a non-nullable string to prevent it JSON schema from including an array. An array breaks VS integration.
+    // resourceName is provided as a non-nullable string to prevent the JSON schema from including an array. An array breaks VS integration.
     [Description("Get distributed traces for resources. A distributed trace is used to track operations. A distributed trace can span multiple resources across a distributed system. Includes a list of distributed traces with their IDs, resources in the trace, duration and whether an error occurred in the trace.")]
     public async Task<string> GetTracesAsync(
         [Description("The resource name. This limits traces returned to the specified resource. If no resource name is specified then distributed traces for all resources are returned.")]

--- a/src/Aspire.Dashboard/Model/Assistant/AssistantChatViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Assistant/AssistantChatViewModel.cs
@@ -95,7 +95,7 @@ public sealed class AssistantChatViewModel : IDisposable
     private const int MaximumResponseLength = 1024 * 1024 * 10;
     // Small, cheap, fast model for follow up questions.
     private const string FollowUpQuestionsModel = "gpt-4o-mini";
-    private static readonly string[] s_defaultModels = ["gpt-4.1", "gpt-4o"];
+    private static readonly string[] s_defaultModels = ["gpt-5.4", "gpt-4.1", "gpt-4o"];
     // Older models that VS Code returns as available models. Don't show them in the model selector.
     // There are better, cheaper alternatives that should always be used.
     private static readonly string[] s_oldModels = ["gpt-4", "gpt-4-turbo", "gpt-3.5-turbo"];

--- a/tests/Aspire.Dashboard.Tests/Model/AIAssistant/AssistantChatDataContextTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/AIAssistant/AssistantChatDataContextTests.cs
@@ -47,7 +47,7 @@ public class AssistantChatDataContextTests
         var dataContext = CreateAssistantChatDataContext(telemetryRepository: repository);
 
         // Act
-        var result = await dataContext.GetStructuredLogsAsync(resourceName: null, CancellationToken.None);
+        var result = await dataContext.GetStructuredLogsAsync(resourceName: null!, CancellationToken.None);
 
         // Assert
         for (var i = 6; i < 20; i++)
@@ -81,7 +81,7 @@ public class AssistantChatDataContextTests
         var dataContext = CreateAssistantChatDataContext(telemetryRepository: repository);
 
         // Act
-        var result = await dataContext.GetTracesAsync(resourceName: null, CancellationToken.None);
+        var result = await dataContext.GetTracesAsync(resourceName: null!, CancellationToken.None);
 
         // Assert
         for (var i = 7; i < 20; i++)


### PR DESCRIPTION
## Description

Fix dashboard GitHub Copilot integration:

- Update OpenAI package from 2.7.0 to 2.8.0
- Update Microsoft.Extensions.AI.OpenAI package version
- Make `resourceName` parameter required (non-nullable) for `GetStructuredLogsAsync` and `GetTracesAsync` tool methods in `AssistantChatDataContext`
- Add gpt-5.4 to the default models list in `AssistantChatViewModel`

---

The core fix is changing `resourceName` to be non-nullable. I believe the issue is caused by Microsoft.OpenApi being updated to a newer version, and a change in the newer version is to provide the parameter `type` as an array instead of a string. Code in VS breaks on the unexpected JSON.

Changing resourceName to be non-nullable means `type` stays a string.

I've tested 13.2 dashboard GHCP works with 18.4.

Fixes https://github.com/dotnet/aspire/issues/15311

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
