### PR TITLE
Include restored packages in `aspire cache clear`

### DIFF
--- a/src/Aspire.Cli/CliExecutionContext.cs
+++ b/src/Aspire.Cli/CliExecutionContext.cs
@@ -5,12 +5,17 @@ using System.CommandLine;
 
 namespace Aspire.Cli;
 
-internal sealed class CliExecutionContext(DirectoryInfo workingDirectory, DirectoryInfo hivesDirectory, DirectoryInfo cacheDirectory, DirectoryInfo sdksDirectory, DirectoryInfo logsDirectory, string logFilePath, bool debugMode = false, IReadOnlyDictionary<string, string?>? environmentVariables = null, DirectoryInfo? homeDirectory = null)
+internal sealed class CliExecutionContext(DirectoryInfo workingDirectory, DirectoryInfo hivesDirectory, DirectoryInfo cacheDirectory, DirectoryInfo sdksDirectory, DirectoryInfo logsDirectory, string logFilePath, bool debugMode = false, IReadOnlyDictionary<string, string?>? environmentVariables = null, DirectoryInfo? homeDirectory = null, DirectoryInfo? packagesDirectory = null)
 {
     public DirectoryInfo WorkingDirectory { get; } = workingDirectory;
     public DirectoryInfo HivesDirectory { get; } = hivesDirectory;
     public DirectoryInfo CacheDirectory { get; } = cacheDirectory;
     public DirectoryInfo SdksDirectory { get; } = sdksDirectory;
+
+    /// <summary>
+    /// Gets the directory where restored NuGet packages are cached for apphost server sessions.
+    /// </summary>
+    public DirectoryInfo? PackagesDirectory { get; } = packagesDirectory;
 
     /// <summary>
     /// Gets the directory where CLI log files are stored.

--- a/src/Aspire.Cli/Commands/CacheCommand.cs
+++ b/src/Aspire.Cli/Commands/CacheCommand.cs
@@ -113,6 +113,37 @@ internal sealed class CacheCommand : BaseCommand
                 // Also clear the logs directory (skip current process's log file)
                 var logsDirectory = ExecutionContext.LogsDirectory;
                 var currentLogFilePath = ExecutionContext.LogFilePath;
+
+                // Also clear the restored packages directory
+                var packagesDirectory = ExecutionContext.PackagesDirectory;
+                if (packagesDirectory is not null && packagesDirectory.Exists)
+                {
+                    foreach (var file in packagesDirectory.GetFiles("*", SearchOption.AllDirectories))
+                    {
+                        try
+                        {
+                            file.Delete();
+                            filesDeleted++;
+                        }
+                        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
+                        {
+                            // Continue deleting other files even if some fail
+                        }
+                    }
+
+                    // Delete subdirectories
+                    foreach (var directory in packagesDirectory.GetDirectories())
+                    {
+                        try
+                        {
+                            directory.Delete(recursive: true);
+                        }
+                        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
+                        {
+                            // Continue deleting other directories even if some fail
+                        }
+                    }
+                }
                 if (logsDirectory.Exists)
                 {
                     foreach (var file in logsDirectory.GetFiles("*", SearchOption.AllDirectories))

--- a/src/Aspire.Cli/Commands/CacheCommand.cs
+++ b/src/Aspire.Cli/Commands/CacheCommand.cs
@@ -32,7 +32,7 @@ internal sealed class CacheCommand : BaseCommand
         return Task.FromResult(ExitCodeConstants.InvalidCommand);
     }
 
-    private sealed class ClearCommand : BaseCommand
+    internal sealed class ClearCommand : BaseCommand
     {
         public ClearCommand(IInteractionService interactionService, IFeatures features, ICliUpdateNotifier updateNotifier, CliExecutionContext executionContext, AspireCliTelemetry telemetry)
             : base("clear", CacheCommandStrings.ClearCommand_Description, features, updateNotifier, executionContext, interactionService, telemetry)
@@ -45,139 +45,15 @@ internal sealed class CacheCommand : BaseCommand
         {
             try
             {
-                var cacheDirectory = ExecutionContext.CacheDirectory;
                 var filesDeleted = 0;
-
-                // Delete cache files and subdirectories
-                if (cacheDirectory.Exists)
-                {
-                    // Delete all cache files and subdirectories
-                    foreach (var file in cacheDirectory.GetFiles("*", SearchOption.AllDirectories))
-                    {
-                        try
-                        {
-                            file.Delete();
-                            filesDeleted++;
-                        }
-                        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
-                        {
-                            // Continue deleting other files even if some fail
-                        }
-                    }
-
-                    // Delete subdirectories
-                    foreach (var directory in cacheDirectory.GetDirectories())
-                    {
-                        try
-                        {
-                            directory.Delete(recursive: true);
-                        }
-                        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
-                        {
-                            // Continue deleting other directories even if some fail
-                        }
-                    }
-                }
-
-                // Also clear the sdks directory
-                var sdksDirectory = ExecutionContext.SdksDirectory;
-                if (sdksDirectory.Exists)
-                {
-                    foreach (var file in sdksDirectory.GetFiles("*", SearchOption.AllDirectories))
-                    {
-                        try
-                        {
-                            file.Delete();
-                            filesDeleted++;
-                        }
-                        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
-                        {
-                            // Continue deleting other files even if some fail
-                        }
-                    }
-
-                    // Delete subdirectories
-                    foreach (var directory in sdksDirectory.GetDirectories())
-                    {
-                        try
-                        {
-                            directory.Delete(recursive: true);
-                        }
-                        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
-                        {
-                            // Continue deleting other directories even if some fail
-                        }
-                    }
-                }
-
-                // Also clear the logs directory (skip current process's log file)
-                var logsDirectory = ExecutionContext.LogsDirectory;
                 var currentLogFilePath = ExecutionContext.LogFilePath;
 
-                // Also clear the restored packages directory
-                var packagesDirectory = ExecutionContext.PackagesDirectory;
-                if (packagesDirectory is not null && packagesDirectory.Exists)
-                {
-                    foreach (var file in packagesDirectory.GetFiles("*", SearchOption.AllDirectories))
-                    {
-                        try
-                        {
-                            file.Delete();
-                            filesDeleted++;
-                        }
-                        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
-                        {
-                            // Continue deleting other files even if some fail
-                        }
-                    }
-
-                    // Delete subdirectories
-                    foreach (var directory in packagesDirectory.GetDirectories())
-                    {
-                        try
-                        {
-                            directory.Delete(recursive: true);
-                        }
-                        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
-                        {
-                            // Continue deleting other directories even if some fail
-                        }
-                    }
-                }
-                if (logsDirectory.Exists)
-                {
-                    foreach (var file in logsDirectory.GetFiles("*", SearchOption.AllDirectories))
-                    {
-                        // Skip the current process's log file to avoid deleting it while in use
-                        if (file.FullName.Equals(currentLogFilePath, StringComparison.OrdinalIgnoreCase))
-                        {
-                            continue;
-                        }
-
-                        try
-                        {
-                            file.Delete();
-                            filesDeleted++;
-                        }
-                        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
-                        {
-                            // Continue deleting other files even if some fail
-                        }
-                    }
-
-                    // Delete subdirectories
-                    foreach (var directory in logsDirectory.GetDirectories())
-                    {
-                        try
-                        {
-                            directory.Delete(recursive: true);
-                        }
-                        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
-                        {
-                            // Continue deleting other directories even if some fail
-                        }
-                    }
-                }
+                filesDeleted += ClearDirectoryContents(ExecutionContext.CacheDirectory);
+                filesDeleted += ClearDirectoryContents(ExecutionContext.SdksDirectory);
+                filesDeleted += ClearDirectoryContents(ExecutionContext.PackagesDirectory);
+                filesDeleted += ClearDirectoryContents(
+                    ExecutionContext.LogsDirectory,
+                    skipFile: f => f.FullName.Equals(currentLogFilePath, StringComparison.OrdinalIgnoreCase));
 
                 if (filesDeleted == 0)
                 {
@@ -197,6 +73,54 @@ internal sealed class CacheCommand : BaseCommand
                 InteractionService.DisplayError(errorMessage);
                 return Task.FromResult(ExitCodeConstants.InvalidCommand);
             }
+        }
+
+        private static readonly EnumerationOptions s_enumerationOptions = new()
+        {
+            RecurseSubdirectories = true,
+            IgnoreInaccessible = true
+        };
+
+        internal static int ClearDirectoryContents(DirectoryInfo? directory, Func<FileInfo, bool>? skipFile = null)
+        {
+            if (directory is null || !directory.Exists)
+            {
+                return 0;
+            }
+
+            var filesDeleted = 0;
+
+            foreach (var file in directory.EnumerateFiles("*", s_enumerationOptions))
+            {
+                if (skipFile?.Invoke(file) == true)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    file.Delete();
+                    filesDeleted++;
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
+                {
+                    // Continue deleting other files even if some fail (e.g. locked by a running process)
+                }
+            }
+
+            foreach (var subdirectory in directory.EnumerateDirectories())
+            {
+                try
+                {
+                    subdirectory.Delete(recursive: true);
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
+                {
+                    // Continue deleting other directories even if some fail
+                }
+            }
+
+            return filesDeleted;
         }
     }
 }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -517,7 +517,8 @@ public class Program
         var hivesDirectory = GetHivesDirectory();
         var cacheDirectory = GetCacheDirectory();
         var sdksDirectory = GetSdksDirectory();
-        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, sdksDirectory, new DirectoryInfo(logsDirectory), logFilePath, debugMode);
+        var packagesDirectory = GetPackagesDirectory();
+        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, sdksDirectory, new DirectoryInfo(logsDirectory), logFilePath, debugMode, packagesDirectory: packagesDirectory);
     }
 
     private static DirectoryInfo GetCacheDirectory()
@@ -525,6 +526,13 @@ public class Program
         var homeDirectory = GetUsersAspirePath();
         var cacheDirectoryPath = Path.Combine(homeDirectory, "cache");
         return new DirectoryInfo(cacheDirectoryPath);
+    }
+
+    private static DirectoryInfo GetPackagesDirectory()
+    {
+        var homeDirectory = GetUsersAspirePath();
+        var packagesDirectoryPath = Path.Combine(homeDirectory, "packages");
+        return new DirectoryInfo(packagesDirectoryPath);
     }
 
     private static void TrySetLocaleOverride(string? localeOverride, ILogger logger, IStartupErrorWriter errorWriter)

--- a/tests/Aspire.Cli.Tests/Commands/CacheCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/CacheCommandTests.cs
@@ -43,7 +43,7 @@ public class CacheCommandTests(ITestOutputHelper outputHelper)
     public async Task CacheClear_ClearsPackagesDirectory()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var packagesDir = new DirectoryInfo(Path.Combine(workspace.WorkingDirectory.FullName, ".aspire", "packages"));
+        var packagesDir = new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "packages"));
         var restoreDir = packagesDir.CreateSubdirectory("restore").CreateSubdirectory("ABC123");
         File.WriteAllText(Path.Combine(restoreDir.FullName, "test.dll"), "fake");
 
@@ -66,7 +66,7 @@ public class CacheCommandTests(ITestOutputHelper outputHelper)
     public async Task CacheClear_HandlesNonExistentPackagesDirectory()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
-        var packagesDir = new DirectoryInfo(Path.Combine(workspace.WorkingDirectory.FullName, ".aspire", "packages-nonexistent"));
+        var packagesDir = new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "packages-nonexistent"));
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {

--- a/tests/Aspire.Cli.Tests/Commands/CacheCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/CacheCommandTests.cs
@@ -38,4 +38,120 @@ public class CacheCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(0, exitCode);
     }
+
+    [Fact]
+    public async Task CacheClear_ClearsPackagesDirectory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var packagesDir = new DirectoryInfo(Path.Combine(workspace.WorkingDirectory.FullName, ".aspire", "packages"));
+        var restoreDir = packagesDir.CreateSubdirectory("restore").CreateSubdirectory("ABC123");
+        File.WriteAllText(Path.Combine(restoreDir.FullName, "test.dll"), "fake");
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.PackagesDirectory = packagesDir;
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("cache clear");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+        Assert.False(File.Exists(Path.Combine(restoreDir.FullName, "test.dll")));
+    }
+
+    [Fact]
+    public async Task CacheClear_HandlesNonExistentPackagesDirectory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var packagesDir = new DirectoryInfo(Path.Combine(workspace.WorkingDirectory.FullName, ".aspire", "packages-nonexistent"));
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.PackagesDirectory = packagesDir;
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("cache clear");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+    }
+
+    [Fact]
+    public void ClearDirectoryContents_DeletesFilesAndSubdirectories()
+    {
+        var tempDir = new DirectoryInfo(Path.Combine(Path.GetTempPath(), $"aspire-test-{Guid.NewGuid():N}"));
+        try
+        {
+            tempDir.Create();
+            var subDir = tempDir.CreateSubdirectory("nested");
+            File.WriteAllText(Path.Combine(tempDir.FullName, "root.txt"), "root");
+            File.WriteAllText(Path.Combine(subDir.FullName, "nested.txt"), "nested");
+
+            var deleted = CacheCommand.ClearCommand.ClearDirectoryContents(tempDir);
+
+            Assert.Equal(2, deleted);
+            Assert.Empty(tempDir.GetFiles("*", SearchOption.AllDirectories));
+            Assert.Empty(tempDir.GetDirectories());
+        }
+        finally
+        {
+            if (tempDir.Exists)
+            {
+                tempDir.Delete(recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void ClearDirectoryContents_RespectsSkipPredicate()
+    {
+        var tempDir = new DirectoryInfo(Path.Combine(Path.GetTempPath(), $"aspire-test-{Guid.NewGuid():N}"));
+        try
+        {
+            tempDir.Create();
+            var keepFile = Path.Combine(tempDir.FullName, "keep.txt");
+            var deleteFile = Path.Combine(tempDir.FullName, "delete.txt");
+            File.WriteAllText(keepFile, "keep");
+            File.WriteAllText(deleteFile, "delete");
+
+            var deleted = CacheCommand.ClearCommand.ClearDirectoryContents(
+                tempDir,
+                skipFile: f => f.Name == "keep.txt");
+
+            Assert.Equal(1, deleted);
+            Assert.True(File.Exists(keepFile));
+            Assert.False(File.Exists(deleteFile));
+        }
+        finally
+        {
+            if (tempDir.Exists)
+            {
+                tempDir.Delete(recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void ClearDirectoryContents_ReturnsZero_WhenDirectoryDoesNotExist()
+    {
+        var nonExistent = new DirectoryInfo(Path.Combine(Path.GetTempPath(), $"aspire-test-nonexistent-{Guid.NewGuid():N}"));
+
+        var deleted = CacheCommand.ClearCommand.ClearDirectoryContents(nonExistent);
+
+        Assert.Equal(0, deleted);
+    }
+
+    [Fact]
+    public void ClearDirectoryContents_ReturnsZero_WhenNull()
+    {
+        var deleted = CacheCommand.ClearCommand.ClearDirectoryContents(null);
+
+        Assert.Equal(0, deleted);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -247,10 +247,12 @@ internal sealed class CliServiceCollectionTestOptions
         var cacheDirectory = new DirectoryInfo(Path.Combine(WorkingDirectory.FullName, ".aspire", "cache"));
         var logsDirectory = new DirectoryInfo(Path.Combine(WorkingDirectory.FullName, ".aspire", "logs"));
         var logFilePath = Path.Combine(logsDirectory.FullName, "test.log");
-        return new CliExecutionContext(WorkingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")), logsDirectory, logFilePath);
+        return new CliExecutionContext(WorkingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-sdks")), logsDirectory, logFilePath, packagesDirectory: PackagesDirectory);
     }
 
     public DirectoryInfo WorkingDirectory { get; set; }
+
+    public DirectoryInfo? PackagesDirectory { get; set; }
 
     public Action<Dictionary<string, string?>> ConfigurationCallback { get; set; } = (Dictionary<string, string?> config) =>
     {


### PR DESCRIPTION
`aspire cache clear` was not clearing `~/.aspire/packages/` which contains restored NuGet packages used by apphost server sessions. When the CLI binary is updated but the cached DLLs share the same version string (e.g. both `13.2.0`), stale packages persist and cause runtime failures.

For example, after the RPC auth handshake was added in #15344, the CLI enforced authentication but the cached `Aspire.Hosting.CodeGeneration.TypeScript.dll` still contained the old `transport.ts` without auth code — causing `"Client must authenticate before invoking AppHost RPC methods"` errors for TypeScript apphosts.

### Changes

- Add `PackagesDirectory` (`~/.aspire/packages/`) to `CliExecutionContext` as an optional parameter (avoids churn on existing call sites)
- `aspire cache clear` now also wipes `~/.aspire/packages/` alongside cache, sdks, and logs
- Extract `ClearDirectoryContents` helper to deduplicate the repeated directory-clearing pattern
- Use `EnumerateFiles` with `IgnoreInaccessible` instead of `GetFiles` for resilient enumeration
- Add unit tests for packages directory clearing, skip predicate, and edge cases