### PR TITLE
Exclude NuGet cache from project file search in ProjectLocator

### DIFF
--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.IO.Enumeration;
 using System.Text.Json;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.DotNet;
@@ -76,12 +77,30 @@ internal sealed class ProjectLocator(
 
             logger.LogDebug("Searching for patterns: {Patterns}", string.Join(", ", allPatterns));
 
+            var nugetCachePath = GetNuGetPackagesCachePath();
+            var pathComparison = OperatingSystem.IsWindows()
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            logger.LogDebug("NuGet cache path to exclude: {NuGetCachePath}", nugetCachePath ?? "(none)");
+
             // Collect all candidates with their handlers across all patterns
             var candidatesWithHandlers = new List<(FileInfo File, IAppHostProject Handler)>();
 
             foreach (var pattern in allPatterns)
             {
-                var candidateFiles = searchDirectory.GetFiles(pattern, enumerationOptions);
+                var enumerable = new FileSystemEnumerable<FileInfo>(
+                    searchDirectory.FullName,
+                    (ref FileSystemEntry entry) => new FileInfo(entry.ToFullPath()),
+                    enumerationOptions)
+                {
+                    ShouldIncludePredicate = (ref FileSystemEntry entry) =>
+                        !entry.IsDirectory && FileSystemName.MatchesSimpleExpression(pattern, entry.FileName),
+                    ShouldRecursePredicate = (ref FileSystemEntry entry) =>
+                        nugetCachePath is null ||
+                        !entry.ToFullPath().StartsWith(nugetCachePath, pathComparison)
+                };
+                var candidateFiles = enumerable.ToArray();
                 logger.LogDebug("Found {CandidateCount} files matching pattern '{Pattern}'", candidateFiles.Length, pattern);
 
                 foreach (var candidateFile in candidateFiles)
@@ -484,6 +503,23 @@ internal sealed class ProjectLocator(
         }
 
         return settingsDirectory.Parent;
+    }
+
+    private static string? GetNuGetPackagesCachePath()
+    {
+        var envPath = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        if (!string.IsNullOrEmpty(envPath))
+        {
+            return Path.GetFullPath(envPath);
+        }
+
+        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrEmpty(userProfile))
+        {
+            return Path.GetFullPath(Path.Combine(userProfile, ".nuget", "packages"));
+        }
+
+        return null;
     }
 
 }

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -505,15 +505,15 @@ internal sealed class ProjectLocator(
         return settingsDirectory.Parent;
     }
 
-    private static string? GetNuGetPackagesCachePath()
+    private string? GetNuGetPackagesCachePath()
     {
-        var envPath = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        var envPath = executionContext.GetEnvironmentVariable("NUGET_PACKAGES");
         if (!string.IsNullOrEmpty(envPath))
         {
             return Path.GetFullPath(envPath);
         }
 
-        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var userProfile = executionContext.HomeDirectory.FullName;
         if (!string.IsNullOrEmpty(userProfile))
         {
             return Path.GetFullPath(Path.Combine(userProfile, ".nuget", "packages"));

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -97,8 +97,15 @@ internal sealed class ProjectLocator(
                     ShouldIncludePredicate = (ref FileSystemEntry entry) =>
                         !entry.IsDirectory && FileSystemName.MatchesSimpleExpression(pattern, entry.FileName),
                     ShouldRecursePredicate = (ref FileSystemEntry entry) =>
-                        nugetCachePath is null ||
-                        !entry.ToFullPath().StartsWith(nugetCachePath, pathComparison)
+                    {
+                        if (nugetCachePath is null)
+                        {
+                            return true;
+                        }
+                        var dirPath = entry.ToFullPath();
+                        return !dirPath.Equals(nugetCachePath, pathComparison)
+                            && !dirPath.StartsWith(nugetCachePath + Path.DirectorySeparatorChar, pathComparison);
+                    }
                 };
                 var candidateFiles = enumerable.ToArray();
                 logger.LogDebug("Found {CandidateCount} files matching pattern '{Pattern}'", candidateFiles.Length, pattern);

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -78,10 +78,6 @@ internal sealed class ProjectLocator(
             logger.LogDebug("Searching for patterns: {Patterns}", string.Join(", ", allPatterns));
 
             var nugetCachePath = GetNuGetPackagesCachePath();
-            var pathComparison = OperatingSystem.IsWindows()
-                ? StringComparison.OrdinalIgnoreCase
-                : StringComparison.Ordinal;
-
             logger.LogDebug("NuGet cache path to exclude: {NuGetCachePath}", nugetCachePath ?? "(none)");
 
             // Collect all candidates with their handlers across all patterns
@@ -89,25 +85,7 @@ internal sealed class ProjectLocator(
 
             foreach (var pattern in allPatterns)
             {
-                var enumerable = new FileSystemEnumerable<FileInfo>(
-                    searchDirectory.FullName,
-                    (ref FileSystemEntry entry) => new FileInfo(entry.ToFullPath()),
-                    enumerationOptions)
-                {
-                    ShouldIncludePredicate = (ref FileSystemEntry entry) =>
-                        !entry.IsDirectory && FileSystemName.MatchesSimpleExpression(pattern, entry.FileName),
-                    ShouldRecursePredicate = (ref FileSystemEntry entry) =>
-                    {
-                        if (nugetCachePath is null)
-                        {
-                            return true;
-                        }
-                        var dirPath = entry.ToFullPath();
-                        return !dirPath.Equals(nugetCachePath, pathComparison)
-                            && !dirPath.StartsWith(nugetCachePath + Path.DirectorySeparatorChar, pathComparison);
-                    }
-                };
-                var candidateFiles = enumerable.ToArray();
+                var candidateFiles = FindMatchingFiles(searchDirectory, pattern, enumerationOptions, nugetCachePath);
                 logger.LogDebug("Found {CandidateCount} files matching pattern '{Pattern}'", candidateFiles.Length, pattern);
 
                 foreach (var candidateFile in candidateFiles)
@@ -510,6 +488,34 @@ internal sealed class ProjectLocator(
         }
 
         return settingsDirectory.Parent;
+    }
+
+    private static FileInfo[] FindMatchingFiles(DirectoryInfo searchDirectory, string pattern, EnumerationOptions options, string? excludePath)
+    {
+        var pathComparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        var enumerable = new FileSystemEnumerable<FileInfo>(
+            searchDirectory.FullName,
+            (ref FileSystemEntry entry) => new FileInfo(entry.ToFullPath()),
+            options)
+        {
+            ShouldIncludePredicate = (ref FileSystemEntry entry) =>
+                !entry.IsDirectory && FileSystemName.MatchesSimpleExpression(pattern, entry.FileName),
+            ShouldRecursePredicate = (ref FileSystemEntry entry) =>
+            {
+                if (excludePath is null)
+                {
+                    return true;
+                }
+                var dirPath = entry.ToFullPath();
+                return !dirPath.Equals(excludePath, pathComparison)
+                    && !dirPath.StartsWith(excludePath + Path.DirectorySeparatorChar, pathComparison);
+            }
+        };
+
+        return enumerable.ToArray();
     }
 
     private string? GetNuGetPackagesCachePath()

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -1019,6 +1019,125 @@ builder.Build().Run();");
         Assert.False(sdkCheckCalled);
     }
 
+    [Fact]
+    public async Task FindAppHostProjectFilesAsync_ExcludesProjectsInsideNuGetCache()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Create a valid AppHost project in a normal location
+        var normalProject = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "MyApp", "AppHost.csproj"));
+        Directory.CreateDirectory(normalProject.DirectoryName!);
+        await File.WriteAllTextAsync(normalProject.FullName, "Not a real project file.");
+
+        // Create a project inside a simulated NuGet cache path
+        var nugetCacheDir = Path.Combine(workspace.WorkspaceRoot.FullName, ".nuget", "packages",
+            "aspire.projecttemplates", "9.1.0", "content", "templates", "aspire-apphost");
+        Directory.CreateDirectory(nugetCacheDir);
+        var cachedProject = new FileInfo(Path.Combine(nugetCacheDir, "Aspire.AppHost1.csproj"));
+        await File.WriteAllTextAsync(cachedProject.FullName, "Not a real project file.");
+
+        var projectFactory = new TestAppHostProjectFactory
+        {
+            ValidateAppHostCallback = _ => new AppHostValidationResult(IsValid: true)
+        };
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(executionContext, projectFactory: projectFactory);
+
+        // Set NUGET_PACKAGES to point to our simulated cache
+        var originalValue = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        try
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES",
+                Path.Combine(workspace.WorkspaceRoot.FullName, ".nuget", "packages"));
+
+            var foundFiles = await projectLocator.FindAppHostProjectFilesAsync(
+                workspace.WorkspaceRoot.FullName, CancellationToken.None).DefaultTimeout();
+
+            // Should only find the normal project, not the one inside the NuGet cache
+            Assert.Single(foundFiles);
+            Assert.Equal(normalProject.FullName, foundFiles[0].FullName);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", originalValue);
+        }
+    }
+
+    [Fact]
+    public async Task FindAppHostProjectFilesAsync_FindsProjectsOutsideNuGetCache()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Create projects in various subdirectories (none are NuGet cache)
+        var project1 = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "src", "App1", "AppHost.csproj"));
+        Directory.CreateDirectory(project1.DirectoryName!);
+        await File.WriteAllTextAsync(project1.FullName, "Not a real project file.");
+
+        var project2 = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "samples", "App2", "AppHost.csproj"));
+        Directory.CreateDirectory(project2.DirectoryName!);
+        await File.WriteAllTextAsync(project2.FullName, "Not a real project file.");
+
+        var projectFactory = new TestAppHostProjectFactory
+        {
+            ValidateAppHostCallback = _ => new AppHostValidationResult(IsValid: true)
+        };
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(executionContext, projectFactory: projectFactory);
+
+        var foundFiles = await projectLocator.FindAppHostProjectFilesAsync(
+            workspace.WorkspaceRoot.FullName, CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(2, foundFiles.Count);
+        var foundPaths = foundFiles.Select(f => f.FullName).ToHashSet();
+        Assert.Contains(project1.FullName, foundPaths);
+        Assert.Contains(project2.FullName, foundPaths);
+    }
+
+    [Fact]
+    public async Task FindAppHostProjectFilesAsync_RespectsCustomNuGetPackagesEnvVar()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Create a valid AppHost project in a normal location
+        var normalProject = new FileInfo(Path.Combine(workspace.WorkspaceRoot.FullName, "MyApp", "AppHost.csproj"));
+        Directory.CreateDirectory(normalProject.DirectoryName!);
+        await File.WriteAllTextAsync(normalProject.FullName, "Not a real project file.");
+
+        // Create a project inside a custom NuGet cache location (not the default .nuget/packages)
+        var customCacheDir = Path.Combine(workspace.WorkspaceRoot.FullName, "custom-nuget-cache");
+        var cachedProjectDir = Path.Combine(customCacheDir, "aspire.projecttemplates", "9.1.0", "content");
+        Directory.CreateDirectory(cachedProjectDir);
+        var cachedProject = new FileInfo(Path.Combine(cachedProjectDir, "Aspire.AppHost1.csproj"));
+        await File.WriteAllTextAsync(cachedProject.FullName, "Not a real project file.");
+
+        var projectFactory = new TestAppHostProjectFactory
+        {
+            ValidateAppHostCallback = _ => new AppHostValidationResult(IsValid: true)
+        };
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocator(executionContext, projectFactory: projectFactory);
+
+        var originalValue = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        try
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", customCacheDir);
+
+            var foundFiles = await projectLocator.FindAppHostProjectFilesAsync(
+                workspace.WorkspaceRoot.FullName, CancellationToken.None).DefaultTimeout();
+
+            // Should only find the normal project, not the one inside the custom cache
+            Assert.Single(foundFiles);
+            Assert.Equal(normalProject.FullName, foundFiles[0].FullName);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", originalValue);
+        }
+    }
+
     private static ProjectLocator CreateProjectLocator(
         CliExecutionContext executionContext,
         IInteractionService? interactionService = null,

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -19,14 +19,14 @@ namespace Aspire.Cli.Tests.Projects;
 
 public class ProjectLocatorTests(ITestOutputHelper outputHelper)
 {
-    private static Aspire.Cli.CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory)
+    private static Aspire.Cli.CliExecutionContext CreateExecutionContext(DirectoryInfo workingDirectory, IReadOnlyDictionary<string, string?>? environmentVariables = null)
     {
         // NOTE: This would normally be in the users home directory, but for tests we create
         //       it in the temporary workspace directory.
         var settingsDirectory = workingDirectory.CreateSubdirectory(".aspire");
         var hivesDirectory = settingsDirectory.CreateSubdirectory("hives");
         var cacheDirectory = new DirectoryInfo(Path.Combine(workingDirectory.FullName, ".aspire", "cache"));
-        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log");
+        return new CliExecutionContext(workingDirectory, hivesDirectory, cacheDirectory, new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-runtimes")), new DirectoryInfo(Path.Combine(Path.GetTempPath(), "aspire-test-logs")), "test.log", environmentVariables: environmentVariables);
     }
 
     [Fact]
@@ -1041,27 +1041,19 @@ builder.Build().Run();");
             ValidateAppHostCallback = _ => new AppHostValidationResult(IsValid: true)
         };
 
-        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var envVars = new Dictionary<string, string?>
+        {
+            ["NUGET_PACKAGES"] = Path.Combine(workspace.WorkspaceRoot.FullName, ".nuget", "packages")
+        };
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot, environmentVariables: envVars);
         var projectLocator = CreateProjectLocator(executionContext, projectFactory: projectFactory);
 
-        // Set NUGET_PACKAGES to point to our simulated cache
-        var originalValue = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
-        try
-        {
-            Environment.SetEnvironmentVariable("NUGET_PACKAGES",
-                Path.Combine(workspace.WorkspaceRoot.FullName, ".nuget", "packages"));
+        var foundFiles = await projectLocator.FindAppHostProjectFilesAsync(
+            workspace.WorkspaceRoot.FullName, CancellationToken.None).DefaultTimeout();
 
-            var foundFiles = await projectLocator.FindAppHostProjectFilesAsync(
-                workspace.WorkspaceRoot.FullName, CancellationToken.None).DefaultTimeout();
-
-            // Should only find the normal project, not the one inside the NuGet cache
-            Assert.Single(foundFiles);
-            Assert.Equal(normalProject.FullName, foundFiles[0].FullName);
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("NUGET_PACKAGES", originalValue);
-        }
+        // Should only find the normal project, not the one inside the NuGet cache
+        Assert.Single(foundFiles);
+        Assert.Equal(normalProject.FullName, foundFiles[0].FullName);
     }
 
     [Fact]
@@ -1117,25 +1109,19 @@ builder.Build().Run();");
             ValidateAppHostCallback = _ => new AppHostValidationResult(IsValid: true)
         };
 
-        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var envVars = new Dictionary<string, string?>
+        {
+            ["NUGET_PACKAGES"] = customCacheDir
+        };
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot, environmentVariables: envVars);
         var projectLocator = CreateProjectLocator(executionContext, projectFactory: projectFactory);
 
-        var originalValue = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
-        try
-        {
-            Environment.SetEnvironmentVariable("NUGET_PACKAGES", customCacheDir);
+        var foundFiles = await projectLocator.FindAppHostProjectFilesAsync(
+            workspace.WorkspaceRoot.FullName, CancellationToken.None).DefaultTimeout();
 
-            var foundFiles = await projectLocator.FindAppHostProjectFilesAsync(
-                workspace.WorkspaceRoot.FullName, CancellationToken.None).DefaultTimeout();
-
-            // Should only find the normal project, not the one inside the custom cache
-            Assert.Single(foundFiles);
-            Assert.Equal(normalProject.FullName, foundFiles[0].FullName);
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("NUGET_PACKAGES", originalValue);
-        }
+        // Should only find the normal project, not the one inside the custom cache
+        Assert.Single(foundFiles);
+        Assert.Equal(normalProject.FullName, foundFiles[0].FullName);
     }
 
     private static ProjectLocator CreateProjectLocator(

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -1124,6 +1124,46 @@ builder.Build().Run();");
         Assert.Equal(normalProject.FullName, foundFiles[0].FullName);
     }
 
+    [Fact]
+    public async Task FindAppHostProjectFilesAsync_DoesNotExcludeSiblingDirectoriesOfNuGetCache()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        // Use a custom non-hidden cache path so the test isn't affected by hidden-directory skipping
+        var customCacheDir = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget-cache");
+
+        // Create a project inside a sibling directory whose name shares a prefix with the cache
+        var siblingDir = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget-cache-extra", "MyApp");
+        Directory.CreateDirectory(siblingDir);
+        var siblingProject = new FileInfo(Path.Combine(siblingDir, "AppHost.csproj"));
+        await File.WriteAllTextAsync(siblingProject.FullName, "Not a real project file.");
+
+        // Create a project inside the actual cache that should be excluded
+        var cachedProjectDir = Path.Combine(customCacheDir, "aspire.projecttemplates", "9.1.0", "content");
+        Directory.CreateDirectory(cachedProjectDir);
+        var cachedProject = new FileInfo(Path.Combine(cachedProjectDir, "Aspire.AppHost1.csproj"));
+        await File.WriteAllTextAsync(cachedProject.FullName, "Not a real project file.");
+
+        var projectFactory = new TestAppHostProjectFactory
+        {
+            ValidateAppHostCallback = _ => new AppHostValidationResult(IsValid: true)
+        };
+
+        var envVars = new Dictionary<string, string?>
+        {
+            ["NUGET_PACKAGES"] = customCacheDir
+        };
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot, environmentVariables: envVars);
+        var projectLocator = CreateProjectLocator(executionContext, projectFactory: projectFactory);
+
+        var foundFiles = await projectLocator.FindAppHostProjectFilesAsync(
+            workspace.WorkspaceRoot.FullName, CancellationToken.None).DefaultTimeout();
+
+        // Should find the sibling project but not the one inside the cache
+        Assert.Single(foundFiles);
+        Assert.Equal(siblingProject.FullName, foundFiles[0].FullName);
+    }
+
     private static ProjectLocator CreateProjectLocator(
         CliExecutionContext executionContext,
         IInteractionService? interactionService = null,


### PR DESCRIPTION
## Summary

- Fixes `aspire update` incorrectly surfacing immutable NuGet template packages (e.g. `aspire.projecttemplates`) as updatable AppHost projects when run from a broad directory like `~`
- Replaces `Directory.GetFiles` with `FileSystemEnumerable` using `ShouldRecursePredicate` to skip the NuGet cache directory before descending into it
- Resolves the cache path from `NUGET_PACKAGES` env var or the platform-appropriate default (`~/.nuget/packages`)

Fixes #14055

## Test plan

- [x] Added test: `FindAppHostProjectFilesAsync_ExcludesProjectsInsideNuGetCache` — verifies projects inside the NuGet cache are excluded
- [x] Added test: `FindAppHostProjectFilesAsync_FindsProjectsOutsideNuGetCache` — verifies normal project discovery still works
- [x] Added test: `FindAppHostProjectFilesAsync_RespectsCustomNuGetPackagesEnvVar` — verifies custom `NUGET_PACKAGES` paths are honored