### PR TITLE
Remove OtlpConfigurationExtensions.OtlpEndpointEnvironmentVariableName

### DIFF
--- a/src/Aspire.Hosting/Dcp/OtlpEndpointReferenceGatherer.cs
+++ b/src/Aspire.Hosting/Dcp/OtlpEndpointReferenceGatherer.cs
@@ -27,7 +27,7 @@ internal class OtlpEndpointReferenceGatherer : IExecutionConfigurationGatherer
             return;
         }
 
-        if (!context.EnvironmentVariables.TryGetValue(OtlpConfigurationExtensions.OtlpEndpointEnvironmentVariableName, out _))
+        if (!context.EnvironmentVariables.TryGetValue(KnownOtelConfigNames.ExporterOtlpEndpoint, out _))
         {
             // If the OTLP endpoint is not set, do not try to set it.
             return;
@@ -74,7 +74,7 @@ internal class OtlpEndpointReferenceGatherer : IExecutionConfigurationGatherer
             Debug.Assert(url is not null, $"We should be able to get a URL value from the reference dashboard endpoint '{endpointReference.EndpointName}'");
             if (url is not null)
             {
-                context.EnvironmentVariables[OtlpConfigurationExtensions.OtlpEndpointEnvironmentVariableName] = url;
+                context.EnvironmentVariables[KnownOtelConfigNames.ExporterOtlpEndpoint] = url;
             }
         }
     }

--- a/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
@@ -14,11 +14,6 @@ namespace Aspire.Hosting;
 public static class OtlpConfigurationExtensions
 {
     /// <summary>
-    /// The name of the environment variable for configuring the OTLP exporter ingestion URL. This is used by OpenTelemetry SDKs to determine where to send telemetry data.
-    /// </summary>
-    public static readonly string OtlpEndpointEnvironmentVariableName = KnownOtelConfigNames.ExporterOtlpEndpoint;
-
-    /// <summary>
     /// Configures OpenTelemetry in projects using environment variables.
     /// </summary>
     /// <param name="resource">The resource to add annotations to.</param>
@@ -74,7 +69,7 @@ public static class OtlpConfigurationExtensions
             }
 
             var (url, protocol) = OtlpEndpointResolver.ResolveOtlpEndpoint(configuration, otlpExporterAnnotation.RequiredProtocol);
-            context.EnvironmentVariables[OtlpEndpointEnvironmentVariableName] = new HostUrl(url);
+            context.EnvironmentVariables[KnownOtelConfigNames.ExporterOtlpEndpoint] = new HostUrl(url);
             context.EnvironmentVariables[KnownOtelConfigNames.ExporterOtlpProtocol] = protocol;
 
             // Set the service name and instance id to the resource name and UID. Values are injected by DCP.


### PR DESCRIPTION
Replace usages with KnownOtelConfigNames.ExporterOtlpEndpoint directly.

This change was only needed in `main` since it never made it to `release/13.2`.