### PR TITLE
Handle version selector in CPM CLI E2E test

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/CentralPackageManagementTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/CentralPackageManagementTests.cs
@@ -168,16 +168,42 @@ public sealed class CentralPackageManagementTests(ITestOutputHelper output)
             </Project>
             """);
 
-        await auto.TypeAsync($"aspire add Aspire.Hosting.Redis --version 13.1.2");
+        var waitingForVersionSelection = new CellPatternSearcher()
+            .Find("Select a version of Aspire.Hosting.Redis:");
+        var versionSelectionShown = false;
+
+        await auto.TypeAsync("aspire add Aspire.Hosting.Redis");
         await auto.EnterAsync();
+        await auto.WaitUntilAsync(s =>
+        {
+            if (waitingForVersionSelection.Search(s).Count > 0)
+            {
+                versionSelectionShown = true;
+                return true;
+            }
+
+            var successPromptSearcher = new CellPatternSearcher()
+                .FindPattern(counter.Value.ToString())
+                .RightText(" OK] $ ");
+
+            return successPromptSearcher.Search(s).Count > 0;
+        }, timeout: TimeSpan.FromSeconds(90), description: "version selection prompt or success prompt");
+
+        if (versionSelectionShown)
+        {
+            // PR hives can surface multiple channels in CI. Accept the default implicit-channel version
+            // so this test validates CPM behavior without pinning a specific package version.
+            await auto.EnterAsync();
+        }
+
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Verify the PackageVersion for Aspire.Hosting.AppHost was removed
+        // Verify the AppHost project does not end up with a version-pinned Redis PackageReference.
         {
-            var content = File.ReadAllText(appHostCsprojPath);
-            if (content.Contains("Version=\"13.1.2\""))
+            var appHostContent = File.ReadAllText(appHostCsprojPath);
+            if (appHostContent.Contains("<PackageReference Include=\"Aspire.Hosting.Redis\" Version=", StringComparison.Ordinal))
             {
-                throw new InvalidOperationException($"File {appHostCsprojPath} unexpectedly contains: Version=\"13.1.2\"");
+                throw new InvalidOperationException($"File {appHostCsprojPath} unexpectedly contains a version-pinned PackageReference for Aspire.Hosting.Redis");
             }
         }
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/CentralPackageManagementTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/CentralPackageManagementTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Xml.Linq;
+
 using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Tests.Utils;
 using Hex1b.Automation;
@@ -169,7 +171,7 @@ public sealed class CentralPackageManagementTests(ITestOutputHelper output)
             """);
 
         var waitingForVersionSelection = new CellPatternSearcher()
-            .Find("Select a version of Aspire.Hosting.Redis:");
+            .Find("Select a version of");
         var versionSelectionShown = false;
 
         await auto.TypeAsync("aspire add Aspire.Hosting.Redis");
@@ -187,7 +189,7 @@ public sealed class CentralPackageManagementTests(ITestOutputHelper output)
                 .RightText(" OK] $ ");
 
             return successPromptSearcher.Search(s).Count > 0;
-        }, timeout: TimeSpan.FromSeconds(90), description: "version selection prompt or success prompt");
+        }, timeout: TimeSpan.FromSeconds(180), description: "version selection prompt or success prompt");
 
         if (versionSelectionShown)
         {
@@ -200,8 +202,21 @@ public sealed class CentralPackageManagementTests(ITestOutputHelper output)
 
         // Verify the AppHost project does not end up with a version-pinned Redis PackageReference.
         {
-            var appHostContent = File.ReadAllText(appHostCsprojPath);
-            if (appHostContent.Contains("<PackageReference Include=\"Aspire.Hosting.Redis\" Version=", StringComparison.Ordinal))
+            var appHostProject = XDocument.Load(appHostCsprojPath);
+            var hasVersionPinnedRedisReference = false;
+
+            foreach (var element in appHostProject.Descendants())
+            {
+                if (element.Name.LocalName == "PackageReference" &&
+                    string.Equals((string?)element.Attribute("Include"), "Aspire.Hosting.Redis", StringComparison.Ordinal) &&
+                    element.Attribute("Version") is not null)
+                {
+                    hasVersionPinnedRedisReference = true;
+                    break;
+                }
+            }
+
+            if (hasVersionPinnedRedisReference)
             {
                 throw new InvalidOperationException($"File {appHostCsprojPath} unexpectedly contains a version-pinned PackageReference for Aspire.Hosting.Redis");
             }


### PR DESCRIPTION
## Description

Updates `CentralPackageManagementTests` so the CLI E2E scenario no longer depends on an exact Aspire package version being available.

In PR environments with hives present, `aspire add Aspire.Hosting.Redis --version 13.1.2` can now surface the interactive version selector once the implicit NuGet.config feed advances beyond that exact version. This change makes the test accept the default implicit-channel selection when the selector appears, while keeping the CPM assertion focused on avoiding a brittle version pin in the AppHost project.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
