### PR TITLE
Stablize Aspire.Hosting.Azure Network and Sql packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,7 +38,7 @@
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.13.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.4.0" />
     <!-- Azure Management SDK for .NET dependencies -->
-    <PackageVersion Include="Azure.Provisioning" Version="1.4.0" />
+    <PackageVersion Include="Azure.Provisioning" Version="1.5.0" />
     <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.AppContainers" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.AppService" Version="1.3.1" />
@@ -52,7 +52,7 @@
     <PackageVersion Include="Azure.Provisioning.Network" Version="1.0.0" />
     <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="1.1.1" />
-    <PackageVersion Include="Azure.Provisioning.PrivateDns" Version="1.0.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.PrivateDns" Version="1.0.0" />
     <PackageVersion Include="Azure.Provisioning.Redis" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.RedisEnterprise" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.Search" Version="1.0.0" />

--- a/src/Aspire.Hosting.Azure.Network/Aspire.Hosting.Azure.Network.csproj
+++ b/src/Aspire.Hosting.Azure.Network/Aspire.Hosting.Azure.Network.csproj
@@ -6,9 +6,6 @@
     <PackageTags>aspire integration hosting azure network vnet virtual-network subnet nat-gateway public-ip cloud</PackageTags>
     <Description>Azure Virtual Network resource types for Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)Azure_256x.png</PackageIconFullPath>
-    <!-- TEMPORARY: Re-added because Azure.Provisioning.PrivateDns is still in preview (1.0.0-beta.1).
-         Remove once a stable version is available. See https://github.com/dotnet/aspire/issues/15328 -->
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <NoWarn>$(NoWarn);AZPROVISION001;ASPIREAZURE003</NoWarn>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.Sql/Aspire.Hosting.Azure.Sql.csproj
+++ b/src/Aspire.Hosting.Azure.Sql/Aspire.Hosting.Azure.Sql.csproj
@@ -7,9 +7,6 @@
     <PackageTags>aspire integration hosting azure sql database data cloud</PackageTags>
     <Description>Azure SQL Database resource types for Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureSqlServer_256x.png</PackageIconFullPath>
-    <!-- TEMPORARY: Added because Aspire.Hosting.Azure.Network depends on a preview package (Azure.Provisioning.PrivateDns).
-         Remove once a stable version is available. See https://github.com/dotnet/aspire/issues/15328 -->
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Shared/RepoTesting/Directory.Packages.Helix.props
+++ b/tests/Shared/RepoTesting/Directory.Packages.Helix.props
@@ -25,13 +25,14 @@
     <PackageVersion Include="Aspire.Hosting.Azure.EventHubs" Version="13.2.0" />
     <PackageVersion Include="Aspire.Hosting.Azure.Functions" Version="13.2.0" />
     <PackageVersion Include="Aspire.Hosting.Azure.KeyVault" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Network" Version="13.2.0" />
     <PackageVersion Include="Aspire.Hosting.Azure.OperationalInsights" Version="13.2.0" />
     <PackageVersion Include="Aspire.Hosting.Azure.PostgreSQL" Version="13.2.0" />
     <PackageVersion Include="Aspire.Hosting.Azure.Redis" Version="13.2.0" />
     <PackageVersion Include="Aspire.Hosting.Azure.Search" Version="13.2.0" />
     <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.2.0" />
     <PackageVersion Include="Aspire.Hosting.Azure.SignalR" Version="13.2.0" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Sql" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Sql" Version="13.2.0" />
     <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.2.0" />
     <PackageVersion Include="Aspire.Hosting.Azure.WebPubSub" Version="13.2.0" />
     <PackageVersion Include="Aspire.Hosting.Docker" Version="$(PackageVersion)" />


### PR DESCRIPTION
Use stable Azure.Provisioning.PrivateDns and remove SuppressFinalPackageVersion on these two packages so they ship stable.

Fix #15328