### PR TITLE
WithBrowserDebugger: no-op when IDE lacks browser capability

### DIFF
--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -1005,6 +1005,7 @@ public static class JavaScriptHostingExtensions
     /// <summary>
     /// Configures a browser debugger for the JavaScript application resource, enabling browser-based debugging
     /// through a child resource that launches when the parent application is ready.
+    /// This resource relies on IDE support for browser debugging and will not be added if the required IDE capability is missing.
     /// </summary>
     /// <typeparam name="T">The type of the JavaScript application resource.</typeparam>
     /// <param name="builder">The resource builder for the JavaScript application.</param>
@@ -1037,7 +1038,10 @@ public static class JavaScriptHostingExtensions
         ArgumentNullException.ThrowIfNull(builder);
 
         // Validate that the extension supports browser debugging if we're running in an extension context
-        ValidateBrowserCapability(builder);
+        if (!HasBrowserCapability(builder))
+        {
+            return builder;
+        }
 
         var parentResource = builder.Resource;
         var debuggerResourceName = $"{parentResource.Name}-browser";
@@ -1080,24 +1084,35 @@ public static class JavaScriptHostingExtensions
         return builder;
     }
 
-    private static void ValidateBrowserCapability<T>(IResourceBuilder<T> builder) where T : IResource
+    private static bool HasBrowserCapability<T>(IResourceBuilder<T> builder) where T : IResource
     {
         var configuration = builder.ApplicationBuilder.Configuration;
 
         try
         {
-            if (configuration["DEBUG_SESSION_INFO"] is { } debugSessionInfoJson
-                && JsonSerializer.Deserialize<DebugSessionCapabilities>(debugSessionInfoJson) is { } info
-                && info.SupportedLaunchConfigurations is not null
-                && !info.SupportedLaunchConfigurations.Contains(BrowserCapability))
+            var debugSessionInfoJson = configuration["DEBUG_SESSION_INFO"];
+            if (debugSessionInfoJson is null)
+            {
+                return false;
+            }
+
+            if (JsonSerializer.Deserialize<DebugSessionCapabilities>(debugSessionInfoJson) is not { } info || info.SupportedLaunchConfigurations is null)
+            {
+                return false;
+            }
+
+            if (!info.SupportedLaunchConfigurations.Contains(BrowserCapability))
             {
                 throw new InvalidOperationException(
                     "This version of the Aspire extension does not support browser debugging. Please update the Aspire extension to use browser debugging support with WithBrowserDebugger().");
             }
+
+            return true;
         }
         catch (JsonException)
         {
             // If we can't parse the debug session info, skip validation
+            return false;
         }
     }
 

--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -1017,8 +1017,8 @@ public static class JavaScriptHostingExtensions
     /// The parent resource must have at least one HTTP or HTTPS endpoint configured.
     /// </remarks>
     /// <exception cref="InvalidOperationException">
-    /// Thrown when the parent resource does not have an HTTP or HTTPS endpoint, or when the IDE extension
-    /// does not support browser debugging.
+    /// Thrown when the parent resource does not have an HTTP or HTTPS endpoint, or when the IDE capability
+    /// information is present but does not include browser debugging support.
     /// </exception>
     /// <example>
     /// Add browser debugging to a JavaScript application:
@@ -1090,18 +1090,19 @@ public static class JavaScriptHostingExtensions
 
         try
         {
-            var debugSessionInfoJson = configuration["DEBUG_SESSION_INFO"];
+            var debugSessionInfoJson = configuration[KnownConfigNames.DebugSessionInfo];
             if (debugSessionInfoJson is null)
             {
                 return false;
             }
 
-            if (JsonSerializer.Deserialize<DebugSessionCapabilities>(debugSessionInfoJson) is not { } info || info.SupportedLaunchConfigurations is null)
+            if (JsonSerializer.Deserialize<DebugSessionCapabilities>(debugSessionInfoJson) is not { } info)
             {
+                // If we can't deserialize the capabilities object, skip validation
                 return false;
             }
 
-            if (!info.SupportedLaunchConfigurations.Contains(BrowserCapability))
+            if (info.SupportedLaunchConfigurations is null || !info.SupportedLaunchConfigurations.Contains(BrowserCapability))
             {
                 throw new InvalidOperationException(
                     "This version of the Aspire extension does not support browser debugging. Please update the Aspire extension to use browser debugging support with WithBrowserDebugger().");

--- a/tests/Aspire.Hosting.JavaScript.Tests/AddNodeAppTests.cs
+++ b/tests/Aspire.Hosting.JavaScript.Tests/AddNodeAppTests.cs
@@ -595,7 +595,7 @@ public class AddNodeAppTests
     }
 
     [Fact]
-    public void ViteApp_WithBrowserDebugger_NoOps_WhenBrowserCapabilityNotListed()
+    public void ViteApp_WithBrowserDebugger_Throws_WhenBrowserCapabilityNotListed()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
         using var tempDir = new TestTempDirectory();
@@ -605,6 +605,24 @@ public class AddNodeAppTests
         {
             ProtocolsSupported = ["test"],
             SupportedLaunchConfigurations = ["node"]
+        });
+
+        var viteApp = builder.AddViteApp("viteapp", tempDir.Path);
+
+        Assert.Throws<InvalidOperationException>(() => viteApp.WithBrowserDebugger());
+    }
+
+    [Fact]
+    public void ViteApp_WithBrowserDebugger_Throws_WhenSupportedLaunchConfigurationsOmitted()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        using var tempDir = new TestTempDirectory();
+
+        // Set DEBUG_SESSION_INFO without supported_launch_configurations property
+        builder.Configuration["DEBUG_SESSION_INFO"] = JsonSerializer.Serialize(new RunSessionInfo
+        {
+            ProtocolsSupported = ["test"],
+            SupportedLaunchConfigurations = null
         });
 
         var viteApp = builder.AddViteApp("viteapp", tempDir.Path);

--- a/tests/Aspire.Hosting.JavaScript.Tests/AddNodeAppTests.cs
+++ b/tests/Aspire.Hosting.JavaScript.Tests/AddNodeAppTests.cs
@@ -5,6 +5,8 @@
 
 using System.Reflection;
 using Aspire.Hosting.ApplicationModel;
+using System.Text.Json;
+using Aspire.Hosting.Dcp.Model;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
@@ -474,6 +476,12 @@ public class AddNodeAppTests
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
         using var tempDir = new TestTempDirectory();
 
+        builder.Configuration["DEBUG_SESSION_INFO"] = JsonSerializer.Serialize(new RunSessionInfo
+        {
+            ProtocolsSupported = ["test"],
+            SupportedLaunchConfigurations = ["browser"]
+        });
+
         var viteApp = builder.AddViteApp("viteapp", tempDir.Path)
             .WithBrowserDebugger();
 
@@ -501,6 +509,12 @@ public class AddNodeAppTests
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
         using var tempDir = new TestTempDirectory();
 
+        builder.Configuration["DEBUG_SESSION_INFO"] = JsonSerializer.Serialize(new RunSessionInfo
+        {
+            ProtocolsSupported = ["test"],
+            SupportedLaunchConfigurations = ["browser"]
+        });
+
         var viteApp = builder.AddViteApp("viteapp", tempDir.Path)
             .WithBrowserDebugger();
 
@@ -518,6 +532,12 @@ public class AddNodeAppTests
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
         using var tempDir = new TestTempDirectory();
 
+        builder.Configuration["DEBUG_SESSION_INFO"] = JsonSerializer.Serialize(new RunSessionInfo
+        {
+            ProtocolsSupported = ["test"],
+            SupportedLaunchConfigurations = ["browser"]
+        });
+
         var viteApp = builder.AddViteApp("viteapp", tempDir.Path)
             .WithBrowserDebugger(browser: "chrome");
 
@@ -534,6 +554,12 @@ public class AddNodeAppTests
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
         using var tempDir = new TestTempDirectory();
 
+        builder.Configuration["DEBUG_SESSION_INFO"] = JsonSerializer.Serialize(new RunSessionInfo
+        {
+            ProtocolsSupported = ["test"],
+            SupportedLaunchConfigurations = ["browser"]
+        });
+
         // Create a minimal JavaScriptAppResource without endpoints
         var resource = new JavaScriptAppResource("jsapp", "npm", tempDir.Path);
         var jsApp = builder.AddResource(resource);
@@ -548,6 +574,42 @@ public class AddNodeAppTests
         // The browser debugger resource should still be created
         var browserDebuggerResource = appModel.Resources.OfType<BrowserDebuggerResource>().SingleOrDefault();
         Assert.NotNull(browserDebuggerResource);
+    }
+
+    [Fact]
+    public void ViteApp_WithBrowserDebugger_NoOps_WhenDebugSessionInfoNotSet()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        using var tempDir = new TestTempDirectory();
+
+        // Do not set DEBUG_SESSION_INFO — HasBrowserCapability should return false
+        var viteApp = builder.AddViteApp("viteapp", tempDir.Path)
+            .WithBrowserDebugger();
+
+        using var app = builder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        // No browser debugger resource should be created
+        var browserDebuggerResource = appModel.Resources.OfType<BrowserDebuggerResource>().SingleOrDefault();
+        Assert.Null(browserDebuggerResource);
+    }
+
+    [Fact]
+    public void ViteApp_WithBrowserDebugger_NoOps_WhenBrowserCapabilityNotListed()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        using var tempDir = new TestTempDirectory();
+
+        // Set DEBUG_SESSION_INFO without "browser" in supported configurations
+        builder.Configuration["DEBUG_SESSION_INFO"] = JsonSerializer.Serialize(new RunSessionInfo
+        {
+            ProtocolsSupported = ["test"],
+            SupportedLaunchConfigurations = ["node"]
+        });
+
+        var viteApp = builder.AddViteApp("viteapp", tempDir.Path);
+
+        Assert.Throws<InvalidOperationException>(() => viteApp.WithBrowserDebugger());
     }
 
     [Fact]


### PR DESCRIPTION
## Description

`WithBrowserDebugger` previously always created a `BrowserDebuggerResource` child resource, even when the IDE didn't support browser debugging (i.e., `DEBUG_SESSION_INFO` was not set or didn't include `"browser"` in `supported_launch_configurations`). This caused unnecessary resources to be created.

This change makes `WithBrowserDebugger` a no-op when the IDE lacks browser capability:
- Renames `ValidateBrowserCapability` → `HasBrowserCapability` (returns `bool` instead of `void`)
- `WithBrowserDebugger` early-returns without creating the child resource when `HasBrowserCapability` returns `false`
- Still throws `InvalidOperationException` when `DEBUG_SESSION_INFO` is present but doesn't list `"browser"` capability

### Testing
- Updated 4 existing browser debugger tests to set `DEBUG_SESSION_INFO` with browser capability
- Added 2 new tests:
  - `ViteApp_WithBrowserDebugger_NoOps_WhenDebugSessionInfoNotSet` — verifies no child resource when config is absent
  - `ViteApp_WithBrowserDebugger_NoOps_WhenBrowserCapabilityNotListed` — verifies exception when config exists but browser isn't listed
- All 103 JS hosting tests pass

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
