### PR TITLE
[cli] Shorten install script download logging

### DIFF
--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -533,8 +533,6 @@ function Invoke-FileDownload {
         [int]$MaxRetries = 5
     )
 
-    $downloadDescriptor = Get-DownloadDescriptor -Uri $Uri
-
     # Validate content type via HEAD request
     Write-Message "Validating content type for $Uri" -Level Verbose
     $contentType = Get-ContentTypeFromUri -Uri $Uri -TimeoutSec 60 -OperationTimeoutSec $OperationTimeoutSec -MaxRetries $MaxRetries

--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -470,6 +470,49 @@ function Invoke-SecureWebRequest {
     }
 }
 
+# Builds a compact display string for download messages without exposing the full URL.
+function Get-DownloadDescriptor {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Uri
+    )
+
+    try {
+        $downloadUri = [System.Uri]$Uri
+        $fileName = [System.IO.Path]::GetFileName($downloadUri.AbsolutePath)
+        $trimmedPath = $downloadUri.AbsolutePath.Trim("/")
+        $source = $downloadUri.Host
+
+        if ($trimmedPath -match "^dotnet/[^/]+/aspire/(?<source>.+)/(?<file>[^/]+)$") {
+            $source = $Matches["source"]
+            $fileName = $Matches["file"]
+        }
+        elseif ($trimmedPath -match "^public(?:-checksums)?/aspire/+(?<version>[^/]+)/(?<file>[^/]+)$") {
+            $source = "version/$($Matches["version"])"
+            $fileName = $Matches["file"]
+        }
+        elseif ($trimmedPath -match "^(?<source>.+)/(?<file>[^/]+)$") {
+            $source = $Matches["source"]
+            $fileName = $Matches["file"]
+        }
+
+        if ([string]::IsNullOrWhiteSpace($fileName)) {
+            return $Uri
+        }
+
+        if ([string]::IsNullOrWhiteSpace($source)) {
+            return $fileName
+        }
+
+        return "$fileName from '$source'"
+    }
+    catch {
+        return $Uri
+    }
+}
+
 # Enhanced file download wrapper with validation
 function Invoke-FileDownload {
     [CmdletBinding()]
@@ -490,22 +533,24 @@ function Invoke-FileDownload {
         [int]$MaxRetries = 5
     )
 
+    $downloadDescriptor = Get-DownloadDescriptor -Uri $Uri
+
     # Validate content type via HEAD request
-    Write-Message "Validating content type for $Uri" -Level Verbose
+    Write-Message "Validating content type for $downloadDescriptor" -Level Verbose
     $contentType = Get-ContentTypeFromUri -Uri $Uri -TimeoutSec 60 -OperationTimeoutSec $OperationTimeoutSec -MaxRetries $MaxRetries
     Write-Message "Detected content type: $contentType" -Level Verbose
 
     if ($contentType -and $contentType.ToLowerInvariant().StartsWith("text/html")) {
-        throw "Server returned HTML content instead of expected file. Make sure the URL is correct: $Uri"
+        throw "Server returned HTML content instead of expected file while validating $downloadDescriptor."
     }
 
     try {
-        Write-Message "Downloading $Uri to $OutputPath" -Level Verbose
+        Write-Message "Downloading $downloadDescriptor to $OutputPath" -Level Verbose
         Invoke-SecureWebRequest -Uri $Uri -OutFile $OutputPath -TimeoutSec $TimeoutSec -OperationTimeoutSec $OperationTimeoutSec -MaxRetries $MaxRetries
         Write-Message "Successfully downloaded file to: $OutputPath" -Level Verbose
     }
     catch {
-        throw "Failed to download $Uri - $($_.Exception.Message)"
+        throw "Failed to download $downloadDescriptor - $($_.Exception.Message)"
     }
 }
 
@@ -919,11 +964,12 @@ function Get-AspireExtension {
     Write-Message "Downloading Aspire VS Code extension" -Level Info
 
     $extensionUrl = Get-AspireExtensionUrl -Version $Version -Quality $Quality
+    $extensionDescriptor = Get-DownloadDescriptor -Uri $extensionUrl
     $extensionArchive = Join-Path $TempDir $Script:ExtensionArtifactName
 
     try {
-        if ($PSCmdlet.ShouldProcess($extensionArchive, "Download extension from $extensionUrl")) {
-            Write-Message "Downloading from: $extensionUrl" -Level Info
+        if ($PSCmdlet.ShouldProcess($extensionDescriptor, "Download extension")) {
+            Write-Message "Downloading $extensionDescriptor" -Level Info
             Invoke-FileDownload -Uri $extensionUrl -OutputPath $extensionArchive -TimeoutSec $Script:ArchiveDownloadTimeoutSec
             Write-Message "Successfully downloaded extension archive" -Level Verbose
         }
@@ -1144,17 +1190,19 @@ function Install-AspireCli {
         $runtimeIdentifier = "$targetOS-$targetArch"
         $extension = if ($targetOS -eq "win") { "zip" } else { "tar.gz" }
         $urls = Get-AspireCliUrl -Version $Version -Quality $Quality -RuntimeIdentifier $runtimeIdentifier -Extension $extension
+        $archiveDescriptor = Get-DownloadDescriptor -Uri $urls.ArchiveUrl
+        $checksumDescriptor = Get-DownloadDescriptor -Uri $urls.ChecksumUrl
 
         $archivePath = Join-Path $tempDir $urls.ArchiveFilename
         $checksumPath = Join-Path $tempDir $urls.ChecksumFilename
 
-        if ($PSCmdlet.ShouldProcess($urls.ArchiveUrl, "Download CLI archive")) {
+        if ($PSCmdlet.ShouldProcess($archiveDescriptor, "Download CLI archive")) {
             # Download the Aspire CLI archive
-            Write-Message "Downloading from: $($urls.ArchiveUrl)" -Level Info
+            Write-Message "Downloading $archiveDescriptor" -Level Info
             Invoke-FileDownload -Uri $urls.ArchiveUrl -TimeoutSec $Script:ArchiveDownloadTimeoutSec -OutputPath $archivePath
         }
 
-        if ($PSCmdlet.ShouldProcess($urls.ChecksumUrl, "Download CLI archive checksum")) {
+        if ($PSCmdlet.ShouldProcess($checksumDescriptor, "Download CLI archive checksum")) {
             # Download and test the checksum
             Invoke-FileDownload -Uri $urls.ChecksumUrl -TimeoutSec $Script:ChecksumDownloadTimeoutSec -OutputPath $checksumPath
             Test-FileChecksum -ArchiveFile $archivePath -ChecksumFile $checksumPath

--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -968,7 +968,7 @@ function Get-AspireExtension {
     $extensionArchive = Join-Path $TempDir $Script:ExtensionArtifactName
 
     try {
-        if ($PSCmdlet.ShouldProcess($extensionDescriptor, "Download extension")) {
+        if ($PSCmdlet.ShouldProcess($extensionArchive, "Download extension ($extensionDescriptor)")) {
             Write-Message "Downloading $extensionDescriptor" -Level Info
             Invoke-FileDownload -Uri $extensionUrl -OutputPath $extensionArchive -TimeoutSec $Script:ArchiveDownloadTimeoutSec
             Write-Message "Successfully downloaded extension archive" -Level Verbose
@@ -1196,13 +1196,13 @@ function Install-AspireCli {
         $archivePath = Join-Path $tempDir $urls.ArchiveFilename
         $checksumPath = Join-Path $tempDir $urls.ChecksumFilename
 
-        if ($PSCmdlet.ShouldProcess($archiveDescriptor, "Download CLI archive")) {
+        if ($PSCmdlet.ShouldProcess($archivePath, "Download CLI archive ($archiveDescriptor)")) {
             # Download the Aspire CLI archive
             Write-Message "Downloading $archiveDescriptor" -Level Info
             Invoke-FileDownload -Uri $urls.ArchiveUrl -TimeoutSec $Script:ArchiveDownloadTimeoutSec -OutputPath $archivePath
         }
 
-        if ($PSCmdlet.ShouldProcess($checksumDescriptor, "Download CLI archive checksum")) {
+        if ($PSCmdlet.ShouldProcess($checksumPath, "Download CLI archive checksum ($checksumDescriptor)")) {
             # Download and test the checksum
             Invoke-FileDownload -Uri $urls.ChecksumUrl -TimeoutSec $Script:ChecksumDownloadTimeoutSec -OutputPath $checksumPath
             Test-FileChecksum -ArchiveFile $archivePath -ChecksumFile $checksumPath

--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -536,21 +536,21 @@ function Invoke-FileDownload {
     $downloadDescriptor = Get-DownloadDescriptor -Uri $Uri
 
     # Validate content type via HEAD request
-    Write-Message "Validating content type for $downloadDescriptor" -Level Verbose
+    Write-Message "Validating content type for $Uri" -Level Verbose
     $contentType = Get-ContentTypeFromUri -Uri $Uri -TimeoutSec 60 -OperationTimeoutSec $OperationTimeoutSec -MaxRetries $MaxRetries
     Write-Message "Detected content type: $contentType" -Level Verbose
 
     if ($contentType -and $contentType.ToLowerInvariant().StartsWith("text/html")) {
-        throw "Server returned HTML content instead of expected file while validating $downloadDescriptor."
+        throw "Server returned HTML content instead of expected file. Make sure the URL is correct: $Uri"
     }
 
     try {
-        Write-Message "Downloading $downloadDescriptor to $OutputPath" -Level Verbose
+        Write-Message "Downloading $Uri to $OutputPath" -Level Verbose
         Invoke-SecureWebRequest -Uri $Uri -OutFile $OutputPath -TimeoutSec $TimeoutSec -OperationTimeoutSec $OperationTimeoutSec -MaxRetries $MaxRetries
         Write-Message "Successfully downloaded file to: $OutputPath" -Level Verbose
     }
     catch {
-        throw "Failed to download $downloadDescriptor - $($_.Exception.Message)"
+        throw "Failed to download $Uri - $($_.Exception.Message)"
     }
 }
 

--- a/eng/scripts/get-aspire-cli.sh
+++ b/eng/scripts/get-aspire-cli.sh
@@ -293,7 +293,7 @@ secure_curl() {
         curl_args+=(--output "$output_file")
     fi
 
-    say_verbose "Running curl with args: ${curl_args[*]} (download descriptor: $download_descriptor)"
+    say_verbose "curl ${curl_args[*]} $url"
     curl "${curl_args[@]}" "$url"
 }
 
@@ -328,14 +328,14 @@ validate_content_type() {
 
     download_descriptor=$(get_download_descriptor "$url")
 
-    say_verbose "Validating content type for $download_descriptor"
+    say_verbose "Validating content type for $url"
 
     # Get headers via HEAD request
     local headers
     if headers=$(secure_curl "$url" /dev/null 60 "$USER_AGENT" 3 "HEAD" 2>&1); then
         # Check if response suggests HTML content (error page)
         if echo "$headers" | grep -qi "content-type:.*text/html"; then
-            say_error "Server returned HTML content instead of expected file while validating $download_descriptor."
+            say_error "Server returned HTML content instead of expected file. Make sure the URL is correct: $url"
             return 1
         fi
     else
@@ -375,7 +375,7 @@ download_file() {
         fi
     fi
 
-    say_verbose "Downloading $download_descriptor to $target_file"
+    say_verbose "Downloading $url to $target_file"
     say_info "Downloading $download_descriptor"
 
     # Download the file
@@ -388,7 +388,7 @@ download_file() {
         say_verbose "Successfully downloaded file to: $output_path"
         return 0
     else
-        say_error "Failed to download $download_descriptor"
+        say_error "Failed to download $url"
         return 1
     fi
 }

--- a/eng/scripts/get-aspire-cli.sh
+++ b/eng/scripts/get-aspire-cli.sh
@@ -262,6 +262,9 @@ secure_curl() {
     local user_agent="${4:-$USER_AGENT}"
     local max_retries="${5:-5}"
     local method="${6:-GET}"
+    local download_descriptor
+
+    download_descriptor=$(get_download_descriptor "$url")
 
     local curl_args=(
         --fail
@@ -290,22 +293,49 @@ secure_curl() {
         curl_args+=(--output "$output_file")
     fi
 
-    say_verbose "curl ${curl_args[*]} $url"
+    say_verbose "curl ${curl_args[*]} $download_descriptor"
     curl "${curl_args[@]}" "$url"
+}
+
+# Build a compact display string for download messages without exposing the full URL.
+get_download_descriptor() {
+    local url="$1"
+    local file_name source
+
+    if [[ "$url" =~ ^https://aka\.ms/dotnet/[^/]+/aspire/(.+)/([^/]+)$ ]]; then
+        source="${BASH_REMATCH[1]}"
+        file_name="${BASH_REMATCH[2]}"
+    elif [[ "$url" =~ ^https://ci\.dot\.net/public(-checksums)?/aspire/+([^/]+)/([^/]+)$ ]]; then
+        source="version/${BASH_REMATCH[2]}"
+        file_name="${BASH_REMATCH[3]}"
+    else
+        file_name="${url##*/}"
+        source="${url#https://}"
+        source="${source%%/*}"
+    fi
+
+    if [[ -n "$file_name" && -n "$source" ]]; then
+        printf "%s from '%s'" "$file_name" "$source"
+    else
+        printf "%s" "$file_name"
+    fi
 }
 
 # Validate content type via HEAD request
 validate_content_type() {
     local url="$1"
+    local download_descriptor
 
-    say_verbose "Validating content type for $url"
+    download_descriptor=$(get_download_descriptor "$url")
+
+    say_verbose "Validating content type for $download_descriptor"
 
     # Get headers via HEAD request
     local headers
     if headers=$(secure_curl "$url" /dev/null 60 "$USER_AGENT" 3 "HEAD" 2>&1); then
         # Check if response suggests HTML content (error page)
         if echo "$headers" | grep -qi "content-type:.*text/html"; then
-            say_error "Server returned HTML content instead of expected file. Make sure the URL is correct: $url"
+            say_error "Server returned HTML content instead of expected file while validating $download_descriptor."
             return 1
         fi
     else
@@ -324,9 +354,12 @@ download_file() {
     local max_retries="${4:-5}"
     local validate_content_type="${5:-true}"
     local use_temp_file="${6:-true}"
+    local download_descriptor
+
+    download_descriptor=$(get_download_descriptor "$url")
 
     if [[ "$DRY_RUN" == true ]]; then
-        say_info "[DRY RUN] Would download $url"
+        say_info "[DRY RUN] Would download $download_descriptor"
         return 0
     fi
 
@@ -342,8 +375,8 @@ download_file() {
         fi
     fi
 
-    say_verbose "Downloading $url to $target_file"
-    say_info "Downloading from: $url"
+    say_verbose "Downloading $download_descriptor to $target_file"
+    say_info "Downloading $download_descriptor"
 
     # Download the file
     if secure_curl "$url" "$target_file" "$timeout" "$USER_AGENT" "$max_retries"; then
@@ -355,7 +388,7 @@ download_file() {
         say_verbose "Successfully downloaded file to: $output_path"
         return 0
     else
-        say_error "Failed to download $url"
+        say_error "Failed to download $download_descriptor"
         return 1
     fi
 }
@@ -843,7 +876,6 @@ download_aspire_extension() {
 
     extension_archive="${temp_dir}/${EXTENSION_ARTIFACT_NAME}"
 
-    say_info "Downloading from: $url"
     if ! download_file "$url" "$extension_archive" $ARCHIVE_DOWNLOAD_TIMEOUT_SEC; then
         return 1
     fi

--- a/eng/scripts/get-aspire-cli.sh
+++ b/eng/scripts/get-aspire-cli.sh
@@ -262,9 +262,6 @@ secure_curl() {
     local user_agent="${4:-$USER_AGENT}"
     local max_retries="${5:-5}"
     local method="${6:-GET}"
-    local download_descriptor
-
-    download_descriptor=$(get_download_descriptor "$url")
 
     local curl_args=(
         --fail
@@ -324,9 +321,6 @@ get_download_descriptor() {
 # Validate content type via HEAD request
 validate_content_type() {
     local url="$1"
-    local download_descriptor
-
-    download_descriptor=$(get_download_descriptor "$url")
 
     say_verbose "Validating content type for $url"
 

--- a/eng/scripts/get-aspire-cli.sh
+++ b/eng/scripts/get-aspire-cli.sh
@@ -293,7 +293,7 @@ secure_curl() {
         curl_args+=(--output "$output_file")
     fi
 
-    say_verbose "curl ${curl_args[*]} $download_descriptor"
+    say_verbose "Running curl with args: ${curl_args[*]} (download descriptor: $download_descriptor)"
     curl "${curl_args[@]}" "$url"
 }
 


### PR DESCRIPTION
## Description

Shortens install-script download logging so the Bash and PowerShell installers stop printing full download URLs.

The scripts now derive compact descriptors from the existing URL structure and emit messages like `Downloading aspire-cli-win-x64.zip from 'rc/daily'` instead of echoing the raw URL. This applies to both CLI archive downloads and VS Code extension downloads, and also updates related dry-run / `-WhatIf` paths so they no longer surface the full URL through script messaging.

No dependencies are required for this change.

Validation:
- `pwsh -NoProfile -File .\eng\scripts\get-aspire-cli.ps1 -WhatIf -Quality staging -OS win -Architecture x64`
- `pwsh -NoProfile -File .\eng\scripts\get-aspire-cli.ps1 -WhatIf -Quality dev -OS win -Architecture x64 -InstallExtension`
- `C:\Program Files\Git\bin\bash.exe eng/scripts/get-aspire-cli.sh --dry-run --quality staging --os win --arch x64`
- `C:\Program Files\Git\bin\bash.exe eng/scripts/get-aspire-cli.sh --dry-run --quality dev --os win --arch x64 --install-extension`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
