### PR TITLE
fix: migrate from deprecated tseslint.config to eslint/config

### DIFF
--- a/playground/FoundryAgentEnterprise/frontend/eslint.config.js
+++ b/playground/FoundryAgentEnterprise/frontend/eslint.config.js
@@ -1,16 +1,16 @@
 import js from '@eslint/js'
+import { defineConfig, globalIgnores } from 'eslint/config';
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 
-export default tseslint.config(
-  { ignores: ['dist'] },
+export default defineConfig(
+  globalIgnores(['dist']),
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    extends: [js.configs.recommended, tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
-      ecmaVersion: 2020,
       globals: globals.browser,
     },
     plugins: {

--- a/playground/FoundryAgentEnterprise/frontend/eslint.config.js
+++ b/playground/FoundryAgentEnterprise/frontend/eslint.config.js
@@ -1,5 +1,5 @@
 import js from '@eslint/js'
-import { defineConfig, globalIgnores } from 'eslint/config';
+import { defineConfig, globalIgnores } from 'eslint/config'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/eslint.config.mjs
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/eslint.config.mjs
@@ -9,7 +9,6 @@ export default defineConfig({
   languageOptions: {
     parserOptions: {
       projectService: true,
-      tsconfigRootDir: import.meta.dirname,
     },
   },
   rules: {

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/frontend/eslint.config.js
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/frontend/eslint.config.js
@@ -1,16 +1,16 @@
 import js from '@eslint/js';
+import { defineConfig, globalIgnores } from 'eslint/config';
 import globals from 'globals';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 
-export default tseslint.config(
-  { ignores: ['dist'] },
+export default defineConfig(
+  globalIgnores(['dist']),
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    extends: [js.configs.recommended, tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
-      ecmaVersion: 2020,
       globals: globals.browser,
     },
     plugins: {

--- a/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
+++ b/src/Aspire.Hosting.CodeGeneration.TypeScript/TypeScriptLanguageSupport.cs
@@ -96,7 +96,6 @@ public sealed class TypeScriptLanguageSupport : ILanguageSupport
               languageOptions: {
                 parserOptions: {
                   projectService: true,
-                  tsconfigRootDir: import.meta.dirname,
                 },
               },
               rules: {

--- a/src/Aspire.ProjectTemplates/templates/aspire-py-starter/frontend/eslint.config.js
+++ b/src/Aspire.ProjectTemplates/templates/aspire-py-starter/frontend/eslint.config.js
@@ -1,16 +1,16 @@
 import js from '@eslint/js';
+import { defineConfig, globalIgnores } from 'eslint/config';
 import globals from 'globals';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 
-export default tseslint.config(
-  { ignores: ['dist'] },
+export default defineConfig(
+  globalIgnores(['dist']),
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    extends: [js.configs.recommended, tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
-      ecmaVersion: 2020,
       globals: globals.browser,
     },
     plugins: {

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/frontend/eslint.config.js
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/frontend/eslint.config.js
@@ -1,16 +1,16 @@
 import js from '@eslint/js';
+import { defineConfig, globalIgnores } from 'eslint/config';
 import globals from 'globals';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 
-export default tseslint.config(
-  { ignores: ['dist'] },
+export default defineConfig(
+  globalIgnores(['dist']),
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    extends: [js.configs.recommended, tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
-      ecmaVersion: 2020,
       globals: globals.browser,
     },
     plugins: {


### PR DESCRIPTION
## Description

Switches from the deprecated [`tseslint.config()`](https://typescript-eslint.io/packages/typescript-eslint/#config-deprecated) to ESLint core's [`defineConfig()`](https://eslint.org/blog/2025/03/flat-config-extends-define-config-global-ignores/#introducing-defineConfig(...)-for-eslint). I also threw in some little touchups here and there for fun, but I can split those out if you prefer. 😄 

Fixes #15408.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes _(existing tests)_
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No

I know #15408 hasn't been triaged yet, but figured this was a straightforward change 🙂 apologies if I've broken some unspoken etiquette rule.