### PR TITLE
Bump Microsoft.Bcl.Memory to 10.0.5 to fix CVE-2026-26127

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -198,6 +198,7 @@
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="$(MicrosoftExtensionsServiceDiscoveryYarpVersion)" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="$(MicrosoftExtensionsTimeProviderTestingVersion)" />
     <!-- Runtime dependencies ** Common between all TFMs because other dependencies (like Azure.Core) are lifting to the latest versions, so we need to as well ** -->
+    <PackageVersion Include="Microsoft.Bcl.Memory" Version="$(MicrosoftBclMemoryPreviewVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsPreviewVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingPreviewVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsPreviewVersion)" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -81,6 +81,7 @@
     <MicrosoftExtensionsFeaturesPreviewVersion>10.0.5</MicrosoftExtensionsFeaturesPreviewVersion>
     <MicrosoftAspNetCoreSignalRClientPreviewVersion>10.0.5</MicrosoftAspNetCoreSignalRClientPreviewVersion>
     <!-- Runtime -->
+    <MicrosoftBclMemoryPreviewVersion>10.0.5</MicrosoftBclMemoryPreviewVersion>
     <MicrosoftExtensionsHostingAbstractionsPreviewVersion>10.0.5</MicrosoftExtensionsHostingAbstractionsPreviewVersion>
     <MicrosoftExtensionsHostingPreviewVersion>10.0.5</MicrosoftExtensionsHostingPreviewVersion>
     <MicrosoftExtensionsCachingMemoryPreviewVersion>10.0.5</MicrosoftExtensionsCachingMemoryPreviewVersion>

--- a/src/Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.csproj
+++ b/src/Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
@@ -35,7 +35,7 @@
     <PackageReference Include="Azure.Provisioning.CognitiveServices" />
     <PackageReference Include="Azure.Provisioning.ContainerRegistry" />
     <PackageReference Include="Microsoft.AI.Foundry.Local" />
-    <PackageReference Include="Microsoft.Bcl.Memory" VersionOverride="10.0.5" />
+    <PackageReference Include="Microsoft.Bcl.Memory" />
   </ItemGroup>
 
 </Project>

--- a/src/Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.csproj
+++ b/src/Aspire.Hosting.Foundry/Aspire.Hosting.Foundry.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Azure.Provisioning.CognitiveServices" />
     <PackageReference Include="Azure.Provisioning.ContainerRegistry" />
     <PackageReference Include="Microsoft.AI.Foundry.Local" />
-    <PackageReference Include="Microsoft.Bcl.Memory" VersionOverride="10.0.0" />
+    <PackageReference Include="Microsoft.Bcl.Memory" VersionOverride="10.0.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description

Bump `Microsoft.Bcl.Memory` from 10.0.0 to 10.0.5 in `Aspire.Hosting.Foundry` to fix **CVE-2026-26127** ([GHSA-73j8-2gch-69rq](https://github.com/advisories/GHSA-73j8-2gch-69rq)) — a high severity denial of service vulnerability caused by an out-of-bounds read when decoding malformed Base64Url input.

The package is a direct dependency of `Aspire.Hosting.Foundry` (provides `Base64Url` for `net8.0`), pinned via `VersionOverride`. This was causing `error NU1903` build failures in CI.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
