### PR TITLE
[IGNORE] Running Cli E2E tests with 13.2

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -306,6 +306,8 @@ jobs:
           GITHUB_PR_NUMBER: ${{ inputs.requiresCliArchive && github.event.pull_request.number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ inputs.requiresCliArchive && github.event.pull_request.head.sha || '' }}
           GH_TOKEN: ${{ inputs.requiresCliArchive && github.token || '' }}
+          ASPIRE_CLI_INSTALL_SCRIPT: get-aspire-cli
+          ASPIRE_CLI_INSTALL_ARGS: -q staging
         run: |
           # Start heartbeat monitor in background
           ${{ github.workspace }}/${{ env.DOTNET_SCRIPT }} ${{ github.workspace }}/tools/scripts/Heartbeat.cs &
@@ -348,6 +350,8 @@ jobs:
           GITHUB_PR_NUMBER: ${{ inputs.requiresCliArchive && github.event.pull_request.number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ inputs.requiresCliArchive && github.event.pull_request.head.sha || '' }}
           GH_TOKEN: ${{ inputs.requiresCliArchive && github.token || '' }}
+          ASPIRE_CLI_INSTALL_SCRIPT: get-aspire-cli
+          ASPIRE_CLI_INSTALL_ARGS: -q staging
         run: |
           # Start heartbeat monitor in background (output goes to console directly)
           $heartbeatProcess = Start-Process -FilePath "dotnet" `
@@ -392,6 +396,8 @@ jobs:
           GITHUB_PR_NUMBER: ${{ inputs.requiresCliArchive && github.event.pull_request.number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ inputs.requiresCliArchive && github.event.pull_request.head.sha || '' }}
           GH_TOKEN: ${{ inputs.requiresCliArchive && github.token || '' }}
+          ASPIRE_CLI_INSTALL_SCRIPT: get-aspire-cli
+          ASPIRE_CLI_INSTALL_ARGS: -q staging
         run: |
           # Start heartbeat monitor in background
           ${{ env.DOTNET_SCRIPT }} ${{ github.workspace }}/tools/scripts/Heartbeat.cs &
@@ -434,6 +440,8 @@ jobs:
           GITHUB_PR_NUMBER: ${{ inputs.requiresCliArchive && github.event.pull_request.number || '' }}
           GITHUB_PR_HEAD_SHA: ${{ inputs.requiresCliArchive && github.event.pull_request.head.sha || '' }}
           GH_TOKEN: ${{ inputs.requiresCliArchive && github.token || '' }}
+          ASPIRE_CLI_INSTALL_SCRIPT: get-aspire-cli
+          ASPIRE_CLI_INSTALL_ARGS: -q staging
         run: |
           # Start heartbeat monitor in background (output goes to console directly)
           $heartbeatProcess = Start-Process -FilePath "${{ env.DOTNET_SCRIPT }}" `

--- a/tests/Aspire.Cli.EndToEnd.Tests/ConfigMigrationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ConfigMigrationTests.cs
@@ -535,7 +535,6 @@ public sealed class ConfigMigrationTests(ITestOutputHelper output)
 
         // Step 1: Install a released CLI that uses the legacy config format.
         await auto.InstallAspireCliVersionAsync(LegacyCliVersion, counter);
-        await auto.SourceAspireCliEnvironmentAsync(counter);
 
         // Verify the legacy CLI is installed.
         await auto.TypeAsync("aspire --version");

--- a/tests/Aspire.Cli.EndToEnd.Tests/DockerDeploymentTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DockerDeploymentTests.cs
@@ -22,8 +22,6 @@ public sealed class DockerDeploymentTests(ITestOutputHelper output)
     {
         using var workspace = TemporaryWorkspace.Create(output);
 
-        var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
-        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
         var isCI = CliE2ETestHelpers.IsRunningInCI;
         using var terminal = CliE2ETestHelpers.CreateTestTerminal();
 
@@ -35,12 +33,7 @@ public sealed class DockerDeploymentTests(ITestOutputHelper output)
         // PrepareEnvironment
         await auto.PrepareEnvironmentAsync(workspace, counter);
 
-        if (isCI)
-        {
-            await auto.InstallAspireCliFromPullRequestAsync(prNumber, counter);
-            await auto.SourceAspireCliEnvironmentAsync(counter);
-            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
-        }
+        await auto.SetupAspireCliFromPullRequestAsync(counter);
 
         // Step 1: Create a new Aspire Starter App (no Redis cache)
         await auto.AspireNewAsync(ProjectName, counter, useRedisCache: false);
@@ -55,14 +48,9 @@ public sealed class DockerDeploymentTests(ITestOutputHelper output)
         await auto.TypeAsync("aspire add Aspire.Hosting.Docker");
         await auto.EnterAsync();
 
-        // In CI, aspire add shows a version selection prompt (unlike aspire new which auto-selects when channel is set)
-        if (isCI)
-        {
-            await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
-            await auto.EnterAsync(); // select first version (PR build)
-        }
-
-        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+        // The version selector only appears when multiple channels exist (e.g. PR hives).
+        // Bare CLI installs auto-select the single implicit channel without prompting.
+        await auto.AcceptVersionSelectionIfShownAsync(counter, TimeSpan.FromSeconds(180));
 
         // Step 4: Modify AppHost's main file to add Docker Compose environment
         // Note: Aspire templates use AppHost.cs as the main entry point, not Program.cs
@@ -143,8 +131,6 @@ builder.Build().Run();
     {
         using var workspace = TemporaryWorkspace.Create(output);
 
-        var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
-        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
         var isCI = CliE2ETestHelpers.IsRunningInCI;
         using var terminal = CliE2ETestHelpers.CreateTestTerminal();
 
@@ -156,12 +142,7 @@ builder.Build().Run();
         // PrepareEnvironment
         await auto.PrepareEnvironmentAsync(workspace, counter);
 
-        if (isCI)
-        {
-            await auto.InstallAspireCliFromPullRequestAsync(prNumber, counter);
-            await auto.SourceAspireCliEnvironmentAsync(counter);
-            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
-        }
+        await auto.SetupAspireCliFromPullRequestAsync(counter);
 
         // Step 1: Create a new Aspire Starter App (no Redis cache)
         await auto.AspireNewAsync(ProjectName, counter, useRedisCache: false);
@@ -176,14 +157,9 @@ builder.Build().Run();
         await auto.TypeAsync("aspire add Aspire.Hosting.Docker");
         await auto.EnterAsync();
 
-        // In CI, aspire add shows a version selection prompt (unlike aspire new which auto-selects when channel is set)
-        if (isCI)
-        {
-            await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
-            await auto.EnterAsync(); // select first version (PR build)
-        }
-
-        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+        // The version selector only appears when multiple channels exist (e.g. PR hives).
+        // Bare CLI installs auto-select the single implicit channel without prompting.
+        await auto.AcceptVersionSelectionIfShownAsync(counter, TimeSpan.FromSeconds(180));
 
         // Step 4: Modify AppHost's main file to add Docker Compose environment
         // Note: Aspire templates use AppHost.cs as the main entry point, not Program.cs

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -51,40 +51,71 @@ internal static class CliE2EAutomatorHelpers
 
     /// <summary>
     /// Installs the Aspire CLI inside a Docker container based on the detected install mode.
+    /// Installs to a temporary directory rather than the default ~/.aspire.
+    /// <para>Env var overrides:</para>
+    /// <list type="bullet">
+    /// <item><c>ASPIRE_CLI_USE_SYSTEM=true</c> — skip install, use system aspire</item>
+    /// <item><c>ASPIRE_CLI_INSTALL_SCRIPT</c> — <c>get-aspire-cli</c> or <c>get-aspire-cli-pr</c></item>
+    /// <item><c>ASPIRE_CLI_INSTALL_ARGS</c> — extra args for the script (e.g. <c>-q dev</c> or <c>15414</c>)</item>
+    /// </list>
     /// </summary>
     internal static async Task InstallAspireCliInDockerAsync(
         this Hex1bTerminalAutomator auto,
         CliE2ETestHelpers.DockerInstallMode installMode,
         SequenceCounter counter)
     {
+        if (UseSystemCli)
+        {
+            await auto.EchoAspirePathAsync(counter);
+            return;
+        }
+
+        var scriptOverride = Environment.GetEnvironmentVariable("ASPIRE_CLI_INSTALL_SCRIPT");
+        if (!string.IsNullOrEmpty(scriptOverride))
+        {
+            const string installPath = "/tmp/aspire-install";
+            await auto.RemoveDefaultAspireBinAsync(counter);
+            await auto.InstallFromScriptInDockerAsync(scriptOverride, installPath, counter);
+            await auto.EnableStagingChannelIfNeededAsync(counter);
+            return;
+        }
+
+        const string defaultInstallPath = "/tmp/aspire-install";
+
+        // Remove any CLI binary at the default location so only the temp install is used
+        await auto.RemoveDefaultAspireBinAsync(counter);
+
         switch (installMode)
         {
             case CliE2ETestHelpers.DockerInstallMode.SourceBuild:
-                await auto.TypeAsync("mkdir -p ~/.aspire/bin && cp /opt/aspire-cli/aspire ~/.aspire/bin/aspire && chmod +x ~/.aspire/bin/aspire");
+                await auto.TypeAsync($"mkdir -p {defaultInstallPath}/bin && cp /opt/aspire-cli/aspire {defaultInstallPath}/bin/aspire && chmod +x {defaultInstallPath}/bin/aspire");
                 await auto.EnterAsync();
                 await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
-                await auto.TypeAsync("export PATH=~/.aspire/bin:$PATH");
+                await auto.TypeAsync($"export PATH={defaultInstallPath}/bin:$PATH");
                 await auto.EnterAsync();
                 await auto.WaitForSuccessPromptAsync(counter);
+                await auto.EchoAspirePathAsync(counter);
                 break;
 
             case CliE2ETestHelpers.DockerInstallMode.GaRelease:
-                await auto.TypeAsync("/opt/aspire-scripts/get-aspire-cli.sh");
+                await auto.TypeAsync($"/opt/aspire-scripts/get-aspire-cli.sh --install-path {defaultInstallPath}/bin");
                 await auto.EnterAsync();
                 await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromSeconds(120));
-                await auto.TypeAsync("export PATH=~/.aspire/bin:$PATH");
+                await auto.TypeAsync($"export PATH={defaultInstallPath}/bin:$PATH");
                 await auto.EnterAsync();
                 await auto.WaitForSuccessPromptAsync(counter);
+                await auto.EchoAspirePathAsync(counter);
                 break;
 
             case CliE2ETestHelpers.DockerInstallMode.PullRequest:
                 var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
-                await auto.TypeAsync($"/opt/aspire-scripts/get-aspire-cli-pr.sh {prNumber}");
+                await auto.TypeAsync($"/opt/aspire-scripts/get-aspire-cli-pr.sh {prNumber} --install-path {defaultInstallPath}");
                 await auto.EnterAsync();
                 await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromSeconds(300));
-                await auto.TypeAsync("export PATH=~/.aspire/bin:~/.aspire:$PATH");
+                await auto.TypeAsync($"export PATH={defaultInstallPath}/bin:{defaultInstallPath}:$PATH");
                 await auto.EnterAsync();
                 await auto.WaitForSuccessPromptAsync(counter);
+                await auto.EchoAspirePathAsync(counter);
                 break;
 
             default:
@@ -121,14 +152,272 @@ internal static class CliE2EAutomatorHelpers
     }
 
     /// <summary>
-    /// Installs the Aspire CLI from PR build artifacts in a non-Docker environment.
+    /// High-level setup that installs the Aspire CLI and configures the environment.
+    /// Supports env var overrides (see <see cref="InstallAspireCliInDockerAsync"/>).
+    /// No-op when not in CI and no overrides are set.
     /// </summary>
-    internal static async Task InstallAspireCliFromPullRequestAsync(
+    internal static async Task SetupAspireCliFromPullRequestAsync(
         this Hex1bTerminalAutomator auto,
-        int prNumber,
         SequenceCounter counter)
     {
-        var command = $"curl -fsSL https://raw.githubusercontent.com/dotnet/aspire/main/eng/scripts/get-aspire-cli-pr.sh | bash -s -- {prNumber}";
+        if (UseSystemCli)
+        {
+            await auto.EchoAspirePathAsync(counter);
+            return;
+        }
+
+        var scriptOverride = Environment.GetEnvironmentVariable("ASPIRE_CLI_INSTALL_SCRIPT");
+        if (!string.IsNullOrEmpty(scriptOverride))
+        {
+            var installPath = CreateTemporaryInstallPath();
+            await auto.RemoveDefaultAspireBinAsync(counter);
+            await auto.InstallFromScriptAsync(scriptOverride, installPath, counter);
+            await auto.SourceAspireCliEnvironmentAsync(counter, installPath);
+            await auto.EnableStagingChannelIfNeededAsync(counter);
+            return;
+        }
+
+        if (!CliE2ETestHelpers.IsRunningInCI)
+        {
+            return;
+        }
+
+        var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
+        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
+        var prInstallPath = CreateTemporaryInstallPath();
+
+        await auto.RemoveDefaultAspireBinAsync(counter);
+        await auto.InstallAspireCliFromPullRequestAsync(prNumber, counter, prInstallPath);
+        await auto.SourceAspireCliEnvironmentAsync(counter, prInstallPath);
+        await auto.VerifyAspireCliVersionAsync(commitSha, counter);
+    }
+
+    /// <summary>
+    /// High-level setup that installs the Aspire CLI bundle and configures the environment.
+    /// Supports env var overrides (see <see cref="InstallAspireCliInDockerAsync"/>).
+    /// No-op when not in CI and no overrides are set.
+    /// </summary>
+    internal static async Task SetupAspireBundleFromPullRequestAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter)
+    {
+        if (UseSystemCli)
+        {
+            await auto.EchoAspirePathAsync(counter);
+            return;
+        }
+
+        var scriptOverride = Environment.GetEnvironmentVariable("ASPIRE_CLI_INSTALL_SCRIPT");
+        if (!string.IsNullOrEmpty(scriptOverride))
+        {
+            var installPath = CreateTemporaryInstallPath();
+            await auto.RemoveDefaultAspireBinAsync(counter);
+            await auto.InstallFromScriptAsync(scriptOverride, installPath, counter);
+            await auto.SourceAspireBundleEnvironmentAsync(counter, installPath);
+            await auto.EnableStagingChannelIfNeededAsync(counter);
+            return;
+        }
+
+        if (!CliE2ETestHelpers.IsRunningInCI)
+        {
+            return;
+        }
+
+        var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
+        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
+        var prInstallPath = CreateTemporaryInstallPath();
+
+        await auto.RemoveDefaultAspireBinAsync(counter);
+        await auto.InstallAspireBundleFromPullRequestAsync(prNumber, counter, prInstallPath);
+        await auto.SourceAspireBundleEnvironmentAsync(counter, prInstallPath);
+        await auto.VerifyAspireCliVersionAsync(commitSha, counter);
+    }
+
+    /// <summary>
+    /// Creates a unique temporary directory path for CLI installation.
+    /// </summary>
+    private static string CreateTemporaryInstallPath()
+    {
+        return Path.Combine(Path.GetTempPath(), $"aspire-e2e-{Guid.NewGuid():N}");
+    }
+
+    /// <summary>
+    /// Gets whether the tests should use the system-installed <c>aspire</c> already in PATH,
+    /// skipping all installation steps. Enabled by setting <c>ASPIRE_CLI_USE_SYSTEM=true</c>.
+    /// </summary>
+    private static bool UseSystemCli =>
+        string.Equals(Environment.GetEnvironmentVariable("ASPIRE_CLI_USE_SYSTEM"), "true", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Gets whether staging quality was requested via <c>ASPIRE_CLI_INSTALL_ARGS</c>.
+    /// </summary>
+    private static bool IsStagingQuality =>
+        (Environment.GetEnvironmentVariable("ASPIRE_CLI_INSTALL_ARGS") ?? "").Contains("-q staging", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Enables the staging channel in aspire config if staging quality was requested.
+    /// Sets both the feature flag and the default channel so that <c>aspire new</c>
+    /// generates a NuGet.config pointing to the staging feed.
+    /// </summary>
+    private static async Task EnableStagingChannelIfNeededAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter)
+    {
+        if (!IsStagingQuality)
+        {
+            return;
+        }
+
+        await auto.TypeAsync("aspire config set -g features.stagingChannelEnabled true");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+        await auto.TypeAsync("aspire config set -g channel staging");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+    }
+
+    /// <summary>
+    /// Sets the staging channel in the local <c>aspire.config.json</c> so that <c>aspire add</c>
+    /// can find unreleased packages in TypeScript/polyglot apphosts (which don't use NuGet.config).
+    /// Call this after <c>aspire init</c> for TypeScript projects when staging quality is in use.
+    /// </summary>
+    internal static async Task SetLocalStagingChannelIfNeededAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter)
+    {
+        if (!IsStagingQuality)
+        {
+            return;
+        }
+
+        await auto.TypeAsync("aspire config set channel staging");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+    }
+
+    /// <summary>
+    /// Waits for either the version selection prompt or the success prompt after <c>aspire add</c>.
+    /// When multiple channels exist (e.g. PR hives), the version selector appears and is accepted.
+    /// When only the implicit channel exists (bare CLI install), the add completes directly.
+    /// </summary>
+    internal static async Task AcceptVersionSelectionIfShownAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        TimeSpan? timeout = null)
+    {
+        timeout ??= TimeSpan.FromSeconds(180);
+
+        var waitingForVersionSelection = new CellPatternSearcher()
+            .Find("Select a version of");
+        var versionSelectionShown = false;
+
+        var successPromptSearcher = new CellPatternSearcher()
+            .FindPattern(counter.Value.ToString())
+            .RightText(" OK] $ ");
+
+        await auto.WaitUntilAsync(s =>
+        {
+            if (waitingForVersionSelection.Search(s).Count > 0)
+            {
+                versionSelectionShown = true;
+                return true;
+            }
+
+            return successPromptSearcher.Search(s).Count > 0;
+        }, timeout: timeout.Value, description: "version selection prompt or success prompt");
+
+        if (versionSelectionShown)
+        {
+            await auto.EnterAsync(); // Accept the default version
+        }
+
+        await auto.WaitForSuccessPromptAsync(counter);
+    }
+
+    /// <summary>
+    /// Builds the install command for a script override.
+    /// Uses <c>ASPIRE_CLI_INSTALL_SCRIPT</c> to pick the script name and
+    /// <c>ASPIRE_CLI_INSTALL_ARGS</c> for any extra arguments.
+    /// </summary>
+    private static string BuildScriptCommand(string scriptName, string installPathArg)
+    {
+        var extraArgs = Environment.GetEnvironmentVariable("ASPIRE_CLI_INSTALL_ARGS") ?? "";
+        if (!string.IsNullOrEmpty(extraArgs))
+        {
+            extraArgs = " " + extraArgs;
+        }
+
+        return $"curl -fsSL https://raw.githubusercontent.com/dotnet/aspire/main/eng/scripts/{scriptName}.sh | bash -s --{extraArgs} --install-path {installPathArg}";
+    }
+
+    /// <summary>
+    /// Installs the CLI using a script override inside a Docker container.
+    /// The script is fetched from <c>/opt/aspire-scripts/</c> inside the container.
+    /// </summary>
+    private static async Task InstallFromScriptInDockerAsync(
+        this Hex1bTerminalAutomator auto,
+        string scriptName,
+        string installPath,
+        SequenceCounter counter)
+    {
+        var extraArgs = Environment.GetEnvironmentVariable("ASPIRE_CLI_INSTALL_ARGS") ?? "";
+        if (!string.IsNullOrEmpty(extraArgs))
+        {
+            extraArgs = " " + extraArgs;
+        }
+
+        // get-aspire-cli installs directly to --install-path; get-aspire-cli-pr puts bin/ under it
+        var installPathArg = scriptName == "get-aspire-cli" ? $"{installPath}/bin" : installPath;
+        await auto.TypeAsync($"/opt/aspire-scripts/{scriptName}.sh{extraArgs} --install-path {installPathArg}");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromSeconds(300));
+
+        await auto.TypeAsync($"export PATH={installPath}/bin:{installPath}:$PATH");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+        await auto.EchoAspirePathAsync(counter);
+    }
+
+    /// <summary>
+    /// Installs the CLI using a script override in a non-Docker environment (downloads from GitHub).
+    /// </summary>
+    private static async Task InstallFromScriptAsync(
+        this Hex1bTerminalAutomator auto,
+        string scriptName,
+        string installPath,
+        SequenceCounter counter)
+    {
+        // get-aspire-cli installs directly to --install-path; get-aspire-cli-pr puts bin/ under it
+        var installPathArg = scriptName == "get-aspire-cli" ? $"{installPath}/bin" : installPath;
+        var command = BuildScriptCommand(scriptName, installPathArg);
+        await auto.TypeAsync(command);
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromSeconds(300));
+    }
+
+    /// <summary>
+    /// Removes the default <c>~/.aspire/bin</c> directory so a stale install can't interfere.
+    /// </summary>
+    private static async Task RemoveDefaultAspireBinAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter)
+    {
+        await auto.TypeAsync("rm -rf ~/.aspire/bin");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+    }
+
+    /// <summary>
+    /// Installs the Aspire CLI from PR build artifacts in a non-Docker environment.
+    /// </summary>
+    private static async Task InstallAspireCliFromPullRequestAsync(
+        this Hex1bTerminalAutomator auto,
+        int prNumber,
+        SequenceCounter counter,
+        string installPath)
+    {
+        var command = $"curl -fsSL https://raw.githubusercontent.com/dotnet/aspire/main/eng/scripts/get-aspire-cli-pr.sh | bash -s -- {prNumber} --install-path {installPath}";
         await auto.TypeAsync(command);
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromSeconds(300));
@@ -137,13 +426,15 @@ internal static class CliE2EAutomatorHelpers
     /// <summary>
     /// Configures the PATH and environment variables for the Aspire CLI in a non-Docker environment.
     /// </summary>
-    internal static async Task SourceAspireCliEnvironmentAsync(
+    private static async Task SourceAspireCliEnvironmentAsync(
         this Hex1bTerminalAutomator auto,
-        SequenceCounter counter)
+        SequenceCounter counter,
+        string installPath)
     {
-        await auto.TypeAsync("export PATH=~/.aspire/bin:$PATH ASPIRE_PLAYGROUND=true TERM=xterm DOTNET_CLI_TELEMETRY_OPTOUT=true DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true DOTNET_GENERATE_ASPNET_CERTIFICATE=false");
+        await auto.TypeAsync($"export PATH={installPath}/bin:$PATH ASPIRE_PLAYGROUND=true TERM=xterm DOTNET_CLI_TELEMETRY_OPTOUT=true DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true DOTNET_GENERATE_ASPNET_CERTIFICATE=false");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
+        await auto.EchoAspirePathAsync(counter);
     }
 
     /// <summary>
@@ -171,12 +462,13 @@ internal static class CliE2EAutomatorHelpers
     /// <summary>
     /// Installs the Aspire CLI and bundle from PR build artifacts, using the PR head SHA to fetch the install script.
     /// </summary>
-    internal static async Task InstallAspireBundleFromPullRequestAsync(
+    private static async Task InstallAspireBundleFromPullRequestAsync(
         this Hex1bTerminalAutomator auto,
         int prNumber,
-        SequenceCounter counter)
+        SequenceCounter counter,
+        string installPath)
     {
-        var command = $"ref=$(gh api repos/dotnet/aspire/pulls/{prNumber} --jq '.head.sha') && curl -fsSL https://raw.githubusercontent.com/dotnet/aspire/$ref/eng/scripts/get-aspire-cli-pr.sh | bash -s -- {prNumber}";
+        var command = $"ref=$(gh api repos/dotnet/aspire/pulls/{prNumber} --jq '.head.sha') && curl -fsSL https://raw.githubusercontent.com/dotnet/aspire/$ref/eng/scripts/get-aspire-cli-pr.sh | bash -s -- {prNumber} --install-path {installPath}";
         await auto.TypeAsync(command);
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptFailFastAsync(counter, TimeSpan.FromSeconds(300));
@@ -184,13 +476,30 @@ internal static class CliE2EAutomatorHelpers
 
     /// <summary>
     /// Configures the PATH and environment variables for the Aspire CLI bundle in a non-Docker environment.
-    /// Unlike <see cref="SourceAspireCliEnvironmentAsync"/>, this includes <c>~/.aspire</c> in PATH for bundle tools.
     /// </summary>
-    internal static async Task SourceAspireBundleEnvironmentAsync(
+    private static async Task SourceAspireBundleEnvironmentAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        string installPath)
+    {
+        await auto.TypeAsync($"export PATH={installPath}/bin:{installPath}:$PATH ASPIRE_PLAYGROUND=true TERM=xterm DOTNET_CLI_TELEMETRY_OPTOUT=true DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true DOTNET_GENERATE_ASPNET_CERTIFICATE=false");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+        await auto.EchoAspirePathAsync(counter);
+    }
+
+    /// <summary>
+    /// Echoes the resolved path of the <c>aspire</c> binary for diagnostic visibility.
+    /// </summary>
+    private static async Task EchoAspirePathAsync(
         this Hex1bTerminalAutomator auto,
         SequenceCounter counter)
     {
-        await auto.TypeAsync("export PATH=~/.aspire/bin:~/.aspire:$PATH ASPIRE_PLAYGROUND=true TERM=xterm DOTNET_CLI_TELEMETRY_OPTOUT=true DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true DOTNET_GENERATE_ASPNET_CERTIFICATE=false");
+        await auto.TypeAsync("which aspire");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("aspire --version");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
     }
@@ -221,17 +530,37 @@ internal static class CliE2EAutomatorHelpers
     }
 
     /// <summary>
-    /// Installs a specific GA version of the Aspire CLI using the install script.
+    /// Installs a specific GA version of the Aspire CLI using the install script to a temporary directory.
+    /// Also sets up PATH so the installed CLI is available. Used inside Docker containers.
     /// </summary>
     internal static async Task InstallAspireCliVersionAsync(
         this Hex1bTerminalAutomator auto,
         string version,
         SequenceCounter counter)
     {
-        var command = $"curl -fsSL https://raw.githubusercontent.com/dotnet/aspire/main/eng/scripts/get-aspire-cli.sh | bash -s -- --version \"{version}\"";
+        if (UseSystemCli)
+        {
+            await auto.EchoAspirePathAsync(counter);
+            return;
+        }
+
+        const string installPath = "/tmp/aspire-version-install";
+
+        // Remove any CLI binary at the default location and clean up any previous version install
+        await auto.TypeAsync($"rm -rf ~/.aspire/bin {installPath}");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // get-aspire-cli.sh --install-path takes the direct bin directory
+        var command = $"curl -fsSL https://raw.githubusercontent.com/dotnet/aspire/main/eng/scripts/get-aspire-cli.sh | bash -s -- --version \"{version}\" --install-path {installPath}/bin";
         await auto.TypeAsync(command);
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptFailFastAsync(counter, timeout: TimeSpan.FromSeconds(300));
+
+        await auto.TypeAsync($"export PATH={installPath}/bin:$PATH");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+        await auto.EchoAspirePathAsync(counter);
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishTests.cs
@@ -30,9 +30,6 @@ public sealed class KubernetesPublishTests(ITestOutputHelper output)
     {
         using var workspace = TemporaryWorkspace.Create(output);
 
-        var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
-        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
-        var isCI = CliE2ETestHelpers.IsRunningInCI;
         var clusterName = GenerateUniqueClusterName();
 
         output.WriteLine($"Using KinD version: {KindVersion}");
@@ -49,12 +46,7 @@ public sealed class KubernetesPublishTests(ITestOutputHelper output)
         // Prepare environment
         await auto.PrepareEnvironmentAsync(workspace, counter);
 
-        if (isCI)
-        {
-            await auto.InstallAspireCliFromPullRequestAsync(prNumber, counter);
-            await auto.SourceAspireCliEnvironmentAsync(counter);
-            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
-        }
+        await auto.SetupAspireCliFromPullRequestAsync(counter);
 
         try
         {
@@ -130,12 +122,10 @@ public sealed class KubernetesPublishTests(ITestOutputHelper output)
 
             // Step 3: Add Aspire.Hosting.Kubernetes package using aspire add
             // Pass the package name directly as an argument to avoid interactive selection
-            // The version selection prompt always appears for 'aspire add'
+            // The version selector only appears when multiple channels exist (e.g. PR hives).
             await auto.TypeAsync("aspire add Aspire.Hosting.Kubernetes");
             await auto.EnterAsync();
-            await auto.WaitUntilTextAsync("(based on NuGet.config)", timeout: TimeSpan.FromSeconds(60));
-            await auto.EnterAsync(); // select first version
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(180));
+            await auto.AcceptVersionSelectionIfShownAsync(counter, TimeSpan.FromSeconds(180));
 
             // Step 4: Modify AppHost's main file to add Kubernetes environment
             // Note: Aspire templates use AppHost.cs as the main entry point, not Program.cs

--- a/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StartStopTests.cs
@@ -200,9 +200,30 @@ public sealed class StartStopTests(ITestOutputHelper output)
         await auto.WaitUntilTextAsync(AddCommandStrings.SelectAnIntegrationToAdd, timeout: TimeSpan.FromMinutes(1));
         await auto.TypeAsync("mongodb"); // type to filter the list
         await auto.EnterAsync(); // select the filtered result
-        await auto.WaitUntilTextAsync("Select a version of", timeout: TimeSpan.FromSeconds(30));
-        await auto.EnterAsync(); // Accept the default version
-        await auto.WaitUntilTextAsync("was added successfully.", timeout: TimeSpan.FromMinutes(2));
+
+        // The version selector only appears when multiple channels exist (e.g. PR hives).
+        // Bare CLI installs auto-select the single implicit channel without prompting.
+        var waitingForVersionSelection = new CellPatternSearcher()
+            .Find("Select a version of");
+        var versionSelectionShown = false;
+
+        await auto.WaitUntilAsync(s =>
+        {
+            if (waitingForVersionSelection.Search(s).Count > 0)
+            {
+                versionSelectionShown = true;
+                return true;
+            }
+
+            return s.ContainsText("was added successfully.");
+        }, timeout: TimeSpan.FromMinutes(2), description: "version selection prompt or add success");
+
+        if (versionSelectionShown)
+        {
+            await auto.EnterAsync(); // Accept the default version
+            await auto.WaitUntilTextAsync("was added successfully.", timeout: TimeSpan.FromMinutes(2));
+        }
+
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Clean up: stop if still running

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptCodegenValidationTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptCodegenValidationTests.cs
@@ -39,6 +39,8 @@ public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
         await auto.WaitUntilTextAsync("Created apphost.ts", timeout: TimeSpan.FromMinutes(2));
         await auto.WaitForSuccessPromptAsync(counter);
 
+        await auto.SetLocalStagingChannelIfNeededAsync(counter);
+
         // Step 2: Add two integrations
         await auto.TypeAsync("aspire add Aspire.Hosting.Redis");
         await auto.EnterAsync();
@@ -101,10 +103,6 @@ public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
     {
         using var workspace = TemporaryWorkspace.Create(output);
 
-        var prNumber = CliE2ETestHelpers.GetRequiredPrNumber();
-        var commitSha = CliE2ETestHelpers.GetRequiredCommitSha();
-        var isCI = CliE2ETestHelpers.IsRunningInCI;
-
         using var terminal = CliE2ETestHelpers.CreateTestTerminal();
         var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
 
@@ -114,17 +112,14 @@ public sealed class TypeScriptCodegenValidationTests(ITestOutputHelper output)
         // PrepareEnvironment
         await auto.PrepareEnvironmentAsync(workspace, counter);
 
-        if (isCI)
-        {
-            await auto.InstallAspireBundleFromPullRequestAsync(prNumber, counter);
-            await auto.SourceAspireBundleEnvironmentAsync(counter);
-            await auto.VerifyAspireCliVersionAsync(commitSha, counter);
-        }
+        await auto.SetupAspireBundleFromPullRequestAsync(counter);
 
         await auto.TypeAsync("aspire init --language typescript --non-interactive");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("Created apphost.ts", timeout: TimeSpan.FromMinutes(2));
         await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.SetLocalStagingChannelIfNeededAsync(counter);
 
         await auto.TypeAsync("aspire add Aspire.Hosting.PostgreSQL");
         await auto.EnterAsync();

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPolyglotTests.cs
@@ -44,6 +44,8 @@ public sealed class TypeScriptPolyglotTests(ITestOutputHelper output)
         await auto.WaitUntilTextAsync("Created apphost.ts", timeout: TimeSpan.FromMinutes(2));
         await auto.DeclineAgentInitPromptAsync(counter);
 
+        await auto.SetLocalStagingChannelIfNeededAsync(counter);
+
         // Step 2: Create a Vite app using npm create vite
         // Using --template vanilla-ts for a minimal TypeScript Vite app
         // Use -y to skip npm prompts and -- to pass args to create-vite

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPublishTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptPublishTests.cs
@@ -43,6 +43,8 @@ public sealed class TypeScriptPublishTests(ITestOutputHelper output)
         await auto.WaitUntilTextAsync("Created apphost.ts", timeout: TimeSpan.FromMinutes(2));
         await auto.DeclineAgentInitPromptAsync(counter);
 
+        await auto.SetLocalStagingChannelIfNeededAsync(counter);
+
         await auto.TypeAsync("aspire add Aspire.Hosting.Docker");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("The package Aspire.Hosting.", timeout: TimeSpan.FromMinutes(2));


### PR DESCRIPTION
- All install methods now use --install-path to install to temp directories
- Docker tests use /tmp/aspire-install (ephemeral container)
- Non-Docker tests use C#-generated unique paths via Guid
- rm -rf ~/.aspire before each install for clean environment
- Added SetupAspireCliFromPullRequestAsync/SetupAspireBundleFromPullRequestAsync composite helpers that handle install, PATH setup, and version verification
- InstallAspireCliVersionAsync now handles PATH setup internally
- Old individual Install/Source methods made private with installPath parameter
- Simplified callers in all 4 non-Docker test files

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [ ] No
