### PR TITLE
[release/13.2] Store temporary AppHost service under user .aspire directory

### DIFF
--- a/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
@@ -22,7 +22,6 @@ namespace Aspire.Cli.Projects;
 internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
 {
     private const string ProjectHashFileName = ".projecthash";
-    private const string FolderPrefix = ".aspire";
     private const string AppsFolder = "hosts";
     public const string ProjectFileName = "AppHostServer.csproj";
     private const string ProjectDllName = "AppHostServer.dll";
@@ -74,20 +73,7 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
         else
         {
             var pathDir = Convert.ToHexString(pathHash)[..12].ToLowerInvariant();
-            var tempPath = Path.GetTempPath();
-            // On macOS, /var is a symlink to /private/var. MSBuild resolves symlinks when
-            // computing relative paths between projects, but then tries to resolve those
-            // relative paths from the original (unresolved) directory. This mismatch causes
-            // transitive project references to fail. Using the canonical path ensures consistency.
-            if (OperatingSystem.IsMacOS() && tempPath.StartsWith("/var/", StringComparison.Ordinal))
-            {
-                var canonical = "/private" + tempPath;
-                if (Directory.Exists(canonical))
-                {
-                    tempPath = canonical;
-                }
-            }
-            _projectModelPath = Path.Combine(tempPath, FolderPrefix, AppsFolder, pathDir);
+            _projectModelPath = Path.Combine(CliPathHelper.GetAspireHomeDirectory(), AppsFolder, pathDir);
         }
 
         // Create a stable UserSecretsId based on the app path hash

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -74,7 +74,7 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
         // Create a working directory for this app host session
         var pathHash = SHA256.HashData(Encoding.UTF8.GetBytes(_appDirectoryPath));
         var pathDir = Convert.ToHexString(pathHash)[..12].ToLowerInvariant();
-        _workingDirectory = Path.Combine(Path.GetTempPath(), ".aspire", "bundle-hosts", pathDir);
+        _workingDirectory = Path.Combine(CliPathHelper.GetAspireHomeDirectory(), "bundle-hosts", pathDir);
         Directory.CreateDirectory(_workingDirectory);
     }
 

--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.InternalTesting;
+using System.Security.Cryptography;
+using System.Text;
 using System.Xml.Linq;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.NuGet;
@@ -192,16 +194,27 @@ public class AppHostServerProjectTests(ITestOutputHelper outputHelper) : IDispos
     {
         // Arrange
         var project = CreateProject();
+        var normalizedAppPath = Path.GetFullPath(project.AppDirectoryPath);
+        normalizedAppPath = new Uri(normalizedAppPath).LocalPath;
+        normalizedAppPath = OperatingSystem.IsWindows() ? normalizedAppPath.ToLowerInvariant() : normalizedAppPath;
+
+        var pathHash = SHA256.HashData(Encoding.UTF8.GetBytes(normalizedAppPath));
+        var pathDir = Convert.ToHexString(pathHash)[..12].ToLowerInvariant();
         var expectedRoot = Path.Combine(CliPathHelper.GetAspireHomeDirectory(), "hosts");
+        var expectedPath = Path.Combine(expectedRoot, pathDir);
+        var parentDirectory = Path.GetDirectoryName(project.ProjectModelPath);
+        var isSafeToDelete = string.Equals(project.ProjectModelPath, expectedPath, StringComparison.OrdinalIgnoreCase) &&
+            parentDirectory is not null &&
+            string.Equals(parentDirectory, expectedRoot, StringComparison.OrdinalIgnoreCase);
 
         try
         {
             // Assert
-            Assert.StartsWith(expectedRoot, project.ProjectModelPath, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(expectedPath, project.ProjectModelPath);
         }
         finally
         {
-            if (Directory.Exists(project.ProjectModelPath))
+            if (isSafeToDelete && Directory.Exists(project.ProjectModelPath))
             {
                 Directory.Delete(project.ProjectModelPath, recursive: true);
             }

--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
@@ -7,6 +7,7 @@ using Aspire.Cli.Configuration;
 using Aspire.Cli.NuGet;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Projects;
+using Aspire.Cli.Utils;
 using Aspire.Cli.Tests.Mcp;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
@@ -184,6 +185,27 @@ public class AppHostServerProjectTests(ITestOutputHelper outputHelper) : IDispos
 
         // Assert - same app path should result in same project model path
         Assert.Equal(project1.ProjectModelPath, project2.ProjectModelPath);
+    }
+
+    [Fact]
+    public void ProjectModelPath_UsesUserAspireDirectory()
+    {
+        // Arrange
+        var project = CreateProject();
+        var expectedRoot = Path.Combine(CliPathHelper.GetAspireHomeDirectory(), "hosts");
+
+        try
+        {
+            // Assert
+            Assert.StartsWith(expectedRoot, project.ProjectModelPath, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (Directory.Exists(project.ProjectModelPath))
+            {
+                Directory.Delete(project.ProjectModelPath, recursive: true);
+            }
+        }
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -172,16 +172,20 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
                 .GetField("_workingDirectory", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
                 .GetValue(server));
 
+        var rootDirectory = Path.Combine(CliPathHelper.GetAspireHomeDirectory(), "bundle-hosts");
+        var isUnderRoot = workingDirectory.StartsWith(rootDirectory, StringComparison.OrdinalIgnoreCase);
+        var parentDirectory = Path.GetDirectoryName(workingDirectory);
+        var isDirectChildOfRoot = parentDirectory is not null &&
+                                   string.Equals(parentDirectory, rootDirectory, StringComparison.OrdinalIgnoreCase);
+        var isSafeToDelete = isUnderRoot && isDirectChildOfRoot && !string.Equals(workingDirectory, rootDirectory, StringComparison.OrdinalIgnoreCase);
+
         try
         {
-            Assert.StartsWith(
-                Path.Combine(CliPathHelper.GetAspireHomeDirectory(), "bundle-hosts"),
-                workingDirectory,
-                StringComparison.OrdinalIgnoreCase);
+            Assert.True(isSafeToDelete);
         }
         finally
         {
-            if (Directory.Exists(workingDirectory))
+            if (isSafeToDelete && Directory.Exists(workingDirectory))
             {
                 Directory.Delete(workingDirectory, recursive: true);
             }

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -155,7 +155,7 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
-        var nugetService = new BundleNuGetService(new NullLayoutDiscovery(), NullLogger<BundleNuGetService>.Instance);
+        var nugetService = new BundleNuGetService(new NullLayoutDiscovery(), Microsoft.Extensions.Logging.Abstractions.NullLogger<BundleNuGetService>.Instance);
         var server = new PrebuiltAppHostServer(
             workspace.WorkspaceRoot.FullName,
             "test.sock",
@@ -163,9 +163,9 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
             nugetService,
             new TestDotNetCliRunner(),
             new TestDotNetSdkInstaller(),
-            new MockPackagingService(),
+            new Aspire.Cli.Tests.Mcp.MockPackagingService(),
             new TestConfigurationService(),
-            NullLogger.Instance);
+            Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
 
         var workingDirectory = Assert.IsType<string>(
             typeof(PrebuiltAppHostServer)

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -3,11 +3,18 @@
 
 using System.Xml.Linq;
 using Aspire.Cli.Configuration;
+using Aspire.Cli.Layout;
+using Aspire.Cli.NuGet;
 using Aspire.Cli.Projects;
+using Aspire.Cli.Tests.Mcp;
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Projects;
 
-public class PrebuiltAppHostServerTests
+public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
 {
     [Fact]
     public void GenerateIntegrationProjectFile_WithPackagesOnly_ProducesPackageReferences()
@@ -143,6 +150,44 @@ public class PrebuiltAppHostServerTests
         var ns = doc.Root!.GetDefaultNamespace();
         var restoreSources = doc.Descendants(ns + "RestoreAdditionalProjectSources").FirstOrDefault();
         Assert.Null(restoreSources);
+    }
+
+    [Fact]
+    public void Constructor_UsesUserAspireDirectoryForWorkingDirectory()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var nugetService = new BundleNuGetService(new NullLayoutDiscovery(), NullLogger<BundleNuGetService>.Instance);
+        var server = new PrebuiltAppHostServer(
+            workspace.WorkspaceRoot.FullName,
+            "test.sock",
+            new LayoutConfiguration(),
+            nugetService,
+            new TestDotNetCliRunner(),
+            new TestDotNetSdkInstaller(),
+            new MockPackagingService(),
+            new TestConfigurationService(),
+            NullLogger.Instance);
+
+        var workingDirectory = Assert.IsType<string>(
+            typeof(PrebuiltAppHostServer)
+                .GetField("_workingDirectory", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                .GetValue(server));
+
+        try
+        {
+            Assert.StartsWith(
+                Path.Combine(CliPathHelper.GetAspireHomeDirectory(), "bundle-hosts"),
+                workingDirectory,
+                StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (Directory.Exists(workingDirectory))
+            {
+                Directory.Delete(workingDirectory, recursive: true);
+            }
+        }
     }
 
 }

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -6,11 +6,9 @@ using Aspire.Cli.Configuration;
 using Aspire.Cli.Layout;
 using Aspire.Cli.NuGet;
 using Aspire.Cli.Projects;
-using Aspire.Cli.Tests.Mcp;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests.Projects;
 


### PR DESCRIPTION
## Description

This changes the temporary AppHost service storage used by the CLI on `release/13.2` from the machine temp directory to the user-scoped `~/.aspire` directory.

It updates both the generated AppHost server project path and the prebuilt bundle-host working directory so temporary AppHost service artifacts are stored under the user's Aspire home instead of `Path.GetTempPath()`.

It also adds regression tests covering both code paths.

Fixes # (issue)

Validation:
- `./restore.sh`
- `./dotnet.sh test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj -- --filter-class "*.AppHostServerProjectTests" --filter-class "*.PrebuiltAppHostServerTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
