### PR TITLE
Fix default NuGet packages restore folder

### DIFF
--- a/Aspire.slnx
+++ b/Aspire.slnx
@@ -398,6 +398,7 @@
     <Project Path="tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj" />
     <Project Path="tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj" />
     <Project Path="tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj" />
+    <Project Path="tests/Aspire.Managed.Tests/Aspire.Managed.Tests.csproj" />
     <Project Path="tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj" />
     <Project Path="tests/Aspire.Templates.Tests/Aspire.Templates.Tests.csproj" />
     <Project Path="tests/Aspire.TestUtilities/Aspire.TestUtilities.csproj" />

--- a/playground/polyglot/NuGet.config
+++ b/playground/polyglot/NuGet.config
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  NuGet.config for Polyglot playground needs to clear all package sources and mappings so it doesn't use the root NuGet.config.
+  That way when the tests run, they do not respect the root NuGet.config settings - for example the packageSourceMappings.
+  -->
+<configuration>
+  <packageSources>
+    <clear />
+  </packageSources>
+  <packageSourceMapping>
+    <clear />
+  </packageSourceMapping>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+</configuration>

--- a/src/Aspire.Managed/NuGet/Commands/RestoreCommand.cs
+++ b/src/Aspire.Managed/NuGet/Commands/RestoreCommand.cs
@@ -144,9 +144,8 @@ public static class RestoreCommand
         var outputPath = Path.GetFullPath(output);
         Directory.CreateDirectory(outputPath);
 
-        packagesDir ??= Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".nuget", "packages");
+        var settings = Settings.LoadDefaultSettings(workingDir, nugetConfigPath, new XPlatMachineWideSetting());
+        packagesDir ??= SettingsUtility.GetGlobalPackagesFolder(settings);
 
         var logger = new NuGetLogger(verbose);
 

--- a/src/Aspire.Managed/NuGet/Commands/RestoreCommand.cs
+++ b/src/Aspire.Managed/NuGet/Commands/RestoreCommand.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Immutable;
 using System.CommandLine;
-using System.Globalization;
 using NuGet.Commands;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -100,13 +99,6 @@ public static class RestoreCommand
             var noNugetOrg = parseResult.GetValue(noNugetOrgOption);
             var verbose = parseResult.GetValue(verboseOption);
 
-            // Validate that both nuget-config and sources aren't provided together
-            if (!string.IsNullOrEmpty(nugetConfigPath) && sources.Length > 0)
-            {
-                Console.Error.WriteLine("Error: Cannot specify both --nuget-config and --source. Use one or the other.");
-                return 1;
-            }
-
             // Parse packages (format: PackageId,Version)
             var packages = new List<(string Id, string Version)>();
             foreach (var pkgArg in packageArgs)
@@ -124,18 +116,18 @@ public static class RestoreCommand
                 packages.Add((parts[0], parts[1]));
             }
 
-            return await ExecuteRestoreAsync([.. packages], framework, output, packagesDir, sources, nugetConfigPath, workingDir, noNugetOrg, verbose).ConfigureAwait(false);
+            return await ExecuteRestoreAsync(packages, framework, output, packagesDir, sources, nugetConfigPath, workingDir, noNugetOrg, verbose).ConfigureAwait(false);
         });
 
         return command;
     }
 
     private static async Task<int> ExecuteRestoreAsync(
-        (string Id, string Version)[] packages,
+        List<(string Id, string Version)> packages,
         string framework,
         string output,
         string? packagesDir,
-        string[] sources,
+        string[] cliSources,
         string? nugetConfigPath,
         string? workingDir,
         bool noNugetOrg,
@@ -144,18 +136,16 @@ public static class RestoreCommand
         var outputPath = Path.GetFullPath(output);
         Directory.CreateDirectory(outputPath);
 
-        var settings = Settings.LoadDefaultSettings(workingDir, nugetConfigPath, new XPlatMachineWideSetting());
-        packagesDir ??= SettingsUtility.GetGlobalPackagesFolder(settings);
-
         var logger = new NuGetLogger(verbose);
 
         try
         {
-            var nugetFramework = NuGetFramework.Parse(framework);
+            // Load NuGet settings once — handles working dir, config file, and machine-wide settings.
+            var settings = Settings.LoadDefaultSettings(workingDir, nugetConfigPath, new XPlatMachineWideSetting());
 
             if (verbose)
             {
-                Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Restoring {0} packages for {1}", packages.Length, framework));
+                Console.WriteLine($"Restoring {packages.Count} packages for {framework}");
                 Console.WriteLine($"Output: {outputPath}");
                 Console.WriteLine($"Packages: {packagesDir}");
                 if (workingDir is not null)
@@ -168,45 +158,43 @@ public static class RestoreCommand
                 }
             }
 
-            // Load package sources
-            var packageSources = LoadPackageSources(sources, nugetConfigPath, workingDir, noNugetOrg, verbose);
+            // Resolve the default packages path from settings (env var, config, or ~/.nuget/packages).
+            // If --packages-dir is provided, RestoreArgs.GlobalPackagesFolder overrides this.
+            var defaultPackagesPath = SettingsUtility.GetGlobalPackagesFolder(settings);
 
-            // Build PackageSpec
-            var packageSpec = BuildPackageSpec(packages, nugetFramework, outputPath, packagesDir, packageSources);
+            // Resolve package sources using NuGet's PackageSourceProvider
+            var packageSources = ResolvePackageSources(settings, cliSources, noNugetOrg);
 
-            // Create DependencyGraphSpec
+            var nugetFramework = NuGetFramework.Parse(framework);
+
+            // Build PackageSpec and DependencyGraphSpec
+            var packageSpec = BuildPackageSpec(packages, nugetFramework, outputPath, defaultPackagesPath, packageSources, settings);
+
             var dgSpec = new DependencyGraphSpec();
             dgSpec.AddProject(packageSpec);
             dgSpec.AddRestore(packageSpec.RestoreMetadata.ProjectUniqueName);
 
-            // Setup providers
+            // Pass settings to the provider so it reuses our pre-loaded settings
             var providerCache = new RestoreCommandProvidersCache();
-            var providers = new List<IPreLoadedRestoreRequestProvider>
-            {
-                new DependencyGraphSpecRequestProvider(providerCache, dgSpec)
-            };
+            var dgProvider = new DependencyGraphSpecRequestProvider(providerCache, dgSpec, settings);
 
-            // Run restore
+            // Run restore — let NuGet handle source credentials, parallel execution, etc.
             using var cacheContext = new SourceCacheContext();
-            var restoreContext = new RestoreArgs
+            var restoreArgs = new RestoreArgs
             {
                 CacheContext = cacheContext,
                 Log = logger,
-                PreLoadedRequestProviders = providers,
+                PreLoadedRequestProviders = [dgProvider],
                 DisableParallel = Environment.ProcessorCount == 1,
                 AllowNoOp = false,
-                GlobalPackagesFolder = packagesDir
+                GlobalPackagesFolder = packagesDir,
+                MachineWideSettings = new XPlatMachineWideSetting(),
             };
 
-            if (verbose)
-            {
-                Console.WriteLine("Running restore...");
-            }
-
-            var results = await RestoreRunner.RunAsync(restoreContext).ConfigureAwait(false);
+            var results = await RestoreRunner.RunAsync(restoreArgs).ConfigureAwait(false);
             var summary = results.Count > 0 ? results[0] : null;
 
-            if (summary == null)
+            if (summary is null)
             {
                 Console.Error.WriteLine("Error: Restore returned no results");
                 return 1;
@@ -237,70 +225,18 @@ public static class RestoreCommand
         }
     }
 
-    private static List<PackageSource> LoadPackageSources(string[] sources, string? nugetConfigPath, string? workingDir, bool noNugetOrg, bool verbose)
+    private static List<PackageSource> ResolvePackageSources(ISettings settings, string[] cliSources, bool noNugetOrg)
     {
-        var packageSources = new List<PackageSource>();
+        // Load enabled sources from NuGet config
+        var provider = new PackageSourceProvider(settings);
+        var sources = provider.LoadPackageSources().Where(s => s.IsEnabled).ToList();
 
-        // Add explicit sources first (they get priority)
-        foreach (var source in sources)
+        // Append CLI --source values (matching NuGet's behavior of merging, not replacing)
+        foreach (var cliSource in cliSources)
         {
-            packageSources.Add(new PackageSource(source));
-        }
-
-        // Load from specific config file if specified
-        if (!string.IsNullOrEmpty(nugetConfigPath) && File.Exists(nugetConfigPath))
-        {
-            var configDir = Path.GetDirectoryName(nugetConfigPath)!;
-            var configFile = Path.GetFileName(nugetConfigPath);
-            var settings = Settings.LoadSpecificSettings(configDir, configFile);
-            var provider = new PackageSourceProvider(settings);
-
-            foreach (var source in provider.LoadPackageSources())
+            if (!sources.Any(s => s.Source.Equals(cliSource, StringComparison.OrdinalIgnoreCase)))
             {
-                if (source.IsEnabled && !packageSources.Any(s => s.Source == source.Source))
-                {
-                    packageSources.Add(source);
-                }
-            }
-        }
-        // Auto-discover nuget.config from working directory if specified
-        else if (!string.IsNullOrEmpty(workingDir) && Directory.Exists(workingDir))
-        {
-            try
-            {
-                // LoadDefaultSettings walks up the directory tree looking for nuget.config files
-                var settings = Settings.LoadDefaultSettings(workingDir);
-                var provider = new PackageSourceProvider(settings);
-
-                if (verbose)
-                {
-                    // Show the config file paths that were loaded
-                    var configPaths = settings.GetConfigFilePaths();
-                    Console.WriteLine($"Discovering NuGet config from: {workingDir}");
-                    foreach (var configPath in configPaths)
-                    {
-                        Console.WriteLine($"  Loaded config: {configPath}");
-                    }
-                }
-
-                foreach (var source in provider.LoadPackageSources())
-                {
-                    if (source.IsEnabled && !packageSources.Any(s => s.Source == source.Source))
-                    {
-                        if (verbose)
-                        {
-                            Console.WriteLine($"  Discovered source: {source.Name ?? source.Source}");
-                        }
-                        packageSources.Add(source);
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                if (verbose)
-                {
-                    Console.WriteLine($"Warning: Failed to load NuGet config from {workingDir}: {ex.ToString()}");
-                }
+                sources.Add(new PackageSource(cliSource));
             }
         }
 
@@ -308,37 +244,28 @@ public static class RestoreCommand
         if (!noNugetOrg)
         {
             const string nugetOrgUrl = "https://api.nuget.org/v3/index.json";
-            if (!packageSources.Any(s => s.Source.Equals(nugetOrgUrl, StringComparison.OrdinalIgnoreCase)))
+            if (!sources.Any(s => s.Source.Equals(nugetOrgUrl, StringComparison.OrdinalIgnoreCase)))
             {
                 Console.WriteLine("Note: Adding nuget.org as fallback package source. Use --no-nuget-org to disable.");
-                packageSources.Add(new PackageSource(nugetOrgUrl, "nuget.org"));
+                sources.Add(new PackageSource(nugetOrgUrl, "nuget.org"));
             }
         }
 
-        if (verbose)
-        {
-            Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Using {0} package sources:", packageSources.Count));
-            foreach (var source in packageSources)
-            {
-                Console.WriteLine($"  - {source.Name ?? source.Source}");
-            }
-        }
-
-        return packageSources;
+        return sources;
     }
 
     private static PackageSpec BuildPackageSpec(
-        (string Id, string Version)[] packages,
+        List<(string Id, string Version)> packages,
         NuGetFramework framework,
         string outputPath,
         string packagesPath,
-        List<PackageSource> sources)
+        List<PackageSource> sources,
+        ISettings settings)
     {
         var projectName = "AspireRestore";
         var projectPath = Path.Combine(outputPath, "project.json");
         var tfmShort = framework.GetShortFolderName();
 
-        // Build dependencies
         var dependencies = packages.Select(p => new LibraryDependency
         {
             LibraryRange = new LibraryRange(
@@ -347,7 +274,6 @@ public static class RestoreCommand
                 LibraryDependencyTarget.Package)
         }).ToImmutableArray();
 
-        // Build target framework info
         var tfInfo = new TargetFrameworkInformation
         {
             FrameworkName = framework,
@@ -355,7 +281,6 @@ public static class RestoreCommand
             Dependencies = dependencies
         };
 
-        // Build restore metadata
         var restoreMetadata = new ProjectRestoreMetadata
         {
             ProjectUniqueName = projectName,
@@ -365,15 +290,14 @@ public static class RestoreCommand
             OutputPath = outputPath,
             PackagesPath = packagesPath,
             OriginalTargetFrameworks = [tfmShort],
+            ConfigFilePaths = settings.GetConfigFilePaths().ToList(),
         };
 
-        // Add sources
         foreach (var source in sources)
         {
             restoreMetadata.Sources.Add(source);
         }
 
-        // Add target framework
         restoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(framework)
         {
             TargetAlias = tfmShort

--- a/src/Aspire.Managed/NuGet/Commands/RestoreCommand.cs
+++ b/src/Aspire.Managed/NuGet/Commands/RestoreCommand.cs
@@ -48,12 +48,6 @@ public static class RestoreCommand
         };
         command.Options.Add(outputOption);
 
-        var packagesDirOption = new Option<string?>("--packages-dir")
-        {
-            Description = "NuGet packages directory"
-        };
-        command.Options.Add(packagesDirOption);
-
         var sourceOption = new Option<string[]>("--source")
         {
             Description = "NuGet feed URL (can specify multiple)",
@@ -92,7 +86,6 @@ public static class RestoreCommand
             var packageArgs = parseResult.GetValue(packageOption) ?? [];
             var framework = parseResult.GetValue(frameworkOption)!;
             var output = parseResult.GetValue(outputOption)!;
-            var packagesDir = parseResult.GetValue(packagesDirOption);
             var sources = parseResult.GetValue(sourceOption) ?? [];
             var nugetConfigPath = parseResult.GetValue(configOption);
             var workingDir = parseResult.GetValue(workingDirOption);
@@ -116,7 +109,7 @@ public static class RestoreCommand
                 packages.Add((parts[0], parts[1]));
             }
 
-            return await ExecuteRestoreAsync(packages, framework, output, packagesDir, sources, nugetConfigPath, workingDir, noNugetOrg, verbose).ConfigureAwait(false);
+            return await ExecuteRestoreAsync(packages, framework, output, sources, nugetConfigPath, workingDir, noNugetOrg, verbose).ConfigureAwait(false);
         });
 
         return command;
@@ -126,7 +119,6 @@ public static class RestoreCommand
         List<(string Id, string Version)> packages,
         string framework,
         string output,
-        string? packagesDir,
         string[] cliSources,
         string? nugetConfigPath,
         string? workingDir,
@@ -148,7 +140,6 @@ public static class RestoreCommand
             {
                 Console.WriteLine($"Restoring {packages.Count} packages for {framework}");
                 Console.WriteLine($"Output: {outputPath}");
-                Console.WriteLine($"Packages: {packagesDir}");
                 if (workingDir is not null)
                 {
                     Console.WriteLine($"Working dir: {workingDir}");
@@ -184,7 +175,6 @@ public static class RestoreCommand
                 PreLoadedRequestProviders = [dgProvider],
                 DisableParallel = Environment.ProcessorCount == 1,
                 AllowNoOp = false,
-                GlobalPackagesFolder = packagesDir,
                 MachineWideSettings = machineWideSettings,
             };
 

--- a/src/Aspire.Managed/NuGet/Commands/RestoreCommand.cs
+++ b/src/Aspire.Managed/NuGet/Commands/RestoreCommand.cs
@@ -141,7 +141,8 @@ public static class RestoreCommand
         try
         {
             // Load NuGet settings once — handles working dir, config file, and machine-wide settings.
-            var settings = Settings.LoadDefaultSettings(workingDir, nugetConfigPath, new XPlatMachineWideSetting());
+            var machineWideSettings = new XPlatMachineWideSetting();
+            var settings = Settings.LoadDefaultSettings(workingDir, nugetConfigPath, machineWideSettings);
 
             if (verbose)
             {
@@ -158,17 +159,13 @@ public static class RestoreCommand
                 }
             }
 
-            // Resolve the default packages path from settings (env var, config, or ~/.nuget/packages).
-            // If --packages-dir is provided, RestoreArgs.GlobalPackagesFolder overrides this.
-            var defaultPackagesPath = SettingsUtility.GetGlobalPackagesFolder(settings);
-
             // Resolve package sources using NuGet's PackageSourceProvider
             var packageSources = ResolvePackageSources(settings, cliSources, noNugetOrg);
 
             var nugetFramework = NuGetFramework.Parse(framework);
 
             // Build PackageSpec and DependencyGraphSpec
-            var packageSpec = BuildPackageSpec(packages, nugetFramework, outputPath, defaultPackagesPath, packageSources, settings);
+            var packageSpec = BuildPackageSpec(packages, nugetFramework, outputPath, packageSources, settings);
 
             var dgSpec = new DependencyGraphSpec();
             dgSpec.AddProject(packageSpec);
@@ -188,7 +185,7 @@ public static class RestoreCommand
                 DisableParallel = Environment.ProcessorCount == 1,
                 AllowNoOp = false,
                 GlobalPackagesFolder = packagesDir,
-                MachineWideSettings = new XPlatMachineWideSetting(),
+                MachineWideSettings = machineWideSettings,
             };
 
             var results = await RestoreRunner.RunAsync(restoreArgs).ConfigureAwait(false);
@@ -258,7 +255,6 @@ public static class RestoreCommand
         List<(string Id, string Version)> packages,
         NuGetFramework framework,
         string outputPath,
-        string packagesPath,
         List<PackageSource> sources,
         ISettings settings)
     {
@@ -288,7 +284,7 @@ public static class RestoreCommand
             ProjectPath = projectPath,
             ProjectStyle = ProjectStyle.PackageReference,
             OutputPath = outputPath,
-            PackagesPath = packagesPath,
+            PackagesPath = SettingsUtility.GetGlobalPackagesFolder(settings),
             OriginalTargetFrameworks = [tfmShort],
             ConfigFilePaths = settings.GetConfigFilePaths().ToList(),
         };

--- a/src/Aspire.Managed/Properties/launchSettings.json
+++ b/src/Aspire.Managed/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Aspire.Managed": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:50500;http://localhost:50501"
+    }
+  }
+}

--- a/tests/Aspire.Managed.Tests/Aspire.Managed.Tests.csproj
+++ b/tests/Aspire.Managed.Tests/Aspire.Managed.Tests.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(TestsSharedDir)TempDirectory.cs" Link="shared/TempDirectory.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Aspire.Managed\Aspire.Managed.csproj" />
+
+    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Aspire.Managed.Tests/NuGet/RestoreCommandTests.cs
+++ b/tests/Aspire.Managed.Tests/NuGet/RestoreCommandTests.cs
@@ -32,19 +32,19 @@ public class RestoreCommandTests : IDisposable
         // doesn't interfere. The env var takes precedence over config files
         // in NuGet's resolution order.
         var options = new RemoteInvokeOptions();
-        options.StartInfo.RedirectStandardOutput = true;
         options.StartInfo.Environment.Remove("NUGET_PACKAGES");
 
-        using var result = RemoteExecutor.Invoke(static async (tempDirPath) =>
+        RemoteExecutor.Invoke(static async (tempDirPath) =>
         {
             var command = RestoreCommand.Create();
             var outputDir = Path.Combine(tempDirPath, "obj");
 
-            await command.Parse(["--package", "Fake.Package,1.0.0", "--no-nuget-org", "--verbose", "--output", outputDir, "--working-dir", tempDirPath]).InvokeAsync();
-        }, _tempDir.Path, options);
+            await command.Parse(["--package", "Fake.Package,1.0.0", "--no-nuget-org", "--output", outputDir, "--working-dir", tempDirPath]).InvokeAsync();
+        }, _tempDir.Path, options).Dispose();
 
-        var consoleOutput = result.Process.StandardOutput.ReadToEnd();
-        Assert.Contains($"Packages: {customPackagesDir}", consoleOutput);
+        // NuGet writes packageFolders into project.assets.json with the resolved packages directory.
+        var assetsContent = File.ReadAllText(Path.Combine(_tempDir.Path, "obj", "project.assets.json"));
+        Assert.Contains(JsonEncodedPath(customPackagesDir), assetsContent);
     }
 
     [Fact]
@@ -55,18 +55,67 @@ public class RestoreCommandTests : IDisposable
         // Run in a separate process with NUGET_PACKAGES set to the custom directory.
         // The env var takes priority over all config file settings.
         var options = new RemoteInvokeOptions();
-        options.StartInfo.RedirectStandardOutput = true;
         options.StartInfo.Environment["NUGET_PACKAGES"] = customPackagesDir;
 
-        using var result = RemoteExecutor.Invoke(static async (tempDirPath) =>
+        RemoteExecutor.Invoke(static async (tempDirPath) =>
         {
             var command = RestoreCommand.Create();
             var outputDir = Path.Combine(tempDirPath, "obj");
 
-            await command.Parse(["--package", "Fake.Package,1.0.0", "--no-nuget-org", "--verbose", "--output", outputDir, "--working-dir", tempDirPath]).InvokeAsync();
-        }, _tempDir.Path, options);
+            await command.Parse(["--package", "Fake.Package,1.0.0", "--no-nuget-org", "--output", outputDir, "--working-dir", tempDirPath]).InvokeAsync();
+        }, _tempDir.Path, options).Dispose();
 
-        var consoleOutput = result.Process.StandardOutput.ReadToEnd();
-        Assert.Contains($"Packages: {customPackagesDir}", consoleOutput);
+        // NuGet writes packageFolders into project.assets.json with the resolved packages directory.
+        var assetsContent = File.ReadAllText(Path.Combine(_tempDir.Path, "obj", "project.assets.json"));
+        Assert.Contains(JsonEncodedPath(customPackagesDir), assetsContent);
     }
+
+    [Fact]
+    public void RestoreCommand_CliSourcesAreAppendedToConfigSources()
+    {
+        var nugetConfigPath = Path.Combine(_tempDir.Path, "NuGet.config");
+        var configSourcePath = Path.Combine(_tempDir.Path, "config-source");
+        var cliSourcePath = Path.Combine(_tempDir.Path, "cli-source");
+
+        File.WriteAllText(nugetConfigPath, $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="ConfigSource" value="{configSourcePath}" />
+              </packageSources>
+            </configuration>
+            """);
+
+        // Run in a separate process so the parent's NuGet config doesn't interfere.
+        var options = new RemoteInvokeOptions();
+        options.StartInfo.Environment.Remove("NUGET_PACKAGES");
+
+        RemoteExecutor.Invoke(static async (nugetConfig, cliSourcePath, tempDirPath) =>
+        {
+            var command = RestoreCommand.Create();
+            var outputDir = Path.Combine(tempDirPath, "obj");
+
+            // Pass --source in addition to the config source. Both should be used.
+            await command.Parse([
+                "--package", "Fake.Package,1.0.0",
+                "--no-nuget-org",
+                "--nuget-config", nugetConfig,
+                "--source", cliSourcePath,
+                "--output", outputDir,
+                "--working-dir", tempDirPath]).InvokeAsync();
+        }, nugetConfigPath, cliSourcePath, _tempDir.Path, options).Dispose();
+
+        // NuGet writes the resolved sources into project.assets.json regardless of
+        // whether the restore succeeds. Verify both sources are present.
+        var assetsContent = File.ReadAllText(Path.Combine(_tempDir.Path, "obj", "project.assets.json"));
+        Assert.Contains(JsonEncodedPath(configSourcePath), assetsContent);
+        Assert.Contains(JsonEncodedPath(cliSourcePath), assetsContent);
+    }
+
+    /// <summary>
+    /// Converts a file path to its JSON-escaped representation (e.g. backslashes doubled).
+    /// </summary>
+    private static string JsonEncodedPath(string path) =>
+        path.Replace(@"\", @"\\");
 }

--- a/tests/Aspire.Managed.Tests/NuGet/RestoreCommandTests.cs
+++ b/tests/Aspire.Managed.Tests/NuGet/RestoreCommandTests.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Managed.NuGet.Commands;
+using Microsoft.DotNet.RemoteExecutor;
+using Xunit;
+
+namespace Aspire.Managed.Tests.NuGet;
+
+public class RestoreCommandTests : IDisposable
+{
+    private readonly TestTempDirectory _tempDir = new();
+
+    public void Dispose() => _tempDir.Dispose();
+
+    [Fact]
+    public void RestoreCommand_RespectsNuGetConfigGlobalPackagesFolder()
+    {
+        var customPackagesDir = Path.GetFullPath(Path.Combine(_tempDir.Path, "custom-packages"));
+        var nugetConfigPath = Path.Combine(_tempDir.Path, "NuGet.config");
+
+        File.WriteAllText(nugetConfigPath, $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <config>
+                <add key="globalPackagesFolder" value="{customPackagesDir}" />
+              </config>
+            </configuration>
+            """);
+
+        // Run in a separate process so NUGET_PACKAGES env var from the parent
+        // doesn't interfere. The env var takes precedence over config files
+        // in NuGet's resolution order.
+        var options = new RemoteInvokeOptions();
+        options.StartInfo.RedirectStandardOutput = true;
+        options.StartInfo.Environment.Remove("NUGET_PACKAGES");
+
+        using var result = RemoteExecutor.Invoke(static async (tempDirPath) =>
+        {
+            var command = RestoreCommand.Create();
+            var outputDir = Path.Combine(tempDirPath, "obj");
+
+            await command.Parse(["--package", "Fake.Package,1.0.0", "--no-nuget-org", "--verbose", "--output", outputDir, "--working-dir", tempDirPath]).InvokeAsync();
+        }, _tempDir.Path, options);
+
+        var consoleOutput = result.Process.StandardOutput.ReadToEnd();
+        Assert.Contains($"Packages: {customPackagesDir}", consoleOutput);
+    }
+
+    [Fact]
+    public void RestoreCommand_RespectsNuGetPackagesEnvironmentVariable()
+    {
+        var customPackagesDir = Path.GetFullPath(Path.Combine(_tempDir.Path, "env-packages"));
+
+        // Run in a separate process with NUGET_PACKAGES set to the custom directory.
+        // The env var takes priority over all config file settings.
+        var options = new RemoteInvokeOptions();
+        options.StartInfo.RedirectStandardOutput = true;
+        options.StartInfo.Environment["NUGET_PACKAGES"] = customPackagesDir;
+
+        using var result = RemoteExecutor.Invoke(static async (tempDirPath) =>
+        {
+            var command = RestoreCommand.Create();
+            var outputDir = Path.Combine(tempDirPath, "obj");
+
+            await command.Parse(["--package", "Fake.Package,1.0.0", "--no-nuget-org", "--verbose", "--output", outputDir, "--working-dir", tempDirPath]).InvokeAsync();
+        }, _tempDir.Path, options);
+
+        var consoleOutput = result.Process.StandardOutput.ReadToEnd();
+        Assert.Contains($"Packages: {customPackagesDir}", consoleOutput);
+    }
+}


### PR DESCRIPTION
We shouldn't default to ~/.nuget/packages. Instead we should use NuGet defaulting logic.

Refactor the restore code using the patterns from the NuGet.Client sources. This simplifies the code.

Fix #15404
