### PR TITLE
Auto-enable staging channel when channel is set to staging

### DIFF
--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -16,6 +16,7 @@ using Aspire.Cli.Scaffolding;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Templating;
 using Aspire.Cli.Utils;
+using Microsoft.Extensions.Configuration;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 using Semver;
 using Spectre.Console;
@@ -84,7 +85,8 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
         ILanguageDiscovery languageDiscovery,
         IScaffoldingService scaffoldingService,
         AgentInitCommand agentInitCommand,
-        ICliHostEnvironment hostEnvironment)
+        ICliHostEnvironment hostEnvironment,
+        IConfiguration configuration)
         : base("init", InitCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _runner = runner;
@@ -107,7 +109,7 @@ internal sealed class InitCommand : BaseCommand, IPackageMetaPrefetchingCommand
         Options.Add(s_versionOption);
 
         // Customize description based on whether staging channel is enabled
-        var isStagingEnabled = features.IsFeatureEnabled(KnownFeatures.StagingChannelEnabled, false);
+        var isStagingEnabled = KnownFeatures.IsStagingChannelEnabled(features, configuration);
         _channelOption = new Option<string?>("--channel")
         {
             Description = isStagingEnabled

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -12,6 +12,7 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Templating;
 using Aspire.Cli.Utils;
+using Microsoft.Extensions.Configuration;
 using Spectre.Console;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
@@ -74,7 +75,8 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         IPackagingService packagingService,
         IConfigurationService configurationService,
         AgentInitCommand agentInitCommand,
-        ICliHostEnvironment hostEnvironment)
+        ICliHostEnvironment hostEnvironment,
+        IConfiguration configuration)
         : base("new", NewCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _prompter = prompter;
@@ -91,7 +93,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
         Options.Add(s_versionOption);
 
         // Customize description based on whether staging channel is enabled
-        var isStagingEnabled = _features.IsFeatureEnabled(KnownFeatures.StagingChannelEnabled, false);
+        var isStagingEnabled = KnownFeatures.IsStagingChannelEnabled(_features, configuration);
         _channelOption = new Option<string?>("--channel")
         {
             Description = isStagingEnabled

--- a/src/Aspire.Cli/Commands/UpdateCommand.cs
+++ b/src/Aspire.Cli/Commands/UpdateCommand.cs
@@ -13,6 +13,7 @@ using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 
@@ -30,6 +31,7 @@ internal sealed class UpdateCommand : BaseCommand
     private readonly ICliUpdateNotifier _updateNotifier;
     private readonly IFeatures _features;
     private readonly IConfigurationService _configurationService;
+    private readonly IConfiguration _configuration;
 
     private static readonly OptionWithLegacy<FileInfo?> s_appHostOption = new("--apphost", "--project", UpdateCommandStrings.ProjectArgumentDescription);
     private static readonly Option<bool> s_selfOption = new("--self")
@@ -50,7 +52,8 @@ internal sealed class UpdateCommand : BaseCommand
         ICliUpdateNotifier updateNotifier,
         CliExecutionContext executionContext,
         IConfigurationService configurationService,
-        AspireCliTelemetry telemetry)
+        AspireCliTelemetry telemetry,
+        IConfiguration configuration)
         : base("update", UpdateCommandStrings.Description, features, updateNotifier, executionContext, interactionService, telemetry)
     {
         _projectLocator = projectLocator;
@@ -61,12 +64,13 @@ internal sealed class UpdateCommand : BaseCommand
         _updateNotifier = updateNotifier;
         _features = features;
         _configurationService = configurationService;
+        _configuration = configuration;
 
         Options.Add(s_appHostOption);
         Options.Add(s_selfOption);
 
         // Customize description based on whether staging channel is enabled
-        var isStagingEnabled = _features.IsFeatureEnabled(KnownFeatures.StagingChannelEnabled, false);
+        var isStagingEnabled = KnownFeatures.IsStagingChannelEnabled(_features, _configuration);
 
         _channelOption = new Option<string?>("--channel")
         {
@@ -270,7 +274,7 @@ internal sealed class UpdateCommand : BaseCommand
         // for future 'aspire new' and 'aspire init' commands.
         if (string.IsNullOrEmpty(channel))
         {
-            var isStagingEnabled = _features.IsFeatureEnabled(KnownFeatures.StagingChannelEnabled, false);
+            var isStagingEnabled = KnownFeatures.IsStagingChannelEnabled(_features, _configuration);
             var channels = isStagingEnabled
                 ? new[] { PackageChannelNames.Stable, PackageChannelNames.Staging, PackageChannelNames.Daily }
                 : new[] { PackageChannelNames.Stable, PackageChannelNames.Daily };

--- a/src/Aspire.Cli/KnownFeatures.cs
+++ b/src/Aspire.Cli/KnownFeatures.cs
@@ -1,6 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Packaging;
+using Microsoft.Extensions.Configuration;
+
 namespace Aspire.Cli;
 
 /// <summary>
@@ -101,5 +105,20 @@ internal static class KnownFeatures
     public static IEnumerable<string> GetAllFeatureNames()
     {
         return s_featureMetadata.Keys.OrderBy(name => name);
+    }
+
+    /// <summary>
+    /// Determines whether the staging channel is enabled by checking both the feature flag
+    /// and the configured channel. The staging channel is considered enabled if either the
+    /// <see cref="StagingChannelEnabled"/> feature flag is <c>true</c>, or the configured
+    /// channel is set to <c>"staging"</c>.
+    /// </summary>
+    /// <param name="features">The feature flags service.</param>
+    /// <param name="configuration">The configuration to check for the channel setting.</param>
+    /// <returns><c>true</c> if the staging channel should be available; otherwise, <c>false</c>.</returns>
+    public static bool IsStagingChannelEnabled(IFeatures features, IConfiguration configuration)
+    {
+        return features.IsFeatureEnabled(StagingChannelEnabled, false)
+            || string.Equals(configuration["channel"], PackageChannelNames.Staging, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Aspire.Cli/Packaging/PackagingService.cs
+++ b/src/Aspire.Cli/Packaging/PackagingService.cs
@@ -57,7 +57,7 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
         var channels = new List<PackageChannel>([defaultChannel, stableChannel]);
 
         // Add staging channel if feature is enabled (after stable, before daily)
-        if (features.IsFeatureEnabled(KnownFeatures.StagingChannelEnabled, false))
+        if (KnownFeatures.IsStagingChannelEnabled(features, configuration))
         {
             var stagingChannel = CreateStagingChannel();
             if (stagingChannel is not null)

--- a/tests/Aspire.Cli.EndToEnd.Tests/StagingChannelTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/StagingChannelTests.cs
@@ -34,10 +34,8 @@ public sealed class StagingChannelTests(ITestOutputHelper output)
         await auto.InstallAspireCliInDockerAsync(installMode, counter);
 
         // Step 1: Configure staging channel settings via aspire config set
-        // Enable the staging channel feature flag
-        await auto.TypeAsync("aspire config set features.stagingChannelEnabled true -g");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
+        // Note: we do NOT need to enable features.stagingChannelEnabled — setting channel
+        // to staging is sufficient to enable the staging channel behavior.
 
         // Set quality to Prerelease (triggers shared feed mode)
         await auto.TypeAsync("aspire config set overrideStagingQuality Prerelease -g");
@@ -49,7 +47,7 @@ public sealed class StagingChannelTests(ITestOutputHelper output)
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        // Set channel to staging
+        // Set channel to staging — this alone enables staging channel behavior
         await auto.TypeAsync("aspire config set channel staging -g");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
@@ -106,9 +104,6 @@ public sealed class StagingChannelTests(ITestOutputHelper output)
         await auto.WaitForSuccessPromptAsync(counter);
 
         // Clean up: remove staging settings to avoid polluting other tests
-        await auto.TypeAsync("aspire config delete features.stagingChannelEnabled -g");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter);
         await auto.TypeAsync("aspire config delete overrideStagingQuality -g");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);

--- a/tests/Aspire.Cli.Tests/Configuration/KnownFeaturesTests.cs
+++ b/tests/Aspire.Cli.Tests/Configuration/KnownFeaturesTests.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Packaging;
+using Microsoft.Extensions.Configuration;
+
+namespace Aspire.Cli.Tests.Configuration;
+
+public class KnownFeaturesTests
+{
+    [Fact]
+    public void IsStagingChannelEnabled_ReturnsTrue_WhenChannelIsStaging()
+    {
+        var features = new TestFeatures(stagingChannelEnabled: false);
+        var configuration = BuildConfiguration(channel: PackageChannelNames.Staging);
+
+        Assert.True(KnownFeatures.IsStagingChannelEnabled(features, configuration));
+    }
+
+    [Fact]
+    public void IsStagingChannelEnabled_ReturnsTrue_WhenFeatureFlagIsTrue()
+    {
+        var features = new TestFeatures(stagingChannelEnabled: true);
+        var configuration = BuildConfiguration(channel: PackageChannelNames.Stable);
+
+        Assert.True(KnownFeatures.IsStagingChannelEnabled(features, configuration));
+    }
+
+    [Fact]
+    public void IsStagingChannelEnabled_ReturnsTrue_WhenChannelIsStagingAndFlagExplicitlyFalse()
+    {
+        var features = new TestFeatures(stagingChannelEnabled: false);
+        var configuration = BuildConfiguration(channel: PackageChannelNames.Staging);
+
+        Assert.True(KnownFeatures.IsStagingChannelEnabled(features, configuration));
+    }
+
+    [Fact]
+    public void IsStagingChannelEnabled_ReturnsFalse_WhenChannelIsNotStagingAndFlagNotSet()
+    {
+        var features = new TestFeatures(stagingChannelEnabled: false);
+        var configuration = BuildConfiguration(channel: PackageChannelNames.Stable);
+
+        Assert.False(KnownFeatures.IsStagingChannelEnabled(features, configuration));
+    }
+
+    [Fact]
+    public void IsStagingChannelEnabled_ReturnsFalse_WhenChannelIsNullAndFlagNotSet()
+    {
+        var features = new TestFeatures(stagingChannelEnabled: false);
+        var configuration = BuildConfiguration(channel: null);
+
+        Assert.False(KnownFeatures.IsStagingChannelEnabled(features, configuration));
+    }
+
+    [Fact]
+    public void IsStagingChannelEnabled_IsCaseInsensitive_ForChannelValue()
+    {
+        var features = new TestFeatures(stagingChannelEnabled: false);
+        var configuration = BuildConfiguration(channel: "Staging");
+
+        Assert.True(KnownFeatures.IsStagingChannelEnabled(features, configuration));
+    }
+
+    [Fact]
+    public void IsStagingChannelEnabled_IsCaseInsensitive_ForUppercaseChannelValue()
+    {
+        var features = new TestFeatures(stagingChannelEnabled: false);
+        var configuration = BuildConfiguration(channel: "STAGING");
+
+        Assert.True(KnownFeatures.IsStagingChannelEnabled(features, configuration));
+    }
+
+    [Fact]
+    public void IsStagingChannelEnabled_ReturnsFalse_WhenChannelIsDailyAndFlagNotSet()
+    {
+        var features = new TestFeatures(stagingChannelEnabled: false);
+        var configuration = BuildConfiguration(channel: PackageChannelNames.Daily);
+
+        Assert.False(KnownFeatures.IsStagingChannelEnabled(features, configuration));
+    }
+
+    private static IConfiguration BuildConfiguration(string? channel)
+    {
+        var configData = new Dictionary<string, string?>();
+
+        if (channel is not null)
+        {
+            configData["channel"] = channel;
+        }
+
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(configData)
+            .Build();
+    }
+
+    private sealed class TestFeatures(bool stagingChannelEnabled) : IFeatures
+    {
+        public bool IsFeatureEnabled(string featureFlag, bool defaultValue)
+        {
+            return featureFlag switch
+            {
+                "stagingChannelEnabled" => stagingChannelEnabled,
+                _ => defaultValue
+            };
+        }
+    }
+}

--- a/tests/Aspire.Cli.Tests/Configuration/KnownFeaturesTests.cs
+++ b/tests/Aspire.Cli.Tests/Configuration/KnownFeaturesTests.cs
@@ -28,9 +28,9 @@ public class KnownFeaturesTests
     }
 
     [Fact]
-    public void IsStagingChannelEnabled_ReturnsTrue_WhenChannelIsStagingAndFlagExplicitlyFalse()
+    public void IsStagingChannelEnabled_ReturnsTrue_WhenBothChannelIsStagingAndFlagIsTrue()
     {
-        var features = new TestFeatures(stagingChannelEnabled: false);
+        var features = new TestFeatures(stagingChannelEnabled: true);
         var configuration = BuildConfiguration(channel: PackageChannelNames.Staging);
 
         Assert.True(KnownFeatures.IsStagingChannelEnabled(features, configuration));
@@ -99,11 +99,12 @@ public class KnownFeaturesTests
     {
         public bool IsFeatureEnabled(string featureFlag, bool defaultValue)
         {
-            return featureFlag switch
+            if (featureFlag == KnownFeatures.StagingChannelEnabled)
             {
-                "stagingChannelEnabled" => stagingChannelEnabled,
-                _ => defaultValue
-            };
+                return stagingChannelEnabled;
+            }
+
+            return defaultValue;
         }
     }
 }


### PR DESCRIPTION
## Description

Auto-enable the staging channel when `channel` is configured as `"staging"`, removing the need to also explicitly set `features.stagingChannelEnabled: true`.

Previously, users had to set both `channel: staging` and `features.stagingChannelEnabled: true` for the staging channel to work. If they forgot the feature flag, the staging channel was silently unavailable. Now, setting `channel: staging` alone is sufficient — the feature flag still works as an independent toggle for cases where the channel isn't set to staging.

### Changes

- Added `KnownFeatures.IsStagingChannelEnabled(IFeatures, IConfiguration)` static helper that returns `true` if the feature flag is on OR the configured channel is `"staging"` (case-insensitive)
- Updated all 5 staging channel check sites to use the helper: `PackagingService`, `InitCommand`, `NewCommand`, `UpdateCommand` (2 locations)
- Added `IConfiguration` to command constructors where needed (already in DI container)
- Added 8 unit tests for the helper method
- Updated E2E `StagingChannelTests` to verify staging works without the feature flag

### Validation

- Full CLI test suite: 1680/1680 passed
- New `KnownFeaturesTests`: 8/8 passed
- `PackagingServiceTests` + `UpdateCommandTests`: 44/44 passed

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
