### PR TITLE
Fix config discovery to search from apphost directory and add aspire.config.json to .NET templates

### DIFF
--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -37,7 +37,6 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
     private readonly IDotNetCliRunner _runner;
     private readonly IPackagingService _packagingService;
     private readonly IConfiguration _configuration;
-    private readonly IConfigurationService _configurationService;
     private readonly IFeatures _features;
     private readonly ILanguageDiscovery _languageDiscovery;
     private readonly ILogger<GuestAppHostProject> _logger;
@@ -58,7 +57,6 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         IDotNetCliRunner runner,
         IPackagingService packagingService,
         IConfiguration configuration,
-        IConfigurationService configurationService,
         IFeatures features,
         ILanguageDiscovery languageDiscovery,
         ILogger<GuestAppHostProject> logger,
@@ -73,7 +71,6 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         _runner = runner;
         _packagingService = packagingService;
         _configuration = configuration;
-        _configurationService = configurationService;
         _features = features;
         _languageDiscovery = languageDiscovery;
         _logger = logger;
@@ -167,7 +164,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
 
     /// <summary>
     /// Resolves the directory containing the nearest aspire.config.json (or legacy settings file)
-    /// by using the already-resolved path from <see cref="IConfigurationService"/>.
+    /// by searching upward from <paramref name="appHostDirectory"/>.
     /// Falls back to <paramref name="appHostDirectory"/> when no config file is found.
     /// </summary>
     private static DirectoryInfo GetConfigDirectory(DirectoryInfo appHostDirectory)

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -170,24 +170,24 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
     /// by using the already-resolved path from <see cref="IConfigurationService"/>.
     /// Falls back to <paramref name="appHostDirectory"/> when no config file is found.
     /// </summary>
-    private DirectoryInfo GetConfigDirectory(DirectoryInfo appHostDirectory)
+    private static DirectoryInfo GetConfigDirectory(DirectoryInfo appHostDirectory)
     {
-        var settingsFilePath = _configurationService.GetSettingsFilePath(isGlobal: false);
-        var settingsFile = new FileInfo(settingsFilePath);
-
-        // If the settings file exists and has a parent directory, use that
-        if (settingsFile.Directory is { Exists: true })
+        // Search from the apphost's directory upward to find the nearest config file.
+        var nearAppHost = ConfigurationHelper.FindNearestConfigFilePath(appHostDirectory);
+        if (nearAppHost is not null)
         {
-            // For legacy .aspire/settings.json, the config directory is the parent of .aspire/
-            // TODO: Remove legacy .aspire/ check once confident most users have migrated.
-            // Tracked by https://github.com/dotnet/aspire/issues/15239
-            if (string.Equals(settingsFile.Directory.Name, ".aspire", StringComparison.OrdinalIgnoreCase)
-                && settingsFile.Directory.Parent is not null)
+            var configFile = new FileInfo(nearAppHost);
+            if (configFile.Directory is { Exists: true })
             {
-                return settingsFile.Directory.Parent;
-            }
+                // For legacy .aspire/settings.json, the config directory is the parent of .aspire/
+                if (string.Equals(configFile.Directory.Name, ".aspire", StringComparison.OrdinalIgnoreCase)
+                    && configFile.Directory.Parent is not null)
+                {
+                    return configFile.Directory.Parent;
+                }
 
-            return settingsFile.Directory;
+                return configFile.Directory;
+            }
         }
 
         return appHostDirectory;
@@ -209,7 +209,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         }
     }
 
-    private void SaveConfiguration(AspireConfigFile config, DirectoryInfo directory)
+    private static void SaveConfiguration(AspireConfigFile config, DirectoryInfo directory)
     {
         var configDir = GetConfigDirectory(directory);
         config.Save(configDir.FullName);

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -401,6 +401,25 @@ internal sealed class ProjectLocator(
 
     private async Task CreateSettingsFileAsync(FileInfo projectFile, CancellationToken cancellationToken)
     {
+        // Search from the apphost's directory upward for an existing config file.
+        // This handles the case where "aspire new" created a project in a subdirectory
+        // and the user runs "aspire run" from the parent without cd-ing first.
+        if (projectFile.Directory is { } appHostDir)
+        {
+            var nearAppHost = ConfigurationHelper.FindNearestConfigFilePath(appHostDir);
+            if (nearAppHost is not null)
+            {
+                var existingConfig = AspireConfigFile.Load(Path.GetDirectoryName(nearAppHost)!);
+                if (existingConfig?.AppHost?.Path is not null)
+                {
+                    logger.LogDebug(
+                        "Found existing config with valid appHost.path at {Path}, skipping creation",
+                        nearAppHost);
+                    return;
+                }
+            }
+        }
+
         var settingsFile = GetOrCreateLocalAspireConfigFile();
         var fileExisted = settingsFile.Exists;
 

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -410,6 +410,18 @@ internal sealed class ProjectLocator(
             if (nearAppHost is not null)
             {
                 var configDir = Path.GetDirectoryName(nearAppHost)!;
+
+                // For legacy .aspire/settings.json, the config root is the parent of .aspire/
+                var trimmedConfigDir = configDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                if (string.Equals(Path.GetFileName(trimmedConfigDir), ".aspire", StringComparison.OrdinalIgnoreCase))
+                {
+                    var parentDir = Directory.GetParent(trimmedConfigDir);
+                    if (parentDir is not null)
+                    {
+                        configDir = parentDir.FullName;
+                    }
+                }
+
                 var existingConfig = AspireConfigFile.Load(configDir);
                 if (existingConfig?.AppHost?.Path is { } existingPath)
                 {

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -409,13 +409,23 @@ internal sealed class ProjectLocator(
             var nearAppHost = ConfigurationHelper.FindNearestConfigFilePath(appHostDir);
             if (nearAppHost is not null)
             {
-                var existingConfig = AspireConfigFile.Load(Path.GetDirectoryName(nearAppHost)!);
-                if (existingConfig?.AppHost?.Path is not null)
+                var configDir = Path.GetDirectoryName(nearAppHost)!;
+                var existingConfig = AspireConfigFile.Load(configDir);
+                if (existingConfig?.AppHost?.Path is { } existingPath)
                 {
-                    logger.LogDebug(
-                        "Found existing config with valid appHost.path at {Path}, skipping creation",
-                        nearAppHost);
-                    return;
+                    // Resolve the stored path relative to the config file's directory.
+                    var resolvedPath = Path.GetFullPath(
+                        Path.IsPathRooted(existingPath) ? existingPath : Path.Combine(configDir, existingPath));
+
+                    // Only skip creation if the config already points to the discovered apphost.
+                    // If the path is stale/invalid, fall through so the config gets healed.
+                    if (string.Equals(resolvedPath, projectFile.FullName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        logger.LogDebug(
+                            "Config at {Path} already references apphost {AppHost}, skipping creation",
+                            nearAppHost, projectFile.FullName);
+                        return;
+                    }
                 }
             }
         }

--- a/src/Aspire.Cli/Utils/ConfigurationHelper.cs
+++ b/src/Aspire.Cli/Utils/ConfigurationHelper.cs
@@ -70,6 +70,34 @@ internal static class ConfigurationHelper
     }
 
     /// <summary>
+    /// Searches upward from <paramref name="startDirectory"/> for the nearest
+    /// <c>aspire.config.json</c> or legacy <c>.aspire/settings.json</c>.
+    /// </summary>
+    /// <returns>The full path to the config file, or <c>null</c> if none is found.</returns>
+    internal static string? FindNearestConfigFilePath(DirectoryInfo startDirectory)
+    {
+        var searchDir = startDirectory;
+        while (searchDir is not null)
+        {
+            var configPath = Path.Combine(searchDir.FullName, AspireConfigFile.FileName);
+            if (File.Exists(configPath))
+            {
+                return configPath;
+            }
+
+            var legacyPath = BuildPathToSettingsJsonFile(searchDir.FullName);
+            if (File.Exists(legacyPath))
+            {
+                return legacyPath;
+            }
+
+            searchDir = searchDir.Parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Serializes a JsonObject and writes it to a settings file, creating the directory if needed.
     /// </summary>
     internal static async Task WriteSettingsFileAsync(string filePath, JsonObject settings, CancellationToken cancellationToken = default)

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/aspire.config.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "path": "apphost.cs"
+  }
+}

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/aspire.config.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "path": "Aspire.AppHost1.csproj"
+  }
+}

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/aspire.config.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "path": "AspireApplication.1.AppHost/AspireApplication.1.AppHost.csproj"
+  }
+}

--- a/src/Aspire.ProjectTemplates/templates/aspire-py-starter/aspire.config.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-py-starter/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "path": "apphost.cs"
+  }
+}

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/aspire.config.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "path": "Aspire-StarterApplication.1.AppHost/Aspire-StarterApplication.1.AppHost.csproj"
+  }
+}

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/aspire.config.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "path": "Aspire-StarterApplication.1.AppHost/Aspire-StarterApplication.1.AppHost.csproj"
+  }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/ConfigDiscoveryTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ConfigDiscoveryTests.cs
@@ -69,6 +69,8 @@ public sealed class ConfigDiscoveryTests(ITestOutputHelper output)
         // Step 2: Stay in the parent directory (do NOT cd into the project).
         // Run aspire run — this should find the apphost in the subdirectory
         // and use the adjacent aspire.config.json, not create a new one in CWD.
+        // Run aspire run — this should find the apphost in the subdirectory
+        // and use the adjacent aspire.config.json, not create a new one in CWD.
         await auto.TypeAsync($"aspire run --apphost {projectName}");
         await auto.EnterAsync();
 
@@ -101,6 +103,10 @@ public sealed class ConfigDiscoveryTests(ITestOutputHelper output)
             $"aspire.config.json in project directory should still exist: {projectConfigPath}");
 
         var currentContent = File.ReadAllText(projectConfigPath);
+
+        // Verify the config was not modified by the run.
+        Assert.Equal(originalContent, currentContent);
+
         using var doc = JsonDocument.Parse(currentContent);
         var root = doc.RootElement;
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/ConfigDiscoveryTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ConfigDiscoveryTests.cs
@@ -1,0 +1,143 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Tests.Utils;
+using Hex1b.Automation;
+using Hex1b.Input;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests verifying that <c>aspire.config.json</c> is discovered from the
+/// apphost's directory rather than being recreated in the current working directory.
+/// </summary>
+/// <remarks>
+/// Reproduces the bug where <c>aspire new myproject</c> creates the config inside
+/// <c>myproject/</c>, but running <c>aspire run</c> from the parent directory
+/// creates a spurious <c>aspire.config.json</c> in the parent instead of finding
+/// the one adjacent to <c>apphost.ts</c>.
+/// </remarks>
+public sealed class ConfigDiscoveryTests(ITestOutputHelper output)
+{
+    /// <summary>
+    /// Verifies that running <c>aspire run</c> from a parent directory discovers the
+    /// existing <c>aspire.config.json</c> next to the apphost rather than creating a
+    /// new one in the current working directory.
+    /// </summary>
+    [Fact]
+    public async Task RunFromParentDirectory_UsesExistingConfigNearAppHost()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var installMode = CliE2ETestHelpers.DetectDockerInstallMode(repoRoot);
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(
+            repoRoot, installMode, output,
+            variant: CliE2ETestHelpers.DockerfileVariant.Polyglot,
+            mountDockerSocket: true,
+            workspace: workspace);
+
+        var pendingRun = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliInDockerAsync(installMode, counter);
+
+        const string projectName = "ConfigTest";
+
+        // Step 1: Create a TypeScript Empty AppHost project.
+        // This creates a subdirectory with aspire.config.json inside it.
+        await auto.AspireNewAsync(projectName, counter, template: AspireTemplate.TypeScriptEmptyAppHost);
+
+        // Capture the original config content before running from the parent directory.
+        var projectConfigPath = Path.Combine(
+            workspace.WorkspaceRoot.FullName, projectName, "aspire.config.json");
+        var parentConfigPath = Path.Combine(
+            workspace.WorkspaceRoot.FullName, "aspire.config.json");
+
+        // Verify the project config was created by aspire new
+        Assert.True(File.Exists(projectConfigPath),
+            $"aspire new should have created {projectConfigPath}");
+
+        var originalContent = File.ReadAllText(projectConfigPath);
+
+        // Step 2: Stay in the parent directory (do NOT cd into the project).
+        // Run aspire run — this should find the apphost in the subdirectory
+        // and use the adjacent aspire.config.json, not create a new one in CWD.
+        await auto.TypeAsync($"aspire run --apphost {projectName}");
+        await auto.EnterAsync();
+
+        // Wait for the run to start (or fail) — either way the config discovery has happened.
+        await auto.WaitUntilAsync(s =>
+        {
+            // If a "Select an apphost" prompt appears, the bug may have caused multiple detection
+            if (s.ContainsText("Select an apphost to use:"))
+            {
+                throw new InvalidOperationException("Multiple apphosts incorrectly detected");
+            }
+
+            return s.ContainsText("Press CTRL+C to stop the apphost and exit.")
+                || s.ContainsText("ERR:");
+        }, timeout: TimeSpan.FromMinutes(3), description: "aspire run started or errored");
+
+        // Stop the apphost
+        await auto.Ctrl().KeyAsync(Hex1bKey.C);
+        await auto.WaitForAnyPromptAsync(counter, timeout: TimeSpan.FromSeconds(30));
+
+        // Step 3: Assertions on file system state (host-side via bind mount).
+
+        // The parent directory should NOT have an aspire.config.json.
+        Assert.False(File.Exists(parentConfigPath),
+            $"aspire.config.json should NOT be created in the parent/CWD directory. " +
+            $"Found: {parentConfigPath}");
+
+        // The project's aspire.config.json should still exist with its original rich content.
+        Assert.True(File.Exists(projectConfigPath),
+            $"aspire.config.json in project directory should still exist: {projectConfigPath}");
+
+        var currentContent = File.ReadAllText(projectConfigPath);
+        using var doc = JsonDocument.Parse(currentContent);
+        var root = doc.RootElement;
+
+        // Verify appHost.path is "apphost.ts"
+        Assert.True(root.TryGetProperty("appHost", out var appHost),
+            $"aspire.config.json missing 'appHost' property. Content:\n{currentContent}");
+        Assert.True(appHost.TryGetProperty("path", out var pathProp),
+            $"aspire.config.json missing 'appHost.path'. Content:\n{currentContent}");
+        Assert.Equal("apphost.ts", pathProp.GetString());
+
+        // Verify language is typescript
+        Assert.True(appHost.TryGetProperty("language", out var langProp),
+            $"aspire.config.json missing 'appHost.language'. Content:\n{currentContent}");
+        Assert.Contains("typescript", langProp.GetString(), StringComparison.OrdinalIgnoreCase);
+
+        // Verify profiles section exists with applicationUrl
+        Assert.True(root.TryGetProperty("profiles", out var profiles),
+            $"aspire.config.json missing 'profiles' section. Content:\n{currentContent}");
+        Assert.True(profiles.EnumerateObject().Any(),
+            $"aspire.config.json 'profiles' section is empty. Content:\n{currentContent}");
+
+        // At least one profile should have an applicationUrl
+        var hasApplicationUrl = false;
+        foreach (var profile in profiles.EnumerateObject())
+        {
+            if (profile.Value.TryGetProperty("applicationUrl", out _))
+            {
+                hasApplicationUrl = true;
+                break;
+            }
+        }
+        Assert.True(hasApplicationUrl,
+            $"No profile has 'applicationUrl'. Content:\n{currentContent}");
+
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+    }
+}

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -302,7 +302,7 @@ public class GuestAppHostProjectTests(ITestOutputHelper outputHelper) : IDisposa
     [Fact]
     public void GetServerEnvironmentVariables_ParsesLaunchSettingsWithComments()
     {
-        var project = CreateGuestAppHostProject(_workspace.WorkspaceRoot);
+        var project = CreateGuestAppHostProject();
 
         var propertiesDir = _workspace.CreateDirectory("Properties");
         var launchSettingsPath = Path.Combine(propertiesDir.FullName, "launchSettings.json");
@@ -333,7 +333,7 @@ public class GuestAppHostProjectTests(ITestOutputHelper outputHelper) : IDisposa
         Assert.False(envVars.ContainsKey("ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL"));
     }
 
-    private static GuestAppHostProject CreateGuestAppHostProject(DirectoryInfo workspaceRoot)
+    private static GuestAppHostProject CreateGuestAppHostProject()
     {
         var language = new LanguageInfo(
             LanguageId: "typescript/nodejs",
@@ -341,13 +341,6 @@ public class GuestAppHostProjectTests(ITestOutputHelper outputHelper) : IDisposa
             PackageName: "Aspire.Hosting.CodeGeneration.TypeScript",
             DetectionPatterns: ["apphost.ts"],
             CodeGenerator: "TypeScript");
-
-        // Point the config service at a non-existent file so GetConfigDirectory
-        // falls back to the directory we pass to GetServerEnvironmentVariables.
-        var configService = new TestConfigurationService
-        {
-            SettingsFilePath = Path.Combine(workspaceRoot.FullName, "nonexistent", "settings.json")
-        };
 
         var configuration = new ConfigurationBuilder().Build();
 
@@ -362,7 +355,6 @@ public class GuestAppHostProjectTests(ITestOutputHelper outputHelper) : IDisposa
             runner: new TestDotNetCliRunner(),
             packagingService: new TestPackagingService(),
             configuration: configuration,
-            configurationService: configService,
             features: new Features(configuration, NullLogger<Features>.Instance),
             languageDiscovery: new TestLanguageDiscovery(),
             logger: NullLogger<GuestAppHostProject>.Instance,


### PR DESCRIPTION
## Description

When a user runs `aspire new` followed by `aspire run` from the parent directory (without `cd`-ing into the created project), the CLI creates a spurious `aspire.config.json` in the current working directory instead of using the one adjacent to the discovered apphost. This happens because config discovery searches upward from CWD rather than from the apphost's directory.

**Changes:**

1. **Fix config discovery to search from apphost directory** — Added `ConfigurationHelper.FindNearestConfigFilePath()` helper that searches upward from a given directory. Updated `ProjectLocator.CreateSettingsFileAsync` and `GuestAppHostProject.GetConfigDirectory` to search from the apphost's directory rather than CWD.

2. **Handle stale config paths** — Only skip config creation when the stored `appHost.path` resolves to the same apphost that was discovered. If the path is stale/invalid, fall through so the config gets healed.

3. **Add `aspire.config.json` to all .NET apphost templates** — The CLI's TypeScript templates already included `aspire.config.json`, but the .NET SDK templates did not. Added minimal `aspire.config.json` (with `appHost.path`) to all five .NET templates:
   - `aspire-apphost` (csproj)
   - `aspire-apphost-singlefile`
   - `aspire-empty` (solution)
   - `aspire-starter` (solution)
   - `aspire-ts-cs-starter` (solution)

   The template engine's `sourceName` substitution ensures the path matches the actual project name chosen by the user.

4. **E2E test** — `ConfigDiscoveryTests` creates a TypeScript Empty AppHost via `aspire new`, stays in the parent directory, runs `aspire run`, and asserts that no config leaks to CWD and the subdirectory config is preserved.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
