### PR TITLE
Enable CFSClean policies and use dotnet-public feed for winget CLI

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -105,6 +105,8 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean2
     featureFlags:
       autoEnablePREfastWithNewRuleset: false
       autoEnableRoslynWithNewRuleset: false

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -106,7 +106,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     settings:
-      networkIsolationPolicy: Permissive, CFSClean, CFSClean2
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2
     featureFlags:
       autoEnablePREfastWithNewRuleset: false
       autoEnableRoslynWithNewRuleset: false

--- a/eng/pipelines/templates/prepare-winget-manifest.yml
+++ b/eng/pipelines/templates/prepare-winget-manifest.yml
@@ -42,8 +42,13 @@ steps:
     displayName: 🟣Set version ${{ parameters.version }}
 
   - pwsh: |
-      Write-Host "Installing Microsoft.WinGet.Client from PSGallery..."
-      Install-PSResource -Name Microsoft.WinGet.Client -Repository PSGallery -TrustRepository
+      Write-Host "Registering dotnet-public feed as PSResource repository..."
+      Register-PSResourceRepository -Name 'dotnet-public' `
+        -Uri 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json' `
+        -Trusted
+
+      Write-Host "Installing Microsoft.WinGet.Client from dotnet-public feed..."
+      Install-PSResource -Name Microsoft.WinGet.Client -Repository 'dotnet-public' -TrustRepository
 
       Write-Host "Microsoft.WinGet.Client installed. Listing installed version:"
       Get-Module -ListAvailable Microsoft.WinGet.Client | Select-Object Name, Version | Format-Table

--- a/eng/pipelines/templates/prepare-winget-manifest.yml
+++ b/eng/pipelines/templates/prepare-winget-manifest.yml
@@ -42,14 +42,19 @@ steps:
     displayName: 🟣Set version ${{ parameters.version }}
 
   - pwsh: |
-      Write-Host "Registering dotnet-public feed as PSResource repository..."
-      Register-PSResourceRepository -Name 'dotnet-public' `
-        -Uri 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json' `
-        -Trusted
+      $repoName = 'dotnet-public'
+      $repoUri = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json'
 
-      Write-Host "Installing Microsoft.WinGet.Client from dotnet-public feed..."
-      Install-PSResource -Name Microsoft.WinGet.Client -Repository 'dotnet-public' -TrustRepository
+      Write-Host "Ensuring PSResource repository '$repoName' is registered..."
+      $existingRepo = Get-PSResourceRepository -Name $repoName -ErrorAction SilentlyContinue
+      if ($null -eq $existingRepo) {
+        Register-PSResourceRepository -Name $repoName -Uri $repoUri -Trusted
+      } else {
+        Write-Host "PSResource repository '$repoName' is already registered. Skipping registration."
+      }
 
+      Write-Host "Installing Microsoft.WinGet.Client from $repoName feed..."
+      Install-PSResource -Name Microsoft.WinGet.Client -Repository $repoName -TrustRepository
       Write-Host "Microsoft.WinGet.Client installed. Listing installed version:"
       Get-Module -ListAvailable Microsoft.WinGet.Client | Select-Object Name, Version | Format-Table
 


### PR DESCRIPTION
- Add networkIsolationPolicy: Permissive, CFSClean, CFSClean2 to the 1ES official pipeline template parameters
- Switch winget CLI installation from PSGallery to dotnet-public Azure Artifacts feed to comply with CFSClean network restrictions

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [ ] No
