### PR TITLE
Fix Windows CLI backchannel socket path

### DIFF
--- a/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
+++ b/src/Aspire.Cli/DotNet/DotNetCliRunner.cs
@@ -83,7 +83,7 @@ internal sealed class DotNetCliRunner(
 
     internal static string GetBackchannelSocketPath()
     {
-        return CliPathHelper.CreateSocketPath("cli.sock");
+        return CliPathHelper.CreateUnixDomainSocketPath("cli.sock");
     }
 
     private async Task<int> ExecuteAsync(

--- a/src/Aspire.Cli/Projects/AppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/AppHostServerProject.cs
@@ -34,7 +34,7 @@ internal sealed class AppHostServerProjectFactory(
 {
     public async Task<IAppHostServerProject> CreateAsync(string appPath, CancellationToken cancellationToken = default)
     {
-        var socketPath = CliPathHelper.CreateSocketPath("apphost.sock");
+        var socketPath = CliPathHelper.CreateGuestAppHostSocketPath("apphost.sock");
 
         // Priority 1: Check for dev mode (ASPIRE_REPO_ROOT or running from Aspire source repo)
         var repoRoot = AspireRepositoryDetector.DetectRepositoryRoot(appPath);

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -925,7 +925,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
     /// </summary>
     private static string GetBackchannelSocketPath()
     {
-        return CliPathHelper.CreateSocketPath("cli.sock");
+        return CliPathHelper.CreateUnixDomainSocketPath("cli.sock");
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Utils/CliPathHelper.cs
+++ b/src/Aspire.Cli/Utils/CliPathHelper.cs
@@ -18,11 +18,6 @@ internal static class CliPathHelper
     {
         var socketName = $"{socketPrefix}.{BackchannelConstants.CreateRandomIdentifier()}";
 
-        if (OperatingSystem.IsWindows())
-        {
-            return socketName;
-        }
-
         var socketDirectory = GetCliSocketDirectory();
         Directory.CreateDirectory(socketDirectory);
         return Path.Combine(socketDirectory, socketName);

--- a/src/Aspire.Cli/Utils/CliPathHelper.cs
+++ b/src/Aspire.Cli/Utils/CliPathHelper.cs
@@ -14,9 +14,20 @@ internal static class CliPathHelper
     /// Creates a randomized CLI-managed socket path.
     /// </summary>
     /// <param name="socketPrefix">The socket file prefix.</param>
-    internal static string CreateSocketPath(string socketPrefix)
+    internal static string CreateUnixDomainSocketPath(string socketPrefix)
+        => CreateSocketPath(socketPrefix, isGuestAppHost: false);
+
+    internal static string CreateGuestAppHostSocketPath(string socketPrefix)
+        => CreateSocketPath(socketPrefix, isGuestAppHost: true);
+
+    private static string CreateSocketPath(string socketPrefix, bool isGuestAppHost)
     {
         var socketName = $"{socketPrefix}.{BackchannelConstants.CreateRandomIdentifier()}";
+
+        if (isGuestAppHost && OperatingSystem.IsWindows())
+        {
+            return socketName;
+        }
 
         var socketDirectory = GetCliSocketDirectory();
         Directory.CreateDirectory(socketDirectory);

--- a/tests/Aspire.Cli.Tests/Utils/CliPathHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliPathHelperTests.cs
@@ -8,12 +8,12 @@ namespace Aspire.Cli.Tests.Utils;
 public class CliPathHelperTests(ITestOutputHelper outputHelper)
 {
     [Fact]
-    public void CreateSocketPath_UsesRandomizedIdentifier()
+    public void CreateGuestAppHostSocketPath_UsesRandomizedIdentifier()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
 
-        var socketPath1 = CliPathHelper.CreateSocketPath("apphost.sock");
-        var socketPath2 = CliPathHelper.CreateSocketPath("apphost.sock");
+        var socketPath1 = CliPathHelper.CreateGuestAppHostSocketPath("apphost.sock");
+        var socketPath2 = CliPathHelper.CreateGuestAppHostSocketPath("apphost.sock");
 
         Assert.NotEqual(socketPath1, socketPath2);
 
@@ -30,5 +30,22 @@ public class CliPathHelperTests(ITestOutputHelper outputHelper)
             Assert.Matches("^apphost\\.sock\\.[a-f0-9]{12}$", Path.GetFileName(socketPath1));
             Assert.Matches("^apphost\\.sock\\.[a-f0-9]{12}$", Path.GetFileName(socketPath2));
         }
+    }
+
+    [Fact]
+    public void CreateUnixDomainSocketPath_UsesRandomizedIdentifier()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var socketPath1 = CliPathHelper.CreateUnixDomainSocketPath("apphost.sock");
+        var socketPath2 = CliPathHelper.CreateUnixDomainSocketPath("apphost.sock");
+
+        Assert.NotEqual(socketPath1, socketPath2);
+
+        var expectedDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspire", "cli", "runtime", "sockets");
+        Assert.Equal(expectedDirectory, Path.GetDirectoryName(socketPath1));
+        Assert.Equal(expectedDirectory, Path.GetDirectoryName(socketPath2));
+        Assert.Matches("^apphost\\.sock\\.[a-f0-9]{12}$", Path.GetFileName(socketPath1));
+        Assert.Matches("^apphost\\.sock\\.[a-f0-9]{12}$", Path.GetFileName(socketPath2));
     }
 }


### PR DESCRIPTION
## Customer impact

`aspire run` doesn't work on Windows machines because we aren't fully qualifying the socket path.

## Testing

Manual

## Regression

Yes, from previous build.