### PR TITLE
Add Windows CLI starter validation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -225,6 +225,7 @@ jobs:
           aspire --version
 
       - name: Create starter app and validate startup
+        timeout-minutes: 10
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -240,7 +240,7 @@ jobs:
             @{
               TemplateId = 'aspire-ts-starter'
               ProjectName = 'AspireCliTsStarterSmoke'
-              ExpectedResources = @('server', 'webfrontend')
+              ExpectedResources = @('app', 'frontend')
             },
             @{
               TemplateId = 'aspire-starter'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -224,6 +224,14 @@ jobs:
 
           aspire --version
 
+      - name: Trust Aspire HTTPS development certificate
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          aspire certs trust --non-interactive --nologo
+
       - name: Create starter app and validate startup
         timeout-minutes: 10
         shell: pwsh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -262,7 +262,6 @@ jobs:
             $startStdOutPath = Join-Path $diagnosticsDir 'aspire-start.stdout.log'
             $startStdErrPath = Join-Path $diagnosticsDir 'aspire-start.stderr.log'
             $startCombinedPath = Join-Path $diagnosticsDir 'aspire-start.log'
-            $resourcesPath = Join-Path $diagnosticsDir 'aspire-resources.json'
             $stopLogPath = Join-Path $diagnosticsDir 'aspire-stop.log'
 
             New-Item -ItemType Directory -Path $diagnosticsDir -Force | Out-Null
@@ -315,33 +314,32 @@ jobs:
                   throw "${templateId}: aspire start did not report a successful startup."
                 }
 
-                $deadline = (Get-Date).AddSeconds([int]$env:RESOURCE_READY_TIMEOUT_SECONDS)
-                $resourcesReady = $false
+                Set-Location $projectRoot
 
-                do {
-                  Set-Location $projectRoot
+                foreach ($resourceName in $expectedResources) {
+                  $sanitizedResourceName = $resourceName -replace '[^A-Za-z0-9_.-]', '_'
+                  $waitStdOutPath = Join-Path $diagnosticsDir "aspire-wait-${sanitizedResourceName}.stdout.log"
+                  $waitStdErrPath = Join-Path $diagnosticsDir "aspire-wait-${sanitizedResourceName}.stderr.log"
+                  $waitCombinedPath = Join-Path $diagnosticsDir "aspire-wait-${sanitizedResourceName}.log"
 
-                  $resourcesJson = aspire resources --format json
-                  Set-Content -Path $resourcesPath -Value $resourcesJson
+                  $waitProcess = Start-Process -FilePath 'aspire' `
+                    -ArgumentList @('wait', $resourceName, '--status', 'up', '--timeout', $env:RESOURCE_READY_TIMEOUT_SECONDS) `
+                    -WorkingDirectory $projectRoot `
+                    -RedirectStandardOutput $waitStdOutPath `
+                    -RedirectStandardError $waitStdErrPath `
+                    -Wait `
+                    -PassThru
 
-                  $resources = @((ConvertFrom-Json $resourcesJson).resources)
-                  $readyResources = $resources | Where-Object {
-                    $_.Name -in $expectedResources -and
-                    $_.State -eq 'Running' -and
-                    ($null -eq $_.HealthStatus -or $_.HealthStatus -ne 'Unhealthy')
+                  $waitOutput = @(
+                    if (Test-Path $waitStdOutPath) { Get-Content $waitStdOutPath }
+                    if (Test-Path $waitStdErrPath) { Get-Content $waitStdErrPath }
+                  ) -join [Environment]::NewLine
+
+                  Set-Content -Path $waitCombinedPath -Value $waitOutput
+
+                  if ($waitProcess.ExitCode -ne 0) {
+                    throw "${templateId}: aspire wait for resource $resourceName failed with exit code $($waitProcess.ExitCode)."
                   }
-
-                  if ($readyResources.Count -eq $expectedResources.Count) {
-                    $resourcesReady = $true
-                    break
-                  }
-
-                  Start-Sleep -Seconds 5
-                } while ((Get-Date) -lt $deadline)
-
-                if (-not $resourcesReady) {
-                  $expectedResourcesText = $expectedResources -join ', '
-                  throw "${templateId}: expected resources $expectedResourcesText to be running within $($env:RESOURCE_READY_TIMEOUT_SECONDS) seconds."
                 }
 
                 Write-Host "$templateId started in $([math]::Round($elapsed.TotalSeconds, 2)) seconds."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -196,7 +196,6 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && github.repository_owner == 'dotnet' }}
     env:
       GH_TOKEN: ${{ github.token }}
-      START_TIMEOUT_SECONDS: '60'
       MAX_STARTUP_SECONDS: '120'
       RESOURCE_READY_TIMEOUT_SECONDS: '60'
     steps:
@@ -220,10 +219,7 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
-          $scriptUrl = "https://raw.githubusercontent.com/dotnet/aspire/${{ github.event.pull_request.head.sha }}/eng/scripts/get-aspire-cli-pr.ps1"
-          $scriptPath = Join-Path $env:RUNNER_TEMP "get-aspire-cli-pr.ps1"
-
-          Invoke-WebRequest -Uri $scriptUrl -OutFile $scriptPath
+          $scriptPath = Join-Path $env:GITHUB_WORKSPACE "eng/scripts/get-aspire-cli-pr.ps1"
           & $scriptPath ${{ github.event.pull_request.number }} -WorkflowRunId ${{ github.run_id }} -SkipExtension
 
           aspire --version
@@ -264,6 +260,7 @@ jobs:
             $startCombinedPath = Join-Path $diagnosticsDir 'aspire-start.log'
             $stopLogPath = Join-Path $diagnosticsDir 'aspire-stop.log'
 
+            New-Item -ItemType Directory -Path $templateRoot -Force | Out-Null
             New-Item -ItemType Directory -Path $diagnosticsDir -Force | Out-Null
 
             Push-Location $templateRoot
@@ -280,14 +277,14 @@ jobs:
                   -PassThru
 
                 try {
-                  $process | Wait-Process -Timeout ([int]$env:START_TIMEOUT_SECONDS) -ErrorAction Stop
+                  $process | Wait-Process -Timeout ([int]$env:MAX_STARTUP_SECONDS) -ErrorAction Stop
                 }
                 catch {
                   if (-not $process.HasExited) {
                     $process | Stop-Process -Force -ErrorAction SilentlyContinue
                   }
 
-                  throw "${templateId}: aspire start did not exit within $($env:START_TIMEOUT_SECONDS) seconds."
+                  throw "${templateId}: aspire start did not exit within $($env:MAX_STARTUP_SECONDS) seconds."
                 }
 
                 $elapsed = (Get-Date) - $startAt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -288,7 +288,7 @@ jobs:
                     $process | Stop-Process -Force -ErrorAction SilentlyContinue
                   }
 
-                  throw "$templateId: aspire start did not exit within $($env:START_TIMEOUT_SECONDS) seconds."
+                  throw "${templateId}: aspire start did not exit within $($env:START_TIMEOUT_SECONDS) seconds."
                 }
 
                 $elapsed = (Get-Date) - $startAt
@@ -300,19 +300,19 @@ jobs:
                 Set-Content -Path $startCombinedPath -Value $startOutput
 
                 if ($process.ExitCode -ne 0) {
-                  throw "$templateId: aspire start failed with exit code $($process.ExitCode)."
+                  throw "${templateId}: aspire start failed with exit code $($process.ExitCode)."
                 }
 
                 if ($elapsed.TotalSeconds -ge [int]$env:MAX_STARTUP_SECONDS) {
-                  throw "$templateId: aspire start took $([math]::Round($elapsed.TotalSeconds, 2)) seconds, which exceeds the $($env:MAX_STARTUP_SECONDS)-second limit."
+                  throw "${templateId}: aspire start took $([math]::Round($elapsed.TotalSeconds, 2)) seconds, which exceeds the $($env:MAX_STARTUP_SECONDS)-second limit."
                 }
 
                 if ($startOutput -match 'Timeout waiting for apphost to start') {
-                  throw "$templateId: aspire start reported a startup timeout."
+                  throw "${templateId}: aspire start reported a startup timeout."
                 }
 
                 if ($startOutput -notmatch 'Apphost started successfully\.') {
-                  throw "$templateId: aspire start did not report a successful startup."
+                  throw "${templateId}: aspire start did not report a successful startup."
                 }
 
                 $deadline = (Get-Date).AddSeconds([int]$env:RESOURCE_READY_TIMEOUT_SECONDS)
@@ -341,7 +341,7 @@ jobs:
 
                 if (-not $resourcesReady) {
                   $expectedResourcesText = $expectedResources -join ', '
-                  throw "$templateId: expected resources $expectedResourcesText to be running within $($env:RESOURCE_READY_TIMEOUT_SECONDS) seconds."
+                  throw "${templateId}: expected resources $expectedResourcesText to be running within $($env:RESOURCE_READY_TIMEOUT_SECONDS) seconds."
                 }
 
                 Write-Host "$templateId started in $([math]::Round($elapsed.TotalSeconds, 2)) seconds."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -315,6 +315,30 @@ jobs:
 
                 Set-Location $projectRoot
 
+                $resourcesStdOutPath = Join-Path $diagnosticsDir 'aspire-resources.stdout.log'
+                $resourcesStdErrPath = Join-Path $diagnosticsDir 'aspire-resources.stderr.log'
+                $resourcesCombinedPath = Join-Path $diagnosticsDir 'aspire-resources.log'
+
+                $resourcesProcess = Start-Process -FilePath 'aspire' `
+                  -ArgumentList @('resources') `
+                  -WorkingDirectory $projectRoot `
+                  -RedirectStandardOutput $resourcesStdOutPath `
+                  -RedirectStandardError $resourcesStdErrPath `
+                  -Wait `
+                  -PassThru
+
+                $resourcesOutput = @(
+                  if (Test-Path $resourcesStdOutPath) { Get-Content $resourcesStdOutPath }
+                  if (Test-Path $resourcesStdErrPath) { Get-Content $resourcesStdErrPath }
+                ) -join [Environment]::NewLine
+
+                Set-Content -Path $resourcesCombinedPath -Value $resourcesOutput
+                Write-Host $resourcesOutput
+
+                if ($resourcesProcess.ExitCode -ne 0) {
+                  throw "${templateId}: aspire resources failed with exit code $($resourcesProcess.ExitCode)."
+                }
+
                 foreach ($resourceName in $expectedResources) {
                   $sanitizedResourceName = $resourceName -replace '[^A-Za-z0-9_.-]', '_'
                   $waitStdOutPath = Join-Path $diagnosticsDir "aspire-wait-${sanitizedResourceName}.stdout.log"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -198,7 +198,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       MAX_STARTUP_SECONDS: '120'
-      RESOURCE_READY_TIMEOUT_SECONDS: '60'
+      RESOURCE_READY_TIMEOUT_SECONDS: '120'
     steps:
       - name: Checkout PR head
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -245,7 +245,7 @@ jobs:
             @{
               TemplateId = 'aspire-starter'
               ProjectName = 'AspireCliCsStarterSmoke'
-              ExpectedResources = @('apiservice', 'webfrontend')
+              ExpectedResources = @('apiservice')
             }
           )
           $failures = [System.Collections.Generic.List[string]]::new()
@@ -260,6 +260,7 @@ jobs:
             $startStdOutPath = Join-Path $diagnosticsDir 'aspire-start.stdout.log'
             $startStdErrPath = Join-Path $diagnosticsDir 'aspire-start.stderr.log'
             $startCombinedPath = Join-Path $diagnosticsDir 'aspire-start.log'
+            $preStartStopLogPath = Join-Path $diagnosticsDir 'aspire-stop-before-start.log'
             $stopLogPath = Join-Path $diagnosticsDir 'aspire-stop.log'
 
             New-Item -ItemType Directory -Path $templateRoot -Force | Out-Null
@@ -269,6 +270,19 @@ jobs:
             try {
               try {
                 aspire new $templateId --name $projectName --output $projectRoot --channel pr-${{ github.event.pull_request.number }} --non-interactive --nologo
+
+                try {
+                  aspire stop *> $preStartStopLogPath
+                }
+                catch {
+                  $preStartStopOutput = if (Test-Path $preStartStopLogPath) { Get-Content $preStartStopLogPath -Raw } else { '' }
+                  if ($preStartStopOutput -notmatch 'No running apphost found\.') {
+                    Write-Warning "$templateId pre-start cleanup with aspire stop failed: $($_.Exception.Message)"
+                    if ($preStartStopOutput) {
+                      Write-Host $preStartStopOutput
+                    }
+                  }
+                }
 
                 $startAt = Get-Date
                 $process = Start-Process -FilePath 'aspire' `

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -192,6 +192,7 @@ jobs:
   cli_starter_validation_win:
     name: Aspire CLI Starter Validation (Windows)
     runs-on: windows-latest
+    timeout-minutes: 10
     needs: [build_packages, build_cli_archive_windows]
     if: ${{ github.event_name == 'pull_request' && github.repository_owner == 'microsoft' }}
     env:
@@ -225,6 +226,7 @@ jobs:
           aspire --version
 
       - name: Trust Aspire HTTPS development certificate
+        timeout-minutes: 3
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -189,6 +189,215 @@ jobs:
     with:
       versionOverrideArg: ${{ inputs.versionOverrideArg }}
 
+  cli_starter_validation_win:
+    name: Aspire CLI Starter Validation (Windows)
+    runs-on: windows-latest
+    needs: [build_packages, build_cli_archive_windows]
+    if: ${{ github.event_name == 'pull_request' && github.repository_owner == 'dotnet' }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      START_TIMEOUT_SECONDS: '60'
+      MAX_STARTUP_SECONDS: '120'
+      RESOURCE_READY_TIMEOUT_SECONDS: '60'
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          global-json-file: global.json
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+
+      - name: Install Aspire CLI from PR dogfood script
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          $scriptUrl = "https://raw.githubusercontent.com/dotnet/aspire/${{ github.event.pull_request.head.sha }}/eng/scripts/get-aspire-cli-pr.ps1"
+          $scriptPath = Join-Path $env:RUNNER_TEMP "get-aspire-cli-pr.ps1"
+
+          Invoke-WebRequest -Uri $scriptUrl -OutFile $scriptPath
+          & $scriptPath ${{ github.event.pull_request.number }} -WorkflowRunId ${{ github.run_id }} -SkipExtension
+
+          aspire --version
+
+      - name: Create starter app and validate startup
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          $validationRoot = Join-Path $env:RUNNER_TEMP 'aspire-cli-starter-validation'
+          Remove-Item -Recurse -Force $validationRoot -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $validationRoot -Force | Out-Null
+
+          $templates = @(
+            @{
+              TemplateId = 'aspire-ts-starter'
+              ProjectName = 'AspireCliTsStarterSmoke'
+              ExpectedResources = @('server', 'webfrontend')
+            },
+            @{
+              TemplateId = 'aspire-starter'
+              ProjectName = 'AspireCliCsStarterSmoke'
+              ExpectedResources = @('apiservice', 'webfrontend')
+            }
+          )
+          $failures = [System.Collections.Generic.List[string]]::new()
+
+          foreach ($template in $templates) {
+            $templateId = $template.TemplateId
+            $projectName = $template.ProjectName
+            $expectedResources = @($template.ExpectedResources)
+            $templateRoot = Join-Path $validationRoot $templateId
+            $diagnosticsDir = Join-Path $templateRoot 'diagnostics'
+            $projectRoot = Join-Path $templateRoot $projectName
+            $startStdOutPath = Join-Path $diagnosticsDir 'aspire-start.stdout.log'
+            $startStdErrPath = Join-Path $diagnosticsDir 'aspire-start.stderr.log'
+            $startCombinedPath = Join-Path $diagnosticsDir 'aspire-start.log'
+            $resourcesPath = Join-Path $diagnosticsDir 'aspire-resources.json'
+            $stopLogPath = Join-Path $diagnosticsDir 'aspire-stop.log'
+
+            New-Item -ItemType Directory -Path $diagnosticsDir -Force | Out-Null
+
+            Push-Location $templateRoot
+            try {
+              try {
+                aspire new $templateId --name $projectName --output $projectRoot --channel pr-${{ github.event.pull_request.number }} --non-interactive --nologo
+
+                $startAt = Get-Date
+                $process = Start-Process -FilePath 'aspire' `
+                  -ArgumentList @('start') `
+                  -WorkingDirectory $projectRoot `
+                  -RedirectStandardOutput $startStdOutPath `
+                  -RedirectStandardError $startStdErrPath `
+                  -PassThru
+
+                try {
+                  $process | Wait-Process -Timeout ([int]$env:START_TIMEOUT_SECONDS) -ErrorAction Stop
+                }
+                catch {
+                  if (-not $process.HasExited) {
+                    $process | Stop-Process -Force -ErrorAction SilentlyContinue
+                  }
+
+                  throw "$templateId: aspire start did not exit within $($env:START_TIMEOUT_SECONDS) seconds."
+                }
+
+                $elapsed = (Get-Date) - $startAt
+                $startOutput = @(
+                  if (Test-Path $startStdOutPath) { Get-Content $startStdOutPath }
+                  if (Test-Path $startStdErrPath) { Get-Content $startStdErrPath }
+                ) -join [Environment]::NewLine
+
+                Set-Content -Path $startCombinedPath -Value $startOutput
+
+                if ($process.ExitCode -ne 0) {
+                  throw "$templateId: aspire start failed with exit code $($process.ExitCode)."
+                }
+
+                if ($elapsed.TotalSeconds -ge [int]$env:MAX_STARTUP_SECONDS) {
+                  throw "$templateId: aspire start took $([math]::Round($elapsed.TotalSeconds, 2)) seconds, which exceeds the $($env:MAX_STARTUP_SECONDS)-second limit."
+                }
+
+                if ($startOutput -match 'Timeout waiting for apphost to start') {
+                  throw "$templateId: aspire start reported a startup timeout."
+                }
+
+                if ($startOutput -notmatch 'Apphost started successfully\.') {
+                  throw "$templateId: aspire start did not report a successful startup."
+                }
+
+                $deadline = (Get-Date).AddSeconds([int]$env:RESOURCE_READY_TIMEOUT_SECONDS)
+                $resourcesReady = $false
+
+                do {
+                  Set-Location $projectRoot
+
+                  $resourcesJson = aspire resources --format json
+                  Set-Content -Path $resourcesPath -Value $resourcesJson
+
+                  $resources = @((ConvertFrom-Json $resourcesJson).resources)
+                  $readyResources = $resources | Where-Object {
+                    $_.Name -in $expectedResources -and
+                    $_.State -eq 'Running' -and
+                    ($null -eq $_.HealthStatus -or $_.HealthStatus -ne 'Unhealthy')
+                  }
+
+                  if ($readyResources.Count -eq $expectedResources.Count) {
+                    $resourcesReady = $true
+                    break
+                  }
+
+                  Start-Sleep -Seconds 5
+                } while ((Get-Date) -lt $deadline)
+
+                if (-not $resourcesReady) {
+                  $expectedResourcesText = $expectedResources -join ', '
+                  throw "$templateId: expected resources $expectedResourcesText to be running within $($env:RESOURCE_READY_TIMEOUT_SECONDS) seconds."
+                }
+
+                Write-Host "$templateId started in $([math]::Round($elapsed.TotalSeconds, 2)) seconds."
+              }
+              catch {
+                $message = $_.Exception.Message
+                Write-Warning $message
+                $failures.Add($message)
+              }
+            }
+            finally {
+              if (Test-Path $projectRoot) {
+                Push-Location $projectRoot
+                try {
+                  aspire stop *> $stopLogPath
+                }
+                catch {
+                  Write-Warning "$templateId cleanup with aspire stop failed: $($_.Exception.Message)"
+                  if (Test-Path $stopLogPath) {
+                    Get-Content $stopLogPath
+                  }
+                }
+                finally {
+                  Pop-Location
+                }
+              }
+
+              Pop-Location
+            }
+          }
+
+          if ($failures.Count -gt 0) {
+            throw ("Starter validation failures:`n- " + ($failures -join "`n- "))
+          }
+
+      - name: Collect CLI logs
+        if: always()
+        shell: pwsh
+        run: |
+          $validationRoot = Join-Path $env:RUNNER_TEMP 'aspire-cli-starter-validation'
+          $cliLogsDir = Join-Path $HOME '.aspire\logs'
+          $sharedLogsDir = Join-Path $validationRoot 'cli-logs'
+
+          if (Test-Path $cliLogsDir) {
+            New-Item -ItemType Directory -Path $validationRoot -Force | Out-Null
+            Copy-Item -Path $cliLogsDir -Destination $sharedLogsDir -Recurse -Force
+          }
+
+      - name: Upload starter validation diagnostics
+        if: always()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: cli-starter-validation-windows
+          path: ${{ runner.temp }}/aspire-cli-starter-validation
+          if-no-files-found: ignore
+
   extension_tests_win:
     name: Run VS Code extension tests (Windows)
     runs-on: windows-latest
@@ -229,6 +438,7 @@ jobs:
       build_cli_archive_windows,
       build_cli_archive_macos,
       extension_tests_win,
+      cli_starter_validation_win,
       typescript_sdk_tests,
       tests_no_nugets,
       tests_no_nugets_overflow,
@@ -294,11 +504,12 @@ jobs:
                 contains(needs.*.result, 'cancelled') ||
                 (github.event_name == 'pull_request' &&
                  (needs.extension_tests_win.result == 'skipped' ||
-                   needs.typescript_sdk_tests.result == 'skipped' ||
-                   needs.tests_no_nugets.result == 'skipped' ||
-                   needs.tests_requires_nugets_linux.result == 'skipped' ||
-                   needs.tests_requires_nugets_windows.result == 'skipped' ||
-                   (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_macos).include[0] != null &&
+                    needs.cli_starter_validation_win.result == 'skipped' ||
+                    needs.typescript_sdk_tests.result == 'skipped' ||
+                    needs.tests_no_nugets.result == 'skipped' ||
+                    needs.tests_requires_nugets_linux.result == 'skipped' ||
+                    needs.tests_requires_nugets_windows.result == 'skipped' ||
+                    (fromJson(needs.setup_for_tests.outputs.tests_matrix_requires_nugets_macos).include[0] != null &&
                     needs.tests_requires_nugets_macos.result == 'skipped') ||
                    needs.tests_requires_cli_archive.result == 'skipped' ||
                   needs.polyglot_validation.result == 'skipped')) ||

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -193,7 +193,7 @@ jobs:
     name: Aspire CLI Starter Validation (Windows)
     runs-on: windows-latest
     needs: [build_packages, build_cli_archive_windows]
-    if: ${{ github.event_name == 'pull_request' && github.repository_owner == 'dotnet' }}
+    if: ${{ github.event_name == 'pull_request' && github.repository_owner == 'microsoft' }}
     env:
       GH_TOKEN: ${{ github.token }}
       MAX_STARTUP_SECONDS: '120'
@@ -432,7 +432,7 @@ jobs:
     uses: ./.github/workflows/typescript-sdk-tests.yml
 
   results:
-    if: ${{ always() && github.repository_owner == 'dotnet' }}
+    if: ${{ always() && github.repository_owner == 'microsoft' }}
     runs-on: ubuntu-latest
     name: Final Test Results
     needs: [

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -225,15 +225,6 @@ jobs:
 
           aspire --version
 
-      - name: Trust Aspire HTTPS development certificate
-        timeout-minutes: 3
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $PSNativeCommandUseErrorActionPreference = $true
-
-          aspire certs trust --non-interactive --nologo
-
       - name: Create starter app and validate startup
         timeout-minutes: 10
         shell: pwsh

--- a/src/Aspire.Cli/Certificates/CertificateService.cs
+++ b/src/Aspire.Cli/Certificates/CertificateService.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
+using Aspire.Cli.Utils;
 using Microsoft.AspNetCore.Certificates.Generation;
 
 namespace Aspire.Cli.Certificates;
@@ -31,9 +32,12 @@ internal interface ICertificateService
 internal sealed class CertificateService(
     ICertificateToolRunner certificateToolRunner,
     IInteractionService interactionService,
-    AspireCliTelemetry telemetry) : ICertificateService
+    AspireCliTelemetry telemetry,
+    ICliHostEnvironment hostEnvironment,
+    Func<bool>? isWindows = null) : ICertificateService
 {
     private const string SslCertDirEnvVar = "SSL_CERT_DIR";
+    private readonly Func<bool> _isWindows = isWindows ?? OperatingSystem.IsWindows;
 
     public async Task<EnsureCertificatesTrustedResult> EnsureCertificatesTrustedAsync(CancellationToken cancellationToken)
     {
@@ -74,6 +78,24 @@ internal sealed class CertificateService(
         // If not trusted at all, run the trust operation
         if (trustResult.IsNotTrusted)
         {
+            if (_isWindows() && !hostEnvironment.SupportsInteractiveInput)
+            {
+                if (!trustResult.HasCertificates)
+                {
+                    var ensureResultCode = await interactionService.ShowStatusAsync(
+                        InteractionServiceStrings.CheckingCertificates,
+                        () => Task.FromResult(certificateToolRunner.EnsureHttpCertificateExists()),
+                        emoji: KnownEmojis.LockedWithKey);
+
+                    if (!IsSuccessfulEnsureResult(ensureResultCode))
+                    {
+                        interactionService.DisplayMessage(KnownEmojis.Warning, string.Format(CultureInfo.CurrentCulture, ErrorStrings.CertificatesMayNotBeFullyTrusted, ensureResultCode));
+                    }
+                }
+
+                return;
+            }
+
             var trustResultCode = await interactionService.ShowStatusAsync(
                 InteractionServiceStrings.TrustingCertificates,
                 () => Task.FromResult(certificateToolRunner.TrustHttpCertificate()),
@@ -98,6 +120,10 @@ internal sealed class CertificateService(
             ConfigureSslCertDir(environmentVariables);
         }
     }
+
+    private static bool IsSuccessfulEnsureResult(EnsureCertificateResult result) =>
+        result is EnsureCertificateResult.Succeeded
+            or EnsureCertificateResult.ValidCertificatePresent;
 
     private static void ConfigureSslCertDir(Dictionary<string, string> environmentVariables)
     {

--- a/src/Aspire.Cli/Certificates/ICertificateToolRunner.cs
+++ b/src/Aspire.Cli/Certificates/ICertificateToolRunner.cs
@@ -16,6 +16,11 @@ internal interface ICertificateToolRunner
     CertificateTrustResult CheckHttpCertificate();
 
     /// <summary>
+    /// Ensures the HTTPS development certificate exists without trusting it.
+    /// </summary>
+    EnsureCertificateResult EnsureHttpCertificateExists();
+
+    /// <summary>
     /// Trusts the HTTPS development certificate, creating one if necessary.
     /// </summary>
     EnsureCertificateResult TrustHttpCertificate();

--- a/src/Aspire.Cli/Certificates/NativeCertificateToolRunner.cs
+++ b/src/Aspire.Cli/Certificates/NativeCertificateToolRunner.cs
@@ -69,6 +69,16 @@ internal sealed class NativeCertificateToolRunner(CertificateManager certificate
             trust: true);
     }
 
+    public EnsureCertificateResult EnsureHttpCertificateExists()
+    {
+        var now = DateTimeOffset.Now;
+        return certificateManager.EnsureAspNetCoreHttpsDevelopmentCertificate(
+            now,
+            now.Add(TimeSpan.FromDays(365)),
+            trust: false,
+            isInteractive: false);
+    }
+
     /// Win32 ERROR_CANCELLED (0x4C7) encoded as an HRESULT (0x800704C7).
     /// Thrown when the user dismisses the Windows certificate-store security dialog.
     private const int UserCancelledHResult = unchecked((int)0x800704C7);

--- a/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/CertificateServiceTests.cs
@@ -3,7 +3,10 @@
 
 using System.Runtime.InteropServices;
 using Aspire.Cli.Certificates;
+using Aspire.Cli.Interaction;
+using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
 using Microsoft.AspNetCore.Certificates.Generation;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
@@ -221,9 +224,116 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
         Assert.NotNull(result);
     }
 
+    [Fact]
+    public async Task EnsureCertificatesTrustedAsync_OnWindowsCi_WithNotTrustedCert_SkipsTrustOperation()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var trustCalled = false;
+        var ensureCalled = false;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CertificateToolRunnerFactory = sp =>
+            {
+                return new TestCertificateToolRunner
+                {
+                    CheckHttpCertificateCallback = () =>
+                    {
+                        return new CertificateTrustResult
+                        {
+                            HasCertificates = true,
+                            TrustLevel = CertificateManager.TrustLevel.None,
+                            Certificates = [new DevCertInfo { Version = 5, TrustLevel = CertificateManager.TrustLevel.None, IsHttpsDevelopmentCertificate = true, ValidityNotBefore = DateTimeOffset.Now.AddDays(-1), ValidityNotAfter = DateTimeOffset.Now.AddDays(365) }]
+                        };
+                    },
+                    TrustHttpCertificateCallback = () =>
+                    {
+                        trustCalled = true;
+                        return EnsureCertificateResult.ExistingHttpsCertificateTrusted;
+                    },
+                    EnsureHttpCertificateExistsCallback = () =>
+                    {
+                        ensureCalled = true;
+                        return EnsureCertificateResult.ValidCertificatePresent;
+                    }
+                };
+            };
+            options.CertificateServiceFactory = serviceProvider =>
+            {
+                var certificateToolRunner = serviceProvider.GetRequiredService<ICertificateToolRunner>();
+                var interactiveService = serviceProvider.GetRequiredService<IInteractionService>();
+                var telemetry = serviceProvider.GetRequiredService<AspireCliTelemetry>();
+                return new CertificateService(certificateToolRunner, interactiveService, telemetry, new TestCliHostEnvironment(), isWindows: () => true);
+            };
+        });
+
+        var sp = services.BuildServiceProvider();
+        var cs = sp.GetRequiredService<ICertificateService>();
+
+        var result = await cs.EnsureCertificatesTrustedAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+
+        Assert.NotNull(result);
+        Assert.False(trustCalled);
+        Assert.False(ensureCalled);
+    }
+
+    [Fact]
+    public async Task EnsureCertificatesTrustedAsync_OnWindowsCi_WithNoCertificates_EnsuresCertificateExistsWithoutTrust()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var trustCalled = false;
+        var ensureCalled = false;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.CertificateToolRunnerFactory = sp =>
+            {
+                return new TestCertificateToolRunner
+                {
+                    CheckHttpCertificateCallback = () =>
+                    {
+                        return new CertificateTrustResult
+                        {
+                            HasCertificates = false,
+                            TrustLevel = null,
+                            Certificates = []
+                        };
+                    },
+                    TrustHttpCertificateCallback = () =>
+                    {
+                        trustCalled = true;
+                        return EnsureCertificateResult.NewHttpsCertificateTrusted;
+                    },
+                    EnsureHttpCertificateExistsCallback = () =>
+                    {
+                        ensureCalled = true;
+                        return EnsureCertificateResult.Succeeded;
+                    }
+                };
+            };
+            options.CertificateServiceFactory = serviceProvider =>
+            {
+                var certificateToolRunner = serviceProvider.GetRequiredService<ICertificateToolRunner>();
+                var interactiveService = serviceProvider.GetRequiredService<IInteractionService>();
+                var telemetry = serviceProvider.GetRequiredService<AspireCliTelemetry>();
+                return new CertificateService(certificateToolRunner, interactiveService, telemetry, new TestCliHostEnvironment(), isWindows: () => true);
+            };
+        });
+
+        var sp = services.BuildServiceProvider();
+        var cs = sp.GetRequiredService<ICertificateService>();
+
+        var result = await cs.EnsureCertificatesTrustedAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+
+        Assert.NotNull(result);
+        Assert.False(trustCalled);
+        Assert.True(ensureCalled);
+    }
+
     private sealed class TestCertificateToolRunner : ICertificateToolRunner
     {
         public Func<CertificateTrustResult>? CheckHttpCertificateCallback { get; set; }
+        public Func<EnsureCertificateResult>? EnsureHttpCertificateExistsCallback { get; set; }
         public Func<EnsureCertificateResult>? TrustHttpCertificateCallback { get; set; }
 
         public CertificateTrustResult CheckHttpCertificate()
@@ -249,7 +359,23 @@ public class CertificateServiceTests(ITestOutputHelper outputHelper)
                 : EnsureCertificateResult.ExistingHttpsCertificateTrusted;
         }
 
+        public EnsureCertificateResult EnsureHttpCertificateExists()
+        {
+            return EnsureHttpCertificateExistsCallback is not null
+                ? EnsureHttpCertificateExistsCallback()
+                : EnsureCertificateResult.ValidCertificatePresent;
+        }
+
         public CertificateCleanResult CleanHttpCertificate()
             => new CertificateCleanResult { Success = true };
+    }
+
+    private sealed class TestCliHostEnvironment : ICliHostEnvironment
+    {
+        public bool SupportsInteractiveInput => false;
+
+        public bool SupportsInteractiveOutput => false;
+
+        public bool SupportsAnsi => true;
     }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestCertificateToolRunner.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestCertificateToolRunner.cs
@@ -13,6 +13,7 @@ namespace Aspire.Cli.Tests.TestServices;
 internal sealed class TestCertificateToolRunner : ICertificateToolRunner
 {
     public Func<CertificateTrustResult>? CheckHttpCertificateCallback { get; set; }
+    public Func<EnsureCertificateResult>? EnsureHttpCertificateExistsCallback { get; set; }
     public Func<EnsureCertificateResult>? TrustHttpCertificateCallback { get; set; }
     public Func<CertificateCleanResult>? CleanHttpCertificateCallback { get; set; }
 
@@ -37,6 +38,13 @@ internal sealed class TestCertificateToolRunner : ICertificateToolRunner
         return TrustHttpCertificateCallback is not null
             ? TrustHttpCertificateCallback()
             : EnsureCertificateResult.ExistingHttpsCertificateTrusted;
+    }
+
+    public EnsureCertificateResult EnsureHttpCertificateExists()
+    {
+        return EnsureHttpCertificateExistsCallback is not null
+            ? EnsureHttpCertificateExistsCallback()
+            : EnsureCertificateResult.ValidCertificatePresent;
     }
 
     public CertificateCleanResult CleanHttpCertificate()

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -403,7 +403,8 @@ internal sealed class CliServiceCollectionTestOptions
         var certificateToolRunner = serviceProvider.GetRequiredService<ICertificateToolRunner>();
         var interactiveService = serviceProvider.GetRequiredService<IInteractionService>();
         var telemetry = serviceProvider.GetRequiredService<AspireCliTelemetry>();
-        return new CertificateService(certificateToolRunner, interactiveService, telemetry);
+        var hostEnvironment = serviceProvider.GetRequiredService<ICliHostEnvironment>();
+        return new CertificateService(certificateToolRunner, interactiveService, telemetry, hostEnvironment);
     };
 
     public Func<IServiceProvider, IDotNetCliExecutionFactory> DotNetCliExecutionFactoryFactory { get; set; } = (IServiceProvider serviceProvider) =>


### PR DESCRIPTION
## Description

Adds a new Windows PR CI validation for the Aspire CLI in `tests.yml` that dogfoods the CLI from the current PR artifacts, creates starter templates, runs `aspire start`, and verifies the expected resources come up.

This runs alongside the existing PR dogfood flow by downloading `eng/scripts/get-aspire-cli-pr.ps1` from the PR head SHA and passing the current workflow run ID so the job can install the CLI built by the same CI run. The validation now covers both the Express/React starter (`aspire-ts-starter`) and the C# starter equivalent on this branch (`aspire-starter`).

Validation:
- Parsed `.github/workflows/tests.yml` successfully with Ruby YAML parsing.
- Verified local CLI template mapping and command behavior, including the need to pass `--output` in non-interactive mode.
- Local smoke investigation also exposed an existing detached `aspire start` disposed-service-provider failure outside the workflow wiring.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
