### PR TITLE
Update to latest Azure.Provisioning.AppContainers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,9 +38,9 @@
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.13.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.4.0" />
     <!-- Azure Management SDK for .NET dependencies -->
-    <PackageVersion Include="Azure.Provisioning" Version="1.4.0" />
+    <PackageVersion Include="Azure.Provisioning" Version="1.5.0" />
     <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="1.1.0" />
-    <PackageVersion Include="Azure.Provisioning.AppContainers" Version="1.1.0" />
+    <PackageVersion Include="Azure.Provisioning.AppContainers" Version="1.2.0" />
     <PackageVersion Include="Azure.Provisioning.AppService" Version="1.3.1" />
     <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="1.1.0" />
     <PackageVersion Include="Azure.Provisioning.ContainerRegistry" Version="1.1.0" />

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -168,7 +168,7 @@ public static class AzureContainerAppExtensions
 
             if (appEnvResource.EnableDashboard)
             {
-                var dashboard = new ContainerAppEnvironmentDotnetComponentResource("aspireDashboard", "2024-10-02-preview")
+                var dashboard = new ContainerAppEnvironmentDotnetComponentResource("aspireDashboard", "2025-10-02-preview")
                 {
                     Name = "aspire-dashboard",
                     ComponentType = "AspireDashboard",

--- a/src/Aspire.Hosting.Azure.AppContainers/ContainerAppContext.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/ContainerAppContext.cs
@@ -110,11 +110,10 @@ internal sealed class ContainerAppContext(IResource resource, ContainerAppEnviro
         };
         containerApp.Configuration = configuration;
 
-        const string latestPreview = "2025-02-02-preview"; // these properties are currently only available in preview
-
         // default autoConfigureDataProtection to true for .NET projects
         if (Resource is ProjectResource)
         {
+            const string latestPreview = "2025-10-02-preview"; // this property is currently only available in preview
             containerApp.ResourceVersion = latestPreview;
 
             var value = new BicepValue<bool>(true);
@@ -125,11 +124,7 @@ internal sealed class ContainerAppContext(IResource resource, ContainerAppEnviro
         // default kind to functionapp for Azure Functions
         if (Resource.HasAnnotationOfType<AzureFunctionsAnnotation>())
         {
-            containerApp.ResourceVersion = latestPreview;
-
-            var value = new BicepValue<string>("functionapp");
-            ((IBicepValue)value).Self = new BicepValueReference(containerApp, "Kind", ["kind"]);
-            containerApp.ProvisionableProperties["Kind"] = value;
+            containerApp.Kind = ContainerAppKind.Functionapp;
         }
 
         return containerApp;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -1690,11 +1690,11 @@ public class AzureContainerAppsTests
     {
         var containerApp = new ContainerApp("app");
 
-        // In order to set autoConfigureDataProtection and kind=functionapp, we need to use a preview API ContainerApp version.
-        // This test fails on new default versions for ContainerApp so we check if autoConfigureDataProtection/kind exists on the new Azure.Provisioning version.
-        // Also, we need to ensure the new default version isn't newer than the preview version used to set autoConfigureDataProtection/kind because
+        // In order to set autoConfigureDataProtection, we need to use a preview API ContainerApp version.
+        // This test fails on new default versions for ContainerApp so we check if autoConfigureDataProtection exists on the new Azure.Provisioning version.
+        // Also, we need to ensure the new default version isn't newer than the preview version used to set autoConfigureDataProtection because
         // callers will get new APIs that may not work with the preview version we are using.
-        Assert.True(containerApp.ResourceVersion == "2025-01-01", "When we get a new ResourceVersion for ContainerApps, ensure the version used by ContainerAppContext.CreateContainerApp() still works correctly.");
+        Assert.True(containerApp.ResourceVersion == "2025-07-01", "When we get a new ResourceVersion for ContainerApps, ensure the version used by ContainerAppContext.CreateContainerApp() still works correctly.");
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.AddAsExistingResource_RespectsExistingAzureResourceAnnotation_ForAzureContainerAppEnvironmentResource.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.AddAsExistingResource_RespectsExistingAzureResourceAnnotation_ForAzureContainerAppEnvironmentResource.verified.bicep
@@ -5,7 +5,7 @@ param existing_env_name string
 
 param existing_env_rg string
 
-resource test_container_app_env 'Microsoft.App/managedEnvironments@2025-01-01' existing = {
+resource test_container_app_env 'Microsoft.App/managedEnvironments@2025-07-01' existing = {
   name: existing_env_name
   scope: resourceGroup(existing_env_rg)
 }

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.WithAzureLogAnalyticsWorkspace_RespectsExistingWorkspaceInDifferentResourceGroup.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.WithAzureLogAnalyticsWorkspace_RespectsExistingWorkspaceInDifferentResourceGroup.verified.bicep
@@ -36,7 +36,7 @@ resource log_env_shared 'Microsoft.OperationalInsights/workspaces@2025-02-01' ex
   scope: resourceGroup(log_env_shared_rg)
 }
 
-resource app_host 'Microsoft.App/managedEnvironments@2025-01-01' = {
+resource app_host 'Microsoft.App/managedEnvironments@2025-07-01' = {
   name: take('apphost${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -57,7 +57,7 @@ resource app_host 'Microsoft.App/managedEnvironments@2025-01-01' = {
   tags: tags
 }
 
-resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
+resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2025-10-02-preview' = {
   name: 'aspire-dashboard'
   properties: {
     componentType: 'AspireDashboard'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.WithDelegatedSubnet_ConfiguresVnetConfiguration.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppEnvironmentExtensionsTests.WithDelegatedSubnet_ConfiguresVnetConfiguration.verified.bicep
@@ -40,7 +40,7 @@ resource env_law 'Microsoft.OperationalInsights/workspaces@2025-02-01' = {
   tags: tags
 }
 
-resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
+resource env 'Microsoft.App/managedEnvironments@2025-07-01' = {
   name: take('env${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -64,7 +64,7 @@ resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
   tags: tags
 }
 
-resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
+resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2025-10-02-preview' = {
   name: 'aspire-dashboard'
   properties: {
     componentType: 'AspireDashboard'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsDeploymentTargetWithContainerAppToProjectResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsDeploymentTargetWithContainerAppToProjectResources.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_apps_environment_default_domain string
@@ -13,7 +13,7 @@ param api_containerimage string
 
 param api_containerport string
 
-resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource api 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsEnvironmentResource_useAzdNaming=False.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsEnvironmentResource_useAzdNaming=False.verified.bicep
@@ -38,7 +38,7 @@ resource env_law 'Microsoft.OperationalInsights/workspaces@2025-02-01' = {
   tags: tags
 }
 
-resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
+resource env 'Microsoft.App/managedEnvironments@2025-07-01' = {
   name: take('env${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -59,7 +59,7 @@ resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
   tags: tags
 }
 
-resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
+resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2025-10-02-preview' = {
   name: 'aspire-dashboard'
   properties: {
     componentType: 'AspireDashboard'
@@ -95,7 +95,7 @@ resource shares_volumes_cache_0 'Microsoft.Storage/storageAccounts/fileServices/
   parent: storageVolumeFileService
 }
 
-resource managedStorage_volumes_cache_0 'Microsoft.App/managedEnvironments/storages@2025-01-01' = {
+resource managedStorage_volumes_cache_0 'Microsoft.App/managedEnvironments/storages@2025-07-01' = {
   name: take('managedstoragevolumescache${uniqueString(resourceGroup().id)}', 24)
   properties: {
     azureFile: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsEnvironmentResource_useAzdNaming=True.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentAddsEnvironmentResource_useAzdNaming=True.verified.bicep
@@ -40,7 +40,7 @@ resource env_law 'Microsoft.OperationalInsights/workspaces@2025-02-01' = {
   tags: tags
 }
 
-resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
+resource env 'Microsoft.App/managedEnvironments@2025-07-01' = {
   name: 'cae-${resourceToken}'
   location: location
   properties: {
@@ -61,7 +61,7 @@ resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
   tags: tags
 }
 
-resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
+resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2025-10-02-preview' = {
   name: 'aspire-dashboard'
   properties: {
     componentType: 'AspireDashboard'
@@ -97,7 +97,7 @@ resource shares_volumes_cache_0 'Microsoft.Storage/storageAccounts/fileServices/
   parent: storageVolumeFileService
 }
 
-resource managedStorage_volumes_cache_0 'Microsoft.App/managedEnvironments/storages@2025-01-01' = {
+resource managedStorage_volumes_cache_0 'Microsoft.App/managedEnvironments/storages@2025-07-01' = {
   name: take('${toLower('cache')}-${toLower('Appdata')}', 32)
   properties: {
     azureFile: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentWithCompactNamingPreservesUniqueString.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppEnvironmentWithCompactNamingPreservesUniqueString.verified.bicep
@@ -40,7 +40,7 @@ resource my_long_env_name_law 'Microsoft.OperationalInsights/workspaces@2025-02-
   tags: tags
 }
 
-resource my_long_env_name 'Microsoft.App/managedEnvironments@2025-01-01' = {
+resource my_long_env_name 'Microsoft.App/managedEnvironments@2025-07-01' = {
   name: take('mylongenvname${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -61,7 +61,7 @@ resource my_long_env_name 'Microsoft.App/managedEnvironments@2025-01-01' = {
   tags: tags
 }
 
-resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
+resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2025-10-02-preview' = {
   name: 'aspire-dashboard'
   properties: {
     componentType: 'AspireDashboard'
@@ -97,7 +97,7 @@ resource shares_volumes_cache_0 'Microsoft.Storage/storageAccounts/fileServices/
   parent: storageVolumeFileService
 }
 
-resource managedStorage_volumes_cache_0 'Microsoft.App/managedEnvironments/storages@2025-01-01' = {
+resource managedStorage_volumes_cache_0 'Microsoft.App/managedEnvironments/storages@2025-07-01' = {
   name: take('${toLower('cache')}-${toLower('Appdata')}-${resourceToken}', 32)
   properties: {
     azureFile: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppsEntrypointAndArgs.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppsEntrypointAndArgs.verified.bicep
@@ -5,7 +5,7 @@ param env_outputs_azure_container_apps_environment_default_domain string
 
 param env_outputs_azure_container_apps_environment_id string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppsInfrastructureAddsDeploymentTargetWithContainerAppToContainerResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppsInfrastructureAddsDeploymentTargetWithContainerAppToContainerResources.verified.bicep
@@ -5,7 +5,7 @@ param env_outputs_azure_container_apps_environment_default_domain string
 
 param env_outputs_azure_container_apps_environment_id string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppsInfrastructureWithParameterReference.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddContainerAppsInfrastructureWithParameterReference.verified.bicep
@@ -9,7 +9,7 @@ param value string
 
 param minReplicas string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddDockerfileWithAppsInfrastructureAddsDeploymentTargetWithContainerAppToContainerResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddDockerfileWithAppsInfrastructureAddsDeploymentTargetWithContainerAppToContainerResources.verified.bicep
@@ -11,7 +11,7 @@ param env_outputs_azure_container_registry_managed_identity_id string
 
 param api_containerimage string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddExecutableResourceWithPublishAsDockerFileWithAppsInfrastructureAddsDeploymentTargetWithContainerAppToContainerResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AddExecutableResourceWithPublishAsDockerFileWithAppsInfrastructureAddsDeploymentTargetWithContainerAppToContainerResources.verified.bicep
@@ -13,7 +13,7 @@ param api_containerimage string
 
 param env string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AzureContainerAppsBicepGenerationIsIdempotent.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AzureContainerAppsBicepGenerationIsIdempotent.verified.bicep
@@ -33,7 +33,7 @@ resource existingKv_secret 'Microsoft.KeyVault/vaults/secrets@2024-11-01' existi
   parent: existingKv
 }
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AzureContainerAppsMapsPortsForBaitAndSwitchResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.AzureContainerAppsMapsPortsForBaitAndSwitchResources.verified.bicep
@@ -11,7 +11,7 @@ param env_outputs_azure_container_registry_managed_identity_id string
 
 param api_containerimage string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.BindMountNamesWithHyphensAreNormalized.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.BindMountNamesWithHyphensAreNormalized.verified.bicep
@@ -13,7 +13,7 @@ param with_bind_mount_containerimage string
 
 param env_outputs_bindmounts_with_bind_mount_0 string
 
-resource with_bind_mount 'Microsoft.App/containerApps@2025-01-01' = {
+resource with_bind_mount 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'with-bind-mount'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.CanCustomizeWithProvisioningBuildOptions.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.CanCustomizeWithProvisioningBuildOptions.verified.bicep
@@ -5,7 +5,7 @@ param env_outputs_azure_container_apps_environment_default_domain string
 
 param env_outputs_azure_container_apps_environment_id string
 
-resource api1 'Microsoft.App/containerApps@2025-01-01' = {
+resource api1 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api1-my'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.CanPreserveHttpSchemeUsingWithHttpsUpgrade.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.CanPreserveHttpSchemeUsingWithHttpsUpgrade.verified.bicep
@@ -5,7 +5,7 @@ param env_outputs_azure_container_apps_environment_default_domain string
 
 param env_outputs_azure_container_apps_environment_id string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.CanReferenceContainerAppEnvironment.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.CanReferenceContainerAppEnvironment.verified.bicep
@@ -3,7 +3,7 @@ param location string = resourceGroup().location
 
 param env_outputs_azure_container_apps_environment_name string
 
-resource env 'Microsoft.App/managedEnvironments@2025-01-01' existing = {
+resource env 'Microsoft.App/managedEnvironments@2025-07-01' existing = {
   name: env_outputs_azure_container_apps_environment_name
 }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.CanTweakContainerAppEnvironmentUsingPublishAsContainerAppOnExecutable.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.CanTweakContainerAppEnvironmentUsingPublishAsContainerAppOnExecutable.verified.bicep
@@ -11,7 +11,7 @@ param env_outputs_azure_container_registry_managed_identity_id string
 
 param api_containerimage string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.CompactNamingMultipleVolumesHaveUniqueNames.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.CompactNamingMultipleVolumesHaveUniqueNames.verified.bicep
@@ -40,7 +40,7 @@ resource my_ace_law 'Microsoft.OperationalInsights/workspaces@2025-02-01' = {
   tags: tags
 }
 
-resource my_ace 'Microsoft.App/managedEnvironments@2025-01-01' = {
+resource my_ace 'Microsoft.App/managedEnvironments@2025-07-01' = {
   name: take('myace${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -61,7 +61,7 @@ resource my_ace 'Microsoft.App/managedEnvironments@2025-01-01' = {
   tags: tags
 }
 
-resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
+resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2025-10-02-preview' = {
   name: 'aspire-dashboard'
   properties: {
     componentType: 'AspireDashboard'
@@ -97,7 +97,7 @@ resource shares_volumes_druid_0 'Microsoft.Storage/storageAccounts/fileServices/
   parent: storageVolumeFileService
 }
 
-resource managedStorage_volumes_druid_0 'Microsoft.App/managedEnvironments/storages@2025-01-01' = {
+resource managedStorage_volumes_druid_0 'Microsoft.App/managedEnvironments/storages@2025-07-01' = {
   name: take('${toLower('druid')}-${toLower('druid_shared')}-${resourceToken}', 32)
   properties: {
     azureFile: {
@@ -119,7 +119,7 @@ resource shares_volumes_druid_1 'Microsoft.Storage/storageAccounts/fileServices/
   parent: storageVolumeFileService
 }
 
-resource managedStorage_volumes_druid_1 'Microsoft.App/managedEnvironments/storages@2025-01-01' = {
+resource managedStorage_volumes_druid_1 'Microsoft.App/managedEnvironments/storages@2025-07-01' = {
   name: take('${toLower('druid')}-${toLower('coordinator_var')}-${resourceToken}', 32)
   properties: {
     azureFile: {
@@ -141,7 +141,7 @@ resource shares_bindmounts_druid_0 'Microsoft.Storage/storageAccounts/fileServic
   parent: storageVolumeFileService
 }
 
-resource managedStorage_bindmounts_druid_0 'Microsoft.App/managedEnvironments/storages@2025-01-01' = {
+resource managedStorage_bindmounts_druid_0 'Microsoft.App/managedEnvironments/storages@2025-07-01' = {
   name: take('${toLower('druid')}-${toLower('bm0')}-${resourceToken}', 32)
   properties: {
     azureFile: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ConditionalBranchWithParameterReference.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ConditionalBranchWithParameterReference.verified.bicep
@@ -15,7 +15,7 @@ param enable_feature_value string
 
 param connection_prefix_value string
 
-resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource api 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ConditionalExpressionWithParameterCondition.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ConditionalExpressionWithParameterCondition.verified.bicep
@@ -13,7 +13,7 @@ param api_containerimage string
 
 param enable_feature_value string
 
-resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource api 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ConfigureCustomDomainMutatesIngress.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ConfigureCustomDomainMutatesIngress.verified.bicep
@@ -9,7 +9,7 @@ param certificateName string
 
 param customDomain string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ConfigureDuplicateCustomDomainMutatesIngress.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ConfigureDuplicateCustomDomainMutatesIngress.verified.bicep
@@ -11,7 +11,7 @@ param customDomain string
 
 param expectedCertificateName string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ConfigureMultipleCustomDomainsMutatesIngress.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ConfigureMultipleCustomDomainsMutatesIngress.verified.bicep
@@ -13,7 +13,7 @@ param certificateName2 string
 
 param customDomain2 string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomRegistry#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomRegistry#00.verified.bicep
@@ -38,7 +38,7 @@ resource env_law 'Microsoft.OperationalInsights/workspaces@2025-02-01' = {
   tags: tags
 }
 
-resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
+resource env 'Microsoft.App/managedEnvironments@2025-07-01' = {
   name: take('env${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -59,7 +59,7 @@ resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
   tags: tags
 }
 
-resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
+resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2025-10-02-preview' = {
   name: 'aspire-dashboard'
   properties: {
     componentType: 'AspireDashboard'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomRegistry#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomRegistry#01.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_apps_environment_default_domain string
@@ -13,7 +13,7 @@ param api_containerimage string
 
 param api_containerport string
 
-resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource api 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomWorkspace#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomWorkspace#00.verified.bicep
@@ -33,7 +33,7 @@ resource customworkspace 'Microsoft.OperationalInsights/workspaces@2025-02-01' e
   name: customworkspace_outputs_name
 }
 
-resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
+resource env 'Microsoft.App/managedEnvironments@2025-07-01' = {
   name: take('env${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -54,7 +54,7 @@ resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
   tags: tags
 }
 
-resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
+resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2025-10-02-preview' = {
   name: 'aspire-dashboard'
   properties: {
     componentType: 'AspireDashboard'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomWorkspace#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithCustomWorkspace#01.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_apps_environment_default_domain string
@@ -13,7 +13,7 @@ param api_containerimage string
 
 param api_containerport string
 
-resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource api 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithDashboardDisabled.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithDashboardDisabled.verified.bicep
@@ -38,7 +38,7 @@ resource env_law 'Microsoft.OperationalInsights/workspaces@2025-02-01' = {
   tags: tags
 }
 
-resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
+resource env 'Microsoft.App/managedEnvironments@2025-07-01' = {
   name: take('env${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithDashboardEnabled.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppEnvironmentWithDashboardEnabled.verified.bicep
@@ -38,7 +38,7 @@ resource env_law 'Microsoft.OperationalInsights/workspaces@2025-02-01' = {
   tags: tags
 }
 
-resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
+resource env 'Microsoft.App/managedEnvironments@2025-07-01' = {
   name: take('env${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -59,7 +59,7 @@ resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
   tags: tags
 }
 
-resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
+resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2025-10-02-preview' = {
   name: 'aspire-dashboard'
   properties: {
     componentType: 'AspireDashboard'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppWithUppercaseName_ShouldUseLowercaseInManifest.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerAppWithUppercaseName_ShouldUseLowercaseInManifest.verified.bicep
@@ -5,7 +5,7 @@ param env_outputs_azure_container_apps_environment_default_domain string
 
 param env_outputs_azure_container_apps_environment_id string
 
-resource WebFrontEnd 'Microsoft.App/containerApps@2025-01-01' = {
+resource WebFrontEnd 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'webfrontend'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.DefaultHttpIngressUsesPort80EvenWithDifferentDevPort.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.DefaultHttpIngressUsesPort80EvenWithDifferentDevPort.verified.bicep
@@ -5,7 +5,7 @@ param env_outputs_azure_container_apps_environment_default_domain string
 
 param env_outputs_azure_container_apps_environment_id string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.DefaultHttpsIngressUsesPort443EvenWithDifferentDevPort.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.DefaultHttpsIngressUsesPort443EvenWithDifferentDevPort.verified.bicep
@@ -5,7 +5,7 @@ param env_outputs_azure_container_apps_environment_default_domain string
 
 param env_outputs_azure_container_apps_environment_id string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.EndpointWithHttp2SetsTransportToH2.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.EndpointWithHttp2SetsTransportToH2.verified.bicep
@@ -5,7 +5,7 @@ param env_outputs_azure_container_apps_environment_default_domain string
 
 param env_outputs_azure_container_apps_environment_id string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ExternalEndpointBecomesIngress.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ExternalEndpointBecomesIngress.verified.bicep
@@ -5,7 +5,7 @@ param env_outputs_azure_container_apps_environment_default_domain string
 
 param env_outputs_azure_container_apps_environment_id string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.FirstHttpEndpointBecomesIngress.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.FirstHttpEndpointBecomesIngress.verified.bicep
@@ -5,7 +5,7 @@ param env_outputs_azure_container_apps_environment_default_domain string
 
 param env_outputs_azure_container_apps_environment_id string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.KeyVaultReferenceHandling.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.KeyVaultReferenceHandling.verified.bicep
@@ -41,7 +41,7 @@ resource existingKv_secret 'Microsoft.KeyVault/vaults/secrets@2024-11-01' existi
   parent: existingKv
 }
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.MultipleVolumesHaveUniqueNamesInBicep#01.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.MultipleVolumesHaveUniqueNamesInBicep#01.verified.txt
@@ -11,7 +11,7 @@ param my_ace_outputs_volumes_druid_1 string
 
 param my_ace_outputs_bindmounts_druid_0 string
 
-resource druid 'Microsoft.App/containerApps@2025-01-01' = {
+resource druid 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'druid'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.MultipleVolumesHaveUniqueNamesInBicep#03.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.MultipleVolumesHaveUniqueNamesInBicep#03.verified.txt
@@ -38,7 +38,7 @@ resource my_ace_law 'Microsoft.OperationalInsights/workspaces@2025-02-01' = {
   tags: tags
 }
 
-resource my_ace 'Microsoft.App/managedEnvironments@2025-01-01' = {
+resource my_ace 'Microsoft.App/managedEnvironments@2025-07-01' = {
   name: take('myace${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -59,7 +59,7 @@ resource my_ace 'Microsoft.App/managedEnvironments@2025-01-01' = {
   tags: tags
 }
 
-resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
+resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2025-10-02-preview' = {
   name: 'aspire-dashboard'
   properties: {
     componentType: 'AspireDashboard'
@@ -95,7 +95,7 @@ resource shares_volumes_druid_0 'Microsoft.Storage/storageAccounts/fileServices/
   parent: storageVolumeFileService
 }
 
-resource managedStorage_volumes_druid_0 'Microsoft.App/managedEnvironments/storages@2025-01-01' = {
+resource managedStorage_volumes_druid_0 'Microsoft.App/managedEnvironments/storages@2025-07-01' = {
   name: take('managedstoragevolumesdruid${uniqueString(resourceGroup().id)}', 24)
   properties: {
     azureFile: {
@@ -117,7 +117,7 @@ resource shares_volumes_druid_1 'Microsoft.Storage/storageAccounts/fileServices/
   parent: storageVolumeFileService
 }
 
-resource managedStorage_volumes_druid_1 'Microsoft.App/managedEnvironments/storages@2025-01-01' = {
+resource managedStorage_volumes_druid_1 'Microsoft.App/managedEnvironments/storages@2025-07-01' = {
   name: take('managedstoragevolumesdruid${uniqueString(resourceGroup().id)}', 24)
   properties: {
     azureFile: {
@@ -139,7 +139,7 @@ resource shares_bindmounts_druid_0 'Microsoft.Storage/storageAccounts/fileServic
   parent: storageVolumeFileService
 }
 
-resource managedStorage_bindmounts_druid_0 'Microsoft.App/managedEnvironments/storages@2025-01-01' = {
+resource managedStorage_bindmounts_druid_0 'Microsoft.App/managedEnvironments/storages@2025-07-01' = {
   name: take('managedstoragebindmountsdruid${uniqueString(resourceGroup().id)}', 24)
   properties: {
     azureFile: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.NestedConditionalExpressions.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.NestedConditionalExpressions.verified.bicep
@@ -15,7 +15,7 @@ param outer_flag_value string
 
 param inner_flag_value string
 
-resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource api 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectUsesTheTargetPortAsADefaultPortForFirstHttpEndpoint.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectUsesTheTargetPortAsADefaultPortForFirstHttpEndpoint.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_apps_environment_default_domain string
@@ -13,7 +13,7 @@ param api_containerimage string
 
 param api_containerport string
 
-resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource api 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypes#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypes#00.verified.bicep
@@ -50,7 +50,7 @@ resource pg_kv_connectionstrings__db 'Microsoft.KeyVault/vaults/secrets@2024-11-
   parent: pg_kv
 }
 
-resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource api 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypesAndContainerAppEnvironment#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ProjectWithManyReferenceTypesAndContainerAppEnvironment#00.verified.bicep
@@ -47,7 +47,7 @@ resource pg_kv_connectionstrings__db 'Microsoft.KeyVault/vaults/secrets@2024-11-
   parent: pg_kv
 }
 
-resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource api 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.PublishAsAzureContainerAppJobParameterlessConfiguresManualTrigger.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.PublishAsAzureContainerAppJobParameterlessConfiguresManualTrigger.verified.bicep
@@ -5,7 +5,7 @@ param env_outputs_azure_container_apps_environment_default_domain string
 
 param env_outputs_azure_container_apps_environment_id string
 
-resource manual_job 'Microsoft.App/jobs@2025-01-01' = {
+resource manual_job 'Microsoft.App/jobs@2025-07-01' = {
   name: 'manual-job'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.PublishAsContainerAppInfluencesContainerAppDefinition.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.PublishAsContainerAppInfluencesContainerAppDefinition.verified.bicep
@@ -5,7 +5,7 @@ param env_outputs_azure_container_apps_environment_default_domain string
 
 param env_outputs_azure_container_apps_environment_id string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.PublishAsContainerAppJobInfluencesContainerAppDefinition.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.PublishAsContainerAppJobInfluencesContainerAppDefinition.verified.bicep
@@ -5,7 +5,7 @@ param env_outputs_azure_container_apps_environment_default_domain string
 
 param env_outputs_azure_container_apps_environment_id string
 
-resource api 'Microsoft.App/jobs@2025-01-01' = {
+resource api 'Microsoft.App/jobs@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.PublishAsContainerAppJob_WorksForProjectResource.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.PublishAsContainerAppJob_WorksForProjectResource.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_apps_environment_default_domain string
@@ -11,7 +11,7 @@ param env_outputs_azure_container_registry_managed_identity_id string
 
 param job_containerimage string
 
-resource job 'Microsoft.App/jobs@2025-01-01' = {
+resource job 'Microsoft.App/jobs@2025-07-01' = {
   name: 'job'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.PublishAsScheduledAzureContainerAppJobConfiguresScheduleTrigger.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.PublishAsScheduledAzureContainerAppJobConfiguresScheduleTrigger.verified.bicep
@@ -5,7 +5,7 @@ param env_outputs_azure_container_apps_environment_default_domain string
 
 param env_outputs_azure_container_apps_environment_id string
 
-resource scheduled_job 'Microsoft.App/jobs@2025-01-01' = {
+resource scheduled_job 'Microsoft.App/jobs@2025-07-01' = {
   name: 'scheduled-job'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RedisWithConditionalConnectionString.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RedisWithConditionalConnectionString.verified.bicep
@@ -14,7 +14,7 @@ param api_containerimage string
 @secure()
 param cache_password_value string
 
-resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource api 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RedisWithTlsEnabledConditionalConnectionString.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RedisWithTlsEnabledConditionalConnectionString.verified.bicep
@@ -14,7 +14,7 @@ param api_containerimage string
 @secure()
 param cache_password_value string
 
-resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource api 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ResourceWithProbes_HttpEndpoint#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ResourceWithProbes_HttpEndpoint#00.verified.bicep
@@ -5,7 +5,7 @@ param env_outputs_azure_container_apps_environment_default_domain string
 
 param env_outputs_azure_container_apps_environment_id string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ResourceWithProbes_HttpEndpoint#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ResourceWithProbes_HttpEndpoint#01.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_apps_environment_default_domain string
@@ -13,7 +13,7 @@ param project1_containerimage string
 
 param project1_containerport string
 
-resource project1 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource project1 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'project1'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ResourceWithProbes_HttpEndpoint_TargetPort#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ResourceWithProbes_HttpEndpoint_TargetPort#00.verified.bicep
@@ -5,7 +5,7 @@ param env_outputs_azure_container_apps_environment_default_domain string
 
 param env_outputs_azure_container_apps_environment_id string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ResourceWithProbes_HttpEndpoint_TargetPort#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ResourceWithProbes_HttpEndpoint_TargetPort#01.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_apps_environment_default_domain string
@@ -11,7 +11,7 @@ param env_outputs_azure_container_registry_managed_identity_id string
 
 param project1_containerimage string
 
-resource project1 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource project1 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'project1'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ResourceWithProbes_HttpsEndpoint_TargetPort_MatchIngress#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ResourceWithProbes_HttpsEndpoint_TargetPort_MatchIngress#00.verified.bicep
@@ -5,7 +5,7 @@ param env_outputs_azure_container_apps_environment_default_domain string
 
 param env_outputs_azure_container_apps_environment_id string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ResourceWithProbes_HttpsEndpoint_TargetPort_MatchIngress#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ResourceWithProbes_HttpsEndpoint_TargetPort_MatchIngress#01.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_apps_environment_default_domain string
@@ -11,7 +11,7 @@ param env_outputs_azure_container_registry_managed_identity_id string
 
 param project1_containerimage string
 
-resource project1 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource project1 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'project1'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExisting#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExisting#00.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_apps_environment_default_domain string
@@ -15,7 +15,7 @@ param api_identity_outputs_id string
 
 param api_identity_outputs_clientid string
 
-resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource api 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExistingCosmosDB#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExistingCosmosDB#00.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_apps_environment_default_domain string
@@ -17,7 +17,7 @@ param cosmos_outputs_connectionstring string
 
 param api_identity_outputs_clientid string
 
-resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource api 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExistingRedis#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.RoleAssignmentsWithAsExistingRedis#00.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_apps_environment_default_domain string
@@ -19,7 +19,7 @@ param redis_outputs_hostname string
 
 param api_identity_outputs_clientid string
 
-resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource api 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.UnknownManifestExpressionProviderIsHandledWithAllocateParameter.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.UnknownManifestExpressionProviderIsHandledWithAllocateParameter.verified.bicep
@@ -7,7 +7,7 @@ param env_outputs_azure_container_apps_environment_id string
 
 param customvalue string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.VolumesAndBindMountsAreTranslation.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.VolumesAndBindMountsAreTranslation.verified.bicep
@@ -11,7 +11,7 @@ param env_outputs_volumes_api_1 string
 
 param env_outputs_bindmounts_api_0 string
 
-resource api 'Microsoft.App/containerApps@2025-01-01' = {
+resource api 'Microsoft.App/containerApps@2025-07-01' = {
   name: 'api'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.WhenUsedWithAzureContainerAppsEnvironment_GeneratesProperBicep#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureEnvironmentResourceTests.WhenUsedWithAzureContainerAppsEnvironment_GeneratesProperBicep#01.verified.bicep
@@ -38,7 +38,7 @@ resource env_law 'Microsoft.OperationalInsights/workspaces@2025-02-01' = {
   tags: tags
 }
 
-resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
+resource env 'Microsoft.App/managedEnvironments@2025-07-01' = {
   name: take('env${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -59,7 +59,7 @@ resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
   tags: tags
 }
 
-resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
+resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2025-10-02-preview' = {
   name: 'aspire-dashboard'
   properties: {
     componentType: 'AspireDashboard'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFunctionsTests.AddAzureFunctionsProject_WorksWithAddAzureContainerAppsInfrastructure#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureFunctionsTests.AddAzureFunctionsProject_WorksWithAddAzureContainerAppsInfrastructure#00.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_apps_environment_default_domain string
@@ -23,7 +23,7 @@ param funcstorage634f8_outputs_datalakeendpoint string
 
 param funcapp_identity_outputs_clientid string
 
-resource funcapp 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource funcapp 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'funcapp'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureProvisioningResourceExtensionsTests.AsProvisioningParameterTests.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureProvisioningResourceExtensionsTests.AsProvisioningParameterTests.verified.bicep
@@ -5,7 +5,7 @@ param endpointAddressParam string
 
 param someExpressionParam string
 
-resource app 'Microsoft.App/containerApps@2025-01-01' = {
+resource app 'Microsoft.App/containerApps@2025-07-01' = {
   name: take('app-${uniqueString(resourceGroup().id)}', 32)
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_AutoCreatesBothSubnetAndStorage.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_AutoCreatesBothSubnetAndStorage.verified.bicep
@@ -155,7 +155,7 @@ resource env_law 'Microsoft.OperationalInsights/workspaces@2025-02-01' = {
   tags: tags
 }
 
-resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
+resource env 'Microsoft.App/managedEnvironments@2025-07-01' = {
   name: take('env${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -176,7 +176,7 @@ resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
   tags: tags
 }
 
-resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
+resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2025-10-02-preview' = {
   name: 'aspire-dashboard'
   properties: {
     componentType: 'AspireDashboard'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_BothExplicitSubnetAndStorage.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_BothExplicitSubnetAndStorage.verified.bicep
@@ -193,7 +193,7 @@ resource env_law 'Microsoft.OperationalInsights/workspaces@2025-02-01' = {
   tags: tags
 }
 
-resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
+resource env 'Microsoft.App/managedEnvironments@2025-07-01' = {
   name: take('env${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -214,7 +214,7 @@ resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
   tags: tags
 }
 
-resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
+resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2025-10-02-preview' = {
   name: 'aspire-dashboard'
   properties: {
     componentType: 'AspireDashboard'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_ClearDefaultRoleAssignments_RemovesDeploymentScriptInfra.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_ClearDefaultRoleAssignments_RemovesDeploymentScriptInfra.verified.bicep
@@ -39,7 +39,7 @@ resource env_law 'Microsoft.OperationalInsights/workspaces@2025-02-01' = {
   tags: tags
 }
 
-resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
+resource env 'Microsoft.App/managedEnvironments@2025-07-01' = {
   name: take('env${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -60,7 +60,7 @@ resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
   tags: tags
 }
 
-resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
+resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2025-10-02-preview' = {
   name: 'aspire-dashboard'
   properties: {
     componentType: 'AspireDashboard'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_ExplicitStorage_AutoCreatesSubnet.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_ExplicitStorage_AutoCreatesSubnet.verified.bicep
@@ -193,7 +193,7 @@ resource env_law 'Microsoft.OperationalInsights/workspaces@2025-02-01' = {
   tags: tags
 }
 
-resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
+resource env 'Microsoft.App/managedEnvironments@2025-07-01' = {
   name: take('env${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -214,7 +214,7 @@ resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
   tags: tags
 }
 
-resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
+resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2025-10-02-preview' = {
   name: 'aspire-dashboard'
   properties: {
     componentType: 'AspireDashboard'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_ExplicitSubnet_AutoCreatesStorage.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_ExplicitSubnet_AutoCreatesStorage.verified.bicep
@@ -155,7 +155,7 @@ resource env_law 'Microsoft.OperationalInsights/workspaces@2025-02-01' = {
   tags: tags
 }
 
-resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
+resource env 'Microsoft.App/managedEnvironments@2025-07-01' = {
   name: take('env${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -176,7 +176,7 @@ resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
   tags: tags
 }
 
-resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
+resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2025-10-02-preview' = {
   name: 'aspire-dashboard'
   properties: {
     componentType: 'AspireDashboard'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_StorageBeforePrivateEndpoint.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_StorageBeforePrivateEndpoint.verified.bicep
@@ -193,7 +193,7 @@ resource env_law 'Microsoft.OperationalInsights/workspaces@2025-02-01' = {
   tags: tags
 }
 
-resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
+resource env 'Microsoft.App/managedEnvironments@2025-07-01' = {
   name: take('env${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -214,7 +214,7 @@ resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
   tags: tags
 }
 
-resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
+resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2025-10-02-preview' = {
   name: 'aspire-dashboard'
   properties: {
     componentType: 'AspireDashboard'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_SubnetBeforePrivateEndpoint.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureSqlDeploymentScriptTests.SqlWithPrivateEndpoint_SubnetBeforePrivateEndpoint.verified.bicep
@@ -155,7 +155,7 @@ resource env_law 'Microsoft.OperationalInsights/workspaces@2025-02-01' = {
   tags: tags
 }
 
-resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
+resource env 'Microsoft.App/managedEnvironments@2025-07-01' = {
   name: take('env${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -176,7 +176,7 @@ resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
   tags: tags
 }
 
-resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2024-10-02-preview' = {
+resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@2025-10-02-preview' = {
   name: 'aspire-dashboard'
   properties: {
     componentType: 'AspireDashboard'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#00.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param cae_outputs_azure_container_apps_environment_default_domain string
@@ -15,7 +15,7 @@ param myidentity_outputs_id string
 
 param myidentity_outputs_clientid string
 
-resource myapp 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource myapp 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'myapp'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_MultipleProjects_Works#01.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param cae_outputs_azure_container_apps_environment_default_domain string
@@ -15,7 +15,7 @@ param myidentity_outputs_id string
 
 param myidentity_outputs_clientid string
 
-resource myapp2 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource myapp2 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'myapp2'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_Works#00.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_WithRoleAssignments_Works#00.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param cae_outputs_azure_container_apps_environment_default_domain string
@@ -15,7 +15,7 @@ param myidentity_outputs_id string
 
 param myidentity_outputs_clientid string
 
-resource myapp 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource myapp 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'myapp'
   location: location
   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_Works.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureUserAssignedIdentityTests.WithAzureUserAssignedIdentity_Works.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param cae_outputs_azure_container_apps_environment_default_domain string
@@ -15,7 +15,7 @@ param myidentity_outputs_id string
 
 param myidentity_outputs_clientid string
 
-resource myapp 'Microsoft.App/containerApps@2025-02-02-preview' = {
+resource myapp 'Microsoft.App/containerApps@2025-10-02-preview' = {
   name: 'myapp'
   location: location
   properties: {


### PR DESCRIPTION
## Description

This supports the latest resource versions.

- The "Kind" property is now available in a stable version.
- When doing "AutoConfigureDataProtection" we need to use a preview version that is higher than the latest stable version, so all the properties still work.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x ] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
