### PR TITLE
[ci] Support microsoft org CI guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   prepare_for_ci:
     runs-on: ubuntu-latest
     name: Prepare for CI
-    if: ${{ github.repository_owner == 'dotnet' }}
+    if: ${{ github.repository_owner == 'dotnet' || github.repository_owner == 'microsoft' }}
     outputs:
       skip_workflow: ${{ (steps.check_for_changes.outputs.no_changes == 'true' || steps.check_for_changes.outputs.only_changed == 'true') && 'true' || 'false' }}
 
@@ -42,11 +42,11 @@ jobs:
     uses: ./.github/workflows/tests.yml
     name: Tests
     needs: [prepare_for_ci]
-    if: ${{ github.repository_owner == 'dotnet' && needs.prepare_for_ci.outputs.skip_workflow != 'true' }}
+    if: ${{ (github.repository_owner == 'dotnet' || github.repository_owner == 'microsoft') && needs.prepare_for_ci.outputs.skip_workflow != 'true' }}
 
   # This job is used for branch protection. It fails if any of the dependent jobs failed
   results:
-    if: ${{ always() && github.repository_owner == 'dotnet' }}
+    if: ${{ always() && (github.repository_owner == 'dotnet' || github.repository_owner == 'microsoft') }}
     runs-on: ubuntu-latest
     name: Final Results
     needs: [prepare_for_ci, tests]

--- a/.github/workflows/specialized-test-runner.yml
+++ b/.github/workflows/specialized-test-runner.yml
@@ -34,7 +34,7 @@ jobs:
   generate_tests_matrix:
     name: Generate test runsheet
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'dotnet' }}
+    if: ${{ github.repository_owner == 'dotnet' || github.repository_owner == 'microsoft' }}
     outputs:
       runsheet: ${{ steps.generate_tests_matrix.outputs.runsheet }}
       requiresNugets: ${{ steps.check_nugets.outputs.requiresNugets }}
@@ -109,13 +109,13 @@ jobs:
   build_packages:
     name: Build packages
     needs: [generate_tests_matrix]
-    if: ${{ github.repository_owner == 'dotnet' && needs.generate_tests_matrix.outputs.requiresNugets == 'true' }}
+    if: ${{ (github.repository_owner == 'dotnet' || github.repository_owner == 'microsoft') && needs.generate_tests_matrix.outputs.requiresNugets == 'true' }}
     uses: ./.github/workflows/build-packages.yml
 
   build_cli_archives:
     name: Build native CLI archives
     needs: [generate_tests_matrix]
-    if: ${{ github.repository_owner == 'dotnet' && (needs.generate_tests_matrix.outputs.requiresNugets == 'true' || needs.generate_tests_matrix.outputs.requiresCliArchive == 'true') }}
+    if: ${{ (github.repository_owner == 'dotnet' || github.repository_owner == 'microsoft') && (needs.generate_tests_matrix.outputs.requiresNugets == 'true' || needs.generate_tests_matrix.outputs.requiresCliArchive == 'true') }}
     uses: ./.github/workflows/build-cli-native-archives.yml
 
   run_tests:
@@ -125,7 +125,7 @@ jobs:
       fail-fast: false
       matrix:
         tests: ${{ fromJson(needs.generate_tests_matrix.outputs.runsheet) }}
-    if: ${{ github.repository_owner == 'dotnet' && !cancelled() && !failure() }}
+    if: ${{ (github.repository_owner == 'dotnet' || github.repository_owner == 'microsoft') && !cancelled() && !failure() }}
     uses: ./.github/workflows/run-tests.yml
     with:
       testShortName: ${{ matrix.tests.project }}
@@ -138,7 +138,7 @@ jobs:
       requiresCliArchive: ${{ matrix.tests.requiresCliArchive == true }}
 
   results:
-    if: ${{ always() && github.repository_owner == 'dotnet' }}
+    if: ${{ always() && (github.repository_owner == 'dotnet' || github.repository_owner == 'microsoft') }}
     runs-on: ubuntu-latest
     name: Final Results
     needs: [generate_tests_matrix, build_packages, build_cli_archives, run_tests]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -219,7 +219,7 @@ jobs:
     uses: ./.github/workflows/typescript-sdk-tests.yml
 
   results:
-    if: ${{ always() && github.repository_owner == 'dotnet' }}
+    if: ${{ always() && (github.repository_owner == 'dotnet' || github.repository_owner == 'microsoft') }}
     runs-on: ubuntu-latest
     name: Final Test Results
     needs: [


### PR DESCRIPTION
## Description

Updates the CI and test workflow org guards so they continue to run after the repository move from `dotnet/aspire` to `microsoft/aspire`.

This keeps the main `ci.yml` entrypoint, the reusable `tests.yml` results job, and the specialized test runner workflows from being skipped solely because `github.repository_owner` is now `microsoft`.

Validation:
- Parsed the updated workflow YAML with Ruby's `YAML.load_file`
- Ran `git diff --check`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
