### PR TITLE
Disable Kusto emulator tests on Linux

### DIFF
--- a/tests/Aspire.Hosting.Azure.Kusto.Tests/KustoFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kusto.Tests/KustoFunctionalTests.cs
@@ -41,7 +41,7 @@ public class KustoFunctionalTests
     [Fact]
     [RequiresFeature(TestFeature.Docker)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
-    [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/15463", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
     public async Task KustoEmulator_Starts()
     {
         using var timeout = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan);
@@ -92,7 +92,7 @@ public class KustoFunctionalTests
     [Fact]
     [RequiresFeature(TestFeature.Docker)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
-    [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/15463", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
     public async Task KustoEmulator_WithDatabase_CanReadIngestedData()
     {
         using var timeout = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan);
@@ -171,7 +171,7 @@ public class KustoFunctionalTests
     [Fact]
     [RequiresFeature(TestFeature.Docker)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
-    [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/15463", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
     public async Task KustoEmulator_WithDatabaseThatAlreadyExists_ErrorIsIgnored()
     {
         using var timeout = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan);
@@ -199,7 +199,7 @@ public class KustoFunctionalTests
     [Fact]
     [RequiresFeature(TestFeature.Docker)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
-    [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/15463", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
     public async Task KustoEmulator_WithInvalidDatabase_LogsErrorAndContinues()
     {
         using var timeout = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan);
@@ -231,7 +231,7 @@ public class KustoFunctionalTests
     [Fact]
     [RequiresFeature(TestFeature.Docker)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
-    [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/15463", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
     public async Task KustoEmulator_WithBindMount_IsUsedForPersistence()
     {
         using var timeout = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan);

--- a/tests/Aspire.Hosting.Azure.Kusto.Tests/KustoFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kusto.Tests/KustoFunctionalTests.cs
@@ -40,7 +40,7 @@ public class KustoFunctionalTests
 
     [Fact]
     [RequiresFeature(TestFeature.Docker)]
-    [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
+[ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
     public async Task KustoEmulator_Starts()
     {
         using var timeout = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan);
@@ -90,7 +90,7 @@ public class KustoFunctionalTests
 
     [Fact]
     [RequiresFeature(TestFeature.Docker)]
-    [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
+[ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
     public async Task KustoEmulator_WithDatabase_CanReadIngestedData()
     {
         using var timeout = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan);
@@ -168,7 +168,7 @@ public class KustoFunctionalTests
 
     [Fact]
     [RequiresFeature(TestFeature.Docker)]
-    [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
+[ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
     public async Task KustoEmulator_WithDatabaseThatAlreadyExists_ErrorIsIgnored()
     {
         using var timeout = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan);
@@ -195,7 +195,7 @@ public class KustoFunctionalTests
 
     [Fact]
     [RequiresFeature(TestFeature.Docker)]
-    [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
+[ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
     public async Task KustoEmulator_WithInvalidDatabase_LogsErrorAndContinues()
     {
         using var timeout = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan);
@@ -226,7 +226,7 @@ public class KustoFunctionalTests
 
     [Fact]
     [RequiresFeature(TestFeature.Docker)]
-    [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
+[ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
     public async Task KustoEmulator_WithBindMount_IsUsedForPersistence()
     {
         using var timeout = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan);

--- a/tests/Aspire.Hosting.Azure.Kusto.Tests/KustoFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kusto.Tests/KustoFunctionalTests.cs
@@ -40,7 +40,8 @@ public class KustoFunctionalTests
 
     [Fact]
     [RequiresFeature(TestFeature.Docker)]
-[ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
     public async Task KustoEmulator_Starts()
     {
         using var timeout = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan);
@@ -90,7 +91,8 @@ public class KustoFunctionalTests
 
     [Fact]
     [RequiresFeature(TestFeature.Docker)]
-[ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
     public async Task KustoEmulator_WithDatabase_CanReadIngestedData()
     {
         using var timeout = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan);
@@ -168,7 +170,8 @@ public class KustoFunctionalTests
 
     [Fact]
     [RequiresFeature(TestFeature.Docker)]
-[ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
     public async Task KustoEmulator_WithDatabaseThatAlreadyExists_ErrorIsIgnored()
     {
         using var timeout = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan);
@@ -195,7 +198,8 @@ public class KustoFunctionalTests
 
     [Fact]
     [RequiresFeature(TestFeature.Docker)]
-[ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
     public async Task KustoEmulator_WithInvalidDatabase_LogsErrorAndContinues()
     {
         using var timeout = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan);
@@ -226,7 +230,8 @@ public class KustoFunctionalTests
 
     [Fact]
     [RequiresFeature(TestFeature.Docker)]
-[ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
     public async Task KustoEmulator_WithBindMount_IsUsedForPersistence()
     {
         using var timeout = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan);


### PR DESCRIPTION
## Description

This PR temporarily disables the Linux-targeted Kusto emulator functional tests in `tests/Aspire.Hosting.Azure.Kusto.Tests/KustoFunctionalTests.cs` while preserving the existing Azure DevOps skip.

The current Kusto emulator image fails to start on Linux CI because it exits with an unsupported CPU instruction set error (`SSE4.2/AVX2`), which causes the emulator-backed tests to fail before they can become healthy.

Addresses #15463

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No

### Validation

- Reproduced the emulator startup failure locally and confirmed the failing set is the five emulator-backed tests in `KustoFunctionalTests`
- Built `tests/Aspire.Hosting.Azure.Kusto.Tests/Aspire.Hosting.Azure.Kusto.Tests.csproj` successfully after updating the `ActiveIssue` attributes
- Preserved the existing Azure DevOps disable on `#11820` and added a Linux-targeted disable on `#15463`
