### PR TITLE
Improve log message when waiting for an endpoint to be allocated

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -613,6 +613,14 @@ public static class ResourceExtensions
             {
                 logger.LogInformation("Waiting for value for connection string from resource '{ResourceName}'", cs.Name);
             }
+            else if (TryGetEndpointReference(valueProvider, out var endpointReference))
+            {
+                logger.LogInformation(
+                    "Waiting for endpoint '{EndpointName}' on resource '{ResourceName}' for the '{NetworkName}' network",
+                    endpointReference.EndpointName,
+                    endpointReference.Resource.Name,
+                    endpointReference.ContextNetworkID?.Value);
+            }
             else
             {
                 if (key is null)
@@ -627,6 +635,18 @@ public static class ResourceExtensions
         }
 
         return await task.ConfigureAwait(false);
+    }
+
+    private static bool TryGetEndpointReference(IValueProvider valueProvider, [NotNullWhen(true)] out EndpointReference? endpointReference)
+    {
+        endpointReference = valueProvider switch
+        {
+            EndpointReference endpoint => endpoint,
+            EndpointReferenceExpression { Endpoint: var endpoint } => endpoint,
+            _ => null
+        };
+
+        return endpointReference is not null;
     }
 
     /// <summary>


### PR DESCRIPTION
## Description

Improve log message when waiting for an endpoint to be allocated.

Previously it would have said
> Waiting for value from Aspire.Hosting.ApplicationModel.EndpointReference.

Now it says
> Waiting for endpoint 'http' on resource 'nginx' for the 'unknownnetwork' network

Fixes #13912

If you want to reproduce this, easiest way is to use an endpoint reference on a network aspire doesn't know about:

```cs
var nginx = builder.AddContainer("nginx", "nginx", "latest")
       .WithHttpEndpoint(targetPort: 8080);

builder.AddExecutable("test", "test", ".")
       .WithArgs(nginx.GetEndpoint("http", new("unknownnetwork")))
       .WithArgs(nginx.GetEndpoint("http", new("unknownnetwork")).Property(EndpointProperty.Url))
       ;
```

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [X] No
