### PR TITLE
Don't swallow errors from ExecutionConfigurationBuilder

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -261,11 +261,6 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
             await _executorEvents.PublishAsync(new OnEndpointsAllocatedContext(ct)).ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
-        {
-            // This is here so hosting does not throw an exception when CTRL+C during startup.
-            _logger.LogDebug("Cancellation received during application startup.");
-        }
         catch
         {
             _shutdownCancellation.Cancel();

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -490,7 +490,15 @@ public class DistributedApplication : IHost, IAsyncDisposable
             await ExecuteBeforeStartHooksAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        await _host.RunAsync(cancellationToken).ConfigureAwait(false);
+        var lifetime = _host.Services.GetRequiredService<IHostApplicationLifetime>();
+        try
+        {
+            await _host.RunAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (lifetime.ApplicationStopping.IsCancellationRequested)
+        {
+            // Do nothing
+        }
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/DistributedApplicationLifecycle.cs
+++ b/src/Aspire.Hosting/DistributedApplicationLifecycle.cs
@@ -21,7 +21,7 @@ internal sealed class DistributedApplicationLifecycle(
 
     public Task StartedAsync(CancellationToken cancellationToken)
     {
-        if (executionContext.IsRunMode)
+        if (executionContext.IsRunMode && !cancellationToken.IsCancellationRequested)
         {
             logger.LogInformation("Distributed application started. Press Ctrl+C to shut down.");
         }

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -1318,37 +1318,6 @@ public class DcpExecutorTests
         Assert.Equal(ContainerPullPolicy.Never, explicitNeverContainer.Spec.PullPolicy);
     }
 
-    [Fact]
-    public async Task CancelTokenDuringStartup()
-    {
-        // Arrange
-        var builder = DistributedApplication.CreateBuilder();
-
-        const int desiredTargetPort = TestKubernetesService.StartOfAutoPortRange - 999;
-        builder.AddContainer("database", "image")
-            .WithEndpoint(name: "NoPortTargetPortSet", targetPort: desiredTargetPort, env: "NO_PORT_TARGET_PORT_SET", isProxied: true);
-
-        var kubernetesService = new TestKubernetesService();
-
-        using var app = builder.Build();
-        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
-        var dcpEvents = new DcpExecutorEvents();
-        var tokenSource = new CancellationTokenSource();
-        dcpEvents.Subscribe<OnResourcesPreparedContext>((context) =>
-        {
-            tokenSource.Cancel();
-            return Task.CompletedTask;
-        });
-
-        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, events: dcpEvents);
-
-        // Act
-        await appExecutor.RunApplicationAsync(tokenSource.Token);
-
-        // Assert
-        Assert.True(tokenSource.IsCancellationRequested);
-    }
-
     [Theory]
     [InlineData("127.0.0.1", "127.0.0.1")]
     [InlineData("[::1]", "[::1]")]

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -370,6 +370,86 @@ public class DistributedApplicationTests
     }
 
     [Fact]
+    public async Task StartAsync_ThrowsWhenCancelled()
+    {
+        const string testName = "startasync-cancelled-during-startup";
+        using var testProgram = CreateTestProgram(testName, randomizePorts: false, includeIntegrationServices: false);
+
+        using var cts = new CancellationTokenSource();
+        testProgram.AppBuilder.Eventing.Subscribe<BeforeStartEvent>((_, cancellationToken) =>
+        {
+            cts.Cancel();
+            return Task.CompletedTask;
+        });
+
+        using var app = testProgram.Build();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await app.StartAsync(cts.Token);
+        }).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+    }
+
+    [Fact]
+    public async Task StartAsync_ThrowsWhenStopped()
+    {
+        const string testName = "startasync-stopped-during-startup";
+        using var testProgram = CreateTestProgram(testName, randomizePorts: false, includeIntegrationServices: false);
+
+        testProgram.AppBuilder.Eventing.Subscribe<BeforeStartEvent>((evt, cancellationToken) =>
+        {
+            evt.Services.GetRequiredService<IHostApplicationLifetime>().StopApplication();
+            return Task.CompletedTask;
+        });
+
+        using var app = testProgram.Build();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await app.StartAsync();
+        }).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+    }
+
+    [Fact]
+    public async Task RunAsync_ThrowsWhenCancelled()
+    {
+        const string testName = "runasync-cancelled-by-caller-during-startup";
+        using var testProgram = CreateTestProgram(testName, randomizePorts: false, includeIntegrationServices: false);
+        using var cts = new CancellationTokenSource();
+
+        testProgram.AppBuilder.Eventing.Subscribe<BeforeStartEvent>((_, cancellationToken) =>
+        {
+            cts.Cancel();
+            return Task.CompletedTask;
+        });
+
+        using var app = testProgram.Build();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await app.RunAsync(cts.Token);
+        }).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+    }
+
+    [Fact]
+    public async Task RunAsync_DoesNotThrowWhenStopped()
+    {
+        const string testName = "runasync-stopped-during-startup";
+        using var testProgram = CreateTestProgram(testName, randomizePorts: false, includeIntegrationServices: false);
+
+        testProgram.AppBuilder.Eventing.Subscribe<BeforeStartEvent>((evt, cancellationToken) =>
+        {
+            // Simulate ctrl+c by a user
+            evt.Services.GetRequiredService<IHostApplicationLifetime>().StopApplication();
+            return Task.CompletedTask;
+        });
+
+        using var app = testProgram.Build();
+
+        await app.RunAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+    }
+
+    [Fact]
     [RequiresFeature(TestFeature.Docker)]
     public async Task ExplicitStart_StartContainer()
     {


### PR DESCRIPTION
## Description

Don't swallow errors if a resource fails to start due to an exception from `ExecutionConfigurationBuilder`. 

Some improvements could be made to avoid the massive stack trace the current error gives, but getting an error is a big improvement over the reosurce showing `FailedToStart` without any logs to suggest why.

One way to encounter this is:

```cs
var nginx = builder.AddContainer("nginx", "nginx", "latest");

builder.AddContainer("test", "nginx")
       .WithArgs(nginx.GetEndpoint("doesnot-exist"));
```
Which now gives the error:
```
 Failed to create container resource test
System.AggregateException: One or more errors occurred while resolving resource configuration. (The endpoint `doesnot-exist` is not defined for the resource `nginx`.)
 ---> System.InvalidOperationException: The endpoint `doesnot-exist` is not defined for the resource `nginx`.
   at Aspire.Hosting.ApplicationModel.EndpointReference.get_EndpointAnnotation() in s:\aspire\src\Aspire.Hosting\ApplicationModel\EndpointReference.cs:line 24
   at Aspire.Hosting.ApplicationModel.EndpointReferenceExpression.<>c__DisplayClass10_0.<<GetValueAsync>g__ResolveValueWithAllocatedAddress|0>d.MoveNext() in s:\aspire\src\Aspire.Hosting\ApplicationModel\EndpointReference.cs:line 345
--- End of stack trace from previous location ---
   at Aspire.Hosting.ApplicationModel.EndpointReferenceExpression.GetValueAsync(ValueProviderContext context, CancellationToken cancellationToken) in s:\aspire\src\Aspire.Hosting\ApplicationModel\EndpointReference.cs:line 339
   at Aspire.Hosting.ApplicationModel.ExpressionResolver.EvalValueProvider(IValueProvider vp, ValueProviderContext context) in s:\aspire\src\Aspire.Hosting\ApplicationModel\ExpressionResolver.cs:line 50
   at Aspire.Hosting.ApplicationModel.ExpressionResolver.ResolveInternalAsync(Object value, ValueProviderContext context) in s:\aspire\src\Aspire.Hosting\ApplicationModel\ExpressionResolver.cs:line 83
   at Aspire.Hosting.ApplicationModel.ExpressionResolver.ResolveAsync(IValueProvider valueProvider, ValueProviderContext context, CancellationToken cancellationToken) in s:\aspire\src\Aspire.Hosting\ApplicationModel\ExpressionResolver.cs:line 92
   at Aspire.Hosting.ApplicationModel.ResourceExtensions.GetValue(IResource resource, DistributedApplicationExecutionContext executionContext, String key, IValueProvider valueProvider, ILogger logger, CancellationToken cancellationToken) in s:\aspire\src\Aspire.Hosting\ApplicationModel\ResourceExtensions.cs:line 629
   at Aspire.Hosting.ApplicationModel.ResourceExtensions.ResolveValueAsync(IResource resource, DistributedApplicationExecutionContext executionContext, ILogger logger, Object value, String key, CancellationToken cancellationToken) in s:\aspire\src\Aspire.Hosting\ApplicationModel\ResourceExtensions.cs:line 534
   at Aspire.Hosting.ApplicationModel.ExecutionConfigurationGathererContext.ResolveAsync(IResource resource, ILogger resourceLogger, DistributedApplicationExecutionContext executionContext, CancellationToken cancellationToken) in s:\aspire\src\Aspire.Hosting\ApplicationModel\ExecutionConfigurationGathererContext.cs:line 52
   --- End of inner exception stack trace ---
   at Aspire.Hosting.Dcp.DcpExecutor.CreateContainerAsync(RenderedModelResource cr, ILogger resourceLogger, CancellationToken cancellationToken) in s:\aspire\src\Aspire.Hosting\Dcp\DcpExecutor.cs:line 2350
   at Aspire.Hosting.Dcp.DcpExecutor.<>c__DisplayClass82_0.<<CreateContainersAsync>g__CreateContainerAsyncCore|0>d.MoveNext() in s:\aspire\src\Aspire.Hosting\Dcp\DcpExecutor.cs:line 2072
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [X] No

