### PR TITLE
Temporarily disable OneLoc build after repo migration

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -340,13 +340,16 @@ extends:
                 name: computeChannel
                 displayName: 🟣Determine installer channel
 
-      - ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
-        - template: /eng/common/templates-official/job/onelocbuild.yml@self
-          parameters:
-            LclSource: lclFilesfromPackage
-            LclPackageId: 'LCL-JUNO-PROD-ASPIRE'
-            MirrorRepo: aspire
-            MirrorBranch: main
+      # OneLocBuild is temporarily disabled while we work with the loc team
+      # to reconfigure it after the repo migration from dotnet/aspire to microsoft/aspire.
+      # - ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+      #   - template: /eng/common/templates-official/job/onelocbuild.yml@self
+      #     parameters:
+      #       LclSource: lclFilesfromPackage
+      #       LclPackageId: 'LCL-JUNO-PROD-ASPIRE'
+      #       GitHubOrg: microsoft
+      #       MirrorRepo: aspire
+      #       MirrorBranch: main
 
     # ----------------------------------------------------------------
     # Generate and test installer packages (WinGet + Homebrew).


### PR DESCRIPTION
## Description

OneLocBuild is broken after the repo migration from `dotnet/aspire` to `microsoft/aspire`. The build has been failing with `OneLocBuildClient.exe exited with code 1` on every main branch build. Disabling while we work with the loc team to re-enable it.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
