### PR TITLE
Refresh root README for repo move and multi-language positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ builder.Build().Run();
 **TypeScript** (`apphost.ts`)
 
 ```typescript
-import { createBuilder } from "./.modules/aspire.js";
+import { createBuilder } from './.modules/aspire.js';
 
 const builder = await createBuilder();
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Security issues and bugs should be reported privately, via email, to the Microso
 
 ### Note on containers used by Aspire resource and client integrations
 
-The Aspire project cannot evaluate the underlying third-party containers for which it provides API support for suitability for specific customer requirements.
+The Aspire team cannot evaluate the underlying third-party containers for which it provides API support for suitability for specific customer requirements.
 
 You should evaluate whichever containers you chose to compose and automate with Aspire to ensure they meet your, your employers or your government’s requirements on security and safety as well as cryptographic regulations and any other regulatory or corporate standards that may apply to your use of the container.
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,64 @@
 # Aspire
 
+[![CI](https://github.com/microsoft/aspire/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/microsoft/aspire/actions/workflows/ci.yml)
 [![Tests](https://github.com/microsoft/aspire/actions/workflows/tests.yml/badge.svg?branch=main&event=push)](https://github.com/microsoft/aspire/actions/workflows/tests.yml)
-[![Build Status](https://dev.azure.com/dnceng-public/public/_apis/build/status%2Fdotnet%2Faspire%2Fdotnet.aspire?branchName=main)](https://dev.azure.com/dnceng-public/public/_build/latest?definitionId=274&branchName=main)
 [![Help Wanted](https://img.shields.io/github/issues/microsoft/aspire/help%20wanted?style=flat&color=%24EC820&label=help%20wanted)](https://github.com/microsoft/aspire/labels/help%20wanted)
 [![Good First Issue](https://img.shields.io/github/issues/microsoft/aspire/good%20first%20issue?style=flat&color=%24EC820&label=good%20first%20issue)](https://github.com/microsoft/aspire/labels/good%20first%20issue)
 [![Discord](https://img.shields.io/discord/1361488941836140614?style=flat&logo=discord&logoColor=white&label=Join%20our%20Discord&labelColor=512bd4&color=cyan)](https://discord.gg/raNPcaaSj8)
 
 ## What is Aspire?
 
-Aspire provides tools, templates, and packages for building observable, production-ready distributed apps. At the center is the app model—a code-first, single source of truth that defines your app's services, resources, and connections.
+Aspire is a multi-language, code-first toolchain for building, running, and deploying distributed applications.
 
-Aspire gives you a unified toolchain: launch and debug your entire app locally with one command, then deploy anywhere—Kubernetes, the cloud, or your own servers—using the same composition.
+Describe how services, frontends, containers, databases, caches, and connections fit together in code. The Aspire CLI runs the whole app locally, exposes OpenTelemetry-based observability, and carries the same definition into deployment.
 
-## Useful links
+## A simple app definition
 
-- [Aspire overview and documentation](https://aspire.dev/docs/)
-- [Aspire samples repository](https://github.com/microsoft/aspire-samples)
-- [Dogfooding pull requests](docs/dogfooding-pull-requests.md) - Test changes from specific pull requests locally
+The same application definition can be written in different languages.
+
+**C#** (`apphost.cs`)
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+var cache = builder.AddRedis("cache");
+
+var api = builder.AddNodeApp("api", "./api", "src/index.ts")
+    .WithReference(cache)
+    .WaitFor(cache)
+    .WithHttpEndpoint(env: "PORT")
+    .WithExternalHttpEndpoints();
+
+builder.AddViteApp("frontend", "./frontend")
+    .WithReference(api)
+    .WaitFor(api);
+
+builder.Build().Run();
+```
+
+**TypeScript** (`apphost.ts`)
+
+```typescript
+import { createBuilder } from "./.modules/aspire.js";
+
+const builder = await createBuilder();
+
+const cache = await builder.addRedis("cache");
+
+const api = await builder
+    .addNodeApp("api", "./api", "src/index.ts")
+    .withReference(cache)
+    .waitFor(cache)
+    .withHttpEndpoint({ env: "PORT" })
+    .withExternalHttpEndpoints();
+
+await builder
+    .addViteApp("frontend", "./frontend")
+    .withReference(api)
+    .waitFor(api);
+
+await builder.build().run();
+```
 
 ## Getting started
 
@@ -39,38 +81,32 @@ curl -sSL https://aspire.dev/install.sh | bash
 > [!NOTE]
 > If you want to use the latest daily builds instead of the released version, follow the instructions in [docs/using-latest-daily.md](docs/using-latest-daily.md).
 
+## Useful links
+
+- [Documentation](https://aspire.dev/docs/)
+- [Build your first app](https://aspire.dev/get-started/first-app/)
+- [Build status](https://github.com/microsoft/aspire/actions/workflows/ci.yml)
+- [Aspire samples repository](https://github.com/microsoft/aspire-samples)
+- [Developer Control Plane (DCP)](https://github.com/microsoft/dcp)
+- [Dogfooding pull requests](docs/dogfooding-pull-requests.md)
+
 ## What is in this repo?
 
-The Aspire application host, dashboard, service discovery infrastructure, and all Aspire integrations. It also contains the project templates.
+This repo contains the Aspire CLI, AppHost SDK, dashboard, service discovery infrastructure, project templates, and integrations.
 
-## How can I contribute?
+## Contributing
 
-We welcome contributions! Many people all over the world have helped make Aspire better.
-
-Follow instructions in [docs/contributing.md](docs/contributing.md) for working in the code in the repository.
+Follow [docs/contributing.md](docs/contributing.md) for working in the repository.
 
 ## Reporting security issues and security bugs
 
 Security issues and bugs should be reported privately, via email, to the Microsoft Security Response Center (MSRC) <secure@microsoft.com>. You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Further information, including the MSRC PGP key, can be found in the [Security TechCenter](https://www.microsoft.com/msrc/faqs-report-an-issue). You can also find these instructions in this repo's [Security doc](SECURITY.md).
 
-Also see info about related [Microsoft .NET Core and ASP.NET Core Bug Bounty Program](https://www.microsoft.com/msrc/bounty-dot-net-core).
-
 ### Note on containers used by Aspire resource and client integrations
 
-The .NET team cannot evaluate the underlying third-party containers for which we have API support for suitability for specific customer requirements.
+The Aspire project cannot evaluate the underlying third-party containers for which it provides API support for suitability for specific customer requirements.
 
 You should evaluate whichever containers you chose to compose and automate with Aspire to ensure they meet your, your employers or your government’s requirements on security and safety as well as cryptographic regulations and any other regulatory or corporate standards that may apply to your use of the container.
-
-## .NET Foundation
-
-Aspire is a [.NET Foundation](https://www.dotnetfoundation.org/projects) project.
-
-There are many .NET related projects on GitHub.
-
-* [.NET home repo](https://github.com/Microsoft/dotnet) - links to 100s of .NET projects, from Microsoft and the community.
-* [ASP.NET Core home](https://docs.microsoft.com/aspnet/core) - the best place to start learning about ASP.NET Core.
-
-This project has adopted the code of conduct defined by the [Contributor Covenant](https://contributor-covenant.org) to clarify expected behavior in our community. For more information, see the [.NET Foundation Code of Conduct](https://www.dotnetfoundation.org/code-of-conduct).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ curl -sSL https://aspire.dev/install.sh | bash
 
 ## What is in this repo?
 
-This repo contains the Aspire CLI, AppHost SDK, dashboard, service discovery infrastructure, project templates, and integrations.
+This repo contains the Aspire CLI, AppHost SDK, dashboard, service discovery infrastructure, project templates, integrations, and VS Code Extension.
 
 ## Contributing
 


### PR DESCRIPTION
## Description

Refresh the root README after the move to `microsoft/aspire` and tighten the top-level messaging so it reads less like a .NET-only project.

This updates the opening description, adds a small C# and TypeScript app definition example, refreshes the useful links section, and removes stale repo/org and .NET Foundation references from the root README.

No additional dependencies are required for this change.

Validation:
- `git diff --check -- README.md`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
