### PR TITLE
Add 'Open Aspire Dashboard' to Command Palette

### DIFF
--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -289,11 +289,11 @@
     <trans-unit id="extension.description">
       <source xml:lang="en">Official Aspire extension for Visual Studio Code</source>
     </trans-unit>
+    <trans-unit id="command.openDashboard">
+      <source xml:lang="en">Open Aspire Dashboard</source>
+    </trans-unit>
     <trans-unit id="command.openTerminal">
       <source xml:lang="en">Open Aspire terminal</source>
-    </trans-unit>
-    <trans-unit id="command.openDashboard">
-      <source xml:lang="en">Open Dashboard</source>
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.codespacesLink">
       <source xml:lang="en">Open codespaces URL</source>
@@ -351,6 +351,9 @@
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.openCliInstallInstructions">
       <source xml:lang="en">See CLI installation instructions</source>
+    </trans-unit>
+    <trans-unit id="aspire-vscode.strings.selectDashboardPlaceholder">
+      <source xml:lang="en">Select a dashboard to open</source>
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.selectDirectoryTitle">
       <source xml:lang="en">Select directory</source>

--- a/extension/package.json
+++ b/extension/package.json
@@ -344,7 +344,7 @@
         },
         {
           "command": "aspire-vscode.openDashboard",
-          "when": "false"
+          "when": "!aspire.noRunningAppHosts"
         },
         {
           "command": "aspire-vscode.stopAppHost",

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -120,7 +120,7 @@
   "views.runningAppHosts.welcome": "No running Aspire apphost detected in this workspace.\n[Refresh](command:aspire-vscode.refreshRunningAppHosts)",
   "views.runningAppHosts.errorWelcome": "The Aspire CLI is not installed or does not support this feature. Install or update the Aspire CLI and restart VS Code to get started.\n[Update Aspire CLI](command:aspire-vscode.updateSelf)\n[Refresh](command:aspire-vscode.refreshRunningAppHosts)",
   "command.refreshRunningAppHosts": "Refresh running apphosts",
-  "command.openDashboard": "Open Dashboard",
+  "command.openDashboard": "Open Aspire Dashboard",
   "command.stopAppHost": "Stop",
   "command.stopResource": "Stop",
   "command.startResource": "Start",
@@ -146,5 +146,6 @@
   "walkthrough.getStarted.dashboard.description": "The Aspire Dashboard shows your resources, endpoints, logs, traces, and metrics — all in one place.\n\n[Open dashboard](command:aspire-vscode.openDashboard)",
   "walkthrough.getStarted.nextSteps.title": "Next steps",
   "walkthrough.getStarted.nextSteps.description": "You're all set! Add integrations for databases, messaging, and cloud services, or deploy your app to production.\n\n[Add an integration](command:aspire-vscode.add)\n\n[Open Aspire docs](https://aspire.dev/docs/)",
-  "mcpServerDefinitionProviders.aspire.label": "Aspire"
+  "mcpServerDefinitionProviders.aspire.label": "Aspire",
+  "aspire-vscode.strings.selectDashboardPlaceholder": "Select a dashboard to open"
 }

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -62,6 +62,7 @@ export const resourcesGroupLabel = vscode.l10n.t('Resources');
 export const resourceStateLabel = (name: string, state: string) => vscode.l10n.t('{0} — {1}', name, state);
 export const noCommandsAvailable = vscode.l10n.t('No commands available for this resource.');
 export const selectCommandPlaceholder = vscode.l10n.t('Select a command to execute');
+export const selectDashboardPlaceholder = vscode.l10n.t('Select a dashboard to open');
 export const workspaceAppHostLabel = vscode.l10n.t('Workspace apphost');
 export const resourceCountDescription = (count: number) => vscode.l10n.t('({0} resources)', count);
 export const tooltipType = (type: string) => vscode.l10n.t('Type: {0}', type);

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -9,6 +9,7 @@ import {
     resourceStateLabel,
     noCommandsAvailable,
     selectCommandPlaceholder,
+    selectDashboardPlaceholder,
     workspaceAppHostLabel,
     resourceCountDescription,
     tooltipType,
@@ -344,7 +345,7 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
 
     // ── Commands ──
 
-    openDashboard(element?: TreeElement): void {
+    async openDashboard(element?: TreeElement): Promise<void> {
         let url: string | null = null;
 
         if (element instanceof AppHostItem) {
@@ -352,17 +353,31 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
         }
 
         if (element instanceof WorkspaceResourcesItem) {
-            url = element.dashboardUrl;
+            url = getBaseDashboardUrl(element.dashboardUrl);
         }
 
         if (!url) {
             if (this._repository.viewMode === 'workspace') {
                 const resources = [...this._repository.workspaceResources];
-                url = resources.find(r => r.dashboardUrl)?.dashboardUrl ?? null;
+                const resourceUrl = resources.find(r => r.dashboardUrl)?.dashboardUrl ?? null;
+                url = getBaseDashboardUrl(resourceUrl);
             } else {
-                const appHosts = this._repository.appHosts;
-                if (appHosts.length > 0) {
+                const appHosts = this._repository.appHosts.filter(a => a.dashboardUrl);
+                if (appHosts.length === 1) {
                     url = appHosts[0].dashboardUrl;
+                } else if (appHosts.length > 1) {
+                    const items = appHosts.map(a => ({
+                        label: shortenPath(a.appHostPath),
+                        description: pidDescription(a.appHostPid),
+                        dashboardUrl: a.dashboardUrl!,
+                    }));
+                    const selected = await vscode.window.showQuickPick(items, {
+                        placeHolder: selectDashboardPlaceholder,
+                    });
+                    if (!selected) {
+                        return;
+                    }
+                    url = selected.dashboardUrl;
                 }
             }
         }
@@ -454,4 +469,19 @@ export class AspireAppHostTreeProvider implements vscode.TreeDataProvider<TreeEl
     private _findAppHostForResource(element: ResourceItem): AppHostDisplayInfo | undefined {
         return this._repository.appHosts.find(a => a.appHostPid === element.appHostPid);
     }
+}
+
+/**
+ * Strips the resource-specific path suffix from a resource dashboard URL
+ * to return the base dashboard URL.
+ *
+ * Resource dashboard URLs are constructed by appending `/?resource=name` to the
+ * base URL (e.g. `http://localhost:18888/login?t=token/?resource=myservice`).
+ */
+function getBaseDashboardUrl(resourceDashboardUrl: string | null): string | null {
+    if (!resourceDashboardUrl) {
+        return null;
+    }
+    const idx = resourceDashboardUrl.indexOf('/?resource=');
+    return idx >= 0 ? resourceDashboardUrl.substring(0, idx) : resourceDashboardUrl;
 }


### PR DESCRIPTION
## Description

Add "Open Aspire Dashboard" to the VS Code extension Command Palette.

Previously, the `openDashboard` command was only accessible from the tree view inline button. This change:

- Enables the command in the Command Palette when at least one Aspire app host is running (`!aspire.noRunningAppHosts`)
- Renames the command from "Open Dashboard" to "Open Aspire Dashboard" for clarity
- Adds a quick pick selector when multiple app hosts have dashboard URLs (global mode)
- Strips the resource-specific `/?resource=` suffix from workspace dashboard URLs so the base dashboard opens instead of a resource-specific view

Fixes #15445 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
