### PR TITLE
Fix event order and callback calling during container creation

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ArgumentsExecutionConfigurationGatherer.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ArgumentsExecutionConfigurationGatherer.cs
@@ -13,18 +13,24 @@ internal class ArgumentsExecutionConfigurationGatherer : IExecutionConfiguration
     /// <inheritdoc/>
     public async ValueTask GatherAsync(IExecutionConfigurationGathererContext context, IResource resource, ILogger resourceLogger, DistributedApplicationExecutionContext executionContext, CancellationToken cancellationToken = default)
     {
-        if (resource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var callbacks))
+        if (resource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var argumentAnnotations))
         {
-            var callbackContext = new CommandLineArgsCallbackContext(context.Arguments, resource, cancellationToken)
+            IList<object> args = [.. context.Arguments];
+            var callbackContext = new CommandLineArgsCallbackContext(args, resource, cancellationToken)
             {
                 Logger = resourceLogger,
                 ExecutionContext = executionContext
             };
 
-            foreach (var callback in callbacks)
+            foreach (var ann in argumentAnnotations)
             {
-                await callback.Callback(callbackContext).ConfigureAwait(false);
+                // Each annotation operates on a shared context.
+                args = await ann.AsCallbackAnnotation().EvaluateOnceAsync(callbackContext).ConfigureAwait(false);
             }
+
+            // Take the final result and apply to the gatherer context.
+            context.Arguments.Clear();
+            context.Arguments.AddRange(args);
         }
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/CommandLineArgsCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandLineArgsCallbackAnnotation.cs
@@ -1,16 +1,22 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting.ApplicationModel;
 
+using IArgCallbackAnnotation = ICallbackResourceAnnotation<CommandLineArgsCallbackContext, IList<object>>;
+
 /// <summary>
 /// Represents an annotation that provides a callback to be executed with a list of command-line arguments when an executable resource is started.
 /// </summary>
-public class CommandLineArgsCallbackAnnotation : IResourceAnnotation
+public class CommandLineArgsCallbackAnnotation : IResourceAnnotation, IArgCallbackAnnotation
 {
+    private Task<IList<object>>? _callbackTask;
+    private readonly object _lock = new();
+
     /// <summary>
     /// Initializes a new instance of the <see cref="CommandLineArgsCallbackAnnotation"/> class with the specified callback action.
     /// </summary>
@@ -41,6 +47,35 @@ public class CommandLineArgsCallbackAnnotation : IResourceAnnotation
     /// Gets the callback action to be executed when the executable arguments are parsed.
     /// </summary>
     public Func<CommandLineArgsCallbackContext, Task> Callback { get; }
+
+    internal IArgCallbackAnnotation AsCallbackAnnotation() => this;
+
+    Task<IList<object>> IArgCallbackAnnotation.EvaluateOnceAsync(CommandLineArgsCallbackContext context)
+    {
+        lock(_lock)
+        {
+            if (_callbackTask is null)
+            {
+                _callbackTask = ExecuteCallbackAsync(context);
+            }
+            return _callbackTask;
+        }
+    }
+
+    void IArgCallbackAnnotation.ForgetCachedResult()
+    {
+        lock(_lock)
+        {
+            _callbackTask = null;
+        }
+    }
+
+    private async Task<IList<object>> ExecuteCallbackAsync(CommandLineArgsCallbackContext context)
+    {
+        await Callback(context).ConfigureAwait(false);
+        var result = context.Args.ToImmutableList();
+        return result;
+    }
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/EnvironmentCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EnvironmentCallbackAnnotation.cs
@@ -5,13 +5,17 @@ using System.Diagnostics;
 
 namespace Aspire.Hosting.ApplicationModel;
 
+using IEnvCallbackAnnotation = ICallbackResourceAnnotation<EnvironmentCallbackContext, Dictionary<string, object>>;
+
 /// <summary>
 /// Represents an annotation that provides a callback to modify the environment variables of an application.
 /// </summary>
 [DebuggerDisplay("{DebuggerToString(),nq}")]
-public class EnvironmentCallbackAnnotation : IResourceAnnotation
+public class EnvironmentCallbackAnnotation : IResourceAnnotation, IEnvCallbackAnnotation
 {
     private readonly string? _name;
+    private Task<Dictionary<string, object>>? _callbackTask;
+    private readonly object _lock = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EnvironmentCallbackAnnotation"/> class with the specified name and callback function.
@@ -76,6 +80,35 @@ public class EnvironmentCallbackAnnotation : IResourceAnnotation
     /// Gets or sets the callback action to be executed when the environment is being built.
     /// </summary>
     public Func<EnvironmentCallbackContext, Task> Callback { get; private set; }
+
+    internal IEnvCallbackAnnotation AsCallbackAnnotation() => this;
+
+    Task<Dictionary<string, object>> IEnvCallbackAnnotation.EvaluateOnceAsync(EnvironmentCallbackContext context)
+    {
+        lock(_lock)
+        {
+            if (_callbackTask is null)
+            {
+                _callbackTask = ExecuteCallbackAsync(context);
+            }
+            return _callbackTask;
+        }
+    }
+
+    void IEnvCallbackAnnotation.ForgetCachedResult()
+    {
+        lock(_lock)
+        {
+            _callbackTask = null;
+        }
+    }
+
+    private async Task<Dictionary<string, object>> ExecuteCallbackAsync(EnvironmentCallbackContext context)
+    {
+        await Callback(context).ConfigureAwait(false);
+        var result = new Dictionary<string, object>(context.EnvironmentVariables);
+        return result;
+    }
 
     private string DebuggerToString()
     {

--- a/src/Aspire.Hosting/ApplicationModel/EnvironmentVariablesConfigurationGatherer.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EnvironmentVariablesConfigurationGatherer.cs
@@ -13,16 +13,24 @@ internal class EnvironmentVariablesExecutionConfigurationGatherer : IExecutionCo
     /// <inheritdoc/>
     public async ValueTask GatherAsync(IExecutionConfigurationGathererContext context, IResource resource, ILogger resourceLogger, DistributedApplicationExecutionContext executionContext, CancellationToken cancellationToken = default)
     {
-        if (resource.TryGetEnvironmentVariables(out var callbacks))
+        if (resource.TryGetEnvironmentVariables(out var envVarAnnotations))
         {
-            var callbackContext = new EnvironmentCallbackContext(executionContext, resource, context.EnvironmentVariables, cancellationToken)
+            var envVars = new Dictionary<string, object>(context.EnvironmentVariables);
+            var callbackContext = new EnvironmentCallbackContext(executionContext, resource, envVars, cancellationToken: cancellationToken)
             {
                 Logger = resourceLogger,
             };
 
-            foreach (var callback in callbacks)
+            foreach (var ann in envVarAnnotations)
             {
-                await callback.Callback(callbackContext).ConfigureAwait(false);
+                // Each annotation operates on a shared context.
+                envVars = await ann.AsCallbackAnnotation().EvaluateOnceAsync(callbackContext).ConfigureAwait(false);
+            }
+
+            // Take the final result and apply to the gatherer context.
+            foreach (var kvp in envVars)
+            {
+                context.EnvironmentVariables[kvp.Key] = kvp.Value;
             }
         }
     }

--- a/src/Aspire.Hosting/ApplicationModel/ICallbackResourceAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ICallbackResourceAnnotation.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents a resource annotation whose callback should be evaluated at most once,
+/// with the result cached for subsequent retrievals.
+/// </summary>
+/// <typeparam name="TContext">The type of the context passed to the callback.</typeparam>
+/// <typeparam name="TResult">The type of the result produced by the callback.</typeparam>
+internal interface ICallbackResourceAnnotation<TContext, TResult>
+{
+    /// <summary>
+    /// Evaluates the callback if it has not been evaluated yet, caching the result.
+    /// Subsequent calls return the cached result regardless of the context passed.
+    /// </summary>
+    /// <param name="context">The context for the callback evaluation. Only used on the first call.</param>
+    /// <returns>The cached result of the callback evaluation.</returns>
+    Task<TResult> EvaluateOnceAsync(TContext context);
+
+    /// <summary>
+    /// Clears the cached result so that the next call to <see cref="EvaluateOnceAsync"/> will re-execute the callback. 
+    ///</summary>
+    /// <remarks>
+    /// Use <see cref="ForgetCachedResult"/> when a resource decorated with this callback annotation is restarted.
+    /// </remarks>
+    void ForgetCachedResult();
+}

--- a/src/Aspire.Hosting/ApplicationModel/ResourceDependencyDiscoveryMode.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceDependencyDiscoveryMode.cs
@@ -4,7 +4,7 @@
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
-/// Specifies how resource dependencies are discovered.
+/// Represents the mode for discovering resource dependencies.
 /// </summary>
 public enum ResourceDependencyDiscoveryMode
 {
@@ -20,5 +20,5 @@ public enum ResourceDependencyDiscoveryMode
     /// and from environment variables and command-line arguments, but does not recurse
     /// into the dependencies of those dependencies.
     /// </summary>
-    DirectOnly
+    DirectOnly,
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceDependencyDiscoveryOptions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceDependencyDiscoveryOptions.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Changes how resource dependencies are discovered.
+/// </summary>
+public sealed class ResourceDependencyDiscoveryOptions
+{
+    /// <summary>
+    /// Sets the mode for discovering resource dependencies. See <see cref="ResourceDependencyDiscoveryMode"/> for details on the available modes.
+    /// 
+    /// </summary>
+    public ResourceDependencyDiscoveryMode DiscoveryMode { get; init; }
+
+    /// <summary>
+    /// When true, unresolved values from annotation callbacks will be cached and reused 
+    /// on subsequent evaluations of the same annotation, rather than re-evaluating the callback each time.
+    /// </summary>
+    public bool CacheAnnotationCallbackResults { get; init; }
+}

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -1256,7 +1256,7 @@ public static class ResourceExtensions
     /// </summary>
     /// <param name="resource">The resource to compute dependencies for.</param>
     /// <param name="executionContext">The execution context for resolving environment variables and arguments.</param>
-    /// <param name="mode">Specifies whether to discover only direct dependencies or the full transitive closure.</param>
+    /// <param name="mode">Specifies dependency discovery mode.</param>
     /// <param name="cancellationToken">A cancellation token to observe while computing dependencies.</param>
     /// <returns>A set of all resources that the specified resource depends on.</returns>
     /// <remarks>
@@ -1284,15 +1284,15 @@ public static class ResourceExtensions
         ResourceDependencyDiscoveryMode mode = ResourceDependencyDiscoveryMode.Recursive,
         CancellationToken cancellationToken = default)
     {
-        return GetDependenciesAsync([resource], executionContext, mode, cancellationToken);
+        return GetDependenciesAsync([resource], executionContext, new ResourceDependencyDiscoveryOptions { DiscoveryMode = mode }, cancellationToken);
     }
 
     /// <summary>
-    /// Efficiently computes the set of resources that the specified source set of resources depends on.
+    /// Computes the set of resources that the specified <paramref name="resource"/> depends on.
     /// </summary>
-    /// <param name="resources">The source set of resources to compute dependencies for.</param>
+    /// <param name="resource">The resource to compute dependencies for.</param>
     /// <param name="executionContext">The execution context for resolving environment variables and arguments.</param>
-    /// <param name="mode">Specifies whether to discover only direct dependencies or the full transitive closure.</param>
+    /// <param name="options">Changes details of dependency discovery process. See <see cref="ResourceDependencyDiscoveryOptions"/> enumeration for more information.</param>
     /// <param name="cancellationToken">A cancellation token to observe while computing dependencies.</param>
     /// <returns>A set of all resources that the specified resource depends on.</returns>
     /// <remarks>
@@ -1306,9 +1306,35 @@ public static class ResourceExtensions
     /// </list>
     /// </para>
     /// <para>
-    /// When <paramref name="mode"/> is <see cref="ResourceDependencyDiscoveryMode.DirectOnly"/>, only the immediate
-    /// dependencies are returned. When <paramref name="mode"/> is <see cref="ResourceDependencyDiscoveryMode.Recursive"/>,
-    /// all transitive dependencies are included.
+    /// This method invokes environment variable and command-line argument callbacks to discover all references. The context resource (<paramref name="resource"/>) is not considered a dependency (even if it is transitively referenced).
+    /// </para>
+    /// </remarks>
+    public static Task<IReadOnlySet<IResource>> GetResourceDependenciesAsync(
+        this IResource resource,
+        DistributedApplicationExecutionContext executionContext,
+        ResourceDependencyDiscoveryOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        return GetDependenciesAsync([resource], executionContext, options, cancellationToken);
+    }
+
+    /// <summary>
+    /// Efficiently computes the set of resources that the specified source set of resources depends on.
+    /// </summary>
+    /// <param name="resources">The source set of resources to compute dependencies for.</param>
+    /// <param name="executionContext">The execution context for resolving environment variables and arguments.</param>
+    /// <param name="options">Changes details of dependency discovery process. See <see cref="ResourceDependencyDiscoveryOptions"/> enumeration for more information.</param>
+    /// <param name="cancellationToken">A cancellation token to observe while computing dependencies.</param>
+    /// <returns>A set of all resources that the specified resource depends on.</returns>
+    /// <remarks>
+    /// <para>
+    /// Dependencies are computed from multiple sources:
+    /// <list type="bullet">
+    /// <item>Parent resources via <see cref="IResourceWithParent"/></item>
+    /// <item>Wait dependencies via <see cref="WaitAnnotation"/></item>
+    /// <item>Connection string redirects via <see cref="ConnectionStringRedirectAnnotation"/></item>
+    /// <item>References to endpoints in environment variables and command-line arguments (via <see cref="IValueWithReferences"/>)</item>
+    /// </list>
     /// </para>
     /// <para>
     /// This method invokes environment variable and command-line argument callbacks to discover all references.
@@ -1317,23 +1343,24 @@ public static class ResourceExtensions
     internal static async Task<IReadOnlySet<IResource>> GetDependenciesAsync(
         IEnumerable<IResource> resources,
         DistributedApplicationExecutionContext executionContext,
-        ResourceDependencyDiscoveryMode mode = ResourceDependencyDiscoveryMode.Recursive,
+        ResourceDependencyDiscoveryOptions? options = default,
         CancellationToken cancellationToken = default)
     {
         var dependencies = new HashSet<IResource>();
         var newDependencies = new HashSet<IResource>();
         var toProcess = new Queue<IResource>();
+        options ??= new ResourceDependencyDiscoveryOptions { DiscoveryMode = ResourceDependencyDiscoveryMode.Recursive };
 
         foreach (var resource in resources)
         {
             newDependencies.Clear();
-            await GatherDirectDependenciesAsync(resource, dependencies, newDependencies, executionContext, cancellationToken).ConfigureAwait(false);
+            await GatherDirectDependenciesAsync(resource, dependencies, newDependencies, executionContext, options, cancellationToken).ConfigureAwait(false);
 
-            if (mode == ResourceDependencyDiscoveryMode.Recursive)
+            if (options.DiscoveryMode == ResourceDependencyDiscoveryMode.Recursive)
             {
                 // Compute transitive closure by recursively processing dependencies
 
-                foreach(var nd in newDependencies)
+                foreach (var nd in newDependencies)
                 {
                     toProcess.Enqueue(nd);
                 }
@@ -1343,7 +1370,7 @@ public static class ResourceExtensions
                     var dep = toProcess.Dequeue();
                     newDependencies.Clear();
 
-                    await GatherDirectDependenciesAsync(dep, dependencies, newDependencies, executionContext, cancellationToken).ConfigureAwait(false);
+                    await GatherDirectDependenciesAsync(dep, dependencies, newDependencies, executionContext, options, cancellationToken).ConfigureAwait(false);
 
                     foreach (var newDep in newDependencies)
                     {
@@ -1372,12 +1399,14 @@ public static class ResourceExtensions
     /// <param name="dependencies">The set of dependencies (where dependency resources will be placed).</param>
     /// <param name="newDependencies">The set of newly discovered dependencies in this invocation (not present in <paramref name="dependencies"/> at the moment of invocation).</param>
     /// <param name="executionContext">The execution context for resolving environment variables and arguments.</param>
+    /// <param name="options">Changes details of dependency discovery process.</param>
     /// <param name="cancellationToken">A cancellation token to observe while gathering dependencies.</param>
     private static async Task GatherDirectDependenciesAsync(
         IResource resource,
         HashSet<IResource> dependencies,
         HashSet<IResource> newDependencies,
         DistributedApplicationExecutionContext executionContext,
+        ResourceDependencyDiscoveryOptions options,
         CancellationToken cancellationToken)
     {
         var visited = new HashSet<object>();
@@ -1386,7 +1415,7 @@ public static class ResourceExtensions
         CollectAnnotationDependencies(resource, dependencies, newDependencies);
 
         // Collect raw (unresolved) environment variable and argument values
-        var rawValues = await GatherRawEnvironmentAndArgumentValuesAsync(resource, executionContext, cancellationToken).ConfigureAwait(false);
+        var rawValues = await GatherRawEnvironmentAndArgumentValuesAsync(resource, executionContext, options, cancellationToken).ConfigureAwait(false);
 
         foreach (var value in rawValues)
         {
@@ -1400,26 +1429,38 @@ public static class ResourceExtensions
     private static async Task<List<object>> GatherRawEnvironmentAndArgumentValuesAsync(
         IResource resource,
         DistributedApplicationExecutionContext executionContext,
+        ResourceDependencyDiscoveryOptions options,
         CancellationToken cancellationToken)
     {
         var rawValues = new List<object>();
 
         // Gather environment variable values
-        if (resource.TryGetEnvironmentVariables(out var environmentCallbacks))
+        if (resource.TryGetEnvironmentVariables(out var envAnnotations))
         {
             var envVars = new Dictionary<string, object>();
-            var context = new EnvironmentCallbackContext(executionContext, resource, envVars, cancellationToken);
-
-            foreach (var callback in environmentCallbacks)
+            var context = new EnvironmentCallbackContext(executionContext, resource, envVars, cancellationToken: cancellationToken);
+            
+            if (options.CacheAnnotationCallbackResults)
             {
-                await callback.Callback(context).ConfigureAwait(false);
+                foreach (var ann in envAnnotations)
+                {
+                    var resultingVars = await ann.AsCallbackAnnotation().EvaluateOnceAsync(context).ConfigureAwait(false);
+                    rawValues.AddRange(resultingVars.Values);
+                }
+                
             }
-
-            rawValues.AddRange(envVars.Values);
+            else
+            {
+                foreach (var ann in envAnnotations)
+                {
+                    await ann.Callback(context).ConfigureAwait(false);
+                }
+                rawValues.AddRange(envVars.Values);
+            }
         }
 
         // Gather command-line argument values
-        if (resource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var argsCallbacks))
+        if (resource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var argAnnotations))
         {
             var args = new List<object>();
             var context = new CommandLineArgsCallbackContext(args, resource, cancellationToken)
@@ -1427,12 +1468,22 @@ public static class ResourceExtensions
                 ExecutionContext = executionContext
             };
 
-            foreach (var callback in argsCallbacks)
+            if (options.CacheAnnotationCallbackResults)
             {
-                await callback.Callback(context).ConfigureAwait(false);
+                foreach (var ann in argAnnotations)
+                {
+                    var resultingArgs = await ann.AsCallbackAnnotation().EvaluateOnceAsync(context).ConfigureAwait(false);
+                    rawValues.AddRange(resultingArgs);
+                }
             }
-
-            rawValues.AddRange(args);
+            else
+            {
+                foreach (var ann in argAnnotations)
+                {
+                    await ann.Callback(context).ConfigureAwait(false);
+                }
+                rawValues.AddRange(args);
+            }
         }
 
         return rawValues;

--- a/src/Aspire.Hosting/Dcp/ContainerCreationContext.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreationContext.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Channels;
+using Aspire.Hosting.Dcp.Model;
+
+namespace Aspire.Hosting.Dcp;
+
+/// <summary>
+/// A ContainerNetworkService represents a service implemented by a host resource but exposed on a container network.
+/// </summary>
+internal record class ContainerNetworkService
+{
+    public required ServiceAppResource ServiceResource { get; init; }
+    public TunnelConfiguration? TunnelConfig { get; init; }
+}
+
+/// <summary>
+/// Helps coordinate container creation tasks and container tunnel creation and configuration task.
+/// </summary>
+internal sealed class ContainerCreationContext : IDisposable
+{
+    public readonly CountdownEvent ContainerServicesSpecReady;
+    public readonly Channel<ContainerNetworkService> ContainerServicesChan;
+    private readonly Lazy<Task> _createTunnelLazy;
+
+    public Task CreateTunnel => _createTunnelLazy.Value;
+
+    public ContainerCreationContext(int containerCount, Func<ContainerCreationContext, Task> createTunnelFunc)
+    {
+        ContainerServicesSpecReady = new CountdownEvent(containerCount);
+        ContainerServicesChan = Channel.CreateUnbounded<ContainerNetworkService>();
+        _createTunnelLazy = new Lazy<Task>(() => createTunnelFunc(this), LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    /// <summary>
+    /// Disposes resources owned by the container creation context.
+    /// </summary>
+    public void Dispose()
+    {
+        ContainerServicesSpecReady.Dispose();
+    }
+}

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -73,11 +73,17 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
     private readonly IDistributedApplicationEventing _distributedApplicationEventing;
     private readonly IOptions<DcpOptions> _options;
     private readonly DistributedApplicationExecutionContext _executionContext;
-    private readonly List<AppResource> _appResources = [];
+    private readonly ConcurrentBag<AppResource> _appResources = [];
+
+    // Has an entry if we raised ResourceEndpointsAllocatedEvent for a resource with a given name.
+    // We want to ensure we raise the event only once for each app model resource. 
+    // There may be multiple physical replicas of the same app model resource 
+    // which can result in the event being raised multiple times if we are not careful.
+    private readonly HashSet<string> _endpointsAdvertised = new(StringComparers.ResourceName);
+
     private readonly CancellationTokenSource _shutdownCancellation = new();
     private readonly DcpExecutorEvents _executorEvents;
     private readonly Locations _locations;
-    private readonly IDeveloperCertificateService _developerCertificateService;
     private readonly DcpResourceState _resourceState;
     private readonly ResourceSnapshotBuilder _snapshotBuilder;
     private readonly SemaphoreSlim _serverCertificateCacheSemaphore = new(1, 1);
@@ -111,8 +117,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                        IDcpDependencyCheckService dcpDependencyCheckService,
                        DcpNameGenerator nameGenerator,
                        DcpExecutorEvents executorEvents,
-                       Locations locations,
-                       IDeveloperCertificateService developerCertificateService)
+                       Locations locations)
     {
         _distributedApplicationLogger = distributedApplicationLogger;
         _kubernetesService = kubernetesService;
@@ -131,7 +136,6 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         _snapshotBuilder = new(_resourceState);
         _normalizedApplicationName = NormalizeApplicationName(hostEnvironment.ApplicationName);
         _locations = locations;
-        _developerCertificateService = developerCertificateService;
 
         DeleteResourceRetryPipeline = DcpPipelineBuilder.BuildDeleteRetryPipeline(logger);
         WatchResourceRetryPipeline = DcpPipelineBuilder.BuildWatchResourcePipeline(logger);
@@ -163,7 +167,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             AspireEventSource.Instance.DcpServiceObjectPreparationStart();
             try
             {
-                await PrepareServicesAsync(ct).ConfigureAwait(false);
+                PrepareServices();
             }
             finally
             {
@@ -176,10 +180,6 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             await _executorEvents.PublishAsync(new OnResourcesPreparedContext(ct)).ConfigureAwait(false);
 
             WatchResourceChanges();
-
-            // Ensure we fire the event only once for each app model resource. There may be multiple physical replicas of
-            // the same app model resource which can result in the event being fired multiple times.
-            HashSet<string> endpointsAdvertised = new(StringComparers.ResourceName);
 
             var createServices = Task.Run(() => CreateAllDcpObjectsAsync<Service>(ct), ct);
 
@@ -195,15 +195,15 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
 
             var createContainerNetworks = Task.Run(() => CreateAllDcpObjectsAsync<ContainerNetwork>(ct), ct);
 
-            var executables = _appResources.OfType<RenderedModelResource>().Where(ar => ar.DcpResource is Executable);
-            var (regular, tunnelDependent, regularContainerExes, tunnelDependentContainerExes) = await GetContainerCreationSetsAsync(ct).ConfigureAwait(false);
+            var executables = _appResources.OfType<RenderedModelResource>().Where(ar => ar.DcpResource is Executable).ToArray();
+            var containers = _appResources.OfType<RenderedModelResource>().Where(ar => ar.DcpResource is Container).ToArray();
 
             var createExecutableEndpoints = Task.Run(async () =>
             {
                 await getProxyAddresses.ConfigureAwait(false);
 
                 AddAllocatedEndpointInfo(executables, AllocatedEndpointsMode.Workload);
-                await PublishEndpointAllocatedEventAsync(endpointsAdvertised, executables, ct).ConfigureAwait(false);
+                await PublishEndpointAllocatedEventAsync(executables, ct).ConfigureAwait(false);
             }, ct);
 
             var createExecutables = Task.Run(async () =>
@@ -213,62 +213,51 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                 await CreateExecutablesAsync(executables, ct).ConfigureAwait(false);
             }, ct);
 
-            var createRegularContainers = Task.Run(async () =>
+            Task createTunnelFunc(ContainerCreationContext cctx) => Task.Run(async () =>
             {
-                await Task.WhenAll([getProxyAddresses, createContainerNetworks]).ConfigureAwait(false);
+                await Task.WhenAll([getProxyAddresses, createContainerNetworks]).WaitAsync(ct).ConfigureAwait(false);
 
-                AddAllocatedEndpointInfo(regular, AllocatedEndpointsMode.Workload);
-                await PublishEndpointAllocatedEventAsync(endpointsAdvertised, regular, ct).ConfigureAwait(false);
+                // Container creation tasks need to figure out dependencies of each container 
+                // and then create Service and TunnelConfiguration definitions for each of them.
+                cctx.ContainerServicesSpecReady.Wait(ct);
+                cctx.ContainerServicesChan.Writer.Complete();
 
-                await Task.WhenAll(
-                    CreateContainersAsync(regular, ct),
-                    CreateContainerExecutablesAsync(regularContainerExes, ct)
-                ).WaitAsync(ct).ConfigureAwait(false);
-            }, ct);
+                // Now create the container network services for the host resources, update the tunnel, and advertise AllocatedEndpoints.
+                var containerNetworkServices = cctx.ContainerServicesChan.Reader.ReadAllAsync(ct).ToBlockingEnumerable(ct).ToArray();
+                _appResources.AddRange(containerNetworkServices.Select(cns => cns.ServiceResource));
+                var serviceObjects = containerNetworkServices.Select(cns => cns.ServiceResource.Service).ToArray();
+                await CreateDcpObjectsAsync(serviceObjects, ct).ConfigureAwait(false);
 
-            var createTunnel = Task.Run(async () =>
-            {
-                if (!tunnelDependent.Any())
-                {
-                    return; // No tunnel-dependent containers, nothing to do.
-                }
-
-                await Task.WhenAll([getProxyAddresses, createContainerNetworks]).ConfigureAwait(false);
-
+                var tunnels = containerNetworkServices.Where(s => s.TunnelConfig is not null).Select(s => s.TunnelConfig!).ToList();
+                Debug.Assert(tunnels.Count == containerNetworkServices.Length, "Each tunneled service should have a tunnel config");
+                var tunnelAppResource = CreateTunnelProxyResource(tunnels);
+                var tunnelProxy = (ContainerNetworkTunnelProxy)tunnelAppResource.DcpResource;
                 await CreateAllDcpObjectsAsync<ContainerNetworkTunnelProxy>(ct).ConfigureAwait(false);
-                await EnsureContainerServiceAddressInfo(ct).ConfigureAwait(false);
+
+                // Container tunnel initialization can take a while if the container tunnel image needs to be built,
+                // especially if the required image pull is slow, hence 10 minute timeout here.
+                await UpdateWithEffectiveAddressInfo(serviceObjects, ct, TimeSpan.FromMinutes(10)).ConfigureAwait(false);
 
                 AddAllocatedEndpointInfo(executables, AllocatedEndpointsMode.ContainerTunnel);
+
+                // createExecutableEndpoints() is not really part of container tunnel initialization,
+                // but configuring containers that use the tunnel require these host network-side endpoints to be ready,
+                // so instead of having container creation tasks wait on two separate tasks (current one + createExecutableEndpoints), 
+                // we just wait for createExecutableEndpoints here, and container creation tasks can then wait on this one.
+                await createExecutableEndpoints.ConfigureAwait(false);
             }, ct);
 
-            var createTunnelDependentContainers = Task.Run(async () =>
+            using var cctx = new ContainerCreationContext(containers.Length, createTunnelFunc);
+
+            var createContainers = Task.Run(async () =>
             {
-                if (!tunnelDependent.Any())
-                {
-                    return; // No tunnel-dependent containers, nothing to do.
-                }
+                await Task.WhenAll([getProxyAddresses, createContainerNetworks]).WaitAsync(ct).ConfigureAwait(false);
 
-                await Task.WhenAll([getProxyAddresses, createContainerNetworks, createExecutableEndpoints]).ConfigureAwait(false);
-
-                // There is no need to wait with creating tunnel-dependent containers till container tunnel is created.
-                // The containers will not be started until the tunnel endpoints they use are ready, but this is handled internally by DCP.
-
-                AddAllocatedEndpointInfo(tunnelDependent, AllocatedEndpointsMode.Workload);
-                await PublishEndpointAllocatedEventAsync(endpointsAdvertised, tunnelDependent, ct).ConfigureAwait(false);
-
-                await Task.WhenAll(
-                    CreateContainersAsync(tunnelDependent, ct),
-                    CreateContainerExecutablesAsync(tunnelDependentContainerExes, ct)
-                ).WaitAsync(ct).ConfigureAwait(false);
+                await Task.WhenAll(containers.Select(c => Task.Run(() => CreateSingleContainerAsync(c, cctx, ct)))).WaitAsync(ct).ConfigureAwait(false);
             }, ct);
 
-            // Now wait for all creations to complete.
-            await Task.WhenAll(
-                createTunnel,
-                createExecutables,
-                createRegularContainers,
-                createTunnelDependentContainers
-            ).WaitAsync(ct).ConfigureAwait(false);
+            // Now wait for all "leaf" creations to complete.
+            await Task.WhenAll(createExecutables, createContainers).WaitAsync(ct).ConfigureAwait(false);
 
             await _executorEvents.PublishAsync(new OnEndpointsAllocatedContext(ct)).ConfigureAwait(false);
         }
@@ -908,44 +897,16 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                     AspireEventSource.Instance.DcpServiceAddressAllocationFailed(sar.Metadata.Name);
                 }
             }
-        }
-        finally
-        {
-            AspireEventSource.Instance.DcpServiceAddressAllocationStop(initialServiceCount - needAddressAllocated.Count);
-        }
-    }
 
-    // Ensures that services used by containers have their address info.
-    private async Task EnsureContainerServiceAddressInfo(CancellationToken cancellationToken)
-    {
-        if (_options.Value.EnableAspireContainerTunnel)
-        {
-            var containerTunnelProxies = _appResources.Where(r => r.DcpResource is ContainerNetworkTunnelProxy { }).ToImmutableArray();
-            foreach (var ctp in containerTunnelProxies)
+            if (_options.Value.EnableAspireContainerTunnel)
             {
-                var containerNetworkName = (ctp.DcpResource as ContainerNetworkTunnelProxy)?.Spec.ContainerNetworkName;
-
-                // Need to wait for all tunnels to start before advertising AllocatedEndpoints that the tunnel proxy projected
-                // from host network into container network(s).
-                var tunnelServices = _appResources.Where(r => r.DcpResource is Service { }).Select(r => (Service)r.DcpResource)
-                .Where(
-                    sr => !sr.HasCompleteAddress &&
-                    sr.Metadata.Annotations?.TryGetValue(CustomResource.ContainerTunnelInstanceName, out var _) is true &&
-                    sr.Metadata.Annotations?.TryGetValue(CustomResource.ContainerNetworkAnnotation, out var containerNetwork) is true &&
-                    containerNetwork == containerNetworkName
-                );
-
-                _logger.LogInformation($"Waiting for container network '{containerNetworkName}' tunnel initialization...");
-                // Container tunnel initialization can take a while if the container tunnel image needs to be built,
-                // expecially if the network is slow, hence 10 minute timeout here.
-                await UpdateWithEffectiveAddressInfo(tunnelServices, cancellationToken, TimeSpan.FromMinutes(10)).ConfigureAwait(false);
-                _logger.LogInformation($"Tunnel for container network '{containerNetworkName}' initialized");
+                // Tunnel endpoints will be enabled (and get their endpoints) on as-needed basis. We are done for now.
+                return;
             }
-        }
-        else
-        {
+
             // Container services are services that "mirror" their primary (host) service counterparts, but expose addresses usable from container network.
-            // We just need to update their ports from primary services, changing the address to container host.
+            // Without the tunnel we rely on Docker Desktop host.docker.internal bridge,
+            // which means we just need to update their ports from primary services, changing the address to container host.
             var containerServices = _appResources.Where(r => r.DcpResource is Service { }).Select(r => (
                 Service: r.DcpResource as Service,
                 PrimaryServiceName: r.DcpResource.Metadata.Annotations?.TryGetValue(CustomResource.PrimaryServiceNameAnnotation, out var psn) == true ? psn : null)
@@ -955,16 +916,26 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             foreach (var cs in containerServices)
             {
                 var primaryService = _appResources.OfType<ServiceWithModelResource>().Select(sar => sar.Service)
-                    .Where(svc => svc.Metadata.Name.Equals(cs.PrimaryServiceName)).First();
+                    .First(svc => svc.Metadata.Name.Equals(cs.PrimaryServiceName));
                 cs.Service!.ApplyAddressInfoFrom(primaryService);
                 cs.Service!.Status!.EffectiveAddress = ContainerHostName;
             }
         }
+        finally
+        {
+            AspireEventSource.Instance.DcpServiceAddressAllocationStop(initialServiceCount - needAddressAllocated.Count);
+        }
     }
 
-    private async Task CreateAllDcpObjectsAsync<RT>(CancellationToken cancellationToken) where RT : CustomResource, IKubernetesStaticMetadata
+    private Task CreateAllDcpObjectsAsync<RT>(CancellationToken cancellationToken) where RT : CustomResource, IKubernetesStaticMetadata
     {
-        var toCreate = _appResources.Select(r => r.DcpResource).OfType<RT>().ToImmutableArray();
+        var objects = _appResources.Select(r => r.DcpResource).OfType<RT>();
+        return CreateDcpObjectsAsync(objects, cancellationToken);
+    }
+
+    private async Task CreateDcpObjectsAsync<RT>(IEnumerable<RT> objects, CancellationToken cancellationToken) where RT : CustomResource, IKubernetesStaticMetadata
+    {
+        var toCreate = objects.ToImmutableArray();
         if (toCreate.Length == 0)
         {
             return;
@@ -1177,7 +1148,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
     /// <summary>
     /// Creates DCP Service objects that represent services exposed by resources in the model via endpoints (EndpointAnnotations).
     /// </summary>
-    private async Task PrepareServicesAsync(CancellationToken cancellationToken)
+    private void PrepareServices()
     {
         _logger.LogDebug("Preparing services. Ports randomized: {RandomizePorts}", _options.Value.RandomizePorts);
 
@@ -1185,17 +1156,19 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             .Select(r => (ModelResource: r, Endpoints: r.Annotations.OfType<EndpointAnnotation>().ToArray()))
             .Where(sp => sp.Endpoints.Any());
 
-        // We need to ensure that Services have unique names (otherwise we cannot really distinguish between
-        // services produced by different resources).
-        var serviceNames = new HashSet<string>();
-
         foreach (var sp in serviceProducers)
         {
             var endpoints = sp.Endpoints;
 
             foreach (var endpoint in endpoints)
             {
-                var serviceName = _nameGenerator.GetServiceName(sp.ModelResource, endpoint, endpoints.Length > 1, serviceNames);
+                var (serviceName, isNew) = _nameGenerator.GetServiceName(sp.ModelResource, endpoint, endpoint.DefaultNetworkID);
+                if (!isNew)
+                {
+                    _logger.LogWarning("Encountered the same service-endpoint combination more than once for {EndpointName} on resource {ResourceName} when creating default endpoint services. This should never happen.", endpoint.Name, sp.ModelResource.Name);
+                    continue;
+                }
+
                 var svc = Service.Create(serviceName);
 
                 if (!sp.ModelResource.SupportsProxy())
@@ -1239,129 +1212,93 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
             }
         }
 
-        // For container-to-host communication we create a tunnel proxy with a Service/tunnel for each host Endpoint.
-
         var containers = _model.Resources.Where(r => r.IsContainer());
         if (!containers.Any())
         {
-            return; // No container resources--no need to set up container-to-host tunnels.
+            return; // No container resources--no need bother with container-to-host connections.
         }
 
-        var containerDependencies = await ResourceExtensions.GetDependenciesAsync(containers, _executionContext, ResourceDependencyDiscoveryMode.DirectOnly, cancellationToken).ConfigureAwait(false);
-
-        // Host dependencies are host network resources with endpoints that containers depend on.
-        List<HostResourceWithEndpoints> hostDependencies = containerDependencies.Select(AsHostResourceWithEndpoints).OfType<HostResourceWithEndpoints>().ToList();
-
-        // Aspire dashboard is special in the context of Open Telemetry ingestion.
-        // OTLP exporters do not refer to the OTLP ingestion endpoint via EndpointReference when the model is constructed
-        // by the Aspire app host; the endpoint URL is just read from configuration.
-        // If there are containers that are OTLP exporters in the model, we need to project dashboard endpoints into container space.
-        if (containers.Any(c => c.TryGetAnnotationsOfType<OtlpExporterAnnotation>(out _)))
+        if (_options.Value.EnableAspireContainerTunnel)
         {
-            var maybeDashboard = _model.Resources.Where(r => StringComparers.ResourceName.Equals(r.Name, KnownResourceNames.AspireDashboard))
-                    .Select(AsHostResourceWithEndpoints).FirstOrDefault();
-            if (maybeDashboard is HostResourceWithEndpoints dashboardResource)
-            {
-                hostDependencies.Add(dashboardResource);
-            }
-        }
-
-        if (!hostDependencies.Any())
-        {
-            // There are no containers that reference host resource endpoints, so no need for container tunnel.
+            // Tunnel services and tunnel configuration is set up together with containers, dynamically.
             return;
         }
 
-        // Eventually we might want to support multiple container networks, including user-defined ones,
-        // but for now we just have one container network per application, and so we need only one tunnel proxy.
-        ContainerNetworkTunnelProxy? tunnelProxy = null;
-        AppResource? tunnelAppResource = null;
+        // Legacy (no tunnel) mode: we are going to just proxy all host endpoint into the container network.
+        var hostResources = _model.Resources.Select(AsHostResourceWithEndpoints).OfType<HostResourceWithEndpoints>().ToList();
+
+        foreach (var re in hostResources)
+        {
+            var containerNetworkServices = CreateContainerNetworkServicesForHostResource(re);
+            _appResources.AddRange(containerNetworkServices.Select(cns => cns.ServiceResource));
+        }
+    }
+
+    private IEnumerable<ContainerNetworkService> CreateContainerNetworkServicesForHostResource(HostResourceWithEndpoints re)
+    {
+        var resourceLogger = _loggerService.GetLogger(re.Resource);
+        var services = new List<ContainerNetworkService>();
         var useTunnel = _options.Value.EnableAspireContainerTunnel;
-        if (useTunnel)
+        string tunnelProxyName = useTunnel ? GetTunnelProxyResourceName() : "";
+
+        foreach (var endpoint in re.Endpoints)
         {
-            tunnelProxy = ContainerNetworkTunnelProxy.Create(KnownNetworkIdentifiers.DefaultAspireContainerNetwork.Value + "-tunnelproxy");
-            tunnelProxy.Spec.ContainerNetworkName = KnownNetworkIdentifiers.DefaultAspireContainerNetwork.Value;
-            tunnelProxy.Spec.Aliases = [ContainerHostName];
-            tunnelProxy.Spec.Tunnels = [];
-            tunnelAppResource = new AppResource(tunnelProxy);
-            _appResources.Add(tunnelAppResource);
-        }
-
-        // If multiple Containers take a reference to the same host resource, we should only create one Service per each endpoint.
-        HashSet<(string HostResourceName, string OriginalEndpointName)> processedEndpoints = new();
-
-        foreach (var re in hostDependencies)
-        {
-            var resourceLogger = _loggerService.GetLogger(re.Resource);
-
-            foreach (var endpoint in re.Endpoints)
+            var (serviceName, isNew) = _nameGenerator.GetServiceName(re.Resource, endpoint, KnownNetworkIdentifiers.DefaultAspireContainerNetwork);
+            if (!isNew)
             {
-                if (!processedEndpoints.Add((re.Resource.Name, endpoint.Name)))
-                {
-                    continue; // Already processed this endpoint reference.
-                }
-
-                if (useTunnel)
-                {
-                    if (endpoint.Protocol != ProtocolType.Tcp)
-                    {
-                        resourceLogger.LogWarning("Host endpoint '{EndpointName}' on resource '{HostResource}' is referenced by a container resource, but the endpoint is using a network protocol '{Protocol}' other than TCP. Only TCP is supported for container-to-host references.",
-                            endpoint.Name,
-                            re.Resource.Name,
-                            endpoint.Protocol);
-                        continue;
-                    }
-                }
-
-                var hasManyEndpoints = re.Resource.Annotations.OfType<EndpointAnnotation>().Count() > 1;
-                var serviceName = _nameGenerator.GetServiceName(re.Resource, endpoint, hasManyEndpoints, serviceNames);
-                var svc = Service.Create(serviceName);
-                svc.Spec.AddressAllocationMode = AddressAllocationModes.Proxyless;
-                svc.Spec.Protocol = PortProtocol.TCP;
-                // Address and port will be set automatically by DCP.
-
-                var serverSvc = _appResources.OfType<ServiceWithModelResource>().FirstOrDefault(swr =>
-                    string.Equals(swr.ModelResource.Name, re.Resource.Name, StringComparisons.ResourceName) &&
-                    string.Equals(swr.EndpointAnnotation.Name, endpoint.Name, StringComparisons.EndpointAnnotationName)
-                );
-                if (serverSvc is null)
-                {
-                    // This should never happen--if a host resource has an Endpoint, we should have created a Service for it.
-                    throw new InvalidDataException($"Host endpoint '{endpoint.Name}' on resource '{re.Resource.Name}' should have an associated DCP Service resource already set up");
-                }
-
-                if (useTunnel)
-                {
-                    var tunnelConfig = new TunnelConfiguration
-                    {
-                        Name = serviceName,
-                        ServerServiceName = serverSvc.DcpResource.Metadata.Name,
-                        ServerServiceNamespace = string.Empty,
-                        ClientServiceName = svc.Metadata.Name,
-                        ClientServiceNamespace = string.Empty
-                    };
-
-                    // The tunnelProxy is guaranteed to be non-null here but the compiler is not smart enough to realize it.
-                    tunnelProxy?.Spec?.Tunnels?.Add(tunnelConfig);
-                }
-
-                svc.Annotate(CustomResource.ResourceNameAnnotation, re.Resource.Name);  // Resource that implements the service behind the Endpoint.
-                svc.Annotate(CustomResource.EndpointNameAnnotation, endpoint.Name);
-                svc.Annotate(CustomResource.ContainerNetworkAnnotation, tunnelProxy?.Spec?.ContainerNetworkName ?? KnownNetworkIdentifiers.DefaultAspireContainerNetwork.Value);
-                svc.Annotate(CustomResource.PrimaryServiceNameAnnotation, serverSvc.DcpResource.Metadata.Name);
-
-                // We use this to distinguish services based on real tunnel proxies vs "placeholders" for when tunnels are disabled.
-                svc.Annotate(CustomResource.ContainerTunnelInstanceName, tunnelProxy?.Metadata?.Name ?? "");
-
-                var svcAppResource = new ServiceAppResource(svc);
-                _appResources.Add(svcAppResource);
-
-                if (useTunnel)
-                {
-                    tunnelAppResource!.ServicesProduced.Add(svcAppResource);
-                }
+                // Entirely possible that multiple container resources reference the same host resource and endpoint. 
+                // We let the first container creation task (exists == false) create the service and other tasks just leverages it.
+                continue;
             }
+
+            if (useTunnel && endpoint.Protocol != ProtocolType.Tcp)
+            {
+                resourceLogger.LogWarning("Host endpoint '{EndpointName}' on resource '{HostResource}' is referenced by a container resource, but the endpoint is using a network protocol '{Protocol}' other than TCP. Only TCP is supported for container-to-host references.", endpoint.Name, re.Resource.Name, endpoint.Protocol);
+                continue;
+            }
+
+            var svc = Service.Create(serviceName);
+            svc.Spec.AddressAllocationMode = AddressAllocationModes.Proxyless;
+            svc.Spec.Protocol = PortProtocol.FromProtocolType(endpoint.Protocol);
+            // Address and port will be set automatically by DCP.
+
+            var serverSvc = _appResources.OfType<ServiceWithModelResource>().FirstOrDefault(swr =>
+                StringComparers.ResourceName.Equals(swr.ModelResource.Name, re.Resource.Name) &&
+                StringComparers.EndpointAnnotationName.Equals(swr.EndpointAnnotation.Name, endpoint.Name)
+            );
+            if (serverSvc is null)
+            {
+                // This should never happen--if a host resource has an Endpoint, we should have created a Service for it.
+                throw new InvalidDataException($"Host endpoint '{endpoint.Name}' on resource '{re.Resource.Name}' should have an associated DCP Service resource already set up");
+            }
+
+            TunnelConfiguration? tunnelConfig = null;
+            if (useTunnel)
+            {
+                tunnelConfig = new TunnelConfiguration
+                {
+                    Name = serviceName,
+                    ServerServiceName = serverSvc.DcpResource.Metadata.Name,
+                    ServerServiceNamespace = string.Empty,
+                    ClientServiceName = svc.Metadata.Name,
+                    ClientServiceNamespace = string.Empty
+                };
+            }
+
+            svc.Annotate(CustomResource.ResourceNameAnnotation, re.Resource.Name);  // Resource that implements the service behind the Endpoint.
+            svc.Annotate(CustomResource.EndpointNameAnnotation, endpoint.Name);
+            svc.Annotate(CustomResource.ContainerNetworkAnnotation, KnownNetworkIdentifiers.DefaultAspireContainerNetwork.Value);
+            svc.Annotate(CustomResource.PrimaryServiceNameAnnotation, serverSvc.DcpResource.Metadata.Name);
+
+            // We use this to distinguish services based on real tunnel proxies 
+            // vs "placeholders" relying on host.docker.internal bridge (when tunnel is disabled).
+            svc.Annotate(CustomResource.ContainerTunnelInstanceName, tunnelProxyName);
+
+            var svcAppResource = new ServiceAppResource(svc);
+            services.Add(new ContainerNetworkService { ServiceResource = svcAppResource, TunnelConfig = tunnelConfig });
         }
+
+        return services;
     }
 
     private void PrepareExecutables()
@@ -1658,6 +1595,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                 return;
             }
 
+            await _executorEvents.PublishAsync(new OnConnectionStringAvailableContext(cancellationToken, resource)).ConfigureAwait(false);
             await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, resource, DcpResourceName: null)).ConfigureAwait(false);
             foreach (var er in executables)
             {
@@ -2050,316 +1988,352 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         throw new DistributedApplicationException($"Couldn't find required instance ID for index {instanceIndex} on resource {resource.Name}.");
     }
 
-    private async Task CreateContainersAsync(IEnumerable<RenderedModelResource> containerResources, CancellationToken cancellationToken)
+    private async Task CreateSingleContainerAsync(RenderedModelResource cr, ContainerCreationContext cctx, CancellationToken cToken)
     {
-        var containerCount = containerResources.Count();
-        if (containerCount == 0)
-        {
-            return;
-        }
+        var dcpContainer = (Container)cr.DcpResource;
+        AspireEventSource.Instance.DcpObjectCreationStart(dcpContainer.Kind, dcpContainer.Metadata.Name);
+        var signalServicesSpecReadyOnce = ConcurrencyUtils.Once(() => cctx.ContainerServicesSpecReady.Signal());
 
         try
         {
-            AspireEventSource.Instance.DcpObjectSetCreationStart(Model.Dcp.ContainerKind, containerCount);
+            cToken.ThrowIfCancellationRequested();
+            var logger = _loggerService.GetLogger(cr.ModelResource);
+            AddAllocatedEndpointInfo([cr], AllocatedEndpointsMode.Workload);
 
-            async Task CreateContainerAsyncCore(RenderedModelResource cr, CancellationToken cancellationToken)
+            try
             {
-                var logger = _loggerService.GetLogger(cr.ModelResource);
+                // In previous versions of Aspire we would delay raising BeforeResourceStarted event for explicit startup resources.
+                // But we need to determine whether the container is using any host resources, 
+                // and need to call environment and argument annotation callbacks in the process, and this means 
+                // we need to raise this event now, so that "last chance dynamic setup or validation" can be performed for the resource
+                // (see docs/specs/appmodel.md#well-known-lifecycle-events)
+                await _executorEvents.PublishAsync(new OnResourceStartingContext(cToken, KnownResourceTypes.Container, cr.ModelResource, dcpContainer.Metadata.Name)).ConfigureAwait(false);
 
-                try
-                {
-                    await CreateContainerAsync(cr, logger, cancellationToken).ConfigureAwait(false);
-                }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                {
-                    // Expected cancellation during shutdown - propagate clean cancellation
-                    throw;
-                }
-                catch (FailedToApplyEnvironmentException)
-                {
-                    // For this exception we don't want the noise of the stack trace, we've already
-                    // provided more detail where we detected the issue (e.g. envvar name). To get
-                    // more diagnostic information reduce logging level for DCP log category to Debug.
-                    await _executorEvents.PublishAsync(new OnResourceFailedToStartContext(cancellationToken, KnownResourceTypes.Container, cr.ModelResource, cr.DcpResourceName)).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "Failed to create container resource {ResourceName}", cr.ModelResource.Name);
-                    await _executorEvents.PublishAsync(new OnResourceFailedToStartContext(cancellationToken, KnownResourceTypes.Container, cr.ModelResource, cr.DcpResourceName)).ConfigureAwait(false);
-                }
-            }
-
-            var tasks = new List<Task>();
-
-            foreach (var cr in containerResources)
-            {
                 // Publish snapshot built from DCP resource. Do this now to populate more values from DCP (source) to ensure they're
                 // available if the resource isn't immediately started because it's waiting or is configured for explicit start.
                 await _executorEvents.PublishAsync(new OnResourceChangedContext(_shutdownCancellation.Token, KnownResourceTypes.Container, cr.ModelResource, cr.DcpResourceName, new ResourceStatus(null, null, null), s => _snapshotBuilder.ToSnapshot((Container)cr.DcpResource, s))).ConfigureAwait(false);
 
-                if (cr.ModelResource.TryGetLastAnnotation<ExplicitStartupAnnotation>(out _))
+                // Note: resource restart is done by calling StartResourceAsync(), which sets Spec.Start to true and 
+                // calls CreateDcpContainerAsync() directly, bypassing the following check.
+                var explicitStartup = cr.ModelResource.TryGetLastAnnotation<ExplicitStartupAnnotation>(out _);
+                if (explicitStartup)
                 {
-                    if (cr.DcpResource is Container container)
-                    {
-                        container.Spec.Start = false;
-                    }
+                    dcpContainer.Spec.Start = false;
                 }
 
-                // Force this to be async so that blocking code does not stop other containers from being created.
-                tasks.Add(Task.Run(() => CreateContainerAsyncCore(cr, cancellationToken), cancellationToken));
-            }
+                var hostDependencies = (await GetHostDependenciesAsync(cr.ModelResource, cToken).ConfigureAwait(false)).ToImmutableArray();
 
-            await Task.WhenAll(tasks).WaitAsync(cancellationToken).ConfigureAwait(false);
+                if (hostDependencies.Any())
+                {
+                    await CreateTunnelDependentContainerAsync(cr, hostDependencies, cctx, signalServicesSpecReadyOnce, cToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    // There will be no tunnel services for this container; we have complete information about services this container will need. 
+                    signalServicesSpecReadyOnce();
+                    
+                    await CreateDcpContainerAsync(cr, logger, cToken).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException) when (cToken.IsCancellationRequested)
+            {
+                // Expected cancellation during shutdown - propagate clean cancellation
+                throw;
+            }
+            catch (FailedToApplyEnvironmentException)
+            {
+                // For this exception we don't want the noise of the stack trace, we've already
+                // provided more detail where we detected the issue (e.g. envvar name). To get
+                // more diagnostic information reduce logging level for DCP log category to Debug.
+                await _executorEvents.PublishAsync(new OnResourceFailedToStartContext(cToken, KnownResourceTypes.Container, cr.ModelResource, cr.DcpResourceName)).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to create container resource {ResourceName}", cr.ModelResource.Name);
+                await _executorEvents.PublishAsync(new OnResourceFailedToStartContext(cToken, KnownResourceTypes.Container, cr.ModelResource, cr.DcpResourceName)).ConfigureAwait(false);
+            }
         }
         finally
         {
-            AspireEventSource.Instance.DcpObjectSetCreationStop(Model.Dcp.ContainerKind, containerCount);
+            signalServicesSpecReadyOnce();
+            AspireEventSource.Instance.DcpObjectCreationStop(dcpContainer.Kind, dcpContainer.Metadata.Name);
         }
     }
 
-    private async Task CreateContainerAsync(RenderedModelResource cr, ILogger resourceLogger, CancellationToken cancellationToken)
+    private async Task CreateDcpContainerAsync(RenderedModelResource cr, ILogger logger, CancellationToken cToken)
     {
-        try
+        cToken.ThrowIfCancellationRequested();
+
+        await PublishEndpointAllocatedEventAsync([cr], cToken).ConfigureAwait(false);
+        await _executorEvents.PublishAsync(new OnConnectionStringAvailableContext(cToken, cr.ModelResource)).ConfigureAwait(false);
+        // BeforeResourceStarted already published by the caller.
+
+        var dcpContainer = (Container)cr.DcpResource;
+        var modelContainer = cr.ModelResource;
+
+        await ApplyBuildArgumentsAsync(dcpContainer, cr.ModelResource, _executionContext.ServiceProvider, cToken).ConfigureAwait(false);
+
+        var spec = dcpContainer.Spec;
+
+        if (cr.ServicesProduced.Count > 0)
         {
-            var dcpContainerResource = (Container)cr.DcpResource;
-            var modelContainerResource = cr.ModelResource;
-            AspireEventSource.Instance.DcpObjectCreationStart(dcpContainerResource.Kind, dcpContainerResource.Metadata.Name);
-            cancellationToken.ThrowIfCancellationRequested();
-            var explicitStartup = cr.ModelResource.TryGetAnnotationsOfType<ExplicitStartupAnnotation>(out _) is true;
-            if (!explicitStartup)
+            spec.Ports = BuildContainerPorts(cr);
+        }
+
+        spec.VolumeMounts = BuildContainerMounts(cr.ModelResource);
+
+        var (runArgs, failedToApplyRunArgs) = await BuildRunArgsAsync(logger, cr.ModelResource, cToken).ConfigureAwait(false);
+        if (failedToApplyRunArgs)
+        {
+            throw new FailedToApplyEnvironmentException();
+        }
+        spec.RunArgs = runArgs;
+
+        var (configuration, pemCertificates, createFiles) = await BuildContainerConfiguration(cr, logger, cToken).ConfigureAwait(false);
+        if (configuration.Exception is not null)
+        {
+            throw new FailedToApplyEnvironmentException($"Failed to apply configuration to container {cr.ModelResource.Name}", configuration.Exception);
+        }
+
+        var args = configuration.Arguments.Select(a => a.Value);
+        // modelContainer is not necessarily ContainerResource (can be custom resource that produces a container).
+        if (modelContainer is ContainerResource { ShellExecution: true })
+        {
+            spec.Args = ["-c", $"{string.Join(' ', args)}"];
+        }
+        else
+        {
+            spec.Args = args.ToList();
+        }
+        dcpContainer.SetAnnotationAsObjectList(CustomResource.ResourceAppArgsAnnotation, configuration.Arguments.Select(a => new AppLaunchArgumentAnnotation(a.Value, isSensitive: a.IsSensitive)));
+
+        spec.Env = configuration.EnvironmentVariables.Select(kvp => new EnvVar { Name = kvp.Key, Value = kvp.Value }).ToList();
+        spec.CreateFiles = createFiles;
+        if (modelContainer is ContainerResource containerResource)
+        {
+            spec.Command = containerResource.Entrypoint;
+        }
+        spec.PemCertificates = pemCertificates;
+
+        if (_dcpInfo is not null)
+        {
+            DcpDependencyCheck.CheckDcpInfoAndLogErrors(logger, _options.Value, _dcpInfo);
+        }
+
+        await _kubernetesService.CreateAsync(dcpContainer, cToken).ConfigureAwait(false);
+
+        var containerExes = _appResources.OfType<RenderedModelResource>().Where(ar => ar.DcpResource is ContainerExec ce && ce.Spec.ContainerName == dcpContainer.Metadata.Name).ToArray();
+        if (containerExes.Length > 0)
+        {
+            await CreateContainerExecutablesAsync(containerExes, cToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task CreateTunnelDependentContainerAsync(RenderedModelResource cr, ImmutableArray<HostResourceWithEndpoints> hostDependencies, ContainerCreationContext cctx, Action signalServicesSpecReadyOnce, CancellationToken cToken)
+    {
+        cToken.ThrowIfCancellationRequested();
+
+        // Ensure that we have services and tunnel definitions for all host dependencies of this container.
+
+        List<ContainerNetworkService> newServices = [];
+        foreach (var dep in hostDependencies)
+        {
+            var cnetServices = CreateContainerNetworkServicesForHostResource(dep);
+            newServices.AddRange(cnetServices);
+        }
+        if (newServices.Count > 0)
+        {
+            foreach (var s in newServices)
             {
-                // If explicit startup is configured, we aren't going to start the resource now. A DCP resource WILL be created,
-                // but it will be explicitly set to not start. We don't want to send the BeforeResourceStarted event here as it will
-                // be sent later when the resource is explicitly started via user action or API.
-                await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, KnownResourceTypes.Container, cr.ModelResource, cr.DcpResource.Metadata.Name)).ConfigureAwait(false);
+                await cctx.ContainerServicesChan.Writer.WriteAsync(s, cToken).ConfigureAwait(false);
             }
+        }
 
-            await ApplyBuildArgumentsAsync(dcpContainerResource, modelContainerResource, _executionContext.ServiceProvider, cancellationToken).ConfigureAwait(false);
+        signalServicesSpecReadyOnce();
+        await cctx.CreateTunnel.ConfigureAwait(false);
 
-            var spec = dcpContainerResource.Spec;
+        await CreateDcpContainerAsync(cr, _loggerService.GetLogger(cr.ModelResource), cToken).ConfigureAwait(false);
+    }
 
-            if (cr.ServicesProduced.Count > 0)
+    private async Task<(IExecutionConfigurationResult, ContainerPemCertificates?, List<ContainerCreateFileSystem>?)>
+    BuildContainerConfiguration(RenderedModelResource cr, ILogger resourceLogger, CancellationToken cancellationToken)
+    {
+        var certificatesDestination = ContainerCertificatePathsAnnotation.DefaultCustomCertificatesDestination;
+        var bundlePaths = ContainerCertificatePathsAnnotation.DefaultCertificateBundlePaths.ToList();
+        var certificateDirsPaths = ContainerCertificatePathsAnnotation.DefaultCertificateDirectoriesPaths.ToList();
+
+        if (cr.ModelResource.TryGetLastAnnotation<ContainerCertificatePathsAnnotation>(out var pathsAnnotation))
+        {
+            certificatesDestination = pathsAnnotation.CustomCertificatesDestination ?? certificatesDestination;
+            bundlePaths = pathsAnnotation.DefaultCertificateBundles ?? bundlePaths;
+            certificateDirsPaths = pathsAnnotation.DefaultCertificateDirectories ?? certificateDirsPaths;
+        }
+
+        var serverAuthCertificatesBasePath = $"{certificatesDestination}/private";
+
+        var configuration = await ExecutionConfigurationBuilder.Create(cr.ModelResource)
+            .WithArgumentsConfig()
+            .WithEnvironmentVariablesConfig()
+            .WithCertificateTrustConfig(scope =>
             {
-                spec.Ports = BuildContainerPorts(cr);
-            }
-
-            spec.VolumeMounts = BuildContainerMounts(modelContainerResource);
-
-            (spec.RunArgs, var failedToApplyRunArgs) = await BuildRunArgsAsync(resourceLogger, modelContainerResource, cancellationToken).ConfigureAwait(false);
-
-            var certificatesDestination = ContainerCertificatePathsAnnotation.DefaultCustomCertificatesDestination;
-            var bundlePaths = ContainerCertificatePathsAnnotation.DefaultCertificateBundlePaths.ToList();
-            var certificateDirsPaths = ContainerCertificatePathsAnnotation.DefaultCertificateDirectoriesPaths.ToList();
-
-            if (cr.ModelResource.TryGetLastAnnotation<ContainerCertificatePathsAnnotation>(out var pathsAnnotation))
-            {
-                certificatesDestination = pathsAnnotation.CustomCertificatesDestination ?? certificatesDestination;
-                bundlePaths = pathsAnnotation.DefaultCertificateBundles ?? bundlePaths;
-                certificateDirsPaths = pathsAnnotation.DefaultCertificateDirectories ?? certificateDirsPaths;
-            }
-
-            var serverAuthCertificatesBasePath = $"{certificatesDestination}/private";
-
-            var configuration = await ExecutionConfigurationBuilder.Create(cr.ModelResource)
-                .WithArgumentsConfig()
-                .WithEnvironmentVariablesConfig()
-                .WithCertificateTrustConfig(scope =>
+                var dirs = new List<string> { certificatesDestination + "/certs" };
+                if (scope == CertificateTrustScope.Append)
                 {
-                    var dirs = new List<string> { certificatesDestination + "/certs" };
-                    if (scope == CertificateTrustScope.Append)
-                    {
-                        // When appending to the default trust store, include the default certificate directories
-                        dirs.AddRange(certificateDirsPaths!);
-                    }
+                    // When appending to the default trust store, include the default certificate directories
+                    dirs.AddRange(certificateDirsPaths!);
+                }
 
-                    return new()
-                    {
-                        CertificateBundlePath = ReferenceExpression.Create($"{certificatesDestination}/cert.pem"),
-                        // Build Linux PATH style colon-separated list of directories
-                        CertificateDirectoriesPath = ReferenceExpression.Create($"{string.Join(':', dirs)}"),
-                        RootCertificatesPath = certificatesDestination,
-                        IsContainer = true,
-                    };
-                })
-                .WithHttpsCertificateConfig(cert => new()
+                return new()
                 {
-                    CertificatePath = ReferenceExpression.Create($"{serverAuthCertificatesBasePath}/{cert.Thumbprint}.crt"),
-                    KeyPath = ReferenceExpression.Create($"{serverAuthCertificatesBasePath}/{cert.Thumbprint}.key"),
-                    PfxPath = ReferenceExpression.Create($"{serverAuthCertificatesBasePath}/{cert.Thumbprint}.pfx"),
-                })
-                .AddExecutionConfigurationGatherer(new OtlpEndpointReferenceGatherer())
-                .BuildAsync(_executionContext, resourceLogger, cancellationToken)
-                .ConfigureAwait(false);
-
-            List<ContainerFileSystemEntry> customBundleFiles = new();
-
-            // Add the certificates to the executable spec so they'll be placed in the DCP config
-            ContainerPemCertificates? pemCertificates = null;
-            if (configuration.TryGetAdditionalData<CertificateTrustExecutionConfigurationData>(out var certificateTrustConfiguration)
-                && certificateTrustConfiguration.Scope != CertificateTrustScope.None
-                && certificateTrustConfiguration.Certificates.Count > 0)
-            {
-                pemCertificates = new ContainerPemCertificates
-                {
-                    Certificates = certificateTrustConfiguration.Certificates.Select(c =>
-                    {
-                        return new PemCertificate
-                        {
-                            Thumbprint = c.Thumbprint,
-                            Contents = c.ExportCertificatePem(),
-                        };
-                    }).DistinctBy(cert => cert.Thumbprint).ToList(),
-                    Destination = certificatesDestination,
-                    ContinueOnError = true,
+                    CertificateBundlePath = ReferenceExpression.Create($"{certificatesDestination}/cert.pem"),
+                    // Build Linux PATH style colon-separated list of directories
+                    CertificateDirectoriesPath = ReferenceExpression.Create($"{string.Join(':', dirs)}"),
+                    RootCertificatesPath = certificatesDestination,
+                    IsContainer = true,
                 };
-
-                if (certificateTrustConfiguration.Scope != CertificateTrustScope.Append)
-                {
-                    // If overriding the default resource CA bundle, then we want to copy our bundle to the well-known locations
-                    // used by common Linux distributions to make it easier to ensure applications pick it up.
-                    // Group by common directory to avoid creating multiple file system entries for the same root directory.
-                    pemCertificates.OverwriteBundlePaths = bundlePaths;
-                }
-
-                foreach (var bundleFactory in certificateTrustConfiguration.CustomBundlesFactories)
-                {
-                    var bundleId = bundleFactory.Key;
-                    var bundleBytes = await bundleFactory.Value(certificateTrustConfiguration.Certificates, cancellationToken).ConfigureAwait(false);
-
-                    customBundleFiles.Add(new ContainerFileSystemEntry
-                    {
-                        Name = bundleId,
-                        Type = ContainerFileSystemEntryType.File,
-                        RawContents = Convert.ToBase64String(bundleBytes),
-                    });
-                }
-            }
-
-            spec.PemCertificates = pemCertificates;
-
-            var buildCreateFilesContext = new BuildCreateFilesContext
+            })
+            .WithHttpsCertificateConfig(cert => new()
             {
-                Resource = modelContainerResource,
-                CertificateTrustScope = certificateTrustConfiguration?.Scope ?? CertificateTrustScope.None,
-                CertificateTrustBundlePath = $"{certificatesDestination}/cert.pem",
+                CertificatePath = ReferenceExpression.Create($"{serverAuthCertificatesBasePath}/{cert.Thumbprint}.crt"),
+                KeyPath = ReferenceExpression.Create($"{serverAuthCertificatesBasePath}/{cert.Thumbprint}.key"),
+                PfxPath = ReferenceExpression.Create($"{serverAuthCertificatesBasePath}/{cert.Thumbprint}.pfx"),
+            })
+            .AddExecutionConfigurationGatherer(new OtlpEndpointReferenceGatherer())
+            .BuildAsync(_executionContext, resourceLogger, cancellationToken)
+            .ConfigureAwait(false);
+
+        List<ContainerFileSystemEntry> customBundleFiles = new();
+
+        // Add the certificates to the Container spec so they'll be placed in the DCP config
+        ContainerPemCertificates? pemCertificates = null;
+        if (configuration.TryGetAdditionalData<CertificateTrustExecutionConfigurationData>(out var certificateTrustConfiguration)
+            && certificateTrustConfiguration.Scope != CertificateTrustScope.None
+            && certificateTrustConfiguration.Certificates.Count > 0)
+        {
+            pemCertificates = new ContainerPemCertificates
+            {
+                Certificates = certificateTrustConfiguration.Certificates.Select(c =>
+                {
+                    return new PemCertificate
+                    {
+                        Thumbprint = c.Thumbprint,
+                        Contents = c.ExportCertificatePem(),
+                    };
+                }).DistinctBy(cert => cert.Thumbprint).ToList(),
+                Destination = certificatesDestination,
+                ContinueOnError = true,
             };
 
-            if (configuration.TryGetAdditionalData<HttpsCertificateExecutionConfigurationData>(out var tlsCertificateConfiguration))
+            if (certificateTrustConfiguration.Scope != CertificateTrustScope.Append)
             {
-                var thumbprint = tlsCertificateConfiguration.Certificate.Thumbprint;
-                buildCreateFilesContext.HttpsCertificateContext = new ContainerFileSystemCallbackHttpsCertificateContext
-                {
-                    CertificatePath = ReferenceExpression.Create($"{serverAuthCertificatesBasePath}/{thumbprint}.crt"),
-                    KeyPath = tlsCertificateConfiguration.KeyPathReference,
-                    PfxPath = tlsCertificateConfiguration.PfxPathReference,
-                    Password = tlsCertificateConfiguration.Password,
-                };
+                // If overriding the default resource CA bundle, then we want to copy our bundle to the well-known locations
+                // used by common Linux distributions to make it easier to ensure applications pick it up.
+                // Group by common directory to avoid creating multiple file system entries for the same root directory.
+                pemCertificates.OverwriteBundlePaths = bundlePaths;
             }
 
-            // Build files that need to be created inside the container
-            var createFiles = await BuildCreateFilesAsync(
-                buildCreateFilesContext,
-                cancellationToken).ConfigureAwait(false);
-
-            if (customBundleFiles.Count > 0)
+            foreach (var bundleFactory in certificateTrustConfiguration.CustomBundlesFactories)
             {
-                createFiles.Add(new ContainerCreateFileSystem
+                var bundleId = bundleFactory.Key;
+                var bundleBytes = await bundleFactory.Value(certificateTrustConfiguration.Certificates, cancellationToken).ConfigureAwait(false);
+
+                customBundleFiles.Add(new ContainerFileSystemEntry
                 {
-                    Destination = certificatesDestination,
-                    Entries = [
-                        new ContainerFileSystemEntry
-                        {
-                            Name = "bundles",
-                            Type = ContainerFileSystemEntryType.Directory,
-                            Entries = customBundleFiles,
-                        },
-                    ],
+                    Name = bundleId,
+                    Type = ContainerFileSystemEntryType.File,
+                    RawContents = Convert.ToBase64String(bundleBytes),
                 });
             }
+        }
 
-            if (tlsCertificateConfiguration is not null)
+        var buildCreateFilesContext = new BuildCreateFilesContext
+        {
+            Resource = cr.ModelResource,
+            CertificateTrustScope = certificateTrustConfiguration?.Scope ?? CertificateTrustScope.None,
+            CertificateTrustBundlePath = $"{certificatesDestination}/cert.pem",
+        };
+
+        if (configuration.TryGetAdditionalData<HttpsCertificateExecutionConfigurationData>(out var tlsCertificateConfiguration))
+        {
+            var thumbprint = tlsCertificateConfiguration.Certificate.Thumbprint;
+            buildCreateFilesContext.HttpsCertificateContext = new ContainerFileSystemCallbackHttpsCertificateContext
             {
-                var thumbprint = tlsCertificateConfiguration.Certificate.Thumbprint;
-                var publicCertificatePem = tlsCertificateConfiguration.Certificate.ExportCertificatePem();
-                (var keyPem, var pfxBytes) = await GetCertificateKeyMaterialAsync(tlsCertificateConfiguration, cancellationToken).ConfigureAwait(false);
-                var certificateFiles = new List<ContainerFileSystemEntry>()
-                {
+                CertificatePath = ReferenceExpression.Create($"{serverAuthCertificatesBasePath}/{thumbprint}.crt"),
+                KeyPath = tlsCertificateConfiguration.KeyPathReference,
+                PfxPath = tlsCertificateConfiguration.PfxPathReference,
+                Password = tlsCertificateConfiguration.Password,
+            };
+        }
+
+        // Build files that need to be created inside the container
+        var createFiles = await BuildCreateFilesAsync(
+            buildCreateFilesContext,
+            cancellationToken).ConfigureAwait(false);
+
+        if (customBundleFiles.Count > 0)
+        {
+            createFiles.Add(new ContainerCreateFileSystem
+            {
+                Destination = certificatesDestination,
+                Entries = [
                     new ContainerFileSystemEntry
                     {
-                        Name = thumbprint + ".crt",
-                        Type = ContainerFileSystemEntryType.File,
-                        Contents = new string(publicCertificatePem),
-                    }
-                };
-
-                if (keyPem is not null)
-                {
-                    certificateFiles.Add(new ContainerFileSystemEntry
-                    {
-                        Name = thumbprint + ".key",
-                        Type = ContainerFileSystemEntryType.File,
-                        Contents = new string(keyPem),
-                    });
-
-                    Array.Clear(keyPem, 0, keyPem.Length);
-                }
-
-                if (pfxBytes is not null)
-                {
-                    certificateFiles.Add(new ContainerFileSystemEntry
-                    {
-                        Name = thumbprint + ".pfx",
-                        Type = ContainerFileSystemEntryType.File,
-                        RawContents = Convert.ToBase64String(pfxBytes),
-                    });
-
-                    Array.Clear(pfxBytes, 0, pfxBytes.Length);
-                }
-
-                // Write the certificate and key to the container filesystem
-                createFiles.Add(new ContainerCreateFileSystem
-                {
-                    Destination = serverAuthCertificatesBasePath,
-                    Entries = certificateFiles,
-                });
-            }
-
-            // Set the final args, env vars, and create files on the container spec
-            var args = configuration.Arguments.Select(a => a.Value);
-            // Set the final args, env vars, and create files on the container spec
-            if (modelContainerResource is ContainerResource { ShellExecution: true })
-            {
-                spec.Args = ["-c", $"{string.Join(' ', args)}"];
-            }
-            else
-            {
-                spec.Args = args.ToList();
-            }
-            dcpContainerResource.SetAnnotationAsObjectList(CustomResource.ResourceAppArgsAnnotation, configuration.Arguments.Select(a => new AppLaunchArgumentAnnotation(a.Value, isSensitive: a.IsSensitive)));
-            spec.Env = configuration.EnvironmentVariables.Select(kvp => new EnvVar { Name = kvp.Key, Value = kvp.Value }).ToList();
-            spec.CreateFiles = createFiles;
-
-            if (modelContainerResource is ContainerResource containerResource)
-            {
-                spec.Command = containerResource.Entrypoint;
-            }
-
-            if (failedToApplyRunArgs || configuration.Exception is not null)
-            {
-                throw new FailedToApplyEnvironmentException();
-            }
-
-            if (_dcpInfo is not null)
-            {
-                DcpDependencyCheck.CheckDcpInfoAndLogErrors(resourceLogger, _options.Value, _dcpInfo);
-            }
-
-            await _kubernetesService.CreateAsync(dcpContainerResource, cancellationToken).ConfigureAwait(false);
+                        Name = "bundles",
+                        Type = ContainerFileSystemEntryType.Directory,
+                        Entries = customBundleFiles,
+                    },
+                ],
+            });
         }
-        finally
+
+        if (tlsCertificateConfiguration is not null)
         {
-            AspireEventSource.Instance.DcpObjectCreationStop(cr.DcpResource.Kind, cr.DcpResourceName);
+            var thumbprint = tlsCertificateConfiguration.Certificate.Thumbprint;
+            var publicCertificatePem = tlsCertificateConfiguration.Certificate.ExportCertificatePem();
+            (var keyPem, var pfxBytes) = await GetCertificateKeyMaterialAsync(tlsCertificateConfiguration, cancellationToken).ConfigureAwait(false);
+            var certificateFiles = new List<ContainerFileSystemEntry>()
+            {
+                new ContainerFileSystemEntry
+                {
+                    Name = thumbprint + ".crt",
+                    Type = ContainerFileSystemEntryType.File,
+                    Contents = new string(publicCertificatePem),
+                }
+            };
+
+            if (keyPem is not null)
+            {
+                certificateFiles.Add(new ContainerFileSystemEntry
+                {
+                    Name = thumbprint + ".key",
+                    Type = ContainerFileSystemEntryType.File,
+                    Contents = new string(keyPem),
+                });
+
+                Array.Clear(keyPem, 0, keyPem.Length);
+            }
+
+            if (pfxBytes is not null)
+            {
+                certificateFiles.Add(new ContainerFileSystemEntry
+                {
+                    Name = thumbprint + ".pfx",
+                    Type = ContainerFileSystemEntryType.File,
+                    RawContents = Convert.ToBase64String(pfxBytes),
+                });
+
+                Array.Clear(pfxBytes, 0, pfxBytes.Length);
+            }
+
+            // Write the certificate and key to the container filesystem
+            createFiles.Add(new ContainerCreateFileSystem
+            {
+                Destination = serverAuthCertificatesBasePath,
+                Entries = certificateFiles,
+            });
         }
+
+        return (configuration, pemCertificates, createFiles);
     }
 
     private static async Task ApplyBuildArgumentsAsync(Container dcpContainerResource, IResource modelContainerResource, IServiceProvider serviceProvider, CancellationToken cancellationToken)
@@ -2643,6 +2617,9 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         {
             _logger.LogDebug("Starting {ResourceType} '{ResourceName}'.", resourceType, appResource.DcpResourceName);
 
+            // Reset cached callback results so they are re-evaluated on restart.
+            ForgetCachedCallbackResults(appResource.ModelResource);
+
             // Raise event after resource has been deleted. This is required because the event sets the status to "Starting" and resources being
             // deleted will temporarily override the status to a terminal state, such as "Exited".
             switch (appResource.DcpResource)
@@ -2653,12 +2630,14 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
                     // Ensure we explicitly start the container
                     c.Spec.Start = true;
 
+                    await _executorEvents.PublishAsync(new OnConnectionStringAvailableContext(cancellationToken, appResource.ModelResource)).ConfigureAwait(false);
                     await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, appResource.ModelResource, appResource.DcpResourceName)).ConfigureAwait(false);
-                    await CreateContainerAsync(appResource, resourceLogger, cancellationToken).ConfigureAwait(false);
+                    await CreateDcpContainerAsync(appResource, resourceLogger, cancellationToken).ConfigureAwait(false);
                     break;
                 case Executable e:
                     await EnsureResourceDeletedAsync<Executable>(appResource.DcpResourceName).ConfigureAwait(false);
 
+                    await _executorEvents.PublishAsync(new OnConnectionStringAvailableContext(cancellationToken, appResource.ModelResource)).ConfigureAwait(false);
                     await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, appResource.ModelResource, appResource.DcpResourceName)).ConfigureAwait(false);
                     await CreateExecutableAsync(appResource, resourceLogger, cancellationToken).ConfigureAwait(false);
                     break;
@@ -3041,6 +3020,28 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         return endpoint is not null;
     }
 
+    /// <summary>
+    /// Clears cached callback results on resource annotations so they are re-evaluated on restart.
+    /// </summary>
+    private static void ForgetCachedCallbackResults(IResource resource)
+    {
+        if (resource.TryGetEnvironmentVariables(out var envCallbacks))
+        {
+            foreach (var callback in envCallbacks)
+            {
+                ((ICallbackResourceAnnotation<EnvironmentCallbackContext, Dictionary<string, object>>)callback).ForgetCachedResult();
+            }
+        }
+
+        if (resource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var argsCallbacks))
+        {
+            foreach (var callback in argsCallbacks)
+            {
+                ((ICallbackResourceAnnotation<CommandLineArgsCallbackContext, IList<object>>)callback).ForgetCachedResult();
+            }
+        }
+    }
+
     private record struct HostResourceWithEndpoints
     (
         IResourceWithEndpoints Resource,
@@ -3061,79 +3062,68 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IConsoleLogsService, I
         return null;
     }
 
-    private record struct ContainerCreationSets
-    (
-        IEnumerable<RenderedModelResource> RegularContainers,
-        IEnumerable<RenderedModelResource> TunnelDependentContainers,
-        IEnumerable<RenderedModelResource> RegularContainerExecutables,
-        IEnumerable<RenderedModelResource> TunnelDependentContainerExecutables
-    );
-    /// <summary>
-    /// Determines which containers, and container executables, can be created immediately,
-    /// and which ones depend on a tunnel to the host network.
-    /// </summary>
-    /// <param name="cancellationToken">Cancellation token that can be used to cancel the whole operation.</param>
-    /// <returns>
-    /// A record grouping container-related resources into sets, dependent on whether they
-    /// require network tunnels to host resources.
-    /// </returns>
-    private async Task<ContainerCreationSets> GetContainerCreationSetsAsync(CancellationToken cancellationToken)
+    private async Task<IEnumerable<HostResourceWithEndpoints>> GetHostDependenciesAsync(IResource resource, CancellationToken cancellationToken)
     {
-        List<RenderedModelResource> regular = new();
-        List<RenderedModelResource> tunnelDependent = new();
-
-        var containers = _appResources.OfType<RenderedModelResource>().Where(ar => ar.DcpResource is Container);
-
-        if (!_options.Value.EnableAspireContainerTunnel)
-        {
-            regular.AddRange(containers);
-        }
-        else
-        {
-            foreach (var cr in containers)
+        var allDependencies = await ResourceExtensions.GetResourceDependenciesAsync(
+            resource,
+            _executionContext,
+            new ResourceDependencyDiscoveryOptions
             {
-                cancellationToken.ThrowIfCancellationRequested();
+                DiscoveryMode = ResourceDependencyDiscoveryMode.DirectOnly,
+                CacheAnnotationCallbackResults = true,
+            },
+            cancellationToken
+        ).ConfigureAwait(false);
 
-                var dependencies = await cr.ModelResource.GetResourceDependenciesAsync(_executionContext, ResourceDependencyDiscoveryMode.DirectOnly, cancellationToken).ConfigureAwait(false);
+        // Host dependencies are host network resources with endpoints that containers depend on.
+        List<HostResourceWithEndpoints> hostDependencies = [.. allDependencies.Select(AsHostResourceWithEndpoints).OfType<HostResourceWithEndpoints>()];
 
-                if (dependencies.Any(dep => AsHostResourceWithEndpoints(dep) is { }))
-                {
-                    tunnelDependent.Add(cr);
-                }
-                else
-                {
-                    regular.Add(cr);
-                }
+        // Aspire dashboard is special in the context of Open Telemetry ingestion.
+        // OTLP exporters do not refer to the OTLP ingestion endpoint via EndpointReference when the model is constructed
+        // by the Aspire app host; the endpoint URL is just read from configuration.
+        // If there are containers that are OTLP exporters in the model, we need to project dashboard endpoints into container space.
+        if (resource.TryGetAnnotationsOfType<OtlpExporterAnnotation>(out _))
+        {
+            var maybeDashboard = _model.Resources.Where(r => StringComparers.ResourceName.Equals(r.Name, KnownResourceNames.AspireDashboard))
+                    .Select(AsHostResourceWithEndpoints).FirstOrDefault();
+            if (maybeDashboard is HostResourceWithEndpoints dashboardResource)
+            {
+                hostDependencies.Add(dashboardResource);
             }
         }
 
-        var persistentTunnelDependent = tunnelDependent.Where(td => td.DcpResource is Container c && c.Spec.Persistent is true);
-        if (persistentTunnelDependent.Any())
-        {
-            var containerNames = persistentTunnelDependent.Select(td => td.ModelResource.Name).Aggregate(string.Empty, (acc, next) => acc + " '" + next + "'");
-            throw new InvalidOperationException($"The follwing containers are marked as persistent and rely on resources on the host network:{containerNames}. This is not supported.");
-        }
+        return hostDependencies;
+    }
 
-        return new ContainerCreationSets(
-            RegularContainers: regular,
-            TunnelDependentContainers: tunnelDependent,
-            RegularContainerExecutables: _appResources.OfType<RenderedModelResource>()
-                .Where(ar => ar.DcpResource is ContainerExec ce && regular.Any(td => td.DcpResource is Container c && c.Metadata.Name == ce.Spec.ContainerName)),
-            TunnelDependentContainerExecutables: _appResources.OfType<RenderedModelResource>()
-                .Where(ar => ar.DcpResource is ContainerExec ce && tunnelDependent.Any(td => td.DcpResource is Container c && c.Metadata.Name == ce.Spec.ContainerName))
-        );
+    private AppResource CreateTunnelProxyResource(List<TunnelConfiguration>? tunnels)
+    {
+        Debug.Assert(_options.Value.EnableAspireContainerTunnel, "This method should only be called if the container tunnel feature is enabled.");
+        Debug.Assert(!_appResources.Any(ar => ar.DcpResource is ContainerNetworkTunnelProxy), "This method should only be called if a tunnel proxy resource hasn't already been created.");
+
+        var tunnelProxy = ContainerNetworkTunnelProxy.Create(GetTunnelProxyResourceName());
+        tunnelProxy.Spec.ContainerNetworkName = KnownNetworkIdentifiers.DefaultAspireContainerNetwork.Value;
+        tunnelProxy.Spec.Aliases = [ContainerHostName];
+        tunnelProxy.Spec.Tunnels = tunnels;
+        var tunnelAppResource = new AppResource(tunnelProxy);
+        _appResources.Add(tunnelAppResource);
+        return tunnelAppResource;
+    }
+
+    private string GetTunnelProxyResourceName()
+    {
+        Debug.Assert(_options.Value.EnableAspireContainerTunnel, "This method should only be called if the container tunnel feature is enabled.");
+        return KnownNetworkIdentifiers.DefaultAspireContainerNetwork.Value + "-tunnelproxy";
     }
 
     private async Task PublishEndpointAllocatedEventAsync(
-        HashSet<string> endpointsAdvertisedFor,
         IEnumerable<RenderedModelResource> resource,
         CancellationToken ct)
     {
         foreach (var r in resource)
         {
-            lock (endpointsAdvertisedFor)
+            lock (_endpointsAdvertised)
             {
-                if (!endpointsAdvertisedFor.Add(r.ModelResource.Name))
+                if (!_endpointsAdvertised.Add(r.ModelResource.Name))
                 {
                     continue; // Already published for this resource
                 }

--- a/src/Aspire.Hosting/Dcp/DcpExecutorEvents.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutorEvents.cs
@@ -9,6 +9,7 @@ namespace Aspire.Hosting.Dcp;
 internal record ResourceStatus(string? State, DateTime? StartupTimestamp, DateTime? FinishedTimestamp);
 internal record OnEndpointsAllocatedContext(CancellationToken CancellationToken);
 internal record OnResourceStartingContext(CancellationToken CancellationToken, string ResourceType, IResource Resource, string? DcpResourceName);
+internal record OnConnectionStringAvailableContext(CancellationToken CancellationToken, IResource Resource);
 internal record OnResourcesPreparedContext(CancellationToken CancellationToken);
 internal record OnResourceChangedContext(CancellationToken CancellationToken, string ResourceType, IResource Resource, string DcpResourceName, ResourceStatus Status, Func<CustomResourceSnapshot, CustomResourceSnapshot> UpdateSnapshot);
 internal record OnResourceFailedToStartContext(CancellationToken CancellationToken, string ResourceType, IResource Resource, string? DcpResourceName);

--- a/src/Aspire.Hosting/Dcp/DcpNameGenerator.cs
+++ b/src/Aspire.Hosting/Dcp/DcpNameGenerator.cs
@@ -19,6 +19,13 @@ internal sealed class DcpNameGenerator
     private readonly IConfiguration _configuration;
     private readonly IOptions<DcpOptions> _options;
 
+    // A map from (resource name, endpoint name, target network ID) => DCP service name. 
+    // Used for ensuring that we do not create duplicate DCP services for the same resource endpoint.
+    private readonly Dictionary<string, string> _networkServices = new();
+
+    // Helps ensure that service names are unique (service names do not use random suffixes).
+    private readonly HashSet<string> _allServiceNames = new();
+
     public DcpNameGenerator(IConfiguration configuration, IOptions<DcpOptions> options)
     {
         _configuration = configuration;
@@ -77,32 +84,40 @@ internal sealed class DcpNameGenerator
         return (GetObjectNameForResource(project, _options.Value, nameSuffix), nameSuffix);
     }
 
-    public string GetServiceName(IResource resource, EndpointAnnotation endpoint, bool hasMultipleEndpoints, HashSet<string> allServiceNames)
+    // Returns a DCP service name for the given resource/endpoint/network combination. 
+    // The returned boolean indicates whether a new service name was generated (true) or an existing one was returned (false).
+    public (string, bool) GetServiceName(IResource resource, EndpointAnnotation endpoint, NetworkIdentifier targetNetworkId)
     {
-        var candidateServiceName = !hasMultipleEndpoints
-            ? GetObjectNameForResource(resource, _options.Value)
-            : GetObjectNameForResource(resource, _options.Value, endpoint.Name);
+        var hasMultipleEndpoints = resource.Annotations.OfType<EndpointAnnotation>().Count() > 1;
+        var key = NetworkServiceKey(resource, endpoint, targetNetworkId);
 
-        return GenerateUniqueServiceName(allServiceNames, candidateServiceName);
-    }
-
-    private static string GenerateUniqueServiceName(HashSet<string> serviceNames, string candidateName)
-    {
-        int suffix = 1;
-        string uniqueName = candidateName;
-
-        while (!serviceNames.Add(uniqueName))
+        lock(_allServiceNames)
         {
-            uniqueName = $"{candidateName}-{suffix}";
-            suffix++;
-            if (suffix == 100)
+            if (_networkServices.TryGetValue(key, out var name))
             {
-                // Should never happen, but we do not want to ever get into a infinite loop situation either.
-                throw new ArgumentException($"Could not generate a unique name for service '{candidateName}'");
+                return (name, false);
             }
-        }
 
-        return uniqueName;
+            var candidateName = !hasMultipleEndpoints
+                ? GetObjectNameForResource(resource, _options.Value)
+                : GetObjectNameForResource(resource, _options.Value, endpoint.Name);
+
+            int suffix = 1;
+            string uniqueName = candidateName;
+
+            while (!_allServiceNames.Add(uniqueName))
+            {
+                uniqueName = $"{candidateName}-{suffix}";
+                suffix++;
+                if (suffix == 100)
+                {
+                    // Should never happen, but we do not want to ever get into a infinite loop situation either.
+                    throw new ArgumentException($"Could not generate a unique name for service '{candidateName}'");
+                }
+            }
+            _networkServices[key] = uniqueName;
+            return (uniqueName, true); 
+        }
     }
 
     public static string GetRandomNameSuffix()
@@ -137,4 +152,7 @@ internal sealed class DcpNameGenerator
             };
         return maybeWithSuffix(resource.Name, suffix, options.ResourceNameSuffix);
     }
+
+    private static string NetworkServiceKey(IResource resource, EndpointAnnotation endpoint, NetworkIdentifier targetNetworkId)
+        => $"{resource.Name}|{endpoint.Name}|{targetNetworkId.Value}";
 }

--- a/src/Aspire.Hosting/Dcp/DcpResourceState.cs
+++ b/src/Aspire.Hosting/Dcp/DcpResourceState.cs
@@ -7,7 +7,7 @@ using Aspire.Hosting.Dcp.Model;
 
 namespace Aspire.Hosting.Dcp;
 
-internal sealed class DcpResourceState(Dictionary<string, IResource> applicationModel, List<AppResource> appResources)
+internal sealed class DcpResourceState(IDictionary<string, IResource> applicationModel, IEnumerable<AppResource> appResources)
 {
     public readonly ConcurrentDictionary<string, Container> ContainersMap = [];
     public readonly ConcurrentDictionary<string, Executable> ExecutablesMap = [];
@@ -16,6 +16,6 @@ internal sealed class DcpResourceState(Dictionary<string, IResource> application
     public readonly ConcurrentDictionary<string, Endpoint> EndpointsMap = [];
     public readonly ConcurrentDictionary<(string, string), List<string>> ResourceAssociatedServicesMap = [];
 
-    public Dictionary<string, IResource> ApplicationModel { get; } = applicationModel;
-    public List<AppResource> AppResources { get; } = appResources;
+    public IDictionary<string, IResource> ApplicationModel { get; } = applicationModel;
+    public IEnumerable<AppResource> AppResources { get; } = appResources;
 }

--- a/src/Aspire.Hosting/Dcp/Model/ContainerTunnel.cs
+++ b/src/Aspire.Hosting/Dcp/Model/ContainerTunnel.cs
@@ -259,8 +259,17 @@ internal sealed record ContainerNetworkTunnelProxyStatus : V1Status
 
 internal sealed class ContainerNetworkTunnelProxy : CustomResource<ContainerNetworkTunnelProxySpec, ContainerNetworkTunnelProxyStatus>, IKubernetesStaticMetadata
 {
+    /// <summary>
+    /// Contains updated tunnel configurations that have not yet been applied to the proxy pair.
+    /// </summary>
+    [JsonIgnore]
+    public List<TunnelConfiguration> UpdatedTunnels { get; private set; }
+
     [JsonConstructor]
-    public ContainerNetworkTunnelProxy(ContainerNetworkTunnelProxySpec spec) : base(spec) { }
+    public ContainerNetworkTunnelProxy(ContainerNetworkTunnelProxySpec spec) : base(spec)
+    {
+        UpdatedTunnels = spec.Tunnels ?? new List<TunnelConfiguration>();
+    }
 
     public static ContainerNetworkTunnelProxy Create(string name)
     {

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -68,6 +68,7 @@ internal sealed class ApplicationOrchestrator
         dcpExecutorEvents.Subscribe<OnResourceChangedContext>(OnResourceChanged);
         dcpExecutorEvents.Subscribe<OnEndpointsAllocatedContext>(OnEndpointsAllocated);
         dcpExecutorEvents.Subscribe<OnResourceStartingContext>(OnResourceStarting);
+        dcpExecutorEvents.Subscribe<OnConnectionStringAvailableContext>(OnConnectionStringAvailable);
         dcpExecutorEvents.Subscribe<OnResourceFailedToStartContext>(OnResourceFailedToStart);
 
         _eventing.Subscribe<ResourceEndpointsAllocatedEvent>(OnResourceEndpointsAllocated);
@@ -193,8 +194,6 @@ internal sealed class ApplicationOrchestrator
                 break;
         }
 
-        await PublishConnectionStringAvailableEvent(context.Resource, context.CancellationToken).ConfigureAwait(false);
-
         var beforeResourceStartedEvent = new BeforeResourceStartedEvent(context.Resource, _serviceProvider);
         await _eventing.PublishAsync(beforeResourceStartedEvent, context.CancellationToken).ConfigureAwait(false);
 
@@ -209,6 +208,11 @@ internal sealed class ApplicationOrchestrator
     private async Task OnResourcesPrepared(OnResourcesPreparedContext context)
     {
         await PublishResourcesInitialStateAsync(context.CancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task OnConnectionStringAvailable(OnConnectionStringAvailableContext context)
+    {
+        await PublishConnectionStringAvailableEvent(context.Resource, context.CancellationToken).ConfigureAwait(false);
     }
 
     private async Task ProcessResourceUrlCallbacks(IResource resource, CancellationToken cancellationToken)

--- a/src/Aspire.Hosting/Utils/ConcurrencyUtils.cs
+++ b/src/Aspire.Hosting/Utils/ConcurrencyUtils.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+
+namespace Aspire.Hosting.Utils;
+
+internal static class ConcurrencyUtils
+{
+    public static Action Once(Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var invoked = 0;
+
+        return () =>
+        {
+            if (Interlocked.CompareExchange(ref invoked, 1, 0) != 0)
+            {
+                return;
+            }
+
+            action();
+        };
+    }
+
+    public static void AddRange<T>(this ConcurrentBag<T> bag, IEnumerable<T> items)
+    {
+        ArgumentNullException.ThrowIfNull(bag);
+        ArgumentNullException.ThrowIfNull(items);
+
+        foreach (var item in items)
+        {
+            bag.Add(item);
+        }
+    }
+}

--- a/tests/Aspire.Hosting.Tests/ContainerTunnelTests.cs
+++ b/tests/Aspire.Hosting.Tests/ContainerTunnelTests.cs
@@ -45,12 +45,11 @@ public class ContainerTunnelTests(ITestOutputHelper testOutputHelper)
 
     [Fact]
     [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
-    [ActiveIssue("https://github.com/microsoft/aspire/issues/15358")]
     public async Task ProxylessEndpointWorksWithContainerTunnel()
     {
         var port = await Helpers.Network.GetAvailablePortAsync();
 
-        const string testName = "proxyless-endpoint-works-with-container-tunnel";
+        const string testName = "proxyless-endpoint-container-tunnel";
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
         builder.Configuration[KnownConfigNames.EnableContainerTunnel] = "true";
 

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -2323,6 +2323,266 @@ public class DcpExecutorTests
         }
     }
 
+    // Verifies that environment value callbacks are invoked only once per container startup.
+    [Fact]
+    public async Task EnvironmentCallbacksInvokedOnceOnContainer()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var executable = builder.AddExecutable("anExecutable", "command", "")
+            .WithEndpoint(name: "http", targetPort: 1234, port: 5678, isProxied: true);
+
+        var callCount = 0;
+        builder.AddContainer("aContainer", "image")
+            .WithEnvironment(c =>
+            {
+                Interlocked.Increment(ref callCount);
+                c.EnvironmentVariables["EXEC_PORT"] = executable.GetEndpoint("http").Property(EndpointProperty.Port);
+            });
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var dcpOptions = new DcpOptions
+        {
+            EnableAspireContainerTunnel = true,
+        };
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, dcpOptions: dcpOptions);
+        await appExecutor.RunApplicationAsync();
+
+        Assert.Equal(1, callCount);
+    }
+
+    // Ensures that environment value callbacks are invoked after the OnResourceStarting event is raised for the resource, 
+    // allowing users to rely on any state set during that event in their environment callbacks.
+    [Fact]
+    public async Task EnvironmentCallbacksInvokedAfterBeforeResourceStartEvent()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        var envCallCount = 0;
+        var resourceStartingRaised = false;
+        var resourceStartingCalledBeforeEnvCallback = false;
+
+        var executable = builder.AddExecutable("anExecutable", "command", "")
+            .WithEndpoint(name: "http", targetPort: 1234, port: 5678, isProxied: true);
+
+        builder.AddContainer("aContainer", "image")
+            .WithEnvironment(c =>
+            {
+                Interlocked.Increment(ref envCallCount);
+                c.EnvironmentVariables["EXEC_PORT"] = executable.GetEndpoint("http").Property(EndpointProperty.Port);
+            });
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceStartingContext>(context =>
+        {
+            if (context.ResourceType == "Container")
+            {
+                resourceStartingRaised = true;
+                resourceStartingCalledBeforeEnvCallback = envCallCount == 0;
+            }
+            return Task.CompletedTask;
+        });
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, events: events);
+        await appExecutor.RunApplicationAsync();
+
+        Assert.Equal(1, envCallCount);
+        Assert.True(resourceStartingRaised, "OnResourceStarting should be raised for the container");
+        Assert.True(resourceStartingCalledBeforeEnvCallback, "OnResourceStarting should be raised before the environment callback is invoked");
+    }
+
+    // Verifies that command-line argument callbacks are invoked only once per container startup.
+    [Fact]
+    public async Task ArgsCallbacksInvokedOnceOnContainer()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var executable = builder.AddExecutable("anExecutable", "command", "")
+            .WithEndpoint(name: "http", targetPort: 1234, port: 5678, isProxied: true);
+
+        var callCount = 0;
+        builder.AddContainer("aContainer", "image")
+            .WithArgs(c =>
+            {
+                Interlocked.Increment(ref callCount);
+                c.Args.Add("--port");
+                c.Args.Add(executable.GetEndpoint("http").Property(EndpointProperty.Port));
+            });
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var dcpOptions = new DcpOptions
+        {
+            EnableAspireContainerTunnel = true,
+        };
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, dcpOptions: dcpOptions);
+        await appExecutor.RunApplicationAsync();
+
+        Assert.Equal(1, callCount);
+    }
+
+    // Ensures that command-line argument callbacks are invoked after the OnResourceStarting event is raised for the resource,
+    // allowing users to rely on any state set during that event in their argument callbacks.
+    [Fact]
+    public async Task ArgsCallbacksInvokedAfterBeforeResourceStartEvent()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        var argsCallCount = 0;
+        var resourceStartingRaised = false;
+        var resourceStartingCalledBeforeArgsCallback = false;
+
+        var executable = builder.AddExecutable("anExecutable", "command", "")
+            .WithEndpoint(name: "http", targetPort: 1234, port: 5678, isProxied: true);
+
+        builder.AddContainer("aContainer", "image")
+            .WithArgs(c =>
+            {
+                Interlocked.Increment(ref argsCallCount);
+                c.Args.Add("--port");
+                c.Args.Add(executable.GetEndpoint("http").Property(EndpointProperty.Port));
+            });
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceStartingContext>(context =>
+        {
+            if (context.ResourceType == "Container")
+            {
+                resourceStartingRaised = true;
+                resourceStartingCalledBeforeArgsCallback = argsCallCount == 0;
+            }
+            return Task.CompletedTask;
+        });
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, events: events);
+        await appExecutor.RunApplicationAsync();
+
+        Assert.Equal(1, argsCallCount);
+        Assert.True(resourceStartingRaised, "OnResourceStarting should be raised for the container");
+        Assert.True(resourceStartingCalledBeforeArgsCallback, "OnResourceStarting should be raised before the args callback is invoked");
+    }
+
+    [Fact]
+    public async Task TunnelDependentAndIndependentContainersCanStartTogether()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        // An executable with an endpoint — containers that reference it will be tunnel-dependent.
+        var executable = builder.AddExecutable("anExecutable", "command", "")
+            .WithEndpoint(name: "http", targetPort: 1234, port: 5678, isProxied: true);
+
+        // A container that references the executable's endpoint — this makes it tunnel-dependent.
+        builder.AddContainer("tunnelDependent", "image")
+            .WithEnvironment("EXEC_PORT", executable.GetEndpoint("http").Property(EndpointProperty.Port));
+
+        // A container that does NOT reference any host resource — this is tunnel-independent.
+        builder.AddContainer("tunnelIndependent", "image");
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var dcpOptions = new DcpOptions
+        {
+            EnableAspireContainerTunnel = true,
+        };
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, dcpOptions: dcpOptions);
+        await appExecutor.RunApplicationAsync();
+
+        // Both containers should have been created successfully.
+        var createdContainers = kubernetesService.CreatedResources.OfType<Container>().ToList();
+        Assert.Single(createdContainers, c => c.AppModelResourceName == "tunnelDependent");
+        Assert.Single(createdContainers, c => c.AppModelResourceName == "tunnelIndependent");
+    }
+
+    [Fact]
+    public async Task EnvironmentCallbackThrows_OtherResourcesStillStart()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        builder.AddContainer("failing", "image")
+            .WithEnvironment(c =>
+            {
+                throw new InvalidOperationException("env callback failure");
+            });
+
+        builder.AddContainer("healthy", "image");
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var failedResources = new List<string>();
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceFailedToStartContext>(c =>
+        {
+            failedResources.Add(c.Resource.Name);
+            return Task.CompletedTask;
+        });
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, events: events);
+        await appExecutor.RunApplicationAsync();
+
+        // The healthy container should have been created successfully.
+        var createdContainers = kubernetesService.CreatedResources.OfType<Container>().ToList();
+        Assert.Single(createdContainers, c => c.AppModelResourceName == "healthy");
+
+        // The failing container should not have been created and should be reported as failed.
+        Assert.DoesNotContain(createdContainers, c => c.AppModelResourceName == "failing");
+        Assert.Single(failedResources, name => name == "failing");
+    }
+
+    [Fact]
+    public async Task ArgsCallbackThrows_OtherResourcesStillStart()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        builder.AddContainer("failing", "image")
+            .WithArgs(c =>
+            {
+                throw new InvalidOperationException("args callback failure");
+            });
+
+        builder.AddContainer("healthy", "image");
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var failedResources = new List<string>();
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceFailedToStartContext>(c =>
+        {
+            failedResources.Add(c.Resource.Name);
+            return Task.CompletedTask;
+        });
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, events: events);
+        await appExecutor.RunApplicationAsync();
+
+        // The healthy container should have been created successfully.
+        var createdContainers = kubernetesService.CreatedResources.OfType<Container>().ToList();
+        Assert.Single(createdContainers, c => c.AppModelResourceName == "healthy");
+
+        // The failing container should not have been created and should be reported as failed.
+        Assert.DoesNotContain(createdContainers, c => c.AppModelResourceName == "failing");
+        Assert.Single(failedResources, name => name == "failing");
+    }
+
     private static void HasKnownCommandAnnotations(IResource resource)
     {
         var commandAnnotations = resource.Annotations.OfType<ResourceCommandAnnotation>().ToList();
@@ -2587,8 +2847,7 @@ public class DcpExecutorTests
             new TestDcpDependencyCheckService(),
             new DcpNameGenerator(configuration, Options.Create(dcpOptions)),
             events ?? new DcpExecutorEvents(),
-            new Locations(new FileSystemService(configuration ?? new ConfigurationBuilder().Build())),
-            developerCertificateService);
+            new Locations(new FileSystemService(configuration ?? new ConfigurationBuilder().Build())));
 #pragma warning restore ASPIRECERTIFICATES001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -401,7 +401,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
             return Task.CompletedTask;
         });
 
-        await events.PublishAsync(new OnResourceStartingContext(CancellationToken.None, KnownResourceTypes.Container, parentResource.Resource, parentResource.Resource.Name));
+        await events.PublishAsync(new OnConnectionStringAvailableContext(CancellationToken.None, parentResource.Resource));
 
         Assert.True(parentConnectionStringAvailable);
         Assert.True(childConnectionStringAvailable);

--- a/tests/Aspire.Hosting.Tests/ResourceDependencyTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceDependencyTests.cs
@@ -759,7 +759,10 @@ public class ResourceDependencyTests
 
         var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
         var dependencies = await ResourceExtensions.GetDependenciesAsync(
-            [a.Resource, d.Resource], executionContext, ResourceDependencyDiscoveryMode.DirectOnly);
+            [a.Resource, d.Resource], executionContext, new ResourceDependencyDiscoveryOptions
+            {
+                DiscoveryMode = ResourceDependencyDiscoveryMode.DirectOnly
+            });
 
         // DirectOnly should only include B and E (direct deps), not C and F
         Assert.Contains(b.Resource, dependencies);


### PR DESCRIPTION
## Description

This change fixes issues related to environment and invocation argument callback calling and application model events introduced by https://github.com/microsoft/aspire/pull/14557. It ensures that 
- callbacks are invoked after BeforeResourceStart handlers complete for given resource,
- callbacks are invoked only once during resource startup, and that
- exceptions thrown by callbacks do not affect startup of other resources.

Fixes:
https://github.com/microsoft/aspire/issues/14954
https://github.com/microsoft/aspire/issues/15358

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
