### PR TITLE
[release/13.2] Pin Kusto emulator image and backport Cosmos fix

### DIFF
--- a/src/Aspire.Hosting.Azure.CosmosDB/CosmosDBEmulatorContainerImageTags.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/CosmosDBEmulatorContainerImageTags.cs
@@ -11,8 +11,8 @@ internal static class CosmosDBEmulatorContainerImageTags
     /// <remarks>cosmosdb/linux/azure-cosmos-emulator</remarks>
     public const string Image = "cosmosdb/linux/azure-cosmos-emulator";
 
-    /// <remarks>latest</remarks>
-    public const string Tag = "latest";
+    /// <remarks>stable</remarks>
+    public const string Tag = "stable";
 
     /// <remarks>vnext-preview</remarks>
     public const string TagVNextPreview = "vnext-preview";

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoEmulatorContainerImageTags.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoEmulatorContainerImageTags.cs
@@ -23,6 +23,6 @@ internal static class AzureKustoEmulatorContainerImageTags
     /// <summary>
     /// The tag for the Kusto emulator container image.
     /// </summary>
-    /// <remarks>latest</remarks>
-    public static string Tag { get; } = "latest";
+    /// <remarks>2026.03.16.1116-2611-994a3c9-master</remarks>
+    public static string Tag { get; } = "2026.03.16.1116-2611-994a3c9-master";
 }

--- a/tests/Aspire.Hosting.Azure.Kusto.Tests/AddAzureKustoTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kusto.Tests/AddAzureKustoTests.cs
@@ -27,7 +27,7 @@ public class AddAzureKustoTests
     }
 
     [Theory]
-    [InlineData(null, "latest")]
+    [InlineData(null, "2026.03.16.1116-2611-994a3c9-master")]
     [InlineData("custom-tag", "custom-tag")]
     public void RunAsEmulator_ShouldConfigureContainerImageWithCorrectTag(string? customTag, string expectedTag)
     {

--- a/tests/Aspire.Hosting.Azure.Kusto.Tests/KustoFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kusto.Tests/KustoFunctionalTests.cs
@@ -187,9 +187,9 @@ public class KustoFunctionalTests
         var rns = app.Services.GetRequiredService<ResourceNotificationService>();
         await rns.WaitForResourceHealthyAsync(kusto.Resource.Name, cts.Token);
 
-        // Assert the duplicate database definition did not surface as a database creation failure.
+        // Assert no warnings or errors were logged about the database already existing
         var snapshot = app.Services.GetRequiredService<FakeLogCollector>().GetSnapshot();
-        var logs = snapshot.Where(IsDatabaseCreationFailureLog);
+        var logs = snapshot.Where(IsResourceLog).Where(record => record.Level >= LogLevel.Warning);
         Assert.Empty(logs);
     }
 
@@ -218,11 +218,10 @@ public class KustoFunctionalTests
         await rns.WaitForResourceHealthyAsync(db1.Resource.Name, cts.Token);
         await rns.WaitForResourceAsync(db2.Resource.Name, KnownResourceStates.FailedToStart, cts.Token);
 
-        // Assert an error was logged about the invalid database.
+        // Assert an error was logged about the invalid database
         var snapshot = app.Services.GetRequiredService<FakeLogCollector>().GetSnapshot();
-        var log = Assert.Single(snapshot, IsDatabaseCreationFailureLog);
-        Assert.Equal(LogLevel.Error, log.Level);
-        Assert.Contains("Failed to create database '__invalid'", log.Message, StringComparison.Ordinal);
+        var logs = snapshot.Where(IsResourceLog).Where(record => record.Level >= LogLevel.Warning);
+        Assert.Single(logs);
     }
 
     [Fact]
@@ -272,15 +271,6 @@ public class KustoFunctionalTests
     private static bool IsResourceLog(FakeLogRecord record)
     {
         return (record.Category ?? string.Empty).StartsWith("Aspire.Hosting.Tests.Resources", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static bool IsDatabaseCreationFailureLog(FakeLogRecord record)
-    {
-        return IsResourceLog(record)
-            && record.Level >= LogLevel.Error
-            // Matches the error logged by CreateDatabaseAsync in
-            // src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs.
-            && (record.Message?.Contains("Failed to create database", StringComparison.Ordinal) ?? false);
     }
 
     /// <summary>

--- a/tests/Aspire.Hosting.Azure.Kusto.Tests/KustoFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kusto.Tests/KustoFunctionalTests.cs
@@ -187,9 +187,9 @@ public class KustoFunctionalTests
         var rns = app.Services.GetRequiredService<ResourceNotificationService>();
         await rns.WaitForResourceHealthyAsync(kusto.Resource.Name, cts.Token);
 
-        // Assert no warnings or errors were logged about the database already existing
+        // Assert the duplicate database definition did not surface as a database creation failure.
         var snapshot = app.Services.GetRequiredService<FakeLogCollector>().GetSnapshot();
-        var logs = snapshot.Where(IsResourceLog).Where(record => record.Level >= LogLevel.Warning);
+        var logs = snapshot.Where(IsDatabaseCreationFailureLog);
         Assert.Empty(logs);
     }
 
@@ -218,10 +218,11 @@ public class KustoFunctionalTests
         await rns.WaitForResourceHealthyAsync(db1.Resource.Name, cts.Token);
         await rns.WaitForResourceAsync(db2.Resource.Name, KnownResourceStates.FailedToStart, cts.Token);
 
-        // Assert an error was logged about the invalid database
+        // Assert an error was logged about the invalid database.
         var snapshot = app.Services.GetRequiredService<FakeLogCollector>().GetSnapshot();
-        var logs = snapshot.Where(IsResourceLog).Where(record => record.Level >= LogLevel.Warning);
-        Assert.Single(logs);
+        var log = Assert.Single(snapshot, IsDatabaseCreationFailureLog);
+        Assert.Equal(LogLevel.Error, log.Level);
+        Assert.Contains("Failed to create database '__invalid'", log.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -271,6 +272,15 @@ public class KustoFunctionalTests
     private static bool IsResourceLog(FakeLogRecord record)
     {
         return (record.Category ?? string.Empty).StartsWith("Aspire.Hosting.Tests.Resources", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsDatabaseCreationFailureLog(FakeLogRecord record)
+    {
+        return IsResourceLog(record)
+            && record.Level >= LogLevel.Error
+            // Matches the error logged by CreateDatabaseAsync in
+            // src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs.
+            && (record.Message?.Contains("Failed to create database", StringComparison.Ordinal) ?? false);
     }
 
     /// <summary>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBExtensionsTests.cs
@@ -58,7 +58,7 @@ public class AzureCosmosDBExtensionsTests(ITestOutputHelper output)
         Assert.NotNull(containerImageAnnotation);
 
         var actualTag = containerImageAnnotation.Tag;
-        Assert.Equal(imageTag ?? "latest", actualTag);
+        Assert.Equal(imageTag ?? "stable", actualTag);
     }
 
     [Theory]


### PR DESCRIPTION
## Description

Updates the `release/13.2` backport branch to keep the Kusto functional tests enabled, revert the Kusto log-assertion tightening, and pin the Kusto emulator image to `2026.03.16.1116-2611-994a3c9-master`.

This PR now includes:
- the Cosmos DB emulator image default change already backported on this branch
- a release-branch test expectation update for the Cosmos default tag
- a pinned Kusto emulator default image tag
- a matching Kusto unit test expectation update
- a revert of the Kusto functional test assertion changes so the tests stay enabled without the broader log-assertion rewrite

Validation:
- `./dotnet.sh test tests/Aspire.Hosting.Azure.Kusto.Tests/Aspire.Hosting.Azure.Kusto.Tests.csproj -- --filter-method "*.RunAsEmulator_ShouldConfigureContainerImageWithCorrectTag" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `./dotnet.sh test tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj -- --filter-method "*.AddAzureCosmosDBWithEmulatorGetsExpectedImageTag" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- attempted `KustoFunctionalTests` locally after the image pin; the class still failed in this environment

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
