### PR TITLE
Quarantine Docker and Kubernetes E2E tests on main

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/DockerDeploymentTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DockerDeploymentTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Tests.Utils;
+using Aspire.TestUtilities;
 using Hex1b.Automation;
 using Xunit;
 
@@ -18,6 +19,7 @@ public sealed class DockerDeploymentTests(ITestOutputHelper output)
     private const string ProjectName = "AspireDockerDeployTest";
 
     [Fact]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/15511")]
     public async Task CreateAndDeployToDockerCompose()
     {
         using var workspace = TemporaryWorkspace.Create(output);
@@ -139,6 +141,7 @@ builder.Build().Run();
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/15511")]
     public async Task CreateAndDeployToDockerComposeInteractive()
     {
         using var workspace = TemporaryWorkspace.Create(output);

--- a/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/KubernetesPublishTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.EndToEnd.Tests.Helpers;
 using Aspire.Cli.Tests.Utils;
+using Aspire.TestUtilities;
 using Hex1b.Automation;
 using Xunit;
 
@@ -26,6 +27,7 @@ public sealed class KubernetesPublishTests(ITestOutputHelper output)
         $"{ClusterNamePrefix}-{Guid.NewGuid():N}"[..32]; // KinD cluster names max 32 chars
 
     [Fact]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/15511")]
     public async Task CreateAndPublishToKubernetes()
     {
         using var workspace = TemporaryWorkspace.Create(output);


### PR DESCRIPTION
Quarantines the Docker deployment and Kubernetes publish E2E tests on `main` due to a versioning mismatch with `SuppressFinalPackageVersion=true` packages on release branches.

Same change as #15512 (targeting `release/13.2`).

**Root Cause**

On release branches, `StabilizePackageVersion=true` creates a version split:
- **Stable packages** (e.g. `Aspire.Hosting`): version `13.2.0`, assembly version `13.2.0.0` (from nuget.org)
- **Suppressed packages** (`SuppressFinalPackageVersion=true`, e.g. `Aspire.Hosting.Docker`, `Aspire.Hosting.Kubernetes`): version `13.2.0-ci`, assembly version `42.42.42.42`

This causes:
- **Docker tests**: CS1705 assembly version mismatch (`42.42.42.42` vs `13.2.0.0`)
- **Kubernetes tests**: NU1102 — `13.2.0-ci` doesn't satisfy `>= 13.2.0-preview.1.x` constraint

**Changes**

Added `[QuarantinedTest("https://github.com/microsoft/aspire/issues/15511")]` to:
- `DockerDeploymentTests.CreateAndDeployToDockerCompose()`
- `DockerDeploymentTests.CreateAndDeployToDockerComposeInteractive()`
- `KubernetesPublishTests.CreateAndPublishToKubernetes()`

Fixes #15511