### PR TITLE
Use InteractionService.DisplayRawText instead of Console.WriteLine in SdkDumpCommand

### DIFF
--- a/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
+++ b/src/Aspire.Cli/Commands/Sdk/SdkDumpCommand.cs
@@ -219,7 +219,7 @@ internal sealed class SdkDumpCommand : BaseCommand
                 else
                 {
                     // Output to stdout
-                    Console.WriteLine(output);
+                    InteractionService.DisplayRawText(output, consoleOverride: ConsoleOutput.Standard);
                 }
 
                 // Return error code if there are errors in diagnostics


### PR DESCRIPTION
## Description

Replace direct `Console.WriteLine` call with `InteractionService.DisplayRawText` in `SdkDumpCommand` for stdout output. This ensures consistent output handling through the interaction service abstraction rather than bypassing it with a direct console write.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
