### PR TITLE
Log ConsoleInteractionService output to CLI log file

### DIFF
--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -262,7 +262,7 @@ internal sealed class DescribeCommand : BaseCommand
     {
         if (snapshots.Count == 0)
         {
-            _interactionService.DisplayPlainText("No resources found.");
+            _interactionService.DisplayMessage(KnownEmojis.Information, "No resources found.");
             return;
         }
 

--- a/src/Aspire.Cli/Commands/SecretGetCommand.cs
+++ b/src/Aspire.Cli/Commands/SecretGetCommand.cs
@@ -61,7 +61,7 @@ internal sealed class SecretGetCommand : BaseCommand
         }
 
         // Write value to stdout (machine-readable)
-        InteractionService.DisplayPlainText(value);
+        InteractionService.DisplayRawText(value, consoleOverride: ConsoleOutput.Standard);
         return ExitCodeConstants.Success;
     }
 }

--- a/src/Aspire.Cli/Commands/SecretPathCommand.cs
+++ b/src/Aspire.Cli/Commands/SecretPathCommand.cs
@@ -43,7 +43,7 @@ internal sealed class SecretPathCommand : BaseCommand
             return ExitCodeConstants.FailedToFindProject;
         }
 
-        InteractionService.DisplayPlainText(result.Store.FilePath);
+        InteractionService.DisplayRawText(result.Store.FilePath, consoleOverride: ConsoleOutput.Standard);
         return ExitCodeConstants.Success;
     }
 }

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -32,6 +32,7 @@ internal class ConsoleInteractionService : IInteractionService
     /// </summary>
     private IAnsiConsole MessageConsole => Console == ConsoleOutput.Error ? _errorConsole : _outConsole;
 
+    // Limit logging to prompts and messages. Don't log raw text output since it may contain sensitive information.
     private ILogger MessageLogger => Console == ConsoleOutput.Error ? _stderrLogger : _stdoutLogger;
 
     public ConsoleOutput Console { get; set; }

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -327,7 +327,10 @@ internal class ConsoleInteractionService : IInteractionService
     {
         if (MessageLogger.IsEnabled(LogLevel.Information))
         {
-            MessageLogger.LogInformation("{Message}", ConsoleHelpers.FormatEmojiPrefix(emoji, MessageConsole, replaceEmoji: true) + message.RemoveMarkup());
+            // Only attempt to parse/remove markup when the message is expected to contain it.
+            // Plain text messages may contain characters like '[' that would be rejected by the markup parser.
+            var logMessage = allowMarkup ? message.RemoveMarkup() : message;
+            MessageLogger.LogInformation("{Message}", ConsoleHelpers.FormatEmojiPrefix(emoji, MessageConsole, replaceEmoji: true) + logMessage);
         }
 
         var displayMessage = allowMarkup ? message : message.EscapeMarkup();

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -317,20 +317,18 @@ internal class ConsoleInteractionService : IInteractionService
 
     public void DisplayError(string errorMessage)
     {
-        MessageLogger.LogInformation("Error: {ErrorMessage}", errorMessage);
         DisplayMessage(KnownEmojis.CrossMark, $"[red bold]{errorMessage.EscapeMarkup()}[/]", allowMarkup: true);
     }
 
     public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false)
     {
-        MessageLogger.LogInformation("{Message}", message);
+        MessageLogger.LogInformation("{EmojiName}: {Message}", emoji.Name, message);
         var displayMessage = allowMarkup ? message : message.EscapeMarkup();
         MessageConsole.MarkupLine(ConsoleHelpers.FormatEmojiPrefix(emoji, MessageConsole) + displayMessage);
     }
 
     public void DisplayPlainText(string message)
     {
-        MessageLogger.LogInformation("{Message}", message);
         // Write directly to avoid Spectre.Console line wrapping
         MessageConsole.Profile.Out.Writer.WriteLine(message);
     }
@@ -338,8 +336,6 @@ internal class ConsoleInteractionService : IInteractionService
     public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null)
     {
         var effectiveConsole = consoleOverride ?? Console;
-        var logger = effectiveConsole == ConsoleOutput.Error ? _stderrLogger : _stdoutLogger;
-        logger.LogInformation("{Text}", text);
         // Write raw text directly to avoid console wrapping.
         // When consoleOverride is null, respect the Console setting.
         var target = effectiveConsole == ConsoleOutput.Error ? _errorConsole : _outConsole;
@@ -359,8 +355,6 @@ internal class ConsoleInteractionService : IInteractionService
 
     public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false)
     {
-        MessageLogger.LogInformation("{Message}", message);
-
         var style = isErrorMessage ? s_errorMessageStyle
             : type switch
             {
@@ -377,7 +371,6 @@ internal class ConsoleInteractionService : IInteractionService
 
     public void DisplaySuccess(string message, bool allowMarkup = false)
     {
-        MessageLogger.LogInformation("Success: {Message}", message);
         DisplayMessage(KnownEmojis.CheckMark, message, allowMarkup);
     }
 
@@ -387,12 +380,10 @@ internal class ConsoleInteractionService : IInteractionService
         {
             if (stream == OutputLineStream.StdOut)
             {
-                MessageLogger.LogInformation("{Line}", line);
                 MessageConsole.MarkupLineInterpolated($"{line.EscapeMarkup()}");
             }
             else
             {
-                MessageLogger.LogInformation("{Line}", line);
                 MessageConsole.MarkupLineInterpolated($"[red]{line.EscapeMarkup()}[/]");
             }
         }
@@ -426,9 +417,9 @@ internal class ConsoleInteractionService : IInteractionService
             throw new InvalidOperationException(InteractionServiceStrings.InteractiveInputNotSupported);
         }
 
-        _stdoutLogger.LogInformation("Confirm: {PromptText} (default: {DefaultValue})", promptText, defaultValue);
-        var result = await _outConsole.ConfirmAsync(promptText, defaultValue, cancellationToken);
-        _stdoutLogger.LogInformation("Confirm result: {Result}", result);
+        MessageLogger.LogInformation("Confirm: {PromptText} (default: {DefaultValue})", promptText, defaultValue);
+        var result = await MessageConsole.ConfirmAsync(promptText, defaultValue, cancellationToken);
+        MessageLogger.LogInformation("Confirm result: {Result}", result);
         return result;
     }
 
@@ -459,5 +450,4 @@ internal class ConsoleInteractionService : IInteractionService
 
         _errorConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.MoreInfoNewCliVersion, UpdateUrl));
     }
-
 }

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
+using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 
@@ -22,6 +23,8 @@ internal class ConsoleInteractionService : IInteractionService
     private readonly IAnsiConsole _errorConsole;
     private readonly CliExecutionContext _executionContext;
     private readonly ICliHostEnvironment _hostEnvironment;
+    private readonly ILogger _stdoutLogger;
+    private readonly ILogger _stderrLogger;
     private int _inStatus;
 
     /// <summary>
@@ -29,21 +32,28 @@ internal class ConsoleInteractionService : IInteractionService
     /// </summary>
     private IAnsiConsole MessageConsole => Console == ConsoleOutput.Error ? _errorConsole : _outConsole;
 
+    private ILogger MessageLogger => Console == ConsoleOutput.Error ? _stderrLogger : _stdoutLogger;
+
     public ConsoleOutput Console { get; set; }
 
-    public ConsoleInteractionService(ConsoleEnvironment consoleEnvironment, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment)
+    public ConsoleInteractionService(ConsoleEnvironment consoleEnvironment, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, ILoggerFactory loggerFactory)
     {
         ArgumentNullException.ThrowIfNull(consoleEnvironment);
         ArgumentNullException.ThrowIfNull(executionContext);
         ArgumentNullException.ThrowIfNull(hostEnvironment);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
         _outConsole = consoleEnvironment.Out;
         _errorConsole = consoleEnvironment.Error;
         _executionContext = executionContext;
         _hostEnvironment = hostEnvironment;
+        _stdoutLogger = loggerFactory.CreateLogger("Aspire.Cli.Console.Stdout");
+        _stderrLogger = loggerFactory.CreateLogger("Aspire.Cli.Console.Stderr");
     }
 
     public async Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
+        MessageLogger.LogInformation("Status: {StatusText}", statusText);
+
         if (!allowMarkup)
         {
             statusText = statusText.EscapeMarkup();
@@ -86,6 +96,8 @@ internal class ConsoleInteractionService : IInteractionService
 
     public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
+        MessageLogger.LogInformation("Status: {StatusText}", statusText);
+
         if (!allowMarkup)
         {
             statusText = statusText.EscapeMarkup();
@@ -135,6 +147,8 @@ internal class ConsoleInteractionService : IInteractionService
             throw new InvalidOperationException(InteractionServiceStrings.InteractiveInputNotSupported);
         }
 
+        MessageLogger.LogInformation("Prompt: {PromptText} (default: {DefaultValue}, secret: {IsSecret})", promptText, isSecret ? "****" : defaultValue ?? "(none)", isSecret);
+
         var prompt = new TextPrompt<string>(promptText)
         {
             IsSecret = isSecret,
@@ -153,7 +167,9 @@ internal class ConsoleInteractionService : IInteractionService
             prompt.Validate(validator);
         }
 
-        return await _outConsole.PromptAsync(prompt, cancellationToken);
+        var result = await MessageConsole.PromptAsync(prompt, cancellationToken);
+        MessageLogger.LogInformation("Prompt result: {Result}", isSecret ? "****" : result);
+        return result;
     }
 
     public Task<string> PromptForFilePathAsync(string promptText, string? defaultValue = null, Func<string, ValidationResult>? validator = null, bool directory = false, bool required = false, CancellationToken cancellationToken = default)
@@ -185,6 +201,8 @@ internal class ConsoleInteractionService : IInteractionService
         // the text is safe for both rendering and search highlighting.
         var safeFormatter = MakeSafeFormatter(choiceFormatter);
 
+        MessageLogger.LogInformation("Selection prompt: {PromptText}", promptText);
+
         var prompt = new SelectionPrompt<T>()
             .Title(promptText)
             .UseConverter(safeFormatter)
@@ -194,7 +212,9 @@ internal class ConsoleInteractionService : IInteractionService
 
         prompt.SearchHighlightStyle = s_searchHighlightStyle;
 
-        return await _outConsole.PromptAsync(prompt, cancellationToken);
+        var result = await MessageConsole.PromptAsync(prompt, cancellationToken);
+        MessageLogger.LogInformation("Selection result: {Result}", safeFormatter(result));
+        return result;
     }
 
     public async Task<IReadOnlyList<T>> PromptForSelectionsAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, IEnumerable<T>? preSelected = null, bool optional = false, CancellationToken cancellationToken = default) where T : notnull
@@ -219,6 +239,8 @@ internal class ConsoleInteractionService : IInteractionService
 
         var safeFormatter = MakeSafeFormatter(choiceFormatter);
 
+        MessageLogger.LogInformation("Selection prompt: {PromptText}", promptText);
+
         var prompt = new MultiSelectionPrompt<T>()
             .Title(promptText)
             .UseConverter(safeFormatter)
@@ -235,7 +257,8 @@ internal class ConsoleInteractionService : IInteractionService
             }
         }
 
-        var result = await _outConsole.PromptAsync(prompt, cancellationToken);
+        var result = await MessageConsole.PromptAsync(prompt, cancellationToken);
+        MessageLogger.LogInformation("Selection results: {Results}", string.Join(", ", result.Select(safeFormatter)));
         return result;
     }
 
@@ -294,26 +317,31 @@ internal class ConsoleInteractionService : IInteractionService
 
     public void DisplayError(string errorMessage)
     {
+        MessageLogger.LogInformation("Error: {ErrorMessage}", errorMessage);
         DisplayMessage(KnownEmojis.CrossMark, $"[red bold]{errorMessage.EscapeMarkup()}[/]", allowMarkup: true);
     }
 
     public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false)
     {
+        MessageLogger.LogInformation("{Message}", message);
         var displayMessage = allowMarkup ? message : message.EscapeMarkup();
         MessageConsole.MarkupLine(ConsoleHelpers.FormatEmojiPrefix(emoji, MessageConsole) + displayMessage);
     }
 
     public void DisplayPlainText(string message)
     {
+        MessageLogger.LogInformation("{Message}", message);
         // Write directly to avoid Spectre.Console line wrapping
         MessageConsole.Profile.Out.Writer.WriteLine(message);
     }
 
     public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null)
     {
+        var effectiveConsole = consoleOverride ?? Console;
+        var logger = effectiveConsole == ConsoleOutput.Error ? _stderrLogger : _stdoutLogger;
+        logger.LogInformation("{Text}", text);
         // Write raw text directly to avoid console wrapping.
         // When consoleOverride is null, respect the Console setting.
-        var effectiveConsole = consoleOverride ?? Console;
         var target = effectiveConsole == ConsoleOutput.Error ? _errorConsole : _outConsole;
         target.Profile.Out.Writer.WriteLine(text);
     }
@@ -331,6 +359,8 @@ internal class ConsoleInteractionService : IInteractionService
 
     public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false)
     {
+        MessageLogger.LogInformation("{Message}", message);
+
         var style = isErrorMessage ? s_errorMessageStyle
             : type switch
             {
@@ -347,6 +377,7 @@ internal class ConsoleInteractionService : IInteractionService
 
     public void DisplaySuccess(string message, bool allowMarkup = false)
     {
+        MessageLogger.LogInformation("Success: {Message}", message);
         DisplayMessage(KnownEmojis.CheckMark, message, allowMarkup);
     }
 
@@ -356,10 +387,12 @@ internal class ConsoleInteractionService : IInteractionService
         {
             if (stream == OutputLineStream.StdOut)
             {
+                MessageLogger.LogInformation("{Line}", line);
                 MessageConsole.MarkupLineInterpolated($"{line.EscapeMarkup()}");
             }
             else
             {
+                MessageLogger.LogInformation("{Line}", line);
                 MessageConsole.MarkupLineInterpolated($"[red]{line.EscapeMarkup()}[/]");
             }
         }
@@ -386,18 +419,22 @@ internal class ConsoleInteractionService : IInteractionService
         DisplayMessage(KnownEmojis.StopSign, $"[teal bold]{InteractionServiceStrings.StoppingAspire}[/]", allowMarkup: true);
     }
 
-    public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default)
+    public async Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default)
     {
         if (!_hostEnvironment.SupportsInteractiveInput)
         {
             throw new InvalidOperationException(InteractionServiceStrings.InteractiveInputNotSupported);
         }
 
-        return _outConsole.ConfirmAsync(promptText, defaultValue, cancellationToken);
+        _stdoutLogger.LogInformation("Confirm: {PromptText} (default: {DefaultValue})", promptText, defaultValue);
+        var result = await _outConsole.ConfirmAsync(promptText, defaultValue, cancellationToken);
+        _stdoutLogger.LogInformation("Confirm result: {Result}", result);
+        return result;
     }
 
     public void DisplaySubtleMessage(string message, bool allowMarkup = false)
     {
+        MessageLogger.LogInformation("{Message}", message);
         var displayMessage = allowMarkup ? message : message.EscapeMarkup();
         MessageConsole.MarkupLine($"[dim]{displayMessage}[/]");
     }

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -53,8 +53,6 @@ internal class ConsoleInteractionService : IInteractionService
 
     public async Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
-        MessageLogger.LogInformation("Status: {StatusText}", statusText);
-
         if (!allowMarkup)
         {
             statusText = statusText.EscapeMarkup();
@@ -79,6 +77,10 @@ internal class ConsoleInteractionService : IInteractionService
             {
                 // Text has already been escaped and emoji prepended, so pass as markup
                 DisplaySubtleMessage(statusText, allowMarkup: true);
+            }
+            else
+            {
+                MessageLogger.LogInformation("Status: {StatusText}", statusText);
             }
             return await action();
         }
@@ -323,7 +325,11 @@ internal class ConsoleInteractionService : IInteractionService
 
     public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false)
     {
-        MessageLogger.LogInformation("{EmojiName}: {Message}", emoji.Name, message);
+        if (MessageLogger.IsEnabled(LogLevel.Information))
+        {
+            MessageLogger.LogInformation("{Message}", ConsoleHelpers.FormatEmojiPrefix(emoji, MessageConsole, replaceEmoji: true) + message.RemoveMarkup());
+        }
+
         var displayMessage = allowMarkup ? message : message.EscapeMarkup();
         MessageConsole.MarkupLine(ConsoleHelpers.FormatEmojiPrefix(emoji, MessageConsole) + displayMessage);
     }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -801,7 +801,8 @@ public class Program
                 consoleEnvironment.Out.Profile.Width = 256; // VS code terminal will handle wrapping so set a large width here.
                 var executionContext = provider.GetRequiredService<CliExecutionContext>();
                 var hostEnvironment = provider.GetRequiredService<ICliHostEnvironment>();
-                var consoleInteractionService = new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment);
+                var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
+                var consoleInteractionService = new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment, loggerFactory);
                 return new ExtensionInteractionService(consoleInteractionService,
                     provider.GetRequiredService<IExtensionBackchannel>(),
                     extensionPromptEnabled);
@@ -814,7 +815,8 @@ public class Program
                 var consoleEnvironment = provider.GetRequiredService<ConsoleEnvironment>();
                 var executionContext = provider.GetRequiredService<CliExecutionContext>();
                 var hostEnvironment = provider.GetRequiredService<ICliHostEnvironment>();
-                return new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment);
+                var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
+                return new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment, loggerFactory);
             });
         }
     }

--- a/src/Aspire.Cli/Utils/ConsoleHelpers.cs
+++ b/src/Aspire.Cli/Utils/ConsoleHelpers.cs
@@ -14,12 +14,13 @@ internal static class ConsoleHelpers
     /// <summary>
     /// Formats an emoji prefix with trailing space for aligned console output.
     /// </summary>
-    public static string FormatEmojiPrefix(KnownEmoji emoji, IAnsiConsole console)
+    public static string FormatEmojiPrefix(KnownEmoji emoji, IAnsiConsole console, bool replaceEmoji = false)
     {
         const int emojiTargetWidth = 3; // 2 for emoji and 1 trailing space
 
         var cellLength = EmojiWidth.GetCachedCellWidth(emoji.Name, console);
         var padding = Math.Max(1, emojiTargetWidth - cellLength);
-        return $":{emoji.Name}:" + new string(' ', padding);
+        var spectreEmojiText = $":{emoji.Name}:";
+        return (replaceEmoji ? Emoji.Replace(spectreEmojiText) : spectreEmojiText) + new string(' ', padding);
     }
 }

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -6,6 +6,7 @@ using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
 using Spectre.Console;
 
 using System.Text;
@@ -17,7 +18,7 @@ public class ConsoleInteractionServiceTests
     private static ConsoleInteractionService CreateInteractionService(IAnsiConsole console, CliExecutionContext executionContext, ICliHostEnvironment? hostEnvironment = null)
     {
         var consoleEnvironment = new ConsoleEnvironment(console, console);
-        return new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment ?? TestHelpers.CreateInteractiveHostEnvironment());
+        return new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment ?? TestHelpers.CreateInteractiveHostEnvironment(), NullLoggerFactory.Instance);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -392,7 +392,8 @@ internal sealed class CliServiceCollectionTestOptions
         var consoleEnvironment = serviceProvider.GetRequiredService<ConsoleEnvironment>();
         var executionContext = serviceProvider.GetRequiredService<CliExecutionContext>();
         var hostEnvironment = serviceProvider.GetRequiredService<ICliHostEnvironment>();
-        return new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment);
+        var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+        return new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment, loggerFactory);
     };
 
     public Func<IServiceProvider, ICertificateToolRunner> CertificateToolRunnerFactory { get; set; } = (IServiceProvider _) =>


### PR DESCRIPTION
## Description

Log ConsoleInteractionService output to the CLI log file so that console interactions (status messages, text output, prompts, selections, errors, etc.) are captured in the diagnostic log at `~/.aspire/logs/`.

Two ILogger categories are used to distinguish stdout vs stderr output:
- `Aspire.Cli.Console.Stdout` - messages routed to stdout
- `Aspire.Cli.Console.Stderr` - messages routed to stderr

All messages are logged at Information level. Since the FileLoggerProvider is always active, these appear automatically in CLI log files.

### Changes
- **ConsoleInteractionService**: Accept `ILoggerFactory` in constructor, create two loggers with stdout/stderr categories, log key interactions (status, prompts, selections, confirmations, errors, display messages, console logs, output lines)
- **Program.cs**: Resolve `ILoggerFactory` from DI and pass to `ConsoleInteractionService` in both extension and non-extension code paths
- **Tests**: Updated `CliTestHelper.cs` and `ConsoleInteractionServiceTests.cs` to pass `NullLoggerFactory.Instance`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
