### PR TITLE
Fix migration from .aspire/settings.json to aspire.config.json

### DIFF
--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -347,6 +347,11 @@ internal sealed class ProjectLocator(
 
         if (projectFile is not null)
         {
+            if (createSettingsFile)
+            {
+                await CreateSettingsFileAsync(projectFile, cancellationToken);
+            }
+
             return new AppHostProjectSearchResult(projectFile, [projectFile]);
         }
 

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -326,13 +326,20 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
         var appHostProjectFile = new FileInfo(Path.Combine(appHostDirectory.FullName, "MyAppHost.csproj"));
         await File.WriteAllTextAsync(appHostProjectFile.FullName, "Not a real apphost");
 
+        // Add a decoy project so that a directory scan fallback would have another candidate
+        var decoyAppHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("DecoyAppHost");
+        var decoyAppHostProjectFile = new FileInfo(Path.Combine(decoyAppHostDirectory.FullName, "DecoyAppHost.csproj"));
+        await File.WriteAllTextAsync(decoyAppHostProjectFile.FullName, "Not a real apphost");
+
         var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
 
         // Write legacy .aspire/settings.json with a valid appHostPath
         // (CreateExecutionContext already created the .aspire directory)
         var aspireSettingsDir = new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire"));
         var aspireSettingsFile = new FileInfo(Path.Combine(aspireSettingsDir.FullName, "settings.json"));
-        var relativeAppHostPath = Path.GetRelativePath(workspace.WorkspaceRoot.FullName, appHostProjectFile.FullName);
+        var relativeAppHostPath = Path
+            .GetRelativePath(aspireSettingsDir.FullName, appHostProjectFile.FullName)
+            .Replace(Path.DirectorySeparatorChar, '/');
         await File.WriteAllTextAsync(aspireSettingsFile.FullName, JsonSerializer.Serialize(new { appHostPath = relativeAppHostPath }));
 
         // Use real ConfigurationService so migration actually writes to disk
@@ -346,7 +353,7 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
         // Act
         var foundAppHost = await locator.UseOrFindAppHostProjectFileAsync(null, createSettingsFile: true, CancellationToken.None).DefaultTimeout();
 
-        // Assert: correct AppHost was found
+        // Assert: correct AppHost was found (not the decoy, proving legacy settings were used)
         Assert.NotNull(foundAppHost);
         Assert.Equal(appHostProjectFile.FullName, foundAppHost.FullName);
 

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -317,6 +317,49 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task UseOrFindAppHostProjectFile_MigratesLegacySettingsToAspireConfigJson()
+    {
+        // Arrange: create a workspace with a legacy .aspire/settings.json
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var appHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("MyAppHost");
+        var appHostProjectFile = new FileInfo(Path.Combine(appHostDirectory.FullName, "MyAppHost.csproj"));
+        await File.WriteAllTextAsync(appHostProjectFile.FullName, "Not a real apphost");
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+
+        // Write legacy .aspire/settings.json with a valid appHostPath
+        // (CreateExecutionContext already created the .aspire directory)
+        var aspireSettingsDir = new DirectoryInfo(Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire"));
+        var aspireSettingsFile = new FileInfo(Path.Combine(aspireSettingsDir.FullName, "settings.json"));
+        var relativeAppHostPath = Path.GetRelativePath(workspace.WorkspaceRoot.FullName, appHostProjectFile.FullName);
+        await File.WriteAllTextAsync(aspireSettingsFile.FullName, JsonSerializer.Serialize(new { appHostPath = relativeAppHostPath }));
+
+        // Use real ConfigurationService so migration actually writes to disk
+        var globalSettingsFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, ".aspire", "settings.global.json");
+        var globalSettingsFile = new FileInfo(globalSettingsFilePath);
+        var config = new ConfigurationBuilder().Build();
+        var configurationService = new ConfigurationService(config, executionContext, globalSettingsFile, NullLogger<ConfigurationService>.Instance);
+
+        var locator = CreateProjectLocator(executionContext, configurationService: configurationService);
+
+        // Act
+        var foundAppHost = await locator.UseOrFindAppHostProjectFileAsync(null, createSettingsFile: true, CancellationToken.None).DefaultTimeout();
+
+        // Assert: correct AppHost was found
+        Assert.NotNull(foundAppHost);
+        Assert.Equal(appHostProjectFile.FullName, foundAppHost.FullName);
+
+        // Assert: aspire.config.json was created by migration
+        var aspireConfigFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        Assert.True(File.Exists(aspireConfigFilePath), "aspire.config.json should have been created by migration from .aspire/settings.json");
+
+        var configJson = await File.ReadAllTextAsync(aspireConfigFilePath);
+        var migratedConfig = JsonSerializer.Deserialize<AspireConfigFile>(configJson);
+        Assert.NotNull(migratedConfig?.AppHost?.Path);
+    }
+
+    [Fact]
     public async Task FindAppHostProjectFilesAsync_DiscoversSingleFileAppHostInRootDirectory()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);


### PR DESCRIPTION
## Description

Fix migration from `.aspire/settings.json` to `aspire.config.json` when upgrading from Aspire 13.1 (or lower) to 13.2.

**Problem**: In `ProjectLocator.UseOrFindAppHostProjectFileAsync()`, when the AppHost was found from the legacy `.aspire/settings.json`, the method returned early without calling `CreateSettingsFileAsync`. The `createSettingsFile` check was only reachable via the directory-scanning fallback path, so a working `.aspire/settings.json` paradoxically prevented its own migration to `aspire.config.json`.

**Fix**: Call `CreateSettingsFileAsync` when `createSettingsFile` is true and the AppHost is found from settings, ensuring the legacy config is migrated.

**Validation**: All 1681 CLI tests pass, including a new regression test that verifies the migration occurs when the AppHost is discovered from legacy settings.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
