### PR TITLE
[release/13.2] Fix cross-compiled CLI bundles missing DCP (win-arm64, linux-arm64, linux-musl-x64)

### DIFF
--- a/eng/Bundle.proj
+++ b/eng/Bundle.proj
@@ -106,9 +106,22 @@
   <Target Name="_RestoreDcpPackage">
     <PropertyGroup>
       <_DcpBinlog Condition="'$(ContinuousIntegrationBuild)' == 'true'">-bl:$(ArtifactsLogDir)RestoreDcp.binlog</_DcpBinlog>
+
+      <!-- Map TargetRid to DCP BuildOs/BuildArch so the AppHost restore downloads
+           the correct DCP package for the target platform, not the build machine's platform.
+           Without this, cross-compiled bundles (e.g., win-arm64 built on win-x64) would
+           be missing DCP because the default BuildOs/BuildArch resolve to the build machine. -->
+      <_BundleBuildOs Condition="$(TargetRid.StartsWith('win-'))">windows</_BundleBuildOs>
+      <_BundleBuildOs Condition="$(TargetRid.StartsWith('osx-'))">darwin</_BundleBuildOs>
+      <_BundleBuildOs Condition="$(TargetRid.StartsWith('linux-musl-'))">linux-musl</_BundleBuildOs>
+      <_BundleBuildOs Condition="'$(_BundleBuildOs)' == '' and $(TargetRid.StartsWith('linux-'))">linux</_BundleBuildOs>
+
+      <_BundleBuildArch Condition="$(TargetRid.EndsWith('-x64'))">amd64</_BundleBuildArch>
+      <_BundleBuildArch Condition="$(TargetRid.EndsWith('-arm64'))">arm64</_BundleBuildArch>
+      <_BundleBuildArch Condition="$(TargetRid.EndsWith('-x86'))">386</_BundleBuildArch>
     </PropertyGroup>
-    <Message Importance="high" Text="Restoring DCP package..." />
-    <Exec Command="dotnet restore &quot;$(AppHostProjectPath)&quot; $(_DcpBinlog)" />
+    <Message Importance="high" Text="Restoring DCP package for $(TargetRid) (BuildOs=$(_BundleBuildOs), BuildArch=$(_BundleBuildArch))..." />
+    <Exec Command="dotnet restore &quot;$(AppHostProjectPath)&quot; /p:BuildOs=$(_BundleBuildOs) /p:BuildArch=$(_BundleBuildArch) $(_DcpBinlog)" />
   </Target>
 
   <Target Name="_RunCreateLayout">

--- a/eng/Bundle.proj
+++ b/eng/Bundle.proj
@@ -110,7 +110,10 @@
       <!-- Map TargetRid to DCP BuildOs/BuildArch so the AppHost restore downloads
            the correct DCP package for the target platform, not the build machine's platform.
            Without this, cross-compiled bundles (e.g., win-arm64 built on win-x64) would
-           be missing DCP because the default BuildOs/BuildArch resolve to the build machine. -->
+           be missing DCP because the default BuildOs/BuildArch resolve to the build machine.
+           
+           Supported RID format: {os}-{arch} where os is win/osx/linux/linux-musl
+           and arch is x64/arm64/x86. Update this mapping when adding new RID patterns. -->
       <_BundleBuildOs Condition="$(TargetRid.StartsWith('win-'))">windows</_BundleBuildOs>
       <_BundleBuildOs Condition="$(TargetRid.StartsWith('osx-'))">darwin</_BundleBuildOs>
       <_BundleBuildOs Condition="$(TargetRid.StartsWith('linux-musl-'))">linux-musl</_BundleBuildOs>
@@ -120,6 +123,8 @@
       <_BundleBuildArch Condition="$(TargetRid.EndsWith('-arm64'))">arm64</_BundleBuildArch>
       <_BundleBuildArch Condition="$(TargetRid.EndsWith('-x86'))">386</_BundleBuildArch>
     </PropertyGroup>
+    <Error Condition="'$(_BundleBuildOs)' == '' or '$(_BundleBuildArch)' == ''"
+           Text="Could not map TargetRid '$(TargetRid)' to DCP BuildOs/BuildArch. Supported RID patterns: win-x64, win-arm64, linux-x64, linux-arm64, linux-musl-x64, osx-x64, osx-arm64." />
     <Message Importance="high" Text="Restoring DCP package for $(TargetRid) (BuildOs=$(_BundleBuildOs), BuildArch=$(_BundleBuildArch))..." />
     <Exec Command="dotnet restore &quot;$(AppHostProjectPath)&quot; /p:BuildOs=$(_BundleBuildOs) /p:BuildArch=$(_BundleBuildArch) $(_DcpBinlog)" />
   </Target>

--- a/tools/CreateLayout/Program.cs
+++ b/tools/CreateLayout/Program.cs
@@ -189,8 +189,10 @@ internal sealed class LayoutBuilder : IDisposable
         var dcpPath = FindDcpPath();
         if (dcpPath is null)
         {
-            Log("  WARNING: DCP not found. Skipping.");
-            return Task.CompletedTask;
+            throw new InvalidOperationException(
+                $"DCP package not found for RID '{_rid}'. " +
+                $"Ensure the DCP NuGet package for the target platform is restored before running CreateLayout. " +
+                $"A bundle without DCP would fail layout validation at runtime.");
         }
 
         var dcpDir = Path.Combine(_outputPath, "dcp");


### PR DESCRIPTION
## Description

Cherry-pick of #15522 to `release/13.2`.

### Problem

`Bundle.proj`'s `_RestoreDcpPackage` target runs `dotnet restore` on the AppHost project to download the DCP (Developer Control Plane) NuGet package. The AppHost's `PackageDownload` uses `$(BuildOs)-$(BuildArch)` to select the platform-specific DCP package (e.g., `Microsoft.DeveloperControlPlane.windows-amd64`).

The problem is that `BuildOs` and `BuildArch` are defined in `Directory.Build.props` and **auto-detect from the build machine's OS/architecture**:

```xml
<BuildOs Condition="$([MSBuild]::IsOsPlatform('Linux'))">linux</BuildOs>
<BuildOs Condition="$([MSBuild]::IsOsPlatform('OSX'))">darwin</BuildOs>
<BuildOs Condition=" '$(BuildOs)' == '' ">windows</BuildOs>
<BuildArch Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64' ">arm64</BuildArch>
<BuildArch Condition=" '$(BuildArch)' == '' ">amd64</BuildArch>
```

When cross-compiling (e.g., building a `win-arm64` bundle on a `win-x64` CI agent), the restore downloads the **build machine's** DCP (`windows-amd64`) instead of the **target's** (`windows-arm64`). `CreateLayout` then silently skips the missing DCP, producing a bundle with `managed/` but no `dcp/`. This causes "no valid layout found" failures at runtime.

**Affected RIDs:** `win-arm64`, `linux-arm64`, `linux-musl-x64` — any RID where the target platform differs from the CI runner.

### Fix

**`eng/Bundle.proj`**: Map `TargetRid` to `BuildOs`/`BuildArch` and pass them explicitly to the restore command so the correct DCP package is downloaded for the target platform.

**`tools/CreateLayout/Program.cs`**: Promote missing DCP from a silent warning to a hard error, preventing broken bundles from being produced.

### Why a hand-rolled mapping instead of reusing `Aspire.RuntimeIdentifier.Tool`?

The repo already has `Aspire.RuntimeIdentifier.Tool` (in `src/Aspire.AppHost.Sdk/`) which uses NuGet's runtime graph (`RuntimeGraph`) to resolve the best-matching RID for a platform. The Aspire SDK used this to select the correct Dashboard and DCP packages at build time (see PR #5695).

However, it can't be directly reused here because DCP packages use **Go-style naming conventions**, not NuGet RIDs:

| NuGet RID | DCP package suffix |
|---|---|
| `win-x64` | `windows-amd64` |
| `osx-arm64` | `darwin-arm64` |
| `linux-musl-x64` | `linux-musl-amd64` |

The tool resolves `win-x64` from the runtime graph, but the DCP package is named `Microsoft.DeveloperControlPlane.windows-amd64`. So a mapping from NuGet RID conventions → DCP naming (`win`→`windows`, `osx`→`darwin`, `x64`→`amd64`) is still required regardless. The mapping is ~6 lines of MSBuild conditions in `Bundle.proj`, which is pragmatic for a servicing fix.

Eliminating this mapping entirely would require the DCP packages to adopt NuGet RID naming, which is outside this repo's control.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
