### PR TITLE
Fix Azure deployment links

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
@@ -132,10 +132,10 @@ public class AzureContainerAppEnvironmentResource :
 
         var dashboardUrl = $"https://aspire-dashboard.ext.{domainValue}";
 
-        context.Summary.Add("📊 Dashboard", dashboardUrl);
+        context.Summary.Add("📊 Dashboard", new MarkdownString($"[{dashboardUrl}]({dashboardUrl})"));
 
         await context.ReportingStep.CompleteAsync(
-            $"Dashboard available at [{dashboardUrl}]({dashboardUrl})",
+            new MarkdownString($"Dashboard available at [{dashboardUrl}]({dashboardUrl})"),
             CompletionState.Completed,
             context.CancellationToken).ConfigureAwait(false);
     }

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppResource.cs
@@ -54,7 +54,7 @@ public class AzureContainerAppResource : AzureProvisioningResource
                         var endpoint = $"https://{targetResource.Name.ToLowerInvariant()}.{domainValue}";
 
                         ctx.ReportingStep.Log(LogLevel.Information, new MarkdownString($"Successfully deployed **{targetResource.Name}** to [{endpoint}]({endpoint})"));
-                        ctx.Summary.Add(targetResource.Name, endpoint);
+                        ctx.Summary.Add(targetResource.Name, new MarkdownString($"[{endpoint}]({endpoint})"));
                     }
                     else
                     {

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
@@ -147,11 +147,11 @@ public class AzureAppServiceEnvironmentResource :
 
         if (!string.IsNullOrEmpty(dashboardUri))
         {
-            context.Summary.Add("📊 Dashboard", dashboardUri);
+            context.Summary.Add("📊 Dashboard", new MarkdownString($"[{dashboardUri}]({dashboardUri})"));
         }
 
         await context.ReportingStep.CompleteAsync(
-            $"Dashboard available at [{dashboardUri}]({dashboardUri})",
+            new MarkdownString($"Dashboard available at [{dashboardUri}]({dashboardUri})"),
             CompletionState.Completed,
             context.CancellationToken).ConfigureAwait(false);
     }

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
@@ -58,7 +58,7 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
                     var hostName = await GetAppServiceWebsiteNameAsync(ctx, deploymentSlot).ConfigureAwait(false);
                     var endpoint = $"https://{hostName}.azurewebsites.net";
                     ctx.ReportingStep.Log(LogLevel.Information, new MarkdownString($"Successfully deployed **{targetResource.Name}** to [{endpoint}]({endpoint})"));
-                    ctx.Summary.Add(targetResource.Name, endpoint);
+                    ctx.Summary.Add(targetResource.Name, new MarkdownString($"[{endpoint}]({endpoint})"));
                 },
                 Tags = ["print-summary"],
                 RequiredBySteps = [WellKnownPipelineSteps.Deploy]

--- a/src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureEnvironmentResource.cs
@@ -180,7 +180,7 @@ public sealed class AzureEnvironmentResource : Resource
         catch (Exception)
         {
             await context.ReportingStep.CompleteAsync(
-                "Azure CLI authentication failed. Please run `az login` to authenticate before deploying. Learn more at [Azure CLI documentation](https://learn.microsoft.com/cli/azure/authenticate-azure-cli).",
+                new MarkdownString("Azure CLI authentication failed. Please run `az login` to authenticate before deploying. Learn more at [Azure CLI documentation](https://learn.microsoft.com/cli/azure/authenticate-azure-cli)."),
                 CompletionState.CompletedWithError,
                 context.CancellationToken).ConfigureAwait(false);
             throw;

--- a/src/Aspire.Hosting.Foundry/HostedAgent/AzureHostedAgentResource.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/AzureHostedAgentResource.cs
@@ -41,9 +41,7 @@ public class AzureHostedAgentResource : Resource, IComputeResource, IResourceWit
                 Action = async (ctx) =>
                 {
                     var version = await DeployAsync(ctx, project).ConfigureAwait(false);
-#pragma warning disable CS0618
-                    ctx.ReportingStep.Log(LogLevel.Information, $"Successfully deployed **{Name}** as Hosted Agent (version {version})", enableMarkdown: true);
-#pragma warning restore CS0618
+                    ctx.ReportingStep.Log(LogLevel.Information, new MarkdownString($"Successfully deployed **{Name}** as Hosted Agent (version {version})"));
                     Version.Set(version.Version);
                 },
                 Tags = [WellKnownPipelineTags.DeployCompute],

--- a/src/Aspire.Hosting.Foundry/HostedAgent/AzurePromptAgentResource.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/AzurePromptAgentResource.cs
@@ -42,9 +42,7 @@ public class AzurePromptAgentResource : ExecutableResource, IComputeResource
                 Action = async (ctx) =>
                 {
                     var version = await DeployAsync(ctx, project).ConfigureAwait(false);
-#pragma warning disable CS0618
-                    ctx.ReportingStep.Log(LogLevel.Information, $"Successfully deployed **{Name}** as Prompt Agent (version {version})", enableMarkdown: true);
-#pragma warning restore CS0618
+                    ctx.ReportingStep.Log(LogLevel.Information, new MarkdownString($"Successfully deployed **{Name}** as Prompt Agent (version {version})"));
                     Version.Set(version.Version);
                 },
                 Tags = [WellKnownPipelineTags.DeployCompute],


### PR DESCRIPTION
Since these strings weren't using MarkdownStrings, long URLs were wrapping in the terminal and they were no longer clickable.