### PR TITLE
Fix aspire new: move OpenEditor after agent init prompt in VS Code extension

### DIFF
--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -272,13 +272,16 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             Language = template.LanguageId
         };
         var templateResult = await template.ApplyTemplateAsync(inputs, parseResult, cancellationToken);
+
+        var workspaceRoot = new DirectoryInfo(templateResult.OutputPath ?? ExecutionContext.WorkingDirectory.FullName);
+        var exitCode = await _agentInitCommand.PromptAndChainAsync(_hostEnvironment, InteractionService, templateResult.ExitCode, workspaceRoot, cancellationToken);
+
         if (templateResult.OutputPath is not null && ExtensionHelper.IsExtensionHost(InteractionService, out var extensionInteractionService, out _))
         {
             extensionInteractionService.OpenEditor(templateResult.OutputPath);
         }
 
-        var workspaceRoot = new DirectoryInfo(templateResult.OutputPath ?? ExecutionContext.WorkingDirectory.FullName);
-        return await _agentInitCommand.PromptAndChainAsync(_hostEnvironment, InteractionService, templateResult.ExitCode, workspaceRoot, cancellationToken);
+        return exitCode;
     }
 
     private static bool ShouldResolveCliTemplateVersion(ITemplate template)


### PR DESCRIPTION
## Description

When running `aspire new` from the VS Code extension, the `OpenEditor` RPC call was made immediately after template creation but **before** the "Would you like to configure AI agent environments?" prompt (`PromptAndChainAsync`). Opening the new project folder replaces the current VS Code workspace, which destroys the terminal running the CLI process—so the agent init prompt is never shown to the user.

This PR reorders the calls so that `PromptAndChainAsync` completes before `OpenEditor` is invoked, allowing the full CLI interaction to finish before the workspace switches.

IMO this should be seriously considered for 13.2.1 servicing, especially as it's very low risk. Users are prevented from setting up AI skills, which is an area we are prioritizing at the moment.


Fixes #15551

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
