### PR TITLE
[release/13.2] Fix aspire new: move OpenEditor after agent init prompt

### DIFF
--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -278,13 +278,15 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             return templateResult.ExitCode;
         }
 
+        var workspaceRoot = new DirectoryInfo(templateResult.OutputPath ?? ExecutionContext.WorkingDirectory.FullName);
+        var exitCode = await _agentInitCommand.PromptAndChainAsync(_hostEnvironment, InteractionService, templateResult.ExitCode, workspaceRoot, cancellationToken);
+
         if (templateResult.OutputPath is not null && ExtensionHelper.IsExtensionHost(InteractionService, out var extensionInteractionService, out _))
         {
             extensionInteractionService.OpenEditor(templateResult.OutputPath);
         }
 
-        var workspaceRoot = new DirectoryInfo(templateResult.OutputPath ?? ExecutionContext.WorkingDirectory.FullName);
-        return await _agentInitCommand.PromptAndChainAsync(_hostEnvironment, InteractionService, templateResult.ExitCode, workspaceRoot, cancellationToken);
+        return exitCode;
     }
 
     private static bool ShouldResolveCliTemplateVersion(ITemplate template)


### PR DESCRIPTION
## Description

Backport of #15552 to `release/13.2`.

## Customer Impact

## Testing
Manual testing

## Risk
Low, the same operations are being performed. Workspace open is just being moved later
 
## Regression?
It has been broken since the ai agent setup prompt was added