### PR TITLE
[release/13.2] Fix installing playwright-cli with aspire agent init on Windows

### DIFF
--- a/src/Aspire.Cli/Agents/Playwright/PlaywrightCliRunner.cs
+++ b/src/Aspire.Cli/Agents/Playwright/PlaywrightCliRunner.cs
@@ -125,5 +125,28 @@ internal sealed class PlaywrightCliRunner(ILogger<PlaywrightCliRunner> logger) :
             logger.LogDebug(ex, "Failed to run playwright-cli install --skills");
             return false;
         }
+        finally
+        {
+            // playwright-cli install --skills may leave behind an empty .playwright
+            // directory in the working directory. Clean it up if it exists and is empty.
+            CleanupEmptyPlaywrightDirectory(workingDirectory);
+        }
+    }
+
+    private void CleanupEmptyPlaywrightDirectory(string workingDirectory)
+    {
+        try
+        {
+            var playwrightDir = Path.Combine(workingDirectory, ".playwright");
+            if (Directory.Exists(playwrightDir) && Directory.GetFileSystemEntries(playwrightDir).Length == 0)
+            {
+                Directory.Delete(playwrightDir);
+                logger.LogDebug("Removed empty .playwright directory from {WorkingDirectory}", workingDirectory);
+            }
+        }
+        catch (IOException ex)
+        {
+            logger.LogDebug(ex, "Failed to clean up .playwright directory in {WorkingDirectory}", workingDirectory);
+        }
     }
 }

--- a/src/Aspire.Cli/Npm/INpmRunner.cs
+++ b/src/Aspire.Cli/Npm/INpmRunner.cs
@@ -19,6 +19,16 @@ internal sealed class NpmPackageInfo
     /// Gets the SRI integrity hash (e.g., "sha512-...") for the package tarball.
     /// </summary>
     public required string Integrity { get; init; }
+
+    /// <summary>
+    /// Formats a full npm package specifier (e.g., "@playwright/cli@0.1.1").
+    /// </summary>
+    public static string FormatPackageSpecifier(string packageName, string version) => $"{packageName}@{version}";
+
+    /// <summary>
+    /// Formats a full npm package specifier (e.g., "@playwright/cli@0.1.1").
+    /// </summary>
+    public static string FormatPackageSpecifier(string packageName, SemVersion version) => FormatPackageSpecifier(packageName, version.ToString());
 }
 
 /// <summary>
@@ -26,6 +36,11 @@ internal sealed class NpmPackageInfo
 /// </summary>
 internal interface INpmRunner
 {
+    /// <summary>
+    /// Gets a value indicating whether npm is available on the system PATH.
+    /// </summary>
+    bool IsAvailable { get; }
+
     /// <summary>
     /// Resolves a package version and integrity hash from the npm registry.
     /// </summary>

--- a/src/Aspire.Cli/Npm/NpmRunner.cs
+++ b/src/Aspire.Cli/Npm/NpmRunner.cs
@@ -12,6 +12,18 @@ namespace Aspire.Cli.Npm;
 /// </summary>
 internal sealed class NpmRunner(ILogger<NpmRunner> logger) : INpmRunner
 {
+    /// <summary>
+    /// The public npm registry URL. Commands that resolve packages from the registry
+    /// pass this explicitly via <c>--registry</c> to avoid inheriting a project-level
+    /// <c>.npmrc</c> that may redirect to a private feed (e.g. Azure DevOps).
+    /// </summary>
+    private const string PublicRegistry = "https://registry.npmjs.org/";
+
+    private readonly Lazy<string?> _npmPath = new(() => PathLookupHelper.FindFullPathFromPath("npm"));
+
+    /// <inheritdoc />
+    public bool IsAvailable => _npmPath.Value is not null;
+
     /// <inheritdoc />
     public async Task<NpmPackageInfo?> ResolvePackageAsync(string packageName, string versionRange, CancellationToken cancellationToken)
     {
@@ -20,6 +32,8 @@ internal sealed class NpmRunner(ILogger<NpmRunner> logger) : INpmRunner
         {
             return null;
         }
+
+        logger.LogDebug("Resolving npm package {PackageSpecifier}", NpmPackageInfo.FormatPackageSpecifier(packageName, versionRange));
 
         // Use an isolated temp subdirectory so npm doesn't pick up .npmrc or
         // other config files from the shared temp root or the user's CWD.
@@ -30,12 +44,13 @@ internal sealed class NpmRunner(ILogger<NpmRunner> logger) : INpmRunner
             // Resolve version: npm view <package>@<range> version
             var versionOutput = await RunNpmCommandInDirectoryAsync(
                 npmPath,
-                ["view", $"{packageName}@{versionRange}", "version"],
+                ["view", NpmPackageInfo.FormatPackageSpecifier(packageName, versionRange), "version", "--registry", PublicRegistry],
                 tempDir,
                 cancellationToken);
 
             if (versionOutput is null)
             {
+                logger.LogDebug("Failed to resolve version for {PackageSpecifier}", NpmPackageInfo.FormatPackageSpecifier(packageName, versionRange));
                 return null;
             }
 
@@ -49,15 +64,17 @@ internal sealed class NpmRunner(ILogger<NpmRunner> logger) : INpmRunner
             // Resolve integrity hash: npm view <package>@<version> dist.integrity
             var integrityOutput = await RunNpmCommandInDirectoryAsync(
                 npmPath,
-                ["view", $"{packageName}@{version}", "dist.integrity"],
+                ["view", NpmPackageInfo.FormatPackageSpecifier(packageName, version), "dist.integrity", "--registry", PublicRegistry],
                 tempDir,
                 cancellationToken);
 
             if (string.IsNullOrWhiteSpace(integrityOutput))
             {
-                logger.LogDebug("Could not resolve integrity hash for {Package}@{Version}", packageName, version);
+                logger.LogDebug("Could not resolve integrity hash for {PackageSpecifier}", NpmPackageInfo.FormatPackageSpecifier(packageName, version));
                 return null;
             }
+
+            logger.LogDebug("Resolved {PackageSpecifier} with integrity {Integrity}", NpmPackageInfo.FormatPackageSpecifier(packageName, version), integrityOutput.Trim());
 
             return new NpmPackageInfo
             {
@@ -80,14 +97,17 @@ internal sealed class NpmRunner(ILogger<NpmRunner> logger) : INpmRunner
             return null;
         }
 
+        logger.LogDebug("Packing npm package {PackageSpecifier} to {OutputDirectory}", NpmPackageInfo.FormatPackageSpecifier(packageName, version), outputDirectory);
+
         var output = await RunNpmCommandInDirectoryAsync(
             npmPath,
-            ["pack", $"{packageName}@{version}", "--pack-destination", outputDirectory],
+            ["pack", NpmPackageInfo.FormatPackageSpecifier(packageName, version), "--pack-destination", outputDirectory, "--registry", PublicRegistry],
             outputDirectory,
             cancellationToken);
 
         if (output is null)
         {
+            logger.LogDebug("Failed to pack {PackageSpecifier}", NpmPackageInfo.FormatPackageSpecifier(packageName, version));
             return null;
         }
 
@@ -106,6 +126,8 @@ internal sealed class NpmRunner(ILogger<NpmRunner> logger) : INpmRunner
             return null;
         }
 
+        logger.LogDebug("Packed {PackageSpecifier} to {TarballPath}", NpmPackageInfo.FormatPackageSpecifier(packageName, version), tarballPath);
+
         return tarballPath;
     }
 
@@ -117,6 +139,8 @@ internal sealed class NpmRunner(ILogger<NpmRunner> logger) : INpmRunner
         {
             return false;
         }
+
+        logger.LogDebug("Auditing npm signatures for {PackageSpecifier}", NpmPackageInfo.FormatPackageSpecifier(packageName, version));
 
         // npm audit signatures requires a project context (node_modules + package-lock.json).
         // For global tool installs there is no project, so we create a temporary one.
@@ -136,13 +160,13 @@ internal sealed class NpmRunner(ILogger<NpmRunner> logger) : INpmRunner
             // Install the package from the registry to get proper attestation metadata
             var installOutput = await RunNpmCommandInDirectoryAsync(
                 npmPath,
-                ["install", $"{packageName}@{version}", "--ignore-scripts"],
+                ["install", NpmPackageInfo.FormatPackageSpecifier(packageName, version), "--ignore-scripts", "--registry", PublicRegistry],
                 tempDir,
                 cancellationToken);
 
             if (installOutput is null)
             {
-                logger.LogDebug("Failed to install {Package}@{Version} into temporary project for audit", packageName, version);
+                logger.LogDebug("Failed to install {PackageSpecifier} into temporary project for audit", NpmPackageInfo.FormatPackageSpecifier(packageName, version));
                 return false;
             }
 
@@ -153,7 +177,14 @@ internal sealed class NpmRunner(ILogger<NpmRunner> logger) : INpmRunner
                 tempDir,
                 cancellationToken);
 
-            return auditOutput is not null;
+            if (auditOutput is null)
+            {
+                logger.LogDebug("Signature audit failed for {PackageSpecifier}", NpmPackageInfo.FormatPackageSpecifier(packageName, version));
+                return false;
+            }
+
+            logger.LogDebug("Signature audit passed for {PackageSpecifier}", NpmPackageInfo.FormatPackageSpecifier(packageName, version));
+            return true;
         }
         finally
         {
@@ -170,6 +201,8 @@ internal sealed class NpmRunner(ILogger<NpmRunner> logger) : INpmRunner
             return false;
         }
 
+        logger.LogDebug("Installing npm package globally from {TarballPath}", tarballPath);
+
         // Use an isolated temp subdirectory so npm doesn't pick up .npmrc or
         // other config files from the shared temp root or the user's CWD.
         var tempDir = CreateIsolatedTempDirectory();
@@ -182,7 +215,14 @@ internal sealed class NpmRunner(ILogger<NpmRunner> logger) : INpmRunner
                 tempDir,
                 cancellationToken);
 
-            return output is not null;
+            if (output is null)
+            {
+                logger.LogDebug("Failed to install npm package globally from {TarballPath}", tarballPath);
+                return false;
+            }
+
+            logger.LogDebug("Successfully installed npm package globally from {TarballPath}", tarballPath);
+            return true;
         }
         finally
         {
@@ -192,7 +232,7 @@ internal sealed class NpmRunner(ILogger<NpmRunner> logger) : INpmRunner
 
     private string? FindNpmPath()
     {
-        var npmPath = PathLookupHelper.FindFullPathFromPath("npm");
+        var npmPath = _npmPath.Value;
         if (npmPath is null)
         {
             logger.LogDebug("npm is not installed or not found in PATH");
@@ -223,6 +263,45 @@ internal sealed class NpmRunner(ILogger<NpmRunner> logger) : INpmRunner
         }
     }
 
+    /// <summary>
+    /// Creates a <see cref="ProcessStartInfo"/> configured to run an npm command.
+    /// On Windows, .cmd files are invoked via cmd.exe /c for reliable stdout redirection.
+    /// </summary>
+    internal static ProcessStartInfo CreateNpmProcessStartInfo(string npmPath, string[] args, string workingDirectory)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = workingDirectory
+        };
+
+        // On Windows, npm resolves to npm.cmd (a batch wrapper). Launching
+        // .cmd files via Process.Start with redirected stdout can produce empty
+        // output. Use cmd.exe /c to invoke the batch file reliably.
+        // Note: cmd.exe /c has special quote-stripping rules that are incompatible
+        // with ArgumentList (which individually quotes each argument). We must use
+        // the Arguments string property and wrap the entire command in an outer set
+        // of quotes so cmd.exe preserves interior quoting correctly.
+        if (OperatingSystem.IsWindows() && npmPath.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase))
+        {
+            startInfo.FileName = "cmd.exe";
+            startInfo.Arguments = @$"/c """"{npmPath}"" {string.Join(" ", args.Select(a => @$"""{a}"""))}""";
+        }
+        else
+        {
+            startInfo.FileName = npmPath;
+            foreach (var arg in args)
+            {
+                startInfo.ArgumentList.Add(arg);
+            }
+        }
+
+        return startInfo;
+    }
+
     private async Task<string?> RunNpmCommandInDirectoryAsync(string npmPath, string[] args, string workingDirectory, CancellationToken cancellationToken)
     {
         var argsString = string.Join(" ", args);
@@ -230,19 +309,7 @@ internal sealed class NpmRunner(ILogger<NpmRunner> logger) : INpmRunner
 
         try
         {
-            var startInfo = new ProcessStartInfo(npmPath)
-            {
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                WorkingDirectory = workingDirectory
-            };
-
-            foreach (var arg in args)
-            {
-                startInfo.ArgumentList.Add(arg);
-            }
+            var startInfo = CreateNpmProcessStartInfo(npmPath, args, workingDirectory);
 
             using var process = new Process { StartInfo = startInfo };
             process.Start();

--- a/src/Aspire.Cli/Npm/SigstoreNpmProvenanceChecker.cs
+++ b/src/Aspire.Cli/Npm/SigstoreNpmProvenanceChecker.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Sigstore;
 
@@ -29,9 +31,12 @@ internal sealed class SigstoreNpmProvenanceChecker(HttpClient httpClient, ILogge
         CancellationToken cancellationToken,
         string? sriIntegrity = null)
     {
+        logger.LogDebug("Verifying provenance for {PackageSpecifier} from {ExpectedSourceRepository}", NpmPackageInfo.FormatPackageSpecifier(packageName, version), expectedSourceRepository);
+
         var json = await FetchAttestationJsonAsync(packageName, version, cancellationToken).ConfigureAwait(false);
         if (json is null)
         {
+            logger.LogDebug("Attestation fetch failed for {PackageSpecifier}", NpmPackageInfo.FormatPackageSpecifier(packageName, version));
             return new ProvenanceVerificationResult { Outcome = ProvenanceVerificationOutcome.AttestationFetchFailed };
         }
 
@@ -39,11 +44,13 @@ internal sealed class SigstoreNpmProvenanceChecker(HttpClient httpClient, ILogge
         var bundleJson = ExtractSlsaBundleJson(json, out var parseFailed);
         if (bundleJson is null)
         {
+            var outcome = parseFailed
+                    ? ProvenanceVerificationOutcome.AttestationParseFailed
+                    : ProvenanceVerificationOutcome.SlsaProvenanceNotFound;
+            logger.LogDebug("SLSA bundle extraction failed for {PackageSpecifier}: {Outcome}", NpmPackageInfo.FormatPackageSpecifier(packageName, version), outcome);
             return new ProvenanceVerificationResult
             {
-                Outcome = parseFailed
-                    ? ProvenanceVerificationOutcome.AttestationParseFailed
-                    : ProvenanceVerificationOutcome.SlsaProvenanceNotFound
+                Outcome = outcome
             };
         }
 
@@ -54,7 +61,7 @@ internal sealed class SigstoreNpmProvenanceChecker(HttpClient httpClient, ILogge
         }
         catch (Exception ex)
         {
-            logger.LogDebug(ex, "Failed to deserialize Sigstore bundle for {Package}@{Version}", packageName, version);
+            logger.LogDebug(ex, "Failed to deserialize Sigstore bundle for {PackageSpecifier}", NpmPackageInfo.FormatPackageSpecifier(packageName, version));
             return new ProvenanceVerificationResult { Outcome = ProvenanceVerificationOutcome.AttestationParseFailed };
         }
 
@@ -73,12 +80,17 @@ internal sealed class SigstoreNpmProvenanceChecker(HttpClient httpClient, ILogge
         var provenance = ExtractProvenanceFromResult(verificationResult!);
         if (provenance is null)
         {
+            logger.LogDebug("Failed to extract provenance data from verified result for {PackageSpecifier}", NpmPackageInfo.FormatPackageSpecifier(packageName, version));
             return new ProvenanceVerificationResult { Outcome = ProvenanceVerificationOutcome.AttestationParseFailed };
         }
 
-        return VerifyProvenanceFields(
+        var result = VerifyProvenanceFields(
             provenance, expectedSourceRepository, expectedWorkflowPath,
             expectedBuildType, validateWorkflowRef);
+
+        logger.LogDebug("Provenance verification for {PackageSpecifier} completed with outcome {Outcome}", NpmPackageInfo.FormatPackageSpecifier(packageName, version), result.Outcome);
+
+        return result;
     }
 
     /// <summary>
@@ -105,7 +117,7 @@ internal sealed class SigstoreNpmProvenanceChecker(HttpClient httpClient, ILogge
         }
         catch (HttpRequestException ex)
         {
-            logger.LogDebug(ex, "Failed to fetch attestations for {Package}@{Version}", packageName, version);
+            logger.LogDebug(ex, "Failed to fetch attestations for {PackageSpecifier}", NpmPackageInfo.FormatPackageSpecifier(packageName, version));
             return null;
         }
     }
@@ -194,55 +206,254 @@ internal sealed class SigstoreNpmProvenanceChecker(HttpClient httpClient, ILogge
         }
 
         var verifier = new SigstoreVerifier();
+        var identityPolicy = CertificateIdentity.ForGitHubActions(owner, repo);
         var policy = new VerificationPolicy
         {
-            CertificateIdentity = CertificateIdentity.ForGitHubActions(owner, repo)
+            CertificateIdentity = identityPolicy
         };
 
         try
         {
-            bool success;
-            VerificationResult? result;
+            var (success, result) = await VerifyBundleWithPolicyAsync(
+                verifier, bundle, policy, sriIntegrity, cancellationToken).ConfigureAwait(false);
 
-            if (sriIntegrity is not null && sriIntegrity.StartsWith("sha512-", StringComparison.OrdinalIgnoreCase))
+            // Workaround for Sigstore .NET library bug on Windows where ExtractSan() fails because
+            // .NET formats URI-type SANs as "URL=..." but the library checks for "URI". This will be
+            // fixed in Sigstore 0.5.0. See https://github.com/mitchdenny/sigstore-dotnet/issues/14
+            //
+            // When the SAN extraction fails, we retry cryptographic verification without the
+            // CertificateIdentity policy, then manually verify the three identity checks that
+            // ForGitHubActions would have performed (SAN pattern, OIDC issuer, SourceRepositoryUri)
+            // by reading the Fulcio certificate extensions directly from the bundle. This is safe
+            // because:
+            //
+            //   1. Full cryptographic verification still occurs: the Fulcio certificate chain is
+            //      validated against the Sigstore TUF trust root, Signed Certificate Timestamps are
+            //      checked, Rekor transparency log inclusion is verified, and the artifact signature
+            //      (ECDSA over the DSSE envelope) is validated. An attacker cannot forge a bundle
+            //      without Fulcio issuing them a certificate, which requires a valid OIDC token.
+            //
+            //   2. We manually verify the OIDC issuer from the Fulcio certificate extension
+            //      (OID 1.3.6.1.4.1.57264.1.8), confirming the certificate was issued after
+            //      authenticating with GitHub Actions' OIDC provider. These extensions are parsed
+            //      from raw DER bytes (not the platform-dependent Format() method), so they work
+            //      correctly on all platforms.
+            //
+            //   3. We manually verify the SourceRepositoryUri from the Fulcio certificate extension
+            //      (OID 1.3.6.1.4.1.57264.1.12), confirming the signing identity is bound to the
+            //      expected GitHub repository. This is the same check that ForGitHubActions performs
+            //      via CertificateExtensionPolicy.
+            //
+            //   4. We manually verify the SAN matches the expected pattern for the GitHub repository.
+            //      The SAN is extracted using a platform-independent method that handles both the
+            //      "URI:" format (Linux/OpenSSL) and "URL=" format (Windows/CryptoAPI).
+            //
+            //   5. After this method returns, VerifyProvenanceFields() performs additional
+            //      defense-in-depth checks on the SLSA predicate fields (source repository, workflow
+            //      path, build type, workflow ref) from the DSSE payload, which was signature-verified
+            //      in step 1.
+            //
+            // Once the upstream bug is fixed in Sigstore 0.5.0 and we upgrade, this retry logic and
+            // the VerifyCertificateIdentityFromBundle/ExtractSubjectAlternativeNamePortable helpers
+            // can be removed — the initial VerifyBundleWithPolicyAsync call with CertificateIdentity
+            // will succeed on all platforms.
+            if (!success
+                && result?.FailureReason is not null
+                && result.FailureReason.Contains("Subject Alternative Name", StringComparison.OrdinalIgnoreCase))
             {
-                var hashBase64 = sriIntegrity["sha512-".Length..];
-                var digestBytes = Convert.FromBase64String(hashBase64);
+                logger.LogDebug(
+                    "Retrying Sigstore verification without CertificateIdentity due to known SAN extraction bug " +
+                    "(https://github.com/mitchdenny/sigstore-dotnet/issues/14) for {PackageSpecifier}",
+                    NpmPackageInfo.FormatPackageSpecifier(packageName, version));
 
-                (success, result) = await verifier.TryVerifyDigestAsync(
-                    digestBytes, HashAlgorithmType.Sha512, bundle, policy, cancellationToken).ConfigureAwait(false);
-            }
-            else
-            {
-                if (bundle.DsseEnvelope is null)
+                var fallbackPolicy = new VerificationPolicy();
+                (success, result) = await VerifyBundleWithPolicyAsync(
+                    verifier, bundle, fallbackPolicy, sriIntegrity, cancellationToken).ConfigureAwait(false);
+
+                if (success)
                 {
-                    logger.LogDebug("No DSSE envelope found in bundle for {Package}@{Version}", packageName, version);
-                    return (new ProvenanceVerificationResult { Outcome = ProvenanceVerificationOutcome.PayloadDecodeFailed }, null);
+                    var identityFailure = VerifyCertificateIdentityFromBundle(bundle, identityPolicy, packageName, version);
+                    if (identityFailure is not null)
+                    {
+                        return (identityFailure, null);
+                    }
                 }
-
-                (success, result) = await verifier.TryVerifyAsync(
-                    bundle.DsseEnvelope.Payload, bundle, policy, cancellationToken).ConfigureAwait(false);
             }
 
             if (!success)
             {
                 logger.LogWarning(
-                    "Sigstore verification failed for {Package}@{Version}: {FailureReason}",
-                    packageName, version, result?.FailureReason);
+                    "Sigstore verification failed for {PackageSpecifier}: {FailureReason}",
+                    NpmPackageInfo.FormatPackageSpecifier(packageName, version), result?.FailureReason);
                 return (new ProvenanceVerificationResult { Outcome = ProvenanceVerificationOutcome.AttestationParseFailed }, null);
             }
 
             logger.LogDebug(
-                "Sigstore verification passed for {Package}@{Version}. Signed by: {Signer}",
-                packageName, version, result?.SignerIdentity?.SubjectAlternativeName);
+                "Sigstore verification passed for {PackageSpecifier}. Signed by: {Signer}",
+                NpmPackageInfo.FormatPackageSpecifier(packageName, version), result?.SignerIdentity?.SubjectAlternativeName);
 
             return (null, result);
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Sigstore verification threw an exception for {Package}@{Version}", packageName, version);
+            logger.LogWarning(ex, "Sigstore verification threw an exception for {PackageSpecifier}", NpmPackageInfo.FormatPackageSpecifier(packageName, version));
             return (new ProvenanceVerificationResult { Outcome = ProvenanceVerificationOutcome.AttestationParseFailed }, null);
         }
+    }
+
+    /// <summary>
+    /// Dispatches bundle verification to the appropriate Sigstore verifier method
+    /// based on whether an SRI integrity digest is available.
+    /// </summary>
+    private static async Task<(bool Success, VerificationResult? Result)> VerifyBundleWithPolicyAsync(
+        SigstoreVerifier verifier,
+        SigstoreBundle bundle,
+        VerificationPolicy policy,
+        string? sriIntegrity,
+        CancellationToken cancellationToken)
+    {
+        if (sriIntegrity is not null && sriIntegrity.StartsWith("sha512-", StringComparison.OrdinalIgnoreCase))
+        {
+            var hashBase64 = sriIntegrity["sha512-".Length..];
+            var digestBytes = Convert.FromBase64String(hashBase64);
+
+            return await verifier.TryVerifyDigestAsync(
+                digestBytes, HashAlgorithmType.Sha512, bundle, policy, cancellationToken).ConfigureAwait(false);
+        }
+
+        // NOTE: When there is no SRI integrity digest and no DSSE envelope, this returns a generic
+        // VerificationResult with a failure reason string. The caller maps any verification failure
+        // to AttestationParseFailed, which differs from the previous behavior (PayloadDecodeFailed)
+        // that occurred when TryVerifyAsync was called with a null payload.
+        if (bundle.DsseEnvelope is null)
+        {
+            return (false, new VerificationResult { FailureReason = "No DSSE envelope found in bundle." });
+        }
+
+        return await verifier.TryVerifyAsync(
+            bundle.DsseEnvelope.Payload, bundle, policy, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Manually verifies the certificate identity checks that <see cref="CertificateIdentity.ForGitHubActions"/>
+    /// would normally perform, by reading Fulcio certificate extensions directly from the bundle.
+    /// This is the workaround path used when the library's SAN extraction fails on Windows.
+    /// </summary>
+    private ProvenanceVerificationResult? VerifyCertificateIdentityFromBundle(
+        SigstoreBundle bundle,
+        CertificateIdentity expectedIdentity,
+        string packageName,
+        string version)
+    {
+        // Extract the leaf certificate from the bundle's verification material.
+        ReadOnlyMemory<byte>? certBytes = bundle.VerificationMaterial?.Certificate;
+        if (certBytes is null && bundle.VerificationMaterial?.CertificateChain is { Count: > 0 } chain)
+        {
+            certBytes = chain[0];
+        }
+
+        if (certBytes is not { Length: > 0 } leafCertBytes)
+        {
+            logger.LogWarning("No signing certificate found in bundle for {PackageSpecifier}", NpmPackageInfo.FormatPackageSpecifier(packageName, version));
+            return new ProvenanceVerificationResult { Outcome = ProvenanceVerificationOutcome.AttestationParseFailed };
+        }
+
+        using var cert = X509CertificateLoader.LoadCertificate(leafCertBytes.Span);
+        var extensions = FulcioCertificateExtensions.FromCertificate(cert);
+
+        // Check OIDC issuer (OID 1.3.6.1.4.1.57264.1.8).
+        if (expectedIdentity.Issuer is not null)
+        {
+            if (extensions.Issuer is null || !string.Equals(extensions.Issuer, expectedIdentity.Issuer, StringComparison.Ordinal))
+            {
+                logger.LogWarning(
+                    "OIDC issuer mismatch for {PackageSpecifier}: expected '{Expected}', got '{Actual}'",
+                    NpmPackageInfo.FormatPackageSpecifier(packageName, version), expectedIdentity.Issuer, extensions.Issuer);
+                return new ProvenanceVerificationResult { Outcome = ProvenanceVerificationOutcome.AttestationParseFailed };
+            }
+        }
+
+        // Check SourceRepositoryUri extension (OID 1.3.6.1.4.1.57264.1.12).
+        if (expectedIdentity.Extensions?.SourceRepositoryUri is not null)
+        {
+            if (!string.Equals(extensions.SourceRepositoryUri, expectedIdentity.Extensions.SourceRepositoryUri, StringComparison.Ordinal))
+            {
+                logger.LogWarning(
+                    "SourceRepositoryUri mismatch for {PackageSpecifier}: expected '{Expected}', got '{Actual}'",
+                    NpmPackageInfo.FormatPackageSpecifier(packageName, version), expectedIdentity.Extensions.SourceRepositoryUri, extensions.SourceRepositoryUri);
+                return new ProvenanceVerificationResult { Outcome = ProvenanceVerificationOutcome.SourceRepositoryMismatch };
+            }
+        }
+
+        // Check SAN pattern using a platform-independent extraction that handles both "URI:" and "URL=".
+        if (expectedIdentity.SubjectAlternativeNamePattern is not null)
+        {
+            var san = ExtractSubjectAlternativeNamePortable(cert);
+            if (san is null || !Regex.IsMatch(san, expectedIdentity.SubjectAlternativeNamePattern))
+            {
+                logger.LogWarning(
+                    "SAN pattern mismatch for {PackageSpecifier}: expected pattern '{Pattern}', got '{Actual}'",
+                    NpmPackageInfo.FormatPackageSpecifier(packageName, version), expectedIdentity.SubjectAlternativeNamePattern, san);
+                return new ProvenanceVerificationResult { Outcome = ProvenanceVerificationOutcome.AttestationParseFailed };
+            }
+        }
+
+        logger.LogDebug(
+            "Manual certificate identity verification passed for {PackageSpecifier} (issuer: {Issuer}, repo: {Repo})",
+            NpmPackageInfo.FormatPackageSpecifier(packageName, version), extensions.Issuer, extensions.SourceRepositoryUri);
+
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts the URI-type Subject Alternative Name from a certificate in a platform-independent way.
+    /// Handles both "URI:" (Linux/OpenSSL) and "URL=" (Windows/CryptoAPI) formatting
+    /// produced by <c>X509Extension.Format(bool)</c>.
+    /// </summary>
+    internal static string? ExtractSubjectAlternativeNamePortable(X509Certificate2 cert)
+    {
+        foreach (var ext in cert.Extensions)
+        {
+            if (ext.Oid?.Value != "2.5.29.17")
+            {
+                continue;
+            }
+
+            var formatted = ext.Format(false);
+            var uri = ParseUriFromFormattedSan(formatted);
+            if (uri is not null)
+            {
+                return uri;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Parses a URI value from the formatted string representation of a Subject Alternative Name extension.
+    /// Handles both "URI:" (Linux/OpenSSL) and "URL=" (Windows/CryptoAPI) formatting conventions.
+    /// </summary>
+    internal static string? ParseUriFromFormattedSan(string formattedSan)
+    {
+        foreach (var part in formattedSan.Split(',', StringSplitOptions.TrimEntries))
+        {
+            // Linux/OpenSSL formats as "URI:https://..."
+            var uriIdx = part.IndexOf("URI:", StringComparison.OrdinalIgnoreCase);
+            if (uriIdx >= 0)
+            {
+                return part[(uriIdx + 4)..].Trim();
+            }
+
+            // Windows/CryptoAPI formats as "URL=https://..."
+            var urlIdx = part.IndexOf("URL=", StringComparison.OrdinalIgnoreCase);
+            if (urlIdx >= 0)
+            {
+                return part[(urlIdx + 4)..].Trim();
+            }
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/tests/Aspire.Cli.Tests/Agents/PlaywrightCliInstallerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/PlaywrightCliInstallerTests.cs
@@ -540,6 +540,8 @@ public class PlaywrightCliInstallerTests
 
     private sealed class TestNpmRunner : INpmRunner
     {
+        public bool IsAvailable => true;
+
         public NpmPackageInfo? ResolveResult { get; set; }
         public string? PackResult { get; set; }
         public bool AuditResult { get; set; } = true;

--- a/tests/Aspire.Cli.Tests/Agents/SigstoreNpmProvenanceCheckerTests.cs
+++ b/tests/Aspire.Cli.Tests/Agents/SigstoreNpmProvenanceCheckerTests.cs
@@ -1045,4 +1045,125 @@ public class SigstoreNpmProvenanceCheckerTests
     }
 
     #endregion
+
+    #region SAN Extraction Tests
+
+    [Theory]
+    [InlineData("URI:https://github.com/nicolo-ribaudo/chokidar-3-to-2-fork/.github/workflows/publish-npm.yml@refs/heads/main")]
+    [InlineData("uri:https://github.com/nicolo-ribaudo/chokidar-3-to-2-fork/.github/workflows/publish-npm.yml@refs/heads/main")]
+    public void ParseUriFromFormattedSan_WithUriFormat_ExtractsUri(string formatted)
+    {
+        var result = SigstoreNpmProvenanceChecker.ParseUriFromFormattedSan(formatted);
+        Assert.Equal("https://github.com/nicolo-ribaudo/chokidar-3-to-2-fork/.github/workflows/publish-npm.yml@refs/heads/main", result);
+    }
+
+    [Theory]
+    [InlineData("URL=https://github.com/nicolo-ribaudo/chokidar-3-to-2-fork/.github/workflows/publish-npm.yml@refs/heads/main")]
+    [InlineData("url=https://github.com/nicolo-ribaudo/chokidar-3-to-2-fork/.github/workflows/publish-npm.yml@refs/heads/main")]
+    public void ParseUriFromFormattedSan_WithUrlFormat_ExtractsUri(string formatted)
+    {
+        var result = SigstoreNpmProvenanceChecker.ParseUriFromFormattedSan(formatted);
+        Assert.Equal("https://github.com/nicolo-ribaudo/chokidar-3-to-2-fork/.github/workflows/publish-npm.yml@refs/heads/main", result);
+    }
+
+    [Theory]
+    [InlineData("DNS:example.com")]
+    [InlineData("email:test@example.com")]
+    [InlineData("IP Address:192.168.1.1")]
+    public void ParseUriFromFormattedSan_WithNonUriFormat_ReturnsNull(string formatted)
+    {
+        var result = SigstoreNpmProvenanceChecker.ParseUriFromFormattedSan(formatted);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseUriFromFormattedSan_WithMultipleEntries_ExtractsFirstUri()
+    {
+        var formatted = "DNS:example.com, URI:https://actions.github.com/workflow, email:test@test.com";
+        var result = SigstoreNpmProvenanceChecker.ParseUriFromFormattedSan(formatted);
+        Assert.Equal("https://actions.github.com/workflow", result);
+    }
+
+    [Fact]
+    public void ParseUriFromFormattedSan_WithWindowsMultipleEntries_ExtractsFirstUrl()
+    {
+        var formatted = "DNS Name=example.com, URL=https://actions.github.com/workflow, RFC822 Name=test@test.com";
+        var result = SigstoreNpmProvenanceChecker.ParseUriFromFormattedSan(formatted);
+        Assert.Equal("https://actions.github.com/workflow", result);
+    }
+
+    [Fact]
+    public void ParseUriFromFormattedSan_WithWhitespace_TrimsValue()
+    {
+        var formatted = "URI:  https://actions.github.com/workflow  ";
+        var result = SigstoreNpmProvenanceChecker.ParseUriFromFormattedSan(formatted);
+        Assert.Equal("https://actions.github.com/workflow", result);
+    }
+
+    [Fact]
+    public void ExtractSubjectAlternativeNamePortable_WithUriSanCert_ExtractsSan()
+    {
+        var expectedUri = "https://github.com/test-org/test-repo/.github/workflows/publish.yml@refs/heads/main";
+        using var cert = CreateCertificateWithUriSan(expectedUri);
+        var result = SigstoreNpmProvenanceChecker.ExtractSubjectAlternativeNamePortable(cert);
+        Assert.Equal(expectedUri, result);
+    }
+
+    [Fact]
+    public void ExtractSubjectAlternativeNamePortable_WithCertWithoutSan_ReturnsNull()
+    {
+        using var cert = CreateSelfSignedCertWithoutSan();
+        var result = SigstoreNpmProvenanceChecker.ExtractSubjectAlternativeNamePortable(cert);
+        Assert.Null(result);
+    }
+
+    private static System.Security.Cryptography.X509Certificates.X509Certificate2 CreateCertificateWithUriSan(string uri)
+    {
+        using var key = System.Security.Cryptography.RSA.Create(2048);
+        var request = new System.Security.Cryptography.X509Certificates.CertificateRequest(
+            "CN=Test", key, System.Security.Cryptography.HashAlgorithmName.SHA256,
+            System.Security.Cryptography.RSASignaturePadding.Pkcs1);
+
+        // Build the SAN extension with a URI entry using raw ASN.1.
+        // SubjectAlternativeName is SEQUENCE { [6] IMPLICIT IA5String <uri> }
+        // Tag 0x86 = context-specific (bit 7) | constructed=0 | tag number 6
+        var uriBytes = System.Text.Encoding.ASCII.GetBytes(uri);
+        var innerLength = uriBytes.Length;
+        var sanValueBytes = new byte[2 + innerLength + 2]; // SEQUENCE header + content
+        var offset = 0;
+
+        // Write the uniformResourceIdentifier [6] IMPLICIT
+        sanValueBytes[offset++] = 0x86; // context tag 6
+        sanValueBytes[offset++] = (byte)innerLength;
+        Array.Copy(uriBytes, 0, sanValueBytes, offset, innerLength);
+        offset += innerLength;
+
+        // Wrap in SEQUENCE
+        var sequenceContent = sanValueBytes[..offset];
+        var sequenceBytes = new byte[2 + sequenceContent.Length];
+        sequenceBytes[0] = 0x30; // SEQUENCE tag
+        sequenceBytes[1] = (byte)sequenceContent.Length;
+        Array.Copy(sequenceContent, 0, sequenceBytes, 2, sequenceContent.Length);
+
+        var sanExtension = new System.Security.Cryptography.X509Certificates.X509Extension(
+            new System.Security.Cryptography.Oid("2.5.29.17", "Subject Alternative Name"),
+            sequenceBytes,
+            critical: false);
+
+        request.CertificateExtensions.Add(sanExtension);
+
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-1), DateTimeOffset.UtcNow.AddHours(1));
+    }
+
+    private static System.Security.Cryptography.X509Certificates.X509Certificate2 CreateSelfSignedCertWithoutSan()
+    {
+        using var key = System.Security.Cryptography.RSA.Create(2048);
+        var request = new System.Security.Cryptography.X509Certificates.CertificateRequest(
+            "CN=Test", key, System.Security.Cryptography.HashAlgorithmName.SHA256,
+            System.Security.Cryptography.RSASignaturePadding.Pkcs1);
+
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-1), DateTimeOffset.UtcNow.AddHours(1));
+    }
+
+    #endregion
 }

--- a/tests/Aspire.Cli.Tests/Npm/NpmRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/Npm/NpmRunnerTests.cs
@@ -1,0 +1,129 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using Aspire.Cli.Npm;
+
+namespace Aspire.Cli.Tests.Npm;
+
+public class NpmRunnerTests
+{
+    [Fact]
+    public void CreateNpmProcessStartInfo_SetsCommonProperties()
+    {
+        var startInfo = NpmRunner.CreateNpmProcessStartInfo("/usr/bin/npm", ["view", "express", "version"], "/tmp/workdir");
+
+        Assert.True(startInfo.RedirectStandardOutput);
+        Assert.True(startInfo.RedirectStandardError);
+        Assert.False(startInfo.UseShellExecute);
+        Assert.True(startInfo.CreateNoWindow);
+        Assert.Equal("/tmp/workdir", startInfo.WorkingDirectory);
+    }
+
+    [Fact]
+    public void CreateNpmProcessStartInfo_OnWindows_WithCmdExtension_UsesCmdExe()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Windows-only test.");
+
+        var startInfo = NpmRunner.CreateNpmProcessStartInfo(
+            @"C:\Program Files\nodejs\npm.cmd",
+            ["view", "@playwright/cli@0.1.1", "version", "--registry", "https://registry.npmjs.org/"],
+            @"C:\temp\workdir");
+
+        Assert.Equal("cmd.exe", startInfo.FileName);
+        Assert.Empty(startInfo.ArgumentList);
+        Assert.Contains("npm.cmd", startInfo.Arguments);
+        Assert.Contains("view", startInfo.Arguments);
+        Assert.Contains("@playwright/cli@0.1.1", startInfo.Arguments);
+        Assert.Contains("version", startInfo.Arguments);
+        Assert.Contains("--registry", startInfo.Arguments);
+        Assert.StartsWith("/c ", startInfo.Arguments);
+        Assert.Equal(@"C:\temp\workdir", startInfo.WorkingDirectory);
+    }
+
+    [Fact]
+    public void CreateNpmProcessStartInfo_OnWindows_WithCmdExtension_WrapsInOuterQuotes()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Windows-only test.");
+
+        var startInfo = NpmRunner.CreateNpmProcessStartInfo(
+            @"C:\Program Files\nodejs\npm.cmd",
+            ["view", "express", "version"],
+            @"C:\temp");
+
+        // cmd.exe /c requires outer quotes wrapping the entire command:
+        // /c ""C:\Program Files\nodejs\npm.cmd" "view" "express" "version""
+        var args = startInfo.Arguments;
+        Assert.StartsWith(@"/c """, args);
+        Assert.EndsWith(@"""", args);
+    }
+
+    [Fact]
+    public void CreateNpmProcessStartInfo_OnWindows_WithExeExtension_DoesNotUseCmdExe()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Windows-only test.");
+
+        var startInfo = NpmRunner.CreateNpmProcessStartInfo(
+            @"C:\Program Files\nodejs\npm.exe",
+            ["view", "express", "version"],
+            @"C:\temp");
+
+        Assert.Equal(@"C:\Program Files\nodejs\npm.exe", startInfo.FileName);
+        Assert.Equal(["view", "express", "version"], startInfo.ArgumentList);
+        Assert.Empty(startInfo.Arguments);
+    }
+
+    [Fact]
+    public void CreateNpmProcessStartInfo_OnNonWindows_UsesDirectInvocation()
+    {
+        Assert.SkipUnless(!RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Non-Windows-only test.");
+
+        var startInfo = NpmRunner.CreateNpmProcessStartInfo(
+            "/usr/local/bin/npm",
+            ["view", "@playwright/cli@0.1.1", "version"],
+            "/tmp/workdir");
+
+        Assert.Equal("/usr/local/bin/npm", startInfo.FileName);
+        Assert.Equal(["view", "@playwright/cli@0.1.1", "version"], startInfo.ArgumentList);
+        Assert.Empty(startInfo.Arguments);
+    }
+
+    [Fact]
+    public void CreateNpmProcessStartInfo_OnNonWindows_CmdExtensionIsIgnored()
+    {
+        Assert.SkipUnless(!RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Non-Windows-only test.");
+
+        // On non-Windows, even a .cmd path is invoked directly (not via cmd.exe).
+        var startInfo = NpmRunner.CreateNpmProcessStartInfo(
+            "/usr/local/bin/npm.cmd",
+            ["view", "express", "version"],
+            "/tmp");
+
+        Assert.Equal("/usr/local/bin/npm.cmd", startInfo.FileName);
+        Assert.Equal(["view", "express", "version"], startInfo.ArgumentList);
+        Assert.Empty(startInfo.Arguments);
+    }
+
+    [Fact]
+    public void CreateNpmProcessStartInfo_WithEmptyArgs_OnNonWindows_ProducesValidStartInfo()
+    {
+        Assert.SkipUnless(!RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Non-Windows-only test.");
+
+        var startInfo = NpmRunner.CreateNpmProcessStartInfo("/usr/bin/npm", [], "/tmp");
+
+        Assert.Equal("/usr/bin/npm", startInfo.FileName);
+        Assert.Empty(startInfo.ArgumentList);
+    }
+
+    [Fact]
+    public void CreateNpmProcessStartInfo_WithEmptyArgs_OnWindows_ProducesValidStartInfo()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Windows-only test.");
+
+        var startInfo = NpmRunner.CreateNpmProcessStartInfo(@"C:\Program Files\nodejs\npm.cmd", [], @"C:\temp");
+
+        Assert.Equal("cmd.exe", startInfo.FileName);
+        Assert.Contains("npm.cmd", startInfo.Arguments);
+        Assert.Equal(@"C:\temp", startInfo.WorkingDirectory);
+    }
+}

--- a/tests/Aspire.Cli.Tests/TestServices/FakePlaywrightServices.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/FakePlaywrightServices.cs
@@ -12,6 +12,8 @@ namespace Aspire.Cli.Tests.TestServices;
 /// </summary>
 internal sealed class FakeNpmRunner : INpmRunner
 {
+    public bool IsAvailable => true;
+
     public Task<NpmPackageInfo?> ResolvePackageAsync(string packageName, string versionRange, CancellationToken cancellationToken)
         => Task.FromResult<NpmPackageInfo?>(null);
 


### PR DESCRIPTION
## Description

Backport NpmRunner, SigstoreNpmProvenanceChecker, and PlaywrightCliRunner improvements from `mad-skills` to `release/13.2`.

### Changes

- **NpmRunner**: Run npm commands in isolated temp directories to avoid picking up project `.npmrc` files; use `--registry` flag for public registry; improve Windows `.cmd` invocation via `cmd.exe /c`; add `IsAvailable` property; add `NpmPackageInfo.FormatPackageSpecifier` helper.
- **SigstoreNpmProvenanceChecker**: Improve Sigstore SAN extraction with robust parsing; add SAN parsing tests; work around Sigstore SAN extraction bug on Windows.
- **PlaywrightCliRunner**: Clean up empty `.playwright` directory left behind after `playwright-cli install --skills`.
- **Tests**: Add `NpmRunnerTests` and additional `SigstoreNpmProvenanceCheckerTests`.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
