### PR TITLE
Fix Kubernetes publisher crash on Boolean/scalar environment variable values

### DIFF
--- a/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesResource.cs
@@ -472,6 +472,18 @@ public partial class KubernetesResource(string name, IResource resource, Kuberne
                 return s;
             }
 
+            // Handle scalar/primitive types (bool, numerics, DateTimeOffset, TimeSpan, Uri, etc.)
+            // These can appear when third-party integrations set environment variables to non-string values.
+            if (value is bool boolValue)
+            {
+                return boolValue ? "true" : "false";
+            }
+
+            if (value is IFormattable formattable)
+            {
+                return formattable.ToString(null, CultureInfo.InvariantCulture);
+            }
+
             if (value is EndpointReference ep)
             {
                 var referencedResource = ep.Resource == this

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
@@ -703,6 +703,60 @@ public class KubernetesPublisherTests()
         await settingsTask;
     }
 
+    [Fact]
+    public async Task PublishAsync_HandlesScalarEnvironmentVariableTypes()
+    {
+        using var tempDir = new TestTempDirectory();
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+
+        builder.AddKubernetesEnvironment("env");
+
+        var api = builder.AddContainer("myapp", "mcr.microsoft.com/dotnet/aspnet:8.0")
+            .WithEnvironment(context =>
+            {
+                context.EnvironmentVariables["BOOL_TRUE"] = true;
+                context.EnvironmentVariables["BOOL_FALSE"] = false;
+                context.EnvironmentVariables["INT_VALUE"] = 42;
+                context.EnvironmentVariables["DOUBLE_VALUE"] = 3.14;
+                context.EnvironmentVariables["DATETIMEOFFSET_VALUE"] = new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero);
+                context.EnvironmentVariables["TIMESPAN_VALUE"] = TimeSpan.FromMinutes(90);
+                context.EnvironmentVariables["URI_VALUE"] = new Uri("https://example.com/path");
+                int? nullableIntWithValue = 7;
+                context.EnvironmentVariables["NULLABLE_INT_WITH_VALUE"] = nullableIntWithValue!;
+            })
+            .WithEnvironment("STRING_VALUE", "hello");
+
+        var app = builder.Build();
+        app.Run();
+
+        var expectedFiles = new[]
+        {
+            "Chart.yaml",
+            "values.yaml",
+            "templates/myapp/deployment.yaml",
+            "templates/myapp/config.yaml",
+        };
+
+        SettingsTask settingsTask = default!;
+
+        foreach (var expectedFile in expectedFiles)
+        {
+            var filePath = Path.Combine(tempDir.Path, expectedFile);
+            var fileExtension = Path.GetExtension(filePath)[1..];
+
+            if (settingsTask is null)
+            {
+                settingsTask = Verify(File.ReadAllText(filePath), fileExtension);
+            }
+            else
+            {
+                settingsTask = settingsTask.AppendContentAsFile(File.ReadAllText(filePath), fileExtension);
+            }
+        }
+
+        await settingsTask;
+    }
+
     private sealed class TestConditionProvider(string value) : IValueProvider, IManifestExpressionProvider
     {
         public string ValueExpression => "test-condition";

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesScalarEnvironmentVariableTypes#00.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesScalarEnvironmentVariableTypes#00.verified.yaml
@@ -1,0 +1,11 @@
+﻿apiVersion: "v2"
+name: "aspire-hosting-tests"
+version: "0.1.0"
+kubeVersion: ">= 1.18.0-0"
+description: "Aspire Helm Chart"
+type: "application"
+keywords:
+  - "aspire"
+  - "kubernetes"
+appVersion: "0.1.0"
+deprecated: false

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesScalarEnvironmentVariableTypes#01.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesScalarEnvironmentVariableTypes#01.verified.yaml
@@ -1,0 +1,13 @@
+﻿parameters: {}
+secrets: {}
+config:
+  myapp:
+    BOOL_TRUE: "true"
+    BOOL_FALSE: "false"
+    INT_VALUE: "42"
+    DOUBLE_VALUE: "3.14"
+    DATETIMEOFFSET_VALUE: "01/02/2024 03:04:05 +00:00"
+    TIMESPAN_VALUE: "01:30:00"
+    URI_VALUE: "https://example.com/path"
+    NULLABLE_INT_WITH_VALUE: "7"
+    STRING_VALUE: "hello"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesScalarEnvironmentVariableTypes#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesScalarEnvironmentVariableTypes#02.verified.yaml
@@ -1,0 +1,36 @@
+﻿---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  name: "myapp-deployment"
+  labels:
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/component: "myapp"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "{{ .Chart.Name }}"
+        app.kubernetes.io/component: "myapp"
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+    spec:
+      containers:
+        - image: "mcr.microsoft.com/dotnet/aspnet:8.0"
+          name: "myapp"
+          envFrom:
+            - configMapRef:
+                name: "myapp-config"
+          imagePullPolicy: "IfNotPresent"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "{{ .Chart.Name }}"
+      app.kubernetes.io/component: "myapp"
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: "RollingUpdate"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesScalarEnvironmentVariableTypes#03.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesScalarEnvironmentVariableTypes#03.verified.yaml
@@ -1,0 +1,19 @@
+﻿---
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  name: "myapp-config"
+  labels:
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/component: "myapp"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+data:
+  BOOL_TRUE: "{{ .Values.config.myapp.BOOL_TRUE }}"
+  BOOL_FALSE: "{{ .Values.config.myapp.BOOL_FALSE }}"
+  INT_VALUE: "{{ .Values.config.myapp.INT_VALUE }}"
+  DOUBLE_VALUE: "{{ .Values.config.myapp.DOUBLE_VALUE }}"
+  DATETIMEOFFSET_VALUE: "{{ .Values.config.myapp.DATETIMEOFFSET_VALUE }}"
+  TIMESPAN_VALUE: "{{ .Values.config.myapp.TIMESPAN_VALUE }}"
+  URI_VALUE: "{{ .Values.config.myapp.URI_VALUE }}"
+  NULLABLE_INT_WITH_VALUE: "{{ .Values.config.myapp.NULLABLE_INT_WITH_VALUE }}"
+  STRING_VALUE: "{{ .Values.config.myapp.STRING_VALUE }}"


### PR DESCRIPTION
## Description

The Kubernetes publisher's `ProcessValueAsync` method in `KubernetesResource.cs` only handled `string`, resource references, and expression types. When third-party integrations (like [Scalar.Aspire](https://github.com/scalar/scalar)) set environment variables to non-string scalar values (e.g., `bool`, `int`, `double`), the method threw `NotSupportedException: Unsupported value type: Boolean`, crashing the publish pipeline.

This PR adds handling for `IConvertible` types (which covers all .NET primitive types) by converting them to their `InvariantCulture` string representation. This is placed right after the existing `string` check in `ProcessValueAsync` for maximum clarity.

Fixes #15229

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
