### PR TITLE
[release/13.2] Make VerifyAspireCliVersionAsync resilient across branches

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2EAutomatorHelpers.cs
@@ -147,23 +147,33 @@ internal static class CliE2EAutomatorHelpers
     }
 
     /// <summary>
-    /// Verifies the installed Aspire CLI version matches the expected version.
+    /// Verifies the installed Aspire CLI version matches the expected build.
+    /// Always checks the dynamic version prefix from eng/Versions.props.
+    /// For non-stabilized builds (all normal PR builds), also verifies the commit SHA suffix.
     /// </summary>
-#pragma warning disable IDE0060 // commitSha is unused during stabilized builds — restore when merging back to main
     internal static async Task VerifyAspireCliVersionAsync(
         this Hex1bTerminalAutomator auto,
         string commitSha,
         SequenceCounter counter)
-#pragma warning restore IDE0060
     {
+        var versionPrefix = CliE2ETestHelpers.GetVersionPrefix();
+        var isStabilized = CliE2ETestHelpers.IsStabilizedBuild();
+
         await auto.TypeAsync("aspire --version");
         await auto.EnterAsync();
 
-        // When the build is stabilized (StabilizePackageVersion=true), the CLI version
-        // is just "13.2.0" with no commit SHA suffix. When not stabilized, it includes
-        // the SHA (e.g., "13.2.0-preview.1.g<sha>"). In both cases, "13.2.0" is present.
-        // TODO: This change should be reverted on the integration to the main branch.
-        await auto.WaitUntilTextAsync("13.2.0", timeout: TimeSpan.FromSeconds(10));
+        // Always verify the version prefix matches the branch's version (e.g., "13.3.0").
+        await auto.WaitUntilTextAsync(versionPrefix, timeout: TimeSpan.FromSeconds(10));
+
+        // For non-stabilized builds (all PR CI builds), also verify the commit SHA suffix
+        // to uniquely identify the exact build. Stabilized builds (official releases only)
+        // produce versions without SHA suffixes, so we skip this check.
+        if (!isStabilized && commitSha.Length == 40)
+        {
+            var shortCommitSha = commitSha[..8];
+            var expectedVersionSuffix = $"g{shortCommitSha}";
+            await auto.WaitUntilTextAsync(expectedVersionSuffix, timeout: TimeSpan.FromSeconds(10));
+        }
 
         await auto.WaitForSuccessPromptAsync(counter);
     }

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/CliE2ETestHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using System.Xml.Linq;
 using Aspire.Cli.Tests.Utils;
 using Hex1b;
 using Xunit;
@@ -308,5 +309,52 @@ internal static class CliE2ETestHelpers
     {
         var relativePath = Path.GetRelativePath(workspace.WorkspaceRoot.FullName, hostPath);
         return $"/workspace/{workspace.WorkspaceRoot.Name}/" + relativePath.Replace('\\', '/');
+    }
+
+    /// <summary>
+    /// Reads the VersionPrefix (e.g., "13.3.0") from eng/Versions.props by parsing
+    /// the MajorVersion, MinorVersion, and PatchVersion MSBuild properties.
+    /// </summary>
+    internal static string GetVersionPrefix()
+    {
+        var repoRoot = GetRepoRoot();
+        var versionsPropsPath = Path.Combine(repoRoot, "eng", "Versions.props");
+
+        var doc = XDocument.Load(versionsPropsPath);
+        var ns = doc.Root?.Name.Namespace ?? XNamespace.None;
+
+        string? GetProperty(string name) =>
+            doc.Descendants(ns + name).FirstOrDefault()?.Value;
+
+        var major = GetProperty("MajorVersion")
+            ?? throw new InvalidOperationException("MajorVersion not found in eng/Versions.props");
+        var minor = GetProperty("MinorVersion")
+            ?? throw new InvalidOperationException("MinorVersion not found in eng/Versions.props");
+        var patch = GetProperty("PatchVersion")
+            ?? throw new InvalidOperationException("PatchVersion not found in eng/Versions.props");
+
+        return $"{major}.{minor}.{patch}";
+    }
+
+    /// <summary>
+    /// Checks whether the build is stabilized (StabilizePackageVersion=true in eng/Versions.props).
+    /// Stabilized builds produce version strings without commit SHA suffixes (e.g., "13.2.0" instead
+    /// of "13.2.0-preview.1.25175.1+g{sha}"). This is only true for official release builds,
+    /// never for normal PR CI builds.
+    /// </summary>
+    internal static bool IsStabilizedBuild()
+    {
+        var repoRoot = GetRepoRoot();
+        var versionsPropsPath = Path.Combine(repoRoot, "eng", "Versions.props");
+
+        var doc = XDocument.Load(versionsPropsPath);
+        var ns = doc.Root?.Name.Namespace ?? XNamespace.None;
+
+        // The default value in Versions.props uses a Condition to default to "false",
+        // so we read the element's text directly.
+        var stabilize = doc.Descendants(ns + "StabilizePackageVersion")
+            .FirstOrDefault()?.Value;
+
+        return string.Equals(stabilize, "true", StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
## Description

Replaces the hardcoded `"13.2.0"` version check in `VerifyAspireCliVersionAsync` with a dynamic approach that reads the `VersionPrefix` from `eng/Versions.props` at test time.

### Context: Why this fix exists

PR #15540 merges `release/13.2` into `main`. On the `release/13.2` branch, `VerifyAspireCliVersionAsync` was changed to hardcode `"13.2.0"` (with a TODO: "This change should be reverted on the integration to the main branch") because stabilized release builds don't include the commit SHA suffix in the version string.

When that merge PR reaches `main` (where version is `13.3.0-preview.1`), the hardcoded `"13.2.0"` check fails. This pattern will repeat every time `release/*` merges into `main` (or vice versa) if version strings are hardcoded.

**This PR fixes the root cause on `release/13.2` so that future merges in either direction just work.** The same fix was also pushed directly to PR #15540's branch (`merge/release-13.2-to-main`).

### Problem

The version check was hardcoded to `"13.2.0"` on the `release/13.2` branch because stabilized builds don't include the commit SHA suffix. This breaks when:
- Merging to `main` (where version is `13.3.0`)
- Any future branch with a different version number
- The version is bumped (e.g., `13.2.0` → `13.2.1`)

### Solution

- **`CliE2ETestHelpers.cs`**: Added `GetVersionPrefix()` and `IsStabilizedBuild()` that parse `eng/Versions.props` dynamically
- **`CliE2EAutomatorHelpers.cs`**: Updated `VerifyAspireCliVersionAsync` to:
  1. Always verify CLI version contains the dynamic `VersionPrefix` (adapts per branch)
  2. For non-stabilized builds (all PR CI builds), also verify commit SHA suffix for exact build identity
  3. Removed hardcoded `"13.2.0"` and `#pragma warning` suppression

### Why this is safe across branch merges

| Scenario | Versions.props | CLI output | Result |
|---|---|---|---|
| `main` at 13.3.0 | `13.3.0` | `13.3.0-preview.1.xxx+g{sha}` | ✅ prefix match + SHA check |
| `release/13.2` at 13.2.0 | `13.2.0` | `13.2.0-pr.xxx` | ✅ prefix match + SHA check |
| Merge `release→main` | main's version | matches main CLI | ✅ |
| Stabilized official release | `13.2.0` | `13.2.0` | ✅ SHA check skipped |

### NuGet package isolation

PR build packages remain isolated via the hive mechanism:
- Packages have `-pr.XXXX.sha` suffixes (never match published GA versions)
- `StabilizePackageVersion=false` in all PR builds
- NuGet.config source mapping routes `Aspire*` packages to local hive files

### Related PRs

- **#15540** — The merge PR (`release/13.2` → `main`) by @joperezr that surfaced this issue. Same fix pushed to that branch.
- This PR applies the fix to `release/13.2` so it's available for future merges.

## Checklist

- [x] Is this feature complete?
  - [x] Yes
- [x] Has the code been tested?
  - [x] Builds successfully with zero warnings