### PR TITLE
Fix CLI bundle extraction to use ~/.aspire/ for non-standard install paths

### DIFF
--- a/docs/specs/bundle.md
+++ b/docs/specs/bundle.md
@@ -245,6 +245,22 @@ When a polyglot project runs `aspire run`, `AppHostServerProjectFactory.CreateAs
 
 `aspire update --self` downloads the new self-extracting binary, swaps it, then calls `BundleService.ExtractAsync(force: true)` to proactively extract the updated payload.
 
+### Extraction Directory Resolution
+
+The default extraction directory is determined by `BundleService.GetDefaultExtractDir()`:
+
+1. **Standard layout** (`~/.aspire/bin/aspire`): extracts to the parent directory (`~/.aspire/`), keeping
+   all components co-located in the user's Aspire directory.
+2. **Non-standard install locations** (e.g., `/usr/local/bin/aspire` via Homebrew, or
+   `C:\Program Files\WinGet\Links\aspire.exe` via Winget): falls back to the well-known `~/.aspire/`
+   directory to avoid writing into system directories that may not be user-writable.
+
+The `aspire setup --install-path <path>` flag overrides this logic entirely, allowing explicit control
+of the extraction target for advanced scenarios.
+
+Layout discovery (`LayoutDiscovery`) mirrors this hierarchy: it checks environment variables first,
+then relative paths from the CLI binary, and finally the well-known `~/.aspire/` directory.
+
 ### Version Tracking
 
 The file `.aspire-bundle-version` in the layout root contains the assembly informational version string (e.g., `13.2.0-pr.14398.gabc1234`). This enables:

--- a/docs/specs/bundle.md
+++ b/docs/specs/bundle.md
@@ -247,7 +247,8 @@ When a polyglot project runs `aspire run`, `AppHostServerProjectFactory.CreateAs
 
 ### Extraction Directory Resolution
 
-The default extraction directory is determined by `BundleService.GetDefaultExtractDir()`:
+The default extraction directory is determined by `BundleService.GetDefaultExtractDir()`, which uses
+`CliExecutionContext.AspireDirectory` as the well-known `~/.aspire/` path:
 
 1. **Standard layout** (`~/.aspire/bin/aspire`): extracts to the parent directory (`~/.aspire/`), keeping
    all components co-located in the user's Aspire directory.

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -168,7 +168,7 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, CliExecuti
         if (parentDir is not null &&
             string.Equals(Path.GetFullPath(parentDir), Path.GetFullPath(aspireDir), StringComparison.OrdinalIgnoreCase))
         {
-            return parentDir;
+            return Path.GetFullPath(parentDir);
         }
 
         // Non-standard install location — fall back to ~/.aspire/ to avoid writing into

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -14,7 +14,7 @@ namespace Aspire.Cli.Bundles;
 /// <summary>
 /// Manages extraction of the embedded bundle payload from self-extracting CLI binaries.
 /// </summary>
-internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<BundleService> logger) : IBundleService
+internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, CliExecutionContext executionContext, ILogger<BundleService> logger) : IBundleService
 {
     private const string PayloadResourceName = "bundle.tar.gz";
 
@@ -62,11 +62,6 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
         }
 
         var extractDir = GetDefaultExtractDir(processPath);
-        if (extractDir is null)
-        {
-            logger.LogDebug("Could not determine extraction directory from {ProcessPath}, skipping.", processPath);
-            return;
-        }
 
         logger.LogDebug("Ensuring bundle is extracted to {ExtractDir}.", extractDir);
         var result = await ExtractAsync(extractDir, force: false, cancellationToken);
@@ -161,47 +156,24 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
     /// falls back to the well-known <c>~/.aspire/</c> directory so that extraction artifacts
     /// stay in a user-writable, predictable location.
     /// </summary>
-    internal static string? GetDefaultExtractDir(string processPath)
+    public string GetDefaultExtractDir(string processPath)
     {
+        var aspireDir = executionContext.AspireDirectory.FullName;
+
         var cliDir = Path.GetDirectoryName(processPath);
-        if (string.IsNullOrEmpty(cliDir))
-        {
-            return null;
-        }
+        var parentDir = cliDir is not null ? Path.GetDirectoryName(cliDir) : null;
 
-        var parentDir = Path.GetDirectoryName(cliDir);
-        if (parentDir is null)
-        {
-            return GetWellKnownAspireDir();
-        }
-
-        // If the parent directory is the well-known .aspire directory (standard layout),
+        // If the parent directory matches the well-known aspire directory (standard layout),
         // use it directly so extraction lands alongside the CLI.
-        if (IsAspireDirectory(parentDir))
+        if (parentDir is not null &&
+            string.Equals(Path.GetFullPath(parentDir), Path.GetFullPath(aspireDir), StringComparison.OrdinalIgnoreCase))
         {
             return parentDir;
         }
 
         // Non-standard install location — fall back to ~/.aspire/ to avoid writing into
         // system directories like /usr/local/ or C:\Program Files\.
-        return GetWellKnownAspireDir();
-    }
-
-    /// <summary>
-    /// Gets the well-known <c>~/.aspire/</c> directory path.
-    /// </summary>
-    internal static string GetWellKnownAspireDir()
-    {
-        return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspire");
-    }
-
-    /// <summary>
-    /// Checks whether the given directory path is a <c>.aspire</c> directory.
-    /// </summary>
-    private static bool IsAspireDirectory(string directoryPath)
-    {
-        var dirName = Path.GetFileName(directoryPath);
-        return string.Equals(dirName, ".aspire", StringComparison.OrdinalIgnoreCase);
+        return aspireDir;
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -156,8 +156,10 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
 
     /// <summary>
     /// Determines the default extraction directory for the current CLI binary.
-    /// If CLI is at ~/.aspire/bin/aspire, returns ~/.aspire/ so layout discovery
-    /// finds components via the bin/ layout pattern.
+    /// When the CLI is under the well-known <c>~/.aspire/bin/</c> layout, returns the parent
+    /// (<c>~/.aspire/</c>). For non-standard install locations (e.g., Homebrew, Winget),
+    /// falls back to the well-known <c>~/.aspire/</c> directory so that extraction artifacts
+    /// stay in a user-writable, predictable location.
     /// </summary>
     internal static string? GetDefaultExtractDir(string processPath)
     {
@@ -167,7 +169,39 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, ILogger<Bu
             return null;
         }
 
-        return Path.GetDirectoryName(cliDir) ?? cliDir;
+        var parentDir = Path.GetDirectoryName(cliDir);
+        if (parentDir is null)
+        {
+            return GetWellKnownAspireDir();
+        }
+
+        // If the parent directory is the well-known .aspire directory (standard layout),
+        // use it directly so extraction lands alongside the CLI.
+        if (IsAspireDirectory(parentDir))
+        {
+            return parentDir;
+        }
+
+        // Non-standard install location — fall back to ~/.aspire/ to avoid writing into
+        // system directories like /usr/local/ or C:\Program Files\.
+        return GetWellKnownAspireDir();
+    }
+
+    /// <summary>
+    /// Gets the well-known <c>~/.aspire/</c> directory path.
+    /// </summary>
+    internal static string GetWellKnownAspireDir()
+    {
+        return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspire");
+    }
+
+    /// <summary>
+    /// Checks whether the given directory path is a <c>.aspire</c> directory.
+    /// </summary>
+    private static bool IsAspireDirectory(string directoryPath)
+    {
+        var dirName = Path.GetFileName(directoryPath);
+        return string.Equals(dirName, ".aspire", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -171,8 +171,8 @@ internal sealed class BundleService(ILayoutDiscovery layoutDiscovery, CliExecuti
             return Path.GetFullPath(parentDir);
         }
 
-        // Non-standard install location — fall back to ~/.aspire/ to avoid writing into
-        // system directories like /usr/local/ or C:\Program Files\.
+        // Non-standard install location — fall back to ~/.aspire/ to avoid writing
+        // into system directories like /usr/local/ or C:\Program Files\.
         return aspireDir;
     }
 

--- a/src/Aspire.Cli/Bundles/IBundleService.cs
+++ b/src/Aspire.Cli/Bundles/IBundleService.cs
@@ -39,6 +39,14 @@ internal interface IBundleService
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The discovered layout, or <see langword="null"/> if no layout is found.</returns>
     Task<LayoutConfiguration?> EnsureExtractedAndGetLayoutAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Determines the default extraction directory for the given CLI binary path.
+    /// Returns the well-known <c>~/.aspire/</c> directory for non-standard install locations.
+    /// </summary>
+    /// <param name="processPath">The path to the CLI binary.</param>
+    /// <returns>The directory to extract the bundle into.</returns>
+    string GetDefaultExtractDir(string processPath);
 }
 
 /// <summary>

--- a/src/Aspire.Cli/CliExecutionContext.cs
+++ b/src/Aspire.Cli/CliExecutionContext.cs
@@ -29,6 +29,14 @@ internal sealed class CliExecutionContext(DirectoryInfo workingDirectory, Direct
     public string LogFilePath { get; } = logFilePath;
 
     public DirectoryInfo HomeDirectory { get; } = homeDirectory ?? new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
+
+    /// <summary>
+    /// Gets the well-known <c>~/.aspire/</c> directory used for CLI data storage, bundles, and settings.
+    /// </summary>
+    public DirectoryInfo AspireDirectory { get; } = new DirectoryInfo(Path.Combine(
+        (homeDirectory ?? new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile))).FullName,
+        ".aspire"));
+
     public bool DebugMode { get; } = debugMode;
 
     /// <summary>

--- a/src/Aspire.Cli/CliExecutionContext.cs
+++ b/src/Aspire.Cli/CliExecutionContext.cs
@@ -33,9 +33,7 @@ internal sealed class CliExecutionContext(DirectoryInfo workingDirectory, Direct
     /// <summary>
     /// Gets the well-known <c>~/.aspire/</c> directory used for CLI data storage, bundles, and settings.
     /// </summary>
-    public DirectoryInfo AspireDirectory { get; } = new DirectoryInfo(Path.Combine(
-        (homeDirectory ?? new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile))).FullName,
-        ".aspire"));
+    public DirectoryInfo AspireDirectory => new DirectoryInfo(Path.Combine(HomeDirectory.FullName, ".aspire"));
 
     public bool DebugMode { get; } = debugMode;
 

--- a/src/Aspire.Cli/Commands/SetupCommand.cs
+++ b/src/Aspire.Cli/Commands/SetupCommand.cs
@@ -62,12 +62,6 @@ internal sealed class SetupCommand : BaseCommand
             installPath = _bundleService.GetDefaultExtractDir(processPath);
         }
 
-        if (string.IsNullOrEmpty(installPath))
-        {
-            InteractionService.DisplayError("Could not determine the installation path.");
-            return ExitCodeConstants.FailedToBuildArtifacts;
-        }
-
         // Extract with spinner
         BundleExtractResult result = BundleExtractResult.NoPayload;
         var exitCode = await InteractionService.ShowStatusAsync(

--- a/src/Aspire.Cli/Commands/SetupCommand.cs
+++ b/src/Aspire.Cli/Commands/SetupCommand.cs
@@ -59,7 +59,7 @@ internal sealed class SetupCommand : BaseCommand
         // Determine extraction directory
         if (string.IsNullOrEmpty(installPath))
         {
-            installPath = BundleService.GetDefaultExtractDir(processPath);
+            installPath = _bundleService.GetDefaultExtractDir(processPath);
         }
 
         if (string.IsNullOrEmpty(installPath))

--- a/src/Aspire.Cli/Layout/LayoutDiscovery.cs
+++ b/src/Aspire.Cli/Layout/LayoutDiscovery.cs
@@ -64,6 +64,16 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
             return LogEnvironmentOverrides(relativeLayout);
         }
 
+        // 3. Try the well-known ~/.aspire/ directory.
+        // When the CLI is installed outside the standard layout (e.g., via Homebrew or Winget),
+        // the bundle is extracted to ~/.aspire/ instead of adjacent to the binary.
+        var wellKnownLayout = TryDiscoverWellKnownLayout();
+        if (wellKnownLayout is not null)
+        {
+            _logger.LogDebug("Discovered layout at well-known path: {Path}", wellKnownLayout.LayoutPath);
+            return LogEnvironmentOverrides(wellKnownLayout);
+        }
+
         _logger.LogDebug("No bundle layout discovered");
         return null;
     }
@@ -178,6 +188,15 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
         }
 
         return null;
+    }
+
+    private LayoutConfiguration? TryDiscoverWellKnownLayout()
+    {
+        var wellKnownPath = Bundles.BundleService.GetWellKnownAspireDir();
+
+        _logger.LogDebug("TryDiscoverWellKnownLayout: Checking well-known path {Path}...", wellKnownPath);
+
+        return TryInferLayout(wellKnownPath);
     }
 
     private LayoutConfiguration? TryInferLayout(string layoutPath)

--- a/src/Aspire.Cli/Layout/LayoutDiscovery.cs
+++ b/src/Aspire.Cli/Layout/LayoutDiscovery.cs
@@ -36,9 +36,11 @@ public interface ILayoutDiscovery
 public sealed class LayoutDiscovery : ILayoutDiscovery
 {
     private readonly ILogger<LayoutDiscovery> _logger;
+    private readonly CliExecutionContext _executionContext;
 
-    public LayoutDiscovery(ILogger<LayoutDiscovery> logger)
+    internal LayoutDiscovery(CliExecutionContext executionContext, ILogger<LayoutDiscovery> logger)
     {
+        _executionContext = executionContext;
         _logger = logger;
     }
 
@@ -192,7 +194,7 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
 
     private LayoutConfiguration? TryDiscoverWellKnownLayout()
     {
-        var wellKnownPath = Bundles.BundleService.GetWellKnownAspireDir();
+        var wellKnownPath = _executionContext.AspireDirectory.FullName;
 
         _logger.LogDebug("TryDiscoverWellKnownLayout: Checking well-known path {Path}...", wellKnownPath);
 

--- a/src/Aspire.Cli/Layout/LayoutDiscovery.cs
+++ b/src/Aspire.Cli/Layout/LayoutDiscovery.cs
@@ -47,7 +47,7 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
     public LayoutConfiguration? DiscoverLayout(string? projectDirectory = null)
     {
         // 1. Try environment variable for layout path
-        var envLayoutPath = Environment.GetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar);
+        var envLayoutPath = _executionContext.GetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar);
         if (!string.IsNullOrEmpty(envLayoutPath))
         {
             _logger.LogDebug("Found ASPIRE_LAYOUT_PATH: {Path}", envLayoutPath);
@@ -85,8 +85,8 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
         // Check environment variable overrides first
         var envPath = component switch
         {
-            LayoutComponent.Dcp => Environment.GetEnvironmentVariable(BundleDiscovery.DcpPathEnvVar),
-            LayoutComponent.Managed => Environment.GetEnvironmentVariable(BundleDiscovery.ManagedPathEnvVar),
+            LayoutComponent.Dcp => _executionContext.GetEnvironmentVariable(BundleDiscovery.DcpPathEnvVar),
+            LayoutComponent.Managed => _executionContext.GetEnvironmentVariable(BundleDiscovery.ManagedPathEnvVar),
             _ => null
         };
 
@@ -103,7 +103,7 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
     public bool IsBundleModeAvailable(string? projectDirectory = null)
     {
         // Check if user explicitly wants SDK mode
-        var useSdk = Environment.GetEnvironmentVariable(BundleDiscovery.UseGlobalDotNetEnvVar);
+        var useSdk = _executionContext.GetEnvironmentVariable(BundleDiscovery.UseGlobalDotNetEnvVar);
         if (string.Equals(useSdk, "true", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(useSdk, "1", StringComparison.OrdinalIgnoreCase))
         {
@@ -243,11 +243,11 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
         // Environment variables for specific components take precedence
         // These will be checked at GetComponentPath time, but we note them here for logging
 
-        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(BundleDiscovery.DcpPathEnvVar)))
+        if (!string.IsNullOrEmpty(_executionContext.GetEnvironmentVariable(BundleDiscovery.DcpPathEnvVar)))
         {
             _logger.LogDebug("DCP path override from {EnvVar}", BundleDiscovery.DcpPathEnvVar);
         }
-        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(BundleDiscovery.ManagedPathEnvVar)))
+        if (!string.IsNullOrEmpty(_executionContext.GetEnvironmentVariable(BundleDiscovery.ManagedPathEnvVar)))
         {
             _logger.LogDebug("Managed path override from {EnvVar}", BundleDiscovery.ManagedPathEnvVar);
         }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -369,7 +369,8 @@ public class Program
 
         // Bundle layout services (for polyglot apphost without .NET SDK).
         // Registered before NuGetPackageCache so the factory can choose implementation.
-        builder.Services.AddSingleton<ILayoutDiscovery, LayoutDiscovery>();
+        builder.Services.AddSingleton<ILayoutDiscovery>(sp =>
+            new LayoutDiscovery(sp.GetRequiredService<CliExecutionContext>(), sp.GetRequiredService<ILogger<LayoutDiscovery>>()));
         builder.Services.AddSingleton<BundleNuGetService>();
 
         // Git repository operations.

--- a/tests/Aspire.Cli.Tests/BundleServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Bundles;
+using Aspire.Cli.Tests.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Cli.Tests;
 
@@ -55,54 +57,75 @@ public class BundleServiceTests
     [Fact]
     public void GetDefaultExtractDir_ReturnsAspireDir_ForStandardLayout()
     {
-        if (OperatingSystem.IsWindows())
+        // Create a temp directory simulating {home}/.aspire/bin/aspire
+        var fakeHome = Directory.CreateTempSubdirectory("aspire-test-home");
+        try
         {
-            var result = BundleService.GetDefaultExtractDir(@"C:\Users\test\.aspire\bin\aspire.exe");
-            Assert.Equal(@"C:\Users\test\.aspire", result);
+            var aspireDir = Path.Combine(fakeHome.FullName, ".aspire");
+            var binDir = Path.Combine(aspireDir, "bin");
+            Directory.CreateDirectory(binDir);
+            var processPath = Path.Combine(binDir, "aspire");
+
+            var context = CreateContext(fakeHome.FullName);
+            var service = CreateBundleService(context);
+
+            var result = service.GetDefaultExtractDir(processPath);
+            Assert.Equal(aspireDir, result);
         }
-        else
+        finally
         {
-            var result = BundleService.GetDefaultExtractDir("/home/test/.aspire/bin/aspire");
-            Assert.Equal("/home/test/.aspire", result);
+            fakeHome.Delete(recursive: true);
         }
     }
 
     [Fact]
-    public void GetDefaultExtractDir_FallsBackToWellKnownDir_ForNonStandardLayout()
+    public void GetDefaultExtractDir_FallsBackToAspireDir_ForNonStandardLayout()
     {
-        var expected = BundleService.GetWellKnownAspireDir();
+        var fakeHome = Directory.CreateTempSubdirectory("aspire-test-home");
+        try
+        {
+            var expectedAspireDir = Path.Combine(fakeHome.FullName, ".aspire");
+            var context = CreateContext(fakeHome.FullName);
+            var service = CreateBundleService(context);
 
-        if (OperatingSystem.IsWindows())
-        {
-            Assert.Equal(expected, BundleService.GetDefaultExtractDir(@"C:\Program Files\WinGet\Links\aspire.exe"));
+            // Simulate Homebrew/Winget paths that are NOT under the aspire directory
+            Assert.Equal(expectedAspireDir, service.GetDefaultExtractDir("/usr/local/bin/aspire"));
+            Assert.Equal(expectedAspireDir, service.GetDefaultExtractDir("/opt/homebrew/bin/aspire"));
+
+            if (OperatingSystem.IsWindows())
+            {
+                Assert.Equal(expectedAspireDir, service.GetDefaultExtractDir(@"C:\Program Files\WinGet\Links\aspire.exe"));
+            }
         }
-        else
+        finally
         {
-            Assert.Equal(expected, BundleService.GetDefaultExtractDir("/usr/local/bin/aspire"));
-            Assert.Equal(expected, BundleService.GetDefaultExtractDir("/opt/homebrew/bin/aspire"));
+            fakeHome.Delete(recursive: true);
         }
     }
 
     [Fact]
-    public void GetDefaultExtractDir_FallsBackToWellKnownDir_ForCustomInstallLocation()
+    public void GetDefaultExtractDir_FallsBackToAspireDir_ForCustomInstallLocation()
     {
-        var expected = BundleService.GetWellKnownAspireDir();
-
-        if (OperatingSystem.IsWindows())
+        var fakeHome = Directory.CreateTempSubdirectory("aspire-test-home");
+        try
         {
-            Assert.Equal(expected, BundleService.GetDefaultExtractDir(@"D:\tools\aspire\bin\aspire.exe"));
-        }
-        else
-        {
-            Assert.Equal(expected, BundleService.GetDefaultExtractDir("/opt/aspire/bin/aspire"));
-        }
-    }
+            var expectedAspireDir = Path.Combine(fakeHome.FullName, ".aspire");
+            var context = CreateContext(fakeHome.FullName);
+            var service = CreateBundleService(context);
 
-    [Fact]
-    public void GetWellKnownAspireDir_ReturnsExpectedPath()
-    {
-        var expected = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspire");
-        Assert.Equal(expected, BundleService.GetWellKnownAspireDir());
+            if (OperatingSystem.IsWindows())
+            {
+                Assert.Equal(expectedAspireDir, service.GetDefaultExtractDir(@"D:\tools\aspire\bin\aspire.exe"));
+            }
+            else
+            {
+                Assert.Equal(expectedAspireDir, service.GetDefaultExtractDir("/opt/aspire/bin/aspire"));
+            }
+        }
+        finally
+        {
+            fakeHome.Delete(recursive: true);
+        }
     }
 
     [Fact]
@@ -111,5 +134,26 @@ public class BundleServiceTests
         var version = BundleService.GetCurrentVersion();
         Assert.NotNull(version);
         Assert.NotEqual("unknown", version);
+    }
+
+    private static CliExecutionContext CreateContext(string homeDir)
+    {
+        var aspireDir = Path.Combine(homeDir, ".aspire");
+        return new CliExecutionContext(
+            new DirectoryInfo("."),
+            new DirectoryInfo(Path.Combine(aspireDir, "hives")),
+            new DirectoryInfo(Path.Combine(aspireDir, "cache")),
+            new DirectoryInfo(Path.Combine(aspireDir, "sdks")),
+            new DirectoryInfo(Path.Combine(aspireDir, "logs")),
+            "test.log",
+            homeDirectory: new DirectoryInfo(homeDir));
+    }
+
+    private static BundleService CreateBundleService(CliExecutionContext context)
+    {
+        return new BundleService(
+            new NullLayoutDiscovery(),
+            context,
+            NullLogger<BundleService>.Instance);
     }
 }

--- a/tests/Aspire.Cli.Tests/BundleServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceTests.cs
@@ -53,7 +53,7 @@ public class BundleServiceTests
     }
 
     [Fact]
-    public void GetDefaultExtractDir_ReturnsParentOfParent()
+    public void GetDefaultExtractDir_ReturnsAspireDir_ForStandardLayout()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -65,6 +65,44 @@ public class BundleServiceTests
             var result = BundleService.GetDefaultExtractDir("/home/test/.aspire/bin/aspire");
             Assert.Equal("/home/test/.aspire", result);
         }
+    }
+
+    [Fact]
+    public void GetDefaultExtractDir_FallsBackToWellKnownDir_ForNonStandardLayout()
+    {
+        var expected = BundleService.GetWellKnownAspireDir();
+
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Equal(expected, BundleService.GetDefaultExtractDir(@"C:\Program Files\WinGet\Links\aspire.exe"));
+        }
+        else
+        {
+            Assert.Equal(expected, BundleService.GetDefaultExtractDir("/usr/local/bin/aspire"));
+            Assert.Equal(expected, BundleService.GetDefaultExtractDir("/opt/homebrew/bin/aspire"));
+        }
+    }
+
+    [Fact]
+    public void GetDefaultExtractDir_FallsBackToWellKnownDir_ForCustomInstallLocation()
+    {
+        var expected = BundleService.GetWellKnownAspireDir();
+
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Equal(expected, BundleService.GetDefaultExtractDir(@"D:\tools\aspire\bin\aspire.exe"));
+        }
+        else
+        {
+            Assert.Equal(expected, BundleService.GetDefaultExtractDir("/opt/aspire/bin/aspire"));
+        }
+    }
+
+    [Fact]
+    public void GetWellKnownAspireDir_ReturnsExpectedPath()
+    {
+        var expected = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspire");
+        Assert.Equal(expected, BundleService.GetWellKnownAspireDir());
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/LayoutDiscoveryTests.cs
+++ b/tests/Aspire.Cli.Tests/LayoutDiscoveryTests.cs
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Layout;
+using Aspire.Shared;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests;
+
+public class LayoutDiscoveryTests : IDisposable
+{
+    private readonly List<string> _tempDirs = [];
+
+    [Fact]
+    public void DiscoverLayout_PrefersEnvVarOverWellKnownPath()
+    {
+        // Create a temp directory with a valid layout and set it via the env var.
+        // Even if a real layout exists at ~/.aspire/, the env var should take priority.
+        var fakeLayoutDir = CreateTempDirectory();
+        CreateValidBundleLayout(fakeLayoutDir);
+
+        var envBefore = Environment.GetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar, fakeLayoutDir);
+
+            var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance);
+            var layout = discovery.DiscoverLayout();
+
+            Assert.NotNull(layout);
+            Assert.Equal(fakeLayoutDir, layout.LayoutPath);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar, envBefore);
+        }
+    }
+
+    [Fact]
+    public void DiscoverLayout_IgnoresEnvVar_WhenPathHasNoValidLayout()
+    {
+        // Point the env var at an empty directory — it should be skipped.
+        var emptyDir = CreateTempDirectory();
+
+        var envBefore = Environment.GetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar, emptyDir);
+
+            var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance);
+            var layout = discovery.DiscoverLayout();
+
+            // Layout may still be discovered via relative or well-known paths,
+            // but it must NOT come from the invalid env var path.
+            if (layout is not null)
+            {
+                Assert.NotEqual(emptyDir, layout.LayoutPath);
+            }
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar, envBefore);
+        }
+    }
+
+    [Fact]
+    public void DiscoverLayout_RejectsLayout_WhenManagedDirectoriesExistButExecutableIsMissing()
+    {
+        // Create directories but no aspire-managed executable.
+        var incompleteDir = CreateTempDirectory();
+        Directory.CreateDirectory(Path.Combine(incompleteDir, BundleDiscovery.ManagedDirectoryName));
+        Directory.CreateDirectory(Path.Combine(incompleteDir, BundleDiscovery.DcpDirectoryName));
+
+        var envBefore = Environment.GetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar, incompleteDir);
+
+            var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance);
+            var layout = discovery.DiscoverLayout();
+
+            // The incomplete directory should not be selected as the layout path.
+            // The discovery may still find a valid layout elsewhere (relative or well-known).
+            if (layout is not null)
+            {
+                Assert.NotEqual(incompleteDir, layout.LayoutPath);
+            }
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar, envBefore);
+        }
+    }
+
+    private string CreateTempDirectory()
+    {
+        var dir = Directory.CreateTempSubdirectory("aspire-layout-test-").FullName;
+        _tempDirs.Add(dir);
+        return dir;
+    }
+
+    private static void CreateValidBundleLayout(string layoutPath)
+    {
+        var managedDir = Path.Combine(layoutPath, BundleDiscovery.ManagedDirectoryName);
+        var dcpDir = Path.Combine(layoutPath, BundleDiscovery.DcpDirectoryName);
+        Directory.CreateDirectory(managedDir);
+        Directory.CreateDirectory(dcpDir);
+
+        // Create a dummy aspire-managed executable
+        var managedExeName = BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName);
+        File.WriteAllText(Path.Combine(managedDir, managedExeName), "dummy");
+    }
+
+    public void Dispose()
+    {
+        foreach (var dir in _tempDirs)
+        {
+            try
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+            catch
+            {
+                // Best effort cleanup
+            }
+        }
+    }
+}

--- a/tests/Aspire.Cli.Tests/LayoutDiscoveryTests.cs
+++ b/tests/Aspire.Cli.Tests/LayoutDiscoveryTests.cs
@@ -12,83 +12,60 @@ public class LayoutDiscoveryTests : IDisposable
     private readonly List<string> _tempDirs = [];
 
     [Fact]
-    public void DiscoverLayout_PrefersEnvVarOverWellKnownPath()
+    public void DiscoverLayout_FindsWellKnownPath_WhenValidLayoutExists()
     {
-        // Create a temp directory with a valid layout and set it via the env var.
-        // Even if a real layout exists at ~/.aspire/, the env var should take priority.
-        var fakeLayoutDir = CreateTempDirectory();
-        CreateValidBundleLayout(fakeLayoutDir);
+        // Create a temp dir simulating ~/.aspire/ with a valid layout
+        var fakeHome = CreateTempDirectory();
+        var aspireDir = Path.Combine(fakeHome, ".aspire");
+        Directory.CreateDirectory(aspireDir);
+        CreateValidBundleLayout(aspireDir);
 
-        var envBefore = Environment.GetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar);
-        try
-        {
-            Environment.SetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar, fakeLayoutDir);
+        var context = CreateContext(fakeHome);
+        var discovery = new LayoutDiscovery(context, NullLogger<LayoutDiscovery>.Instance);
+        var layout = discovery.DiscoverLayout();
 
-            var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance);
-            var layout = discovery.DiscoverLayout();
-
-            Assert.NotNull(layout);
-            Assert.Equal(fakeLayoutDir, layout.LayoutPath);
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar, envBefore);
-        }
+        Assert.NotNull(layout);
+        Assert.Equal(aspireDir, layout.LayoutPath);
     }
 
     [Fact]
-    public void DiscoverLayout_IgnoresEnvVar_WhenPathHasNoValidLayout()
+    public void DiscoverLayout_ReturnsNull_WhenNoValidLayout()
     {
-        // Point the env var at an empty directory — it should be skipped.
-        var emptyDir = CreateTempDirectory();
+        // Create a temp dir with no valid layout anywhere
+        var fakeHome = CreateTempDirectory();
+        var aspireDir = Path.Combine(fakeHome, ".aspire");
+        Directory.CreateDirectory(aspireDir);
+        // No managed/dcp directories
 
-        var envBefore = Environment.GetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar);
-        try
+        var context = CreateContext(fakeHome);
+        var discovery = new LayoutDiscovery(context, NullLogger<LayoutDiscovery>.Instance);
+        var layout = discovery.DiscoverLayout();
+
+        // Layout could still be found via relative path (unlikely in test), but
+        // it should NOT find one at the well-known path because it's incomplete
+        if (layout is not null)
         {
-            Environment.SetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar, emptyDir);
-
-            var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance);
-            var layout = discovery.DiscoverLayout();
-
-            // Layout may still be discovered via relative or well-known paths,
-            // but it must NOT come from the invalid env var path.
-            if (layout is not null)
-            {
-                Assert.NotEqual(emptyDir, layout.LayoutPath);
-            }
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar, envBefore);
+            Assert.NotEqual(aspireDir, layout.LayoutPath);
         }
     }
 
     [Fact]
     public void DiscoverLayout_RejectsLayout_WhenManagedDirectoriesExistButExecutableIsMissing()
     {
-        // Create directories but no aspire-managed executable.
-        var incompleteDir = CreateTempDirectory();
-        Directory.CreateDirectory(Path.Combine(incompleteDir, BundleDiscovery.ManagedDirectoryName));
-        Directory.CreateDirectory(Path.Combine(incompleteDir, BundleDiscovery.DcpDirectoryName));
+        var fakeHome = CreateTempDirectory();
+        var aspireDir = Path.Combine(fakeHome, ".aspire");
+        Directory.CreateDirectory(Path.Combine(aspireDir, BundleDiscovery.ManagedDirectoryName));
+        Directory.CreateDirectory(Path.Combine(aspireDir, BundleDiscovery.DcpDirectoryName));
+        // No aspire-managed executable
 
-        var envBefore = Environment.GetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar);
-        try
+        var context = CreateContext(fakeHome);
+        var discovery = new LayoutDiscovery(context, NullLogger<LayoutDiscovery>.Instance);
+        var layout = discovery.DiscoverLayout();
+
+        // The incomplete directory should not be selected
+        if (layout is not null)
         {
-            Environment.SetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar, incompleteDir);
-
-            var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance);
-            var layout = discovery.DiscoverLayout();
-
-            // The incomplete directory should not be selected as the layout path.
-            // The discovery may still find a valid layout elsewhere (relative or well-known).
-            if (layout is not null)
-            {
-                Assert.NotEqual(incompleteDir, layout.LayoutPath);
-            }
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(BundleDiscovery.LayoutPathEnvVar, envBefore);
+            Assert.NotEqual(aspireDir, layout.LayoutPath);
         }
     }
 
@@ -97,6 +74,19 @@ public class LayoutDiscoveryTests : IDisposable
         var dir = Directory.CreateTempSubdirectory("aspire-layout-test-").FullName;
         _tempDirs.Add(dir);
         return dir;
+    }
+
+    private static CliExecutionContext CreateContext(string homeDir)
+    {
+        var aspireDir = Path.Combine(homeDir, ".aspire");
+        return new CliExecutionContext(
+            new DirectoryInfo("."),
+            new DirectoryInfo(Path.Combine(aspireDir, "hives")),
+            new DirectoryInfo(Path.Combine(aspireDir, "cache")),
+            new DirectoryInfo(Path.Combine(aspireDir, "sdks")),
+            new DirectoryInfo(Path.Combine(aspireDir, "logs")),
+            "test.log",
+            homeDirectory: new DirectoryInfo(homeDir));
     }
 
     private static void CreateValidBundleLayout(string layoutPath)

--- a/tests/Aspire.Cli.Tests/LayoutDiscoveryTests.cs
+++ b/tests/Aspire.Cli.Tests/LayoutDiscoveryTests.cs
@@ -76,7 +76,7 @@ public class LayoutDiscoveryTests : IDisposable
         return dir;
     }
 
-    private static CliExecutionContext CreateContext(string homeDir)
+    private static CliExecutionContext CreateContext(string homeDir, IReadOnlyDictionary<string, string?>? environmentVariables = null)
     {
         var aspireDir = Path.Combine(homeDir, ".aspire");
         return new CliExecutionContext(
@@ -86,6 +86,7 @@ public class LayoutDiscoveryTests : IDisposable
             new DirectoryInfo(Path.Combine(aspireDir, "sdks")),
             new DirectoryInfo(Path.Combine(aspireDir, "logs")),
             "test.log",
+            environmentVariables: environmentVariables ?? new Dictionary<string, string?>(),
             homeDirectory: new DirectoryInfo(homeDir));
     }
 

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -595,6 +595,9 @@ internal sealed class NullBundleService : IBundleService
 
     public Task<Layout.LayoutConfiguration?> EnsureExtractedAndGetLayoutAsync(CancellationToken cancellationToken = default)
         => Task.FromResult<Layout.LayoutConfiguration?>(null);
+
+    public string GetDefaultExtractDir(string processPath)
+        => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspire");
 }
 
 /// <summary>
@@ -611,6 +614,9 @@ internal sealed class TestBundleService(bool isBundle) : IBundleService
 
     public Task<Layout.LayoutConfiguration?> EnsureExtractedAndGetLayoutAsync(CancellationToken cancellationToken = default)
         => Task.FromResult<Layout.LayoutConfiguration?>(null);
+
+    public string GetDefaultExtractDir(string processPath)
+        => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspire");
 }
 
 internal sealed class TestOutputTextWriter : TextWriter


### PR DESCRIPTION
## Description

Fixes #15454

When the Aspire CLI is installed outside the standard `~/.aspire/bin/` layout (e.g., via Homebrew at `/usr/local/bin/` or Winget at `C:\Program Files\`), the bundle extraction previously wrote `.aspire-bundle-version` and extracted `managed/`/`dcp/` directories to the parent of the CLI's parent directory — which could be a system directory like `/usr/local/` or `C:\Program Files\`.

This PR changes the default extraction directory logic to detect non-standard install locations and fall back to the well-known `~/.aspire/` directory instead.

## Changes

### `BundleService.cs`
- Updated `GetDefaultExtractDir` to check if the parent-of-parent is a `.aspire` directory (standard layout). If not, falls back to `~/.aspire/`.
- Added `GetWellKnownAspireDir()` helper that returns `~/.aspire/` cross-platform.
- Added `IsAspireDirectory()` helper for the directory name check.

### `LayoutDiscovery.cs`
- Added `~/.aspire/` as a well-known fallback in `DiscoverLayout()` (step 3, after env var and relative-path checks).
- This ensures the CLI can find extracted content even when installed outside `~/.aspire/bin/`.

### `BundleServiceTests.cs`
- Renamed existing test to `GetDefaultExtractDir_ReturnsAspireDir_ForStandardLayout`.
- Added `GetDefaultExtractDir_FallsBackToWellKnownDir_ForNonStandardLayout` (Homebrew, Winget).
- Added `GetDefaultExtractDir_FallsBackToWellKnownDir_ForCustomInstallLocation`.
- Added `GetWellKnownAspireDir_ReturnsExpectedPath`.

### `LayoutDiscoveryTests.cs` (new)
- Tests for layout discovery priority: env var > relative > well-known path.
- Tests that invalid layouts at the env var path are skipped.

### `docs/specs/bundle.md`
- Documented the extraction directory resolution logic.

## Backward Compatibility

For the standard install path (`~/.aspire/bin/aspire`), behavior is unchanged — `GetDefaultExtractDir` returns `~/.aspire/` in both the old and new code paths. The `--install-path` flag on `aspire setup` continues to override all default logic.