### PR TITLE
Fix Swarm UpdateConfig property types

### DIFF
--- a/src/Aspire.Hosting.Docker/Resources/ServiceNodes/Swarm/UpdateConfig.cs
+++ b/src/Aspire.Hosting.Docker/Resources/ServiceNodes/Swarm/UpdateConfig.cs
@@ -16,12 +16,10 @@ namespace Aspire.Hosting.Docker.Resources.ServiceNodes.Swarm;
 public sealed class UpdateConfig
 {
     /// <summary>
-    /// Gets or sets the level of parallelism applied during the update process.
-    /// This property specifies the maximum number of service tasks that can
-    /// be updated simultaneously.
+    /// Gets or sets the maximum number of service tasks that can be updated simultaneously.
     /// </summary>
     [YamlMember(Alias = "parallelism")]
-    public string? Parallelism { get; set; }
+    public int? Parallelism { get; set; }
 
     /// <summary>
     /// Represents the delay between each update operation for a service node in a swarm configuration.
@@ -30,10 +28,11 @@ public sealed class UpdateConfig
     public string? Delay { get; set; }
 
     /// <summary>
-    /// Indicates whether the update process should stop and fail upon encountering an error.
+    /// Gets or sets the action to take when an update fails.
+    /// Valid values are <c>"continue"</c>, <c>"rollback"</c>, and <c>"pause"</c>.
     /// </summary>
     [YamlMember(Alias = "failure_action")]
-    public bool? FailOnError { get; set; }
+    public string? FailureAction { get; set; }
 
     /// <summary>
     /// Gets or sets the duration or interval for monitoring the progress of an update.

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposeTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposeTests.cs
@@ -211,6 +211,43 @@ public class DockerComposeTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public async Task DockerSwarmUpdateConfigSerializedCorrectly()
+    {
+        using var tempDir = new TestTempDirectory();
+
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, tempDir.Path);
+        builder.Services.AddSingleton<IResourceContainerImageManager, MockImageBuilder>();
+
+        builder.AddDockerComposeEnvironment("swarm-env");
+
+        builder.AddContainer("my-service", "my-image:latest")
+            .PublishAsDockerComposeService((resource, service) =>
+            {
+                service.Deploy = new Aspire.Hosting.Docker.Resources.ServiceNodes.Swarm.Deploy
+                {
+                    UpdateConfig = new Aspire.Hosting.Docker.Resources.ServiceNodes.Swarm.UpdateConfig
+                    {
+                        Parallelism = 2,
+                        Delay = "10s",
+                        FailureAction = "rollback",
+                        Monitor = "5s",
+                        MaxFailureRatio = "0.3",
+                        Order = "start-first"
+                    }
+                };
+            });
+
+        using var app = builder.Build();
+        app.Run();
+
+        var composeFile = Path.Combine(tempDir.Path, "docker-compose.yaml");
+        Assert.True(File.Exists(composeFile), "Docker Compose file was not created.");
+        var composeContent = File.ReadAllText(composeFile);
+
+        await Verify(composeContent, "yaml");
+    }
+
+    [Fact]
     public async Task GetHostAddressExpression()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DockerSwarmUpdateConfigSerializedCorrectly.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DockerSwarmUpdateConfigSerializedCorrectly.verified.yaml
@@ -1,0 +1,26 @@
+﻿services:
+  swarm-env-dashboard:
+    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+    ports:
+      - "18888"
+    expose:
+      - "18889"
+      - "18890"
+    networks:
+      - "aspire"
+    restart: "always"
+  my-service:
+    image: "my-image:latest"
+    networks:
+      - "aspire"
+    deploy:
+      update_config:
+        parallelism: 2
+        delay: "10s"
+        failure_action: "rollback"
+        monitor: "5s"
+        max_failure_ratio: "0.3"
+        order: "start-first"
+networks:
+  aspire:
+    driver: "bridge"


### PR DESCRIPTION
## Description

Fix incorrect property types in the Docker Swarm `UpdateConfig` class that cause invalid Docker Compose YAML to be generated.

Two bugs:
- **`Parallelism`** was `string?` but Docker Compose spec requires an integer. This caused the value to be serialized as `"2"` (quoted string) instead of `2` (integer), which Docker rejects.
- **`FailOnError`** was `bool?` mapped to `failure_action`, but Docker Compose spec requires a string enum (`"continue"`, `"rollback"`, or `"pause"`). Renamed to `FailureAction` to better reflect the YAML alias `failure_action` and its semantics.

Also added a snapshot unit test verifying correct YAML serialization of all `UpdateConfig` properties.

Fixes #11691

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
