### PR TITLE
Add regression test for RabbitMQ management port ACA publish

### DIFF
--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -1260,6 +1260,42 @@ public class AzureContainerAppsTests
     }
 
     [Fact]
+    public async Task ContainerWithTcpAndHttpEndpointsPublishesToAzureContainerApps()
+    {
+        // Regression test for https://github.com/microsoft/aspire/issues/11841
+        // A container with both a TCP endpoint (e.g. AMQP on 5672) and an HTTP
+        // endpoint on a non-standard port (e.g. management UI on 15672) should
+        // publish successfully. The HTTP endpoint becomes the primary ingress and
+        // the TCP endpoint goes to additionalPortMappings.
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        builder.AddAzureContainerAppEnvironment("env");
+
+        builder.AddContainer("messaging", "rabbitmq:management")
+            .WithEndpoint(targetPort: 5672, name: "amqp")
+            .WithHttpEndpoint(port: 15672, targetPort: 15672, name: "management");
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var container = Assert.Single(model.GetContainerResources());
+
+        container.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var target);
+
+        var resource = target?.DeploymentTarget as AzureProvisioningResource;
+
+        Assert.NotNull(resource);
+
+        var (manifest, bicep) = await GetManifestWithBicep(resource);
+
+        await Verify(manifest.ToString(), "json")
+              .AppendContentAsFile(bicep, "bicep");
+    }
+
+    [Fact]
     public async Task CanPreserveHttpSchemeUsingWithHttpsUpgrade()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerWithTcpAndHttpEndpointsPublishesToAzureContainerApps.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerWithTcpAndHttpEndpointsPublishesToAzureContainerApps.verified.bicep
@@ -1,0 +1,39 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param env_outputs_azure_container_apps_environment_default_domain string
+
+param env_outputs_azure_container_apps_environment_id string
+
+resource messaging 'Microsoft.App/containerApps@2025-01-01' = {
+  name: 'messaging'
+  location: location
+  properties: {
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        external: false
+        targetPort: 15672
+        transport: 'http'
+        additionalPortMappings: [
+          {
+            external: false
+            targetPort: 5672
+          }
+        ]
+      }
+    }
+    environmentId: env_outputs_azure_container_apps_environment_id
+    template: {
+      containers: [
+        {
+          image: 'rabbitmq:management'
+          name: 'messaging'
+        }
+      ]
+      scale: {
+        minReplicas: 1
+      }
+    }
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerWithTcpAndHttpEndpointsPublishesToAzureContainerApps.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureContainerAppsTests.ContainerWithTcpAndHttpEndpointsPublishesToAzureContainerApps.verified.json
@@ -1,0 +1,8 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "messaging-containerapp.module.bicep",
+  "params": {
+    "env_outputs_azure_container_apps_environment_default_domain": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}",
+    "env_outputs_azure_container_apps_environment_id": "{env.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}"
+  }
+}


### PR DESCRIPTION
## Description

Adds a regression test for #11841 where publishing a RabbitMQ container with the management plugin to Azure Container Apps failed with `"The endpoint 'management' is an http endpoint and must use port 80"`.

The ACA endpoint processing logic in `ContainerAppContext.ProcessEndpoints()` has since been refactored and this scenario now works correctly — the HTTP management endpoint (port 15672) becomes the primary ingress and the TCP AMQP endpoint (port 5672) goes to `additionalPortMappings`. This test ensures it stays fixed.

The test uses the same pattern as existing ACA endpoint tests (`DefaultHttpIngressUsesPort80EvenWithDifferentDevPort`, `UnsupportedTransportThrows`, etc.) — it simulates a container with mixed TCP + HTTP endpoints and verifies the generated Bicep via snapshot testing.

Fixes #11841

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
