### PR TITLE
Re-enable disabled CLI test (#14321)

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/BannerTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/BannerTests.cs
@@ -88,7 +88,6 @@ public sealed class BannerTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/microsoft/aspire/issues/14307")]
     public async Task Banner_NotDisplayedWithNoLogoFlag()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.EndToEnd.Tests/BannerTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/BannerTests.cs
@@ -88,6 +88,7 @@ public sealed class BannerTests(ITestOutputHelper output)
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/14307")]
     public async Task Banner_NotDisplayedWithNoLogoFlag()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -483,7 +483,6 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/microsoft/aspire/issues/14321")]
     public async Task RunCommand_SkipsBuild_WhenExtensionDevKitCapabilityIsAvailable()
     {
         var buildCalled = false;

--- a/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/RunCommandTests.cs
@@ -483,7 +483,7 @@ public class RunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task RunCommand_SkipsBuild_WhenExtensionDevKitCapabilityIsAvailable()
+    public async Task RunCommand_SkipsBuild_WhenBuildDotNetUsingCliCapabilityIsAvailable()
     {
         var buildCalled = false;
 


### PR DESCRIPTION
## Description

Re-enable a disabled CLI test by removing its `[ActiveIssue]` attribute.

### Test re-enabled

- **`RunCommand_SkipsBuild_WhenExtensionDevKitCapabilityIsAvailable`** (RunCommandTests.cs) — was disabled by #14321

### Why it's safe to re-enable

The underlying issue was resolved by #14150 ("Build in CLI if not in extension host or extension has new build capability"). That PR refactored the build-skip logic in `DotNetAppHostProject.RunAsync`:

- **Before**: The build was skipped only when the extension reported the `"devkit"` capability via `HasCapabilityAsync(KnownCapabilities.DevKit)`. The check lived in `RunCommand` itself and had race/timing issues with the test harness.
- **After**: The build is now skipped for *all* extension hosts by default. It only runs if the extension explicitly reports the `"build-dotnet-using-cli"` capability. Additionally, watch mode is automatically enabled for extension hosts (without `--start-debug-session`), meaning the build code path is never reached in this scenario. The `BuildCompletionSource` signaling pattern also ensures `RunCommand` doesn't hang waiting for build results.

The test passes locally.

Fixes #14321

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
