### PR TITLE
Fix Banner_NotDisplayedWithNoLogoFlag E2E test (#14307)

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj
@@ -64,6 +64,8 @@
 
   <ItemGroup>
     <Compile Include="..\..\src\Aspire.Cli\Resources\AddCommandStrings.Designer.cs" Link="Resources\AddCommandStrings.Designer.cs" />
+    <Compile Include="..\..\src\Aspire.Cli\Resources\HelpGroupStrings.Designer.cs" Link="Resources\HelpGroupStrings.Designer.cs" />
+    <Compile Include="..\..\src\Aspire.Cli\Resources\RootCommandStrings.Designer.cs" Link="Resources\RootCommandStrings.Designer.cs" />
     <Compile Include="..\..\src\Aspire.Cli\Resources\RunCommandStrings.Designer.cs" Link="Resources\RunCommandStrings.Designer.cs" />
     <Compile Include="..\..\src\Aspire.Cli\Resources\SharedCommandStrings.Designer.cs" Link="Resources\SharedCommandStrings.Designer.cs" />
     <Compile Include="..\..\src\Aspire.Cli\Resources\StopCommandStrings.Designer.cs" Link="Resources\StopCommandStrings.Designer.cs" />
@@ -71,6 +73,8 @@
 
   <ItemGroup>
     <EmbeddedResource Include="..\..\src\Aspire.Cli\Resources\AddCommandStrings.resx" Link="Resources\AddCommandStrings.resx" LogicalName="Aspire.Cli.Resources.AddCommandStrings.resources" />
+    <EmbeddedResource Include="..\..\src\Aspire.Cli\Resources\HelpGroupStrings.resx" Link="Resources\HelpGroupStrings.resx" LogicalName="Aspire.Cli.Resources.HelpGroupStrings.resources" />
+    <EmbeddedResource Include="..\..\src\Aspire.Cli\Resources\RootCommandStrings.resx" Link="Resources\RootCommandStrings.resx" LogicalName="Aspire.Cli.Resources.RootCommandStrings.resources" />
     <EmbeddedResource Include="..\..\src\Aspire.Cli\Resources\RunCommandStrings.resx" Link="Resources\RunCommandStrings.resx" LogicalName="Aspire.Cli.Resources.RunCommandStrings.resources" />
     <EmbeddedResource Include="..\..\src\Aspire.Cli\Resources\SharedCommandStrings.resx" Link="Resources\SharedCommandStrings.resx" LogicalName="Aspire.Cli.Resources.SharedCommandStrings.resources" />
     <EmbeddedResource Include="..\..\src\Aspire.Cli\Resources\StopCommandStrings.resx" Link="Resources\StopCommandStrings.resx" LogicalName="Aspire.Cli.Resources.StopCommandStrings.resources" />

--- a/tests/Aspire.Cli.EndToEnd.Tests/BannerTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/BannerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.Utils;
 using Hex1b.Automation;
 using Xunit;
@@ -46,7 +47,7 @@ public sealed class BannerTests(ITestOutputHelper output)
         await auto.TypeAsync("aspire cache clear");
         await auto.EnterAsync();
         await auto.WaitUntilAsync(
-            s => s.ContainsText("Welcome to the") && s.ContainsText("Telemetry"),
+            s => s.ContainsText(RootCommandStrings.BannerWelcomeText) && s.ContainsText("Telemetry"),
             timeout: TimeSpan.FromSeconds(30), description: "waiting for banner and telemetry notice on first run");
         await auto.WaitForSuccessPromptAsync(counter);
         await auto.TypeAsync("exit");
@@ -78,7 +79,7 @@ public sealed class BannerTests(ITestOutputHelper output)
         await auto.TypeAsync("aspire --banner");
         await auto.EnterAsync();
         await auto.WaitUntilAsync(
-            s => s.ContainsText("Welcome to the") && s.ContainsText("CLI"),
+            s => s.ContainsText(RootCommandStrings.BannerWelcomeText) && s.ContainsText("CLI"),
             timeout: TimeSpan.FromSeconds(30), description: "waiting for banner with version info");
         await auto.WaitForSuccessPromptAsync(counter);
         await auto.TypeAsync("exit");
@@ -114,23 +115,21 @@ public sealed class BannerTests(ITestOutputHelper output)
         await auto.ClearScreenAsync(counter);
         await auto.TypeAsync("aspire --nologo --help");
         await auto.EnterAsync();
+        // Wait for the help hint that appears at the very end of help output.
+        // This ensures the full help text has been rendered to the visible console
+        // before we check for the absence of the banner.
         await auto.WaitUntilAsync(s =>
         {
-            // Wait for help output to confirm command completed
-            if (!s.ContainsText("Commands:"))
-            {
-                return false;
-            }
-
             // Verify the banner does NOT appear
-            if (s.ContainsText("Welcome to the"))
+            if (s.ContainsText(RootCommandStrings.BannerWelcomeText))
             {
                 throw new InvalidOperationException(
                     "Unexpected banner displayed when --nologo flag was used!");
             }
 
-            return true;
-        }, timeout: TimeSpan.FromSeconds(30), description: "waiting for help output without banner");
+            // Only return true once the help hint is visible at the end of the output
+            return s.ContainsText(HelpGroupStrings.HelpHint);
+        }, timeout: TimeSpan.FromSeconds(30), description: "waiting for help output to complete");
         await auto.WaitForSuccessPromptAsync(counter);
         await auto.TypeAsync("exit");
         await auto.EnterAsync();

--- a/tests/Aspire.Cli.EndToEnd.Tests/BannerTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/BannerTests.cs
@@ -89,7 +89,6 @@ public sealed class BannerTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/microsoft/aspire/issues/14307")]
     public async Task Banner_NotDisplayedWithNoLogoFlag()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();


### PR DESCRIPTION
## Description

Fix the `Banner_NotDisplayedWithNoLogoFlag` E2E test and re-enable it by removing the `[ActiveIssue]` attribute.

**Root cause**: The test was checking for `"Commands:"` in the help output to confirm the command completed, but help output was refactored to use grouped headings (`"App commands:"`, `"Resource management:"`, etc.) instead of a single `"Commands:"` heading. This meant the `WaitUntilAsync` would never find a match and timed out after 30 seconds.

**Fix**:
- Replace the `"Commands:"` check with `HelpGroupStrings.HelpHint` — the help hint text that appears at the very end of help output, ensuring the full output has rendered before asserting
- Replace all hardcoded `"Welcome to the"` strings with `RootCommandStrings.BannerWelcomeText` resource references
- Add `RootCommandStrings` and `HelpGroupStrings` resource references to the E2E test csproj (following existing pattern for other resource files)
- Remove `[ActiveIssue]` to re-enable the test

Fixes #14307

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
