### PR TITLE
Use Spectre.Console link markup for CLI URL output

### DIFF
--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -82,6 +82,7 @@
     <Compile Include="$(SharedDir)CircularBuffer.cs" Link="Utils\CircularBuffer.cs" />
     <Compile Include="$(SharedDir)ColorGenerator.cs" Link="Utils\ColorGenerator.cs" />
     <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />
+    <Compile Include="$(SharedDir)KnownUnsupportedUrlSchemes.cs" Link="Utils\KnownUnsupportedUrlSchemes.cs" />
     <Compile Include="$(SharedDir)LocaleHelpers.cs" Link="Utils\LocaleHelpers.cs" />
     <Compile Include="$(SharedDir)DurationFormatter.cs" Link="Utils\DurationFormatter.cs" />
     <Compile Include="$(SharedDir)IConfigurationExtensions.cs" Link="Utils\IConfigurationExtensions.cs" />

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -11,6 +11,7 @@ using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
+using Aspire.Shared;
 using Aspire.Shared.Model.Serialization;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
@@ -281,7 +282,8 @@ internal sealed class DescribeCommand : BaseCommand
         foreach (var (snapshot, displayName) in orderedItems)
         {
             var endpoints = snapshot.Urls.Length > 0
-                ? string.Join(", ", snapshot.Urls.Where(e => !e.IsInternal).Select(e => e.Url.EscapeMarkup()))
+                ? string.Join(", ", OrderUrls(snapshot.Urls.Where(e => !e.IsInternal))
+                    .Select(e => FormatEndpointUrl(e.Url, e.DisplayProperties?.DisplayName)))
                 : "-";
 
             var type = snapshot.ResourceType?.EscapeMarkup() ?? "-";
@@ -298,9 +300,9 @@ internal sealed class DescribeCommand : BaseCommand
     {
         var displayName = ResourceSnapshotMapper.GetResourceName(snapshot, allResources);
 
-        var endpoints = snapshot.Urls.Length > 0
-            ? string.Join(", ", snapshot.Urls.Where(e => !e.IsInternal).Select(e => e.Url))
-            : "";
+        var endpoints = OrderUrls(snapshot.Urls.Where(e => !e.IsInternal))
+            .Select(e => (e.Url, DisplayName: e.DisplayProperties?.DisplayName ?? ""))
+            .ToArray();
 
         return new ResourceDisplayState(displayName, snapshot.State, snapshot.HealthStatus, endpoints);
     }
@@ -309,7 +311,9 @@ internal sealed class DescribeCommand : BaseCommand
     {
         var stateText = ColorState(state.State);
         var healthText = !string.IsNullOrEmpty(state.HealthStatus) ? $" ({ColorHealth(state.HealthStatus.EscapeMarkup())})" : "";
-        var endpointsStr = !string.IsNullOrEmpty(state.Endpoints) ? $" - {state.Endpoints.EscapeMarkup()}" : "";
+        var endpointsStr = state.Endpoints.Length > 0
+            ? $" - {string.Join(", ", state.Endpoints.Select(e => FormatEndpointUrl(e.Url, e.DisplayName)))}"
+            : "";
 
         _interactionService.DisplayMarkupLine($"{ColorResourceName(state.DisplayName, $"[[{state.DisplayName.EscapeMarkup()}]]")} {stateText}{healthText}{endpointsStr}");
     }
@@ -335,6 +339,20 @@ internal sealed class DescribeCommand : BaseCommand
         };
     }
 
+    private static IOrderedEnumerable<ResourceSnapshotUrl> OrderUrls(IEnumerable<ResourceSnapshotUrl> urls) =>
+        urls.OrderByDescending(e => e.DisplayProperties?.SortOrder ?? 0)
+            .ThenByDescending(e => e.Url.StartsWith("https", StringComparison.OrdinalIgnoreCase))
+            .ThenBy(e => e.Name, StringComparer.OrdinalIgnoreCase);
+
+    private static string FormatEndpointUrl(string url, string? displayName = null)
+    {
+        var escaped = url.EscapeMarkup();
+        var text = !string.IsNullOrEmpty(displayName) ? displayName.EscapeMarkup() : escaped;
+        return KnownUnsupportedUrlSchemes.IsLinkableUrl(url)
+            ? $"[link={escaped}]{text}[/]"
+            : text;
+    }
+
     private static string ColorHealth(string health) => health.ToUpperInvariant() switch
     {
         "HEALTHY" => $"[green]{health}[/]",
@@ -346,5 +364,5 @@ internal sealed class DescribeCommand : BaseCommand
     /// <summary>
     /// Represents the display state of a resource for deduplication during watch mode.
     /// </summary>
-    private sealed record ResourceDisplayState(string DisplayName, string? State, string? HealthStatus, string Endpoints);
+    private sealed record ResourceDisplayState(string DisplayName, string? State, string? HealthStatus, (string Url, string DisplayName)[] Endpoints);
 }

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -364,14 +364,21 @@ internal sealed class DescribeCommand : BaseCommand
     /// <summary>
     /// Represents the display state of a resource for deduplication during watch mode.
     /// </summary>
-    private sealed record ResourceDisplayState(string DisplayName, string? State, string? HealthStatus, (string Url, string DisplayName)[] Endpoints)
+    private sealed class ResourceDisplayState(string displayName, string? state, string? healthStatus, (string Url, string DisplayName)[] endpoints) : IEquatable<ResourceDisplayState>
     {
+        public string DisplayName { get; } = displayName;
+        public string? State { get; } = state;
+        public string? HealthStatus { get; } = healthStatus;
+        public (string Url, string DisplayName)[] Endpoints { get; } = endpoints;
+
         public bool Equals(ResourceDisplayState? other) =>
             other is not null &&
             DisplayName == other.DisplayName &&
             State == other.State &&
             HealthStatus == other.HealthStatus &&
             Endpoints.AsSpan().SequenceEqual(other.Endpoints);
+
+        public override bool Equals(object? obj) => Equals(obj as ResourceDisplayState);
 
         public override int GetHashCode() =>
             HashCode.Combine(DisplayName, State, HealthStatus, Endpoints.Length);

--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -364,5 +364,16 @@ internal sealed class DescribeCommand : BaseCommand
     /// <summary>
     /// Represents the display state of a resource for deduplication during watch mode.
     /// </summary>
-    private sealed record ResourceDisplayState(string DisplayName, string? State, string? HealthStatus, (string Url, string DisplayName)[] Endpoints);
+    private sealed record ResourceDisplayState(string DisplayName, string? State, string? HealthStatus, (string Url, string DisplayName)[] Endpoints)
+    {
+        public bool Equals(ResourceDisplayState? other) =>
+            other is not null &&
+            DisplayName == other.DisplayName &&
+            State == other.State &&
+            HealthStatus == other.HealthStatus &&
+            Endpoints.AsSpan().SequenceEqual(other.Endpoints);
+
+        public override int GetHashCode() =>
+            HashCode.Combine(DisplayName, State, HealthStatus, Endpoints.Length);
+    }
 }

--- a/src/Aspire.Cli/Commands/DoctorCommand.cs
+++ b/src/Aspire.Cli/Commands/DoctorCommand.cs
@@ -121,7 +121,8 @@ internal sealed class DoctorCommand : BaseCommand
         // Show link to detailed prerequisites if there are warnings or failures
         if (warnings > 0 || failed > 0)
         {
-            _ansiConsole.MarkupLine(DoctorCommandStrings.DetailedPrerequisitesLink);
+            const string prerequisitesUrl = "https://aka.ms/aspire-prerequisites";
+            _ansiConsole.MarkupLine(string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DetailedPrerequisitesLink, $"[link]{prerequisitesUrl}[/]"));
         }
     }
 
@@ -159,7 +160,7 @@ internal sealed class DoctorCommand : BaseCommand
 
             if (hasLink)
             {
-                detailGrid.AddRow(new Markup($"See: {result.Link!.EscapeMarkup()}"));
+                detailGrid.AddRow(new Markup($"See: [link={result.Link!.EscapeMarkup()}]{result.Link!.EscapeMarkup()}[/]"));
             }
 
             if (hasDetails)

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -214,13 +214,18 @@ internal sealed class PsCommand : BaseCommand
         {
             var shortPath = ShortenPath(appHost.AppHostPath);
             var cliPid = appHost.CliPid?.ToString(CultureInfo.InvariantCulture) ?? "-";
-            var dashboard = string.IsNullOrEmpty(appHost.DashboardUrl) ? "-" : appHost.DashboardUrl;
+            var dashboard = "-";
+            if (!string.IsNullOrEmpty(appHost.DashboardUrl) && Uri.TryCreate(appHost.DashboardUrl, UriKind.Absolute, out var dashboardUri))
+            {
+                var displayText = $"{dashboardUri.Scheme}://{dashboardUri.Authority}";
+                dashboard = $"[link={Markup.Escape(appHost.DashboardUrl)}]{Markup.Escape(displayText)}[/]";
+            }
 
             table.AddRow(
                 Markup.Escape(shortPath),
                 appHost.AppHostPid.ToString(CultureInfo.InvariantCulture),
                 cliPid,
-                Markup.Escape(dashboard));
+                dashboard);
         }
 
         _interactionService.DisplayRenderable(table);

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -215,10 +215,17 @@ internal sealed class PsCommand : BaseCommand
             var shortPath = ShortenPath(appHost.AppHostPath);
             var cliPid = appHost.CliPid?.ToString(CultureInfo.InvariantCulture) ?? "-";
             var dashboard = "-";
-            if (!string.IsNullOrEmpty(appHost.DashboardUrl) && Uri.TryCreate(appHost.DashboardUrl, UriKind.Absolute, out var dashboardUri))
+            if (!string.IsNullOrEmpty(appHost.DashboardUrl))
             {
-                var displayText = $"{dashboardUri.Scheme}://{dashboardUri.Authority}";
-                dashboard = $"[link={Markup.Escape(appHost.DashboardUrl)}]{Markup.Escape(displayText)}[/]";
+                if (Uri.TryCreate(appHost.DashboardUrl, UriKind.Absolute, out var dashboardUri))
+                {
+                    var displayText = $"{dashboardUri.Scheme}://{dashboardUri.Authority}";
+                    dashboard = $"[link={Markup.Escape(appHost.DashboardUrl)}]{Markup.Escape(displayText)}[/]";
+                }
+                else
+                {
+                    dashboard = Markup.Escape(appHost.DashboardUrl);
+                }
             }
 
             table.AddRow(

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -589,8 +589,10 @@ public class Program
                 // Write to stderr to avoid interfering with tools that parse stdout
                 var consoleEnvironment = serviceProvider.GetRequiredService<ConsoleEnvironment>();
 
+                const string telemetryUrl = "https://aka.ms/aspire/cli-telemetry";
+
                 consoleEnvironment.Error.WriteLine();
-                consoleEnvironment.Error.WriteLine(RootCommandStrings.FirstTimeUseTelemetryNotice);
+                consoleEnvironment.Error.MarkupLine(string.Format(CultureInfo.CurrentCulture, RootCommandStrings.FirstTimeUseTelemetryNotice, $"[link]{telemetryUrl}[/]"));
                 consoleEnvironment.Error.WriteLine();
             }
 

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
@@ -123,7 +123,7 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to For detailed prerequisites: https://aka.ms/aspire-prerequisites.
+        ///   Looks up a localized string similar to For detailed prerequisites: {0}.
         /// </summary>
         public static string DetailedPrerequisitesLink {
             get {

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
@@ -80,7 +80,8 @@
     <value>Summary: {0} passed, {1} warnings, {2} failed</value>
   </data>
   <data name="DetailedPrerequisitesLink" xml:space="preserve">
-    <value>For detailed prerequisites: https://aka.ms/aspire-prerequisites</value>
+    <value>For detailed prerequisites: {0}</value>
+    <comment>{0} is a clickable URL</comment>
   </data>
   <data name="CheckingPrerequisites" xml:space="preserve">
     <value>Checking Aspire environment...</value>

--- a/src/Aspire.Cli/Resources/RootCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/RootCommandStrings.Designer.cs
@@ -138,15 +138,6 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Welcome to Aspire! Learn more about Aspire at https://aspire.dev.
-        /// </summary>
-        public static string FirstTimeUseWelcome {
-            get {
-                return ResourceManager.GetString("FirstTimeUseWelcome", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to Suppress the startup banner and telemetry notice..
         /// </summary>
         public static string NoLogoArgumentDescription {

--- a/src/Aspire.Cli/Resources/RootCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/RootCommandStrings.Designer.cs
@@ -129,7 +129,7 @@ namespace Aspire.Cli.Resources {
         ///
         ///The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to &apos;1&apos; or &apos;true&apos; using your preferred shell.
         ///
-        ///Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry.
+        ///Read more about Aspire CLI telemetry: {0}.
         /// </summary>
         public static string FirstTimeUseTelemetryNotice {
             get {

--- a/src/Aspire.Cli/Resources/RootCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/RootCommandStrings.resx
@@ -150,9 +150,6 @@
   <data name="NonInteractiveArgumentDescription" xml:space="preserve">
     <value>Run the command in non-interactive mode, disabling all interactive prompts and spinners</value>
   </data>
-  <data name="FirstTimeUseWelcome" xml:space="preserve">
-    <value>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</value>
-  </data>
   <data name="FirstTimeUseTelemetryNotice" xml:space="preserve">
     <value>Telemetry
 ---------

--- a/src/Aspire.Cli/Resources/RootCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/RootCommandStrings.resx
@@ -159,6 +159,7 @@
 
 The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</value>
+Read more about Aspire CLI telemetry: {0}</value>
+    <comment>{0} is a clickable URL</comment>
   </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
@@ -18,9 +18,9 @@
         <note />
       </trans-unit>
       <trans-unit id="DetailedPrerequisitesLink">
-        <source>For detailed prerequisites: https://aka.ms/aspire-prerequisites</source>
-        <target state="translated">Podrobné informace o požadavcích: https://aka.ms/aspire-prerequisites</target>
-        <note />
+        <source>For detailed prerequisites: {0}</source>
+        <target state="new">For detailed prerequisites: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="DevCertsCleanAndTrustFixFormat">
         <source>Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
@@ -18,9 +18,9 @@
         <note />
       </trans-unit>
       <trans-unit id="DetailedPrerequisitesLink">
-        <source>For detailed prerequisites: https://aka.ms/aspire-prerequisites</source>
-        <target state="translated">Für detaillierte Voraussetzungen: https://aka.ms/aspire-prerequisites</target>
-        <note />
+        <source>For detailed prerequisites: {0}</source>
+        <target state="new">For detailed prerequisites: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="DevCertsCleanAndTrustFixFormat">
         <source>Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
@@ -18,9 +18,9 @@
         <note />
       </trans-unit>
       <trans-unit id="DetailedPrerequisitesLink">
-        <source>For detailed prerequisites: https://aka.ms/aspire-prerequisites</source>
-        <target state="translated">Para conocer los requisitos previos detallados: https://aka.ms/aspire-prerequisites</target>
-        <note />
+        <source>For detailed prerequisites: {0}</source>
+        <target state="new">For detailed prerequisites: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="DevCertsCleanAndTrustFixFormat">
         <source>Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
@@ -18,9 +18,9 @@
         <note />
       </trans-unit>
       <trans-unit id="DetailedPrerequisitesLink">
-        <source>For detailed prerequisites: https://aka.ms/aspire-prerequisites</source>
-        <target state="translated">Pour les prérequis détaillés : https://aka.ms/aspire-prerequisites</target>
-        <note />
+        <source>For detailed prerequisites: {0}</source>
+        <target state="new">For detailed prerequisites: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="DevCertsCleanAndTrustFixFormat">
         <source>Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
@@ -18,9 +18,9 @@
         <note />
       </trans-unit>
       <trans-unit id="DetailedPrerequisitesLink">
-        <source>For detailed prerequisites: https://aka.ms/aspire-prerequisites</source>
-        <target state="translated">Per prerequisiti dettagliati: https://aka.ms/aspire-prerequisites</target>
-        <note />
+        <source>For detailed prerequisites: {0}</source>
+        <target state="new">For detailed prerequisites: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="DevCertsCleanAndTrustFixFormat">
         <source>Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
@@ -18,9 +18,9 @@
         <note />
       </trans-unit>
       <trans-unit id="DetailedPrerequisitesLink">
-        <source>For detailed prerequisites: https://aka.ms/aspire-prerequisites</source>
-        <target state="translated">前提条件の詳細: https://aka.ms/aspire-prerequisites</target>
-        <note />
+        <source>For detailed prerequisites: {0}</source>
+        <target state="new">For detailed prerequisites: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="DevCertsCleanAndTrustFixFormat">
         <source>Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
@@ -18,9 +18,9 @@
         <note />
       </trans-unit>
       <trans-unit id="DetailedPrerequisitesLink">
-        <source>For detailed prerequisites: https://aka.ms/aspire-prerequisites</source>
-        <target state="translated">필수 구성 요소 확인: https://aka.ms/aspire-prerequisites</target>
-        <note />
+        <source>For detailed prerequisites: {0}</source>
+        <target state="new">For detailed prerequisites: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="DevCertsCleanAndTrustFixFormat">
         <source>Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
@@ -18,9 +18,9 @@
         <note />
       </trans-unit>
       <trans-unit id="DetailedPrerequisitesLink">
-        <source>For detailed prerequisites: https://aka.ms/aspire-prerequisites</source>
-        <target state="translated">Szczegółowe wymagania wstępne znajdziesz na: https://aka.ms/aspire-prerequisites</target>
-        <note />
+        <source>For detailed prerequisites: {0}</source>
+        <target state="new">For detailed prerequisites: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="DevCertsCleanAndTrustFixFormat">
         <source>Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
@@ -18,9 +18,9 @@
         <note />
       </trans-unit>
       <trans-unit id="DetailedPrerequisitesLink">
-        <source>For detailed prerequisites: https://aka.ms/aspire-prerequisites</source>
-        <target state="translated">Para obter os pré-requisitos detalhados: https://aka.ms/aspire-prerequisites</target>
-        <note />
+        <source>For detailed prerequisites: {0}</source>
+        <target state="new">For detailed prerequisites: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="DevCertsCleanAndTrustFixFormat">
         <source>Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
@@ -18,9 +18,9 @@
         <note />
       </trans-unit>
       <trans-unit id="DetailedPrerequisitesLink">
-        <source>For detailed prerequisites: https://aka.ms/aspire-prerequisites</source>
-        <target state="translated">Подробнее о предварительных требованиях: https://aka.ms/aspire-prerequisites</target>
-        <note />
+        <source>For detailed prerequisites: {0}</source>
+        <target state="new">For detailed prerequisites: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="DevCertsCleanAndTrustFixFormat">
         <source>Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
@@ -18,9 +18,9 @@
         <note />
       </trans-unit>
       <trans-unit id="DetailedPrerequisitesLink">
-        <source>For detailed prerequisites: https://aka.ms/aspire-prerequisites</source>
-        <target state="translated">Ayrıntılı önkoşullar için: https://aka.ms/aspire-prerequisites</target>
-        <note />
+        <source>For detailed prerequisites: {0}</source>
+        <target state="new">For detailed prerequisites: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="DevCertsCleanAndTrustFixFormat">
         <source>Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
@@ -18,9 +18,9 @@
         <note />
       </trans-unit>
       <trans-unit id="DetailedPrerequisitesLink">
-        <source>For detailed prerequisites: https://aka.ms/aspire-prerequisites</source>
-        <target state="translated">详细先决条件请参见: https://aka.ms/aspire-prerequisites</target>
-        <note />
+        <source>For detailed prerequisites: {0}</source>
+        <target state="new">For detailed prerequisites: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="DevCertsCleanAndTrustFixFormat">
         <source>Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
@@ -18,9 +18,9 @@
         <note />
       </trans-unit>
       <trans-unit id="DetailedPrerequisitesLink">
-        <source>For detailed prerequisites: https://aka.ms/aspire-prerequisites</source>
-        <target state="translated">如需詳細的先決條件: https://aka.ms/aspire-prerequisites</target>
-        <note />
+        <source>For detailed prerequisites: {0}</source>
+        <target state="new">For detailed prerequisites: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="DevCertsCleanAndTrustFixFormat">
         <source>Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</source>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.cs.xlf
@@ -52,11 +52,6 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
-      <trans-unit id="FirstTimeUseWelcome">
-        <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>
-        <target state="translated">Vítá vás Aspire! Další informace o Aspire najdete na https://aspire.dev</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Umožňuje potlačit banner spuštění a oznámení o telemetrii.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.cs.xlf
@@ -43,14 +43,14 @@
 
 The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
-        <target state="translated">Telemetrie
+Read more about Aspire CLI telemetry: {0}</source>
+        <target state="new">Telemetry
 ---------
 
-Rozhraní příkazového řádku Aspire shromažďuje data o využití. Shromažďuje je společnost Microsoft a slouží k vylepšování vašich možností. Výslovný nesouhlas s telemetrií můžete vyjádřit tak, že pomocí vašeho preferovaného prostředí nastavíte proměnnou prostředí ASPIRE_CLI_TELEMETRY_OPTOUT na hodnotu 1 nebo true.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Další informace o telemetrii rozhraní příkazového řádku Aspire: https://aka.ms/aspire/cli-telemetry</target>
-        <note />
+Read more about Aspire CLI telemetry: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="FirstTimeUseWelcome">
         <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.de.xlf
@@ -43,14 +43,14 @@
 
 The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
-        <target state="translated">Telemetrie
+Read more about Aspire CLI telemetry: {0}</source>
+        <target state="new">Telemetry
 ---------
 
-Die Aspire-CLI sammelt Nutzungsdaten. Sie wird von Microsoft erfasst und verwendet, um uns bei der Verbesserung des Benutzererlebnisses zu unterstützen. Sie können das Erfassen von Telemetriedaten deaktivieren, indem Sie die Umgebungsvariable ASPIRE_CLI_TELEMETRY_OPTOUT in Ihrer bevorzugten Shell auf „1“ oder TRUE festlegen.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Weitere Informationen zur Aspire-CLI-Telemetrie finden Sie unter: https://aka.ms/aspire/cli-telemetry</target>
-        <note />
+Read more about Aspire CLI telemetry: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="FirstTimeUseWelcome">
         <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.de.xlf
@@ -52,11 +52,6 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
-      <trans-unit id="FirstTimeUseWelcome">
-        <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>
-        <target state="translated">Willkommen bei Aspire! Weitere Informationen zu Aspire finden Sie unter https://aspire.dev</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Unterdrücken Sie das Startupbanner und den Telemetriehinweis.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.es.xlf
@@ -52,11 +52,6 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
-      <trans-unit id="FirstTimeUseWelcome">
-        <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>
-        <target state="translated">Bienvenido a Aspire. Obtenga más información sobre Aspire en https://aspire.dev</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Suprima el banner de inicio y el aviso de telemetría.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.es.xlf
@@ -43,14 +43,14 @@
 
 The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
-        <target state="translated">Telemetría
+Read more about Aspire CLI telemetry: {0}</source>
+        <target state="new">Telemetry
 ---------
 
-La CLI de Aspire recopila datos de uso. Lo recopila Microsoft y se usa para ayudarnos a mejorar su experiencia. Puede rechazar la telemetría estableciendo la variable de entorno ASPIRE_CLI_TELEMETRY_OPTOUT en "1" o "true" mediante el shell que prefiera.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Más información acerca de la telemetría de la CLI de Aspire: https://aka.ms/aspire/cli-telemetry</target>
-        <note />
+Read more about Aspire CLI telemetry: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="FirstTimeUseWelcome">
         <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.fr.xlf
@@ -52,11 +52,6 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
-      <trans-unit id="FirstTimeUseWelcome">
-        <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>
-        <target state="translated">Bienvenue sur Aspire ! En savoir plus sur Aspire à l’adresse https://aspire.dev</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Supprimer la bannière de démarrage et la notification de télémétrie.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.fr.xlf
@@ -43,14 +43,14 @@
 
 The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
-        <target state="translated">Télémétrie
+Read more about Aspire CLI telemetry: {0}</source>
+        <target state="new">Telemetry
 ---------
 
-L’interface CLI Aspire collecte des données d’utilisation. Il est collecté par Microsoft et utilisé pour nous aider à améliorer votre expérience. Vous pouvez désactiver la télémétrie en définissant la variable d’environnement ASPIRE_CLI_TELEMETRY_OPTOUT sur « 1 » ou « true » à l’aide de votre shell préféré.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-En savoir plus sur la télémétrie de l’interface CLI Aspire : https://aka.ms/aspire/cli-telemetry</target>
-        <note />
+Read more about Aspire CLI telemetry: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="FirstTimeUseWelcome">
         <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.it.xlf
@@ -52,11 +52,6 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
-      <trans-unit id="FirstTimeUseWelcome">
-        <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>
-        <target state="translated">Vi diamo il benvenuto in Aspire! Per altre informazioni su Aspire, vedere https://aspire.dev</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Consente di disabilitare il banner di avvio e l'avviso di telemetria.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.it.xlf
@@ -43,14 +43,14 @@
 
 The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
-        <target state="translated">Dati di telemetria
+Read more about Aspire CLI telemetry: {0}</source>
+        <target state="new">Telemetry
 ---------
 
-L'interfaccia della riga di comando di Aspire raccoglie i dati di utilizzo. Vengono raccolti da Microsoft e usati per contribuire al miglioramento dell'esperienza. È possibile rifiutare esplicitamente la raccolta dei dati di telemetria impostando la variabile di ambiente ASPIRE_CLI_TELEMETRY_OPTOUT su "1" o "true" nella shell preferita.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Altre informazioni sui dati di telemetria dell'interfaccia della riga di comando di Aspire: https://aka.ms/aspire/cli-telemetry</target>
-        <note />
+Read more about Aspire CLI telemetry: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="FirstTimeUseWelcome">
         <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ja.xlf
@@ -43,14 +43,14 @@
 
 The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
-        <target state="translated">テレメトリ
+Read more about Aspire CLI telemetry: {0}</source>
+        <target state="new">Telemetry
 ---------
 
-Aspire CLI は使用状況データを収集します。これは Microsoft によって収集され、エクスペリエンスを向上させるために役立てられます。テレメトリをオプトアウトするには、お好きなシェルを使って、ASPIRE_CLI_TELEMETRY_OPTOUT 環境変数を '1' または 'true' に設定します。
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Aspire CLI テレメトリの詳細情報: https://aka.ms/aspire/cli-telemetry</target>
-        <note />
+Read more about Aspire CLI telemetry: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="FirstTimeUseWelcome">
         <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ja.xlf
@@ -52,11 +52,6 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
-      <trans-unit id="FirstTimeUseWelcome">
-        <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>
-        <target state="translated">Aspire へようこそ!https://aspire.dev で Aspire の詳細情報をご覧ください</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">スタートアップ バナーとテレメトリ通知を非表示にします。</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ko.xlf
@@ -52,11 +52,6 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
-      <trans-unit id="FirstTimeUseWelcome">
-        <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>
-        <target state="translated">Aspire에 오신 것을 환영합니다! https://aspire.dev에서 Aspire에 대해 자세히 알아보기</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">시작 배너 및 원격 분석 알림을 표시하지 않습니다.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ko.xlf
@@ -43,14 +43,14 @@
 
 The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
-        <target state="translated">원격 분석
+Read more about Aspire CLI telemetry: {0}</source>
+        <target state="new">Telemetry
 ---------
 
-Aspire CLI는 사용량 현황 데이터를 수집합니다. Microsoft에서는 이를 수집하여 사용자 환경을 개선하는 데 활용합니다. 원하는 셸에서 ASPIRE_CLI_TELEMETRY_OPTOUT 환경 변수를 '1' 또는 'true'로 설정하여 원격 분석을 옵트아웃할 수 있습니다.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Aspire CLI 원격 분석에 대해 자세히 알아보기: https://aka.ms/aspire/cli-telemetry</target>
-        <note />
+Read more about Aspire CLI telemetry: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="FirstTimeUseWelcome">
         <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pl.xlf
@@ -43,14 +43,14 @@
 
 The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
-        <target state="translated">Telemetria
+Read more about Aspire CLI telemetry: {0}</source>
+        <target state="new">Telemetry
 ---------
 
-Interfejs wiersza polecenia usługi Aspire zbiera dane o użyciu. Dane te są zbierane przez firmę Microsoft i pomagają nam ulepszać Twoje doświadczenia. Możesz zrezygnować z telemetrii, ustawiając dla zmiennej środowiskowej DOTNET_CLI_TELEMETRY_OPTOUT wartość „1” lub „true” przy użyciu preferowanej powłoki.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Dowiedz się więcej o telemetrii wiersza polecenia usługi Aspire: https://aka.ms/aspire/cli-telemetry</target>
-        <note />
+Read more about Aspire CLI telemetry: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="FirstTimeUseWelcome">
         <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pl.xlf
@@ -52,11 +52,6 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
-      <trans-unit id="FirstTimeUseWelcome">
-        <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>
-        <target state="translated">Witamy w usłudze Aspire! Dowiedz się więcej o usłudze Aspire na https://aspire.dev</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Wstrzymaj baner startowy i powiadomienie o telemetrii.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pt-BR.xlf
@@ -52,11 +52,6 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
-      <trans-unit id="FirstTimeUseWelcome">
-        <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>
-        <target state="translated">Bem-vindo(a) ao Aspire! Saiba mais sobre o Aspire em https://aspire.dev</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Suprima a faixa de inicialização e o aviso de telemetria.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.pt-BR.xlf
@@ -43,14 +43,14 @@
 
 The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
-        <target state="translated">Telemetria
+Read more about Aspire CLI telemetry: {0}</source>
+        <target state="new">Telemetry
 ---------
 
-A CLI do Aspire coleta dados de uso. Eles são coletados pela Microsoft e usados para nos ajudar a melhorar sua experiência. Você pode recusar a telemetria definindo a variável de ambiente DOTNET_CLI_TELEMETRY_OPTOUT como "1" ou "true" usando seu shell favorito.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Leia mais sobre a telemetria da CLI do Aspire: https://aka.ms/aspire/cli-telemetry</target>
-        <note />
+Read more about Aspire CLI telemetry: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="FirstTimeUseWelcome">
         <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ru.xlf
@@ -43,14 +43,14 @@
 
 The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
-        <target state="translated">Телеметрия
+Read more about Aspire CLI telemetry: {0}</source>
+        <target state="new">Telemetry
 ---------
 
-Aspire CLI собирает данные об использовании. Корпорация Майкрософт собирает и использует их для улучшения взаимодействия. Вы можете отказаться от отправки телеметрии, установив значение "1" или "true" для переменной среды ASPIRE_CLI_TELEMETRY_OPTOUT в предпочтительной оболочке.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Подробнее о телеметрии Aspire CLI: https://aka.ms/aspire/cli-telemetry</target>
-        <note />
+Read more about Aspire CLI telemetry: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="FirstTimeUseWelcome">
         <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.ru.xlf
@@ -52,11 +52,6 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
-      <trans-unit id="FirstTimeUseWelcome">
-        <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>
-        <target state="translated">Добро пожаловать в Aspire! Подробнее об Aspire см. на странице https://aspire.dev</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Отключить баннер запуска и уведомление о телеметрии.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.tr.xlf
@@ -43,14 +43,14 @@
 
 The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
-        <target state="translated">Telemetri
-----------
+Read more about Aspire CLI telemetry: {0}</source>
+        <target state="new">Telemetry
+---------
 
-Aspire CLI kullanım verilerini toplar. Microsoft tarafından toplanır ve deneyiminizi geliştirmemize yardımcı olması için kullanılır. Telemetriyi geri çevirmek için tercih ettiğiniz kabuğu kullanarak ASPIRE_CLI_TELEMETRY_OPTOUT ortam değişkenini '1' veya 'true' olarak ayarlayabilirsiniz.
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Aspire CLI telemetrisi hakkında daha fazla bilgi edinin: https://aka.ms/aspire/cli-telemetry</target>
-        <note />
+Read more about Aspire CLI telemetry: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="FirstTimeUseWelcome">
         <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.tr.xlf
@@ -52,11 +52,6 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
-      <trans-unit id="FirstTimeUseWelcome">
-        <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>
-        <target state="translated">Aspire'a hoş geldiniz! Aspire hakkında daha fazla bilgi için https://aspire.dev adresini ziyaret edin</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">Başlangıç başlığını ve telemetri bildirimini gizle.</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hans.xlf
@@ -52,11 +52,6 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
-      <trans-unit id="FirstTimeUseWelcome">
-        <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>
-        <target state="translated">欢迎使用 Aspire!如需详细了解 Aspire，请访问 https://aspire.dev</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">抑制显示启动横幅和遥测通知。</target>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hans.xlf
@@ -43,14 +43,14 @@
 
 The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
-        <target state="translated">遥测
+Read more about Aspire CLI telemetry: {0}</source>
+        <target state="new">Telemetry
 ---------
 
-Aspire CLI 收集使用情况数据。该数据由 Microsoft 收集，用于帮助我们提升你的体验。可以通过使用首选 shell 将环境变量 ASPIRE_CLI_TELEMETRY_OPTOUT 设置为 "1" 或 "true" 来选择退出遥测。
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-详细了解 Aspire CLI 遥测: https://aka.ms/aspire/cli-telemetry</target>
-        <note />
+Read more about Aspire CLI telemetry: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="FirstTimeUseWelcome">
         <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hant.xlf
@@ -43,14 +43,14 @@
 
 The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-Read more about Aspire CLI telemetry: https://aka.ms/aspire/cli-telemetry</source>
-        <target state="translated">遙測
+Read more about Aspire CLI telemetry: {0}</source>
+        <target state="new">Telemetry
 ---------
 
-Aspire CLI 會收集使用方式資料。它由 Microsoft 收集，用於協助我們改善您的體驗。您可以使用您偏好的殼層，將 ASPIRE_CLI_TELEMETRY_OPTOUT 環境變數設定為 '1' 或 'true'，以選擇退出遙測。
+The Aspire CLI collects usage data. It is collected by Microsoft and is used to help us improve your experience. You can opt out of telemetry by setting the ASPIRE_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your preferred shell.
 
-閱讀關於 Aspire CLI 遙測的詳細資訊: https://aka.ms/aspire/cli-telemetry</target>
-        <note />
+Read more about Aspire CLI telemetry: {0}</target>
+        <note>{0} is a clickable URL</note>
       </trans-unit>
       <trans-unit id="FirstTimeUseWelcome">
         <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>

--- a/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/RootCommandStrings.zh-Hant.xlf
@@ -52,11 +52,6 @@ The Aspire CLI collects usage data. It is collected by Microsoft and is used to 
 Read more about Aspire CLI telemetry: {0}</target>
         <note>{0} is a clickable URL</note>
       </trans-unit>
-      <trans-unit id="FirstTimeUseWelcome">
-        <source>Welcome to Aspire! Learn more about Aspire at https://aspire.dev</source>
-        <target state="translated">歡迎使用 Azure!請造訪 https://aspire.dev 以了解更多有關 Aspire 的資訊</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoLogoArgumentDescription">
         <source>Suppress the startup banner and telemetry notice</source>
         <target state="needs-review-translation">抑制啟動橫幅與遙測通知。</target>

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -292,6 +292,7 @@
     <Compile Include="$(SharedDir)KnownResourceNames.cs" Link="Utils\KnownResourceNames.cs" />
     <Compile Include="$(SharedDir)KnownFormats.cs" Link="Utils\KnownFormats.cs" />
     <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />
+    <Compile Include="$(SharedDir)KnownUnsupportedUrlSchemes.cs" Link="Utils\KnownUnsupportedUrlSchemes.cs" />
     <Compile Include="$(SharedDir)TaskHelpers.cs" Link="Utils\TaskHelpers.cs" />
     <Compile Include="$(SharedDir)Model\KnownProperties.cs" Link="Utils\KnownProperties.cs" />
     <Compile Include="$(SharedDir)Model\KnownResourceTypes.cs" Link="Utils\KnownResourceTypes.cs" />

--- a/src/Aspire.Dashboard/Model/ResourceUrlHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ResourceUrlHelpers.cs
@@ -35,7 +35,7 @@ internal static class ResourceUrlHelpers
                     Name = url.EndpointName ?? "-",
                     Address = url.Url.Host,
                     Port = url.Url.Port,
-                    Url = !KnownUnsupportedUrlSchemes.Schemes.Contains(url.Url.Scheme) ? url.Url.OriginalString : null,
+                    Url = !KnownUnsupportedUrlSchemes.IsUnsupportedScheme(url.Url.Scheme) ? url.Url.OriginalString : null,
                     SortOrder = url.DisplayProperties.SortOrder,
                     DisplayName = string.IsNullOrEmpty(url.DisplayProperties.DisplayName) ? null : url.DisplayProperties.DisplayName,
                     OriginalUrlString = url.Url.OriginalString,

--- a/src/Aspire.Dashboard/Model/ResourceUrlHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ResourceUrlHelpers.cs
@@ -4,24 +4,12 @@
 using System.Diagnostics;
 using Aspire.Dashboard.Components.Controls;
 
+using Aspire.Shared;
+
 namespace Aspire.Dashboard.Model;
 
 internal static class ResourceUrlHelpers
 {
-    // These are known URL schemes that browsers don't support opening. Don't attempt to display them as a link.
-    // Not displaying them as a link makes it clear what can be opened in a browser (http, https) vs what can't (tcp, ws).
-    // This is a deny list because custom schemes could hand off the link to an app registered with the OS. For example, vscode://.
-    private static readonly HashSet<string> s_browserUnsupportedSchemes = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "gopher",
-        "ws",
-        "wss",
-        "news",
-        "nntp",
-        "telnet",
-        "tcp"
-    };
-
     public static List<DisplayedUrl> GetUrls(ResourceViewModel resource, bool includeInternalUrls = false, bool includeNonEndpointUrls = false)
     {
         var urls = new List<DisplayedUrl>(resource.Urls.Length);
@@ -47,7 +35,7 @@ internal static class ResourceUrlHelpers
                     Name = url.EndpointName ?? "-",
                     Address = url.Url.Host,
                     Port = url.Url.Port,
-                    Url = !s_browserUnsupportedSchemes.Contains(url.Url.Scheme) ? url.Url.OriginalString : null,
+                    Url = !KnownUnsupportedUrlSchemes.Schemes.Contains(url.Url.Scheme) ? url.Url.OriginalString : null,
                     SortOrder = url.DisplayProperties.SortOrder,
                     DisplayName = string.IsNullOrEmpty(url.DisplayProperties.DisplayName) ? null : url.DisplayProperties.DisplayName,
                     OriginalUrlString = url.Url.OriginalString,

--- a/src/Shared/KnownUnsupportedUrlSchemes.cs
+++ b/src/Shared/KnownUnsupportedUrlSchemes.cs
@@ -14,8 +14,7 @@ namespace Aspire.Shared;
 /// </remarks>
 internal static class KnownUnsupportedUrlSchemes
 {
-    private static readonly FrozenSet<string> s_schemes = new[]
-    {
+    private static readonly HashSet<string> s_schemes = [
         "gopher",
         "ws",
         "wss",
@@ -25,7 +24,7 @@ internal static class KnownUnsupportedUrlSchemes
         "tcp",
         "redis",
         "rediss"
-    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+    ];
 
     /// <summary>
     /// Returns <c>true</c> when the given scheme is in the unsupported set.

--- a/src/Shared/KnownUnsupportedUrlSchemes.cs
+++ b/src/Shared/KnownUnsupportedUrlSchemes.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Shared;
+
+/// <summary>
+/// URL schemes that terminals and browsers don't support opening as links.
+/// </summary>
+/// <remarks>
+/// This is a deny list because custom schemes could hand off the link to an app registered with the OS.
+/// For example, vscode://.
+/// </remarks>
+internal static class KnownUnsupportedUrlSchemes
+{
+    public static readonly HashSet<string> Schemes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "gopher",
+        "ws",
+        "wss",
+        "news",
+        "nntp",
+        "telnet",
+        "tcp",
+        "redis",
+        "rediss"
+    };
+
+    /// <summary>
+    /// Returns <c>true</c> when the URL scheme is known to be linkable (i.e. not in the unsupported set).
+    /// </summary>
+    public static bool IsLinkableUrl(string url) =>
+        Uri.TryCreate(url, UriKind.Absolute, out var uri) && !Schemes.Contains(uri.Scheme);
+}

--- a/src/Shared/KnownUnsupportedUrlSchemes.cs
+++ b/src/Shared/KnownUnsupportedUrlSchemes.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Frozen;
+
 namespace Aspire.Shared;
 
 /// <summary>
@@ -12,7 +14,7 @@ namespace Aspire.Shared;
 /// </remarks>
 internal static class KnownUnsupportedUrlSchemes
 {
-    public static readonly HashSet<string> Schemes = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly FrozenSet<string> s_schemes = new[]
     {
         "gopher",
         "ws",
@@ -23,11 +25,16 @@ internal static class KnownUnsupportedUrlSchemes
         "tcp",
         "redis",
         "rediss"
-    };
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns <c>true</c> when the given scheme is in the unsupported set.
+    /// </summary>
+    public static bool IsUnsupportedScheme(string scheme) => s_schemes.Contains(scheme);
 
     /// <summary>
     /// Returns <c>true</c> when the URL scheme is known to be linkable (i.e. not in the unsupported set).
     /// </summary>
     public static bool IsLinkableUrl(string url) =>
-        Uri.TryCreate(url, UriKind.Absolute, out var uri) && !Schemes.Contains(uri.Scheme);
+        Uri.TryCreate(url, UriKind.Absolute, out var uri) && !s_schemes.Contains(uri.Scheme);
 }


### PR DESCRIPTION
## Description

Use Spectre.Console `[link]` markup for all CLI URL output so terminal hyperlinks work correctly and aren't broken by line wrapping.

### Changes

- **DescribeCommand**: Endpoint URLs use `[link]` markup with `DisplayName` as link text when present. Endpoints are sorted matching the dashboard order (SortOrder desc, https first, then by Name).
- **PsCommand**: Dashboard URL uses `[link]` markup with `scheme://authority` as display text (hides the login token path/querystring).
- **DoctorCommand**: Prerequisites URL and environment check result links use `[link]` markup. URL extracted from resource string into code.
- **Program.cs**: Telemetry notice URL uses `[link]` markup via `MarkupLine`. URL extracted from resource string into code.
- **Shared `KnownUnsupportedUrlSchemes`**: Extracted the browser-unsupported URL scheme deny-list from `ResourceUrlHelpers.cs` into a shared file under `src/Shared/`, now used by both CLI and Dashboard. Added `redis` and `rediss` to the list.

### Validation

- All 1708 CLI unit tests pass
- All 11 Dashboard `ResourceUrlHelpers` tests pass
- Both CLI and Dashboard projects compile cleanly

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
