### PR TITLE
Add rebuild guidance to Aspire skill for per-resource code changes

### DIFF
--- a/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
+++ b/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
@@ -207,7 +207,7 @@ internal static class CommonAgentApplicators
         |---|---|---|
         | AppHost project (`apphost.cs`/`apphost.ts`) | `aspire start` | Resource graph changed; full restart required |
         | Compiled resource (C#, Go, Java, etc.) | `aspire resource <name> rebuild` | Rebuilds and restarts only that resource |
-        | Interpreted resource (JavaScript, Python) | Nothing — file watchers handle it | Hot reload picks up changes automatically |
+        | Interpreted resource (JavaScript, Python) | Typically nothing — most run with file watchers | Restart the resource if no watch mode is configured |
 
         **Never restart the entire AppHost just because a single resource changed.** Use `aspire resource <name> rebuild` for compiled resources — it coordinates stop, build, and restart for just that resource.
 

--- a/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
+++ b/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
@@ -165,7 +165,7 @@ internal static class CommonAgentApplicators
         | List resources | `aspire describe` or `aspire resources` |
         | Run resource command | `aspire resource <resource> <command>` |
         | Start/stop/restart resource | `aspire resource <resource> start|stop|restart` |
-        | Rebuild a resource | `aspire resource <resource> rebuild` |
+        | Rebuild a .NET project resource | `aspire resource <resource> rebuild` |
         | View console logs | `aspire logs [resource]` |
         | View structured logs | `aspire otel logs [resource]` |
         | View traces | `aspire otel traces [resource]` |
@@ -206,7 +206,7 @@ internal static class CommonAgentApplicators
         | What changed | Action | Why |
         |---|---|---|
         | AppHost project (`apphost.cs`/`apphost.ts`) | `aspire start` | Resource graph changed; full restart required |
-        | Compiled resource (C#, Go, Java, etc.) | `aspire resource <name> rebuild` | Rebuilds and restarts only that resource |
+        | Compiled .NET project resource | `aspire resource <name> rebuild` | Rebuilds and restarts only that resource |
         | Interpreted resource (JavaScript, Python) | Typically nothing — most run with file watchers | Restart the resource if no watch mode is configured |
 
         **Never restart the entire AppHost just because a single resource changed.** Use `aspire resource <name> rebuild` for compiled resources — it coordinates stop, build, and restart for just that resource.
@@ -240,7 +240,7 @@ internal static class CommonAgentApplicators
 
         - **Always start the app first** (`aspire start`) before making changes to verify the starting state.
         - **To restart, just run `aspire start` again** — it automatically stops the previous instance. NEVER use `aspire stop` then `aspire run`. NEVER use `aspire run` at all.
-        - **Only restart the AppHost when AppHost code changes.** For individual compiled resources, use `aspire resource <name> rebuild` instead.
+        - **Only restart the AppHost when AppHost code changes.** For .NET project resources, use `aspire resource <name> rebuild` instead.
         - Use `--isolated` when working in a worktree.
         - **Avoid persistent containers** early in development to prevent state management issues.
         - **Never install the Aspire workload** — it is obsolete.

--- a/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
+++ b/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
@@ -244,6 +244,7 @@ internal static class CommonAgentApplicators
         - Use `--isolated` when working in a worktree.
         - **Avoid persistent containers** early in development to prevent state management issues.
         - **Never install the Aspire workload** — it is obsolete.
+        - **For Aspire API reference and documentation, always use `aspire docs search <query>` and `aspire docs get <slug>`.** Do NOT search NuGet package caches, XML doc files, or local package folders for Aspire documentation. The CLI docs commands provide accurate, up-to-date content from aspire.dev.
         - Prefer `aspire.dev` and `learn.microsoft.com/microsoft/aspire` for official documentation.
 
         ## Playwright CLI

--- a/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
+++ b/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
@@ -209,7 +209,7 @@ internal static class CommonAgentApplicators
         | Compiled .NET project resource | `aspire resource <name> rebuild` | Rebuilds and restarts only that resource |
         | Interpreted resource (JavaScript, Python) | Typically nothing — most run with file watchers | Restart the resource if no watch mode is configured |
 
-        **Never restart the entire AppHost just because a single resource changed.** Use `aspire resource <name> rebuild` for compiled resources — it coordinates stop, build, and restart for just that resource.
+        **Never restart the entire AppHost just because a single resource changed.** Use `aspire resource <name> rebuild` for .NET project resources — it coordinates stop, build, and restart for just that resource. Use `aspire describe --format Json` to check which commands a resource supports.
 
         ### Debugging issues
 

--- a/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
+++ b/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
@@ -165,6 +165,7 @@ internal static class CommonAgentApplicators
         | List resources | `aspire describe` or `aspire resources` |
         | Run resource command | `aspire resource <resource> <command>` |
         | Start/stop/restart resource | `aspire resource <resource> start|stop|restart` |
+        | Rebuild a resource | `aspire resource <resource> rebuild` |
         | View console logs | `aspire logs [resource]` |
         | View structured logs | `aspire otel logs [resource]` |
         | View traces | `aspire otel traces [resource]` |
@@ -198,7 +199,17 @@ internal static class CommonAgentApplicators
         aspire wait myapi
         ```
 
-        Relaunching is safe — `aspire start` automatically stops any previous instance. Re-run `aspire start` whenever changes are made to the AppHost project.
+        ### Applying code changes
+
+        Choose the right action based on what changed:
+
+        | What changed | Action | Why |
+        |---|---|---|
+        | AppHost project (`apphost.cs`/`apphost.ts`) | `aspire start` | Resource graph changed; full restart required |
+        | Compiled resource (C#, Go, Java, etc.) | `aspire resource <name> rebuild` | Rebuilds and restarts only that resource |
+        | Interpreted resource (JavaScript, Python) | Nothing — file watchers handle it | Hot reload picks up changes automatically |
+
+        **Never restart the entire AppHost just because a single resource changed.** Use `aspire resource <name> rebuild` for compiled resources — it coordinates stop, build, and restart for just that resource.
 
         ### Debugging issues
 
@@ -229,6 +240,7 @@ internal static class CommonAgentApplicators
 
         - **Always start the app first** (`aspire start`) before making changes to verify the starting state.
         - **To restart, just run `aspire start` again** — it automatically stops the previous instance. NEVER use `aspire stop` then `aspire run`. NEVER use `aspire run` at all.
+        - **Only restart the AppHost when AppHost code changes.** For individual compiled resources, use `aspire resource <name> rebuild` instead.
         - Use `--isolated` when working in a worktree.
         - **Avoid persistent containers** early in development to prevent state management issues.
         - **Never install the Aspire workload** — it is obsolete.

--- a/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
+++ b/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
@@ -244,7 +244,7 @@ internal static class CommonAgentApplicators
         - Use `--isolated` when working in a worktree.
         - **Avoid persistent containers** early in development to prevent state management issues.
         - **Never install the Aspire workload** — it is obsolete.
-        - **For Aspire API reference and documentation, always use `aspire docs search <query>` and `aspire docs get <slug>`.** Do NOT search NuGet package caches, XML doc files, or local package folders for Aspire documentation. The CLI docs commands provide accurate, up-to-date content from aspire.dev.
+        - **For Aspire API reference and documentation, prefer `aspire docs search <query>` and `aspire docs get <slug>`** over searching NuGet package caches or XML doc files. The CLI provides up-to-date content from aspire.dev.
         - Prefer `aspire.dev` and `learn.microsoft.com/microsoft/aspire` for official documentation.
 
         ## Playwright CLI


### PR DESCRIPTION
## Description

Improves the Aspire skill content to teach agents better workflows for applying code changes and finding documentation, based on real user feedback.

### Changes

**1. "Applying code changes" decision table**

Agents were restarting the entire AppHost when only a single project changed. Added a decision tree:

| What changed | Action |
|---|---|
| AppHost project | `aspire start` (full restart) |
| .NET project resource | `aspire resource <name> rebuild` |
| Interpreted resource (JS, Python) | Typically nothing — file watchers handle it |

**2. Documentation lookup guidance**

Users reported Copilot digging through `~/.nuget/packages` XML doc files instead of using the built-in `aspire docs search` command. Added a rule using the "prefer X over Y" pattern (medium freedom):

> **Prefer `aspire docs search` and `aspire docs get`** over searching NuGet package caches or XML doc files.

We chose "prefer" over "Do NOT" following [Claude skill best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) — the NuGet approach *technically* works, it's just a poor experience. A hard block ("never") would be appropriate only for operations that are truly dangerous or broken.

**3. Command reference**

Added `aspire resource <resource> rebuild` to the CLI command table, scoped to .NET project resources. Added `aspire describe --format Json` hint for agents to discover available commands per resource.

### Design choices

- **Decision table over prose** — agents pattern-match well on tables; conditional workflow pattern from Claude skill best practices
- **"Prefer" over "Do NOT"** — medium-freedom degree; acknowledges alternatives exist but strongly nudges the right path
- **Scoped rebuild to .NET** — `rebuild` is only available on `ProjectResource` (verified via `KnownResourceCommands.cs` and `ProjectResourceBuilderExtensions.cs`)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No — skill content change only
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No