### PR TITLE
[release/13.2] Simplify TelemetryApiService.GetTrace and support short trace IDs

### DIFF
--- a/src/Aspire.Dashboard/Api/TelemetryApiService.cs
+++ b/src/Aspire.Dashboard/Api/TelemetryApiService.cs
@@ -167,16 +167,7 @@ internal sealed class TelemetryApiService(
     /// </summary>
     public TelemetryApiResponse? GetTrace(string traceId)
     {
-        var result = telemetryRepository.GetTraces(new GetTracesRequest
-        {
-            ResourceKey = null,
-            StartIndex = 0,
-            Count = MaxQueryCount,
-            Filters = [],
-            FilterText = string.Empty
-        });
-
-        var trace = result.PagedResult.Items.FirstOrDefault(t => OtlpHelpers.MatchTelemetryId(t.TraceId, traceId));
+        var trace = telemetryRepository.GetTrace(traceId);
         if (trace is null)
         {
             return null;

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -995,6 +995,11 @@ public sealed partial class TelemetryRepository : IDisposable
     {
         Debug.Assert(_tracesLock.IsReadLockHeld || _tracesLock.IsWriteLockHeld, $"Must get lock before calling {nameof(GetTraceUnsynchronized)}.");
 
+        if (traceId.Length < OtlpHelpers.ShortenedIdLength)
+        {
+            return null;
+        }
+
         foreach (var trace in _traces)
         {
             if (OtlpHelpers.MatchTelemetryId(traceId, trace.TraceId))

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -995,11 +995,6 @@ public sealed partial class TelemetryRepository : IDisposable
     {
         Debug.Assert(_tracesLock.IsReadLockHeld || _tracesLock.IsWriteLockHeld, $"Must get lock before calling {nameof(GetTraceUnsynchronized)}.");
 
-        if (traceId.Length < OtlpHelpers.ShortenedIdLength)
-        {
-            return null;
-        }
-
         foreach (var trace in _traces)
         {
             if (OtlpHelpers.MatchTelemetryId(traceId, trace.TraceId))

--- a/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
@@ -410,7 +410,7 @@ public class TelemetryApiServiceTests
     }
 
     [Theory]
-    [InlineData("747261636531", true)] // full hex trace ID for "trace1"
+    [InlineData("747261636531", true)] // full hex trace ID
     [InlineData("7472616", true)] // shortened (7 char) prefix
     [InlineData("747261", false)] // too short
     [InlineData("nonexistent", false)]

--- a/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
@@ -408,6 +408,49 @@ public class TelemetryApiServiceTests
         Assert.Empty(receivedItems);
     }
 
+    [Theory]
+    [InlineData("747261636531", true)] // full hex trace ID for "trace1"
+    [InlineData("7472616", true)] // shortened (7 char) prefix
+    [InlineData("747261", false)] // too short
+    [InlineData("nonexistent", false)]
+    public void GetTrace_VariousTraceIds_ReturnsExpectedResult(string lookupId, bool expectFound)
+    {
+        var repository = CreateRepository();
+
+        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "service1", instanceId: "inst1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "trace1", spanId: "span1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1))
+                        }
+                    }
+                }
+            }
+        });
+
+        var service = CreateService(repository);
+
+        var result = service.GetTrace(lookupId);
+
+        if (expectFound)
+        {
+            Assert.NotNull(result);
+            Assert.Equal(1, result.ReturnedCount);
+        }
+        else
+        {
+            Assert.Null(result);
+        }
+    }
+
     /// <summary>
     /// Creates a TelemetryApiService instance for testing with optional custom dependencies.
     /// </summary>

--- a/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text;
 using Aspire.Dashboard.Api;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
@@ -416,6 +417,7 @@ public class TelemetryApiServiceTests
     public void GetTrace_VariousTraceIds_ReturnsExpectedResult(string lookupId, bool expectFound)
     {
         var repository = CreateRepository();
+        var traceId = Encoding.UTF8.GetString(Convert.FromHexString("747261636531"));
 
         repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
         {
@@ -429,7 +431,7 @@ public class TelemetryApiServiceTests
                         Scope = CreateScope(),
                         Spans =
                         {
-                            CreateSpan(traceId: "trace1", spanId: "span1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1))
+                            CreateSpan(traceId: traceId, spanId: "span1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1))
                         }
                     }
                 }


### PR DESCRIPTION
## Description

Simplify `TelemetryApiService.GetTrace` and add support for short trace ID lookups.

**Changes:**
- **`TelemetryApiService.GetTrace`**: Replaced manual `GetTraces()` + LINQ search with a direct call to `TelemetryRepository.GetTrace(traceId)`, which already handles short trace ID matching via `OtlpHelpers.MatchTelemetryId`.
- **`TelemetryRepository.GetTraceUnsynchronized`**: Added early return for trace IDs shorter than `ShortenedIdLength` (7 chars) to skip the loop when the ID is too short for a meaningful prefix match.
- **Unit tests**: Added parameterized test covering full trace ID, shortened (7-char prefix) trace ID, and non-existent trace ID scenarios.

Fixes https://github.com/microsoft/aspire/issues/15611

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
