### PR TITLE
Create bugs as bug issues rather than tagging them as bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/10_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/10_bug_report.yml
@@ -1,6 +1,6 @@
 name: 🐞 Bug Report
 description: Create a report about something that is not working
-labels: ["bug"]
+type: Bug
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Description

Based on https://github.com/microsoft/aspire/issues/15578#issuecomment-4131607783, change the bug issue template to use the bug issue type rather than tagging the issue as bug.

Additionally you may want to consider assigning these issues to a project to help with any triaging processes you do.

```yaml
projects: ["octo-org/1", "octo-org/44"]
```