### PR TITLE
Add command result support for resource commands

### DIFF
--- a/playground/Stress/Stress.AppHost/Program.cs
+++ b/playground/Stress/Stress.AppHost/Program.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -124,7 +125,51 @@ builder.AddProject<Projects.Stress_TelemetryService>("stress-telemetryservice")
                await ExecuteCommandForAllResourcesAsync(c.ServiceProvider, KnownResourceCommands.StartCommand, c.CancellationToken);
                return CommandResults.Success();
            },
-           commandOptions: new() { IconName = "Play", IconVariant = IconVariant.Filled });
+           commandOptions: new() { IconName = "Play", IconVariant = IconVariant.Filled })
+       .WithCommand(
+           name: "generate-token",
+           displayName: "Generate Token",
+           executeCommand: (c) =>
+           {
+               var token = new
+               {
+                   accessToken = Convert.ToBase64String(Guid.NewGuid().ToByteArray()) + Convert.ToBase64String(Guid.NewGuid().ToByteArray()),
+                   tokenType = "Bearer",
+                   expiresIn = 3600,
+                   scope = "api.read api.write",
+                   issuedAt = DateTime.UtcNow
+               };
+               var json = JsonSerializer.Serialize(token, new JsonSerializerOptions { WriteIndented = true });
+               return Task.FromResult(CommandResults.Success(json, CommandResultFormat.Json));
+           },
+           commandOptions: new() { IconName = "Key", Description = "Generate a temporary access token" })
+       .WithCommand(
+           name: "get-connection-string",
+           displayName: "Get Connection String",
+           executeCommand: (c) =>
+           {
+               var connectionString = $"Server=localhost,1433;Database=StressDb;User Id=sa;Password={Guid.NewGuid():N};TrustServerCertificate=true";
+               return Task.FromResult(CommandResults.Success(connectionString, CommandResultFormat.Text));
+           },
+           commandOptions: new() { IconName = "LinkMultiple", Description = "Get the connection string for this resource" })
+       .WithCommand(
+           name: "validate-config",
+           displayName: "Validate Config",
+           executeCommand: (c) =>
+           {
+               var errors = new { errors = new[] { new { field = "connectionString", message = "Invalid host" }, new { field = "timeout", message = "Must be positive" } } };
+               var json = JsonSerializer.Serialize(errors, new JsonSerializerOptions { WriteIndented = true });
+               return Task.FromResult(CommandResults.Failure("Validation failed", json, CommandResultFormat.Json));
+           },
+           commandOptions: new() { IconName = "Warning", Description = "Validate resource configuration (always fails with details)" })
+       .WithCommand(
+           name: "check-health",
+           displayName: "Check Health",
+           executeCommand: (c) =>
+           {
+               return Task.FromResult(CommandResults.Failure("Health check failed", "Connection refused: ECONNREFUSED 127.0.0.1:5432\nRetries exhausted after 3 attempts", CommandResultFormat.Text));
+           },
+           commandOptions: new() { IconName = "HeartBroken", Description = "Check resource health (always fails with details)" });
 
 #if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging

--- a/src/Aspire.Cli/Commands/ResourceCommandHelper.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommandHelper.cs
@@ -59,7 +59,7 @@ internal static class ResourceCommandHelper
     {
         logger.LogDebug("Executing command '{CommandName}' on resource '{ResourceName}'", commandName, resourceName);
 
-        // Route status messages to stderr so command results can be piped (e.g., | jq)
+        // Route status messages to stderr so command results in stdout remain pipeable (e.g., | jq)
         interactionService.Console = ConsoleOutput.Error;
 
         var response = await interactionService.ShowStatusAsync(

--- a/src/Aspire.Cli/Commands/ResourceCommandHelper.cs
+++ b/src/Aspire.Cli/Commands/ResourceCommandHelper.cs
@@ -59,6 +59,9 @@ internal static class ResourceCommandHelper
     {
         logger.LogDebug("Executing command '{CommandName}' on resource '{ResourceName}'", commandName, resourceName);
 
+        // Route status messages to stderr so command results can be piped (e.g., | jq)
+        interactionService.Console = ConsoleOutput.Error;
+
         var response = await interactionService.ShowStatusAsync(
             $"Executing command '{commandName}' on resource '{resourceName}'...",
             async () => await connection.ExecuteResourceCommandAsync(resourceName, commandName, cancellationToken));
@@ -66,7 +69,6 @@ internal static class ResourceCommandHelper
         if (response.Success)
         {
             interactionService.DisplaySuccess($"Command '{commandName}' executed successfully on resource '{resourceName}'.");
-            return ExitCodeConstants.Success;
         }
         else if (response.Canceled)
         {
@@ -77,8 +79,14 @@ internal static class ResourceCommandHelper
         {
             var errorMessage = GetFriendlyErrorMessage(response.ErrorMessage);
             interactionService.DisplayError($"Failed to execute command '{commandName}' on resource '{resourceName}': {errorMessage}");
-            return ExitCodeConstants.FailedToExecuteResourceCommand;
         }
+
+        if (response.Result is not null)
+        {
+            interactionService.DisplayRawText(response.Result, ConsoleOutput.Standard);
+        }
+
+        return response.Success ? ExitCodeConstants.Success : ExitCodeConstants.FailedToExecuteResourceCommand;
     }
 
     private static int HandleResponse(
@@ -92,7 +100,6 @@ internal static class ResourceCommandHelper
         if (response.Success)
         {
             interactionService.DisplaySuccess($"Resource '{resourceName}' {pastTenseVerb} successfully.");
-            return ExitCodeConstants.Success;
         }
         else if (response.Canceled)
         {
@@ -103,8 +110,14 @@ internal static class ResourceCommandHelper
         {
             var errorMessage = GetFriendlyErrorMessage(response.ErrorMessage);
             interactionService.DisplayError($"Failed to {baseVerb} resource '{resourceName}': {errorMessage}");
-            return ExitCodeConstants.FailedToExecuteResourceCommand;
         }
+
+        if (response.Result is not null)
+        {
+            interactionService.DisplayRawText(response.Result, ConsoleOutput.Standard);
+        }
+
+        return response.Success ? ExitCodeConstants.Success : ExitCodeConstants.FailedToExecuteResourceCommand;
     }
 
     private static string GetFriendlyErrorMessage(string? errorMessage)

--- a/src/Aspire.Cli/Mcp/Tools/ExecuteResourceCommandTool.cs
+++ b/src/Aspire.Cli/Mcp/Tools/ExecuteResourceCommandTool.cs
@@ -74,9 +74,19 @@ internal sealed class ExecuteResourceCommandTool(
 
             if (response.Success)
             {
+                var content = new List<TextContentBlock>
+                {
+                    new() { Text = $"Command '{commandName}' executed successfully on resource '{resourceName}'." }
+                };
+
+                if (response.Result is not null)
+                {
+                    content.Add(new TextContentBlock { Text = response.Result });
+                }
+
                 return new CallToolResult
                 {
-                    Content = [new TextContentBlock { Text = $"Command '{commandName}' executed successfully on resource '{resourceName}'." }]
+                    Content = [.. content]
                 };
             }
             else if (response.Canceled)
@@ -86,7 +96,22 @@ internal sealed class ExecuteResourceCommandTool(
             else
             {
                 var message = response.ErrorMessage is { Length: > 0 } ? response.ErrorMessage : "Unknown error. See logs for details.";
-                throw new McpProtocolException($"Command '{commandName}' failed for resource '{resourceName}': {message}", McpErrorCode.InternalError);
+
+                var content = new List<TextContentBlock>
+                {
+                    new() { Text = $"Command '{commandName}' failed for resource '{resourceName}': {message}" }
+                };
+
+                if (response.Result is not null)
+                {
+                    content.Add(new TextContentBlock { Text = response.Result });
+                }
+
+                return new CallToolResult
+                {
+                    IsError = true,
+                    Content = [.. content]
+                };
             }
         }
         catch (McpProtocolException)

--- a/src/Aspire.Dashboard/Model/DashboardCommandExecutor.cs
+++ b/src/Aspire.Dashboard/Model/DashboardCommandExecutor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using Aspire.Dashboard.Components.Dialogs;
 using Aspire.Dashboard.Telemetry;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
@@ -13,7 +14,7 @@ namespace Aspire.Dashboard.Model;
 
 public sealed class DashboardCommandExecutor(
     IDashboardClient dashboardClient,
-    IDialogService dialogService,
+    DashboardDialogService dialogService,
     IToastService toastService,
     IStringLocalizer<Dashboard.Resources.Resources> loc,
     NavigationManager navigationManager,
@@ -166,6 +167,18 @@ public sealed class DashboardCommandExecutor(
             toastParameters.Content.Details = response.ErrorMessage;
             toastParameters.PrimaryAction = loc[nameof(Dashboard.Resources.Resources.ResourceCommandToastViewLogs)];
             toastParameters.OnPrimaryAction = EventCallback.Factory.Create<ToastResult>(this, () => navigationManager.NavigateTo(DashboardUrls.ConsoleLogsUrl(resource: getResourceName(resource))));
+        }
+
+        if (response.Result is not null)
+        {
+            var fixedFormat = response.ResultFormat == CommandResultFormat.Json ? DashboardUIHelpers.JsonFormat : null;
+            await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
+            {
+                DialogService = dialogService,
+                ValueDescription = command.GetDisplayName(),
+                Value = response.Result,
+                FixedFormat = fixedFormat
+            }).ConfigureAwait(false);
         }
 
         if (!toastClosed)

--- a/src/Aspire.Dashboard/Model/ResourceCommandResponseViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceCommandResponseViewModel.cs
@@ -7,6 +7,8 @@ public class ResourceCommandResponseViewModel
 {
     public required ResourceCommandResponseKind Kind { get; init; }
     public string? ErrorMessage { get; init; }
+    public string? Result { get; init; }
+    public CommandResultFormat ResultFormat { get; init; }
 }
 
 // Must be kept in sync with ResourceCommandResponseKind in the resource_service.proto file
@@ -16,4 +18,25 @@ public enum ResourceCommandResponseKind
     Succeeded = 1,
     Failed = 2,
     Cancelled = 3
+}
+
+/// <summary>
+/// Specifies the format of a command result.
+/// </summary>
+public enum CommandResultFormat
+{
+    /// <summary>
+    /// No result data.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Plain text result.
+    /// </summary>
+    Text = 1,
+
+    /// <summary>
+    /// JSON result.
+    /// </summary>
+    Json = 2
 }

--- a/src/Aspire.Dashboard/Model/ResourceCommandResponseViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceCommandResponseViewModel.cs
@@ -8,7 +8,7 @@ public class ResourceCommandResponseViewModel
     public required ResourceCommandResponseKind Kind { get; init; }
     public string? ErrorMessage { get; init; }
     public string? Result { get; init; }
-    public CommandResultFormat ResultFormat { get; init; }
+    public CommandResultFormat? ResultFormat { get; init; }
 }
 
 // Must be kept in sync with ResourceCommandResponseKind in the resource_service.proto file
@@ -26,17 +26,12 @@ public enum ResourceCommandResponseKind
 public enum CommandResultFormat
 {
     /// <summary>
-    /// No result data.
-    /// </summary>
-    None = 0,
-
-    /// <summary>
     /// Plain text result.
     /// </summary>
-    Text = 1,
+    Text,
 
     /// <summary>
     /// JSON result.
     /// </summary>
-    Json = 2
+    Json
 }

--- a/src/Aspire.Dashboard/ServiceClient/Partials.cs
+++ b/src/Aspire.Dashboard/ServiceClient/Partials.cs
@@ -203,10 +203,9 @@ partial class ResourceCommandResponse
             Result = HasResult ? Result : null,
             ResultFormat = ResultFormat switch
             {
-                CommandResultFormat.None => Dashboard.Model.CommandResultFormat.None,
                 CommandResultFormat.Text => Dashboard.Model.CommandResultFormat.Text,
                 CommandResultFormat.Json => Dashboard.Model.CommandResultFormat.Json,
-                _ => Dashboard.Model.CommandResultFormat.None
+                _ => null
             }
         };
     }

--- a/src/Aspire.Dashboard/ServiceClient/Partials.cs
+++ b/src/Aspire.Dashboard/ServiceClient/Partials.cs
@@ -201,7 +201,13 @@ partial class ResourceCommandResponse
             ErrorMessage = ErrorMessage,
             Kind = (Dashboard.Model.ResourceCommandResponseKind)Kind,
             Result = HasResult ? Result : null,
-            ResultFormat = (Dashboard.Model.CommandResultFormat)ResultFormat
+            ResultFormat = ResultFormat switch
+            {
+                CommandResultFormat.None => Dashboard.Model.CommandResultFormat.None,
+                CommandResultFormat.Text => Dashboard.Model.CommandResultFormat.Text,
+                CommandResultFormat.Json => Dashboard.Model.CommandResultFormat.Json,
+                _ => Dashboard.Model.CommandResultFormat.None
+            }
         };
     }
 }

--- a/src/Aspire.Dashboard/ServiceClient/Partials.cs
+++ b/src/Aspire.Dashboard/ServiceClient/Partials.cs
@@ -199,7 +199,9 @@ partial class ResourceCommandResponse
         return new ResourceCommandResponseViewModel()
         {
             ErrorMessage = ErrorMessage,
-            Kind = (Dashboard.Model.ResourceCommandResponseKind)Kind
+            Kind = (Dashboard.Model.ResourceCommandResponseKind)Kind,
+            Result = HasResult ? Result : null,
+            ResultFormat = (Dashboard.Model.CommandResultFormat)ResultFormat
         };
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
@@ -120,19 +120,14 @@ public enum IconVariant
 public enum CommandResultFormat
 {
     /// <summary>
-    /// No result data.
-    /// </summary>
-    None = 0,
-
-    /// <summary>
     /// Plain text result.
     /// </summary>
-    Text = 1,
+    Text,
 
     /// <summary>
     /// JSON result.
     /// </summary>
-    Json = 2
+    Json
 }
 
 /// <summary>
@@ -207,7 +202,7 @@ public sealed class ExecuteCommandResult
     /// <summary>
     /// The format of the <see cref="Result"/> value.
     /// </summary>
-    public CommandResultFormat ResultFormat { get; init; }
+    public CommandResultFormat? ResultFormat { get; init; }
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
@@ -115,6 +115,27 @@ public enum IconVariant
 }
 
 /// <summary>
+/// Specifies the format of a command result.
+/// </summary>
+public enum CommandResultFormat
+{
+    /// <summary>
+    /// No result data.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Plain text result.
+    /// </summary>
+    Text = 1,
+
+    /// <summary>
+    /// JSON result.
+    /// </summary>
+    Json = 2
+}
+
+/// <summary>
 /// A factory for <see cref="ExecuteCommandResult"/>.
 /// </summary>
 public static class CommandResults
@@ -125,10 +146,25 @@ public static class CommandResults
     public static ExecuteCommandResult Success() => new() { Success = true };
 
     /// <summary>
+    /// Produces a success result with result data.
+    /// </summary>
+    /// <param name="result">The result data.</param>
+    /// <param name="resultFormat">The format of the result data. Defaults to <see cref="CommandResultFormat.Text"/>.</param>
+    public static ExecuteCommandResult Success(string result, CommandResultFormat resultFormat = CommandResultFormat.Text) => new() { Success = true, Result = result, ResultFormat = resultFormat };
+
+    /// <summary>
     /// Produces an unsuccessful result with an error message.
     /// </summary>
     /// <param name="errorMessage">An optional error message.</param>
     public static ExecuteCommandResult Failure(string? errorMessage = null) => new() { Success = false, ErrorMessage = errorMessage };
+
+    /// <summary>
+    /// Produces an unsuccessful result with an error message and result data.
+    /// </summary>
+    /// <param name="errorMessage">The error message.</param>
+    /// <param name="result">The result data.</param>
+    /// <param name="resultFormat">The format of the result data. Defaults to <see cref="CommandResultFormat.Text"/>.</param>
+    public static ExecuteCommandResult Failure(string errorMessage, string result, CommandResultFormat resultFormat = CommandResultFormat.Text) => new() { Success = false, ErrorMessage = errorMessage, Result = result, ResultFormat = resultFormat };
 
     /// <summary>
     /// Produces a canceled result.
@@ -162,6 +198,16 @@ public sealed class ExecuteCommandResult
     /// An optional error message that can be set when the command is unsuccessful.
     /// </summary>
     public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// An optional result value produced by the command.
+    /// </summary>
+    public string? Result { get; init; }
+
+    /// <summary>
+    /// The format of the <see cref="Result"/> value.
+    /// </summary>
+    public CommandResultFormat ResultFormat { get; init; }
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
@@ -111,7 +111,7 @@ public class ResourceCommandService
             {
                 Success = true,
                 Result = successWithResult?.Result,
-                ResultFormat = successWithResult?.ResultFormat ?? CommandResultFormat.None
+                ResultFormat = successWithResult?.ResultFormat
             };
         }
         else if (failures.Count == 0 && cancellations.Count > 0)

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
@@ -106,7 +106,13 @@ public class ResourceCommandService
 
         if (failures.Count == 0 && cancellations.Count == 0)
         {
-            return new ExecuteCommandResult { Success = true };
+            var successWithResult = results.FirstOrDefault(r => r.Result is not null);
+            return new ExecuteCommandResult
+            {
+                Success = true,
+                Result = successWithResult?.Result,
+                ResultFormat = successWithResult?.ResultFormat ?? CommandResultFormat.None
+            };
         }
         else if (failures.Count == 0 && cancellations.Count > 0)
         {

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -220,7 +220,7 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
             Canceled = result.Canceled,
             ErrorMessage = result.ErrorMessage,
             Result = result.Result,
-            ResultFormat = result.ResultFormat.ToString().ToLowerInvariant()
+            ResultFormat = result.ResultFormat?.ToString().ToLowerInvariant()
         };
     }
 

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -218,7 +218,9 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
         {
             Success = result.Success,
             Canceled = result.Canceled,
-            ErrorMessage = result.ErrorMessage
+            ErrorMessage = result.ErrorMessage,
+            Result = result.Result,
+            ResultFormat = result.ResultFormat.ToString().ToLowerInvariant()
         };
     }
 

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -285,6 +285,16 @@ internal sealed class ExecuteResourceCommandResponse
     /// Gets the error message if the command failed.
     /// </summary>
     public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// Gets the result data produced by the command.
+    /// </summary>
+    public string? Result { get; init; }
+
+    /// <summary>
+    /// Gets the format of the result data (e.g. "none", "text", "json").
+    /// </summary>
+    public string? ResultFormat { get; init; }
 }
 
 #endregion

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -360,7 +360,7 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
 
     public override async Task<ResourceCommandResponse> ExecuteResourceCommand(ResourceCommandRequest request, ServerCallContext context)
     {
-        var (result, errorMessage) = await serviceData.ExecuteCommandAsync(request.ResourceName, request.CommandName, context.CancellationToken).ConfigureAwait(false);
+        var (result, errorMessage, commandResult, resultFormat) = await serviceData.ExecuteCommandAsync(request.ResourceName, request.CommandName, context.CancellationToken).ConfigureAwait(false);
         var responseKind = result switch
         {
             ExecuteCommandResultType.Success => ResourceCommandResponseKind.Succeeded,
@@ -369,11 +369,19 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
             _ => ResourceCommandResponseKind.Undefined
         };
 
-        return new ResourceCommandResponse
+        var response = new ResourceCommandResponse
         {
             Kind = responseKind,
-            ErrorMessage = errorMessage ?? string.Empty
+            ErrorMessage = errorMessage ?? string.Empty,
+            ResultFormat = (Aspire.DashboardService.Proto.V1.CommandResultFormat)resultFormat
         };
+
+        if (commandResult is not null)
+        {
+            response.Result = commandResult;
+        }
+
+        return response;
     }
 
     private async Task ExecuteAsync(Func<CancellationToken, Task> execute, ServerCallContext serverCallContext)

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -375,7 +375,6 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
             ErrorMessage = errorMessage ?? string.Empty,
             ResultFormat = resultFormat switch
             {
-                ApplicationModel.CommandResultFormat.None => Aspire.DashboardService.Proto.V1.CommandResultFormat.None,
                 ApplicationModel.CommandResultFormat.Text => Aspire.DashboardService.Proto.V1.CommandResultFormat.Text,
                 ApplicationModel.CommandResultFormat.Json => Aspire.DashboardService.Proto.V1.CommandResultFormat.Json,
                 _ => Aspire.DashboardService.Proto.V1.CommandResultFormat.None

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -373,7 +373,13 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
         {
             Kind = responseKind,
             ErrorMessage = errorMessage ?? string.Empty,
-            ResultFormat = (Aspire.DashboardService.Proto.V1.CommandResultFormat)resultFormat
+            ResultFormat = resultFormat switch
+            {
+                ApplicationModel.CommandResultFormat.None => Aspire.DashboardService.Proto.V1.CommandResultFormat.None,
+                ApplicationModel.CommandResultFormat.Text => Aspire.DashboardService.Proto.V1.CommandResultFormat.Text,
+                ApplicationModel.CommandResultFormat.Json => Aspire.DashboardService.Proto.V1.CommandResultFormat.Json,
+                _ => Aspire.DashboardService.Proto.V1.CommandResultFormat.None
+            }
         };
 
         if (commandResult is not null)

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -94,21 +94,21 @@ internal sealed class DashboardServiceData : IDisposable
         _cts.Dispose();
     }
 
-    internal async Task<(ExecuteCommandResultType result, string? errorMessage, string? commandResult, ApplicationModel.CommandResultFormat resultFormat)> ExecuteCommandAsync(string resourceId, string type, CancellationToken cancellationToken)
+    internal async Task<(ExecuteCommandResultType result, string? errorMessage, string? commandResult, ApplicationModel.CommandResultFormat? resultFormat)> ExecuteCommandAsync(string resourceId, string type, CancellationToken cancellationToken)
     {
         try
         {
             var result = await _resourceCommandService.ExecuteCommandAsync(resourceId, type, cancellationToken).ConfigureAwait(false);
             if (result.Canceled)
             {
-                return (ExecuteCommandResultType.Canceled, result.ErrorMessage, null, ApplicationModel.CommandResultFormat.None);
+                return (ExecuteCommandResultType.Canceled, result.ErrorMessage, null, null);
             }
             return (result.Success ? ExecuteCommandResultType.Success : ExecuteCommandResultType.Failure, result.ErrorMessage, result.Result, result.ResultFormat);
         }
         catch
         {
             // Note: Exception is already logged in the command executor.
-            return (ExecuteCommandResultType.Failure, "Unhandled exception thrown while executing command.", null, ApplicationModel.CommandResultFormat.None);
+            return (ExecuteCommandResultType.Failure, "Unhandled exception thrown while executing command.", null, null);
         }
     }
 

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -94,21 +94,21 @@ internal sealed class DashboardServiceData : IDisposable
         _cts.Dispose();
     }
 
-    internal async Task<(ExecuteCommandResultType result, string? errorMessage)> ExecuteCommandAsync(string resourceId, string type, CancellationToken cancellationToken)
+    internal async Task<(ExecuteCommandResultType result, string? errorMessage, string? commandResult, ApplicationModel.CommandResultFormat resultFormat)> ExecuteCommandAsync(string resourceId, string type, CancellationToken cancellationToken)
     {
         try
         {
             var result = await _resourceCommandService.ExecuteCommandAsync(resourceId, type, cancellationToken).ConfigureAwait(false);
             if (result.Canceled)
             {
-                return (ExecuteCommandResultType.Canceled, result.ErrorMessage);
+                return (ExecuteCommandResultType.Canceled, result.ErrorMessage, null, ApplicationModel.CommandResultFormat.None);
             }
-            return (result.Success ? ExecuteCommandResultType.Success : ExecuteCommandResultType.Failure, result.ErrorMessage);
+            return (result.Success ? ExecuteCommandResultType.Success : ExecuteCommandResultType.Failure, result.ErrorMessage, result.Result, result.ResultFormat);
         }
         catch
         {
             // Note: Exception is already logged in the command executor.
-            return (ExecuteCommandResultType.Failure, "Unhandled exception thrown while executing command.");
+            return (ExecuteCommandResultType.Failure, "Unhandled exception thrown while executing command.", null, ApplicationModel.CommandResultFormat.None);
         }
     }
 

--- a/src/Aspire.Hosting/Dashboard/proto/dashboard_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/dashboard_service.proto
@@ -92,6 +92,14 @@ enum ResourceCommandResponseKind {
 message ResourceCommandResponse {
     ResourceCommandResponseKind kind = 1;
     optional string error_message = 2;
+    optional string result = 3;
+    CommandResultFormat result_format = 4;
+}
+
+enum CommandResultFormat {
+    COMMAND_RESULT_FORMAT_NONE = 0;
+    COMMAND_RESULT_FORMAT_TEXT = 1;
+    COMMAND_RESULT_FORMAT_JSON = 2;
 }
 
 ////////////////////////////////////////////

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandHelperTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
+using Aspire.Cli.Interaction;
 using Aspire.Cli.Tests.TestServices;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -101,5 +102,36 @@ public class ResourceCommandHelperTests
         Assert.NotEqual(0, exitCode);
         Assert.NotNull(capturedRawText);
         Assert.Equal("{\"errors\": [\"invalid host\"]}", capturedRawText);
+    }
+
+    [Fact]
+    public async Task ExecuteGenericCommandAsync_RoutesStatusToStderr_ResultToStdout()
+    {
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
+            {
+                Success = true,
+                Result = "some output",
+                ResultFormat = "text"
+            }
+        };
+
+        var interactionService = new TestInteractionService
+        {
+            DisplayRawTextCallback = (_) => { }
+        };
+
+        var exitCode = await ResourceCommandHelper.ExecuteGenericCommandAsync(
+            connection,
+            interactionService,
+            NullLogger.Instance,
+            "myResource",
+            "my-command",
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+        // Status messages should be routed to stderr
+        Assert.Equal(ConsoleOutput.Error, interactionService.Console);
     }
 }

--- a/tests/Aspire.Cli.Tests/Commands/ResourceCommandHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/ResourceCommandHelperTests.cs
@@ -1,0 +1,105 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Backchannel;
+using Aspire.Cli.Commands;
+using Aspire.Cli.Tests.TestServices;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Commands;
+
+public class ResourceCommandHelperTests
+{
+    [Fact]
+    public async Task ExecuteGenericCommandAsync_WithResult_OutputsRawText()
+    {
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
+            {
+                Success = true,
+                Result = "{\"items\": [\"a\", \"b\"]}",
+                ResultFormat = "json"
+            }
+        };
+
+        string? capturedRawText = null;
+        var interactionService = new TestInteractionService
+        {
+            DisplayRawTextCallback = (text) => capturedRawText = text
+        };
+
+        var exitCode = await ResourceCommandHelper.ExecuteGenericCommandAsync(
+            connection,
+            interactionService,
+            NullLogger.Instance,
+            "myResource",
+            "generate-token",
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(capturedRawText);
+        // Verify the raw result is passed through without any escaping
+        Assert.Equal("{\"items\": [\"a\", \"b\"]}", capturedRawText);
+    }
+
+    [Fact]
+    public async Task ExecuteGenericCommandAsync_WithoutResult_DoesNotCallDisplayMessage()
+    {
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true }
+        };
+
+        var displayRawTextCalled = false;
+        var interactionService = new TestInteractionService
+        {
+            DisplayRawTextCallback = (_) => displayRawTextCalled = true
+        };
+
+        var exitCode = await ResourceCommandHelper.ExecuteGenericCommandAsync(
+            connection,
+            interactionService,
+            NullLogger.Instance,
+            "myResource",
+            "start",
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+        Assert.False(displayRawTextCalled);
+    }
+
+    [Fact]
+    public async Task ExecuteGenericCommandAsync_ErrorWithResult_OutputsRawText()
+    {
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
+            {
+                Success = false,
+                ErrorMessage = "Validation failed",
+                Result = "{\"errors\": [\"invalid host\"]}",
+                ResultFormat = "json"
+            }
+        };
+
+        string? capturedRawText = null;
+        var interactionService = new TestInteractionService
+        {
+            DisplayRawTextCallback = (text) => capturedRawText = text
+        };
+
+        var exitCode = await ResourceCommandHelper.ExecuteGenericCommandAsync(
+            connection,
+            interactionService,
+            NullLogger.Instance,
+            "myResource",
+            "validate-config",
+            CancellationToken.None).DefaultTimeout();
+
+        Assert.NotEqual(0, exitCode);
+        Assert.NotNull(capturedRawText);
+        Assert.Equal("{\"errors\": [\"invalid host\"]}", capturedRawText);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Mcp/ExecuteResourceCommandToolTests.cs
+++ b/tests/Aspire.Cli.Tests/Mcp/ExecuteResourceCommandToolTests.cs
@@ -61,7 +61,7 @@ public class ExecuteResourceCommandToolTests
     }
 
     [Fact]
-    public async Task ExecuteResourceCommandTool_ThrowsException_WhenCommandFails()
+    public async Task ExecuteResourceCommandTool_ReturnsError_WhenCommandFails()
     {
         var monitor = new TestAuxiliaryBackchannelMonitor();
         var connection = new TestAppHostAuxiliaryBackchannel
@@ -76,10 +76,10 @@ public class ExecuteResourceCommandToolTests
 
         var tool = new ExecuteResourceCommandTool(monitor, NullLogger<ExecuteResourceCommandTool>.Instance);
 
-        var exception = await Assert.ThrowsAsync<ModelContextProtocol.McpProtocolException>(
-            () => tool.CallToolAsync(CallToolContextTestHelper.Create(CreateArguments("nonexistent", "start")), CancellationToken.None).AsTask()).DefaultTimeout();
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(CreateArguments("nonexistent", "start")), CancellationToken.None).DefaultTimeout();
 
-        Assert.Contains("Resource not found", exception.Message);
+        Assert.True(result.IsError);
+        Assert.Contains(result.Content, c => c is ModelContextProtocol.Protocol.TextContentBlock t && t.Text.Contains("Resource not found"));
     }
 
     [Fact]
@@ -149,6 +149,55 @@ public class ExecuteResourceCommandToolTests
         var exception2 = await Assert.ThrowsAsync<ModelContextProtocol.McpProtocolException>(
             () => tool.CallToolAsync(CallToolContextTestHelper.Create(partialArgs), CancellationToken.None).AsTask()).DefaultTimeout();
         Assert.Contains("Missing required arguments", exception2.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteResourceCommandTool_ReturnsResult_WhenCommandReturnsResultData()
+    {
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse
+            {
+                Success = true,
+                Result = "{\"token\": \"abc123\"}",
+                ResultFormat = "json"
+            }
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var tool = new ExecuteResourceCommandTool(monitor, NullLogger<ExecuteResourceCommandTool>.Instance);
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(CreateArguments("api-service", "generate-token")), CancellationToken.None).DefaultTimeout();
+
+        Assert.True(result.IsError is null or false);
+        Assert.NotNull(result.Content);
+        Assert.Equal(2, result.Content.Count);
+
+        var successText = result.Content[0] as ModelContextProtocol.Protocol.TextContentBlock;
+        Assert.NotNull(successText);
+        Assert.Contains("successfully", successText.Text);
+
+        var resultText = result.Content[1] as ModelContextProtocol.Protocol.TextContentBlock;
+        Assert.NotNull(resultText);
+        Assert.Contains("abc123", resultText.Text);
+    }
+
+    [Fact]
+    public async Task ExecuteResourceCommandTool_NoExtraContent_WhenCommandSucceedsWithoutResult()
+    {
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            ExecuteResourceCommandResult = new ExecuteResourceCommandResponse { Success = true }
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var tool = new ExecuteResourceCommandTool(monitor, NullLogger<ExecuteResourceCommandTool>.Instance);
+        var result = await tool.CallToolAsync(CallToolContextTestHelper.Create(CreateArguments("api-service", "start")), CancellationToken.None).DefaultTimeout();
+
+        Assert.True(result.IsError is null or false);
+        Assert.NotNull(result.Content);
+        Assert.Single(result.Content);
     }
 }
 

--- a/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
@@ -146,8 +146,11 @@ internal sealed class TestInteractionService : IInteractionService
         DisplayedErrors.Add(errorMessage);
     }
 
+    public Action<KnownEmoji, string>? DisplayMessageCallback { get; set; }
+
     public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false)
     {
+        DisplayMessageCallback?.Invoke(emoji, message);
     }
 
     public void DisplaySuccess(string message, bool allowMarkup = false)
@@ -197,8 +200,11 @@ internal sealed class TestInteractionService : IInteractionService
     {
     }
 
+    public Action<string>? DisplayRawTextCallback { get; set; }
+
     public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null)
     {
+        DisplayRawTextCallback?.Invoke(text);
     }
 
     public void DisplayMarkdown(string markdown)

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -853,7 +853,7 @@ public partial class ConsoleLogsTests : DashboardTestContext
         Services.AddSingleton<IToastService, ToastService>();
         Services.AddSingleton<IconResolver>();
         Services.AddSingleton<IDashboardClient>(dashboardClient ?? new TestDashboardClient());
-        Services.AddSingleton<DashboardCommandExecutor>();
+        Services.AddScoped<DashboardCommandExecutor>();
         Services.AddSingleton<ConsoleLogsManager>();
     }
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -127,6 +127,15 @@ const (
 	EndpointPropertyTlsEnabled EndpointProperty = "TlsEnabled"
 )
 
+// CommandResultFormat represents CommandResultFormat.
+type CommandResultFormat string
+
+const (
+	CommandResultFormatNone CommandResultFormat = "None"
+	CommandResultFormatText CommandResultFormat = "Text"
+	CommandResultFormatJson CommandResultFormat = "Json"
+)
+
 // UrlDisplayLocation represents UrlDisplayLocation.
 type UrlDisplayLocation string
 
@@ -235,6 +244,8 @@ type ExecuteCommandResult struct {
 	Success bool `json:"Success,omitempty"`
 	Canceled bool `json:"Canceled,omitempty"`
 	ErrorMessage string `json:"ErrorMessage,omitempty"`
+	Result string `json:"Result,omitempty"`
+	ResultFormat CommandResultFormat `json:"ResultFormat,omitempty"`
 }
 
 // ToMap converts the DTO to a map for JSON serialization.
@@ -243,6 +254,8 @@ func (d *ExecuteCommandResult) ToMap() map[string]any {
 		"Success": SerializeValue(d.Success),
 		"Canceled": SerializeValue(d.Canceled),
 		"ErrorMessage": SerializeValue(d.ErrorMessage),
+		"Result": SerializeValue(d.Result),
+		"ResultFormat": SerializeValue(d.ResultFormat),
 	}
 }
 

--- a/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
+++ b/tests/Aspire.Hosting.CodeGeneration.Go.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.go
@@ -131,7 +131,6 @@ const (
 type CommandResultFormat string
 
 const (
-	CommandResultFormatNone CommandResultFormat = "None"
 	CommandResultFormatText CommandResultFormat = "Text"
 	CommandResultFormatJson CommandResultFormat = "Json"
 )

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -2750,6 +2750,36 @@ public class CommandOptions {
     }
 }
 
+// ===== CommandResultFormat.java =====
+// CommandResultFormat.java - GENERATED CODE - DO NOT EDIT
+
+package aspire;
+
+import java.util.*;
+import java.util.function.*;
+
+/** CommandResultFormat enum. */
+public enum CommandResultFormat implements WireValueEnum {
+    NONE("None"),
+    TEXT("Text"),
+    JSON("Json");
+
+    private final String value;
+
+    CommandResultFormat(String value) {
+        this.value = value;
+    }
+
+    public String getValue() { return value; }
+
+    public static CommandResultFormat fromValue(String value) {
+        for (CommandResultFormat e : values()) {
+            if (e.value.equals(value)) return e;
+        }
+        throw new IllegalArgumentException("Unknown value: " + value);
+    }
+}
+
 // ===== CompleteStepMarkdownOptions.java =====
 // CompleteStepMarkdownOptions.java - GENERATED CODE - DO NOT EDIT
 
@@ -9117,6 +9147,8 @@ public class ExecuteCommandResult {
     private boolean success;
     private boolean canceled;
     private String errorMessage;
+    private String result;
+    private CommandResultFormat resultFormat;
 
     public boolean getSuccess() { return success; }
     public void setSuccess(boolean value) { this.success = value; }
@@ -9124,12 +9156,18 @@ public class ExecuteCommandResult {
     public void setCanceled(boolean value) { this.canceled = value; }
     public String getErrorMessage() { return errorMessage; }
     public void setErrorMessage(String value) { this.errorMessage = value; }
+    public String getResult() { return result; }
+    public void setResult(String value) { this.result = value; }
+    public CommandResultFormat getResultFormat() { return resultFormat; }
+    public void setResultFormat(CommandResultFormat value) { this.resultFormat = value; }
 
     public Map<String, Object> toMap() {
         Map<String, Object> map = new HashMap<>();
         map.put("Success", AspireClient.serializeValue(success));
         map.put("Canceled", AspireClient.serializeValue(canceled));
         map.put("ErrorMessage", AspireClient.serializeValue(errorMessage));
+        map.put("Result", AspireClient.serializeValue(result));
+        map.put("ResultFormat", AspireClient.serializeValue(resultFormat));
         return map;
     }
 }
@@ -20081,6 +20119,7 @@ public final class WithVolumeOptions {
 .modules/CertificateTrustScope.java
 .modules/CommandLineArgsCallbackContext.java
 .modules/CommandOptions.java
+.modules/CommandResultFormat.java
 .modules/CompleteStepMarkdownOptions.java
 .modules/CompleteStepOptions.java
 .modules/CompleteTaskMarkdownOptions.java

--- a/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
+++ b/tests/Aspire.Hosting.CodeGeneration.Java.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.java
@@ -2760,7 +2760,6 @@ import java.util.function.*;
 
 /** CommandResultFormat enum. */
 public enum CommandResultFormat implements WireValueEnum {
-    NONE("None"),
     TEXT("Text"),
     JSON("Json");
 

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -1491,7 +1491,7 @@ def _validate_dict_types(args: typing.Any, arg_types: typing.Any) -> bool:
 
 CertificateTrustScope = typing.Literal["None", "Append", "Override", "System"]
 
-CommandResultFormat = typing.Literal["None", "Text", "Json"]
+CommandResultFormat = typing.Literal["Text", "Json"]
 
 ContainerLifetime = typing.Literal["Session", "Persistent"]
 

--- a/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
+++ b/tests/Aspire.Hosting.CodeGeneration.Python.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.py
@@ -1491,6 +1491,8 @@ def _validate_dict_types(args: typing.Any, arg_types: typing.Any) -> bool:
 
 CertificateTrustScope = typing.Literal["None", "Append", "Override", "System"]
 
+CommandResultFormat = typing.Literal["None", "Text", "Json"]
+
 ContainerLifetime = typing.Literal["Session", "Persistent"]
 
 DistributedApplicationOperation = typing.Literal["Run", "Publish"]
@@ -1678,6 +1680,8 @@ class ExecuteCommandResult(typing.TypedDict, total=False):
     Success: bool
     Canceled: bool
     ErrorMessage: str
+    Result: str
+    ResultFormat: CommandResultFormat
 
 class ResourceEventDto(typing.TypedDict, total=False):
     ResourceName: str

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -315,6 +315,28 @@ impl std::fmt::Display for EndpointProperty {
     }
 }
 
+/// CommandResultFormat
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CommandResultFormat {
+    #[default]
+    #[serde(rename = "None")]
+    None,
+    #[serde(rename = "Text")]
+    Text,
+    #[serde(rename = "Json")]
+    Json,
+}
+
+impl std::fmt::Display for CommandResultFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "None"),
+            Self::Text => write!(f, "Text"),
+            Self::Json => write!(f, "Json"),
+        }
+    }
+}
+
 /// UrlDisplayLocation
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum UrlDisplayLocation {
@@ -493,6 +515,10 @@ pub struct ExecuteCommandResult {
     pub canceled: bool,
     #[serde(rename = "ErrorMessage")]
     pub error_message: String,
+    #[serde(rename = "Result")]
+    pub result: String,
+    #[serde(rename = "ResultFormat")]
+    pub result_format: CommandResultFormat,
 }
 
 impl ExecuteCommandResult {
@@ -501,6 +527,8 @@ impl ExecuteCommandResult {
         map.insert("Success".to_string(), serde_json::to_value(&self.success).unwrap_or(Value::Null));
         map.insert("Canceled".to_string(), serde_json::to_value(&self.canceled).unwrap_or(Value::Null));
         map.insert("ErrorMessage".to_string(), serde_json::to_value(&self.error_message).unwrap_or(Value::Null));
+        map.insert("Result".to_string(), serde_json::to_value(&self.result).unwrap_or(Value::Null));
+        map.insert("ResultFormat".to_string(), serde_json::to_value(&self.result_format).unwrap_or(Value::Null));
         map
     }
 }

--- a/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
+++ b/tests/Aspire.Hosting.CodeGeneration.Rust.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.rs
@@ -319,8 +319,6 @@ impl std::fmt::Display for EndpointProperty {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CommandResultFormat {
     #[default]
-    #[serde(rename = "None")]
-    None,
     #[serde(rename = "Text")]
     Text,
     #[serde(rename = "Json")]
@@ -330,7 +328,6 @@ pub enum CommandResultFormat {
 impl std::fmt::Display for CommandResultFormat {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::None => write!(f, "None"),
             Self::Text => write!(f, "Text"),
             Self::Json => write!(f, "Json"),
         }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -252,7 +252,6 @@ export enum CertificateTrustScope {
 
 /** Enum type for CommandResultFormat */
 export enum CommandResultFormat {
-    None = "None",
     Text = "Text",
     Json = "Json",
 }

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -250,6 +250,13 @@ export enum CertificateTrustScope {
     System = "System",
 }
 
+/** Enum type for CommandResultFormat */
+export enum CommandResultFormat {
+    None = "None",
+    Text = "Text",
+    Json = "Json",
+}
+
 /** Enum type for ContainerLifetime */
 export enum ContainerLifetime {
     Session = "Session",
@@ -390,6 +397,8 @@ export interface ExecuteCommandResult {
     success?: boolean;
     canceled?: boolean;
     errorMessage?: string;
+    result?: string;
+    resultFormat?: CommandResultFormat;
 }
 
 /** DTO interface for ResourceEventDto */

--- a/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
@@ -405,7 +405,7 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
 
         Assert.True(result.Success);
         Assert.Null(result.Result);
-        Assert.Equal(CommandResultFormat.None, result.ResultFormat);
+        Assert.Null(result.ResultFormat);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
@@ -368,6 +368,96 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
         Assert.True(result.Success);
     }
 
+    [Fact]
+    public async Task ExecuteCommandAsync_SuccessWithResult_ReturnsResultData()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var custom = builder.AddResource(new CustomResource("myResource"));
+        custom.WithCommand(name: "generate-token",
+                displayName: "Generate Token",
+                executeCommand: _ => Task.FromResult(CommandResults.Success("{\"token\": \"abc123\"}", CommandResultFormat.Json)));
+
+        var app = builder.Build();
+        await app.StartAsync();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(custom.Resource, "generate-token");
+
+        Assert.True(result.Success);
+        Assert.Equal("{\"token\": \"abc123\"}", result.Result);
+        Assert.Equal(CommandResultFormat.Json, result.ResultFormat);
+    }
+
+    [Fact]
+    public async Task ExecuteCommandAsync_SuccessWithoutResult_ReturnsNoResultData()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var custom = builder.AddResource(new CustomResource("myResource"));
+        custom.WithCommand(name: "mycommand",
+                displayName: "My command",
+                executeCommand: _ => Task.FromResult(CommandResults.Success()));
+
+        var app = builder.Build();
+        await app.StartAsync();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(custom.Resource, "mycommand");
+
+        Assert.True(result.Success);
+        Assert.Null(result.Result);
+        Assert.Equal(CommandResultFormat.None, result.ResultFormat);
+    }
+
+    [Fact]
+    public async Task ExecuteCommandAsync_HasReplicas_SuccessWithResult_ReturnsFirstResultData()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var callCount = 0;
+        var custom = builder.AddResource(new CustomResource("myResource"));
+        custom.WithAnnotation(new DcpInstancesAnnotation([
+            new DcpInstance("myResource-abcdwxyz", "abcdwxyz", 0),
+            new DcpInstance("myResource-efghwxyz", "efghwxyz", 1)
+            ]));
+        custom.WithCommand(name: "generate-token",
+                displayName: "Generate Token",
+                executeCommand: e =>
+                {
+                    var count = Interlocked.Increment(ref callCount);
+                    return Task.FromResult(CommandResults.Success($"token-{count}", CommandResultFormat.Text));
+                });
+
+        var app = builder.Build();
+        await app.StartAsync();
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(custom.Resource, "generate-token");
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Result);
+        Assert.StartsWith("token-", result.Result);
+        Assert.Equal(CommandResultFormat.Text, result.ResultFormat);
+    }
+
+    [Fact]
+    public void CommandResults_SuccessWithResult_ProducesCorrectResult()
+    {
+        var result = CommandResults.Success("{\"key\": \"value\"}", CommandResultFormat.Json);
+
+        Assert.True(result.Success);
+        Assert.Equal("{\"key\": \"value\"}", result.Result);
+        Assert.Equal(CommandResultFormat.Json, result.ResultFormat);
+    }
+
+    [Fact]
+    public void CommandResults_SuccessWithTextResult_DefaultsToText()
+    {
+        var result = CommandResults.Success("hello world");
+
+        Assert.True(result.Success);
+        Assert.Equal("hello world", result.Result);
+        Assert.Equal(CommandResultFormat.Text, result.ResultFormat);
+    }
+
     private sealed class CustomResource(string name) : Resource(name), IResourceWithEndpoints, IResourceWithWaitSupport
     {
 


### PR DESCRIPTION
## Description

Adds `Result` and `ResultFormat` properties to `ExecuteCommandResult`, allowing resource commands to return structured output data (text or JSON) back to the caller. The result flows through the entire pipeline: model → proto/gRPC → backchannel → Dashboard UI → CLI → MCP tools.

**Model**: New `CommandResultFormat` enum (`None`, `Text`, `Json`), `Result`/`ResultFormat` on `ExecuteCommandResult`, and `CommandResults.Success(result, format)` overload.

**Proto/gRPC**: `ResourceCommandResponse` gets `optional string result` and `CommandResultFormat result_format` fields.

**Backchannel**: `ExecuteResourceCommandResponse` gains `Result` and `ResultFormat` (string) properties.

**Dashboard**: On command success with result data, opens `TextVisualizerDialog` with syntax highlighting. JSON results lock the viewer to JSON mode.

**CLI**: Result written to stdout via `DisplayRawText(result, ConsoleOutput.Standard)`. Status messages routed to stderr, enabling clean piping (e.g., `aspire resource myResource generate-token | jq .token`). MCP tool returns result as additional `TextContentBlock`.

**Replica aggregation**: Takes the first successful replica's result when multiple replicas return data.

**Playground**: Added "Generate Token" (JSON) and "Get Connection String" (text) demo commands on `stress-telemetryservice`.

Fixes https://github.com/microsoft/aspire/issues/15610

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [ ] No