### PR TITLE
[release/13.2] Fix TS AppHost restore config resolution

### DIFF
--- a/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetBasedAppHostServerProject.cs
@@ -324,8 +324,8 @@ internal sealed class DotNetBasedAppHostServerProject : IAppHostServerProject
         }
 
         var channels = await _packagingService.GetChannelsAsync(cancellationToken);
-        var localConfig = AspireJsonConfiguration.Load(_appPath);
-        var configuredChannelName = localConfig?.Channel;
+        var configuredChannelName = AspireConfigFile.Load(_appPath)?.Channel
+            ?? AspireJsonConfiguration.Load(_appPath)?.Channel;
 
         if (string.IsNullOrEmpty(configuredChannelName))
         {

--- a/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
+++ b/src/Aspire.Cli/Projects/PrebuiltAppHostServer.cs
@@ -330,13 +330,13 @@ internal sealed class PrebuiltAppHostServer : IAppHostServerProject
     }
 
     /// <summary>
-    /// Resolves the configured channel name from local settings.json or global config.
+    /// Resolves the configured channel name from local project config or global config.
     /// </summary>
     private async Task<string?> ResolveChannelNameAsync(CancellationToken cancellationToken)
     {
-        // Check local settings.json first
-        var localConfig = AspireJsonConfiguration.Load(_appDirectoryPath);
-        var channelName = localConfig?.Channel;
+        // Check aspire.config.json first, then fall back to legacy .aspire/settings.json.
+        var channelName = AspireConfigFile.Load(_appDirectoryPath)?.Channel
+            ?? AspireJsonConfiguration.Load(_appDirectoryPath)?.Channel;
 
         // Fall back to global config
         if (string.IsNullOrEmpty(channelName))

--- a/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
+++ b/src/Aspire.Cli/Templating/CliTemplateFactory.TypeScriptStarterTemplate.cs
@@ -61,16 +61,14 @@ internal sealed partial class CliTemplateFactory
                     _logger.LogDebug("Copying embedded TypeScript starter template files to '{OutputPath}'.", outputPath);
                     await CopyTemplateTreeToDiskAsync("ts-starter", outputPath, ApplyAllTokens, cancellationToken);
 
-                    // Write channel to settings.json before restore so package resolution uses the selected channel.
+                    // Persist the template SDK version before restore so integration and codegen package
+                    // resolution stays aligned with the project we just created.
+                    var config = AspireConfigFile.LoadOrCreate(outputPath, aspireVersion);
                     if (!string.IsNullOrEmpty(inputs.Channel))
                     {
-                        var config = AspireJsonConfiguration.Load(outputPath);
-                        if (config is not null)
-                        {
-                            config.Channel = inputs.Channel;
-                            config.Save(outputPath);
-                        }
+                        config.Channel = inputs.Channel;
                     }
+                    config.Save(outputPath);
 
                     var appHostProject = _projectFactory.TryGetProject(new FileInfo(Path.Combine(outputPath, "apphost.ts")));
                     if (appHostProject is not IGuestAppHostSdkGenerator guestProject)

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1296,6 +1296,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         var buildAndGenerateCalled = false;
         string? channelSeenByProject = null;
+        string? sdkVersionSeenByProject = null;
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
@@ -1342,8 +1343,9 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         services.AddSingleton<IAppHostProjectFactory>(new TestTypeScriptStarterProjectFactory((directory, cancellationToken) =>
         {
             buildAndGenerateCalled = true;
-            var config = AspireJsonConfiguration.Load(directory.FullName);
+            var config = AspireConfigFile.Load(directory.FullName);
             channelSeenByProject = config?.Channel;
+            sdkVersionSeenByProject = config?.SdkVersion;
 
             var modulesDir = Directory.CreateDirectory(Path.Combine(directory.FullName, ".modules"));
             File.WriteAllText(Path.Combine(modulesDir.FullName, "aspire.ts"), "// generated sdk");
@@ -1360,6 +1362,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(0, exitCode);
         Assert.True(buildAndGenerateCalled);
         Assert.Equal("daily", channelSeenByProject);
+        Assert.Equal("9.2.0", sdkVersionSeenByProject);
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, ".modules", "aspire.ts")));
     }
 

--- a/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostServerProjectTests.cs
@@ -237,12 +237,12 @@ public class AppHostServerProjectTests(ITestOutputHelper outputHelper) : IDispos
 
     /// <summary>
     /// Regression test for channel switching bug.
-    /// When a project has a channel configured in .aspire/settings.json (project-local),
+    /// When a project has a channel configured in aspire.config.json (project-local),
     /// the NuGet.config should use that channel's hive path, NOT the global config channel.
     /// 
     /// Bug scenario:
     /// 1. User runs `aspire update` and selects "pr-new" channel
-    /// 2. UpdatePackagesAsync saves channel="pr-new" to project-local .aspire/settings.json
+    /// 2. UpdatePackagesAsync saves channel="pr-new" to project-local aspire.config.json
     /// 3. BuildAndGenerateSdkAsync calls CreateProjectFilesAsync
     /// 4. BUG: CreateProjectFilesAsync reads channel from GLOBAL config (returns "pr-old")
     /// 5. NuGet.config is generated with pr-old hive path instead of pr-new
@@ -259,14 +259,15 @@ public class AppHostServerProjectTests(ITestOutputHelper outputHelper) : IDispos
         var prOldHive = hivesDir.CreateSubdirectory("pr-old");
         var prNewHive = hivesDir.CreateSubdirectory("pr-new");
 
-        // Create project-local .aspire/settings.json with channel="pr-new"
+        // Create project-local aspire.config.json with channel="pr-new"
         // This simulates what happens after `aspire update` saves the selected channel
-        var aspireDir = _workspace.WorkspaceRoot.CreateSubdirectory(".aspire");
-        var settingsJson = Path.Combine(aspireDir.FullName, "settings.json");
-        await File.WriteAllTextAsync(settingsJson, """
+        var aspireConfigPath = Path.Combine(_workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        await File.WriteAllTextAsync(aspireConfigPath, """
             {
                 "channel": "pr-new",
-                "sdkVersion": "13.1.0"
+                "sdk": {
+                    "version": "13.1.0"
+                }
             }
             """);
 

--- a/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/PrebuiltAppHostServerTests.cs
@@ -192,4 +192,42 @@ public class PrebuiltAppHostServerTests(ITestOutputHelper outputHelper)
         }
     }
 
+    [Fact]
+    public async Task ResolveChannelNameAsync_UsesProjectLocalAspireConfig_NotGlobalChannel()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var aspireConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        await File.WriteAllTextAsync(aspireConfigPath, """
+            {
+                "channel": "pr-new"
+            }
+            """);
+
+        var configurationService = new TestConfigurationService
+        {
+            OnGetConfiguration = key => key == "channel" ? "pr-old" : null
+        };
+
+        var nugetService = new BundleNuGetService(new NullLayoutDiscovery(), Microsoft.Extensions.Logging.Abstractions.NullLogger<BundleNuGetService>.Instance);
+        var server = new PrebuiltAppHostServer(
+            workspace.WorkspaceRoot.FullName,
+            "test.sock",
+            new LayoutConfiguration(),
+            nugetService,
+            new TestDotNetCliRunner(),
+            new TestDotNetSdkInstaller(),
+            new Aspire.Cli.Tests.Mcp.MockPackagingService(),
+            configurationService,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+
+        var method = typeof(PrebuiltAppHostServer).GetMethod("ResolveChannelNameAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var channelTask = Assert.IsType<Task<string?>>(method.Invoke(server, [CancellationToken.None]));
+        var channel = await channelTask;
+
+        Assert.Equal("pr-new", channel);
+    }
+
 }


### PR DESCRIPTION
## Description

`aspire new` for TypeScript AppHost projects was already triggering restore, but some of the first-run restore/code generation paths still read legacy `.aspire/settings.json` instead of the `aspire.config.json` that new templates produce. As a result, project-local channel and package resolution settings could be missed until a later `aspire restore` or `aspire run`.

This change updates the TypeScript starter and guest AppHost server preparation paths to prefer `aspire.config.json` with legacy fallback preserved. It also persists the template SDK version before the automatic restore/code generation step so the initial generated project resolves integrations against the same version it was created with.

The test updates cover the new-format config path in the starter flow and in both generated and prebuilt AppHost server channel resolution behavior.

Fixes #15413

Validation:
- `./dotnet.sh test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj -- --filter-method "*.NewCommandWithTypeScriptStarterGeneratesSdkArtifacts" --filter-method "*.CreateProjectFiles_NuGetConfig_UsesProjectLocalChannel_NotGlobalChannel_MatchesSnapshot" --filter-method "*.ResolveChannelNameAsync_UsesProjectLocalAspireConfig_NotGlobalChannel" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `./dotnet.sh test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj -- --filter-class "*.NewCommandTests" --filter-class "*.AppHostServerProjectTests" --filter-class "*.PrebuiltAppHostServerTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No