### PR TITLE
Accept whole-number ATS values for integral parameters

### DIFF
--- a/src/Aspire.Hosting.RemoteHost/Ats/AtsMarshaller.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/AtsMarshaller.cs
@@ -537,6 +537,43 @@ internal sealed class AtsMarshaller
         return type.ToString();
     }
 
+    private static decimal ReadNumericValue(JsonValue value, Type targetType)
+    {
+        if (value.TryGetValue<decimal>(out var decimalValue))
+        {
+            return decimalValue;
+        }
+
+        if (value.TryGetValue<long>(out var longValue))
+        {
+            return longValue;
+        }
+
+        if (value.TryGetValue<ulong>(out var ulongValue))
+        {
+            return ulongValue;
+        }
+
+        if (value.TryGetValue<double>(out var doubleValue) && double.IsFinite(doubleValue))
+        {
+            return (decimal)doubleValue;
+        }
+
+        throw new InvalidCastException($"Value cannot be converted to {targetType.Name}.");
+    }
+
+    private static decimal ReadIntegralNumericValue(JsonValue value, Type targetType, decimal minValue, decimal maxValue)
+    {
+        var numericValue = ReadNumericValue(value, targetType);
+
+        if (decimal.Truncate(numericValue) != numericValue || numericValue < minValue || numericValue > maxValue)
+        {
+            throw new InvalidCastException($"Value cannot be converted to {targetType.Name}.");
+        }
+
+        return numericValue;
+    }
+
     /// <summary>
     /// Converts a JSON primitive to the target .NET type.
     /// </summary>
@@ -570,27 +607,57 @@ internal sealed class AtsMarshaller
 
         if (underlyingType == typeof(int))
         {
-            return value.GetValue<int>();
+            return decimal.ToInt32(ReadIntegralNumericValue(value, underlyingType, int.MinValue, int.MaxValue));
         }
 
         if (underlyingType == typeof(long))
         {
-            return value.GetValue<long>();
+            return decimal.ToInt64(ReadIntegralNumericValue(value, underlyingType, long.MinValue, long.MaxValue));
+        }
+
+        if (underlyingType == typeof(byte))
+        {
+            return decimal.ToByte(ReadIntegralNumericValue(value, underlyingType, byte.MinValue, byte.MaxValue));
+        }
+
+        if (underlyingType == typeof(short))
+        {
+            return decimal.ToInt16(ReadIntegralNumericValue(value, underlyingType, short.MinValue, short.MaxValue));
+        }
+
+        if (underlyingType == typeof(uint))
+        {
+            return decimal.ToUInt32(ReadIntegralNumericValue(value, underlyingType, uint.MinValue, uint.MaxValue));
+        }
+
+        if (underlyingType == typeof(ulong))
+        {
+            return decimal.ToUInt64(ReadIntegralNumericValue(value, underlyingType, ulong.MinValue, ulong.MaxValue));
+        }
+
+        if (underlyingType == typeof(ushort))
+        {
+            return decimal.ToUInt16(ReadIntegralNumericValue(value, underlyingType, ushort.MinValue, ushort.MaxValue));
+        }
+
+        if (underlyingType == typeof(sbyte))
+        {
+            return decimal.ToSByte(ReadIntegralNumericValue(value, underlyingType, sbyte.MinValue, sbyte.MaxValue));
         }
 
         if (underlyingType == typeof(double))
         {
-            return value.GetValue<double>();
+            return (double)ReadNumericValue(value, underlyingType);
         }
 
         if (underlyingType == typeof(float))
         {
-            return (float)value.GetValue<double>();
+            return (float)ReadNumericValue(value, underlyingType);
         }
 
         if (underlyingType == typeof(decimal))
         {
-            return value.GetValue<decimal>();
+            return ReadNumericValue(value, underlyingType);
         }
 
         // TimeSpan: accept milliseconds (number) or parseable string

--- a/src/Aspire.Hosting.RemoteHost/Ats/AtsMarshaller.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/AtsMarshaller.cs
@@ -537,8 +537,15 @@ internal sealed class AtsMarshaller
         return type.ToString();
     }
 
-    private static decimal ReadNumericValue(JsonValue value, Type targetType)
+    private const double MaxSafeIntegerDouble = 9_007_199_254_740_991d;
+
+    private static decimal ReadDecimalValue(JsonValue value, Type targetType)
     {
+        if (value.TryGetValue<int>(out var intValue))
+        {
+            return intValue;
+        }
+
         if (value.TryGetValue<decimal>(out var decimalValue))
         {
             return decimalValue;
@@ -556,7 +563,14 @@ internal sealed class AtsMarshaller
 
         if (value.TryGetValue<double>(out var doubleValue) && double.IsFinite(doubleValue))
         {
-            return (decimal)doubleValue;
+            try
+            {
+                return (decimal)doubleValue;
+            }
+            catch (OverflowException)
+            {
+                throw new InvalidCastException($"Value cannot be converted to {targetType.Name}.");
+            }
         }
 
         throw new InvalidCastException($"Value cannot be converted to {targetType.Name}.");
@@ -564,8 +578,41 @@ internal sealed class AtsMarshaller
 
     private static decimal ReadIntegralNumericValue(JsonValue value, Type targetType, decimal minValue, decimal maxValue)
     {
-        var numericValue = ReadNumericValue(value, targetType);
+        if (value.TryGetValue<int>(out var intValue))
+        {
+            return ValidateIntegralNumericValue(intValue, targetType, minValue, maxValue);
+        }
 
+        if (value.TryGetValue<long>(out var longValue))
+        {
+            return ValidateIntegralNumericValue(longValue, targetType, minValue, maxValue);
+        }
+
+        if (value.TryGetValue<ulong>(out var ulongValue))
+        {
+            return ValidateIntegralNumericValue(ulongValue, targetType, minValue, maxValue);
+        }
+
+        if (value.TryGetValue<decimal>(out var decimalValue))
+        {
+            return ValidateIntegralNumericValue(decimalValue, targetType, minValue, maxValue);
+        }
+
+        if (value.TryGetValue<double>(out var doubleValue) && double.IsFinite(doubleValue))
+        {
+            if (Math.Abs(doubleValue) > MaxSafeIntegerDouble)
+            {
+                throw new InvalidCastException($"Value cannot be converted to {targetType.Name}.");
+            }
+
+            return ValidateIntegralNumericValue((decimal)doubleValue, targetType, minValue, maxValue);
+        }
+
+        throw new InvalidCastException($"Value cannot be converted to {targetType.Name}.");
+    }
+
+    private static decimal ValidateIntegralNumericValue(decimal numericValue, Type targetType, decimal minValue, decimal maxValue)
+    {
         if (decimal.Truncate(numericValue) != numericValue || numericValue < minValue || numericValue > maxValue)
         {
             throw new InvalidCastException($"Value cannot be converted to {targetType.Name}.");
@@ -647,17 +694,17 @@ internal sealed class AtsMarshaller
 
         if (underlyingType == typeof(double))
         {
-            return (double)ReadNumericValue(value, underlyingType);
+            return value.GetValue<double>();
         }
 
         if (underlyingType == typeof(float))
         {
-            return (float)ReadNumericValue(value, underlyingType);
+            return value.TryGetValue<float>(out var floatValue) ? floatValue : (float)value.GetValue<double>();
         }
 
         if (underlyingType == typeof(decimal))
         {
-            return ReadNumericValue(value, underlyingType);
+            return ReadDecimalValue(value, underlyingType);
         }
 
         // TimeSpan: accept milliseconds (number) or parseable string

--- a/src/Aspire.Hosting.RemoteHost/Ats/AtsMarshaller.cs
+++ b/src/Aspire.Hosting.RemoteHost/Ats/AtsMarshaller.cs
@@ -537,6 +537,7 @@ internal sealed class AtsMarshaller
         return type.ToString();
     }
 
+    // IEEE 754 doubles can exactly represent integers only through 2^53 - 1.
     private const double MaxSafeIntegerDouble = 9_007_199_254_740_991d;
 
     private static decimal ReadDecimalValue(JsonValue value, Type targetType)
@@ -546,6 +547,7 @@ internal sealed class AtsMarshaller
             return intValue;
         }
 
+        // Prefer decimal here because this helper is only used for decimal targets.
         if (value.TryGetValue<decimal>(out var decimalValue))
         {
             return decimalValue;

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsMarshallerTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsMarshallerTests.cs
@@ -583,7 +583,7 @@ public class AtsMarshallerTests
     [Fact]
     public void ConvertPrimitive_RejectsLongFromUnsafeDouble()
     {
-        var value = JsonValue.Create(9007199254740993d);
+        var value = JsonValue.Create(9007199254740992d);
 
         Assert.Throws<InvalidCastException>(() => AtsMarshaller.ConvertPrimitive(value!, typeof(long)));
     }

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsMarshallerTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsMarshallerTests.cs
@@ -46,6 +46,36 @@ public class AtsMarshallerTests
         return CreateTestMarshaller(registry);
     }
 
+    public static TheoryData<Type, JsonValue, object> WholeDoubleAdditionalIntegralTypes => new()
+    {
+        { typeof(byte), JsonValue.Create(42.0)!, (byte)42 },
+        { typeof(short), JsonValue.Create(42.0)!, (short)42 },
+        { typeof(uint), JsonValue.Create(42.0)!, 42u },
+        { typeof(ulong), JsonValue.Create(42.0)!, 42ul },
+        { typeof(ushort), JsonValue.Create(42.0)!, (ushort)42 },
+        { typeof(sbyte), JsonValue.Create(42.0)!, (sbyte)42 },
+    };
+
+    public static TheoryData<Type, JsonValue> FractionalAdditionalIntegralTypes => new()
+    {
+        { typeof(byte), JsonValue.Create(42.5)! },
+        { typeof(short), JsonValue.Create(42.5)! },
+        { typeof(uint), JsonValue.Create(42.5)! },
+        { typeof(ulong), JsonValue.Create(42.5)! },
+        { typeof(ushort), JsonValue.Create(42.5)! },
+        { typeof(sbyte), JsonValue.Create(42.5)! },
+    };
+
+    public static TheoryData<Type, JsonValue> OverflowAdditionalIntegralTypes => new()
+    {
+        { typeof(byte), JsonValue.Create(256.0)! },
+        { typeof(short), JsonValue.Create(32768.0)! },
+        { typeof(uint), JsonValue.Create(-1.0)! },
+        { typeof(ulong), JsonValue.Create(-1.0)! },
+        { typeof(ushort), JsonValue.Create(65536.0)! },
+        { typeof(sbyte), JsonValue.Create(128.0)! },
+    };
+
     [Theory]
     [InlineData(typeof(string))]
     [InlineData(typeof(bool))]
@@ -238,6 +268,29 @@ public class AtsMarshallerTests
         var value = JsonValue.Create(11433.5);
 
         Assert.Throws<InvalidCastException>(() => AtsMarshaller.ConvertPrimitive(value!, typeof(int)));
+    }
+
+    [Theory]
+    [MemberData(nameof(WholeDoubleAdditionalIntegralTypes))]
+    public void ConvertPrimitive_ConvertsWholeDoubleForAdditionalIntegralTypes(Type targetType, JsonValue value, object expected)
+    {
+        var result = AtsMarshaller.ConvertPrimitive(value, targetType);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [MemberData(nameof(FractionalAdditionalIntegralTypes))]
+    public void ConvertPrimitive_RejectsFractionalDoubleForAdditionalIntegralTypes(Type targetType, JsonValue value)
+    {
+        Assert.Throws<InvalidCastException>(() => AtsMarshaller.ConvertPrimitive(value, targetType));
+    }
+
+    [Theory]
+    [MemberData(nameof(OverflowAdditionalIntegralTypes))]
+    public void ConvertPrimitive_RejectsOutOfRangeValuesForAdditionalIntegralTypes(Type targetType, JsonValue value)
+    {
+        Assert.Throws<InvalidCastException>(() => AtsMarshaller.ConvertPrimitive(value, targetType));
     }
 
     [Fact]
@@ -528,6 +581,14 @@ public class AtsMarshallerTests
     }
 
     [Fact]
+    public void ConvertPrimitive_RejectsLongFromUnsafeDouble()
+    {
+        var value = JsonValue.Create(9007199254740993d);
+
+        Assert.Throws<InvalidCastException>(() => AtsMarshaller.ConvertPrimitive(value!, typeof(long)));
+    }
+
+    [Fact]
     public void ConvertPrimitive_ConvertsDouble()
     {
         var value = JsonValue.Create(3.14159);
@@ -535,6 +596,16 @@ public class AtsMarshallerTests
         var result = AtsMarshaller.ConvertPrimitive(value!, typeof(double));
 
         Assert.Equal(3.14159, result);
+    }
+
+    [Fact]
+    public void ConvertPrimitive_ConvertsLargeDoubleWithoutDecimalCoercion()
+    {
+        var value = JsonValue.Create(1e100);
+
+        var result = AtsMarshaller.ConvertPrimitive(value!, typeof(double));
+
+        Assert.Equal(1e100, result);
     }
 
     [Fact]
@@ -555,6 +626,14 @@ public class AtsMarshallerTests
         var result = AtsMarshaller.ConvertPrimitive(value!, typeof(decimal));
 
         Assert.Equal(123.456m, result);
+    }
+
+    [Fact]
+    public void ConvertPrimitive_RejectsDecimalFromOutOfRangeDouble()
+    {
+        var value = JsonValue.Create(1e100);
+
+        Assert.Throws<InvalidCastException>(() => AtsMarshaller.ConvertPrimitive(value!, typeof(decimal)));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.RemoteHost.Tests/AtsMarshallerTests.cs
+++ b/tests/Aspire.Hosting.RemoteHost.Tests/AtsMarshallerTests.cs
@@ -223,6 +223,24 @@ public class AtsMarshallerTests
     }
 
     [Fact]
+    public void ConvertPrimitive_ConvertsIntFromWholeDouble()
+    {
+        var value = JsonValue.Create(11433.0);
+
+        var result = AtsMarshaller.ConvertPrimitive(value!, typeof(int));
+
+        Assert.Equal(11433, result);
+    }
+
+    [Fact]
+    public void ConvertPrimitive_ThrowsForIntFromFractionalDouble()
+    {
+        var value = JsonValue.Create(11433.5);
+
+        Assert.Throws<InvalidCastException>(() => AtsMarshaller.ConvertPrimitive(value!, typeof(int)));
+    }
+
+    [Fact]
     public void ConvertPrimitive_ConvertsBoolCorrectly()
     {
         var value = JsonValue.Create(true);
@@ -497,6 +515,16 @@ public class AtsMarshallerTests
         var result = AtsMarshaller.ConvertPrimitive(value!, typeof(long));
 
         Assert.Equal(9223372036854775807L, result);
+    }
+
+    [Fact]
+    public void ConvertPrimitive_ConvertsLongFromWholeDouble()
+    {
+        var value = JsonValue.Create(5000000000d);
+
+        var result = AtsMarshaller.ConvertPrimitive(value!, typeof(long));
+
+        Assert.Equal(5000000000L, result);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

This change updates the shared ATS marshaller to accept whole-number JSON values for integral CLR parameters.

Motivation/context:
Java playground AppHosts can currently pass integral values through the ATS `number` wire type, which caused runtime `TYPE_MISMATCH` failures when the server expected CLR integral types such as `System.Int32`. This change makes the marshaller coerce whole-number payloads into the requested integral CLR type while still rejecting fractional values for integral parameters.

Validation:
- Ran `./dotnet.sh test tests/Aspire.Hosting.RemoteHost.Tests/Aspire.Hosting.RemoteHost.Tests.csproj -- --filter-method "*.ConvertPrimitive_ConvertsIntFromWholeDouble" --filter-method "*.ConvertPrimitive_ThrowsForIntFromFractionalDouble" --filter-method "*.ConvertPrimitive_ConvertsLongFromWholeDouble" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- Reproduced `playground/polyglot/Java/Aspire.Hosting.SqlServer/ValidationAppHost` with the local CLI and confirmed the previous `withHostPort` type mismatch no longer occurs; execution now proceeds to a separate runtime issue.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
