### PR TITLE
[release/13.2] Fix guest AppHost launch profile env propagation

### DIFF
--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -383,8 +383,9 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             // Signal that build/preparation is complete
             context.BuildCompletionSource?.TrySetResult(true);
 
-            // Read launch settings and set shared environment variables
-            var launchSettingsEnvVars = GetServerEnvironmentVariables(directory);
+            // Read launch settings once and reuse them for both the temporary server and guest AppHost.
+            var launchProfileEnvironmentVariables = ReadLaunchSettingsEnvironmentVariables(directory);
+            var launchSettingsEnvVars = GetServerEnvironmentVariables(launchProfileEnvironmentVariables);
 
             // Apply certificate environment variables (e.g., SSL_CERT_DIR on Linux)
             foreach (var kvp in certEnvVars)
@@ -472,7 +473,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
 
             // Pass the launch profile and certificate environment variables through to the guest AppHost
             // so it sees the same dashboard and resource service endpoints as the temporary .NET server.
-            var environmentVariables = CreateGuestEnvironmentVariables(directory, context.EnvironmentVariables, certEnvVars);
+            var environmentVariables = CreateGuestEnvironmentVariables(context.EnvironmentVariables, launchProfileEnvironmentVariables, certEnvVars);
             environmentVariables["REMOTE_APP_HOST_SOCKET_PATH"] = socketPath;
             environmentVariables["ASPIRE_PROJECT_DIRECTORY"] = directory.FullName;
             environmentVariables["ASPIRE_APPHOST_FILEPATH"] = appHostFile.FullName;
@@ -580,9 +581,13 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
 
     internal Dictionary<string, string> GetServerEnvironmentVariables(DirectoryInfo directory)
     {
-        var envVars = new Dictionary<string, string>();
-        MergeLaunchProfileEnvironmentVariables(directory, envVars, defaultEnvironment: "Development");
+        return GetServerEnvironmentVariables(ReadLaunchSettingsEnvironmentVariables(directory));
+    }
 
+    private static Dictionary<string, string> GetServerEnvironmentVariables(IDictionary<string, string>? launchProfileEnvironmentVariables)
+    {
+        var envVars = new Dictionary<string, string>();
+        MergeLaunchProfileEnvironmentVariables(launchProfileEnvironmentVariables, envVars, defaultEnvironment: "Development");
         return envVars;
     }
 
@@ -591,9 +596,20 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         IDictionary<string, string> contextEnvironmentVariables,
         IDictionary<string, string>? additionalEnvironmentVariables = null)
     {
+        return CreateGuestEnvironmentVariables(
+            contextEnvironmentVariables,
+            ReadLaunchSettingsEnvironmentVariables(directory),
+            additionalEnvironmentVariables);
+    }
+
+    internal static Dictionary<string, string> CreateGuestEnvironmentVariables(
+        IDictionary<string, string> contextEnvironmentVariables,
+        IDictionary<string, string>? launchProfileEnvironmentVariables,
+        IDictionary<string, string>? additionalEnvironmentVariables = null)
+    {
         var environmentVariables = new Dictionary<string, string>(contextEnvironmentVariables);
 
-        MergeLaunchProfileEnvironmentVariables(directory, environmentVariables);
+        MergeLaunchProfileEnvironmentVariables(launchProfileEnvironmentVariables, environmentVariables);
 
         if (additionalEnvironmentVariables is not null)
         {
@@ -606,13 +622,11 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
         return environmentVariables;
     }
 
-    private void MergeLaunchProfileEnvironmentVariables(
-        DirectoryInfo directory,
+    private static void MergeLaunchProfileEnvironmentVariables(
+        IDictionary<string, string>? launchProfileEnvironmentVariables,
         IDictionary<string, string> environmentVariables,
         string? defaultEnvironment = null)
     {
-        var launchProfileEnvironmentVariables = ReadLaunchSettingsEnvironmentVariables(directory);
-
         if (launchProfileEnvironmentVariables is not null)
         {
             foreach (var (key, value) in launchProfileEnvironmentVariables)
@@ -804,8 +818,9 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
             // Store output collector in context for exception handling
             context.OutputCollector = prepareOutput;
 
-            // Read launch settings and set shared environment variables
-            var launchSettingsEnvVars = GetServerEnvironmentVariables(directory);
+            // Read launch settings once and reuse them for both the temporary server and guest AppHost.
+            var launchProfileEnvironmentVariables = ReadLaunchSettingsEnvironmentVariables(directory);
+            var launchSettingsEnvVars = GetServerEnvironmentVariables(launchProfileEnvironmentVariables);
 
             // Generate a backchannel socket path for CLI to connect to AppHost server
             var backchannelSocketPath = GetBackchannelSocketPath();
@@ -881,7 +896,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
 
             // Pass the launch profile environment variables through to the guest AppHost so publish mode
             // uses the same dashboard and resource service endpoints as the temporary .NET server.
-            var environmentVariables = CreateGuestEnvironmentVariables(directory, context.EnvironmentVariables);
+            var environmentVariables = CreateGuestEnvironmentVariables(context.EnvironmentVariables, launchProfileEnvironmentVariables);
             environmentVariables["REMOTE_APP_HOST_SOCKET_PATH"] = jsonRpcSocketPath;
             environmentVariables["ASPIRE_PROJECT_DIRECTORY"] = directory.FullName;
             environmentVariables["ASPIRE_APPHOST_FILEPATH"] = appHostFile.FullName;

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -470,14 +470,13 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
 
             // Step 8: Execute the guest apphost
 
-            // Pass the socket path, project directory, and apphost file path to the guest process
-            var environmentVariables = new Dictionary<string, string>(context.EnvironmentVariables)
-            {
-                ["REMOTE_APP_HOST_SOCKET_PATH"] = socketPath,
-                ["ASPIRE_PROJECT_DIRECTORY"] = directory.FullName,
-                ["ASPIRE_APPHOST_FILEPATH"] = appHostFile.FullName,
-                [KnownConfigNames.RemoteAppHostToken] = authenticationToken
-            };
+            // Pass the launch profile and certificate environment variables through to the guest AppHost
+            // so it sees the same dashboard and resource service endpoints as the temporary .NET server.
+            var environmentVariables = CreateGuestEnvironmentVariables(directory, context.EnvironmentVariables, certEnvVars);
+            environmentVariables["REMOTE_APP_HOST_SOCKET_PATH"] = socketPath;
+            environmentVariables["ASPIRE_PROJECT_DIRECTORY"] = directory.FullName;
+            environmentVariables["ASPIRE_APPHOST_FILEPATH"] = appHostFile.FullName;
+            environmentVariables[KnownConfigNames.RemoteAppHostToken] = authenticationToken;
 
             // Check if the extension should launch the guest app host (for VS Code debugging).
             // This mirrors the pattern in DotNetCliRunner.ExecuteAsync for .NET app hosts.
@@ -581,17 +580,57 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
 
     internal Dictionary<string, string> GetServerEnvironmentVariables(DirectoryInfo directory)
     {
-        var envVars = ReadLaunchSettingsEnvironmentVariables(directory) ?? new Dictionary<string, string>();
-
-        // Support ASPIRE_ENVIRONMENT from the launch profile to set both DOTNET_ENVIRONMENT and ASPNETCORE_ENVIRONMENT
-        envVars.TryGetValue("ASPIRE_ENVIRONMENT", out var environment);
-        environment ??= "Development";
-
-        // Set the environment for the AppHost server process
-        envVars["DOTNET_ENVIRONMENT"] = environment;
-        envVars["ASPNETCORE_ENVIRONMENT"] = environment;
+        var envVars = new Dictionary<string, string>();
+        MergeLaunchProfileEnvironmentVariables(directory, envVars, defaultEnvironment: "Development");
 
         return envVars;
+    }
+
+    internal Dictionary<string, string> CreateGuestEnvironmentVariables(
+        DirectoryInfo directory,
+        IDictionary<string, string> contextEnvironmentVariables,
+        IDictionary<string, string>? additionalEnvironmentVariables = null)
+    {
+        var environmentVariables = new Dictionary<string, string>(contextEnvironmentVariables);
+
+        MergeLaunchProfileEnvironmentVariables(directory, environmentVariables);
+
+        if (additionalEnvironmentVariables is not null)
+        {
+            foreach (var (key, value) in additionalEnvironmentVariables)
+            {
+                environmentVariables[key] = value;
+            }
+        }
+
+        return environmentVariables;
+    }
+
+    private void MergeLaunchProfileEnvironmentVariables(
+        DirectoryInfo directory,
+        IDictionary<string, string> environmentVariables,
+        string? defaultEnvironment = null)
+    {
+        var launchProfileEnvironmentVariables = ReadLaunchSettingsEnvironmentVariables(directory);
+
+        if (launchProfileEnvironmentVariables is not null)
+        {
+            foreach (var (key, value) in launchProfileEnvironmentVariables)
+            {
+                environmentVariables[key] = value;
+            }
+        }
+
+        if (launchProfileEnvironmentVariables?.TryGetValue("ASPIRE_ENVIRONMENT", out var environment) == true)
+        {
+            environmentVariables["DOTNET_ENVIRONMENT"] = environment;
+            environmentVariables["ASPNETCORE_ENVIRONMENT"] = environment;
+        }
+        else if (defaultEnvironment is not null)
+        {
+            environmentVariables["DOTNET_ENVIRONMENT"] = defaultEnvironment;
+            environmentVariables["ASPNETCORE_ENVIRONMENT"] = defaultEnvironment;
+        }
     }
 
     private Dictionary<string, string>? ReadLaunchSettingsEnvironmentVariables(DirectoryInfo directory)
@@ -840,14 +879,13 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                     cancellationToken);
             }
 
-            // Pass the socket path, project directory, and apphost file path to the guest process
-            var environmentVariables = new Dictionary<string, string>(context.EnvironmentVariables)
-            {
-                ["REMOTE_APP_HOST_SOCKET_PATH"] = jsonRpcSocketPath,
-                ["ASPIRE_PROJECT_DIRECTORY"] = directory.FullName,
-                ["ASPIRE_APPHOST_FILEPATH"] = appHostFile.FullName,
-                [KnownConfigNames.RemoteAppHostToken] = authenticationToken
-            };
+            // Pass the launch profile environment variables through to the guest AppHost so publish mode
+            // uses the same dashboard and resource service endpoints as the temporary .NET server.
+            var environmentVariables = CreateGuestEnvironmentVariables(directory, context.EnvironmentVariables);
+            environmentVariables["REMOTE_APP_HOST_SOCKET_PATH"] = jsonRpcSocketPath;
+            environmentVariables["ASPIRE_PROJECT_DIRECTORY"] = directory.FullName;
+            environmentVariables["ASPIRE_APPHOST_FILEPATH"] = appHostFile.FullName;
+            environmentVariables[KnownConfigNames.RemoteAppHostToken] = authenticationToken;
 
             // Step 6: Execute the guest apphost for publishing
             // Pass the publish arguments (e.g., --operation publish --step deploy)

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -333,6 +333,49 @@ public class GuestAppHostProjectTests(ITestOutputHelper outputHelper) : IDisposa
         Assert.False(envVars.ContainsKey("ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL"));
     }
 
+    [Fact]
+    public void CreateGuestEnvironmentVariables_MergesLaunchProfileContextAndAdditionalEnvironmentVariables()
+    {
+        var project = CreateGuestAppHostProject();
+
+        var aspireConfigPath = Path.Combine(_workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        File.WriteAllText(aspireConfigPath, """
+            {
+              "profiles": {
+                "https": {
+                  "applicationUrl": "https://localhost:16319;http://localhost:16320",
+                  "environmentVariables": {
+                    "ASPIRE_ENVIRONMENT": "Staging",
+                    "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:17269",
+                    "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:18269"
+                  }
+                }
+              }
+            }
+            """);
+
+        var envVars = project.CreateGuestEnvironmentVariables(
+            _workspace.WorkspaceRoot,
+            new Dictionary<string, string>
+            {
+                ["CUSTOM_CONTEXT_VARIABLE"] = "context",
+                ["ASPNETCORE_URLS"] = "http://context"
+            },
+            new Dictionary<string, string>
+            {
+                ["SSL_CERT_DIR"] = "/tmp/certs"
+            });
+
+        Assert.Equal("context", envVars["CUSTOM_CONTEXT_VARIABLE"]);
+        Assert.Equal("https://localhost:16319;http://localhost:16320", envVars["ASPNETCORE_URLS"]);
+        Assert.Equal("Staging", envVars["ASPIRE_ENVIRONMENT"]);
+        Assert.Equal("Staging", envVars["DOTNET_ENVIRONMENT"]);
+        Assert.Equal("Staging", envVars["ASPNETCORE_ENVIRONMENT"]);
+        Assert.Equal("https://localhost:17269", envVars["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]);
+        Assert.Equal("https://localhost:18269", envVars["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"]);
+        Assert.Equal("/tmp/certs", envVars["SSL_CERT_DIR"]);
+    }
+
     private static GuestAppHostProject CreateGuestAppHostProject()
     {
         var language = new LanguageInfo(


### PR DESCRIPTION
## Description

Fixes guest AppHost launch-profile environment propagation for non-.NET AppHosts on `release/13.2`.

The shared `GuestAppHostProject` launcher was reading launch-profile values such as `ASPNETCORE_URLS`, `ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL`, and `ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL`, but only passing them to the temporary .NET AppHost server. The actual guest process only received the remote socket/apphost variables, so TypeScript/Python/Java/Go/Rust AppHosts could miss the dashboard and OTLP endpoint configuration.

This change merges launch-profile environment variables into the guest process environment for both `run` and `publish`, preserves the existing default environment behavior for the temporary server, and adds a regression test covering the shared merge path.

Fixes # (issue)

Validation:
- `./restore.sh`
- `./dotnet.sh test tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj -- --filter-class "*.GuestAppHostProjectTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `./dotnet.sh run --project ./src/Aspire.Cli/Aspire.Cli.csproj -- restore --non-interactive --apphost playground/polyglot/TypeScript/Aspire.Hosting.SqlServer/ValidationAppHost/apphost.ts`
- `./dotnet.sh run --project ./src/Aspire.Cli/Aspire.Cli.csproj -- start --isolated --non-interactive -l debug --apphost playground/polyglot/TypeScript/Aspire.Hosting.SqlServer/ValidationAppHost/apphost.ts`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
