### PR TITLE
Port: Strip /login path from dashboard base URL in describe command

### DIFF
--- a/src/Aspire.Cli/Commands/DescribeCommand.cs
+++ b/src/Aspire.Cli/Commands/DescribeCommand.cs
@@ -143,7 +143,7 @@ internal sealed class DescribeCommand : BaseCommand
 
         await Task.WhenAll(dashboardUrlsTask, snapshotsTask).ConfigureAwait(false);
 
-        var dashboardBaseUrl = (await dashboardUrlsTask.ConfigureAwait(false))?.BaseUrlWithLoginToken;
+        var dashboardBaseUrl = TelemetryCommandHelpers.ExtractDashboardBaseUrl((await dashboardUrlsTask.ConfigureAwait(false))?.BaseUrlWithLoginToken);
         var snapshots = await snapshotsTask.ConfigureAwait(false);
 
         // Pre-resolve colors for all resource names so that assignment is

--- a/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
+++ b/src/Aspire.Cli/Commands/TelemetryCommandHelpers.cs
@@ -136,7 +136,7 @@ internal static class TelemetryCommandHelpers
     /// <summary>
     /// Extracts the base URL from a dashboard URL (removes /login?t=... path).
     /// </summary>
-    private static string? ExtractDashboardBaseUrl(string? dashboardUrlWithToken)
+    internal static string? ExtractDashboardBaseUrl(string? dashboardUrlWithToken)
     {
         if (string.IsNullOrEmpty(dashboardUrlWithToken))
         {

--- a/tests/Aspire.Cli.Tests/Commands/DescribeCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DescribeCommandTests.cs
@@ -331,11 +331,71 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal("[redis] Stopping", resourceLines[1]);
     }
 
+    [Fact]
+    public async Task DescribeCommand_JsonFormat_StripsLoginPathFromDashboardUrl()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var provider = CreateDescribeTestServices(workspace, outputWriter, [
+            new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
+        ], dashboardUrlsState: new DashboardUrlsState
+        {
+            BaseUrlWithLoginToken = "http://localhost:18888/login?t=abcd1234"
+        });
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("describe --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var jsonOutput = string.Join("", outputWriter.Logs);
+        var deserialized = JsonSerializer.Deserialize(jsonOutput, ResourcesCommandJsonContext.RelaxedEscaping.ResourcesOutput);
+
+        Assert.NotNull(deserialized);
+        Assert.Single(deserialized.Resources);
+
+        Assert.Equal("http://localhost:18888/?resource=redis", deserialized.Resources[0].DashboardUrl);
+    }
+
+    [Fact]
+    public async Task DescribeCommand_Follow_JsonFormat_StripsLoginPathFromDashboardUrl()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        var provider = CreateDescribeTestServices(workspace, outputWriter, [
+            new ResourceSnapshot { Name = "redis", DisplayName = "redis", ResourceType = "Container", State = "Running" },
+        ], dashboardUrlsState: new DashboardUrlsState
+        {
+            BaseUrlWithLoginToken = "http://localhost:18888/login?t=abcd1234"
+        });
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("describe --follow --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var jsonLines = outputWriter.Logs
+            .Where(l => l.TrimStart().StartsWith("{", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.NotEmpty(jsonLines);
+
+        var resource = JsonSerializer.Deserialize(jsonLines[0], ResourcesCommandJsonContext.Ndjson.ResourceJson);
+        Assert.NotNull(resource);
+
+        Assert.Equal("http://localhost:18888/?resource=redis", resource.DashboardUrl);
+    }
+
     private ServiceProvider CreateDescribeTestServices(
         TemporaryWorkspace workspace,
         TestOutputTextWriter outputWriter,
         List<ResourceSnapshot> resourceSnapshots,
-        bool disableAnsi = false)
+        bool disableAnsi = false,
+        DashboardUrlsState? dashboardUrlsState = null)
     {
         var monitor = new TestAuxiliaryBackchannelMonitor();
         var connection = new TestAppHostAuxiliaryBackchannel
@@ -346,7 +406,8 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
                 AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "TestAppHost", "TestAppHost.csproj"),
                 ProcessId = 1234
             },
-            ResourceSnapshots = resourceSnapshots
+            ResourceSnapshots = resourceSnapshots,
+            DashboardUrlsState = dashboardUrlsState
         };
         monitor.AddConnection("hash1", "socket.hash1", connection);
 


### PR DESCRIPTION
## Description

Port of #15495 from release/13.2 to main.

Strip /login path from dashboard base URL in describe command. The describe command was passing `BaseUrlWithLoginToken` (e.g., `http://localhost:18888/login?t=token`) directly to the resource snapshot mapper, producing broken dashboard URLs like `http://localhost:18888/login?t=token/?resource=redis`.

Reuse `TelemetryCommandHelpers.ExtractDashboardBaseUrl` to strip the `/login?t=...` path before combining with resource URLs.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
