### PR TITLE
Port: Fix installing playwright-cli with aspire agent init on Windows

### DIFF
--- a/src/Aspire.Cli/Agents/Playwright/PlaywrightCliRunner.cs
+++ b/src/Aspire.Cli/Agents/Playwright/PlaywrightCliRunner.cs
@@ -125,5 +125,28 @@ internal sealed class PlaywrightCliRunner(ILogger<PlaywrightCliRunner> logger) :
             logger.LogDebug(ex, "Failed to run playwright-cli install --skills");
             return false;
         }
+        finally
+        {
+            // playwright-cli install --skills may leave behind an empty .playwright
+            // directory in the working directory. Clean it up if it exists and is empty.
+            CleanupEmptyPlaywrightDirectory(workingDirectory);
+        }
+    }
+
+    private void CleanupEmptyPlaywrightDirectory(string workingDirectory)
+    {
+        try
+        {
+            var playwrightDir = Path.Combine(workingDirectory, ".playwright");
+            if (Directory.Exists(playwrightDir) && Directory.GetFileSystemEntries(playwrightDir).Length == 0)
+            {
+                Directory.Delete(playwrightDir);
+                logger.LogDebug("Removed empty .playwright directory from {WorkingDirectory}", workingDirectory);
+            }
+        }
+        catch (IOException ex)
+        {
+            logger.LogDebug(ex, "Failed to clean up .playwright directory in {WorkingDirectory}", workingDirectory);
+        }
     }
 }

--- a/src/Aspire.Cli/Npm/SigstoreNpmProvenanceChecker.cs
+++ b/src/Aspire.Cli/Npm/SigstoreNpmProvenanceChecker.cs
@@ -263,8 +263,8 @@ internal sealed class SigstoreNpmProvenanceChecker(HttpClient httpClient, ILogge
             {
                 logger.LogDebug(
                     "Retrying Sigstore verification without CertificateIdentity due to known SAN extraction bug " +
-                    "(https://github.com/mitchdenny/sigstore-dotnet/issues/14) for {Package}@{Version}",
-                    packageName, version);
+                    "(https://github.com/mitchdenny/sigstore-dotnet/issues/14) for {PackageSpecifier}",
+                    NpmPackageInfo.FormatPackageSpecifier(packageName, version));
 
                 var fallbackPolicy = new VerificationPolicy();
                 (success, result) = await VerifyBundleWithPolicyAsync(
@@ -354,7 +354,7 @@ internal sealed class SigstoreNpmProvenanceChecker(HttpClient httpClient, ILogge
 
         if (certBytes is not { Length: > 0 } leafCertBytes)
         {
-            logger.LogWarning("No signing certificate found in bundle for {Package}@{Version}", packageName, version);
+            logger.LogWarning("No signing certificate found in bundle for {PackageSpecifier}", NpmPackageInfo.FormatPackageSpecifier(packageName, version));
             return new ProvenanceVerificationResult { Outcome = ProvenanceVerificationOutcome.AttestationParseFailed };
         }
 
@@ -379,8 +379,8 @@ internal sealed class SigstoreNpmProvenanceChecker(HttpClient httpClient, ILogge
             if (!string.Equals(extensions.SourceRepositoryUri, expectedIdentity.Extensions.SourceRepositoryUri, StringComparison.Ordinal))
             {
                 logger.LogWarning(
-                    "SourceRepositoryUri mismatch for {Package}@{Version}: expected '{Expected}', got '{Actual}'",
-                    packageName, version, expectedIdentity.Extensions.SourceRepositoryUri, extensions.SourceRepositoryUri);
+                    "SourceRepositoryUri mismatch for {PackageSpecifier}: expected '{Expected}', got '{Actual}'",
+                    NpmPackageInfo.FormatPackageSpecifier(packageName, version), expectedIdentity.Extensions.SourceRepositoryUri, extensions.SourceRepositoryUri);
                 return new ProvenanceVerificationResult { Outcome = ProvenanceVerificationOutcome.SourceRepositoryMismatch };
             }
         }
@@ -392,15 +392,15 @@ internal sealed class SigstoreNpmProvenanceChecker(HttpClient httpClient, ILogge
             if (san is null || !Regex.IsMatch(san, expectedIdentity.SubjectAlternativeNamePattern))
             {
                 logger.LogWarning(
-                    "SAN pattern mismatch for {Package}@{Version}: expected pattern '{Pattern}', got '{Actual}'",
-                    packageName, version, expectedIdentity.SubjectAlternativeNamePattern, san);
+                    "SAN pattern mismatch for {PackageSpecifier}: expected pattern '{Pattern}', got '{Actual}'",
+                    NpmPackageInfo.FormatPackageSpecifier(packageName, version), expectedIdentity.SubjectAlternativeNamePattern, san);
                 return new ProvenanceVerificationResult { Outcome = ProvenanceVerificationOutcome.AttestationParseFailed };
             }
         }
 
         logger.LogDebug(
-            "Manual certificate identity verification passed for {Package}@{Version} (issuer: {Issuer}, repo: {Repo})",
-            packageName, version, extensions.Issuer, extensions.SourceRepositoryUri);
+            "Manual certificate identity verification passed for {PackageSpecifier} (issuer: {Issuer}, repo: {Repo})",
+            NpmPackageInfo.FormatPackageSpecifier(packageName, version), extensions.Issuer, extensions.SourceRepositoryUri);
 
         return null;
     }

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1109,6 +1109,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
             options.InteractionServiceFactory = _ => new TestInteractionService
             {
+                ConfirmCallback = (_, _) => false,
                 PromptForSelectionCallback = (promptText, choices, choiceFormatter, cancellationToken) =>
                 {
                     if (string.Equals(promptText, TemplatingStrings.UseLocalhostTld_Prompt, StringComparison.Ordinal))
@@ -1286,6 +1287,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
             options.InteractionServiceFactory = _ => new TestInteractionService
             {
+                ConfirmCallback = (_, _) => false,
                 PromptForSelectionCallback = (promptText, choices, choiceFormatter, cancellationToken) =>
                 {
                     if (string.Equals(promptText, TemplatingStrings.UseLocalhostTld_Prompt, StringComparison.Ordinal))

--- a/tests/Aspire.Cli.Tests/TestServices/FakePlaywrightServices.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/FakePlaywrightServices.cs
@@ -12,7 +12,7 @@ namespace Aspire.Cli.Tests.TestServices;
 /// </summary>
 internal sealed class FakeNpmRunner : INpmRunner
 {
-    public bool IsAvailable => false;
+    public bool IsAvailable => true;
 
     public Task<NpmPackageInfo?> ResolvePackageAsync(string packageName, string versionRange, CancellationToken cancellationToken)
         => Task.FromResult<NpmPackageInfo?>(null);


### PR DESCRIPTION
## Description

Port of #15559 from release/13.2 to main.

Fix installing playwright-cli with `aspire agent init` on Windows:

- Backport NpmRunner and SigstoreNpmProvenanceChecker improvements
- Clean up empty .playwright directory after skill installation
- Add missing `IsAvailable` property to test `INpmRunner` implementations

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
