### PR TITLE
Deprecate Aspire.Hosting.NodeJs in CLI integration listings

### DIFF
--- a/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
@@ -21,13 +21,6 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
     private readonly ILogger<BundleNuGetPackageCache> _logger;
     private readonly IFeatures _features;
 
-    // List of deprecated packages that should be filtered by default
-    private static readonly HashSet<string> s_deprecatedPackages = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "Aspire.Hosting.Dapr",
-        "Aspire.Hosting.NodeJs"
-    };
-
     public BundleNuGetPackageCache(
         IBundleService bundleService,
         ILogger<BundleNuGetPackageCache> logger,
@@ -227,7 +220,7 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
             // Apply deprecated package filter unless the user wants to show deprecated packages
             if (isOfficialPackage && !_features.IsFeatureEnabled(KnownFeatures.ShowDeprecatedPackages, defaultValue: false))
             {
-                return !s_deprecatedPackages.Contains(p.Id);
+                return !DeprecatedPackages.All.Contains(p.Id);
             }
 
             return isOfficialPackage;

--- a/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
@@ -220,7 +220,7 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
             // Apply deprecated package filter unless the user wants to show deprecated packages
             if (isOfficialPackage && !_features.IsFeatureEnabled(KnownFeatures.ShowDeprecatedPackages, defaultValue: false))
             {
-                return !DeprecatedPackages.All.Contains(p.Id);
+                return !DeprecatedPackages.IsDeprecated(p.Id);
             }
 
             return isOfficialPackage;

--- a/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
@@ -24,7 +24,8 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
     // List of deprecated packages that should be filtered by default
     private static readonly HashSet<string> s_deprecatedPackages = new(StringComparer.OrdinalIgnoreCase)
     {
-        "Aspire.Hosting.Dapr"
+        "Aspire.Hosting.Dapr",
+        "Aspire.Hosting.NodeJs"
     };
 
     public BundleNuGetPackageCache(

--- a/src/Aspire.Cli/NuGet/NuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/NuGetPackageCache.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Resources;
+using System.Collections.Frozen;
 using System.Globalization;
 using Aspire.Cli.Telemetry;
 using Microsoft.Extensions.Caching.Memory;
@@ -24,11 +25,13 @@ internal interface INuGetPackageCache
 /// </summary>
 internal static class DeprecatedPackages
 {
-    public static readonly HashSet<string> All = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly FrozenSet<string> s_all = new[]
     {
         "Aspire.Hosting.Dapr",
         "Aspire.Hosting.NodeJs"
-    };
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    public static bool IsDeprecated(string packageId) => s_all.Contains(packageId);
 }
 
 internal sealed class NuGetPackageCache(IDotNetCliRunner cliRunner, IMemoryCache memoryCache, AspireCliTelemetry telemetry, IFeatures features) : INuGetPackageCache
@@ -139,7 +142,7 @@ internal sealed class NuGetPackageCache(IDotNetCliRunner cliRunner, IMemoryCache
             // Apply deprecated package filter unless the user wants to show deprecated packages
             if (isOfficialPackage && !features.IsFeatureEnabled(KnownFeatures.ShowDeprecatedPackages, defaultValue: false))
             {
-                return !DeprecatedPackages.All.Contains(p.Id);
+                return !DeprecatedPackages.IsDeprecated(p.Id);
             }
 
             return isOfficialPackage;

--- a/src/Aspire.Cli/NuGet/NuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/NuGetPackageCache.cs
@@ -26,7 +26,8 @@ internal sealed class NuGetPackageCache(IDotNetCliRunner cliRunner, IMemoryCache
     // List of deprecated packages that should be filtered by default
     private static readonly HashSet<string> s_deprecatedPackages = new(StringComparer.OrdinalIgnoreCase)
     {
-        "Aspire.Hosting.Dapr"
+        "Aspire.Hosting.Dapr",
+        "Aspire.Hosting.NodeJs"
     };
 
     public async Task<IEnumerable<NuGetPackage>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)

--- a/src/Aspire.Cli/NuGet/NuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/NuGetPackageCache.cs
@@ -19,16 +19,21 @@ internal interface INuGetPackageCache
     Task<IEnumerable<NuGetPackage>> GetPackagesAsync(DirectoryInfo workingDirectory, string packageId, Func<string, bool>? filter, bool prerelease, FileInfo? nugetConfigFile, bool useCache, CancellationToken cancellationToken);
 }
 
-internal sealed class NuGetPackageCache(IDotNetCliRunner cliRunner, IMemoryCache memoryCache, AspireCliTelemetry telemetry, IFeatures features) : INuGetPackageCache
+/// <summary>
+/// Packages that have been superseded and should be hidden from integration listings by default.
+/// </summary>
+internal static class DeprecatedPackages
 {
-    private const int SearchPageSize = 1000;
-    
-    // List of deprecated packages that should be filtered by default
-    private static readonly HashSet<string> s_deprecatedPackages = new(StringComparer.OrdinalIgnoreCase)
+    public static readonly HashSet<string> All = new(StringComparer.OrdinalIgnoreCase)
     {
         "Aspire.Hosting.Dapr",
         "Aspire.Hosting.NodeJs"
     };
+}
+
+internal sealed class NuGetPackageCache(IDotNetCliRunner cliRunner, IMemoryCache memoryCache, AspireCliTelemetry telemetry, IFeatures features) : INuGetPackageCache
+{
+    private const int SearchPageSize = 1000;
 
     public async Task<IEnumerable<NuGetPackage>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, bool prerelease, FileInfo? nugetConfigFile, CancellationToken cancellationToken)
     {
@@ -134,7 +139,7 @@ internal sealed class NuGetPackageCache(IDotNetCliRunner cliRunner, IMemoryCache
             // Apply deprecated package filter unless the user wants to show deprecated packages
             if (isOfficialPackage && !features.IsFeatureEnabled(KnownFeatures.ShowDeprecatedPackages, defaultValue: false))
             {
-                return !s_deprecatedPackages.Contains(p.Id);
+                return !DeprecatedPackages.All.Contains(p.Id);
             }
 
             return isOfficialPackage;

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetPackageCacheTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetPackageCacheTests.cs
@@ -60,6 +60,7 @@ public class NuGetPackageCacheTests(ITestOutputHelper outputHelper)
                     return (0, [
                         new NuGetPackage { Id = "Aspire.Hosting.Redis", Version = "9.4.0", Source = "nuget.org" },
                         new NuGetPackage { Id = "Aspire.Hosting.Dapr", Version = "9.4.0", Source = "nuget.org" }, // Deprecated
+                        new NuGetPackage { Id = "Aspire.Hosting.NodeJs", Version = "9.4.0", Source = "nuget.org" }, // Deprecated
                         new NuGetPackage { Id = "Aspire.Hosting.PostgreSQL", Version = "9.4.0", Source = "nuget.org" }
                     ]);
                 };
@@ -78,6 +79,7 @@ public class NuGetPackageCacheTests(ITestOutputHelper outputHelper)
         Assert.Contains("Aspire.Hosting.Redis", packageIds);
         Assert.Contains("Aspire.Hosting.PostgreSQL", packageIds);
         Assert.DoesNotContain("Aspire.Hosting.Dapr", packageIds);
+        Assert.DoesNotContain("Aspire.Hosting.NodeJs", packageIds);
     }
 
     [Fact]
@@ -98,6 +100,7 @@ public class NuGetPackageCacheTests(ITestOutputHelper outputHelper)
                     return (0, [
                         new NuGetPackage { Id = "Aspire.Hosting.Redis", Version = "9.4.0", Source = "nuget.org" },
                         new NuGetPackage { Id = "Aspire.Hosting.Dapr", Version = "9.4.0", Source = "nuget.org" }, // Deprecated
+                        new NuGetPackage { Id = "Aspire.Hosting.NodeJs", Version = "9.4.0", Source = "nuget.org" }, // Deprecated
                         new NuGetPackage { Id = "Aspire.Hosting.PostgreSQL", Version = "9.4.0", Source = "nuget.org" }
                     ]);
                 };
@@ -116,6 +119,7 @@ public class NuGetPackageCacheTests(ITestOutputHelper outputHelper)
         Assert.Contains("Aspire.Hosting.Redis", packageIds);
         Assert.Contains("Aspire.Hosting.PostgreSQL", packageIds);
         Assert.Contains("Aspire.Hosting.Dapr", packageIds);
+        Assert.Contains("Aspire.Hosting.NodeJs", packageIds);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Deprecate `Aspire.Hosting.NodeJs` in the CLI integration listings. The replacement package is `Aspire.Hosting.JavaScript`.

- Add `Aspire.Hosting.NodeJs` to the deprecated packages filter so it no longer appears in `aspire add` results
- Extract the duplicated `s_deprecatedPackages` HashSet from `BundleNuGetPackageCache` and `NuGetPackageCache` into a shared `DeprecatedPackages` static class

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
