### PR TITLE
Fix VS Code workspace view switching

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -71,12 +71,12 @@
       {
         "view": "aspire-vscode.runningAppHosts",
         "contents": "%views.runningAppHosts.welcome%",
-        "when": "aspire.noRunningAppHosts && !aspire.fetchAppHostsError && !aspire.loading && aspire.viewMode != global"
+        "when": "aspire.noRunningAppHosts && !aspire.fetchAppHostsError && !aspire.loading && aspire.viewMode != 'global'"
       },
       {
         "view": "aspire-vscode.runningAppHosts",
         "contents": "%views.runningAppHosts.globalWelcome%",
-        "when": "aspire.noRunningAppHosts && !aspire.fetchAppHostsError && !aspire.loading && aspire.viewMode == global"
+        "when": "aspire.noRunningAppHosts && !aspire.fetchAppHostsError && !aspire.loading && aspire.viewMode == 'global'"
       },
       {
         "view": "aspire-vscode.runningAppHosts",
@@ -498,12 +498,12 @@
       "view/title": [
         {
           "command": "aspire-vscode.switchToGlobalView",
-          "when": "view == aspire-vscode.runningAppHosts && aspire.viewMode != global",
+          "when": "view == aspire-vscode.runningAppHosts && aspire.viewMode != 'global'",
           "group": "navigation"
         },
         {
           "command": "aspire-vscode.switchToWorkspaceView",
-          "when": "view == aspire-vscode.runningAppHosts && aspire.viewMode == global",
+          "when": "view == aspire-vscode.runningAppHosts && aspire.viewMode == 'global'",
           "group": "navigation"
         },
         {

--- a/extension/package.json
+++ b/extension/package.json
@@ -498,17 +498,17 @@
       "view/title": [
         {
           "command": "aspire-vscode.switchToGlobalView",
-          "when": "view == aspire-vscode.runningAppHosts && aspire.viewMode != 'global'",
+          "when": "view == 'aspire-vscode.runningAppHosts' && aspire.viewMode != 'global'",
           "group": "navigation"
         },
         {
           "command": "aspire-vscode.switchToWorkspaceView",
-          "when": "view == aspire-vscode.runningAppHosts && aspire.viewMode == 'global'",
+          "when": "view == 'aspire-vscode.runningAppHosts' && aspire.viewMode == 'global'",
           "group": "navigation"
         },
         {
           "command": "aspire-vscode.refreshRunningAppHosts",
-          "when": "view == aspire-vscode.runningAppHosts",
+          "when": "view == 'aspire-vscode.runningAppHosts'",
           "group": "navigation"
         }
       ],

--- a/extension/src/test/packageManifest.test.ts
+++ b/extension/src/test/packageManifest.test.ts
@@ -21,6 +21,10 @@ function readManifest(): ExtensionManifest {
     return JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as ExtensionManifest;
 }
 
+function assertContains(whenClause: string | undefined, fragment: string): void {
+    assert.ok(whenClause?.includes(fragment), `Expected "${whenClause}" to contain "${fragment}"`);
+}
+
 suite('extension/package.json', () => {
     test('running apphosts welcome states use string view mode checks', () => {
         const manifest = readManifest();
@@ -29,30 +33,22 @@ suite('extension/package.json', () => {
         const workspaceWelcome = runningAppHostsWelcome.find(item => item.contents === '%views.runningAppHosts.welcome%');
         const globalWelcome = runningAppHostsWelcome.find(item => item.contents === '%views.runningAppHosts.globalWelcome%');
 
-        assert.strictEqual(
-            workspaceWelcome?.when,
-            "aspire.noRunningAppHosts && !aspire.fetchAppHostsError && !aspire.loading && aspire.viewMode != 'global'"
-        );
-        assert.strictEqual(
-            globalWelcome?.when,
-            "aspire.noRunningAppHosts && !aspire.fetchAppHostsError && !aspire.loading && aspire.viewMode == 'global'"
-        );
+        assertContains(workspaceWelcome?.when, "aspire.viewMode != 'global'");
+        assertContains(globalWelcome?.when, "aspire.viewMode == 'global'");
     });
 
-    test('running apphosts title actions use string view mode checks', () => {
+    test('running apphosts title actions use string view and view mode checks', () => {
         const manifest = readManifest();
         const titleMenus = manifest.contributes.menus?.['view/title'] ?? [];
 
         const switchToGlobal = titleMenus.find(item => item.command === 'aspire-vscode.switchToGlobalView');
         const switchToWorkspace = titleMenus.find(item => item.command === 'aspire-vscode.switchToWorkspaceView');
+        const refreshRunningAppHosts = titleMenus.find(item => item.command === 'aspire-vscode.refreshRunningAppHosts');
 
-        assert.strictEqual(
-            switchToGlobal?.when,
-            "view == aspire-vscode.runningAppHosts && aspire.viewMode != 'global'"
-        );
-        assert.strictEqual(
-            switchToWorkspace?.when,
-            "view == aspire-vscode.runningAppHosts && aspire.viewMode == 'global'"
-        );
+        assertContains(switchToGlobal?.when, "view == 'aspire-vscode.runningAppHosts'");
+        assertContains(switchToGlobal?.when, "aspire.viewMode != 'global'");
+        assertContains(switchToWorkspace?.when, "view == 'aspire-vscode.runningAppHosts'");
+        assertContains(switchToWorkspace?.when, "aspire.viewMode == 'global'");
+        assertContains(refreshRunningAppHosts?.when, "view == 'aspire-vscode.runningAppHosts'");
     });
 });

--- a/extension/src/test/packageManifest.test.ts
+++ b/extension/src/test/packageManifest.test.ts
@@ -1,0 +1,58 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+
+type ManifestMenuItem = {
+    command?: string;
+    when?: string;
+};
+
+type ExtensionManifest = {
+    contributes: {
+        viewsWelcome?: Array<{ view?: string; contents?: string; when?: string }>;
+        menus?: {
+            'view/title'?: ManifestMenuItem[];
+        };
+    };
+};
+
+function readManifest(): ExtensionManifest {
+    const manifestPath = path.resolve(__dirname, '../../package.json');
+    return JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as ExtensionManifest;
+}
+
+suite('extension/package.json', () => {
+    test('running apphosts welcome states use string view mode checks', () => {
+        const manifest = readManifest();
+        const runningAppHostsWelcome = manifest.contributes.viewsWelcome?.filter(item => item.view === 'aspire-vscode.runningAppHosts') ?? [];
+
+        const workspaceWelcome = runningAppHostsWelcome.find(item => item.contents === '%views.runningAppHosts.welcome%');
+        const globalWelcome = runningAppHostsWelcome.find(item => item.contents === '%views.runningAppHosts.globalWelcome%');
+
+        assert.strictEqual(
+            workspaceWelcome?.when,
+            "aspire.noRunningAppHosts && !aspire.fetchAppHostsError && !aspire.loading && aspire.viewMode != 'global'"
+        );
+        assert.strictEqual(
+            globalWelcome?.when,
+            "aspire.noRunningAppHosts && !aspire.fetchAppHostsError && !aspire.loading && aspire.viewMode == 'global'"
+        );
+    });
+
+    test('running apphosts title actions use string view mode checks', () => {
+        const manifest = readManifest();
+        const titleMenus = manifest.contributes.menus?.['view/title'] ?? [];
+
+        const switchToGlobal = titleMenus.find(item => item.command === 'aspire-vscode.switchToGlobalView');
+        const switchToWorkspace = titleMenus.find(item => item.command === 'aspire-vscode.switchToWorkspaceView');
+
+        assert.strictEqual(
+            switchToGlobal?.when,
+            "view == aspire-vscode.runningAppHosts && aspire.viewMode != 'global'"
+        );
+        assert.strictEqual(
+            switchToWorkspace?.when,
+            "view == aspire-vscode.runningAppHosts && aspire.viewMode == 'global'"
+        );
+    });
+});


### PR DESCRIPTION
## Description

Fixes the Running AppHosts view mode toggle so the extension can switch back from global mode to workspace mode.

The root cause was the VS Code `when` clauses comparing `aspire.viewMode` against a bare identifier instead of the actual string value. This prevented the view title toggle actions, and the workspace/global welcome states, from updating correctly.

Validation:
- `npm run compile`
- `npm run lint`
- `npm run unit-test -- --grep "running apphosts"`
- manual verification in an Extension Development Host against `/Users/davidfowler/dev/git/rich-term`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
