### PR TITLE
Refactor ZIP extraction for PowerShell compatibility

### DIFF
--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -732,8 +732,12 @@ function Expand-AspireCliArchive {
             if (-not (Get-Command Expand-Archive -ErrorAction SilentlyContinue)) {
                 throw "Expand-Archive cmdlet not found. Please use PowerShell 5.0 or later to extract ZIP files."
             }
-
-            Expand-Archive -Path $ArchiveFile -DestinationPath $DestinationPath -Force -ErrorAction Stop
+            
+            Invoke-WithPowerShellVersion -ModernAction {
+                Expand-Archive -Path $ArchiveFile -OutputPath $DestinationPath -Force -ErrorAction Stop
+            } -LegacyAction {
+                Expand-Archive -Path $ArchiveFile -DestinationPath $DestinationPath -Force -ErrorAction Stop
+            }
         }
         else {
             # Use tar for tar.gz files on Unix systems


### PR DESCRIPTION
## Description

Powershell core Expand-Archive cmdlet does not define the -DestinationPath parameter causing a failure to unpack.  Powershell core uses -OutputPath instead.


## Checklist

- Is this feature complete?
  - [X ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [X ] No
