### PR TITLE
Update YARP TypeScript playground chaining

### DIFF
--- a/playground/polyglot/TypeScript/Aspire.Hosting.Yarp/ValidationAppHost/apphost.ts
+++ b/playground/polyglot/TypeScript/Aspire.Hosting.Yarp/ValidationAppHost/apphost.ts
@@ -25,7 +25,47 @@ await proxy.withBuildSecret("MY_SECRET", buildSecret);
 
 await proxy.withConfiguration(async (config) => {
     const endpoint = await backend.getEndpoint("http");
-    const endpointCluster = await config.addClusterFromEndpoint(endpoint);
+    const endpointCluster = await config.addClusterFromEndpoint(endpoint)
+        .withForwarderRequestConfig({
+            activityTimeout: 30_000_000,
+            allowResponseBuffering: true,
+            version: "2.0",
+        })
+        .withHttpClientConfig({
+            dangerousAcceptAnyServerCertificate: true,
+            enableMultipleHttp2Connections: true,
+            maxConnectionsPerServer: 10,
+            requestHeaderEncoding: "utf-8",
+            responseHeaderEncoding: "utf-8",
+        })
+        .withSessionAffinityConfig({
+            affinityKeyName: ".Aspire.Affinity",
+            enabled: true,
+            failurePolicy: "Redistribute",
+            policy: "Cookie",
+            cookie: {
+                domain: "example.com",
+                httpOnly: true,
+                isEssential: true,
+                path: "/",
+            },
+        })
+        .withHealthCheckConfig({
+            availableDestinationsPolicy: "HealthyOrPanic",
+            active: {
+                enabled: true,
+                interval: 50_000_000,
+                path: "/health",
+                policy: "ConsecutiveFailures",
+                query: "probe=1",
+                timeout: 20_000_000,
+            },
+            passive: {
+                enabled: true,
+                policy: "TransportFailureRateHealthPolicy",
+                reactivationPeriod: 100_000_000,
+            },
+        });
     const resourceCluster = await config.addClusterFromResource(backend);
     const externalServiceCluster = await config.addClusterFromExternalService(externalBackend);
     const singleDestinationCluster = await config.addClusterWithDestination("single-destination", "https://example.net");
@@ -33,54 +73,6 @@ await proxy.withConfiguration(async (config) => {
         "https://example.org",
         "https://example.edu"
     ]);
-    const routeFromEndpoint = await config.addRouteFromEndpoint("/from-endpoint/{**catchall}", endpoint);
-    const routeFromResource = await config.addRouteFromResource("/from-resource/{**catchall}", backend);
-    const routeFromExternalService = await config.addRouteFromExternalService("/from-external/{**catchall}", externalBackend);
-    const catchAllRoute = await config.addCatchAllRoute(endpointCluster);
-    const catchAllRouteFromEndpoint = await config.addCatchAllRouteFromEndpoint(endpoint);
-    const catchAllRouteFromResource = await config.addCatchAllRouteFromResource(backend);
-    const catchAllRouteFromExternalService = await config.addCatchAllRouteFromExternalService(externalBackend);
-
-    await endpointCluster.withForwarderRequestConfig({
-        activityTimeout: 30_000_000,
-        allowResponseBuffering: true,
-        version: "2.0",
-    });
-    await endpointCluster.withHttpClientConfig({
-        dangerousAcceptAnyServerCertificate: true,
-        enableMultipleHttp2Connections: true,
-        maxConnectionsPerServer: 10,
-        requestHeaderEncoding: "utf-8",
-        responseHeaderEncoding: "utf-8",
-    });
-    await endpointCluster.withSessionAffinityConfig({
-        affinityKeyName: ".Aspire.Affinity",
-        enabled: true,
-        failurePolicy: "Redistribute",
-        policy: "Cookie",
-        cookie: {
-            domain: "example.com",
-            httpOnly: true,
-            isEssential: true,
-            path: "/",
-        },
-    });
-    await endpointCluster.withHealthCheckConfig({
-        availableDestinationsPolicy: "HealthyOrPanic",
-        active: {
-            enabled: true,
-            interval: 50_000_000,
-            path: "/health",
-            policy: "ConsecutiveFailures",
-            query: "probe=1",
-            timeout: 20_000_000,
-        },
-        passive: {
-            enabled: true,
-            policy: "TransportFailureRateHealthPolicy",
-            reactivationPeriod: 100_000_000,
-        },
-    });
 
     await config.addRoute("/{**catchall}", endpointCluster)
         .withTransformXForwarded()
@@ -109,33 +101,40 @@ await proxy.withConfiguration(async (config) => {
         .withTransformResponseTrailerRemove("X-Remove-Trailer")
         .withTransformResponseTrailersAllowed(["X-Response-Trailer"]);
 
-    await routeFromEndpoint.withMatch({
-        path: "/from-endpoint/{**catchall}",
-        methods: ["GET", "POST"],
-        hosts: ["endpoint.example.com"],
-    });
-    await routeFromEndpoint.withTransform({
-        PathPrefix: "/endpoint",
-        RequestHeadersCopy: "true",
-    });
-    await routeFromResource.withTransform({
-        PathPrefix: "/resource",
-    });
-    await routeFromExternalService.withTransform({
-        PathPrefix: "/external",
-    });
-    await catchAllRoute.withTransform({
-        PathPrefix: "/cluster",
-    });
-    await catchAllRouteFromEndpoint.withTransform({
-        PathPrefix: "/catchall-endpoint",
-    });
-    await catchAllRouteFromResource.withTransform({
-        PathPrefix: "/catchall-resource",
-    });
-    await catchAllRouteFromExternalService.withTransform({
-        PathPrefix: "/catchall-external",
-    });
+    await config.addRouteFromEndpoint("/from-endpoint/{**catchall}", endpoint)
+        .withMatch({
+            path: "/from-endpoint/{**catchall}",
+            methods: ["GET", "POST"],
+            hosts: ["endpoint.example.com"],
+        })
+        .withTransform({
+            PathPrefix: "/endpoint",
+            RequestHeadersCopy: "true",
+        });
+    await config.addRouteFromResource("/from-resource/{**catchall}", backend)
+        .withTransform({
+            PathPrefix: "/resource",
+        });
+    await config.addRouteFromExternalService("/from-external/{**catchall}", externalBackend)
+        .withTransform({
+            PathPrefix: "/external",
+        });
+    await config.addCatchAllRoute(endpointCluster)
+        .withTransform({
+            PathPrefix: "/cluster",
+        });
+    await config.addCatchAllRouteFromEndpoint(endpoint)
+        .withTransform({
+            PathPrefix: "/catchall-endpoint",
+        });
+    await config.addCatchAllRouteFromResource(backend)
+        .withTransform({
+            PathPrefix: "/catchall-resource",
+        });
+    await config.addCatchAllRouteFromExternalService(externalBackend)
+        .withTransform({
+            PathPrefix: "/catchall-external",
+        });
 
     await config.addRoute("/resource/{**catchall}", resourceCluster);
     await config.addRoute("/external/{**catchall}", externalServiceCluster);


### PR DESCRIPTION
## Description

The TypeScript YARP `withConfiguration` surface already supports fluent async chaining, but the polyglot validation app host was still using the older pattern of awaiting helper calls before continuing configuration. This makes the sample line up with the intended `await a().b().c()` style from #15531 and gives us playground coverage for the scenario the issue calls out.

This change updates the YARP TypeScript validation app host to chain cluster and route helper calls directly inside the `withConfiguration` callback, including follow-up route and cluster configuration calls. No product API changes are included.

Dependencies: N/A

Fixes #15531

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No