### PR TITLE
Fix staging feed URL after org rename to microsoft/aspire

### DIFF
--- a/src/Aspire.Cli/Packaging/PackagingService.cs
+++ b/src/Aspire.Cli/Packaging/PackagingService.cs
@@ -124,7 +124,7 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
         }
 
         // Extract commit hash from assembly version to build staging feed URL
-        // Staging feed URL template: https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspire-{commitHash}/nuget/v3/index.json
+        // Staging feed URL template: https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-{commitHash}/nuget/v3/index.json
         var assembly = Assembly.GetExecutingAssembly();
         var informationalVersion = assembly
             .GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false)
@@ -145,7 +145,7 @@ internal class PackagingService(CliExecutionContext executionContext, INuGetPack
         var commitHash = informationalVersion[(plusIndex + 1)..];
         var truncatedHash = commitHash.Length >= 8 ? commitHash[..8] : commitHash;
         
-        return $"https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspire-{truncatedHash}/nuget/v3/index.json";
+        return $"https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-{truncatedHash}/nuget/v3/index.json";
     }
 
     private PackageChannelQuality GetStagingQuality()

--- a/tests/Aspire.Cli.Tests/Packaging/PackageChannelTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackageChannelTests.cs
@@ -76,7 +76,7 @@ public class PackageChannelTests
     {
         // Arrange
         var cache = new FakeNuGetPackageCache();
-        var stagingUrl = "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspire-48a11dae/nuget/v3/index.json";
+        var stagingUrl = "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-48a11dae/nuget/v3/index.json";
         var mappings = new[]
         {
             new PackageMapping("Aspire*", stagingUrl),

--- a/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs
@@ -162,7 +162,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.StagingChannelEnabled, true);
         
-        var azureDevOpsFeedUrl = "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspire-abcd1234/nuget/v3/index.json";
+        var azureDevOpsFeedUrl = "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-abcd1234/nuget/v3/index.json";
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -350,7 +350,7 @@ public class PackagingServiceTests(ITestOutputHelper outputHelper)
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["overrideStagingFeed"] = "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspire-48a11dae/nuget/v3/index.json"
+                ["overrideStagingFeed"] = "https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-microsoft-aspire-48a11dae/nuget/v3/index.json"
             })
             .Build();
 


### PR DESCRIPTION
## Description

Fix the staging channel feed URL after the repository migration from `dotnet/aspire` to `microsoft/aspire`.

The DARC-published feed prefix changed from `darc-pub-dotnet-aspire-{hash}` to `darc-pub-microsoft-aspire-{hash}` as part of the org rename. This updates the feed URL template in `PackagingService.GetStagingFeedUrl()` and the corresponding test assertions so the staging channel correctly resolves packages from the new feed.

**Changes:**
- `src/Aspire.Cli/Packaging/PackagingService.cs` — URL template and comment
- `tests/Aspire.Cli.Tests/Packaging/PackagingServiceTests.cs` — Two test URLs
- `tests/Aspire.Cli.Tests/Packaging/PackageChannelTests.cs` — One test URL

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
