### PR TITLE
Skip name validation for ProjectRebuilderResource

### DIFF
--- a/src/Aspire.Hosting.JavaScript/JavaScriptInstallerResource.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptInstallerResource.cs
@@ -8,7 +8,15 @@ namespace Aspire.Hosting.JavaScript;
 /// <summary>
 /// A resource that represents a package installer for a JavaScript app.
 /// </summary>
-/// <param name="name">The name of the resource.</param>
-/// <param name="workingDirectory">The working directory to use for the command.</param>
-public class JavaScriptInstallerResource(string name, string workingDirectory)
-    : ExecutableResource(name, "node", workingDirectory);
+public class JavaScriptInstallerResource : ExecutableResource
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JavaScriptInstallerResource"/> class.
+    /// </summary>
+    /// <param name="name">The name of the resource.</param>
+    /// <param name="workingDirectory">The working directory to use for the command.</param>
+    public JavaScriptInstallerResource(string name, string workingDirectory)
+        : base(name, "node", workingDirectory, skipValidation: true) // Validation is skipped because appending "-installer" to the parent name can exceed the 64-char limit.
+    {
+    }
+}

--- a/src/Aspire.Hosting.Python/PythonInstallerResource.cs
+++ b/src/Aspire.Hosting.Python/PythonInstallerResource.cs
@@ -11,6 +11,6 @@ namespace Aspire.Hosting.Python;
 /// <param name="name">The name of the resource.</param>
 /// <param name="parent">The parent Python application resource.</param>
 internal sealed class PythonInstallerResource(string name, PythonAppResource parent)
-    : ExecutableResource(name, "python", parent.WorkingDirectory)
+    : ExecutableResource(name, "python", parent.WorkingDirectory, skipValidation: true) // Validation is skipped because appending "-installer" to the parent name can exceed the 64-char limit.
 {
 }

--- a/src/Aspire.Hosting.Python/PythonVenvCreatorResource.cs
+++ b/src/Aspire.Hosting.Python/PythonVenvCreatorResource.cs
@@ -12,7 +12,7 @@ namespace Aspire.Hosting.Python;
 /// <param name="parent">The parent Python application resource.</param>
 /// <param name="venvPath">The path where the virtual environment should be created.</param>
 internal sealed class PythonVenvCreatorResource(string name, PythonAppResource parent, string venvPath)
-    : ExecutableResource(name, "python", parent.WorkingDirectory)
+    : ExecutableResource(name, "python", parent.WorkingDirectory, skipValidation: true) // Validation is skipped because appending "-venv-creator" to the parent name can exceed the 64-char limit.
 {
     /// <summary>
     /// Gets the path where the virtual environment will be created.

--- a/src/Aspire.Hosting/ApplicationModel/ExecutableResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExecutableResource.cs
@@ -25,7 +25,15 @@ public class ExecutableResource : Resource, IResourceWithEnvironment, IResourceW
     /// <param name="name">The name of the resource.</param>
     /// <param name="command">The command to execute.</param>
     /// <param name="workingDirectory">The working directory of the executable. Can be empty.</param>
-    public ExecutableResource(string name, string command, string workingDirectory) : base(name)
+    public ExecutableResource(string name, string command, string workingDirectory) : this(name, command, workingDirectory, skipValidation: false)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExecutableResource"/> class without name validation.
+    /// Used for internal resources that are never deployed and don't need to follow naming rules.
+    /// </summary>
+    internal ExecutableResource(string name, string command, string workingDirectory, bool skipValidation) : base(name, skipValidation)
     {
         Annotations.Add(new ExecutableAnnotation
         {

--- a/src/Aspire.Hosting/ApplicationModel/ProjectRebuilderResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProjectRebuilderResource.cs
@@ -20,7 +20,7 @@ internal sealed class ProjectRebuilderResource : ExecutableResource, IResourceWi
     /// <param name="parent">The project resource this rebuilder is associated with.</param>
     /// <param name="projectPath">The path to the project file.</param>
     public ProjectRebuilderResource(string name, ProjectResource parent, string projectPath)
-        : base(name, "dotnet", Path.GetDirectoryName(projectPath)!)
+        : base(name, "dotnet", Path.GetDirectoryName(projectPath)!, skipValidation: true) // Validation is skipped because appending "-rebuilder" to the parent name can exceed the 64-char limit.
     {
         Parent = parent;
         ProjectPath = projectPath;

--- a/src/Aspire.Hosting/ApplicationModel/Resource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/Resource.cs
@@ -25,9 +25,22 @@ public abstract class Resource : IResource
     /// Initializes a new instance of the <see cref="Resource"/> class.
     /// </summary>
     /// <param name="name">The name of the resource.</param>
-    protected Resource(string name)
+    protected Resource(string name) : this(name, skipValidation: false)
     {
-        ModelName.ValidateName(nameof(Resource), name);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Resource"/> class without name validation.
+    /// Used for internal resources that are never deployed and don't need to follow naming rules.
+    /// </summary>
+    /// <param name="name">The name of the resource.</param>
+    /// <param name="skipValidation">When <c>true</c>, skips name validation.</param>
+    internal Resource(string name, bool skipValidation)
+    {
+        if (!skipValidation)
+        {
+            ModelName.ValidateName(nameof(Resource), name);
+        }
 
         Name = name;
     }

--- a/tests/Aspire.Hosting.Tests/ModelNameTests.cs
+++ b/tests/Aspire.Hosting.Tests/ModelNameTests.cs
@@ -109,4 +109,14 @@ public class ModelNameTests
     {
         ModelName.ValidateName(nameof(Resource), name);
     }
+
+    [Fact]
+    public void ProjectRebuilderResource_LongName_DoesNotThrow()
+    {
+        var longName = new string('a', 64) + "-rebuilder";
+        var parent = new ProjectResource("parent");
+        var rebuilder = new ProjectRebuilderResource(longName, parent, "/some/project.csproj");
+
+        Assert.Equal(longName, rebuilder.Name);
+    }
 }


### PR DESCRIPTION
## Description

Resource names have a 64-character limit enforced by `ModelName.ValidateName`. The `ProjectRebuilderResource` appends `-rebuilder` to the parent resource name, which can push it over the limit even when the user's resource name is valid.

Since rebuilder resources are never deployed, they don't need to follow naming rules. This PR adds internal constructors to `Resource` and `ExecutableResource` that skip name validation, and uses them in `ProjectRebuilderResource`.

Fixes #15693

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
