### PR TITLE
Fix TelemetryManager disposal and DI registration

### DIFF
--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -291,7 +291,7 @@ public class Program
         // separate TracerProvider instances:
         // - Azure Monitor provider with filtering (only exports activities with EXTERNAL_TELEMETRY=true)
         // - Diagnostic provider for OTLP/console exporters (exports all activities, DEBUG only)
-        builder.Services.AddSingleton(new TelemetryManager(builder.Configuration, args));
+        builder.Services.AddSingleton(sp => new TelemetryManager(sp.GetRequiredService<IConfiguration>(), args));
 
         // Shared services.
         builder.Services.AddSingleton(sp =>
@@ -692,6 +692,10 @@ public class Program
         // Ensure dispose of app when Main exits.
         using var _ = app;
 
+        // Immediately get telemetry and telemetry manager so they are created by DI and telemetry is configured.
+        var telemetry = app.Services.GetRequiredService<AspireCliTelemetry>();
+        var telemetryManager = app.Services.GetRequiredService<TelemetryManager>();
+
         // Display first run experience if this is the first time the CLI is run on this machine
         await DisplayFirstTimeUseNoticeIfNeededAsync(app.Services, args, cts.Token);
 
@@ -701,9 +705,6 @@ public class Program
             // Disable default exception handler so we can log exceptions to telemetry.
             EnableDefaultExceptionHandler = false
         };
-
-        var telemetry = app.Services.GetRequiredService<AspireCliTelemetry>();
-        var telemetryManager = app.Services.GetRequiredService<TelemetryManager>();
 
         using var mainActivity = telemetry.StartReportedActivity(name: TelemetryConstants.Activities.Main, kind: ActivityKind.Internal);
 

--- a/src/Aspire.Cli/Telemetry/TelemetryManager.cs
+++ b/src/Aspire.Cli/Telemetry/TelemetryManager.cs
@@ -14,7 +14,7 @@ namespace Aspire.Cli.Telemetry;
 /// Manages OpenTelemetry TracerProvider instances for the CLI.
 /// Maintains separate providers for Azure Monitor (production telemetry) and debug exporters (OTLP/console).
 /// </summary>
-internal sealed class TelemetryManager
+internal sealed class TelemetryManager : IDisposable
 {
     // Remote export connection string for Application Insights. Intentionally hard-coded.
     private const string ApplicationInsightsConnectionString = "InstrumentationKey=e39510fc-95a1-423d-9f33-6121bf0d2113;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/;ApplicationId=4d8bb9db-b7ab-49f9-978b-80ae1e83f6da";
@@ -31,6 +31,8 @@ internal sealed class TelemetryManager
 #if DEBUG
     private readonly TracerProvider? _diagnosticProvider;
 #endif
+
+    private bool _shuttingDown;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TelemetryManager"/> class.
@@ -127,6 +129,8 @@ internal sealed class TelemetryManager
     /// </summary>
     public Task ShutdownAsync()
     {
+        _shuttingDown = true;
+
         return Task.Run(() =>
         {
             _azureMonitorProvider?.Shutdown(ShutDownTimeoutMilliseconds);
@@ -140,5 +144,18 @@ internal sealed class TelemetryManager
     {
         var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         return Path.Combine(homeDirectory, ".aspire", "cli", "telemetrystorage");
+    }
+
+    public void Dispose()
+    {
+        if (!_shuttingDown)
+        {
+            // Ensure everything is cleaned up for tests.
+            // This covers the situation where the host is displayed without a call to ShutdownAsync
+            _azureMonitorProvider?.Shutdown(0);
+#if DEBUG
+            _diagnosticProvider?.Shutdown(0);
+#endif
+        }
     }
 }

--- a/src/Aspire.Cli/Telemetry/TelemetryManager.cs
+++ b/src/Aspire.Cli/Telemetry/TelemetryManager.cs
@@ -151,7 +151,7 @@ internal sealed class TelemetryManager : IDisposable
         if (!_shuttingDown)
         {
             // Ensure everything is cleaned up for tests.
-            // This covers the situation where the host is displayed without a call to ShutdownAsync
+            // This covers the situation where the host is disposed without a call to ShutdownAsync
             _azureMonitorProvider?.Shutdown(0);
 #if DEBUG
             _diagnosticProvider?.Shutdown(0);

--- a/src/Aspire.Cli/Telemetry/TelemetryManager.cs
+++ b/src/Aspire.Cli/Telemetry/TelemetryManager.cs
@@ -150,8 +150,9 @@ internal sealed class TelemetryManager : IDisposable
     {
         if (!_shuttingDown)
         {
-            // Ensure everything is cleaned up for tests.
-            // This covers the situation where the host is disposed without a call to ShutdownAsync
+            // Ensure everything is cleaned up for tests. This covers the situation where the host is disposed without a call to ShutdownAsync.
+            // The shutdown timeout is zero so not to wait for telemetry to be flushed. Don't want to delay tests.
+            // Dispose isn't used here because it always flushes telemetry and waits for completion.
             _azureMonitorProvider?.Shutdown(0);
 #if DEBUG
             _diagnosticProvider?.Shutdown(0);


### PR DESCRIPTION
## Description

I noticed OTLP telemetry coming from running tests. Cause was telemetry listeners not being correctly cleaned at the end of tests.

---

Fix `TelemetryManager` DI registration and add proper disposal support for test cleanup.

**Changes:**
- **DI factory for `TelemetryManager`**: Changed from `AddSingleton(new TelemetryManager(builder.Configuration, args))` to `AddSingleton(sp => new TelemetryManager(sp.GetRequiredService<IConfiguration>(), args))` so that `IConfiguration` is resolved from the service provider at creation time rather than captured from the builder.
- **Eager telemetry resolution**: Moved `GetRequiredService<AspireCliTelemetry>()` and `GetRequiredService<TelemetryManager>()` earlier in `Main` to ensure telemetry is initialized before any work begins.
- **`IDisposable` on `TelemetryManager`**: Added `IDisposable` implementation so DI disposes the telemetry providers when the host shuts down, ensuring proper cleanup especially in test scenarios where `ShutdownAsync` may not be called.
- **`#if DEBUG` guard in `Dispose`**: `_diagnosticProvider` is conditionally compiled, so the `Dispose` method wraps its shutdown call in `#if DEBUG` to match the field declaration and avoid Release build failures.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
