### PR TITLE
Use secure temp directories

### DIFF
--- a/.github/instructions/temp-directory.instructions.md
+++ b/.github/instructions/temp-directory.instructions.md
@@ -1,5 +1,3 @@
-This instruction applies to files matching the pattern: **/*.cs
-
 ---
 applyTo: "**/*.cs"
 ---

--- a/.github/instructions/temp-directory.instructions.md
+++ b/.github/instructions/temp-directory.instructions.md
@@ -1,0 +1,16 @@
+This instruction applies to files matching the pattern: **/*.cs
+
+---
+applyTo: "**/*.cs"
+---
+
+# Temporary directory guidance
+
+When reviewing or generating C# code in this repository:
+
+* Prefer the repository temp directory abstractions first (for example `IFileSystemService.TempDirectory` / `ITempFileSystemService`) when they are available.
+* Otherwise, use `Directory.CreateTempSubdirectory()` for temporary directories instead of `Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())`.
+* If code needs a temporary file path, create it under a securely created temporary directory rather than composing a path directly under `Path.GetTempPath()`.
+* Preserve the caller's behavior when migrating existing code. If the final path must stay absent or needs broader permissions for bind mounts, use a secure temporary parent directory and derive the child path from it instead of pre-creating the final path.
+
+When reviewing pull requests, flag new uses of `Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())` for temporary directories and suggest the secure alternatives above.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Instructions for GitHub Copilot and other AI coding agents working with the Aspi
 * Never change global.json unless explicitly asked to.
 * Never change package.json or package-lock.json files unless explicitly asked to.
 * Never change NuGet.config files unless explicitly asked to.
+* When code needs a temporary directory, prefer `Directory.CreateTempSubdirectory()` (or the repository temp directory abstractions) instead of `Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())`; if you need a temporary file path, place it under a directory created that way.
 * Don't update files under `*/api/*.cs` (e.g. src/Aspire.Hosting/api/Aspire.Hosting.cs) as they are generated.
 
 ## Code Review Instructions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Instructions for GitHub Copilot and other AI coding agents working with the Aspi
 * Never change global.json unless explicitly asked to.
 * Never change package.json or package-lock.json files unless explicitly asked to.
 * Never change NuGet.config files unless explicitly asked to.
-* When code needs a temporary directory, prefer `Directory.CreateTempSubdirectory()` (or the repository temp directory abstractions) instead of `Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())`; if you need a temporary file path, place it under a directory created that way.
+* When code needs a temporary directory, prefer the repository temp directory abstractions first (for example `IFileSystemService.TempDirectory` / `ITempFileSystemService`) and otherwise use `Directory.CreateTempSubdirectory()` instead of `Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())`; if you need a temporary file path, place it under a securely created temp directory.
 * Don't update files under `*/api/*.cs` (e.g. src/Aspire.Hosting/api/Aspire.Hosting.cs) as they are generated.
 
 ## Code Review Instructions

--- a/src/Aspire.Cli/Packaging/TemporaryNuGetConfig.cs
+++ b/src/Aspire.Cli/Packaging/TemporaryNuGetConfig.cs
@@ -19,8 +19,7 @@ internal sealed class TemporaryNuGetConfig : IDisposable
 
     public static async Task<TemporaryNuGetConfig> CreateAsync(PackageMapping[] mappings)
     {
-        var tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        Directory.CreateDirectory(tempDirectory);
+        var tempDirectory = Directory.CreateTempSubdirectory("aspire-nuget-config").FullName;
         var tempFilePath = Path.Combine(tempDirectory, "nuget.config");
         var configFile = new FileInfo(tempFilePath);
         await GenerateNuGetConfigAsync(mappings, configFile);

--- a/tests/Aspire.Cli.EndToEnd.Tests/AgentCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/AgentCommandTests.cs
@@ -137,9 +137,11 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
         await auto.WaitUntilAsync(
             s => s.ContainsText("skills should be installed"),
             timeout: TimeSpan.FromSeconds(30), description: "skill selection prompt");
-        await auto.EnterAsync(); // Accept default skills
-        await auto.WaitUntilTextAsync("complete", timeout: TimeSpan.FromSeconds(30));
-        await auto.WaitForSuccessPromptAsync(counter);
+        await auto.DownAsync();
+        await auto.TypeAsync(" "); // Deselect playwright-cli to avoid npm dependency in CI
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("configuration complete", timeout: TimeSpan.FromSeconds(30));
+        await auto.WaitForSuccessPromptFailFastAsync(counter);
 
         // Step 3: Verify config was updated to new format
         // The updated config should contain "agent" and "mcp" but not "start"
@@ -221,7 +223,8 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
         // Create .vscode folder so the scanner detects VS Code environment
         Directory.CreateDirectory(vscodePath);
 
-        // Run aspire agent init and accept defaults through both prompts
+        // Run aspire agent init and accept the default location, but keep only the
+        // built-in skills that do not require downloading external npm packages.
         await auto.TypeAsync("aspire agent init");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync("workspace:", timeout: TimeSpan.FromSeconds(30));
@@ -234,9 +237,11 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
         await auto.WaitUntilAsync(
             s => s.ContainsText("skills should be installed"),
             timeout: TimeSpan.FromSeconds(30), description: "skill selection prompt");
-        await auto.EnterAsync(); // Accept default skills (all pre-selected, MCP not pre-selected)
-        await auto.WaitUntilTextAsync("complete", timeout: TimeSpan.FromSeconds(30));
-        await auto.WaitForSuccessPromptAsync(counter);
+        await auto.DownAsync();
+        await auto.TypeAsync(" "); // Deselect playwright-cli to avoid npm dependency in CI
+        await auto.EnterAsync();
+        await auto.WaitUntilTextAsync("configuration complete", timeout: TimeSpan.FromSeconds(30));
+        await auto.WaitForSuccessPromptFailFastAsync(counter);
 
         // Verify skill file was created (skills are now installed at .agents/skills/ by StandardLocationAgentEnvironmentScanner)
         var skillFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, ".agents", "skills", "aspire", "SKILL.md");
@@ -249,4 +254,3 @@ public sealed class AgentCommandTests(ITestOutputHelper output)
         await pendingRun;
     }
 }
-

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -137,19 +137,28 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
     [InlineData(KnownConfigNames.Legacy.DashboardConfigFilePath)]
     public async Task Configuration_ConfigFilePathDoesntExist_Error(string dashboardConfigFilePathNameKey)
     {
-        // Arrange & Act
-        var configFilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        var ex = await Assert.ThrowsAsync<FileNotFoundException>(async () =>
-        {
-            await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper,
-                additionalConfiguration: data =>
-                {
-                    data[dashboardConfigFilePathNameKey] = configFilePath;
-                });
-        }).DefaultTimeout();
+        var tempDirectory = Directory.CreateTempSubdirectory();
 
-        // Assert
-        Assert.Contains(configFilePath, ex.Message);
+        try
+        {
+            // Arrange & Act
+            var configFilePath = Path.Combine(tempDirectory.FullName, Path.GetRandomFileName());
+            var ex = await Assert.ThrowsAsync<FileNotFoundException>(async () =>
+            {
+                await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper,
+                    additionalConfiguration: data =>
+                    {
+                        data[dashboardConfigFilePathNameKey] = configFilePath;
+                    });
+            }).DefaultTimeout();
+
+            // Assert
+            Assert.Contains(configFilePath, ex.Message);
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory.FullName, recursive: true);
+        }
     }
 
     [Theory]
@@ -237,7 +246,8 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
     public async Task Configuration_FileConfigDirectoryDoesntExist_Error()
     {
         // Arrange & Act
-        var fileConfigDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var fileConfigDirectory = Directory.CreateTempSubdirectory().FullName;
+        Directory.Delete(fileConfigDirectory);
         var ex = await Assert.ThrowsAsync<DirectoryNotFoundException>(async () =>
         {
             await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper,
@@ -551,7 +561,8 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
     public async Task Configuration_Logging_FileConfig_OverrideDefaults(string dashboardConfigFilePathNameKey)
     {
         // Arrange
-        var configFilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var tempDirectory = Directory.CreateTempSubdirectory();
+        var configFilePath = Path.Combine(tempDirectory.FullName, Path.GetRandomFileName());
         var configJson = new JsonObject
         {
             ["Logging"] = new JsonObject
@@ -587,7 +598,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         }
         finally
         {
-            File.Delete(configFilePath);
+            Directory.Delete(tempDirectory.FullName, recursive: true);
         }
     }
 

--- a/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
@@ -260,9 +260,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     public async Task WithDockerfileResultsInBuildAttributeBeingAddedToManifest()
     {
         using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
         var tempContextPath = tempDockerfileContext.ContextPath;
-
         var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var manifestOutputPath = Path.Combine(tempContextPath, "aspire-manifest.json");
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
@@ -312,9 +310,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     public async Task AddDockerfileResultsInBuildAttributeBeingAddedToManifest()
     {
         using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
         var tempContextPath = tempDockerfileContext.ContextPath;
-
         var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var manifestOutputPath = Path.Combine(tempContextPath, "aspire-manifest.json");
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
@@ -363,9 +359,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     public async Task WithDockerfileWithBuildSecretResultsInManifestReferencingSecretParameter()
     {
         using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
         var tempContextPath = tempDockerfileContext.ContextPath;
-
         var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var manifestOutputPath = Path.Combine(tempContextPath, "aspire-manifest.json");
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
@@ -413,9 +407,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     public async Task AddDockerfileWithBuildSecretResultsInManifestReferencingSecretParameter()
     {
         using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
         var tempContextPath = tempDockerfileContext.ContextPath;
-
         var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var manifestOutputPath = Path.Combine(tempContextPath, "aspire-manifest.json");
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions

--- a/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
@@ -25,8 +25,9 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync(includeSecrets: true);
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync(includeSecrets: true);
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         builder.Configuration["Parameters:secret"] = "open sesame from env";
         var parameter = builder.AddParameter("secret", secret: true);
 
@@ -59,8 +60,9 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
             logging.AddXunit(testOutputHelper);
         });
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         builder.AddContainer("testcontainer", "testimage")
                .WithHttpEndpoint(targetPort: 80)
                .WithDockerfile(tempContextPath, tempDockerfilePath);
@@ -95,8 +97,9 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var dockerFile = builder.AddDockerfile(resourceName, tempContextPath, tempDockerfilePath);
 
         // The effective image name (from TryGetContainerImageName) should be the lowercase resource name
@@ -118,8 +121,9 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var dockerFile = builder.AddContainer(resourceName, "someimagename")
             .WithDockerfile(tempContextPath, tempDockerfilePath);
 
@@ -142,8 +146,9 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var dockerFile = builder.AddContainer("testcontainer", "someimagename")
             .WithDockerfile(tempContextPath, tempDockerfilePath);
         Assert.True(dockerFile.Resource.TryGetLastAnnotation<DockerfileBuildAnnotation>(out var buildAnnotation1));
@@ -162,8 +167,9 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var dockerFile = builder.AddContainer("testcontainer", "someimagename")
             .WithDockerfile(tempContextPath, tempDockerfilePath);
 
@@ -189,8 +195,9 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         builder.AddContainer("testcontainer", "testimage")
                .WithHttpEndpoint(targetPort: 80)
                .WithDockerfile(tempContextPath, tempDockerfilePath);
@@ -223,8 +230,9 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         builder.AddDockerfile("testcontainer", tempContextPath, tempDockerfilePath)
                .WithHttpEndpoint(targetPort: 80);
 
@@ -251,7 +259,11 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task WithDockerfileResultsInBuildAttributeBeingAddedToManifest()
     {
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+
+        var tempContextPath = tempDockerfileContext.ContextPath;
+
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var manifestOutputPath = Path.Combine(tempContextPath, "aspire-manifest.json");
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
         {
@@ -299,7 +311,11 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task AddDockerfileResultsInBuildAttributeBeingAddedToManifest()
     {
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+
+        var tempContextPath = tempDockerfileContext.ContextPath;
+
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var manifestOutputPath = Path.Combine(tempContextPath, "aspire-manifest.json");
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
         {
@@ -346,7 +362,11 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task WithDockerfileWithBuildSecretResultsInManifestReferencingSecretParameter()
     {
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+
+        var tempContextPath = tempDockerfileContext.ContextPath;
+
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var manifestOutputPath = Path.Combine(tempContextPath, "aspire-manifest.json");
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
         {
@@ -392,7 +412,11 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task AddDockerfileWithBuildSecretResultsInManifestReferencingSecretParameter()
     {
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+
+        var tempContextPath = tempDockerfileContext.ContextPath;
+
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var manifestOutputPath = Path.Combine(tempContextPath, "aspire-manifest.json");
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
         {
@@ -441,8 +465,9 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         builder.Configuration["Parameters:message"] = "hello";
         var parameter = builder.AddParameter("message");
 
@@ -512,8 +537,9 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         builder.Configuration["Parameters:message"] = "hello";
         var parameter = builder.AddParameter("message");
 
@@ -629,8 +655,9 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var container = builder.AddContainer("mycontainer", "myimage")
                                .WithDockerfile(tempContextPath);
 
@@ -645,8 +672,9 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var container = builder.AddDockerfile("mycontainer", tempContextPath);
 
         var annotation = Assert.Single(container.Resource.Annotations.OfType<DockerfileBuildAnnotation>());
@@ -660,8 +688,9 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var container = builder.AddContainer("mycontainer", "myimage")
                                .WithDockerfile(tempContextPath, "Dockerfile");
 
@@ -676,8 +705,9 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var container = builder.AddDockerfile("mycontainer", tempContextPath, "Dockerfile");
 
         var annotation = Assert.Single(container.Resource.Annotations.OfType<DockerfileBuildAnnotation>());
@@ -691,8 +721,9 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync("Otherdockerfile");
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync("Otherdockerfile");
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var container = builder.AddContainer("mycontainer", "myimage")
                                .WithDockerfile(tempContextPath, "Otherdockerfile");
 
@@ -707,8 +738,9 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync("Otherdockerfile");
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync("Otherdockerfile");
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var container = builder.AddDockerfile("mycontainer", tempContextPath, "Otherdockerfile");
 
         var annotation = Assert.Single(container.Resource.Annotations.OfType<DockerfileBuildAnnotation>());
@@ -722,8 +754,9 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var container = builder.AddContainer("mycontainer", "myimage")
                                .WithDockerfile(tempContextPath, tempDockerfilePath);
 
@@ -738,8 +771,9 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var container = builder.AddDockerfile("mycontainer", tempContextPath, tempDockerfilePath);
 
         var annotation = Assert.Single(container.Resource.Annotations.OfType<DockerfileBuildAnnotation>());
@@ -760,7 +794,8 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, _) = await DockerfileUtils.CreateTemporaryDockerfileAsync(createDockerfile: false);
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync(createDockerfile: false);
+        var tempContextPath = tempDockerfileContext.ContextPath;
 
         var dockerfileContent = "FROM alpine:latest\nRUN echo 'Hello from factory'";
         var container = builder.AddContainer("mycontainer", "myimage")
@@ -807,7 +842,8 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, _) = await DockerfileUtils.CreateTemporaryDockerfileAsync(createDockerfile: false);
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync(createDockerfile: false);
+        var tempContextPath = tempDockerfileContext.ContextPath;
 
         var dockerfileContent = "FROM alpine:latest\nRUN echo 'Hello from async factory'";
         var container = builder.AddContainer("mycontainer", "myimage")
@@ -836,7 +872,9 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task WithDockerfileFactoryGeneratesFileAtBuildTime()
     {
-        var (tempContextPath, _) = await DockerfileUtils.CreateTemporaryDockerfileAsync(createDockerfile: false);
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync(createDockerfile: false);
+
+        var tempContextPath = tempDockerfileContext.ContextPath;
         var manifestOutputPath = Path.Combine(tempContextPath, "aspire-manifest.json");
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
         {
@@ -860,7 +898,8 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create();
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var (tempContextPath, _) = await DockerfileUtils.CreateTemporaryDockerfileAsync(createDockerfile: false);
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync(createDockerfile: false);
+        var tempContextPath = tempDockerfileContext.ContextPath;
 
         var dockerfileContent = "FROM alpine:latest AS builder\nFROM alpine:latest AS runner";
         var container = builder.AddContainer("mycontainer", "myimage")
@@ -917,8 +956,9 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         builder.AddContainer("test-container", "test-image")
                .WithDockerfile(tempContextPath, tempDockerfilePath);
 
@@ -957,9 +997,14 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
-        var (tempContextPath1, tempDockerfilePath1) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-        var (tempContextPath2, tempDockerfilePath2) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        using var tempDockerfileContext1 = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath1 = tempDockerfileContext1.ContextPath;
+        var tempDockerfilePath1 = tempDockerfileContext1.DockerfilePath;
+        using var tempDockerfileContext2 = await DockerfileUtils.CreateTemporaryDockerfileAsync();
 
+        var tempContextPath2 = tempDockerfileContext2.ContextPath;
+
+        var tempDockerfilePath2 = tempDockerfileContext2.DockerfilePath;
         var containerBuilder = builder.AddContainer("test-container", "test-image")
                                      .WithDockerfile(tempContextPath1, tempDockerfilePath1)
                                      .WithDockerfile(tempContextPath1, tempDockerfilePath1); // Call twice to start

--- a/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
@@ -124,9 +124,7 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-
-                Directory.CreateDirectory(bindMountPath);
+                bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
                 if (!OperatingSystem.IsWindows())
                 {

--- a/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
@@ -138,9 +138,7 @@ public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-
-                Directory.CreateDirectory(bindMountPath);
+                bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
                 if (!OperatingSystem.IsWindows())
                 {

--- a/tests/Aspire.Hosting.Keycloak.Tests/KeycloakPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Keycloak.Tests/KeycloakPublicApiTests.cs
@@ -150,13 +150,12 @@ public class KeycloakPublicApiTests
     public async Task WithRealmImportDirectoryAddsContainerFilesAnnotation()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
-
-        var tempDirectory = Directory.CreateTempSubdirectory().FullName;
+        using var tempDirectory = new TestTempDirectory();
 
         var resourceName = "keycloak";
         var keycloak = builder.AddKeycloak(resourceName);
 
-        keycloak.WithRealmImport(tempDirectory);
+        keycloak.WithRealmImport(tempDirectory.Path);
 
         using var app = builder.Build();
         var keycloakResource = builder.Resources.Single(r => r.Name.Equals(resourceName, StringComparison.Ordinal));
@@ -172,11 +171,10 @@ public class KeycloakPublicApiTests
     public async Task WithRealmImportFileAddsContainerFilesAnnotation()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
-
-        var tempDirectory = Directory.CreateTempSubdirectory().FullName;
+        using var tempDirectory = new TestTempDirectory();
 
         var file = "realm.json";
-        var filePath = Path.Combine(tempDirectory, file);
+        var filePath = Path.Combine(tempDirectory.Path, file);
         File.WriteAllText(filePath, string.Empty);
 
         var resourceName = "keycloak";

--- a/tests/Aspire.Hosting.Keycloak.Tests/KeycloakPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Keycloak.Tests/KeycloakPublicApiTests.cs
@@ -151,8 +151,7 @@ public class KeycloakPublicApiTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
-        var tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        Directory.CreateDirectory(tempDirectory);
+        var tempDirectory = Directory.CreateTempSubdirectory().FullName;
 
         var resourceName = "keycloak";
         var keycloak = builder.AddKeycloak(resourceName);
@@ -174,8 +173,7 @@ public class KeycloakPublicApiTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
-        var tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        Directory.CreateDirectory(tempDirectory);
+        var tempDirectory = Directory.CreateTempSubdirectory().FullName;
 
         var file = "realm.json";
         var filePath = Path.Combine(tempDirectory, file);

--- a/tests/Aspire.Hosting.Milvus.Tests/MilvusFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Milvus.Tests/MilvusFunctionalTests.cs
@@ -94,7 +94,7 @@ public class MilvusFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Directory.CreateTempSubdirectory().FullName;
+                bindMountPath = Path.Combine(Directory.CreateTempSubdirectory().FullName, "data");
 
                 milvus1.WithDataBindMount(bindMountPath);
             }
@@ -193,7 +193,7 @@ public class MilvusFunctionalTests(ITestOutputHelper testOutputHelper)
             {
                 try
                 {
-                    Directory.Delete(bindMountPath, recursive: true);
+                    Directory.Delete(Path.GetDirectoryName(bindMountPath)!, recursive: true);
                 }
                 catch
                 {

--- a/tests/Aspire.Hosting.Milvus.Tests/MilvusFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Milvus.Tests/MilvusFunctionalTests.cs
@@ -94,8 +94,7 @@ public class MilvusFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                // Milvus container runs as root and will create the directory.
-                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
                 milvus1.WithDataBindMount(bindMountPath);
             }

--- a/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
@@ -260,6 +260,16 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
+        if (!OperatingSystem.IsWindows())
+        {
+            const UnixFileMode BindMountPermissions =
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
+
+            File.SetUnixFileMode(bindMountPath, BindMountPermissions);
+        }
+
         try
         {
             var initFilePath = Path.Combine(bindMountPath, "mongo-init.js");

--- a/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
@@ -134,7 +134,7 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Directory.CreateTempSubdirectory().FullName;
+                bindMountPath = Path.Combine(Directory.CreateTempSubdirectory().FullName, "data");
 
                 mongodb1.WithDataBindMount(bindMountPath);
             }
@@ -235,7 +235,7 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
             {
                 try
                 {
-                    Directory.Delete(bindMountPath, recursive: true);
+                    Directory.Delete(Path.GetDirectoryName(bindMountPath)!, recursive: true);
                 }
                 catch
                 {

--- a/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
@@ -134,8 +134,7 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                // MongoDB container runs as root and will create the directory.
-                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
                 mongodb1.WithDataBindMount(bindMountPath);
             }
@@ -259,8 +258,7 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
             .AddRetry(new() { MaxRetryAttempts = 10, BackoffType = DelayBackoffType.Linear, Delay = TimeSpan.FromSeconds(2) })
             .Build();
 
-        var bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        Directory.CreateDirectory(bindMountPath);
+        var bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
         try
         {
@@ -357,8 +355,7 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
             .AddRetry(new() { MaxRetryAttempts = 10, BackoffType = DelayBackoffType.Linear, Delay = TimeSpan.FromSeconds(2) })
             .Build();
 
-        var initFilesPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        Directory.CreateDirectory(initFilesPath);
+        var initFilesPath = Directory.CreateTempSubdirectory().FullName;
 
         try
         {

--- a/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
@@ -308,6 +308,16 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
+        if (!OperatingSystem.IsWindows())
+        {
+            const UnixFileMode BindMountPermissions =
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
+
+            File.SetUnixFileMode(bindMountPath, BindMountPermissions);
+        }
+
         try
         {
             File.WriteAllText(Path.Combine(bindMountPath, "init.sql"), """

--- a/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
@@ -306,9 +306,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
             .AddRetry(new() { MaxRetryAttempts = 10, BackoffType = DelayBackoffType.Linear, Delay = TimeSpan.FromSeconds(2), ShouldHandle = new PredicateBuilder().Handle<MySqlException>() })
             .Build();
 
-        var bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-
-        Directory.CreateDirectory(bindMountPath);
+        var bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
         try
         {
@@ -393,9 +391,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
             .AddRetry(new() { MaxRetryAttempts = 10, BackoffType = DelayBackoffType.Linear, Delay = TimeSpan.FromSeconds(2), ShouldHandle = new PredicateBuilder().Handle<MySqlException>() })
             .Build();
 
-        var initFilesPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-
-        Directory.CreateDirectory(initFilesPath);
+        var initFilesPath = Directory.CreateTempSubdirectory().FullName;
 
         try
         {

--- a/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
@@ -147,7 +147,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Directory.CreateTempSubdirectory().FullName;
+                bindMountPath = Path.Combine(Directory.CreateTempSubdirectory().FullName, "data");
 
                 mysql1.WithDataBindMount(bindMountPath);
             }
@@ -285,7 +285,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
             {
                 try
                 {
-                    Directory.Delete(bindMountPath);
+                    Directory.Delete(Path.GetDirectoryName(bindMountPath)!, recursive: true);
                 }
                 catch
                 {

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
@@ -368,6 +368,16 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
 
         var bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
+        if (!OperatingSystem.IsWindows())
+        {
+            const UnixFileMode BindMountPermissions =
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
+
+            File.SetUnixFileMode(bindMountPath, BindMountPermissions);
+        }
+
         try
         {
             File.WriteAllText(Path.Combine(bindMountPath, "init.sql"), """

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
@@ -221,7 +221,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
                 postgres1.WithDataBindMount(bindMountPath);
             }
@@ -366,9 +366,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
             .AddRetry(new() { MaxRetryAttempts = 3, Delay = TimeSpan.FromSeconds(2) })
             .Build();
 
-        var bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-
-        Directory.CreateDirectory(bindMountPath);
+        var bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
         try
         {
@@ -454,9 +452,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
             .AddRetry(new() { MaxRetryAttempts = 3, Delay = TimeSpan.FromSeconds(2) })
             .Build();
 
-        var initFilesPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-
-        Directory.CreateDirectory(initFilesPath);
+        var initFilesPath = Directory.CreateTempSubdirectory().FullName;
 
         try
         {

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
@@ -221,7 +221,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Directory.CreateTempSubdirectory().FullName;
+                bindMountPath = Path.Combine(Directory.CreateTempSubdirectory().FullName, "data");
 
                 postgres1.WithDataBindMount(bindMountPath);
             }
@@ -345,7 +345,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
             {
                 try
                 {
-                    Directory.Delete(bindMountPath, recursive: true);
+                    Directory.Delete(Path.GetDirectoryName(bindMountPath)!, recursive: true);
                 }
                 catch
                 {

--- a/tests/Aspire.Hosting.Python.Tests/AddPythonAppTests.cs
+++ b/tests/Aspire.Hosting.Python.Tests/AddPythonAppTests.cs
@@ -263,8 +263,7 @@ public class AddPythonAppTests(ITestOutputHelper outputHelper)
 
     private static (string projectDirectory, string pythonExecutable, string scriptName) CreateTempPythonProject(ITestOutputHelper outputHelper, bool instrument = false)
     {
-        var projectDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        Directory.CreateDirectory(projectDirectory);
+        var projectDirectory = Directory.CreateTempSubdirectory().FullName;
 
         if (instrument)
         {

--- a/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
@@ -113,7 +113,7 @@ public class QdrantFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Directory.CreateTempSubdirectory().FullName;
+                bindMountPath = Path.Combine(Directory.CreateTempSubdirectory().FullName, "data");
 
                 qdrant1.WithDataBindMount(bindMountPath);
             }
@@ -211,7 +211,7 @@ public class QdrantFunctionalTests(ITestOutputHelper testOutputHelper)
             {
                 try
                 {
-                    Directory.Delete(bindMountPath, recursive: true);
+                    Directory.Delete(Path.GetDirectoryName(bindMountPath)!, recursive: true);
                 }
                 catch
                 {

--- a/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
@@ -113,7 +113,7 @@ public class QdrantFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
                 qdrant1.WithDataBindMount(bindMountPath);
             }

--- a/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
@@ -283,9 +283,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
     [RequiresFeature(TestFeature.Docker)]
     public async Task WithDataBindMountShouldPersistStateBetweenUsages()
     {
-        var bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-
-        Directory.CreateDirectory(bindMountPath);
+        var bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
         // Use a bind mount to do a snapshot save
 

--- a/tests/Aspire.Hosting.Seq.Tests/SeqFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Seq.Tests/SeqFunctionalTests.cs
@@ -93,7 +93,7 @@ public class SeqFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                bindMountPath = Directory.CreateTempSubdirectory().FullName;
                 seq1.WithDataBindMount(bindMountPath);
             }
 

--- a/tests/Aspire.Hosting.Seq.Tests/SeqFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Seq.Tests/SeqFunctionalTests.cs
@@ -93,7 +93,7 @@ public class SeqFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Directory.CreateTempSubdirectory().FullName;
+                bindMountPath = Path.Combine(Directory.CreateTempSubdirectory().FullName, "data");
                 seq1.WithDataBindMount(bindMountPath);
             }
 
@@ -175,7 +175,7 @@ public class SeqFunctionalTests(ITestOutputHelper testOutputHelper)
             {
                 try
                 {
-                    Directory.Delete(bindMountPath, recursive: true);
+                    Directory.Delete(Path.GetDirectoryName(bindMountPath)!, recursive: true);
                 }
                 catch
                 {

--- a/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
@@ -154,9 +154,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-
-                Directory.CreateDirectory(bindMountPath);
+                bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
                 if (!OperatingSystem.IsWindows())
                 {

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -31,14 +31,15 @@ public class ProjectResourceTests
     [Fact]
     public async Task AddProjectWithTrailingCommasInLaunchSettingsDoesNotThrow()
     {
-        var projectDetails = await PrepareProjectWithTrailingCommasInLaunchSettingsAsync().DefaultTimeout();
+        using var tempDirectory = new TestTempDirectory();
+        var projectDetails = await PrepareProjectWithTrailingCommasInLaunchSettingsAsync(tempDirectory.Path).DefaultTimeout();
 
         var appBuilder = CreateBuilder();
 
         // Should not throw - trailing commas are common in hand-edited JSON.
         appBuilder.AddProject("project", projectDetails.ProjectFilePath);
 
-        async static Task<(string ProjectFilePath, string LaunchSettingsFilePath)> PrepareProjectWithTrailingCommasInLaunchSettingsAsync()
+        async static Task<(string ProjectFilePath, string LaunchSettingsFilePath)> PrepareProjectWithTrailingCommasInLaunchSettingsAsync(string projectDirectoryPath)
         {
             var csProjContent = """
                                 <Project Sdk="Microsoft.NET.Sdk.Web">
@@ -58,7 +59,6 @@ public class ProjectResourceTests
                                         }
                                         """;
 
-            var projectDirectoryPath = Directory.CreateTempSubdirectory().FullName;
             var projectFilePath = Path.Combine(projectDirectoryPath, "Project.csproj");
             var propertiesDirectoryPath = Path.Combine(projectDirectoryPath, "Properties");
             var launchSettingsFilePath = Path.Combine(propertiesDirectoryPath, "launchSettings.json");
@@ -75,7 +75,8 @@ public class ProjectResourceTests
     [Fact]
     public async Task AddProjectWithInvalidLaunchSettingsShouldThrowSpecificError()
     {
-        var projectDetails = await PrepareProjectWithMalformedLaunchSettingsAsync().DefaultTimeout();
+        using var tempDirectory = new TestTempDirectory();
+        var projectDetails = await PrepareProjectWithMalformedLaunchSettingsAsync(tempDirectory.Path).DefaultTimeout();
 
         var ex = Assert.Throws<DistributedApplicationException>(() =>
         {
@@ -86,7 +87,7 @@ public class ProjectResourceTests
         var expectedMessage = $"Failed to get effective launch profile for project resource 'project'. There is malformed JSON in the project's launch settings file at '{projectDetails.LaunchSettingsFilePath}'.";
         Assert.Equal(expectedMessage, ex.Message);
 
-        async static Task<(string ProjectFilePath, string LaunchSettingsFilePath)> PrepareProjectWithMalformedLaunchSettingsAsync()
+        async static Task<(string ProjectFilePath, string LaunchSettingsFilePath)> PrepareProjectWithMalformedLaunchSettingsAsync(string projectDirectoryPath)
         {
             var csProjContent = """
                                 <Project Sdk="Microsoft.NET.Sdk.Web">
@@ -98,7 +99,6 @@ public class ProjectResourceTests
                                         this { is } { mal formed! >
                                         """;
 
-            var projectDirectoryPath = Directory.CreateTempSubdirectory().FullName;
             var projectFilePath = Path.Combine(projectDirectoryPath, "Project.csproj");
             var propertiesDirectoryPath = Path.Combine(projectDirectoryPath, "Properties");
             var launchSettingsFilePath = Path.Combine(propertiesDirectoryPath, "launchSettings.json");

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -58,12 +58,11 @@ public class ProjectResourceTests
                                         }
                                         """;
 
-            var projectDirectoryPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            var projectDirectoryPath = Directory.CreateTempSubdirectory().FullName;
             var projectFilePath = Path.Combine(projectDirectoryPath, "Project.csproj");
             var propertiesDirectoryPath = Path.Combine(projectDirectoryPath, "Properties");
             var launchSettingsFilePath = Path.Combine(propertiesDirectoryPath, "launchSettings.json");
 
-            Directory.CreateDirectory(projectDirectoryPath);
             await File.WriteAllTextAsync(projectFilePath, csProjContent).DefaultTimeout();
 
             Directory.CreateDirectory(propertiesDirectoryPath);
@@ -99,12 +98,11 @@ public class ProjectResourceTests
                                         this { is } { mal formed! >
                                         """;
 
-            var projectDirectoryPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            var projectDirectoryPath = Directory.CreateTempSubdirectory().FullName;
             var projectFilePath = Path.Combine(projectDirectoryPath, "Project.csproj");
             var propertiesDirectoryPath = Path.Combine(projectDirectoryPath, "Properties");
             var launchSettingsFilePath = Path.Combine(propertiesDirectoryPath, "launchSettings.json");
 
-            Directory.CreateDirectory(projectDirectoryPath);
             await File.WriteAllTextAsync(projectFilePath, csProjContent).DefaultTimeout();
 
             Directory.CreateDirectory(propertiesDirectoryPath);

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
@@ -92,7 +92,9 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
             logging.AddXunit(output);
         });
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var servicea = builder.AddDockerfile("container", tempContextPath, tempDockerfilePath);
 
         using var app = builder.Build();
@@ -223,7 +225,9 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
             logging.AddXunit(output);
         });
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var tempOutputPath = Path.GetTempPath();
         var container = builder.AddDockerfile("container", tempContextPath, tempDockerfilePath)
             .WithContainerBuildOptions(ctx =>
@@ -261,7 +265,9 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
             logging.AddXunit(output);
         });
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         using var tempDir = new TestTempDirectory();
         var container = builder.AddDockerfile("container", tempContextPath, tempDockerfilePath)
             .WithContainerBuildOptions(ctx =>
@@ -411,8 +417,9 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
             logging.AddXunit(output);
         });
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         // Add trailing slashes to simulate the issue scenario
         var contextPathWithTrailingSlash = tempContextPath + Path.DirectorySeparatorChar;
         var servicea = builder.AddDockerfile("container", contextPathWithTrailingSlash, tempDockerfilePath);
@@ -533,7 +540,9 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: false);
         builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var dockerfileResource = builder.AddDockerfile("test-dockerfile", tempContextPath, tempDockerfilePath);
 
         using var app = builder.Build();
@@ -562,8 +571,9 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: false);
         builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         // Add trailing slashes to context path to test normalization
         var contextPathWithTrailingSlash = tempContextPath + Path.DirectorySeparatorChar + Path.DirectorySeparatorChar;
         var dockerfileResource = builder.AddDockerfile("test-dockerfile", contextPathWithTrailingSlash, tempDockerfilePath);
@@ -601,7 +611,9 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 
         builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", new FakeContainerRuntime(shouldFail: true));
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var container = builder.AddDockerfile("container", tempContextPath, tempDockerfilePath);
 
         using var app = builder.Build();
@@ -637,8 +649,9 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: false);
         builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         // Add parameters for build args and secrets
         builder.Configuration["Parameters:goversion"] = "1.22";
         builder.Configuration["Parameters:secret"] = "mysecret";
@@ -698,8 +711,9 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: false);
         builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         // Add parameters for different value types
         builder.Configuration["Parameters:stringparam"] = "test-value";
         builder.Configuration["Parameters:valueprovider"] = "provider-value";
@@ -807,8 +821,9 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: false);
         builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         // Add parameters for different value types
         builder.Configuration["Parameters:stringsecret"] = "secret-value";
         builder.Configuration["Parameters:nullsecret"] = null;
@@ -853,8 +868,9 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: false);
         builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         // Create a temporary file to use as a file-based secret
         using var tempDir = new TestTempDirectory();
         var tempSecretFile = System.IO.Path.Combine(tempDir.Path, ".npmrc");
@@ -1056,7 +1072,9 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
             logging.AddXunit(output);
         });
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var container = builder.AddDockerfile("mycontainer", tempContextPath, tempDockerfilePath);
 
         using var app = builder.Build();
@@ -1086,8 +1104,9 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
             logging.AddXunit(output);
         });
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
-
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var dockerfileBuildAnnotation = new DockerfileBuildAnnotation(tempContextPath, tempDockerfilePath, null)
         {
             ImageName = "custom-image",
@@ -1289,7 +1308,9 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: false, isRunning: false);
         builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
 
-        var (tempContextPath, tempDockerfilePath) = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync();
+        var tempContextPath = tempDockerfileContext.ContextPath;
+        var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         var container = builder.AddDockerfile("container", tempContextPath, tempDockerfilePath);
 
         using var app = builder.Build();

--- a/tests/Aspire.Hosting.Tests/Utils/DockerfileUtils.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/DockerfileUtils.cs
@@ -35,23 +35,49 @@ public static class DockerfileUtils
         RUN chmod -R 777 /usr/share/nginx/html
         """;
 
-    public static async Task<(string ContextPath, string DockerfilePath)> CreateTemporaryDockerfileAsync(string dockerfileName = "Dockerfile", bool createDockerfile = true, bool includeSecrets = false)
+    public static async Task<TemporaryDockerfileContext> CreateTemporaryDockerfileAsync(string dockerfileName = "Dockerfile", bool createDockerfile = true, bool includeSecrets = false)
     {
-        var tempContextPath = Directory.CreateTempSubdirectory().FullName;
+        var tempDirectory = new TestTempDirectory();
 
-        var tempDockerfilePath = Path.Combine(tempContextPath, dockerfileName);
-
-        if (createDockerfile)
+        try
         {
-            var dockerfileTemplate = includeSecrets ? HelloWorldDockerfileWithSecrets : HelloWorldDockerfile;
-            // We apply this random value to the Dockerfile to make sure that we get a clean
-            // build each time with no possible caching.
-            var cacheBuster = Guid.NewGuid();
-            var dockerfileContent = dockerfileTemplate.Replace("!!!CACHEBUSTER!!!", cacheBuster.ToString());
+            var tempContextPath = tempDirectory.Path;
+            var tempDockerfilePath = Path.Combine(tempContextPath, dockerfileName);
 
-            await File.WriteAllTextAsync(tempDockerfilePath, dockerfileContent);
+            if (createDockerfile)
+            {
+                var dockerfileTemplate = includeSecrets ? HelloWorldDockerfileWithSecrets : HelloWorldDockerfile;
+                // We apply this random value to the Dockerfile to make sure that we get a clean
+                // build each time with no possible caching.
+                var cacheBuster = Guid.NewGuid();
+                var dockerfileContent = dockerfileTemplate.Replace("!!!CACHEBUSTER!!!", cacheBuster.ToString());
+
+                await File.WriteAllTextAsync(tempDockerfilePath, dockerfileContent);
+            }
+
+            return new TemporaryDockerfileContext(tempDirectory, tempDockerfilePath);
         }
-
-        return (tempContextPath, tempDockerfilePath);
+        catch
+        {
+            tempDirectory.Dispose();
+            throw;
+        }
     }
+}
+
+public sealed class TemporaryDockerfileContext(TestTempDirectory tempDirectory, string dockerfilePath) : IDisposable
+{
+    private readonly TestTempDirectory _tempDirectory = tempDirectory;
+
+    public string ContextPath => _tempDirectory.Path;
+
+    public string DockerfilePath { get; } = dockerfilePath;
+
+    public void Deconstruct(out string contextPath, out string dockerfilePath)
+    {
+        contextPath = ContextPath;
+        dockerfilePath = DockerfilePath;
+    }
+
+    public void Dispose() => _tempDirectory.Dispose();
 }

--- a/tests/Aspire.Hosting.Tests/Utils/DockerfileUtils.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/DockerfileUtils.cs
@@ -37,8 +37,7 @@ public static class DockerfileUtils
 
     public static async Task<(string ContextPath, string DockerfilePath)> CreateTemporaryDockerfileAsync(string dockerfileName = "Dockerfile", bool createDockerfile = true, bool includeSecrets = false)
     {
-        var tempContextPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        Directory.CreateDirectory(tempContextPath);
+        var tempContextPath = Directory.CreateTempSubdirectory().FullName;
 
         var tempDockerfilePath = Path.Combine(tempContextPath, dockerfileName);
 

--- a/tests/Aspire.Hosting.Tests/Utils/DockerfileUtils.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/DockerfileUtils.cs
@@ -73,11 +73,5 @@ public sealed class TemporaryDockerfileContext(TestTempDirectory tempDirectory, 
 
     public string DockerfilePath { get; } = dockerfilePath;
 
-    public void Deconstruct(out string contextPath, out string dockerfilePath)
-    {
-        contextPath = ContextPath;
-        dockerfilePath = DockerfilePath;
-    }
-
     public void Dispose() => _tempDirectory.Dispose();
 }

--- a/tests/Aspire.Hosting.Valkey.Tests/ValkeyFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Valkey.Tests/ValkeyFunctionalTests.cs
@@ -82,7 +82,7 @@ public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                bindMountPath = Directory.CreateTempSubdirectory().FullName;
 
                 valkey1.WithDataBindMount(bindMountPath);
             }

--- a/tests/Aspire.Hosting.Valkey.Tests/ValkeyFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Valkey.Tests/ValkeyFunctionalTests.cs
@@ -82,7 +82,7 @@ public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
             }
             else
             {
-                bindMountPath = Directory.CreateTempSubdirectory().FullName;
+                bindMountPath = Path.Combine(Directory.CreateTempSubdirectory().FullName, "data");
 
                 valkey1.WithDataBindMount(bindMountPath);
             }
@@ -188,7 +188,7 @@ public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
             {
                 try
                 {
-                    Directory.Delete(bindMountPath, recursive: true);
+                    Directory.Delete(Path.GetDirectoryName(bindMountPath)!, recursive: true);
                 }
                 catch
                 {


### PR DESCRIPTION
## Description

This updates temp directory creation to use secure temp subdirectories instead of combining `Path.GetTempPath()` with `Path.GetRandomFileName()`. The old pattern could create directories without the tighter default permissions we want, so this change aligns the CLI and the affected tests with `Directory.CreateTempSubdirectory()`.

For cases that still need a missing file or missing directory path, the tests now create those paths under a secure temp directory so the original scenarios stay intact. This also updates `AGENTS.md` so future temp directory usage follows the same pattern.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No