### PR TITLE
Fix NpmRunner to handle multi-version npm view output

### DIFF
--- a/src/Aspire.Cli/Agents/Playwright/PlaywrightCliInstaller.cs
+++ b/src/Aspire.Cli/Agents/Playwright/PlaywrightCliInstaller.cs
@@ -55,9 +55,9 @@ internal sealed class PlaywrightCliInstaller(
     internal const string PackageName = "@playwright/cli";
 
     /// <summary>
-    /// The version range to resolve. Accepts any version from 0.1.1 onwards.
+    /// The version range to resolve. Accepts any version from 0.1.3 onwards.
     /// </summary>
-    internal const string VersionRange = ">=0.1.1";
+    internal const string VersionRange = ">=0.1.3";
 
     /// <summary>
     /// The expected source repository for provenance verification.

--- a/src/Aspire.Cli/Npm/NpmRunner.cs
+++ b/src/Aspire.Cli/Npm/NpmRunner.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Semver;
 
@@ -54,7 +55,12 @@ internal sealed class NpmRunner(ILogger<NpmRunner> logger) : INpmRunner
                 return null;
             }
 
-            var versionString = versionOutput.Trim();
+            if (!TryExtractLastVersion(versionOutput, out var versionString))
+            {
+                logger.LogDebug("Could not extract version from npm output: {Output}", versionOutput.Trim());
+                return null;
+            }
+
             if (!SemVersion.TryParse(versionString, SemVersionStyles.Any, out var version))
             {
                 logger.LogDebug("Could not parse npm version from output: {Output}", versionString);
@@ -300,6 +306,44 @@ internal sealed class NpmRunner(ILogger<NpmRunner> logger) : INpmRunner
         }
 
         return startInfo;
+    }
+
+    /// <summary>
+    /// Tries to extract the version string from npm view output. When a version range
+    /// matches multiple versions, npm returns multi-line output in the format
+    /// <c>@scope/pkg@version 'version'</c> per line, sorted ascending. This method
+    /// returns the last (highest) version from such output, or the trimmed output
+    /// when it contains a single version.
+    /// </summary>
+    internal static bool TryExtractLastVersion(string npmOutput, [NotNullWhen(true)] out string? version)
+    {
+        version = null;
+
+        var lastLine = npmOutput
+            .Split(['\n', '\r'], StringSplitOptions.RemoveEmptyEntries)
+            .LastOrDefault()?
+            .Trim();
+
+        if (string.IsNullOrEmpty(lastLine))
+        {
+            return false;
+        }
+
+        // Multi-version format: "@scope/pkg@version 'version'" — extract the quoted version.
+        // Single-version format: just "version" — return as-is.
+        var quoteStart = lastLine.IndexOf('\'');
+        if (quoteStart >= 0)
+        {
+            var quoteEnd = lastLine.IndexOf('\'', quoteStart + 1);
+            if (quoteEnd > quoteStart)
+            {
+                version = lastLine[(quoteStart + 1)..quoteEnd];
+                return !string.IsNullOrEmpty(version);
+            }
+        }
+
+        version = lastLine;
+        return true;
     }
 
     private async Task<string?> RunNpmCommandInDirectoryAsync(string npmPath, string[] args, string workingDirectory, CancellationToken cancellationToken)

--- a/tests/Aspire.Cli.Tests/Npm/NpmRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/Npm/NpmRunnerTests.cs
@@ -126,4 +126,63 @@ public class NpmRunnerTests
         Assert.Contains("npm.cmd", startInfo.Arguments);
         Assert.Equal(@"C:\temp", startInfo.WorkingDirectory);
     }
+
+    [Fact]
+    public void TryExtractLastVersion_SingleVersion_ReturnsTrimmedVersion()
+    {
+        var result = NpmRunner.TryExtractLastVersion("0.1.1\n", out var version);
+        Assert.True(result);
+        Assert.Equal("0.1.1", version);
+    }
+
+    [Fact]
+    public void TryExtractLastVersion_MultipleVersions_ReturnsLastVersion()
+    {
+        var output = "@playwright/cli@0.1.1 '0.1.1'\n@playwright/cli@0.1.2 '0.1.2'\n@playwright/cli@0.1.3 '0.1.3'\n";
+        var result = NpmRunner.TryExtractLastVersion(output, out var version);
+        Assert.True(result);
+        Assert.Equal("0.1.3", version);
+    }
+
+    [Fact]
+    public void TryExtractLastVersion_MultipleVersions_WindowsLineEndings_ReturnsLastVersion()
+    {
+        var output = "@playwright/cli@0.1.1 '0.1.1'\r\n@playwright/cli@0.1.2 '0.1.2'\r\n@playwright/cli@0.1.3 '0.1.3'\r\n";
+        var result = NpmRunner.TryExtractLastVersion(output, out var version);
+        Assert.True(result);
+        Assert.Equal("0.1.3", version);
+    }
+
+    [Fact]
+    public void TryExtractLastVersion_EmptyString_ReturnsFalse()
+    {
+        var result = NpmRunner.TryExtractLastVersion("", out var version);
+        Assert.False(result);
+        Assert.Null(version);
+    }
+
+    [Fact]
+    public void TryExtractLastVersion_WhitespaceOnly_ReturnsFalse()
+    {
+        var result = NpmRunner.TryExtractLastVersion("  \n  \n  ", out var version);
+        Assert.False(result);
+        Assert.Null(version);
+    }
+
+    [Fact]
+    public void TryExtractLastVersion_SingleVersionNoNewline_ReturnsTrimmedVersion()
+    {
+        var result = NpmRunner.TryExtractLastVersion("1.2.3", out var version);
+        Assert.True(result);
+        Assert.Equal("1.2.3", version);
+    }
+
+    [Fact]
+    public void TryExtractLastVersion_MultipleVersionsWithPrerelease_ReturnsLastVersion()
+    {
+        var output = "@scope/pkg@1.0.0-alpha '1.0.0-alpha'\n@scope/pkg@1.0.0 '1.0.0'\n";
+        var result = NpmRunner.TryExtractLastVersion(output, out var version);
+        Assert.True(result);
+        Assert.Equal("1.0.0", version);
+    }
 }


### PR DESCRIPTION
## Description

When `npm view @playwright/cli@>=0.1.1 version` matches multiple published versions, npm returns multi-line output in the format `@scope/pkg@version 'version'` per line. `NpmRunner.ResolvePackageAsync()` was calling `.Trim()` on the entire multi-line string and passing it to `SemVersion.TryParse()`, which failed.

This broke after versions 0.1.2 and 0.1.3 of `@playwright/cli` were published on March 31, 2026 — previously only 0.1.1 matched the range, so the output was a single parseable version string.

The fix adds an `ExtractLastVersion()` method that parses the last (highest) version from multi-line npm output, handling both single-version and multi-version formats.

Fixes #15738

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
