### PR TITLE
Fix flaky ExternalService tests by awaiting StartAsync before StopAsync

### DIFF
--- a/tests/Aspire.Hosting.Tests/ExternalServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExternalServiceTests.cs
@@ -326,8 +326,8 @@ public class ExternalServiceTests(ITestOutputHelper testOutputHelper)
         // Verify the resource is in the correct state
         Assert.Equal(KnownResourceStates.FailedToStart, resourceEvent.Snapshot.State?.Text);
 
+        await appStartTask; // Ensure start completes before stopping
         await app.StopAsync();
-        await appStartTask; // Ensure start completes
     }
 
     [Fact]
@@ -353,8 +353,8 @@ public class ExternalServiceTests(ITestOutputHelper testOutputHelper)
         // Verify the resource is in the correct state
         Assert.Equal(KnownResourceStates.FailedToStart, resourceEvent.Snapshot.State?.Text);
 
+        await appStartTask; // Ensure start completes before stopping
         await app.StopAsync();
-        await appStartTask; // Ensure start completes
     }
 
     [Fact]
@@ -380,8 +380,8 @@ public class ExternalServiceTests(ITestOutputHelper testOutputHelper)
         // Verify the resource is in the correct state
         Assert.Equal(KnownResourceStates.Running, resourceEvent.Snapshot.State?.Text);
 
+        await appStartTask; // Ensure start completes before stopping
         await app.StopAsync();
-        await appStartTask; // Ensure start completes
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Fix flaky `ExternalServiceWithValidParameterMarksAsRunning` test (and two sibling tests) that intermittently fail with `TaskCanceledException` during CI.

**Root cause:** The tests called `app.StartAsync()` without awaiting it, then called `app.StopAsync()` after observing the resource notification. When DCP startup was slow (e.g. kubeconfig read taking ~1s under CI load), `StopAsync` cancelled the host's startup token while `DcpExecutor.RunApplicationAsync` was still in progress, causing the `TaskCanceledException`.

**Fix:** Move `await appStartTask` before `app.StopAsync()` so that DCP startup completes before the host is told to stop. The `var appStartTask = app.StartAsync()` pattern is preserved to allow concurrent observation of resource notifications during startup.

**Validated with 100 consecutive local passes (0 failures).**

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
