### PR TITLE
Improve create-pr skill with cross-platform support and best practices

### DIFF
--- a/.github/skills/create-pr/SKILL.md
+++ b/.github/skills/create-pr/SKILL.md
@@ -41,7 +41,7 @@ Before starting, verify:
 - Fill known details in `## Description` (summary, motivation/context, dependencies, validation).
 - Fill checklist choices by selecting known answers and leaving only unknown choices unchecked.
 - Keep `Fixes # (issue)` unless a concrete issue number is provided.
-- Write the body to a temporary file (e.g., `pr-body.md` in the repo root).
+- Write the body to a temporary file named `pr-body.md` in the repo root.
 
 ### 4. Create the PR
 
@@ -70,13 +70,7 @@ gh pr create `
 
 > **Shell differences:** `VAR=val command` is bash syntax for setting an env var for a single command. PowerShell requires a separate `$env:VAR = "val"` statement (persists for the session, which is harmless here).
 
-### 5. Clean up
-
-Delete the temporary body file after the PR is created:
-- **bash:** `rm pr-body.md`
-- **PowerShell:** `Remove-Item pr-body.md`
-
-### 6. Handle existing PRs
+### 5. Handle existing PRs
 
 If a PR already exists for the branch:
 - Do not create another.
@@ -87,6 +81,12 @@ If a PR already exists for the branch:
   **PowerShell:** `$env:GH_PAGER = "cat"; gh pr edit <pr-number-or-url> --body-file pr-body.md`
 
 - Return the existing PR URL.
+
+### 6. Clean up
+
+After you are completely finished creating or updating the PR (after step 4 and, if needed, step 5), delete the temporary body file:
+- **bash:** `rm pr-body.md`
+- **PowerShell:** `Remove-Item pr-body.md`
 
 ## Error handling
 

--- a/.github/skills/create-pr/SKILL.md
+++ b/.github/skills/create-pr/SKILL.md
@@ -1,51 +1,101 @@
 ---
 name: create-pr
-description: Create a PR using the repository PR template. Use this when asked to push and open a pull request.
+description: 'Create a pull request using the repository PR template. Use when asked to: create PR, open PR, push and create PR, submit PR, open pull request, send changes for review.'
 ---
 
 You are a specialized pull request creation agent for this repository.
 
 Your goal is to **create a PR** and always **use the repository PR template** at `.github/pull_request_template.md`.
 
-## Required behavior
+## Example requests
 
-1. Ensure the current branch is ready to open a PR:
-   - Confirm branch name.
-   - Confirm changes are committed.
-   - Push with upstream if needed.
+- "Create a PR for this change"
+- "Push and open a pull request"
+- "Submit a PR with these fixes"
+- "Open a PR against the release branch"
 
-2. Determine PR metadata:
-   - Head branch: current branch unless user specifies otherwise.
-   - Base branch: user-specified base when provided; otherwise infer from context (or repository default branch).
-   - Title: concise summary of the change.
+## Prerequisites
 
-3. Build PR body from template:
-   - Read `.github/pull_request_template.md`.
-   - Use the template structure as the PR body.
-   - Fill known details in `## Description` (summary, motivation/context, dependencies, validation).
-   - Fill checklist choices by selecting known answers and leaving only unknown choices unchecked.
-   - Keep `Fixes # (issue)` unless a concrete issue number is provided.
+Before starting, verify:
+- `gh` CLI is available: run `gh --version`. If missing, tell the user to install it from https://cli.github.com/.
+- Authentication is configured: run `gh auth status`. If not authenticated, tell the user to run `gh auth login`.
 
-4. Create the PR with `gh` using the template-derived body:
+## Procedure
 
+### 1. Prepare the branch
+
+- Confirm the current branch name with `git branch --show-current`.
+- Ensure changes are committed (`git status` should show a clean working tree or only untracked files).
+- Push the branch with `git push -u origin <branch-name>`. If the push is rejected, inform the user (do not force-push without explicit permission).
+
+### 2. Determine PR metadata
+
+- **Head branch**: current branch unless the user specifies otherwise.
+- **Base branch**: user-specified base when provided; otherwise infer from context (or use the repository default branch).
+- **Title**: concise summary of the change.
+
+### 3. Build PR body from template
+
+- Read `.github/pull_request_template.md`.
+- Use the template structure as the PR body.
+- Fill known details in `## Description` (summary, motivation/context, dependencies, validation).
+- Fill checklist choices by selecting known answers and leaving only unknown choices unchecked.
+- Keep `Fixes # (issue)` unless a concrete issue number is provided.
+- Write the body to a temporary file (e.g., `pr-body.md` in the repo root).
+
+### 4. Create the PR
+
+Set `GH_PAGER` to `cat` to prevent interactive paging, then create the PR. The syntax differs by shell:
+
+**bash/Linux/macOS:**
 ```bash
 GH_PAGER=cat gh pr create \
   --base <base-branch> \
   --head <head-branch> \
   --title "<pr-title>" \
-  --body-file <prepared-template-body-file>
+  --body-file pr-body.md
 ```
 
-5. If a PR already exists for the branch:
-   - Do not create another.
-   - If requested (or if the body is still mostly unfilled template text), update it with:
-
-```bash
-GH_PAGER=cat gh pr edit <pr-number-or-url> \
-  --body-file <prepared-template-body-file>
+**PowerShell/Windows:**
+```powershell
+$env:GH_PAGER = "cat"
+gh pr create `
+  --base <base-branch> `
+  --head <head-branch> `
+  --title "<pr-title>" `
+  --body-file pr-body.md
 ```
 
-   - Return the existing PR URL.
+> **Why `GH_PAGER=cat`?** The `gh` CLI pipes long output through a pager (like `less`) by default, which blocks in non-interactive terminals. Setting it to `cat` disables paging so output prints directly.
+
+> **Shell differences:** `VAR=val command` is bash syntax for setting an env var for a single command. PowerShell requires a separate `$env:VAR = "val"` statement (persists for the session, which is harmless here).
+
+### 5. Clean up
+
+Delete the temporary body file after the PR is created:
+- **bash:** `rm pr-body.md`
+- **PowerShell:** `Remove-Item pr-body.md`
+
+### 6. Handle existing PRs
+
+If a PR already exists for the branch:
+- Do not create another.
+- If requested (or if the body is still mostly unfilled template text), update it:
+
+  **bash:** `GH_PAGER=cat gh pr edit <pr-number-or-url> --body-file pr-body.md`
+
+  **PowerShell:** `$env:GH_PAGER = "cat"; gh pr edit <pr-number-or-url> --body-file pr-body.md`
+
+- Return the existing PR URL.
+
+## Error handling
+
+| Error | Action |
+|-------|--------|
+| `gh: command not found` | Tell the user to install `gh` from https://cli.github.com/ |
+| `gh auth` not logged in | Tell the user to run `gh auth login` |
+| `git push` rejected | Inform the user; do not force-push without explicit permission |
+| PR already exists | Follow step 6 above |
 
 ## Notes
 


### PR DESCRIPTION
## Description

Improve the `create-pr` AI skill to follow best practices and work cross-platform.

Changes:
- **Keyword-rich description** for better agent discovery (includes trigger phrases like "create PR", "open PR", "submit PR")
- **Example requests** section to help agent match user intent
- **Prerequisites** section to check for `gh` CLI and auth before starting
- **Cross-platform commands** with both bash and PowerShell syntax, plus explanation of differences (`GH_PAGER=cat` is bash-only; PowerShell needs `$env:GH_PAGER`)
- **`GH_PAGER` explanation** so agents understand why it's needed
- **Temp file cleanup** step after PR creation
- **Error handling table** covering common failures (`gh` not found, auth issues, push rejected)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
