### PR TITLE
[release/13.2] Backport: Show anonymous dashboard URLs in aspire ps

### DIFF
--- a/src/Aspire.Cli/Backchannel/IAppHostAuxiliaryBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/IAppHostAuxiliaryBackchannel.cs
@@ -50,7 +50,7 @@ internal interface IAppHostAuxiliaryBackchannel : IDisposable
     /// Gets the Dashboard URLs from the AppHost.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The Dashboard URLs state including health and login URLs.</returns>
+    /// <returns>The dashboard URL state including health and resolved dashboard URLs.</returns>
     Task<DashboardUrlsState?> GetDashboardUrlsAsync(CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -416,10 +416,10 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
     }
 
     /// <summary>
-    /// Gets the Dashboard URLs including the login token.
+    /// Gets the dashboard URLs for the running AppHost.
     /// </summary>
     /// <param name="cancellationToken">A cancellation token.</param>
-    /// <returns>The Dashboard URLs state including health and login URLs.</returns>
+    /// <returns>The dashboard URL state including health and resolved dashboard URLs.</returns>
     public async Task<DashboardUrlsState> GetDashboardUrlsAsync(CancellationToken cancellationToken = default)
     {
         logger.LogInformation("GetDashboardUrlsAsync called on auxiliary backchannel");

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -392,19 +392,21 @@ internal sealed class RpcResourceState
 }
 
 /// <summary>
-/// Represents dashboard URLs with authentication tokens.
+/// Represents dashboard URLs for the running AppHost.
 /// </summary>
 internal sealed class DashboardUrlsState
 {
     public bool DashboardHealthy { get; init; } = true;
 
     /// <summary>
-    /// Gets the base dashboard URL with a login token.
+    /// Gets the dashboard URL.
+    /// When browser token authentication is enabled, this value includes the login token.
     /// </summary>
     public string? BaseUrlWithLoginToken { get; init; }
 
     /// <summary>
-    /// Gets the Codespaces dashboard URL with a login token, if available.
+    /// Gets the Codespaces dashboard URL, if available.
+    /// When browser token authentication is enabled, this value includes the login token.
     /// </summary>
     public string? CodespacesUrlWithLoginToken { get; init; }
 }

--- a/src/Aspire.Hosting/Backchannel/DashboardUrlsHelper.cs
+++ b/src/Aspire.Hosting/Backchannel/DashboardUrlsHelper.cs
@@ -94,14 +94,18 @@ internal static class DashboardUrlsHelper
             }
         }
 
-        // Build login URLs
+        // Build dashboard URLs. When browser token auth is enabled, include the login token.
+        // When anonymous access is enabled, return the base URL directly.
         var codespacesUrlRewriter = serviceProvider.GetService<CodespacesUrlRewriter>();
         string? baseUrlWithLoginToken = null;
         string? codespacesUrlWithLoginToken = null;
 
-        if (!string.IsNullOrEmpty(apiBaseUrl) && !string.IsNullOrEmpty(dashboardOptions.DashboardToken))
+        if (!string.IsNullOrEmpty(apiBaseUrl))
         {
-            baseUrlWithLoginToken = $"{apiBaseUrl.TrimEnd('/')}/login?t={dashboardOptions.DashboardToken}";
+            baseUrlWithLoginToken = !string.IsNullOrEmpty(dashboardOptions.DashboardToken)
+                ? $"{apiBaseUrl.TrimEnd('/')}/login?t={dashboardOptions.DashboardToken}"
+                : apiBaseUrl;
+
             var rewrittenUrl = codespacesUrlRewriter?.RewriteUrl(baseUrlWithLoginToken);
             if (rewrittenUrl != baseUrlWithLoginToken)
             {
@@ -122,13 +126,13 @@ internal static class DashboardUrlsHelper
     }
 
     /// <summary>
-    /// Gets the dashboard URLs including the login token.
+    /// Gets the dashboard URLs for the running AppHost.
     /// Waits for the dashboard to become healthy before returning.
     /// </summary>
     /// <param name="serviceProvider">The service provider.</param>
     /// <param name="logger">The logger for diagnostic output.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
-    /// <returns>The Dashboard URLs state including health and login URLs.</returns>
+    /// <returns>The dashboard URL state including health and resolved dashboard URLs.</returns>
     public static async Task<DashboardUrlsState> GetDashboardUrlsAsync(
         IServiceProvider serviceProvider,
         ILogger logger,
@@ -156,6 +160,14 @@ internal sealed class DashboardConnectionInfo
     public string? ApiToken { get; init; }
     public string? McpBaseUrl { get; init; }
     public string? McpApiToken { get; init; }
+    /// <summary>
+    /// Gets the resolved dashboard URL.
+    /// When browser token authentication is enabled, this value includes the login token.
+    /// </summary>
     public string? BaseUrlWithLoginToken { get; init; }
+    /// <summary>
+    /// Gets the resolved Codespaces dashboard URL, if available.
+    /// When browser token authentication is enabled, this value includes the login token.
+    /// </summary>
     public string? CodespacesUrlWithLoginToken { get; init; }
 }

--- a/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PsCommandTests.cs
@@ -167,6 +167,50 @@ public class PsCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task PsCommand_JsonFormat_ReturnsAnonymousDashboardUrl()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var textWriter = new TestOutputTextWriter(outputHelper);
+
+        var monitor = new TestAuxiliaryBackchannelMonitor();
+        var connection = new TestAppHostAuxiliaryBackchannel
+        {
+            IsInScope = true,
+            AppHostInfo = new AppHostInformation
+            {
+                AppHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "App1", "App1.AppHost.csproj"),
+                ProcessId = 1234
+            },
+            DashboardUrlsState = new DashboardUrlsState
+            {
+                BaseUrlWithLoginToken = "http://localhost:18888"
+            }
+        };
+        monitor.AddConnection("hash1", "socket.hash1", connection);
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.OutputTextWriter = textWriter;
+            options.AuxiliaryBackchannelMonitorFactory = _ => monitor;
+        });
+        var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("ps --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(ExitCodeConstants.Success, exitCode);
+
+        var jsonOutput = string.Join(string.Empty, textWriter.Logs);
+
+        var appHosts = JsonSerializer.Deserialize(jsonOutput, PsCommandJsonContext.RelaxedEscaping.ListAppHostDisplayInfo);
+        Assert.NotNull(appHosts);
+        Assert.Single(appHosts);
+        Assert.Equal("http://localhost:18888", appHosts[0].DashboardUrl);
+    }
+
+    [Fact]
     public async Task PsCommand_JsonFormat_NoResults_WritesEmptyArrayToStdout()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -411,5 +412,41 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
         Assert.Equal($"{TestTimestamp} Second log", logs[1].Content);
 
         await app.StopAsync();
+    }
+
+    [Fact]
+    public async Task GetDashboardUrlsAsync_ReturnsBaseUrl_WhenDashboardAllowsAnonymousAccess()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(
+            options => options.DisableDashboard = false,
+            outputHelper,
+            $"{KnownConfigNames.AspNetCoreUrls}=http://localhost",
+            $"{KnownConfigNames.DashboardOtlpGrpcEndpointUrl}=http://localhost",
+            $"{KnownConfigNames.DashboardUnsecuredAllowAnonymous}=true");
+
+        using var app = builder.Build();
+        await app.ExecuteBeforeStartHooksAsync(default).DefaultTimeout();
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var dashboard = Assert.Single(model.Resources, r => r.Name == KnownResourceNames.AspireDashboard);
+        var endpoint = dashboard.Annotations.OfType<EndpointAnnotation>().Single(e => e.Name == "http");
+        endpoint.AllocatedEndpoint = new(endpoint, "localhost", 18888, targetPortExpression: "18888");
+
+        var notificationService = app.Services.GetRequiredService<ResourceNotificationService>();
+        await notificationService.PublishUpdateAsync(dashboard, snapshot => snapshot with
+        {
+            State = KnownResourceStates.Running,
+            ResourceReadyEvent = new EventSnapshot(Task.CompletedTask)
+        });
+
+        var target = new AuxiliaryBackchannelRpcTarget(
+            NullLogger<AuxiliaryBackchannelRpcTarget>.Instance,
+            app.Services);
+
+        var result = await target.GetDashboardUrlsAsync().DefaultTimeout();
+
+        Assert.True(result.DashboardHealthy);
+        Assert.Equal("http://localhost:18888", result.BaseUrlWithLoginToken);
+        Assert.Null(result.CodespacesUrlWithLoginToken);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
@@ -46,6 +46,11 @@ public static class TestDistributedApplicationBuilder
         return CreateCore([], configureOptions, testOutputHelper);
     }
 
+    public static IDistributedApplicationTestingBuilder Create(Action<DistributedApplicationOptions>? configureOptions, ITestOutputHelper testOutputHelper, params string[] args)
+    {
+        return CreateCore(args, configureOptions, testOutputHelper);
+    }
+
     public static IDistributedApplicationTestingBuilder CreateWithTestContainerRegistry(ITestOutputHelper testOutputHelper) =>
         Create(o => o.ContainerRegistryOverride = ComponentTestConstants.AspireTestContainerRegistry, testOutputHelper);
 


### PR DESCRIPTION
## Description

Backport of #15731 to `release/13.2`.

`aspire ps` left the Dashboard column empty when the AppHost was configured with anonymous dashboard access (`ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS` / `DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS`). This change makes the backchannel surface the dashboard base URL in anonymous mode so CLI output can display it.

Cherry-picked from `010f4a76a2` with two merge conflicts resolved (MCP-related code in `AuxiliaryBackchannelRpcTarget.cs` and `DashboardUrlsHelper.cs` that exists on `release/13.2` but not on `main`).

**Validation**: All 1770 CLI tests pass, all 9 AuxiliaryBackchannelRpcTargetTests pass.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No
