### PR TITLE
Fix mardown rendering during failed deployment

### DIFF
--- a/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
+++ b/src/Aspire.Cli/Utils/ConsoleActivityLogger.cs
@@ -410,10 +410,12 @@ internal sealed class ConsoleActivityLogger
                 ActivityState.Failure => _enableColor ? "[red]" + FailureSymbol + "[/]" : FailureSymbol,
                 _ => _enableColor ? "[cyan]" + InProgressSymbol + "[/]" : InProgressSymbol
             };
+            // DisplayName and FailureReason are already Spectre-safe (pre-processed
+            // through ConvertTextWithMarkdownFlag which escapes or converts markdown).
             var displayName = GetIndentedDisplayName(rec);
             var name = (renderTimeline ? displayName.PadRight(nameWidth) : displayName).EscapeMarkup();
             var reason = rec.State == ActivityState.Failure && !string.IsNullOrEmpty(rec.FailureReason)
-                ? (_enableColor ? $" [red]— {HighlightMessage(rec.FailureReason!.EscapeMarkup())}[/]" : $" — {rec.FailureReason!.EscapeMarkup()}")
+                ? (_enableColor ? $" [red]— {HighlightMessage(rec.FailureReason!)}[/]" : $" — {rec.FailureReason!}")
                 : string.Empty;
 
             var lineSb = new StringBuilder();

--- a/tests/Aspire.Cli.Tests/Utils/ConsoleActivityLoggerTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/ConsoleActivityLoggerTests.cs
@@ -171,7 +171,7 @@ public class ConsoleActivityLoggerTests
     }
 
     [Fact]
-    public void WriteSummary_WithMarkupCharactersInFailureReason_EscapesCorrectly()
+    public void WriteSummary_WithMarkupCharactersInFailureReason_RendersCorrectly()
     {
         var output = new StringBuilder();
         var logger = CreateLogger(output, interactive: true, color: true);
@@ -179,20 +179,51 @@ public class ConsoleActivityLoggerTests
         logger.StartTask("step1", "Test Step");
         logger.Failure("step1", "Failed");
 
+        // In the real code path, FailureReason values are pre-processed through
+        // ConvertTextWithMarkdownFlag which escapes brackets. Simulate that here.
         var records = new[]
         {
-            new ConsoleActivityLogger.StepDurationRecord("step1", "Test Step", ConsoleActivityLogger.ActivityState.Failure, TimeSpan.FromSeconds(1.5), "Error: Type[T] is invalid [details]")
+            new ConsoleActivityLogger.StepDurationRecord("step1", "Test Step", ConsoleActivityLogger.ActivityState.Failure, TimeSpan.FromSeconds(1.5), "Error: Type[[T]] is invalid [[details]]")
         };
         logger.SetStepDurations(records);
         logger.SetFinalResult(false);
 
-        // Should not throw — failure reason with brackets must be escaped
+        // Should not throw — failure reason with pre-escaped brackets renders correctly
         logger.WriteSummary();
 
         var result = output.ToString();
 
-        // The literal bracket text from the failure reason should appear
+        // The escaped brackets should render as literal brackets in output
         Assert.Contains("Type[T]", result);
+    }
+
+    [Fact]
+    public void WriteSummary_WithSpectreMarkupInFailureReason_RendersMarkupCorrectly()
+    {
+        var output = new StringBuilder();
+        var logger = CreateLogger(output, interactive: true, color: true);
+
+        logger.StartTask("step1", "Test Step");
+        logger.Failure("step1", "Failed");
+
+        // Simulate what happens when ConvertTextWithMarkdownFlag converts
+        // markdown like "Failed to provision **storage-roles**: Deployment failed"
+        // into Spectre markup.
+        var records = new[]
+        {
+            new ConsoleActivityLogger.StepDurationRecord("step1", "Test Step", ConsoleActivityLogger.ActivityState.Failure, TimeSpan.FromSeconds(1.5), "Failed to provision [bold]storage-roles[/]: Deployment failed")
+        };
+        logger.SetStepDurations(records);
+        logger.SetFinalResult(false);
+
+        logger.WriteSummary();
+
+        var result = output.ToString();
+
+        // The resource name should appear in the output without literal [bold] tags
+        Assert.Contains("storage-roles", result);
+        Assert.DoesNotContain("[bold]", result);
+        Assert.DoesNotContain("[/]", result);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

When aspire deploy fails to provision in Azure, the message says

```
Failed to provision [bold]storage-roles[/]: Deployment failed
```

The `[bold]` is getting escaped instead of processed by Spectre.

The fix is to not EscapeMarkup inside the ConsoleActivityLogger because these strings have already been escaped if necessary.