### PR TITLE
Remove stale .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,7 +124,7 @@ config.ps1
 # Node.js modules
 node_modules/
 
-# Generated Aspire TypeScript modules
+# Generated Aspire polyglot modules
 .modules/
 
 # Maven build outputs
@@ -136,10 +136,6 @@ playground/**/.java-build/
 playground/**/*.class
 tests/PolyglotAppHosts/**/.java-build/
 tests/PolyglotAppHosts/**/Java/**/*.class
-
-# Generated Java AppHost SDK sources
-/playground/JavaAppHost/.modules/
-/tests/PolyglotAppHosts/**/Java/.modules/
 
 # Ignore cache created with the Angular CLI.
 .angular/
@@ -180,9 +176,6 @@ tests/PolyglotAppHosts/**/TypeScript/dist/
 
 #Aspire CLI
 .aspire/
-
-# Required for polyglot apps
-!tests/PolyglotAppHosts/**/.aspire/
 
 # Release notes automation output
 tools/ReleaseNotes/analysis-output/


### PR DESCRIPTION
## Description

Some of the root `.gitignore` entries were pointing at paths we no longer use, which makes the file harder to reason about during polyglot work. This removes the stale exceptions while keeping the broad generated-output rules that still protect `aspire restore` results.

Specifically, this drops the unused `tests/PolyglotAppHosts/**/.aspire/` unignore, removes Java-specific `.modules` rules that are already covered by the global `.modules/` entry, and renames the comment so it reflects polyglot module generation instead of only TypeScript.

Fixes # (issue): N/A

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to `aspire.dev` issue:
      - [New issue](https://github.com/microsoft/aspire.dev/issues/new)
  - [x] No