### PR TITLE
Improve Aspire VS Code extension discoverability

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -19,15 +19,23 @@
     "Other"
   ],
   "keywords": [
+    "aspire",
     "dotnet",
+    "distributed",
     "orchestrator",
     "apphost"
   ],
+  "galleryBanner": {
+    "color": "#512BD4",
+    "theme": "dark"
+  },
   "activationEvents": [
     "onDebugResolve:aspire",
     "onDebugInitialConfigurations:aspire",
     "onDebugDynamicConfigurations:aspire",
     "workspaceContains:**/*.csproj",
+    "workspaceContains:**/aspire.config.json",
+    "workspaceContains:**/.aspire/**",
     "onView:workbench.view.debug",
     "workspaceContains:**/apphost.cs",
     "workspaceContains:**/apphost.ts",

--- a/extension/package.json
+++ b/extension/package.json
@@ -21,6 +21,7 @@
   "keywords": [
     "aspire",
     "dotnet",
+    "typescript",
     "distributed",
     "orchestrator",
     "apphost"

--- a/src/Aspire.Cli/Templating/Templates/empty-apphost/.vscode/extensions.json
+++ b/src/Aspire.Cli/Templating/Templates/empty-apphost/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "microsoft-aspire.aspire-vscode"
+  ]
+}

--- a/src/Aspire.Cli/Templating/Templates/py-starter/.vscode/extensions.json
+++ b/src/Aspire.Cli/Templating/Templates/py-starter/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "microsoft-aspire.aspire-vscode"
+  ]
+}

--- a/src/Aspire.Cli/Templating/Templates/ts-starter/.vscode/extensions.json
+++ b/src/Aspire.Cli/Templating/Templates/ts-starter/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "microsoft-aspire.aspire-vscode"
+  ]
+}


### PR DESCRIPTION
## Description

Improves the discoverability of the Aspire VS Code extension through several targeted changes:

**CLI Templates** — Added `.vscode/extensions.json` to all 3 active CLI templates (`empty-apphost`, `ts-starter`, `py-starter`) so that every project created via `aspire new` or `aspire init` automatically recommends the Aspire extension when opened in VS Code.

**Activation Events** — Added `workspaceContains:**/aspire.config.json` and `workspaceContains:**/.aspire/**` activation events so the extension activates on Aspire-specific project markers (not just any `.csproj`). This ensures polyglot Aspire projects (TypeScript, Python) also trigger activation.

**Marketplace Metadata** — Expanded keywords from 3 to 5 (added `aspire`, `distributed`) and added a `galleryBanner` with the Aspire brand purple (`#512BD4`) for visual presence in search results.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No
